### PR TITLE
Fixes #11152 - Time Series Visual Builder - calculateIndices() should return pattern if no indices are found.

### DIFF
--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/calculate_indices.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/calculate_indices.js
@@ -41,16 +41,16 @@ describe('calculateIndices', () => {
           'metricbeat-2017.01.03': {}
         }
       };
-      expect(handleResponse(resp)).to.eql([
+      expect(handleResponse('metricbeat-*')(resp)).to.eql([
         'metricbeat-2017.01.01',
         'metricbeat-2017.01.02',
         'metricbeat-2017.01.03',
       ]);
     });
 
-    it('returns an empty array if none found', () => {
+    it('returns an array with the index pattern if none found', () => {
       const resp = { indices: { } };
-      expect(handleResponse(resp)).to.have.length(0);
+      expect(handleResponse('metricbeat-*')(resp)).to.eql(['metricbeat-*']);
     });
   });
 });

--- a/src/core_plugins/metrics/server/lib/vis_data/calculate_indices.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/calculate_indices.js
@@ -37,7 +37,11 @@ function calculateIndices(req, indexPattern = '*', timeField = '@timestamp', off
   const { callWithRequest } = server.plugins.elasticsearch.getCluster('data');
   const params = getParams(req, indexPattern, timeField, offsetBy);
   return callWithRequest(req, 'fieldStats', params)
-    .then(handleResponse);
+    .then(handleResponse)
+    .then(indices => {
+      if (!indices.length) return [indexPattern];
+      return indices;
+    });
 }
 
 

--- a/src/core_plugins/metrics/server/lib/vis_data/calculate_indices.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/calculate_indices.js
@@ -23,13 +23,15 @@ function getParams(req, indexPattern, timeField, offsetBy) {
 
 }
 
-function handleResponse(resp) {
-  const indices = _.map(resp.indices, (_info, index) => index);
-  if (indices.length === 0) {
-    // there are no relevant indices for the given timeframe in the data
-    return [];
-  }
-  return indices;
+function handleResponse(indexPattern) {
+  return resp => {
+    const indices = _.map(resp.indices, (_info, index) => index);
+    if (indices.length === 0) {
+      // there are no relevant indices for the given timeframe in the data
+      return [indexPattern];
+    }
+    return indices;
+  };
 }
 
 function calculateIndices(req, indexPattern = '*', timeField = '@timestamp', offsetBy) {
@@ -37,11 +39,7 @@ function calculateIndices(req, indexPattern = '*', timeField = '@timestamp', off
   const { callWithRequest } = server.plugins.elasticsearch.getCluster('data');
   const params = getParams(req, indexPattern, timeField, offsetBy);
   return callWithRequest(req, 'fieldStats', params)
-    .then(handleResponse)
-    .then(indices => {
-      if (!indices.length) return [indexPattern];
-      return indices;
-    });
+    .then(handleResponse(indexPattern));
 }
 
 


### PR DESCRIPTION
This PR fixes #11152 - When field stats doesn't return indices for an index pattern it should just return the index pattern otherwise Elasticsearch will run the query against everything.