### PR TITLE
[backport] PR #8349 to 5.0 - Always set output.params.min_doc_count on Histograms

### DIFF
--- a/src/ui/public/agg_types/__tests__/buckets/_histogram.js
+++ b/src/ui/public/agg_types/__tests__/buckets/_histogram.js
@@ -67,15 +67,15 @@ describe('Histogram Agg', function () {
         expect(output.params).to.have.property('min_doc_count', 0);
       });
 
-      it('writes nothing for false values', function () {
+      it('writes 1 for falsey values', function () {
         let output = paramWriter.write({ min_doc_count: '' });
-        expect(output.params).to.not.have.property('min_doc_count');
+        expect(output.params).to.have.property('min_doc_count', 1);
 
         output = paramWriter.write({ min_doc_count: null });
-        expect(output.params).to.not.have.property('min_doc_count');
+        expect(output.params).to.have.property('min_doc_count', 1);
 
         output = paramWriter.write({ min_doc_count: undefined });
-        expect(output.params).to.not.have.property('min_doc_count');
+        expect(output.params).to.have.property('min_doc_count', 1);
       });
     });
 

--- a/src/ui/public/agg_types/buckets/histogram.js
+++ b/src/ui/public/agg_types/buckets/histogram.js
@@ -40,6 +40,8 @@ export default function HistogramAggDefinition(Private) {
         write: function (aggConfig, output) {
           if (aggConfig.params.min_doc_count) {
             output.params.min_doc_count = 0;
+          } else {
+            output.params.min_doc_count = 1;
           }
         }
       },


### PR DESCRIPTION
## Backport PR #8349

**Commit 1:**
Always set output.params.min_doc_count instead of leaving Elasticsearch default (which changed).  Ref: 5665
- Original sha: 5eb43cf70b526d67ad8946ff67d9d6ecaa05ccf9
- Authored by LeeDr lee.drengenberg@elastic.co on 2016-09-19T20:47:34Z

**Commit 2:**
Fix tests for min_doc_count change
- Original sha: fe60886cddc9f7ace996edff7047ffc4389ce67f
- Authored by LeeDr lee.drengenberg@elastic.co on 2016-09-19T23:07:46Z
