### PR TITLE
[vis] Cap max precision at tilemap:maxPrecision

### DIFF
--- a/src/ui/public/agg_types/buckets/geo_hash.js
+++ b/src/ui/public/agg_types/buckets/geo_hash.js
@@ -77,7 +77,7 @@ export default function GeoHashAggDefinition(Private, config) {
           const vis = aggConfig.vis;
           const currZoom = vis.hasUiState() && vis.uiStateVal('mapZoom');
           const autoPrecisionVal = zoomPrecision[(currZoom || vis.params.mapZoom)];
-          output.params.precision = aggConfig.params.autoPrecision ? autoPrecisionVal : getPrecision(aggConfig.params.precision);
+          output.params.precision = getPrecision(aggConfig.params.autoPrecision ? autoPrecisionVal : aggConfig.params.precision);
         }
       }
     ]


### PR DESCRIPTION
This fix makes sure max precision is capped by the global visualization:tileMap:maxPrecision.  I believe this was inadvertently removed in https://github.com/elastic/kibana/commit/ad62b600a22527afcc8186f4e4f22050e29c6c20.  
