### PR TITLE
Fix Drilldown URL for Top N in Time Series Visual Builder

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
@@ -45,7 +45,7 @@ function TopNVisualization(props) {
 
   if (model.drilldown_url) {
     params.onClick = (item) => {
-      window.location = replaceVars(model.drilldown_url, {}, { key: item.id });
+      window.location = replaceVars(model.drilldown_url, {}, { key: item.label });
     };
   }
   const style = { backgroundColor: panelBackgroundColor };

--- a/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
@@ -2,6 +2,7 @@ import tickFormatter from '../../lib/tick_formatter';
 import _ from 'lodash';
 import { TopN, getLastValue } from 'plugins/metrics/visualizations';
 import color from 'color';
+import replaceVars from '../../lib/replace_vars';
 
 import React, { PropTypes } from 'react';
 function TopNVisualization(props) {
@@ -40,6 +41,12 @@ function TopNVisualization(props) {
 
   if (panelBackgroundColor && panelBackgroundColor !== 'inherit') {
     params.reversed = color(panelBackgroundColor).luminosity() < 0.45;
+  }
+
+  if (model.drilldown_url) {
+    params.onClick = (item) => {
+      window.location = replaceVars(model.drilldown_url, {}, { key: item.id });
+    };
   }
   const style = { backgroundColor: panelBackgroundColor };
   return (


### PR DESCRIPTION
Looks like this was changed at some point. This re-implements the drill down feature for Top N visualization.