### PR TITLE
Fixes #11232 - Add option for panel and global filters to annotations for TSVB

### DIFF
--- a/src/core_plugins/metrics/public/components/annotations_editor.js
+++ b/src/core_plugins/metrics/public/components/annotations_editor.js
@@ -15,7 +15,8 @@ function newAnnotation() {
     index_pattern: '*',
     time_field: '@timestamp',
     icon: 'fa-tag',
-    include_filters: 0
+    ignore_global_filters: 1,
+    ignore_panel_filters: 1
   };
 }
 
@@ -85,18 +86,18 @@ class AnnotationsEditor extends Component {
                 value={model.query_string} />
             </div>
             <div className="vis_editor__row-item-small">
-              <div className="vis_editor__label">Include Global Filters</div>
+              <div className="vis_editor__label">Ignore Global Filters</div>
               <YesNo
-                value={model.include_global_filters}
-                name="include_global_filters"
+                value={model.ignore_global_filters}
+                name="ignore_global_filters"
                 onChange={handleChange}/>
 
             </div>
             <div className="vis_editor__row-item-small">
-              <div className="vis_editor__label">Include Panel Filters</div>
+              <div className="vis_editor__label">Ignore Panel Filters</div>
               <YesNo
-                value={model.include_panel_filters}
-                name="include_panel_filters"
+                value={model.ignore_panel_filters}
+                name="ignore_panel_filters"
                 onChange={handleChange}/>
 
             </div>

--- a/src/core_plugins/metrics/public/components/annotations_editor.js
+++ b/src/core_plugins/metrics/public/components/annotations_editor.js
@@ -6,6 +6,7 @@ import ColorPicker from './color_picker';
 import FieldSelect from './aggs/field_select';
 import uuid from 'node-uuid';
 import IconSelect from './icon_select';
+import YesNo from './yes_no';
 
 function newAnnotation() {
   return {
@@ -13,7 +14,8 @@ function newAnnotation() {
     color: '#F00',
     index_pattern: '*',
     time_field: '@timestamp',
-    icon: 'fa-tag'
+    icon: 'fa-tag',
+    include_filters: 0
   };
 }
 
@@ -81,6 +83,22 @@ class AnnotationsEditor extends Component {
                 type="text"
                 onChange={this.handleChange(model, 'query_string')}
                 value={model.query_string} />
+            </div>
+            <div className="vis_editor__row-item-small">
+              <div className="vis_editor__label">Include Global Filters</div>
+              <YesNo
+                value={model.include_global_filters}
+                name="include_global_filters"
+                onChange={handleChange}/>
+
+            </div>
+            <div className="vis_editor__row-item-small">
+              <div className="vis_editor__label">Include Panel Filters</div>
+              <YesNo
+                value={model.include_panel_filters}
+                name="include_panel_filters"
+                onChange={handleChange}/>
+
             </div>
           </div>
           <div className="vis_editor__row">

--- a/src/core_plugins/metrics/public/less/editor.less
+++ b/src/core_plugins/metrics/public/less/editor.less
@@ -416,6 +416,10 @@
       margin-bottom: 4px;
     }
   }
+  .vis_editor__row-item-small {
+    .vis_editor__row-item;
+    flex-grow: 0;
+  }
 }
 
 .vis_editor__icon_select-option {

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/annotations/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/annotations/query.js
@@ -35,6 +35,20 @@ export default function query(req, panel, annotation) {
       });
     }
 
+    const globalFilters = req.payload.filters;
+    if (annotation.include_global_filters) {
+      doc.query.bool.must = doc.query.bool.must.concat(globalFilters);
+    }
+
+    if (annotation.include_panel_filters && panel.filter) {
+      doc.query.bool.must.push({
+        query_string: {
+          query: panel.filter,
+          analyze_wildcard: true
+        }
+      });
+    }
+
     if (annotation.fields) {
       const fields = annotation.fields.split(/[,\s]+/) || [];
       fields.forEach(field => {

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/annotations/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/annotations/query.js
@@ -36,11 +36,11 @@ export default function query(req, panel, annotation) {
     }
 
     const globalFilters = req.payload.filters;
-    if (annotation.include_global_filters) {
+    if (!annotation.ignore_global_filters) {
       doc.query.bool.must = doc.query.bool.must.concat(globalFilters);
     }
 
-    if (annotation.include_panel_filters && panel.filter) {
+    if (!annotation.ignore_panel_filters && panel.filter) {
       doc.query.bool.must.push({
         query_string: {
           query: panel.filter,


### PR DESCRIPTION
This PR fixes #11232 by adding an two separate options for including panel and global filters for annotations for TSVB. 

![image](https://cloud.githubusercontent.com/assets/41702/25054991/20c08b6a-2115-11e7-9a7a-440e0db9cf94.png)
