### PR TITLE
fix #7332 - saving vis with % in name causes error

### DIFF
--- a/src/core_plugins/kibana/public/visualize/saved_visualizations/saved_visualizations.js
+++ b/src/core_plugins/kibana/public/visualize/saved_visualizations/saved_visualizations.js
@@ -84,7 +84,7 @@ app.service('savedVisualizations', function (Promise, es, kbnIndex, SavedVis, Pr
       body = {
         query: {
           simple_query_string: {
-            query: searchString + '*',
+            query: searchString + (['/', '!', '?', '&', '=', '%'].indexOf(searchString[searchString.length - 1]) === -1 ? '' : ' ') + '*',
             fields: ['title^3', 'description'],
             default_operator: 'AND'
           }

--- a/src/core_plugins/kibana/public/visualize/saved_visualizations/saved_visualizations.js
+++ b/src/core_plugins/kibana/public/visualize/saved_visualizations/saved_visualizations.js
@@ -84,9 +84,10 @@ app.service('savedVisualizations', function (Promise, es, kbnIndex, SavedVis, Pr
       body = {
         query: {
           simple_query_string: {
-            query: searchString + (['/', '!', '?', '&', '=', '%'].indexOf(searchString[searchString.length - 1]) === -1 ? '' : ' ') + '*',
+            query: searchString + '*',
             fields: ['title^3', 'description'],
-            default_operator: 'AND'
+            default_operator: 'AND',
+            analyze_wildcard: true
           }
         }
       };

--- a/src/ui/public/utils/__tests__/slugify_id.js
+++ b/src/ui/public/utils/__tests__/slugify_id.js
@@ -9,18 +9,22 @@ describe('slugifyId()', function () {
     ['test?test', 'test-questionmark-test'],
     ['test=test', 'test-equal-test'],
     ['test&test', 'test-ampersand-test'],
+    ['test%test', 'test-percent-test'],
     ['test / test', 'test-slash-test'],
     ['test ? test', 'test-questionmark-test'],
     ['test = test', 'test-equal-test'],
     ['test & test', 'test-ampersand-test'],
+    ['test % test', 'test-percent-test'],
     ['test / ^test', 'test-slash-^test'],
     ['test ?  test', 'test-questionmark-test'],
     ['test =  test', 'test-equal-test'],
     ['test &  test', 'test-ampersand-test'],
+    ['test %  test', 'test-percent-test'],
     ['test/test/test', 'test-slash-test-slash-test'],
     ['test?test?test', 'test-questionmark-test-questionmark-test'],
     ['test&test&test', 'test-ampersand-test-ampersand-test'],
-    ['test=test=test', 'test-equal-test-equal-test']
+    ['test=test=test', 'test-equal-test-equal-test'],
+    ['test%test%test', 'test-percent-test-percent-test']
   ];
 
   _.each(fixtures, function (fixture) {

--- a/src/ui/public/utils/slugify_id.js
+++ b/src/ui/public/utils/slugify_id.js
@@ -6,7 +6,8 @@ export default function (id) {
     '/' : '-slash-',
     '\\?' : '-questionmark-',
     '\\&' : '-ampersand-',
-    '=' : '-equal-'
+    '=' : '-equal-',
+    '%' : '-percent-'
   };
   _.each(trans, function (val, key) {
     let regex = new RegExp(key, 'g');

--- a/test/functional/apps/visualize/_area_chart.js
+++ b/test/functional/apps/visualize/_area_chart.js
@@ -60,7 +60,7 @@ bdd.describe('visualize app', function describeIndexTests() {
   });
 
   bdd.describe('area charts', function indexPatternCreation() {
-    var vizName1 = 'Visualization AreaChart';
+    var vizName1 = 'Visualization % AreaChart';
 
     bdd.it('should save and load', function pageHeader() {
       return PageObjects.visualize.saveVisualization(vizName1)

--- a/test/functional/apps/visualize/_area_chart.js
+++ b/test/functional/apps/visualize/_area_chart.js
@@ -68,6 +68,9 @@ bdd.describe('visualize app', function describeIndexTests() {
       .then(function (message) {
         PageObjects.common.debug(`Saved viz message = ${message}`);
         expect(message).to.be(`Visualization Editor: Saved Visualization "${vizNamewithSpecialChars}"`);
+      })
+      .then(function testVisualizeWaitForToastMessageGone() {
+        return PageObjects.visualize.waitForToastMessageGone();
       });
     });
 

--- a/test/functional/apps/visualize/_area_chart.js
+++ b/test/functional/apps/visualize/_area_chart.js
@@ -63,28 +63,13 @@ bdd.describe('visualize app', function describeIndexTests() {
     var vizName1 = 'Visualization AreaChart';
 
     bdd.it('should save and load with special characters', function pageHeader() {
-      let vizName2 = vizName1 + '/?&=%';
-      return PageObjects.visualize.saveVisualization(vizName2)
-        .then(function (message) {
-          PageObjects.common.debug('Saved viz message = ' + message);
-          PageObjects.common.saveScreenshot('Visualize-area-chart-save-toast');
-          expect(message).to.be('Visualization Editor: Saved Visualization \"' + vizName2 + '\"');
-        })
-        .then(function testVisualizeWaitForToastMessageGone() {
-          return PageObjects.visualize.waitForToastMessageGone();
-        })
-        .then(function loadSavedVisualization() {
-          return PageObjects.visualize.loadSavedVisualization(vizName2);
-        })
-        .then(function () {
-          return PageObjects.visualize.waitForVisualization();
-        })
-        // We have to sleep sometime between loading the saved visTitle
-        // and trying to access the chart below with getXAxisLabels
-        // otherwise it hangs.
-        .then(function sleep() {
-          return PageObjects.common.sleep(2000);
-        });
+      const vizNamewithSpecialChars = vizName1 + '/?&=%';
+      return PageObjects.visualize.saveVisualization(vizNamewithSpecialChars)
+      .then(function (message) {
+        PageObjects.common.debug(`Saved viz message = ${message}`);
+        PageObjects.common.saveScreenshot('Visualize-area-chart-save-toast');
+        expect(message).to.be(`Visualization Editor: Saved Visualization "${vizNamewithSpecialChars}"`);
+      });
     });
 
     bdd.it('should save and load', function pageHeader() {

--- a/test/functional/apps/visualize/_area_chart.js
+++ b/test/functional/apps/visualize/_area_chart.js
@@ -60,7 +60,32 @@ bdd.describe('visualize app', function describeIndexTests() {
   });
 
   bdd.describe('area charts', function indexPatternCreation() {
-    var vizName1 = 'Visualization % AreaChart';
+    var vizName1 = 'Visualization AreaChart';
+
+    bdd.it('should save and load with special characters', function pageHeader() {
+      let vizName2 = vizName1 + '/?&=%';
+      return PageObjects.visualize.saveVisualization(vizName2)
+        .then(function (message) {
+          PageObjects.common.debug('Saved viz message = ' + message);
+          PageObjects.common.saveScreenshot('Visualize-area-chart-save-toast');
+          expect(message).to.be('Visualization Editor: Saved Visualization \"' + vizName2 + '\"');
+        })
+        .then(function testVisualizeWaitForToastMessageGone() {
+          return PageObjects.visualize.waitForToastMessageGone();
+        })
+        .then(function loadSavedVisualization() {
+          return PageObjects.visualize.loadSavedVisualization(vizName2);
+        })
+        .then(function () {
+          return PageObjects.visualize.waitForVisualization();
+        })
+        // We have to sleep sometime between loading the saved visTitle
+        // and trying to access the chart below with getXAxisLabels
+        // otherwise it hangs.
+        .then(function sleep() {
+          return PageObjects.common.sleep(2000);
+        });
+    });
 
     bdd.it('should save and load', function pageHeader() {
       return PageObjects.visualize.saveVisualization(vizName1)

--- a/test/functional/apps/visualize/_area_chart.js
+++ b/test/functional/apps/visualize/_area_chart.js
@@ -67,7 +67,6 @@ bdd.describe('visualize app', function describeIndexTests() {
       return PageObjects.visualize.saveVisualization(vizNamewithSpecialChars)
       .then(function (message) {
         PageObjects.common.debug(`Saved viz message = ${message}`);
-        PageObjects.common.saveScreenshot('Visualize-area-chart-save-toast');
         expect(message).to.be(`Visualization Editor: Saved Visualization "${vizNamewithSpecialChars}"`);
       });
     });


### PR DESCRIPTION
Fixes #7332 
- slugify_id.js utility was updated to replace % sign with -percentage-
- tests for slugify_id utility were updated

I was looking for UI test of saving visualization but couldn't locate it .. can you please help me locate it ?
