### PR TITLE
Use the latest version of esvm

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "karma-ie-launcher": "0.2.0",
     "karma-mocha": "0.2.0",
     "karma-safari-launcher": "0.1.1",
-    "libesvm": "1.0.7",
+    "libesvm": "3.2.0",
     "license-checker": "3.1.0",
     "load-grunt-config": "0.7.2",
     "marked-text-renderer": "0.1.0",


### PR DESCRIPTION
We need the latest version of esvm in order to do plugin configuration
via the esvm config.
