### PR TITLE
Fixing legend when the label is zero for TSVB

### DIFF
--- a/src/core_plugins/metrics/public/visualizations/lib/create_legend_series.js
+++ b/src/core_plugins/metrics/public/visualizations/lib/create_legend_series.js
@@ -12,7 +12,7 @@ export default props => (row, i) => {
   const classes = ['rhythm_chart__legend_item'];
   const key = row.id;
   if (!_.includes(props.seriesFilter, row.id)) classes.push('disabled');
-  if (!row.label || row.legend === false) return (<div key={ key } style={{ display: 'none' }}/>);
+  if (row.label == null || row.legend === false) return (<div key={ key } style={{ display: 'none' }}/>);
   return (
     <div
       className={ classes.join(' ') }


### PR DESCRIPTION
This PR fixes a bug where if the label is set to zero (or falsey) it won't display.

Before:

![image](https://cloud.githubusercontent.com/assets/41702/25058321/f41b574e-212c-11e7-8619-a40062308d08.png)
 

After:

![image](https://cloud.githubusercontent.com/assets/41702/25058305/bc2618e2-212c-11e7-8261-c6a6da146c72.png)
