### PR TITLE
Increase ElasticSearch client timeout from 30s to 5m (probably a bit …

### DIFF
--- a/test/fixtures/scenarioManager.js
+++ b/test/fixtures/scenarioManager.js
@@ -7,7 +7,8 @@ function ScenarioManager(server) {
   if (!server) throw new Error('No server defined');
 
   this.client = new elasticsearch.Client({
-    host: server
+    host: server,
+    requestTimeout: 300000
   });
 }
 


### PR DESCRIPTION
…overkill).
