### PR TITLE
Lift restriction of not allowing '_'-prefixed fields. Close #2551

### DIFF
--- a/src/kibana/components/doc_viewer/doc_viewer.html
+++ b/src/kibana/components/doc_viewer/doc_viewer.html
@@ -37,11 +37,7 @@
           </td>
 
           <td>
-            <i ng-if="!mapping[field] && field[0] === '_'"
-              tooltip-placement="top"
-              tooltip="Field names beginning with _ are not supported"
-              class="fa fa-warning text-color-warning ng-scope doc-viewer-underscore"></i>
-            <i ng-if="!mapping[field] && field[0] !== '_' && !showArrayInObjectsWarning(doc, field)"
+            <i ng-if="!mapping[field] && !showArrayInObjectsWarning(doc, field)"
               tooltip-placement="top"
               tooltip="No cached mapping for this field. Refresh your mapping from the Settings > Indices page"
               class="fa fa-warning text-color-warning ng-scope doc-viewer-no-mapping"></i>

--- a/src/kibana/components/index_patterns/_flatten_hit.js
+++ b/src/kibana/components/index_patterns/_flatten_hit.js
@@ -41,7 +41,6 @@ define(function (require) {
 
       // unwrap computed fields
       _.forOwn(hit.fields, function (val, key) {
-        if (key[0] === '_' && !_.contains(metaFields, key)) return;
         flat[key] = _.isArray(val) && val.length === 1 ? val[0] : val;
       });
 

--- a/src/kibana/components/index_patterns/_map_field.js
+++ b/src/kibana/components/index_patterns/_map_field.js
@@ -11,7 +11,7 @@ define(function (require) {
      */
     return function mapField(field, name) {
       var keys = Object.keys(field.mapping);
-      if (keys.length === 0 || (name[0] === '_') && !_.contains(config.get('metaFields'), name)) return;
+      if (keys.length === 0) return;
 
       var mapping = _.cloneDeep(field.mapping[keys.shift()]);
       mapping.type = castMappingType(mapping.type);

--- a/src/kibana/components/index_patterns/_transform_mapping_into_fields.js
+++ b/src/kibana/components/index_patterns/_transform_mapping_into_fields.js
@@ -20,7 +20,7 @@ define(function (require) {
         _.each(index.mappings, function (mappings) {
           _.each(mappings, function (field, name) {
             var keys = Object.keys(field.mapping);
-            if (keys.length === 0 || (name[0] === '_') && !_.contains(config.get('metaFields'), name)) return;
+            if (keys.length === 0) return;
 
             var mapping = mapField(field, name);
 

--- a/test/unit/specs/components/doc_viewer/doc_viewer.js
+++ b/test/unit/specs/components/doc_viewer/doc_viewer.js
@@ -104,13 +104,6 @@ define(function (require) {
       });
 
       describe('warnings', function () {
-        it('displays a warning about field name starting with underscore', function () {
-          var cells = $elem.find('td[title="_underscore"]').siblings();
-          expect(cells.find('.doc-viewer-underscore').length).to.be(1);
-          expect(cells.find('.doc-viewer-no-mapping').length).to.be(0);
-          expect(cells.find('.doc-viewer-object-array').length).to.be(0);
-        });
-
         it('displays a warning about missing mappings', function () {
           var cells = $elem.find('td[title="noMapping"]').siblings();
           expect(cells.find('.doc-viewer-underscore').length).to.be(0);

--- a/test/unit/specs/index_patterns/flatten_hit.js
+++ b/test/unit/specs/index_patterns/flatten_hit.js
@@ -105,11 +105,11 @@ define(function (require) {
       expect(flat).to.have.property('random', 0.12345);
     });
 
-    it('ignores fields that start with an _ and are not in the metaFields', function () {
+    it('does not ignore fields that start with an _', function () {
       config.set('metaFields', ['_metaKey']);
-      hit.fields._notMetaKey = [100];
+      hit.fields._myUnderscoreField = [100];
       flat = flattenHit(hit);
-      expect(flat).to.not.have.property('_notMetaKey');
+      expect(flat).to.have.property('_myUnderscoreField');
     });
 
     it('includes underscore-prefixed keys that are in the metaFields', function () {
@@ -128,7 +128,7 @@ define(function (require) {
 
       config.set('metaFields', []);
       flat = flattenHit(hit);
-      expect(flat).to.not.have.property('_metaKey');
+      expect(flat).to.have.property('_metaKey');
     });
 
     it('handles fields that are not arrays, like _timestamp', function () {


### PR DESCRIPTION
As long as Elasticsearch does not enforce this rule, neither should
Kibana.
