### PR TITLE
[field formatters] IP should return - on null or undefined

### DIFF
--- a/src/ui/public/stringify/__tests__/_ip.js
+++ b/src/ui/public/stringify/__tests__/_ip.js
@@ -2,16 +2,20 @@ import expect from 'expect.js';
 import ngMock from 'ng_mock';
 import RegistryFieldFormatsProvider from 'ui/registry/field_formats';
 describe('IP Address Format', function () {
-  let fieldFormats;
-
+  let ip;
   beforeEach(ngMock.module('kibana'));
   beforeEach(ngMock.inject(function (Private) {
-    fieldFormats = Private(RegistryFieldFormatsProvider);
+    const fieldFormats = Private(RegistryFieldFormatsProvider);
+    ip = fieldFormats.getInstance('ip');
   }));
 
   it('converts a value from a decimal to a string', function () {
-    let ip = fieldFormats.getInstance('ip');
     expect(ip.convert(1186489492)).to.be('70.184.100.148');
+  });
+
+  it('converts null and undefined to -',  function () {
+    expect(ip.convert(null)).to.be('-');
+    expect(ip.convert(undefined)).to.be('-');
   });
 
 });

--- a/src/ui/public/stringify/types/ip.js
+++ b/src/ui/public/stringify/types/ip.js
@@ -13,6 +13,7 @@ export default function IpFormatProvider(Private) {
   Ip.fieldType = 'ip';
 
   Ip.prototype._convert = function (val) {
+    if (val === undefined || val === null) return '-';
     if (!isFinite(val)) return val;
 
     // shazzam!


### PR DESCRIPTION
Null ip addresses were turning into 0.0.0.0 after running through the ip formatter.  This changes null/undefined to render as -.

```
POST /foo/bar
PUT /foo/bar/_mapping
{
  "properties": {
    "test": {
      "type": "ip"
    }
  }
}
POST /foo/bar/1
{
  "test": "192.168.1.1"
}
POST /foo/bar/2
{
  "test": null
}
```

Closes #7182 
