### PR TITLE
Uses uuid for auto-generated ids and prepends type

### DIFF
--- a/src/server/saved_objects/client/lib/compatibility.js
+++ b/src/server/saved_objects/client/lib/compatibility.js
@@ -1,3 +1,4 @@
+import uuid from 'uuid';
 import { V6_TYPE } from '../saved_objects_client';
 
 /**
@@ -29,7 +30,7 @@ export function v6BulkCreate(objects, options = {}) {
 
     acc.push({ [method]: {
       _type: V6_TYPE,
-      _id: object.id ? `${object.type}:${object.id}` : undefined
+      _id: `${object.type}:${object.id || uuid.v1()}`,
     } });
 
     acc.push(Object.assign({},

--- a/src/server/saved_objects/client/lib/handle_es_error.js
+++ b/src/server/saved_objects/client/lib/handle_es_error.js
@@ -13,13 +13,6 @@ const {
   BadRequest
 } = elasticsearch.errors;
 
-export function isSingleTypeError(error) {
-  if (!error) return;
-
-  return error.type === 'illegal_argument_exception' &&
-    error.reason.match(/the final mapping would have more than 1 type/);
-}
-
 export function handleEsError(error) {
   if (!(error instanceof Error)) {
     throw new Error('Expected an instance of Error');
@@ -50,10 +43,6 @@ export function handleEsError(error) {
   }
 
   if (error instanceof BadRequest) {
-    if (isSingleTypeError(get(error, 'body.error'))) {
-      details.type = 'is_single_type';
-    }
-
     throw Boom.badRequest(reason, details);
   }
 


### PR DESCRIPTION
This PR uses self-generated id's when creating documents. This will allow us to create type prepended id's in 6.x, allowing for direct get/update/delete instead of by query.

Without this, we will be forced to do things like this: https://github.com/elastic/kibana/pull/12794/files#diff-cc9fbe8850c8f590da1323a91d29717dR220

Here is some manual testing guidance: https://github.com/elastic/kibana/pull/12648#issuecomment-313137183

Also, ES also now returning `type_missing_exception` in 5.6 instead of an `illegal_argument_exception`