### PR TITLE
histogram: option to enable/disable zero-fill

### DIFF
--- a/src/app/panels/histogram/module.js
+++ b/src/app/panels/histogram/module.js
@@ -159,6 +159,7 @@ function (angular, app, $, _, kbn, moment, timeSeries) {
        * linewidth:: Weight of lines in pixels
        */
       linewidth     : 3,
+      gapfill       : 'minimal',
       /** @scratch /panels/histogram/3
        * points:: Show points on chart
        */
@@ -409,7 +410,7 @@ function (angular, app, $, _, kbn, moment, timeSeries) {
                 interval: _interval,
                 start_date: _range && _range.from,
                 end_date: _range && _range.to,
-                fill_style: $scope.panel.derivative ? 'null' : 'minimal'
+                fill_style: $scope.panel.derivative ? 'null' : $scope.panel.gapfill
               };
               time_series = new timeSeries.ZeroFilled(tsOpts);
               hits = 0;

--- a/src/app/panels/histogram/styleEditor.html
+++ b/src/app/panels/histogram/styleEditor.html
@@ -17,6 +17,10 @@
       <label class="small">xAxis</label><input type="checkbox" ng-model="panel['x-axis']" ng-checked="panel['x-axis']"></div>
     <div class="editor-option">
       <label class="small">yAxis</label><input type="checkbox" ng-model="panel['y-axis']" ng-checked="panel['y-axis']"></div>
+    <div class="editor-option" ng-hide="panel.derivative">
+      <label class="small">Gap Fill</label>
+      <select class="input-mini" ng-model="panel.gapfill" ng-options="f for f in ['all','null','no']">
+    </div>
     <div class="editor-option" ng-show="panel.lines">
       <label class="small">Line Fill</label>
       <select class="input-mini" ng-model="panel.fill" ng-options="f for f in [0,1,2,3,4,5,6,7,8,9,10]"></select>


### PR DESCRIPTION
For some graph types (particularly point style), it's useful to
explicitly avoid filling missing data points with zeros.  For example,
when plotting the min/max/mean value of a particular field, filling with
zeros might present the wrong picture of the data, since the value is
not actually zero but simply missing.
