### PR TITLE
Add "Positive Only" agg to Time Series Visual Builder

### DIFF
--- a/src/core_plugins/metrics/common/__tests__/agg_lookup.js
+++ b/src/core_plugins/metrics/common/__tests__/agg_lookup.js
@@ -16,7 +16,7 @@ describe('aggLookup', () => {
 
     it('returns options for all aggs', () => {
       const options = createOptions();
-      expect(options).to.have.length(26);
+      expect(options).to.have.length(27);
       options.forEach((option) => {
         expect(option).to.have.property('label');
         expect(option).to.have.property('value');
@@ -32,13 +32,13 @@ describe('aggLookup', () => {
 
     it('returns options for pipeline', () => {
       const options = createOptions('pipeline');
-      expect(options).to.have.length(13);
+      expect(options).to.have.length(14);
       expect(options.every(opt => !isBasicAgg({ type: opt.value }))).to.equal(true);
     });
 
     it('returns options for all if given unknown key', () => {
       const options = createOptions('foo');
-      expect(options).to.have.length(26);
+      expect(options).to.have.length(27);
     });
 
   });

--- a/src/core_plugins/metrics/common/agg_lookup.js
+++ b/src/core_plugins/metrics/common/agg_lookup.js
@@ -25,7 +25,8 @@ const lookup = {
   'std_deviation_bucket': 'Overall Std. Deviation',
   'series_agg': 'Series Agg',
   'serial_diff': 'Serial Difference',
-  'filter_ratio': 'Filter Ratio'
+  'filter_ratio': 'Filter Ratio',
+  'positive_only': 'Positive Only'
 };
 
 const pipeline = [
@@ -41,7 +42,8 @@ const pipeline = [
   'sum_of_squares_bucket',
   'std_deviation_bucket',
   'series_agg',
-  'serial_diff'
+  'serial_diff',
+  'positive_only'
 ];
 
 const byType = {

--- a/src/core_plugins/metrics/common/calculate_label.js
+++ b/src/core_plugins/metrics/common/calculate_label.js
@@ -11,7 +11,8 @@ const paths = [
   'std_deviation_bucket',
   'variance_bucket',
   'sum_of_squares_bucket',
-  'serial_diff'
+  'serial_diff',
+  'positive_only'
 ];
 export default function calculateLabel(metric, metrics) {
   if (!metric) return 'Unknown';

--- a/src/core_plugins/metrics/public/components/aggs/agg_select.js
+++ b/src/core_plugins/metrics/public/components/aggs/agg_select.js
@@ -22,6 +22,7 @@ const pipelineAggs = [
   { label: 'Cumulative Sum', value: 'cumulative_sum' },
   { label: 'Derivative', value: 'derivative' },
   { label: 'Moving Average', value: 'moving_average' },
+  { label: 'Positive Only', value: 'positive_only' },
   { label: 'Serial Difference', value: 'serial_diff' },
   { label: 'Series Agg', value: 'series_agg' }
 ];

--- a/src/core_plugins/metrics/public/components/aggs/positive_only.js
+++ b/src/core_plugins/metrics/public/components/aggs/positive_only.js
@@ -1,0 +1,59 @@
+import React, { Component, PropTypes } from 'react';
+import AggSelect from './agg_select';
+import MetricSelect from './metric_select';
+import AggRow from './agg_row';
+import createChangeHandler from '../lib/create_change_handler';
+import createSelectHandler from '../lib/create_select_handler';
+
+class PositiveOnlyAgg extends Component {
+
+  render() {
+    const { siblings } = this.props;
+
+    const defaults = { unit: '' };
+    const model = { ...defaults, ...this.props.model };
+
+    const handleChange = createChangeHandler(this.props.onChange, model);
+    const handleSelectChange = createSelectHandler(handleChange);
+
+    return (
+      <AggRow
+        disableDelete={this.props.disableDelete}
+        model={this.props.model}
+        onAdd={this.props.onAdd}
+        onDelete={this.props.onDelete}
+        siblings={this.props.siblings}>
+        <div className="vis_editor__row_item">
+          <div className="vis_editor__label">Aggregation</div>
+          <AggSelect
+            siblings={this.props.siblings}
+            value={model.type}
+            onChange={handleSelectChange('type')}/>
+        </div>
+        <div className="vis_editor__row_item">
+          <div className="vis_editor__label">Metric</div>
+          <MetricSelect
+            onChange={handleSelectChange('field')}
+            metrics={siblings}
+            metric={model}
+            value={model.field}/>
+        </div>
+      </AggRow>
+    );
+  }
+
+}
+
+PositiveOnlyAgg.propTypes = {
+  disableDelete: PropTypes.bool,
+  fields: PropTypes.object,
+  model: PropTypes.object,
+  onAdd: PropTypes.func,
+  onChange: PropTypes.func,
+  onDelete: PropTypes.func,
+  panel: PropTypes.object,
+  series: PropTypes.object,
+  siblings: PropTypes.array,
+};
+
+export default PositiveOnlyAgg;

--- a/src/core_plugins/metrics/public/components/lib/agg_to_component.js
+++ b/src/core_plugins/metrics/public/components/lib/agg_to_component.js
@@ -8,6 +8,7 @@ import StdDeviation from '../aggs/std_deviation';
 import StdSibling from '../aggs/std_sibling';
 import SeriesAgg from '../aggs/series_agg';
 import SerialDiff from '../aggs/serial_diff';
+import PositiveOnly from '../aggs/positive_only';
 import FilterRatio from '../aggs/filter_ratio';
 import PercentileRank from '../aggs/percentile_rank';
 export default {
@@ -36,7 +37,8 @@ export default {
   derivative: Derivative,
   series_agg: SeriesAgg,
   serial_diff: SerialDiff,
-  filter_ratio: FilterRatio
+  filter_ratio: FilterRatio,
+  positive_only: PositiveOnly
 };
 
 

--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/bucket_transform.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/bucket_transform.js
@@ -351,4 +351,30 @@ describe('bucketTransform', () => {
       expect(run).to.throw(Error, 'Metric missing script');
     });
   });
+
+  describe('positive_only', () => {
+    it('returns bucket_script', () => {
+      const metric = {
+        id: '2',
+        type: 'positive_only',
+        field: '1'
+      };
+      const metrics = [{ id: '1', type: 'avg', field: 'cpu.idle.pct' }, metric];
+      const fn = bucketTransform.positive_only;
+      expect(fn(metric, metrics, '10s')).is.eql({
+        bucket_script: {
+          buckets_path: {
+            value: '1'
+          },
+          gap_policy: 'skip',
+          script: {
+            inline: 'params.value > 0 ? params.value : 0',
+            lang: 'painless'
+          }
+        }
+      });
+    });
+  });
+
+
 });

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/bucket_transform.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/bucket_transform.js
@@ -162,6 +162,25 @@ export default {
     };
     if (bucket.gap_policy) body.bucket_script.gap_policy = bucket.gap_policy;
     return body;
+  },
+
+  positive_only: (bucket, metrics) => {
+    checkMetric(bucket, ['field', 'type']);
+    const body = {
+      bucket_script: {
+        buckets_path: {
+          value: getBucketsPath(bucket.field, metrics)
+        },
+        script: {
+          inline: 'params.value > 0 ? params.value : 0',
+          lang: 'painless'
+        },
+        gap_policy: 'skip' // seems sane
+      }
+    };
+    return body;
   }
+
+
 };
 


### PR DESCRIPTION
This PR adds a new aggregation to the Time Series Visual Builder that will return only the positive values. This is useful when used in conjunction with derivatives where the counter might reset (or rollover). This is normally done with a calculation (bucket_script) using painless; this is basically a shortcut for that calculation.

![image](https://cloud.githubusercontent.com/assets/41702/24718221/1c9615dc-19ea-11e7-99cc-96b0ebb32be1.png)

@monicasarbu @andrewkroh 