### PR TITLE
Return Boom errors directly to the browser for Time Series Visual Builder

### DIFF
--- a/src/core_plugins/metrics/server/lib/vis_data/handle_error_response.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/handle_error_response.js
@@ -1,5 +1,5 @@
 export default panel => error => {
-  console.log(error);
+  if (error.isBoom) throw error;
   const result = {};
   let errorResponse;
   try {

--- a/src/core_plugins/metrics/server/lib/vis_data/handle_error_response.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/handle_error_response.js
@@ -1,5 +1,5 @@
 export default panel => error => {
-  if (error.isBoom) throw error;
+  if (error.isBoom && error.status === 401) throw error;
   const result = {};
   let errorResponse;
   try {

--- a/src/core_plugins/metrics/server/routes/fields.js
+++ b/src/core_plugins/metrics/server/routes/fields.js
@@ -5,7 +5,7 @@ export default (server) => {
     path: '/api/metrics/fields',
     method: 'GET',
     handler: (req, reply) => {
-      return getFields(req)
+      getFields(req)
         .then(reply)
         .catch((err) => {
           if (err.isBoom && err.status === 401) return reply(err);

--- a/src/core_plugins/metrics/server/routes/fields.js
+++ b/src/core_plugins/metrics/server/routes/fields.js
@@ -8,9 +8,7 @@ export default (server) => {
       return getFields(req)
         .then(reply)
         .catch((err) => {
-          if (err.isBoom) {
-            return reply(err);
-          }
+          if (err.isBoom && err.status === 401) return reply(err);
           reply([]);
         });
     }

--- a/src/core_plugins/metrics/server/routes/fields.js
+++ b/src/core_plugins/metrics/server/routes/fields.js
@@ -7,7 +7,12 @@ export default (server) => {
     handler: (req, reply) => {
       return getFields(req)
         .then(reply)
-        .catch(() => reply([]));
+        .catch((err) => {
+          if (err.isBoom) {
+            return reply(err);
+          }
+          reply([]);
+        });
     }
   });
 

--- a/src/core_plugins/metrics/server/routes/vis.js
+++ b/src/core_plugins/metrics/server/routes/vis.js
@@ -9,7 +9,6 @@ export default (server) => {
       return getVisData(req)
         .then(reply)
         .catch(err => {
-          if (err.isBoom) return reply(err);
           reply(Boom.wrap(err, 400));
         });
     }

--- a/src/core_plugins/metrics/server/routes/vis.js
+++ b/src/core_plugins/metrics/server/routes/vis.js
@@ -6,7 +6,7 @@ export default (server) => {
     path: '/api/metrics/vis/data',
     method: 'POST',
     handler: (req, reply) => {
-      return getVisData(req)
+      getVisData(req)
         .then(reply)
         .catch(err => {
           reply(Boom.wrap(err, 400));

--- a/src/core_plugins/metrics/server/routes/vis.js
+++ b/src/core_plugins/metrics/server/routes/vis.js
@@ -9,7 +9,7 @@ export default (server) => {
       return getVisData(req)
         .then(reply)
         .catch(err => {
-          console.error(err.stack);
+          if (err.isBoom) return reply(err);
           reply(Boom.wrap(err, 400));
         });
     }


### PR DESCRIPTION
This PR fixes #11643 by returning Boom errors to the client directly instead of serializing them into the response. Errors from the ES client usually are Boom errors when there is an authentication issue.