### PR TITLE
Adding option for controlling if last bucket is dropped for TSVB

### DIFF
--- a/src/core_plugins/metrics/public/components/index_pattern.js
+++ b/src/core_plugins/metrics/public/components/index_pattern.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import FieldSelect from './aggs/field_select';
 import createSelectHandler from './lib/create_select_handler';
 import createTextHandler from './lib/create_text_handler';
+import YesNo from './yes_no';
 
 class IndexPattern extends Component {
   render() {
@@ -11,10 +12,12 @@ class IndexPattern extends Component {
     const timeFieldName = `${prefix}time_field`;
     const indexPatternName = `${prefix}index_pattern`;
     const intervalName = `${prefix}interval`;
+    const dropBucketName = `${prefix}drop_last_bucket`;
 
     const defaults = {
       [indexPatternName]: '*',
-      [intervalName]: 'auto'
+      [intervalName]: 'auto',
+      [dropBucketName]: 1
     };
 
     const model = { ...defaults, ...this.props.model };
@@ -42,6 +45,11 @@ class IndexPattern extends Component {
           disabled={this.props.disabled}
           onChange={handleTextChange(intervalName, 'auto')}
           value={model[intervalName]}/>
+        <div className="vis_editor__label">Drop Last Bucket</div>
+        <YesNo
+          value={model[dropBucketName]}
+          name={dropBucketName}
+          onChange={this.props.onChange}/>
       </div>
     );
   }

--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/build_request_body.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/build_request_body.js
@@ -72,7 +72,7 @@ describe('buildRequestBody(req)', () => {
               'range': {
                 '@timestamp': {
                   'gte': 1485463055881,
-                  'lte': 1485463945881,
+                  'lte': 1485463955881,
                   'format': 'epoch_millis'
                 }
               }
@@ -106,7 +106,7 @@ describe('buildRequestBody(req)', () => {
                 'min_doc_count': 0,
                 'extended_bounds': {
                   'min': 1485463055881,
-                  'max': 1485463945881
+                  'max': 1485463955881
                 }
               },
               'aggs': {

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
@@ -44,7 +44,7 @@ describe('dateHistogram(req, panel, series)', () => {
                 min_doc_count: 0,
                 extended_bounds: {
                   min: 1483228800000,
-                  max: 1483232390000
+                  max: 1483232400000
                 }
               }
             }
@@ -69,7 +69,7 @@ describe('dateHistogram(req, panel, series)', () => {
                 min_doc_count: 0,
                 extended_bounds: {
                   min: 1483225200000,
-                  max: 1483228790000
+                  max: 1483228800000
                 }
               }
             }
@@ -97,7 +97,7 @@ describe('dateHistogram(req, panel, series)', () => {
                 min_doc_count: 0,
                 extended_bounds: {
                   min: 1483228800000,
-                  max: 1483232380000
+                  max: 1483232400000
                 }
               }
             }

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/query.js
@@ -42,7 +42,7 @@ describe('query(req, panel, series)', () => {
               range: {
                 timestamp: {
                   gte: 1483228800000,
-                  lte: 1483232390000,
+                  lte: 1483232400000,
                   format: 'epoch_millis'
                 }
               }
@@ -66,7 +66,7 @@ describe('query(req, panel, series)', () => {
               range: {
                 timestamp: {
                   gte: 1483225200000,
-                  lte: 1483228790000,
+                  lte: 1483228800000,
                   format: 'epoch_millis'
                 }
               }
@@ -102,7 +102,7 @@ describe('query(req, panel, series)', () => {
               range: {
                 timestamp: {
                   gte: 1483228800000,
-                  lte: 1483232390000,
+                  lte: 1483232400000,
                   format: 'epoch_millis'
                 }
               }
@@ -150,7 +150,7 @@ describe('query(req, panel, series)', () => {
               range: {
                 timestamp: {
                   gte: 1483228800000,
-                  lte: 1483232390000,
+                  lte: 1483232400000,
                   format: 'epoch_millis'
                 }
               }
@@ -205,7 +205,7 @@ describe('query(req, panel, series)', () => {
               range: {
                 timestamp: {
                   gte: 1483228800000,
-                  lte: 1483232390000,
+                  lte: 1483232400000,
                   format: 'epoch_millis'
                 }
               }

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -1,19 +1,20 @@
-import _ from 'lodash';
 import getBucketSize from '../../helpers/get_bucket_size';
 import offsetTime from '../../offset_time';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
+import { set } from 'lodash';
 export default function dateHistogram(req, panel, series) {
   return next => doc => {
     const { timeField, interval } = getIntervalAndTimefield(panel, series);
-    const { bucketSize, intervalString } = getBucketSize(req, interval);
+    const { intervalString } = getBucketSize(req, interval);
     const { from, to }  = offsetTime(req, series.offset_time);
-    _.set(doc, `aggs.${series.id}.aggs.timeseries.date_histogram`, {
+
+    set(doc, `aggs.${series.id}.aggs.timeseries.date_histogram`, {
       field: timeField,
       interval: intervalString,
       min_doc_count: 0,
       extended_bounds: {
         min: from.valueOf(),
-        max: to.valueOf() - (bucketSize * 1000)
+        max: to.valueOf()
       }
     });
     return next(doc);

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/query.js
@@ -1,12 +1,8 @@
-import getBucketSize from '../../helpers/get_bucket_size';
 import offsetTime from '../../offset_time';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 export default function query(req, panel, series) {
   return next => doc => {
-    const { timeField, interval } = getIntervalAndTimefield(panel, series);
-    const {
-      bucketSize
-    } = getBucketSize(req, interval);
+    const { timeField } = getIntervalAndTimefield(panel, series);
     const { from, to } = offsetTime(req, series.offset_time);
 
     doc.size = 0;
@@ -20,7 +16,7 @@ export default function query(req, panel, series) {
       range: {
         [timeField]: {
           gte: from.valueOf(),
-          lte: to.valueOf() - (bucketSize * 1000),
+          lte: to.valueOf(),
           format: 'epoch_millis',
         }
       }

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/drop_last_bucket.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/drop_last_bucket.js
@@ -1,0 +1,14 @@
+import { get } from 'lodash';
+export function dropLastBucket(resp, panel, series) {
+  return next => results => {
+    const seriesDropLastBucket = get(series, 'override_drop_last_bucket', 1);
+    const dropLastBucket = get(panel, 'drop_last_bucket', seriesDropLastBucket);
+    if (dropLastBucket) {
+      results.forEach(item => {
+        item.data = item.data.slice(0, item.data.length - 1);
+      });
+    }
+    return next(results);
+  };
+}
+

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/index.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/index.js
@@ -5,6 +5,7 @@ import stdDeviationSibling from './std_deviation_sibling';
 import stdMetric from './std_metric';
 import stdSibling from './std_sibling';
 import timeShift from './time_shift';
+import { dropLastBucket } from './drop_last_bucket';
 
 export default [
   percentile,
@@ -13,6 +14,7 @@ export default [
   stdMetric,
   stdSibling,
   seriesAgg,
-  timeShift
+  timeShift,
+  dropLastBucket
 ];
 


### PR DESCRIPTION
Release note: This PR creates an option in "Panel Options" and the metric index pattern override to allow the user to control if the last bucket should be dropped. By default TSVB will drop the last bucket since most of the time it's incomplete. This also changes the method for dropping the last bucket to a more reliable method.

CC: @tbragin @alexfrancoeur  