### PR TITLE
Steps to debug and/or fix functional test timeouts.

### DIFF
--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -12,7 +12,6 @@ define(function (require) {
       var settingsPage;
       var discoverPage;
       var remote;
-      this.timeout = 60000;
 
       bdd.before(function () {
         common = new Common(this.remote);
@@ -71,7 +70,6 @@ define(function (require) {
 
         bdd.it('save query should show toast message and display query name', function () {
           var expectedSavedQueryMessage = 'Discover: Saved Data Source "' + queryName1 + '"';
-          this.timeout = 60000;
           return discoverPage.saveSearch(queryName1)
           .then(function () {
             return headerPage.getToastMessage();

--- a/test/functional/apps/discover/index.js
+++ b/test/functional/apps/discover/index.js
@@ -19,6 +19,7 @@ define(function (require) {
     bdd.before(function () {
       common = new Common(this.remote);
       remote = this.remote;
+      this.timeout = 120000;
     });
 
     bdd.after(function unloadMakelogs() {

--- a/test/functional/apps/discover/index.js
+++ b/test/functional/apps/discover/index.js
@@ -13,13 +13,13 @@ define(function (require) {
     var scenarioManager;
     var remote;
     var scenarioManager = new ScenarioManager(url.format(config.servers.elasticsearch));
+    this.timeout = 120000;
 
     // on setup, we create an settingsPage instance
     // that we will use for all the tests
     bdd.before(function () {
       common = new Common(this.remote);
       remote = this.remote;
-      this.timeout = 120000;
     });
 
     bdd.after(function unloadMakelogs() {

--- a/test/functional/apps/settings/index.js
+++ b/test/functional/apps/settings/index.js
@@ -16,6 +16,7 @@ define(function (require) {
     // on setup, we create an settingsPage instance
     // that we will use for all the tests
     bdd.before(function () {
+      this.timeout = 120000;
       return scenarioManager.reload('emptyKibana')
       .then(function () {
         return scenarioManager.loadIfEmpty('makelogs');

--- a/test/functional/apps/settings/index.js
+++ b/test/functional/apps/settings/index.js
@@ -12,11 +12,11 @@ define(function (require) {
 
   bdd.describe('settings app', function () {
     var scenarioManager = new ScenarioManager(url.format(config.servers.elasticsearch));
+    this.timeout = 120000;
 
     // on setup, we create an settingsPage instance
     // that we will use for all the tests
     bdd.before(function () {
-      this.timeout = 120000;
       return scenarioManager.reload('emptyKibana')
       .then(function () {
         return scenarioManager.loadIfEmpty('makelogs');

--- a/test/intern.js
+++ b/test/intern.js
@@ -3,7 +3,7 @@ define(function (require) {
   var _ = require('intern/dojo/node!lodash');
 
   return _.assign({
-    debug: false,
+    debug: true,
     capabilities: {
       'selenium-version': '2.47.1',
       'idle-timeout': 30

--- a/test/support/pages/Common.js
+++ b/test/support/pages/Common.js
@@ -32,8 +32,9 @@ define(function (require) {
               return self.checkForKibanaApp()
               .then(function (kibanaLoaded) {
                 if (!kibanaLoaded) {
-                  self.debug('Kibana is not loaded, retrying');
-                  throw new Error('Kibana is not loaded, retrying');
+                  var msg = 'Kibana is not loaded, retrying';
+                  self.debug(msg);
+                  throw new Error(msg);
                 }
               });
             }
@@ -44,12 +45,11 @@ define(function (require) {
           .then(function (currentUrl) {
             var navSuccessful = new RegExp(appUrl).test(currentUrl);
             if (!navSuccessful) {
-              self.debug('App failed to load: ' + appName +
+              var msg = 'App failed to load: ' + appName +
               ' in ' + defaultTimeout + 'ms' +
-              ' currentUrl = ' + currentUrl);
-              throw new Error('App failed to load: ' + appName +
-              ' in ' + defaultTimeout + 'ms' +
-              ' currentUrl = ' + currentUrl);
+              ' currentUrl = ' + currentUrl;
+              self.debug(msg);
+              throw new Error(msg);
             }
           });
         });

--- a/test/support/pages/Common.js
+++ b/test/support/pages/Common.js
@@ -31,7 +31,10 @@ define(function (require) {
             if (testStatusPage !== false) {
               return self.checkForKibanaApp()
               .then(function (kibanaLoaded) {
-                if (!kibanaLoaded) throw new Error('Kibana is not loaded, retrying');
+                if (!kibanaLoaded) {
+                  throw new Error(moment().format('HH:mm:ss.SSS') + ': ' +
+                  'Kibana is not loaded, retrying');
+                }
               });
             }
           })
@@ -40,7 +43,12 @@ define(function (require) {
           })
           .then(function (currentUrl) {
             var navSuccessful = new RegExp(appUrl).test(currentUrl);
-            if (!navSuccessful) throw new Error('App failed to load: ' + appName);
+            if (!navSuccessful) {
+              throw new Error(moment().format('HH:mm:ss.SSS') + ': ' +
+              'App failed to load: ' + appName +
+              ' in ' + defaultTimeout + 'ms' +
+              ' currentUrl = ' + currentUrl);
+            }
           });
         });
       };

--- a/test/support/pages/Common.js
+++ b/test/support/pages/Common.js
@@ -32,8 +32,8 @@ define(function (require) {
               return self.checkForKibanaApp()
               .then(function (kibanaLoaded) {
                 if (!kibanaLoaded) {
-                  throw new Error(moment().format('HH:mm:ss.SSS') + ': ' +
-                  'Kibana is not loaded, retrying');
+                  self.debug('Kibana is not loaded, retrying');
+                  throw new Error('Kibana is not loaded, retrying');
                 }
               });
             }
@@ -44,8 +44,10 @@ define(function (require) {
           .then(function (currentUrl) {
             var navSuccessful = new RegExp(appUrl).test(currentUrl);
             if (!navSuccessful) {
-              throw new Error(moment().format('HH:mm:ss.SSS') + ': ' +
-              'App failed to load: ' + appName +
+              self.debug('App failed to load: ' + appName +
+              ' in ' + defaultTimeout + 'ms' +
+              ' currentUrl = ' + currentUrl);
+              throw new Error('App failed to load: ' + appName +
               ' in ' + defaultTimeout + 'ms' +
               ' currentUrl = ' + currentUrl);
             }


### PR DESCRIPTION
Setting 'debug: true' in test/intern.js.
Move 'this.timeout' to from _discover.js (tests) to index.js bdd.before.  It appears this timeout setting (2 minutes now) applies to each test.
Added more debug logging in Common.js so that if we do have failures we can figure out why.

One of the specific failures we've seen in Jenkins is;
(http://build-eu-00.elastic.co/job/kibana_core_pr/1149/console)

SUITE ERROR
Error: timeout App failed to load: discover
