### PR TITLE
Fixes #14127 - TSVB should check id vis params instead of type

### DIFF
--- a/src/core_plugins/metrics/public/kbn_vis_types/editor_controller.js
+++ b/src/core_plugins/metrics/public/kbn_vis_types/editor_controller.js
@@ -45,7 +45,7 @@ app.controller('MetricsEditorController', (
   // If the model doesn't exist we need to either intialize it with a copy from
   // the $scope.vis._editableVis.params or create a new panel all together.
   if (!$scope.model) {
-    if ($scope.vis._editableVis.params.type) {
+    if ($scope.vis._editableVis.params.id) {
       $scope.model = _.assign({}, $scope.vis._editableVis.params);
     } else {
       $scope.model = createNewPanel();

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -1,0 +1,48 @@
+import expect from 'expect.js';
+
+export default function ({ getService, getPageObjects }) {
+  const log = getService('log');
+  const PageObjects = getPageObjects(['common', 'visualize', 'header', 'settings', 'visualBuilder']);
+
+  describe('visualize app', function describeIndexTests() {
+    before(function () {
+      const fromTime = '2015-09-19 06:31:44.000';
+      const toTime = '2015-09-22 18:31:44.000';
+
+      log.debug('navigateToApp visualize');
+      return PageObjects.common.navigateToUrl('visualize', 'new')
+        .then(function () {
+          log.debug('clickVisualBuilderChart');
+          return PageObjects.visualize.clickVisualBuilder();
+        })
+        .then(function setAbsoluteRange() {
+          log.debug('Set absolute time range from \"' + fromTime + '\" to \"' + toTime + '\"');
+          return PageObjects.header.setAbsoluteRange(fromTime, toTime);
+        })
+        .then(function () {
+          return PageObjects.header.waitUntilLoadingHasFinished();
+        })
+        .then(function sleep() {
+          return PageObjects.common.sleep(1003);
+        })
+        .then(function clickMetric() {
+          return PageObjects.visualBuilder.clickMetric();
+        });
+    });
+
+
+    describe('Visual Builder chart', function indexPatternCreation() {
+
+      it('should show correct data', function () {
+        const expectedMetricValue =  '156';
+
+        return PageObjects.visualBuilder.getMetricValue()
+          .then(function (value) {
+            log.debug(`metric value: ${value}`);
+            expect(value).to.eql(expectedMetricValue);
+          });
+      });
+    });
+  });
+}
+


### PR DESCRIPTION
This fixes #14127 by changing which property on `$scope.vis._editableVis.params` TSVB determines if the visualization is new or not. This but was introduced by #14091 https://github.com/elastic/kibana/commit/b55100e46f44265f2aeb0fd27517bcfbd16b03be#diff-ec5231bf824e6368f1bc9150f9f9946cR102