### PR TITLE
Flag scripted fields as searchable and aggregatable

### DIFF
--- a/src/ui/public/index_patterns/_field.js
+++ b/src/ui/public/index_patterns/_field.js
@@ -58,8 +58,8 @@ export default function FieldObjectProvider(Private, shortDotsFilter, $rootScope
     obj.fact('doc_values', !!spec.doc_values);
 
     // stats
-    obj.fact('searchable', !!spec.searchable);
-    obj.fact('aggregatable', !!spec.aggregatable);
+    obj.fact('searchable', !!spec.searchable || scripted);
+    obj.fact('aggregatable', !!spec.aggregatable || scripted);
 
     // usage flags, read-only and won't be saved
     obj.comp('format', format);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/8585

Scripted fields were being filtered out of the available field list in the viz editor because of the new reliance on the searchable and aggregatable flags https://github.com/elastic/kibana/pull/8421

This PR ensures that all scripted fields get flagged as searchable and aggregatable.
