### PR TITLE
Improve discovery test stability and readability

### DIFF
--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -237,39 +237,15 @@ bdd.describe('discover app', function describeIndexTests() {
       expect(isVisible).to.be(true);
     });
 
-    bdd.it('should open and close the time picker', () => {
-      let i = 0;
+    bdd.it('should have a link that opens and closes the time picker', async function() {
+      var noResultsTimepickerLink = await PageObjects.discover.getNoResultsTimepicker();
+      expect(await PageObjects.header.isTimepickerOpen()).to.be(false);
 
-      return closeTimepicker() // close
-        .then(() => isTimepickerOpen(false)
-          .then(el => el.click()) // open
-          .then(() => isTimepickerOpen(true))
-          .then(el => el.click()) // close
-          .then(() => isTimepickerOpen(false))
-          .catch(PageObjects.common.createErrorHandler(this))
-        );
+      await noResultsTimepickerLink.click();
+      expect(await PageObjects.header.isTimepickerOpen()).to.be(true);
 
-      function closeTimepicker() {
-        return PageObjects.header.isTimepickerOpen().then(shown => {
-          if (!shown) {
-            return;
-          }
-          return PageObjects.discover
-            .getNoResultsTimepicker()
-            .click(); // close
-        });
-      }
-
-      function isTimepickerOpen(expected) {
-        return PageObjects.header.isTimepickerOpen().then(shown => {
-          PageObjects.common.debug(`expect (#${++i}) timepicker to be ${peek(expected)} (is ${peek(shown)}).`);
-          expect(shown).to.be(expected);
-          return PageObjects.discover.getNoResultsTimepicker();
-          function peek(state) {
-            return state ? 'open' : 'closed';
-          }
-        });
-      }
+      await noResultsTimepickerLink.click();
+      expect(await PageObjects.header.isTimepickerOpen()).to.be(false);
     });
   });
 });

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -36,7 +36,8 @@ bdd.describe('discover app', function describeIndexTests() {
     bdd.it('should show correct time range string by timepicker', async function () {
       var actualTimeString = await PageObjects.discover.getTimespanText();
 
-      expect(actualTimeString).to.be(`${fromTimeString} to ${toTimeString}`);
+      var expectedTimeString = `${fromTimeString} to ${toTimeString}`;
+      expect(actualTimeString).to.be(expectedTimeString);
     });
 
     bdd.it('save query should show toast message and display query name', async function () {
@@ -44,7 +45,8 @@ bdd.describe('discover app', function describeIndexTests() {
       var toastMessage = await PageObjects.header.getToastMessage();
       await PageObjects.common.saveScreenshot('Discover-save-query-toast');
 
-      expect(toastMessage).to.be(`Discover: Saved Data Source "${queryName1}"`);
+      var expectedToastMessage = `Discover: Saved Data Source "${queryName1}"`;
+      expect(toastMessage).to.be(expectedToastMessage);
 
       await PageObjects.header.waitForToastMessageGone();
       var actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
@@ -62,8 +64,9 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show the correct hit count', async function () {
+      var expectedHitCount = '14,004';
       await PageObjects.common.try(async function() {
-        expect(await PageObjects.discover.getHitCount()).to.be('14,004');
+        expect(await PageObjects.discover.getHitCount()).to.be(expectedHitCount);
       });
     });
 
@@ -80,13 +83,15 @@ bdd.describe('discover app', function describeIndexTests() {
     bdd.it('should show correct time range string in chart', async function () {
       var actualTimeString = await PageObjects.discover.getChartTimespan();
 
-      expect(actualTimeString).to.be(`${fromTimeString} - ${toTimeString}`);
+      var expectedTimeString = `${fromTimeString} - ${toTimeString}`;
+      expect(actualTimeString).to.be(expectedTimeString);
     });
 
     bdd.it('should show correct initial chart interval of 3 hours', async function () {
       var actualInterval = await PageObjects.discover.getChartInterval();
 
-      expect(actualInterval).to.be('by 3 hours');
+      var expectedInterval = 'by 3 hours';
+      expect(actualInterval).to.be(expectedInterval);
     });
 
     bdd.it('should show correct data for chart interval Hourly', async function () {

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -54,22 +54,20 @@ bdd.describe('discover app', function describeIndexTests() {
 
     bdd.it('load query should show query name', async function () {
       await PageObjects.discover.loadSavedSearch(queryName1);
-      await PageObjects.common.sleep(3000);
 
-      var actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
       await PageObjects.common.saveScreenshot('Discover-load-query');
-      expect(actualQueryNameString).to.be(queryName1);
+      await PageObjects.common.try(async function() {
+        expect(await PageObjects.discover.getCurrentQueryName()).to.be(queryName1);
+      });
     });
 
     bdd.it('should show the correct hit count', async function () {
-      var hitCount = await PageObjects.discover.getHitCount();
-
-      expect(hitCount).to.be('14,004');
+      await PageObjects.common.try(async function() {
+        expect(await PageObjects.discover.getHitCount()).to.be('14,004');
+      });
     });
 
     bdd.it('should show the correct bar chart', async function () {
-      await PageObjects.common.sleep(4000);
-
       var expectedBarChartData = [ '3.237',
         '17.674', '64.75', '125.737', '119.962', '65.712', '16.449',
         '2.712', '3.675', '17.674', '59.762', '119.087', '123.812',
@@ -93,7 +91,6 @@ bdd.describe('discover app', function describeIndexTests() {
 
     bdd.it('should show correct data for chart interval Hourly', async function () {
       await PageObjects.discover.setChartInterval('Hourly');
-      await PageObjects.common.sleep(4000);
 
       var expectedBarChartData = [ '1.527', '2.290',
         '5.599', '7.890', '13.236', '30.290', '46.072', '55.490', '86.8',
@@ -151,7 +148,6 @@ bdd.describe('discover app', function describeIndexTests() {
       var expectedBarChartData = [ '122.535'];
 
       await PageObjects.discover.setChartInterval(chartInterval);
-      await PageObjects.common.sleep(2000);
       await verifyChartData(expectedBarChartData);
     });
 
@@ -160,7 +156,6 @@ bdd.describe('discover app', function describeIndexTests() {
       var expectedBarChartData = [ '122.535'];
 
       await PageObjects.discover.setChartInterval(chartInterval);
-      await PageObjects.common.sleep(2000);
       await verifyChartData(expectedBarChartData);
     });
 
@@ -174,7 +169,6 @@ bdd.describe('discover app', function describeIndexTests() {
       ];
 
       await PageObjects.discover.setChartInterval(chartInterval);
-      await PageObjects.common.sleep(4000);
       await verifyChartData(expectedBarChartData);
     });
 

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -11,120 +11,90 @@ import {
 import PageObjects from '../../../support/page_objects';
 
 bdd.describe('discover app', function describeIndexTests() {
-  bdd.before(function () {
-    var fromTime = '2015-09-19 06:31:44.000';
-    var toTime = '2015-09-23 18:31:44.000';
+  var fromTime = '2015-09-19 06:31:44.000';
+  var fromTimeString = 'September 19th 2015, 06:31:44.000';
+  var toTime = '2015-09-23 18:31:44.000';
+  var toTimeString = 'September 23rd 2015, 18:31:44.000';
 
+  bdd.before(async function () {
     // delete .kibana index and update configDoc
-    return esClient.deleteAndUpdateConfigDoc({'dateFormat:tz':'UTC', 'defaultIndex':'logstash-*'})
-    .then(function loadkibanaIndexPattern() {
-      PageObjects.common.debug('load kibana index with default index pattern');
-      return elasticDump.elasticLoad('visualize','.kibana');
-    })
-    // and load a set of makelogs data
-    .then(function loadIfEmptyMakelogs() {
-      return scenarioManager.loadIfEmpty('logstashFunctional');
-    })
-    .then(function () {
-      PageObjects.common.debug('discover');
-      return PageObjects.common.navigateToApp('discover');
-    })
-    .then(function () {
-      PageObjects.common.debug('setAbsoluteRange');
-      return PageObjects.header.setAbsoluteRange(fromTime, toTime);
-    });
-  });
+    await esClient.deleteAndUpdateConfigDoc({'dateFormat:tz':'UTC', 'defaultIndex':'logstash-*'});
+    PageObjects.common.debug('load kibana index with default index pattern');
+    await elasticDump.elasticLoad('visualize','.kibana');
 
+    // and load a set of makelogs data
+    await scenarioManager.loadIfEmpty('logstashFunctional');
+    PageObjects.common.debug('discover');
+    await PageObjects.common.navigateToApp('discover');
+    PageObjects.common.debug('setAbsoluteRange');
+    await PageObjects.header.setAbsoluteRange(fromTime, toTime);
+  });
 
   bdd.describe('query', function () {
     var queryName1 = 'Query # 1';
-    var fromTimeString = 'September 19th 2015, 06:31:44.000';
-    var toTimeString = 'September 23rd 2015, 18:31:44.000';
 
-    bdd.it('should show correct time range string by timepicker', function () {
-      var expectedTimeRangeString = fromTimeString + ' to ' + toTimeString;
-      return PageObjects.discover.getTimespanText()
-      .then(function (actualTimeString) {
-        expect(actualTimeString).to.be(expectedTimeRangeString);
-      });
+    bdd.it('should show correct time range string by timepicker', async function () {
+      var actualTimeString = await PageObjects.discover.getTimespanText();
+
+      expect(actualTimeString).to.be(`${fromTimeString} to ${toTimeString}`);
     });
 
-    bdd.it('save query should show toast message and display query name', function () {
-      var expectedSavedQueryMessage = 'Discover: Saved Data Source "' + queryName1 + '"';
-      return PageObjects.discover.saveSearch(queryName1)
-      .then(function () {
-        return PageObjects.header.getToastMessage();
-      })
-      .then(function (toastMessage) {
-        PageObjects.common.saveScreenshot('Discover-save-query-toast');
-        expect(toastMessage).to.be(expectedSavedQueryMessage);
-      })
-      .then(function () {
-        return PageObjects.header.waitForToastMessageGone();
-      })
-      .then(function () {
-        return PageObjects.discover.getCurrentQueryName();
-      })
-      .then(function (actualQueryNameString) {
-        expect(actualQueryNameString).to.be(queryName1);
-      });
+    bdd.it('save query should show toast message and display query name', async function () {
+      await PageObjects.discover.saveSearch(queryName1);
+      var toastMessage = await PageObjects.header.getToastMessage();
+      await PageObjects.common.saveScreenshot('Discover-save-query-toast');
+
+      expect(toastMessage).to.be(`Discover: Saved Data Source "${queryName1}"`);
+
+      await PageObjects.header.waitForToastMessageGone();
+      var actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
+
+      expect(actualQueryNameString).to.be(queryName1);
     });
 
-    bdd.it('load query should show query name', function () {
-      return PageObjects.discover.loadSavedSearch(queryName1)
-      .then(function () {
-        return PageObjects.common.sleep(3000);
-      })
-      .then(function () {
-        return PageObjects.discover.getCurrentQueryName();
-      })
-      .then(function (actualQueryNameString) {
-        PageObjects.common.saveScreenshot('Discover-load-query');
-        expect(actualQueryNameString).to.be(queryName1);
-      });
+    bdd.it('load query should show query name', async function () {
+      await PageObjects.discover.loadSavedSearch(queryName1);
+      await PageObjects.common.sleep(3000);
+
+      var actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
+      await PageObjects.common.saveScreenshot('Discover-load-query');
+      expect(actualQueryNameString).to.be(queryName1);
     });
 
-    bdd.it('should show the correct hit count', function () {
-      var expectedHitCount = '14,004';
-      return PageObjects.common.try(function tryingForTime() {
-        return PageObjects.discover.getHitCount()
-        .then(function compareData(hitCount) {
-          expect(hitCount).to.be(expectedHitCount);
-        });
-      });
+    bdd.it('should show the correct hit count', async function () {
+      var hitCount = await PageObjects.discover.getHitCount();
+
+      expect(hitCount).to.be('14,004');
     });
 
-    bdd.it('should show the correct bar chart', function () {
+    bdd.it('should show the correct bar chart', async function () {
+      await PageObjects.common.sleep(4000);
+
       var expectedBarChartData = [ '3.237',
         '17.674', '64.75', '125.737', '119.962', '65.712', '16.449',
         '2.712', '3.675', '17.674', '59.762', '119.087', '123.812',
         '61.862', '15.487', '2.362', '2.800', '15.312', '61.862', '123.2',
         '118.562', '63.524', '17.587', '2.537'
       ];
-      return PageObjects.common.sleep(4000)
-      .then(function () {
-        return verifyChartData(expectedBarChartData);
-      });
+      await verifyChartData(expectedBarChartData);
     });
 
-    bdd.it('should show correct time range string in chart', function () {
-      var expectedTimeRangeString = fromTimeString + ' - ' + toTimeString;
-      return PageObjects.discover.getChartTimespan()
-      .then(function (actualTimeString) {
-        expect(actualTimeString).to.be(expectedTimeRangeString);
-      });
+    bdd.it('should show correct time range string in chart', async function () {
+      var actualTimeString = await PageObjects.discover.getChartTimespan();
+
+      expect(actualTimeString).to.be(`${fromTimeString} - ${toTimeString}`);
     });
 
-    bdd.it('should show correct initial chart interval of 3 hours', function () {
-      var expectedChartInterval = 'by 3 hours';
-      return PageObjects.discover.getChartInterval()
-      .then(function (actualInterval) {
-        expect(actualInterval).to.be(expectedChartInterval);
-      });
+    bdd.it('should show correct initial chart interval of 3 hours', async function () {
+      var actualInterval = await PageObjects.discover.getChartInterval();
+
+      expect(actualInterval).to.be('by 3 hours');
     });
 
-    bdd.it('should show correct data for chart interval Hourly', function () {
-      var chartInterval = 'Hourly';
+    bdd.it('should show correct data for chart interval Hourly', async function () {
+      await PageObjects.discover.setChartInterval('Hourly');
+      await PageObjects.common.sleep(4000);
+
       var expectedBarChartData = [ '1.527', '2.290',
         '5.599', '7.890', '13.236', '30.290', '46.072', '55.490', '86.8',
         '112', '122.181', '131.6', '132.872', '113.527', '102.581',
@@ -138,13 +108,7 @@ bdd.describe('discover app', function describeIndexTests() {
         '120.4', '96.472', '74.581', '70.509', '39.709', '25.199', '13.490',
         '12.472', '4.072', '2.290', '1.018'
       ];
-      return PageObjects.discover.setChartInterval(chartInterval)
-      .then(function () {
-        return PageObjects.common.sleep(4000);
-      })
-      .then(function () {
-        return verifyChartData(expectedBarChartData);
-      });
+      await verifyChartData(expectedBarChartData);
     });
 
     bdd.it('should show correct data for chart interval Daily', async function () {
@@ -161,56 +125,46 @@ bdd.describe('discover app', function describeIndexTests() {
     bdd.it('should show correct data for chart interval Weekly', async function () {
       var chartInterval = 'Weekly';
       var expectedBarChartData = [ '66.598', '129.458'];
+
       await PageObjects.discover.setChartInterval(chartInterval);
       await PageObjects.common.try(async () => {
         await verifyChartData(expectedBarChartData);
       });
     });
 
-    bdd.it('browser back button should show previous interval Daily', function () {
+    bdd.it('browser back button should show previous interval Daily', async function () {
       var expectedChartInterval = 'Daily';
       var expectedBarChartData = [
         '133.196', '129.192', '129.724'
       ];
-      return this.remote.goBack()
-      .then(function () {
-        return PageObjects.common.try(function tryingForTime() {
-          return PageObjects.discover.getChartInterval()
-          .then(function (actualInterval) {
-            expect(actualInterval).to.be(expectedChartInterval);
-          });
-        });
-      })
-      .then(function () {
-        return verifyChartData(expectedBarChartData);
+
+      await this.remote.goBack();
+      await PageObjects.common.try(async function tryingForTime() {
+        var actualInterval = await PageObjects.discover.getChartInterval();
+        expect(actualInterval).to.be(expectedChartInterval);
       });
+      await verifyChartData(expectedBarChartData);
     });
 
-    bdd.it('should show correct data for chart interval Monthly', function () {
+    bdd.it('should show correct data for chart interval Monthly', async function () {
       var chartInterval = 'Monthly';
       var expectedBarChartData = [ '122.535'];
-      return PageObjects.discover.setChartInterval(chartInterval)
-      .then(function () {
-        return PageObjects.common.sleep(2000);
-      })
-      .then(function () {
-        return verifyChartData(expectedBarChartData);
-      });
+
+      await PageObjects.discover.setChartInterval(chartInterval);
+      await PageObjects.common.sleep(2000);
+      await verifyChartData(expectedBarChartData);
     });
 
-    bdd.it('should show correct data for chart interval Yearly', function () {
+    bdd.it('should show correct data for chart interval Yearly', async function () {
       var chartInterval = 'Yearly';
       var expectedBarChartData = [ '122.535'];
-      return PageObjects.discover.setChartInterval(chartInterval)
-      .then(function () {
-        return PageObjects.common.sleep(2000);
-      })
-      .then(function () {
-        return verifyChartData(expectedBarChartData);
-      });
+
+      await PageObjects.discover.setChartInterval(chartInterval);
+      await PageObjects.common.sleep(2000);
+      await verifyChartData(expectedBarChartData);
     });
 
-    bdd.it('should show correct data for chart interval Auto', function () {
+    bdd.it('should show correct data for chart interval Auto', async function () {
       var chartInterval = 'Auto';
       var expectedBarChartData = [ '3.237',
         '17.674', '64.75', '125.737', '119.962', '65.712', '16.449',
@@ -218,54 +172,46 @@ bdd.describe('discover app', function describeIndexTests() {
         '61.862', '15.487', '2.362', '2.800', '15.312', '61.862', '123.2',
         '118.562', '63.524', '17.587', '2.537'
       ];
-      return PageObjects.discover.setChartInterval(chartInterval)
-      .then(function () {
-        return PageObjects.common.sleep(4000);
-      })
-      .then(function () {
-        return verifyChartData(expectedBarChartData);
-      });
+
+      await PageObjects.discover.setChartInterval(chartInterval);
+      await PageObjects.common.sleep(4000);
+      await verifyChartData(expectedBarChartData);
     });
 
-    bdd.it('should show Auto chart interval of 3 hours', function () {
+    bdd.it('should show Auto chart interval of 3 hours', async function () {
       var expectedChartInterval = 'by 3 hours';
-      return PageObjects.discover.getChartInterval()
-      .then(function (actualInterval) {
-        expect(actualInterval).to.be(expectedChartInterval);
-      });
+
+      var actualInterval = await PageObjects.discover.getChartInterval();
+      expect(actualInterval).to.be(expectedChartInterval);
     });
 
-    bdd.it('should not show "no results"', () => {
-      return PageObjects.discover.hasNoResults().then(visible => {
-        expect(visible).to.be(false);
-      });
+    bdd.it('should not show "no results"', async () => {
+      var isVisible = await PageObjects.discover.hasNoResults();
+      expect(isVisible).to.be(false);
     });
 
-    function verifyChartData(expectedBarChartData) {
-      return PageObjects.common.try(function tryingForTime() {
-        return PageObjects.discover.getBarChartData()
-        .then(function compareData(paths) {
-          // the largest bars are over 100 pixels high so this is less than 1% tolerance
-          var barHeightTolerance = 1;
-          var stringResults = '';
-          var hasFailure = false;
-          for (var y = 0; y < expectedBarChartData.length; y++) {
-            stringResults += y + ': expected = ' + expectedBarChartData[y] + ', actual = ' + paths[y] +
-             ', Pass = ' + (Math.abs(expectedBarChartData[y] - paths[y]) < barHeightTolerance) + '\n';
-            if ((Math.abs(expectedBarChartData[y] - paths[y]) > barHeightTolerance)) {
-              hasFailure = true;
-            };
+    async function verifyChartData(expectedBarChartData) {
+      await PageObjects.common.try(async function tryingForTime() {
+        var paths = await PageObjects.discover.getBarChartData();
+        // the largest bars are over 100 pixels high so this is less than 1% tolerance
+        var barHeightTolerance = 1;
+        var stringResults = '';
+        var hasFailure = false;
+        for (var y = 0; y < expectedBarChartData.length; y++) {
+          stringResults += y + ': expected = ' + expectedBarChartData[y] + ', actual = ' + paths[y] +
+           ', Pass = ' + (Math.abs(expectedBarChartData[y] - paths[y]) < barHeightTolerance) + '\n';
+          if ((Math.abs(expectedBarChartData[y] - paths[y]) > barHeightTolerance)) {
+            hasFailure = true;
           };
-          if (hasFailure) {
-            PageObjects.common.log(stringResults);
-            PageObjects.common.log(paths);
-          }
-          for (var x = 0; x < expectedBarChartData.length; x++) {
-            expect(Math.abs(expectedBarChartData[x] - paths[x]) < barHeightTolerance).to.be.ok();
-          }
-        });
+        };
+        if (hasFailure) {
+          PageObjects.common.log(stringResults);
+          PageObjects.common.log(paths);
+        }
+        for (var x = 0; x < expectedBarChartData.length; x++) {
+          expect(Math.abs(expectedBarChartData[x] - paths[x]) < barHeightTolerance).to.be.ok();
+        }
       });
-
     }
 
   });
@@ -280,17 +226,15 @@ bdd.describe('discover app', function describeIndexTests() {
         .setAbsoluteRange(fromTime, toTime);
     });
 
-    bdd.it('should show "no results"', () => {
-      return PageObjects.discover.hasNoResults().then(visible => {
-        PageObjects.common.saveScreenshot('Discover-no-results');
-        expect(visible).to.be(true);
-      });
+    bdd.it('should show "no results"', async () => {
+      var isVisible = await PageObjects.discover.hasNoResults();
+      await PageObjects.common.saveScreenshot('Discover-no-results');
+      expect(isVisible).to.be(true);
     });
 
-    bdd.it('should suggest a new time range is picked', () => {
-      return PageObjects.discover.hasNoResultsTimepicker().then(visible => {
-        expect(visible).to.be(true);
-      });
+    bdd.it('should suggest a new time range is picked', async () => {
+      var isVisible = await PageObjects.discover.hasNoResultsTimepicker();
+      expect(isVisible).to.be(true);
     });
 
     bdd.it('should open and close the time picker', () => {

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -11,10 +11,10 @@ import {
 import PageObjects from '../../../support/page_objects';
 
 bdd.describe('discover app', function describeIndexTests() {
-  var fromTime = '2015-09-19 06:31:44.000';
-  var fromTimeString = 'September 19th 2015, 06:31:44.000';
-  var toTime = '2015-09-23 18:31:44.000';
-  var toTimeString = 'September 23rd 2015, 18:31:44.000';
+  const fromTime = '2015-09-19 06:31:44.000';
+  const fromTimeString = 'September 19th 2015, 06:31:44.000';
+  const toTime = '2015-09-23 18:31:44.000';
+  const toTimeString = 'September 23rd 2015, 18:31:44.000';
 
   bdd.before(async function () {
     // delete .kibana index and update configDoc
@@ -31,25 +31,25 @@ bdd.describe('discover app', function describeIndexTests() {
   });
 
   bdd.describe('query', function () {
-    var queryName1 = 'Query # 1';
+    const queryName1 = 'Query # 1';
 
     bdd.it('should show correct time range string by timepicker', async function () {
-      var actualTimeString = await PageObjects.discover.getTimespanText();
+      const actualTimeString = await PageObjects.discover.getTimespanText();
 
-      var expectedTimeString = `${fromTimeString} to ${toTimeString}`;
+      const expectedTimeString = `${fromTimeString} to ${toTimeString}`;
       expect(actualTimeString).to.be(expectedTimeString);
     });
 
     bdd.it('save query should show toast message and display query name', async function () {
       await PageObjects.discover.saveSearch(queryName1);
-      var toastMessage = await PageObjects.header.getToastMessage();
+      const toastMessage = await PageObjects.header.getToastMessage();
 
-      var expectedToastMessage = `Discover: Saved Data Source "${queryName1}"`;
+      const expectedToastMessage = `Discover: Saved Data Source "${queryName1}"`;
       expect(toastMessage).to.be(expectedToastMessage);
       await PageObjects.common.saveScreenshot('Discover-save-query-toast');
 
       await PageObjects.header.waitForToastMessageGone();
-      var actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
+      const actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
 
       expect(actualQueryNameString).to.be(queryName1);
     });
@@ -64,14 +64,14 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show the correct hit count', async function () {
-      var expectedHitCount = '14,004';
+      const expectedHitCount = '14,004';
       await PageObjects.common.try(async function() {
         expect(await PageObjects.discover.getHitCount()).to.be(expectedHitCount);
       });
     });
 
     bdd.it('should show the correct bar chart', async function () {
-      var expectedBarChartData = [ '3.237',
+      const expectedBarChartData = [ '3.237',
         '17.674', '64.75', '125.737', '119.962', '65.712', '16.449',
         '2.712', '3.675', '17.674', '59.762', '119.087', '123.812',
         '61.862', '15.487', '2.362', '2.800', '15.312', '61.862', '123.2',
@@ -81,23 +81,23 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show correct time range string in chart', async function () {
-      var actualTimeString = await PageObjects.discover.getChartTimespan();
+      const actualTimeString = await PageObjects.discover.getChartTimespan();
 
-      var expectedTimeString = `${fromTimeString} - ${toTimeString}`;
+      const expectedTimeString = `${fromTimeString} - ${toTimeString}`;
       expect(actualTimeString).to.be(expectedTimeString);
     });
 
     bdd.it('should show correct initial chart interval of 3 hours', async function () {
-      var actualInterval = await PageObjects.discover.getChartInterval();
+      const actualInterval = await PageObjects.discover.getChartInterval();
 
-      var expectedInterval = 'by 3 hours';
+      const expectedInterval = 'by 3 hours';
       expect(actualInterval).to.be(expectedInterval);
     });
 
     bdd.it('should show correct data for chart interval Hourly', async function () {
       await PageObjects.discover.setChartInterval('Hourly');
 
-      var expectedBarChartData = [ '1.527', '2.290',
+      const expectedBarChartData = [ '1.527', '2.290',
         '5.599', '7.890', '13.236', '30.290', '46.072', '55.490', '86.8',
         '112', '122.181', '131.6', '132.872', '113.527', '102.581',
         '81.709', '65.672', '43.781', '24.181', '14', '9.672', '6.109',
@@ -114,8 +114,8 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show correct data for chart interval Daily', async function () {
-      var chartInterval = 'Daily';
-      var expectedBarChartData = [
+      const chartInterval = 'Daily';
+      const expectedBarChartData = [
         '133.196', '129.192', '129.724'
       ];
       await PageObjects.discover.setChartInterval(chartInterval);
@@ -125,8 +125,8 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show correct data for chart interval Weekly', async function () {
-      var chartInterval = 'Weekly';
-      var expectedBarChartData = [ '66.598', '129.458'];
+      const chartInterval = 'Weekly';
+      const expectedBarChartData = [ '66.598', '129.458'];
 
       await PageObjects.discover.setChartInterval(chartInterval);
       await PageObjects.common.try(async () => {
@@ -135,38 +135,38 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('browser back button should show previous interval Daily', async function () {
-      var expectedChartInterval = 'Daily';
-      var expectedBarChartData = [
+      const expectedChartInterval = 'Daily';
+      const expectedBarChartData = [
         '133.196', '129.192', '129.724'
       ];
 
       await this.remote.goBack();
       await PageObjects.common.try(async function tryingForTime() {
-        var actualInterval = await PageObjects.discover.getChartInterval();
+        const actualInterval = await PageObjects.discover.getChartInterval();
         expect(actualInterval).to.be(expectedChartInterval);
       });
       await verifyChartData(expectedBarChartData);
     });
 
     bdd.it('should show correct data for chart interval Monthly', async function () {
-      var chartInterval = 'Monthly';
-      var expectedBarChartData = [ '122.535'];
+      const chartInterval = 'Monthly';
+      const expectedBarChartData = [ '122.535'];
 
       await PageObjects.discover.setChartInterval(chartInterval);
       await verifyChartData(expectedBarChartData);
     });
 
     bdd.it('should show correct data for chart interval Yearly', async function () {
-      var chartInterval = 'Yearly';
-      var expectedBarChartData = [ '122.535'];
+      const chartInterval = 'Yearly';
+      const expectedBarChartData = [ '122.535'];
 
       await PageObjects.discover.setChartInterval(chartInterval);
       await verifyChartData(expectedBarChartData);
     });
 
     bdd.it('should show correct data for chart interval Auto', async function () {
-      var chartInterval = 'Auto';
-      var expectedBarChartData = [ '3.237',
+      const chartInterval = 'Auto';
+      const expectedBarChartData = [ '3.237',
         '17.674', '64.75', '125.737', '119.962', '65.712', '16.449',
         '2.712', '3.675', '17.674', '59.762', '119.087', '123.812',
         '61.862', '15.487', '2.362', '2.800', '15.312', '61.862', '123.2',
@@ -178,25 +178,25 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show Auto chart interval of 3 hours', async function () {
-      var expectedChartInterval = 'by 3 hours';
+      const expectedChartInterval = 'by 3 hours';
 
-      var actualInterval = await PageObjects.discover.getChartInterval();
+      const actualInterval = await PageObjects.discover.getChartInterval();
       expect(actualInterval).to.be(expectedChartInterval);
     });
 
     bdd.it('should not show "no results"', async () => {
-      var isVisible = await PageObjects.discover.hasNoResults();
+      const isVisible = await PageObjects.discover.hasNoResults();
       expect(isVisible).to.be(false);
     });
 
     async function verifyChartData(expectedBarChartData) {
       await PageObjects.common.try(async function tryingForTime() {
-        var paths = await PageObjects.discover.getBarChartData();
+        const paths = await PageObjects.discover.getBarChartData();
         // the largest bars are over 100 pixels high so this is less than 1% tolerance
-        var barHeightTolerance = 1;
-        var stringResults = '';
-        var hasFailure = false;
-        for (var y = 0; y < expectedBarChartData.length; y++) {
+        const barHeightTolerance = 1;
+        let stringResults = '';
+        let hasFailure = false;
+        for (let y = 0; y < expectedBarChartData.length; y++) {
           stringResults += y + ': expected = ' + expectedBarChartData[y] + ', actual = ' + paths[y] +
            ', Pass = ' + (Math.abs(expectedBarChartData[y] - paths[y]) < barHeightTolerance) + '\n';
           if ((Math.abs(expectedBarChartData[y] - paths[y]) > barHeightTolerance)) {
@@ -207,7 +207,7 @@ bdd.describe('discover app', function describeIndexTests() {
           PageObjects.common.log(stringResults);
           PageObjects.common.log(paths);
         }
-        for (var x = 0; x < expectedBarChartData.length; x++) {
+        for (let x = 0; x < expectedBarChartData.length; x++) {
           expect(Math.abs(expectedBarChartData[x] - paths[x]) < barHeightTolerance).to.be.ok();
         }
       });
@@ -216,8 +216,8 @@ bdd.describe('discover app', function describeIndexTests() {
   });
 
   bdd.describe('query #2, which has an empty time range', function () {
-    var fromTime = '1999-06-11 09:22:11.000';
-    var toTime = '1999-06-12 11:21:04.000';
+    const fromTime = '1999-06-11 09:22:11.000';
+    const toTime = '1999-06-12 11:21:04.000';
 
     bdd.before(() => {
       PageObjects.common.debug('setAbsoluteRangeForAnotherQuery');
@@ -226,18 +226,18 @@ bdd.describe('discover app', function describeIndexTests() {
     });
 
     bdd.it('should show "no results"', async () => {
-      var isVisible = await PageObjects.discover.hasNoResults();
+      const isVisible = await PageObjects.discover.hasNoResults();
       expect(isVisible).to.be(true);
       await PageObjects.common.saveScreenshot('Discover-no-results');
     });
 
     bdd.it('should suggest a new time range is picked', async () => {
-      var isVisible = await PageObjects.discover.hasNoResultsTimepicker();
+      const isVisible = await PageObjects.discover.hasNoResultsTimepicker();
       expect(isVisible).to.be(true);
     });
 
     bdd.it('should have a link that opens and closes the time picker', async function() {
-      var noResultsTimepickerLink = await PageObjects.discover.getNoResultsTimepicker();
+      const noResultsTimepickerLink = await PageObjects.discover.getNoResultsTimepicker();
       expect(await PageObjects.header.isTimepickerOpen()).to.be(false);
 
       await noResultsTimepickerLink.click();

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -43,10 +43,10 @@ bdd.describe('discover app', function describeIndexTests() {
     bdd.it('save query should show toast message and display query name', async function () {
       await PageObjects.discover.saveSearch(queryName1);
       var toastMessage = await PageObjects.header.getToastMessage();
-      await PageObjects.common.saveScreenshot('Discover-save-query-toast');
 
       var expectedToastMessage = `Discover: Saved Data Source "${queryName1}"`;
       expect(toastMessage).to.be(expectedToastMessage);
+      await PageObjects.common.saveScreenshot('Discover-save-query-toast');
 
       await PageObjects.header.waitForToastMessageGone();
       var actualQueryNameString = await PageObjects.discover.getCurrentQueryName();
@@ -57,10 +57,10 @@ bdd.describe('discover app', function describeIndexTests() {
     bdd.it('load query should show query name', async function () {
       await PageObjects.discover.loadSavedSearch(queryName1);
 
-      await PageObjects.common.saveScreenshot('Discover-load-query');
       await PageObjects.common.try(async function() {
         expect(await PageObjects.discover.getCurrentQueryName()).to.be(queryName1);
       });
+      await PageObjects.common.saveScreenshot('Discover-load-query');
     });
 
     bdd.it('should show the correct hit count', async function () {
@@ -227,8 +227,8 @@ bdd.describe('discover app', function describeIndexTests() {
 
     bdd.it('should show "no results"', async () => {
       var isVisible = await PageObjects.discover.hasNoResults();
-      await PageObjects.common.saveScreenshot('Discover-no-results');
       expect(isVisible).to.be(true);
+      await PageObjects.common.saveScreenshot('Discover-no-results');
     });
 
     bdd.it('should suggest a new time range is picked', async () => {


### PR DESCRIPTION
As suggested in #8543, static `sleep()` calls tend to make the tests less reliable and more time-intensive to run. Using the built-in waiting mechanism in selenium or the `try()` helper are preferable if the test needs to wait for specific conditions.

This PR tries to improve that in several ways:
- It removes `sleep()` calls where the preceding or subsequent operations already include polling (e.g. via `getSpinnerDone()`).
- It removes `sleep()` calls before `verifyChartData()` calls, because that already includes retrying via `try()`.
- It wraps some time-sensitive expectations in `try()` calls.

Additionally, it improves the readability of the file by converting most promise chains to `async/await` and clarifying the intent of some test cases.
