### PR TITLE
[TSVB] Adding check for model and visData

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_editor.js
+++ b/src/core_plugins/metrics/public/components/vis_editor.js
@@ -59,6 +59,7 @@ class VisEditor extends Component {
     };
 
     if (!this.props.vis.isEditorMode()) {
+      if (!this.props.vis.params || !this.props.visData) return null;
       const reversed = this.state.reversed;
       return (
         <Visualization
@@ -75,7 +76,7 @@ class VisEditor extends Component {
 
     const { model } = this.state;
 
-    if (model) {
+    if (model && this.props.visData) {
       return (
         <div className="vis_editor">
           <VisPicker


### PR DESCRIPTION
This PR adds a check for the `model` and `visData` properties. These two values should essentially never be null. Due to a recent PR there is now a race condition which requires us to check to make sure these values are valid before rendering the rest of the React tree.