### PR TITLE
[filterbar] Only warn about non-filterable field when it's actually being filtered by

### DIFF
--- a/src/fixtures/logstash_fields.js
+++ b/src/fixtures/logstash_fields.js
@@ -16,7 +16,7 @@ function stubbedLogstashFields() {
     { name: 'extension',          type: 'string',     indexed: true,  analyzed: true, sortable:  true,  filterable: true },
     { name: 'machine.os',         type: 'string',     indexed: true,  analyzed: true, sortable:  true,  filterable: true },
     { name: 'geo.src',            type: 'string',     indexed: true,  analyzed: true, sortable:  true,  filterable: true },
-    { name: '_type',              type: 'string',     indexed: true,  analyzed: true, sortable:  true,  filterable: true },
+    { name: '_type',              type: 'string',     indexed: false,  analyzed: true, sortable:  true,  filterable: true },
     { name: '_id',                type: 'string',     indexed: false, analyzed: false, sortable: false, filterable: true},
     { name: '_source',            type: 'string',     indexed: false, analyzed: false, sortable: false, filterable: false},
     { name: 'custom_user_field',  type: 'conflict',   indexed: false, analyzed: false, sortable: false, filterable: true },

--- a/src/ui/public/filter_bar/__tests__/filter_bar_click_handler.js
+++ b/src/ui/public/filter_bar/__tests__/filter_bar_click_handler.js
@@ -1,0 +1,61 @@
+import ngMock from 'ng_mock';
+import expect from 'expect.js';
+
+import MockState from 'fixtures/mock_state';
+import notify from 'ui/notify';
+import AggConfigResult from 'ui/vis/agg_config_result';
+
+import VisProvider from 'ui/vis';
+import StubbedLogstashIndexPatternProvider from 'fixtures/stubbed_logstash_index_pattern';
+import FilterBarClickHandlerProvider from 'ui/filter_bar/filter_bar_click_handler';
+
+describe('filterBarClickHandler', function () {
+  let setup = null;
+
+  beforeEach(ngMock.module('kibana'));
+  beforeEach(ngMock.inject(function (Private) {
+    setup = function () {
+      const Vis = Private(VisProvider);
+      const createClickHandler = Private(FilterBarClickHandlerProvider);
+      const indexPattern = Private(StubbedLogstashIndexPatternProvider);
+
+      const vis = new Vis(indexPattern, {
+        type: 'histogram',
+        aggs: [
+          { type: 'count', schema: 'metric' },
+          {
+            type: 'terms',
+            schema: 'segment',
+            params: { field: '_type' }
+          }
+        ]
+      });
+      const aggConfigResult = new AggConfigResult(vis.aggs[1], void 0, 'apache', 'apache');
+
+      const $state = new MockState({ filters: [] });
+      const clickHandler = createClickHandler($state);
+
+      return { clickHandler, $state, aggConfigResult };
+    };
+  }));
+
+  afterEach(function () {
+    notify._notifs.splice(0);
+  });
+
+  context('on non-filterable fields', function () {
+    it('warns about trying to filter on a non-filterable field', function () {
+      const { clickHandler, aggConfigResult } = setup();
+      expect(notify._notifs).to.have.length(0);
+      clickHandler({ point: { aggConfigResult }});
+      expect(notify._notifs).to.have.length(1);
+    });
+
+    it('does not warn if the event is click is being simulated', function () {
+      const { clickHandler, aggConfigResult } = setup();
+      expect(notify._notifs).to.have.length(0);
+      clickHandler({ point: { aggConfigResult }}, true);
+      expect(notify._notifs).to.have.length(0);
+    });
+  });
+});

--- a/src/ui/public/filter_bar/filter_bar_click_handler.js
+++ b/src/ui/public/filter_bar/filter_bar_click_handler.js
@@ -39,7 +39,9 @@ export default function (Notifier) {
           try {
             return result.createFilter();
           } catch (e) {
-            notify.warning(e.message);
+            if (!simulate) {
+              notify.warning(e.message);
+            }
           }
         })
         .filter(Boolean)


### PR DESCRIPTION
Fixes #6573

The vis legend currently simulates clicking adding a filter to the filter bar in order to tell if the field is filterable. When the field is not filterable it would add a warning to the notifier, which wasn't helpful (because the user hadn't actually tried to filter by it) and because the check for if something is filterable was being done in a watcher, causing an infinite digest loop.

To prevent this the warning is only logged when the event is not being simulated.
