### PR TITLE
Fix a bug with the interval label for TSVB

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
@@ -84,6 +84,7 @@ function TimeseriesVisualization(props) {
       const seriesInterval = item.data[1][0] - item.data[0][0];
       if (!currentInterval || seriesInterval < currentInterval) return seriesInterval;
     }
+    return currentInterval;
   }, 0);
 
   let axisCount = 1;

--- a/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
@@ -80,8 +80,10 @@ function TimeseriesVisualization(props) {
   });
 
   const interval = series.reduce((currentInterval, item) => {
-    const seriesInterval = item.data[1][0] - item.data[0][0];
-    if (!currentInterval || seriesInterval < currentInterval) return seriesInterval;
+    if (item.data.length > 1) {
+      const seriesInterval = item.data[1][0] - item.data[0][0];
+      if (!currentInterval || seriesInterval < currentInterval) return seriesInterval;
+    }
   }, 0);
 
   let axisCount = 1;


### PR DESCRIPTION
This fixes a bug with the interval label that occurs when there is only one data point returned. The best way to reproduce this bug is to set the time range to something less the 1 day. Then change the interval to `1d` under panel options. With this PR the issue is resolved.