### PR TITLE
Fixes #12763 - Add show_grid to the default vis structure for TSVB

### DIFF
--- a/src/core_plugins/metrics/public/kbn_vis_types/index.js
+++ b/src/core_plugins/metrics/public/kbn_vis_types/index.js
@@ -51,7 +51,8 @@ export default function MetricsVisProvider(Private) {
         interval: 'auto',
         axis_position: 'left',
         axis_formatter: 'number',
-        show_legend:1
+        show_legend:1,
+        show_grid: 1
       },
       component: require('../components/vis_editor')
     },


### PR DESCRIPTION
This PR fixes a bug that was introduced with the Visualize refactor. The default visualization structure for TSVB is missing the `show_grid` attribute, this PR adds that attribute

*Before*

![image](https://user-images.githubusercontent.com/41702/28077980-282dc2f8-6618-11e7-9395-4362cafebf1b.png)


*After*

![image](https://user-images.githubusercontent.com/41702/28077921-002e9822-6618-11e7-8ab2-834021e26a99.png)
