### PR TITLE
Fixes #11231 - Adds check for max_bucket size for Time Series Visual Builder

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -78,7 +78,7 @@ Markdown.
 `notifications:lifetime:error`:: Specifies the duration in milliseconds for error notification displays. The default value is 300000. Set this field to `Infinity` to disable error notifications.
 `notifications:lifetime:warning`:: Specifies the duration in milliseconds for warning notification displays. The default value is 10000. Set this field to `Infinity` to disable warning notifications.
 `notifications:lifetime:info`:: Specifies the duration in milliseconds for information notification displays. The default value is 5000. Set this field to `Infinity` to disable information notifications.
-`metrics:max_buckets`:: Used for calculating automatic intervals in Time Series Visual Builder visualizations, this is the maximum number of buckets to represent.
+`metrics:max_buckets`:: The maximum numbers of buckets that cannot be exceeded. For example, this can arise when the user selects a short interval like (e.g. 1s) for a long time period (e.g. 1 year)
 `timelion:showTutorial`:: Set this property to `true` to show the Timelion tutorial to users when they first open Timelion.
 `timelion:es.timefield`:: Default field containing a timestamp when using the `.es()` query.
 `timelion:es.default_index`:: Default index when using the `.es()` query.

--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -78,6 +78,7 @@ Markdown.
 `notifications:lifetime:error`:: Specifies the duration in milliseconds for error notification displays. The default value is 300000. Set this field to `Infinity` to disable error notifications.
 `notifications:lifetime:warning`:: Specifies the duration in milliseconds for warning notification displays. The default value is 10000. Set this field to `Infinity` to disable warning notifications.
 `notifications:lifetime:info`:: Specifies the duration in milliseconds for information notification displays. The default value is 5000. Set this field to `Infinity` to disable information notifications.
+`metrics:max_buckets`:: Used for calculating automatic intervals in Time Series Visual Builder visualizations, this is the maximum number of buckets to represent.
 `timelion:showTutorial`:: Set this property to `true` to show the Timelion tutorial to users when they first open Timelion.
 `timelion:es.timefield`:: Default field containing a timestamp when using the `.es()` query.
 `timelion:es.default_index`:: Default index when using the `.es()` query.

--- a/src/core_plugins/metrics/public/lib/fetch.js
+++ b/src/core_plugins/metrics/public/lib/fetch.js
@@ -1,8 +1,10 @@
+import { validateInterval } from './validate_interval';
 export default (
   timefilter,
   Private,
   Notifier,
-  $http
+  $http,
+  config
 ) => {
   const dashboardContext = Private(require('../../../timelion/public/services/dashboard_context'));
   const notify = new Notifier({ location: 'Metrics' });
@@ -15,16 +17,23 @@ export default (
         panels: [panel]
       };
 
-      return $http.post('../api/metrics/vis/data', params)
-        .success(resp => {
-          $scope.visData = resp;
-        })
-        .error(resp => {
-          $scope.visData = {};
-          const err = new Error(resp.message);
-          err.stack = resp.stack;
-          notify.error(err);
-        });
+      try {
+        const maxBuckets = config.get('metrics:max_buckets');
+        validateInterval(timefilter, panel, maxBuckets);
+        return $http.post('../api/metrics/vis/data', params)
+          .success(resp => {
+            $scope.visData = resp;
+          })
+          .error(resp => {
+            $scope.visData = {};
+            const err = new Error(resp.message);
+            err.stack = resp.stack;
+            notify.error(err);
+          });
+      } catch (e) {
+        notify.error(e);
+        return Promise.resolve();
+      }
     }
     return Promise.resolve();
   };

--- a/src/core_plugins/metrics/public/lib/validate_interval.js
+++ b/src/core_plugins/metrics/public/lib/validate_interval.js
@@ -1,0 +1,16 @@
+import parseInterval from 'ui/utils/parse_interval';
+export function validateInterval(timefilter, panel, maxBuckets) {
+  const { interval } = panel;
+  const { min, max } = timefilter.getBounds();
+  // No need to check auto it will return around 100
+  if (interval === 'auto') return;
+  const duration = parseInterval(interval);
+  if (!duration) {
+    throw new Error(`Invalid interval: ${interval} is not a valid interval`);
+  }
+  const span = max.valueOf() - min.valueOf();
+  const buckets = span / duration.asMilliseconds();
+  if (buckets > maxBuckets) {
+    throw new Error(`Max buckets exceeded: ${buckets} is greater than ${maxBuckets}, try a larger interval or use auto.`);
+  }
+}

--- a/src/core_plugins/metrics/public/lib/validate_interval.js
+++ b/src/core_plugins/metrics/public/lib/validate_interval.js
@@ -9,8 +9,8 @@ export function validateInterval(timefilter, panel, maxBuckets) {
     throw new Error(`Invalid interval: ${interval} is not a valid interval`);
   }
   const span = max.valueOf() - min.valueOf();
-  const buckets = span / duration.asMilliseconds();
+  const buckets = Math.floor(span / duration.asMilliseconds());
   if (buckets > maxBuckets) {
-    throw new Error(`Max buckets exceeded: ${buckets} is greater than ${maxBuckets}, try a larger interval or use auto.`);
+    throw new Error(`Max buckets exceeded: ${buckets} is greater than ${maxBuckets}, try a larger time interval in the panel options.`);
   }
 }

--- a/src/ui/settings/defaults.js
+++ b/src/ui/settings/defaults.js
@@ -264,6 +264,10 @@ export default function defaultSettingsProvider() {
       description: 'The time in milliseconds which an information notification ' +
         'will be displayed on-screen for. Setting to Infinity will disable.'
     },
+    'metrics:max_buckets': {
+      value: 2000,
+      description: 'The maximum number of buckets a single datasource can return'
+    },
     // Timelion stuff
     'timelion:showTutorial': {
       value: false,


### PR DESCRIPTION
This PR fixes #11231 
- Adds new setting `metrics:max_buckets`
- Adds validation for the interval to make sure it's not larger then the max buckets