### PR TITLE
Filter integration tests from npm command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Run the tests for just your particular plugin. Assuming you plugin lives outside
 The following will start Kibana, Elasticsearch and the chromedriver for you. To run the functional UI tests use the following commands
 
 `npm run test:ui`
-Run the functional UI tests one time and exit. This is used by the CI systems and is great for quickly checking that things pass. It is essentially a combination of the next two tasks.
+Run the functional UI tests one time and exit. This is used by the CI systems and is great for quickly checking that things pass. It is essentially a combination of the next two tasks.  This supports options `--grep=foo` for only running tests that match a regular expression, and `--apps=management` for running tests for a specific application.
 
 `npm run test:ui:server`
 Start the server required for the `test:ui:runner` tasks. Once the server is started `test:ui:runner` can be run multiple times without waiting for the server to start.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Run the tests for just your particular plugin. Assuming you plugin lives outside
 The following will start Kibana, Elasticsearch and the chromedriver for you. To run the functional UI tests use the following commands
 
 `npm run test:ui`
-Run the functional UI tests one time and exit. This is used by the CI systems and is great for quickly checking that things pass. It is essentially a combination of the next two tasks.  This supports options `--grep=foo` for only running tests that match a regular expression, and `--apps=management` for running tests for a specific application.
+Run the functional UI tests one time and exit. This is used by the CI systems and is great for quickly checking that things pass. It is essentially a combination of the next two tasks.  This supports options `--grep=foo` for only running tests that match a regular expression, and `--appSuites=management` for running tests for a specific application.
 
 `npm run test:ui:server`
 Start the server required for the `test:ui:runner` tasks. Once the server is started `test:ui:runner` can be run multiple times without waiting for the server to start.

--- a/tasks/config/intern.js
+++ b/tasks/config/intern.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
       reporters: ['Console'],
       grep: grunt.option('grep'),
       functionalSuites: grunt.option('functionalSuites'),
-      apps: grunt.option('apps')
+      appSuites: grunt.option('appSuites')
     },
     dev: {},
     api: {

--- a/tasks/config/intern.js
+++ b/tasks/config/intern.js
@@ -7,7 +7,8 @@ module.exports = function (grunt) {
       runType: 'runner',
       config: 'test/intern',
       bail: true,
-      reporters: ['Console']
+      reporters: ['Console'],
+      grep: grunt.option('grep')
     },
     dev: {},
     api: {

--- a/tasks/config/intern.js
+++ b/tasks/config/intern.js
@@ -8,7 +8,8 @@ module.exports = function (grunt) {
       config: 'test/intern',
       bail: true,
       reporters: ['Console'],
-      grep: grunt.option('grep')
+      grep: grunt.option('grep') || '.*',
+      apps: grunt.option('apps')
     },
     dev: {},
     api: {

--- a/tasks/config/intern.js
+++ b/tasks/config/intern.js
@@ -8,7 +8,8 @@ module.exports = function (grunt) {
       config: 'test/intern',
       bail: true,
       reporters: ['Console'],
-      grep: grunt.option('grep') || '.*',
+      grep: grunt.option('grep'),
+      functionalSuites: grunt.option('functionalSuites'),
       apps: grunt.option('apps')
     },
     dev: {},

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -25,7 +25,7 @@ define(function (require) {
       const option = arg.split('=');
       const key = option[0];
       const value = option[1];
-      if (key === 'apps' && value) return value.split(',');
+      if (key === 'appSuites' && value) return value.split(',');
     });
 
     const apps = [

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -16,17 +16,33 @@ define(function (require) {
       PageObjects.init(this.remote);
       support.init(this.remote);
     });
-
-    require([
+    const supportPages = [
       'intern/dojo/node!../support/page_objects',
-      'intern/dojo/node!../support',
+      'intern/dojo/node!../support'
+    ];
+
+    const requestedApps = process.argv.reduce((previous, arg) => {
+      const option = arg.split('=');
+      const key = option[0];
+      const value = option[1];
+      if (key === 'apps' && value) return value.split(',');
+    });
+
+    const apps = [
       'intern/dojo/node!./apps/discover',
-      'intern/dojo/node!./status_page',
       'intern/dojo/node!./apps/management',
       'intern/dojo/node!./apps/visualize',
       'intern/dojo/node!./apps/console',
-      'intern/dojo/node!./apps/dashboard'
-    ], (loadedPageObjects, loadedSupport) => {
+      'intern/dojo/node!./apps/dashboard',
+      'intern/dojo/node!./status_page'
+    ].filter((suite) => {
+      if (!requestedApps) return true;
+      return requestedApps.reduce((previous, app) => {
+        return previous || ~suite.indexOf(app);
+      }, false);
+    });
+
+    require(supportPages.concat(apps), (loadedPageObjects, loadedSupport) => {
       PageObjects = loadedPageObjects;
       support = loadedSupport;
     });


### PR DESCRIPTION
This lets you `npm run test:ui -- --grep=foo` instead of running the intern bin directly.  I didn't add functionalSuites because it needs the main index file for babel transpilation now.

edit:  added functionalSuites for api tests, and an 'apps' filter too.

Using grep alone will not prevent the before block of every test from running, so it can be useful to filter by suite.   Currently, filtering tests by suite doesn't work because tests are all loaded together, ran through babel, and then passed in as one suite.  This allows us to filter test runs by application.

Usage:

```
npm run test:ui -- --appSuites=management,status
```

and with grep:

```
npm run test:ui -- --appSuites=management --grep=initial\ state
...snip
>> 0/23 tests failed (18 skipped)
```

An alternative is to split tests back out into individual suites and run each suite through babel, but that adds some boilerplate to each test.
