### PR TITLE
upgrade chromedriver 2.21.2 -> 2.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "auto-release-sinon": "1.0.3",
     "babel-eslint": "4.1.8",
     "chokidar": "1.4.3",
-    "chromedriver": "2.21.2",
+    "chromedriver": "2.18.0",
     "elasticdump": "2.1.1",
     "eslint": "1.10.3",
     "eslint-plugin-mocha": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "auto-release-sinon": "1.0.3",
     "babel-eslint": "4.1.8",
     "chokidar": "1.4.3",
-    "chromedriver": "2.18.0",
+    "chromedriver": "2.22.1",
     "elasticdump": "2.1.1",
     "eslint": "1.10.3",
     "eslint-plugin-mocha": "1.1.0",


### PR DESCRIPTION
tests involving alert or confirm boxes were failing for me with "unexpected alert box" error message.

it also happened at CI ... but cant find that log now.
