### PR TITLE
[tests/functional] auto-rebuild assets in test:ui:server task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 trash
 /optimize/bundles
 /optimize/testdev
+/optimize/testUiServer
 target
 /build
 .jruby

--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -77,6 +77,28 @@ module.exports = function (grunt) {
       ]
     },
 
+    testUIDevServer: {
+      options: {
+        wait: false,
+        ready: /Server running/,
+        quiet: false,
+        failOnError: false
+      },
+      cmd: binScript,
+      args: [
+        ...stdDevArgs,
+        '--server.port=' + uiConfig.servers.kibana.port,
+        '--elasticsearch.url=' + format(uiConfig.servers.elasticsearch),
+        '--dev',
+        '--no-base-path',
+        '--no-ssl',
+        '--optimize.lazyPort=5611',
+        '--optimize.lazyPrebuild=true',
+        '--optimize.bundleDir=optimize/testUiServer',
+        ...kbnServerFlags,
+      ]
+    },
+
     testCoverageServer: {
       options: {
         wait: false,

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test:ui:server', [
     'esvm:ui',
-    'run:testUIServer',
+    'run:testUIDevServer',
     'run:devChromeDriver:keepalive'
   ]);
 


### PR DESCRIPTION
While working on some functional tests I had to re-run the `test:ui:server` task several times to rebuild the front-end assets. I'm not sure why that should be necessary, so this updates the server used in that specific task to auto-rebuild the assets.
