### PR TITLE
Fix build windows cygwin

### DIFF
--- a/tasks/build/archives.js
+++ b/tasks/build/archives.js
@@ -1,6 +1,6 @@
 module.exports = function createPackages(grunt) {
   let { config } = grunt;
-  let { resolve } = require('path');
+  let { resolve, relative } = require('path');
   let { execFile } = require('child_process');
   let { all, fromNode } = require('bluebird');
 
@@ -13,13 +13,13 @@ module.exports = function createPackages(grunt) {
 
   let archives = async (platform) => {
     // kibana.tar.gz
-    await exec('tar', ['-zchf', platform.tarPath, platform.buildName]);
+    await exec('tar', ['-zchf', relative(buildPath, platform.tarPath), platform.buildName]);
 
     // kibana.zip
     if (/windows/.test(platform.name)) {
-      await exec('zip', ['-rq', '-ll', platform.zipPath, platform.buildName]);
+      await exec('zip', ['-rq', '-ll', relative(buildPath, platform.zipPath), platform.buildName]);
     } else {
-      await exec('zip', ['-rq', platform.zipPath, platform.buildName]);
+      await exec('zip', ['-rq', relative(buildPath, platform.zipPath), platform.buildName]);
     }
   };
 

--- a/tasks/build/shasums.js
+++ b/tasks/build/shasums.js
@@ -1,6 +1,9 @@
 var { promisify } = require('bluebird');
 var readdir = promisify(require('fs').readdir);
 var exec = promisify(require('child_process').exec);
+var platform = require('os').platform();
+var cmd = /^win/.test(platform) ? 'sha1sum ' : 'shasum ';
+
 
 module.exports = function (grunt) {
   grunt.registerTask('_build:shasums', function () {
@@ -11,7 +14,7 @@ module.exports = function (grunt) {
       // only sha the archives
       if (!archive.match(/\.zip$|\.tar.gz$/)) return;
 
-      return exec('shasum ' + archive + ' > ' + archive + '.sha1.txt', {
+      return exec(cmd + archive + ' > ' + archive + '.sha1.txt', {
         cwd: targetDir
       });
     })

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -4,6 +4,7 @@ module.exports = function (grunt) {
   let {resolve} = require('path');
   let root = p => resolve(__dirname, '../../', p);
   let binScript =  /^win/.test(platform) ? '.\\bin\\kibana.bat' : './bin/kibana';
+  let buildedBinScript =  /^win/.test(platform) ? '.\\build\\kibana\\bin\\kibana.bat' : '.build/kibana/bin/kibana';
   let uiConfig = require(root('test/serverConfig'));
 
   const stdDevArgs = [
@@ -150,7 +151,7 @@ module.exports = function (grunt) {
         ready: /Optimization .+ complete/,
         quiet: true
       },
-      cmd: './build/kibana/bin/kibana',
+      cmd: buildedBinScript,
       args: [
         '--env.name=production',
         '--logging.json=false',

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -4,7 +4,7 @@ module.exports = function (grunt) {
   let {resolve} = require('path');
   let root = p => resolve(__dirname, '../../', p);
   let binScript =  /^win/.test(platform) ? '.\\bin\\kibana.bat' : './bin/kibana';
-  let buildedBinScript =  /^win/.test(platform) ? '.\\build\\kibana\\bin\\kibana.bat' : '.build/kibana/bin/kibana';
+  let buildedBinScript =  /^win/.test(platform) ? '.\\build\\kibana\\bin\\kibana.bat' : './build/kibana/bin/kibana';
   let uiConfig = require(root('test/serverConfig'));
 
   const stdDevArgs = [

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -4,7 +4,7 @@ module.exports = function (grunt) {
   let {resolve} = require('path');
   let root = p => resolve(__dirname, '../../', p);
   let binScript =  /^win/.test(platform) ? '.\\bin\\kibana.bat' : './bin/kibana';
-  let buildedBinScript =  /^win/.test(platform) ? '.\\build\\kibana\\bin\\kibana.bat' : './build/kibana/bin/kibana';
+  let buildScript =  /^win/.test(platform) ? '.\\build\\kibana\\bin\\kibana.bat' : './build/kibana/bin/kibana';
   let uiConfig = require(root('test/serverConfig'));
 
   const stdDevArgs = [
@@ -151,7 +151,7 @@ module.exports = function (grunt) {
         ready: /Optimization .+ complete/,
         quiet: true
       },
-      cmd: buildedBinScript,
+      cmd: buildScript,
       args: [
         '--env.name=production',
         '--logging.json=false',


### PR DESCRIPTION
Closes #6266 
- `tasks/config/run.js` -> The optimize step cmd now reflects the **right path for each system**.
- `tasks/config/archives.js` -> Using **tar from cygwin** requires to use **relative paths** or full paths with **unix format**. I prefer to use relative paths than converting the paths from windows to unix format.
- `tasks/build/shasums.js` -> Even if you have installed the command **shasum** in cygwin, executing from node returns an error. For windows the command is replaced by **sha1sum** that works perfectly.

This fixes the build of kibana only:
`npm run build`

and the [cygwin](https://www.cygwin.com/) should be installed and also all the packages used for the build. Usually the default ones plus **zip**, **tar** and **shasum**.

![win-build-evidence2](https://cloud.githubusercontent.com/assets/3710022/13092168/d1eccf8e-d4fe-11e5-9a6a-77a772d5883a.PNG)
