### PR TITLE
Implement functional test helpers

### DIFF
--- a/test/support/page_objects/common.js
+++ b/test/support/page_objects/common.js
@@ -1,6 +1,7 @@
 
 import bluebird, {
-  promisify
+  promisify,
+  filter as filterAsync
 } from 'bluebird';
 import fs from 'fs';
 import _ from 'lodash';
@@ -307,6 +308,13 @@ export default class Common {
     return this.remote
       .setFindTimeout(defaultFindTimeout)
       .findDisplayedByCssSelector(testSubjSelector(selector));
+  }
+
+  async findAllTestSubjects(selector) {
+    this.debug('in findAllTestSubjects: ' + testSubjSelector(selector));
+    const remote = this.remote.setFindTimeout(defaultFindTimeout);
+    const all = await remote.findAllByCssSelector(testSubjSelector(selector));
+    return await filterAsync(all, el => el.isDisplayed());
   }
 
 }

--- a/test/support/page_objects/common.js
+++ b/test/support/page_objects/common.js
@@ -254,6 +254,10 @@ export default class Common {
     return Try.try(block);
   }
 
+  tryMethod(object, method, ...args) {
+    return this.try(() => object[method](...args));
+  }
+
   log(...args) {
     Log.log(...args);
   }


### PR DESCRIPTION
Just adding a couple helper functions to the common page object.

**`common.tryMethod()`** accepts an object, a method name, and optional arguments that it will call within a `try`. This helps call pageObject methods in a `try()` in a single line.

example:

``` js
const fieldCount = await PageObjects.common.tryMethod(PageObjects.settings, 'getPageFieldCount')
```

**`common.findAllTestSubjects()`** is the same as `common.findTestSubject()`, except that if finds all of the instances on a page, not just the first.
