### PR TITLE
Adds abortable timeout counter to notifications

### DIFF
--- a/src/ui/public/config/defaults.js
+++ b/src/ui/public/config/defaults.js
@@ -213,6 +213,21 @@ export default function configDefaultsProvider() {
     'filters:pinnedByDefault': {
       value: false,
       description: 'Whether the filters should have a global state (be pinned) by default'
+    },
+    'notifications:lifetime:error': {
+      value: 300000,
+      description: 'The time in milliseconds which an error notification ' +
+      'will be displayed on-screen for. Setting to Infinity will disable.'
+    },
+    'notifications:lifetime:warning': {
+      value: 10000,
+      description: 'The time in milliseconds which a warning notification ' +
+        'will be displayed on-screen for. Setting to Infinity will disable.'
+    },
+    'notifications:lifetime:info': {
+      value: 5000,
+      description: 'The time in milliseconds which an information notification ' +
+        'will be displayed on-screen for. Setting to Infinity will disable.'
     }
   };
 };

--- a/src/ui/public/notify/notify.js
+++ b/src/ui/public/notify/notify.js
@@ -7,7 +7,6 @@ import 'ui/notify/directives';
 var module = modules.get('kibana/notify');
 var rootNotifier = new Notifier();
 
-
 module.factory('createNotifier', function () {
   return function (opts) {
     return new Notifier(opts);
@@ -18,9 +17,26 @@ module.factory('Notifier', function () {
   return Notifier;
 });
 
-module.run(function ($timeout) {
-  // provide alternate methods for setting timeouts, which will properly trigger digest cycles
-  Notifier.setTimerFns($timeout, $timeout.cancel);
+module.run(function ($interval, $rootScope, config) {
+  var configInitListener = $rootScope.$on('init:config', function () {
+    applyConfig();
+    configInitListener();
+  });
+
+  $rootScope.$on('change:config', applyConfig);
+
+  Notifier.applyConfig({
+    setInterval: $interval,
+    clearInterval: $interval.cancel
+  });
+
+  function applyConfig() {
+    Notifier.applyConfig({
+      errorLifetime: config.get('notifications:lifetime:error'),
+      warningLifetime: config.get('notifications:lifetime:warning'),
+      infoLifetime: config.get('notifications:lifetime:info')
+    });
+  }
 });
 
 /**
@@ -40,4 +56,3 @@ window.onerror = function (err, url, line) {
 };
 
 export default rootNotifier;
-

--- a/src/ui/public/notify/partials/toaster.html
+++ b/src/ui/public/notify/partials/toaster.html
@@ -11,10 +11,17 @@
         <div class="btn-group pull-right toast-controls">
           <button
             type="button"
+            ng-if="notif.isTimed()"
+            class="btn btn-sm"
+            ng-class="'btn-' + notif.type"
+            ng-click="notif.cancelTimer()"
+            >Auto-closing in {{notif.timeRemaining}}</button>
+          <button
+            type="button"
             ng-if="notif.stack && !notif.showStack"
             class="btn"
             ng-class="'btn-' + notif.type"
-            ng-click="notif.showStack = true"
+            ng-click="notif.cancelTimer(); notif.showStack = true"
             >More Info</button>
           <button
             type="button"


### PR DESCRIPTION
Adds abortable timeout counter to notifications

This prevents errors from stacking up for long running dashboards.
- Clicking "Auto-closing in X" dismisses timer
- Clicking "More Info" dismisses timer
- Timer is reset when a stack is added to the notification

![kibana-6364](https://cloud.githubusercontent.com/assets/40265/13619851/3bbc7094-e540-11e5-8a2a-dd5be4d0d7cf.gif)
