### PR TITLE
Kibana server should not use admin role in tests

### DIFF
--- a/test/serverConfig.js
+++ b/test/serverConfig.js
@@ -17,7 +17,7 @@ module.exports = {
       protocol: process.env.TEST_UI_ES_PROTOCOL || 'http',
       hostname: process.env.TEST_UI_ES_HOSTNAME || 'localhost',
       port: parseInt(process.env.TEST_UI_ES_PORT, 10) || 9220,
-      auth: 'admin:notsecure'
+      auth: 'kibana:notsecure'
     }
   },
   apps: {


### PR DESCRIPTION
The kibana server has a specific shield role, which during development
we generally assign to the user "kibana". We don't recommend using an
admin role in Kibana at all, so it doesn't make sense to use it during
tests.
