### PR TITLE
Fixes #14171 - Handle boom errors properly for vis data requests

### DIFF
--- a/src/core_plugins/metrics/server/routes/vis.js
+++ b/src/core_plugins/metrics/server/routes/vis.js
@@ -9,7 +9,8 @@ export default (server) => {
       getVisData(req)
         .then(reply)
         .catch(err => {
-          reply(Boom.wrap(err, 400));
+          if (err.isBoom && err.status === 401) return reply(err);
+          reply(Boom.wrap(err, 500));
         });
     }
   });


### PR DESCRIPTION
This PR changes the strategy for handing Boom errors. Previously we were relying on `Boom.wrap` to do the right thing. It seems as if that doesn't work properly so I reverted back to my original approach which is to check if it's a Boom error and a 401 and just responding.