### PR TITLE
Fix dirty checking for changes to Time Series Visual Builder

### DIFF
--- a/src/core_plugins/metrics/public/kbn_vis_types/editor_controller.js
+++ b/src/core_plugins/metrics/public/kbn_vis_types/editor_controller.js
@@ -67,7 +67,7 @@ app.controller('MetricsEditorController', (
   $scope.$watchCollection('model', (newValue, oldValue) => {
     angular.copy(newValue, $scope.vis._editableVis.params);
     $scope.stageEditableVis();
-    $scope.dirty = !_.isEqual(newValue.series, oldValue.series);
+    $scope.dirty = !_.isEqual(newValue, oldValue);
 
     if ($scope.dirty && $scope.autoApply) {
       debouncedFetch();


### PR DESCRIPTION
This PR changes the dirty checking from just the series to the entire panel. So now when the user makes changes to the panel options the applly button will activate.