### PR TITLE
Adding label templates to legend keys for TSVB

### DIFF
--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/format_key.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/format_key.js
@@ -1,0 +1,6 @@
+export function formatKey(key, series) {
+  if (/{{\s*key\s*}}/.test(series.label)) {
+    return series.label.replace(/{{\s*key\s*}}/, key);
+  }
+  return key;
+}

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/get_splits.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/get_splits.js
@@ -3,6 +3,7 @@ import calculateLabel from '../../../../common/calculate_label';
 import _ from 'lodash';
 import getLastMetric from './get_last_metric';
 import getSplitColors from './get_split_colors';
+import { formatKey } from './format_key';
 export default function getSplits(resp, series) {
   const metric = getLastMetric(series);
   if (_.has(resp, `aggregations.${series.id}.buckets`)) {
@@ -12,7 +13,7 @@ export default function getSplits(resp, series) {
       const colors = getSplitColors(series.color, size, series.split_color_mode);
       return buckets.map(bucket => {
         bucket.id = `${series.id}:${bucket.key}`;
-        bucket.label = bucket.key;
+        bucket.label = formatKey(bucket.key, series);
         bucket.color = colors.shift();
         return bucket;
       });


### PR DESCRIPTION
This PR adds the ability to create a label template using `{{ key }}` in the label field

Before:

![image](https://cloud.githubusercontent.com/assets/41702/25058704/5c6000b2-2131-11e7-86da-f5818c490753.png)


After:

![image](https://cloud.githubusercontent.com/assets/41702/25058688/3c262d08-2131-11e7-8595-aa79d97b369d.png)
