### PR TITLE
One new discover test for issue #5937 use back button.

### DIFF
--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -152,7 +152,7 @@ import {
           ];
           return discoverPage.setChartInterval(chartInterval)
           .then(function () {
-            return common.sleep(8000);
+            return common.sleep(4000);
           })
           .then(function () {
             return verifyChartData(expectedBarChartData);
@@ -167,7 +167,7 @@ import {
           ];
           return discoverPage.setChartInterval(chartInterval)
           .then(function () {
-            return common.sleep(8000);
+            return common.sleep(4000);
           })
           .then(function () {
             return verifyChartData(expectedBarChartData);
@@ -181,6 +181,26 @@ import {
           return discoverPage.setChartInterval(chartInterval)
           .then(function () {
             return common.sleep(2000);
+          })
+          .then(function () {
+            return verifyChartData(expectedBarChartData);
+          })
+          .catch(common.handleError(this));
+        });
+
+        bdd.it('browser back button should show previous interval Daily', function () {
+          var expectedChartInterval = 'Daily';
+          var expectedBarChartData = [
+            '133.196', '129.192', '129.724'
+          ];
+          return this.remote.goBack()
+          .then(function () {
+            return common.try(function tryingForTime() {
+              return discoverPage.getChartInterval()
+              .then(function (actualInterval) {
+                expect(actualInterval).to.be(expectedChartInterval);
+              });
+            });
           })
           .then(function () {
             return verifyChartData(expectedBarChartData);

--- a/test/support/pages/discover_page.js
+++ b/test/support/pages/discover_page.js
@@ -100,7 +100,21 @@ export default (function () {
     getChartInterval: function getChartInterval() {
       return thisTime
       .findByCssSelector('a[ng-click="toggleInterval()"]')
-      .getVisibleText();
+      .getVisibleText()
+      .then(function (intervalText) {
+        if (intervalText.length > 0) {
+          return intervalText;
+        } else {
+          return thisTime
+          .findByCssSelector('select[ng-model="state.interval"]')
+          .getProperty('value') // this gets 'string:d' for Daily
+          .then(function (selectedValue) {
+            return thisTime
+            .findByCssSelector('option[value="' + selectedValue + '"]')
+            .getVisibleText();
+          });
+        }
+      });
     },
 
     setChartInterval: function setChartInterval(interval) {


### PR DESCRIPTION
Addresses one additional test case from https://github.com/elastic/kibana/issues/5937 
- [ ] Use browser 'Back' button to undo the interval change above.

This test required changes to discover_page.getChartInterval() so that it works both when the interval is a link and when it's a selection list.

I also cut sleep time from 8 to 4 seconds in 2 other tests.
