### PR TITLE
Fixes a bug with PR #13854

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_editor.js
+++ b/src/core_plugins/metrics/public/components/vis_editor.js
@@ -114,6 +114,10 @@ class VisEditor extends Component {
 
 }
 
+VisEditor.defaultProps = {
+  visData: {}
+};
+
 VisEditor.propTypes = {
   vis: PropTypes.object,
   visData: PropTypes.object,


### PR DESCRIPTION
This PR fixes a bug with PR #13854 where when the user types in an invalid interval pattern the screen goes blank because visData ends up being undefined. This PR ensures there is always a visData and model object.
