### PR TITLE
[backport] PR #6792 to 4.x

### DIFF
--- a/tasks/config/downloadSelenium.js
+++ b/tasks/config/downloadSelenium.js
@@ -5,9 +5,9 @@ module.exports = function (grunt) {
   return {
     options: {
       selenium: {
-        filename: 'selenium-server-standalone-2.48.2.jar',
-        server: 'https://selenium-release.storage.googleapis.com/2.48/',
-        md5: 'b2784fc67c149d3c13c83d2108104689',
+        filename: 'selenium-server-standalone-2.53.0.jar',
+        server: 'https://selenium-release.storage.googleapis.com/2.53/',
+        md5: '774efe2d84987fb679f2dea038c2fa32',
         directory: path.join(grunt.config.get('root'), 'selenium')
       }
     }

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -88,7 +88,7 @@ module.exports = function (grunt) {
       cmd: 'java',
       args: [
         '-jar',
-        'selenium/selenium-server-standalone-2.48.2.jar',
+        'selenium/selenium-server-standalone-2.53.0.jar',
         '-port',
         uiConfig.servers.webdriver.port
       ]
@@ -104,7 +104,7 @@ module.exports = function (grunt) {
       cmd: 'java',
       args: [
         '-jar',
-        'selenium/selenium-server-standalone-2.48.2.jar',
+        'selenium/selenium-server-standalone-2.53.0.jar',
         '-port',
         uiConfig.servers.webdriver.port
       ]

--- a/test/intern.js
+++ b/test/intern.js
@@ -5,7 +5,7 @@ define(function (require) {
   return _.assign({
     debug: true,
     capabilities: {
-      'selenium-version': '2.48.2',
+      'selenium-version': '2.53.0',
       'idle-timeout': 99
     },
     environments: [{


### PR DESCRIPTION
## Backport PR #6792

**Commit 1:**
Update selenium from 2.48.2 to 2.53.0 to work with latest Firefox 45.0.1
- Original sha: 81821fc99de800e01d2697c133639ee726fc525e
- Authored by LeeDr lee.drengenberg@elastic.co on 2016-04-05T20:46:06Z

**Commit 2:**
Update downloadSelenium to match version in intern.js.
- Original sha: 431fe52cecd8ec55c2945e7bbfac90f2fd6eb2c5
- Authored by LeeDr lee.drengenberg@elastic.co on 2016-04-06T12:36:06Z

**Commit 3:**
Add selenium-server-standalone jar md5.
- Original sha: 4002140a9cfec2fdd8645523868d3f5ca310b01c
- Authored by LeeDr lee.drengenberg@elastic.co on 2016-04-06T13:46:17Z
