### PR TITLE
Remove Version Check for Dashboard Import API

### DIFF
--- a/src/core_plugins/kibana/server/lib/import/__tests__/import_dashboards.js
+++ b/src/core_plugins/kibana/server/lib/import/__tests__/import_dashboards.js
@@ -41,13 +41,6 @@ describe('importDashboards(req)', () => {
 
   });
 
-  it('should throw an error if the version doesn\'t match', () => {
-    req.payload.version = '5.5.0';
-    return importDashboards(req).catch((err) => {
-      expect(err).to.have.property('message', 'Version 5.5.0 does not match 6.0.0.');
-    });
-  });
-
   it('should make a bulk request to create each asset', () => {
     return importDashboards(req).then(() => {
       expect(requestStub.calledOnce).to.equal(true);

--- a/src/core_plugins/kibana/server/lib/import/import_dashboards.js
+++ b/src/core_plugins/kibana/server/lib/import/import_dashboards.js
@@ -12,10 +12,6 @@ export async function importDashboards(req) {
   const savedObjectsClient = new SavedObjectsClient(config.get('kibana.index'), callAdminCluster);
 
 
-  if (payload.version !== config.get('pkg.version')) {
-    throw new Error(`Version ${payload.version} does not match ${config.get('pkg.version')}.`);
-  }
-
   const docs = payload.objects
     .filter(item => !exclude.includes(item.type));
 


### PR DESCRIPTION
This PR removes the version check for the `/api/kibana/dashboards/import` API. This causes issues for the Beats template generation script because the beats version doesn't always match up with the Elastic Stack version.

cc @monicasarbu 