### PR TITLE
Changed Timelion dependencies to use relative paths for Time Series Visual Builder

### DIFF
--- a/src/core_plugins/metrics/public/lib/fetch.js
+++ b/src/core_plugins/metrics/public/lib/fetch.js
@@ -4,7 +4,7 @@ export default (
   Notifier,
   $http
 ) => {
-  const dashboardContext = Private(require('plugins/timelion/services/dashboard_context'));
+  const dashboardContext = Private(require('../../../timelion/public/services/dashboard_context'));
   const notify = new Notifier({ location: 'Metrics' });
   return $scope => () => {
     const panel = $scope.model;


### PR DESCRIPTION
This PR changes the Timelion dependencies  in Time Series Visual Builder to use relative paths; Fixes #10923 