### PR TITLE
Add Help Text to Painless Script for Time Series Visual Builder

### DIFF
--- a/src/core_plugins/metrics/public/components/aggs/calculation.js
+++ b/src/core_plugins/metrics/public/components/aggs/calculation.js
@@ -52,7 +52,10 @@ class CalculationAgg extends Component {
                 model={model}/>
             </div>
             <div className="vis_editor__row_item">
-              <div className="vis_editor__label">Script (Painless)</div>
+              <div className="vis_editor__label">
+                Painless Script - Variables are keys on the <code>params</code>
+                object, i.e. <code>params.&lt;name&gt;</code>
+              </div>
               <input
                 className="vis_editor__input-grows-100"
                 type="text"


### PR DESCRIPTION
Users are confused on how to use the variables for Painless scripts in the calculation aggregation. This PR adds some help text:

![image](https://cloud.githubusercontent.com/assets/41702/26270655/a2372b56-3cb1-11e7-8593-c033b93e851a.png)
