### PR TITLE
Fixes #4784 Double scrollbar on IE

### DIFF
--- a/src/ui/public/styles/base.less
+++ b/src/ui/public/styles/base.less
@@ -91,7 +91,7 @@ ul.navbar-inline li {
 }
 
 .application {
-  .flex-parent();
+  .flex-parent(@shrink: 0);
   position: relative;
   z-index: 0;
 }


### PR DESCRIPTION
In IE, a flex-shrink value of 1 allowed the application container to shrink below its default size, creating a scrollbar on that div and the body. Switching to flex-shrink: 0 prevents this from happening.
