### PR TITLE
Use devicePixelRatio to scale up and down canvas values in TSVB for Tooltip

### DIFF
--- a/src/core_plugins/metrics/public/visualizations/components/timeseries_chart.js
+++ b/src/core_plugins/metrics/public/visualizations/components/timeseries_chart.js
@@ -4,6 +4,14 @@ import reactcss from 'reactcss';
 import FlotChart from './flot_chart';
 import Annotation from './annotation';
 
+export function scaleUp(value) {
+  return window.devicePixelRatio * value;
+}
+
+export function scaleDown(value) {
+  return value / window.devicePixelRatio;
+}
+
 class TimeseriesChart extends Component {
 
   constructor(props) {
@@ -22,11 +30,11 @@ class TimeseriesChart extends Component {
   calculateLeftRight(item, plot) {
     const canvas = plot.getCanvas();
     const point = plot.pointOffset({ x: item.datapoint[0], y: item.datapoint[1] });
-    const edge = (point.left + 10) / canvas.width;
+    const edge = (scaleUp(point.left) + 10) / canvas.width;
     let right;
     let left;
     if (edge > 0.5) {
-      right = canvas.width - point.left;
+      right = scaleDown(canvas.width) - point.left;
       left = null;
     } else {
       right = null;


### PR DESCRIPTION
This PR fixes #12866 by using devicePixelRatio to scale up the point when deciding to change the tooltip direction. It also scales down the canvas size when determining the right value for the tooltip when it switches direction. To verify this actually fixes the issue you must test this on a Mac with a Retina display. First open TSVB with any "Time Series chart" in Chrome on the retina display. Then move the tooltip to the right edge of the chart (it should cut off the tooltip). Now checkout this PR and reload the same page (on the retina display). 

Before

![image](https://user-images.githubusercontent.com/41702/29435706-e23626ca-835c-11e7-8ec9-eca23b3a85df.png)


After

![image](https://user-images.githubusercontent.com/41702/29435673-c2565fbe-835c-11e7-9676-867258e15d1d.png)
