### PR TITLE
[TSVB] Adding the ability to sort terms split by terms and change order

### DIFF
--- a/src/core_plugins/metrics/public/components/splits/terms.js
+++ b/src/core_plugins/metrics/public/components/splits/terms.js
@@ -5,15 +5,22 @@ import createTextHandler from '../lib/create_text_handler';
 import createSelectHandler from '../lib/create_select_handler';
 import FieldSelect from '../aggs/field_select';
 import MetricSelect from '../aggs/metric_select';
+import Select from 'react-select';
 
 export const SplitByTerms = props => {
   const handleTextChange = createTextHandler(props.onChange);
   const handleSelectChange = createSelectHandler(props.onChange);
   const { indexPattern } = props;
-  const defaults = { terms_size: 10, terms_order_by: '_count' };
+  const defaults = { terms_direction: 'desc', terms_size: 10, terms_order_by: '_count' };
   const model = { ...defaults, ...props.model };
   const { metrics } = model;
   const defaultCount = { value: '_count', label: 'Doc Count (default)' };
+  const terms = { value: '_term', label: 'Terms' };
+
+  const dirOptions = [
+    { value: 'desc', label: 'Descending' },
+    { value: 'asc', label: 'Ascending' },
+  ];
 
   return (
     <div className="vis_editor__split-container">
@@ -46,10 +53,19 @@ export const SplitByTerms = props => {
         <MetricSelect
           metrics={metrics}
           clearable={false}
-          additionalOptions={[defaultCount]}
+          additionalOptions={[defaultCount, terms]}
           onChange={handleSelectChange('terms_order_by')}
           restrict="basic"
           value={model.terms_order_by}
+        />
+      </div>
+      <div className="vis_editor__label">Direction</div>
+      <div className="vis_editor__split-aggs">
+        <Select
+          options={dirOptions}
+          clearable={false}
+          value={model.terms_direction}
+          onChange={handleSelectChange('terms_direction')}
         />
       </div>
     </div>

--- a/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
@@ -1,20 +1,39 @@
 import tickFormatter from '../../lib/tick_formatter';
-import _ from 'lodash';
 import TopN from 'plugins/metrics/visualizations/components/top_n';
 import getLastValue from 'plugins/metrics/visualizations/lib/get_last_value';
-
 import color from 'color';
 import replaceVars from '../../lib/replace_vars';
-
 import PropTypes from 'prop-types';
-
 import React from 'react';
+import { sortBy, first, get, gt, gte, lt, lte } from 'lodash';
+const OPPERATORS = [ gt, gte, lt, lte ];
+
+function sortByDirection(data, direction, fn) {
+  if (direction === 'desc') {
+    return sortBy(data, fn).reverse();
+  }
+  return sortBy(data, fn);
+}
+
+function sortSeries(visData, model) {
+  const series = get(visData, `${model.id}.series`, []);
+  return model.series.reduce((acc, item) => {
+    const itemSeries =  series.filter(s => {
+      const id = first(s.id.split(/:/));
+      return id === item.id;
+    });
+    const direction = item.terms_direction || 'desc';
+    if (item.terms_order_by === '_term') return acc.concat(itemSeries);
+    return acc.concat(sortByDirection(itemSeries, direction , s => getLastValue(s.data)));
+  }, []);
+}
+
 function TopNVisualization(props) {
   const { backgroundColor, model, visData } = props;
 
-  const series = _.get(visData, `${model.id}.series`, [])
+  const series = sortSeries(visData, model)
     .map(item => {
-      const id = _.first(item.id.split(/:/));
+      const id = first(item.id.split(/:/));
       const seriesConfig = model.series.find(s => s.id === id);
       if (seriesConfig) {
         const formatter = tickFormatter(seriesConfig.formatter, seriesConfig.value_template);
@@ -23,16 +42,17 @@ function TopNVisualization(props) {
         if (model.bar_color_rules) {
           model.bar_color_rules.forEach(rule => {
             if (rule.opperator && rule.value != null && rule.bar_color) {
-              if (_[rule.opperator](value, rule.value)) {
+              if (OPPERATORS[rule.opperator](value, rule.value)) {
                 color = rule.bar_color;
               }
             }
           });
         }
-        return _.assign({}, item, {
+        return {
+          ...item,
           color,
           tickFormatter: formatter
-        });
+        };
       }
       return item;
     });

--- a/src/core_plugins/metrics/public/less/editor.less
+++ b/src/core_plugins/metrics/public/less/editor.less
@@ -222,7 +222,7 @@
 }
 .vis_editor__split-term_count {
   .vis_editor__input;
-  width: 50;
+  width: 60px;
 }
 
 // vis_picker.js

--- a/src/core_plugins/metrics/public/visualizations/components/top_n.js
+++ b/src/core_plugins/metrics/public/visualizations/components/top_n.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import _ from 'lodash';
 import getLastValue from '../lib/get_last_value';
 import reactcss from 'reactcss';
 
@@ -61,9 +60,7 @@ class TopN extends Component {
       return lastValue > max ? lastValue : max;
     }, 0);
 
-    const rows = _.sortBy(this.props.series, s => getLastValue(s.data, s.data.length))
-      .reverse()
-      .map(this.renderRow(maxValue));
+    const rows = this.props.series.map(this.renderRow(maxValue));
     let className = 'rhythm_top_n';
     if (this.props.reversed) {
       className += ' reversed';
@@ -84,14 +81,16 @@ class TopN extends Component {
 
 TopN.defaultProps = {
   tickFormatter: n => n,
-  onClick: i => i
+  onClick: i => i,
+  direction: 'desc'
 };
 
 TopN.propTypes = {
   tickFormatter: PropTypes.func,
   onClick: PropTypes.func,
   series: PropTypes.array,
-  reversed: PropTypes.bool
+  reversed: PropTypes.bool,
+  direction: PropTypes.string
 };
 
 export default TopN;

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/split_by_terms.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/split_by_terms.js
@@ -42,6 +42,29 @@ describe('splitByTerms(req, panel, series)', () => {
         test: {
           terms: {
             field: 'host',
+            order: {
+              _count: 'desc'
+            },
+            size: 10
+          }
+        }
+      }
+    });
+  });
+
+  it('returns a valid terms agg sort by terms', () => {
+    const next = doc => doc;
+    series.terms_order_by = '_term';
+    series.terms_direction = 'asc';
+    const doc = splitByTerms(req, panel, series)(next)({});
+    expect(doc).to.eql({
+      aggs: {
+        test: {
+          terms: {
+            field: 'host',
+            order: {
+              _term: 'asc'
+            },
             size: 10
           }
         }

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/split_by_terms.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/split_by_terms.js
@@ -17,6 +17,8 @@ export default function splitByTerm(req, panel, series) {
         to
       }  = getTimerange(req);
 
+      const direction = series.terms_direction || 'desc';
+
       _.set(doc, `aggs.${series.id}.terms.field`, series.terms_field);
       _.set(doc, `aggs.${series.id}.terms.size`, series.terms_size);
       const metric = series.metrics.find(item => item.id === series.terms_order_by);
@@ -25,7 +27,7 @@ export default function splitByTerm(req, panel, series) {
         const fn = bucketTransform[metric.type];
         const bucketPath = getBucketsPath(series.terms_order_by, series.metrics)
           .replace(series.terms_order_by, `${sortAggKey} > SORT`);
-        _.set(doc, `aggs.${series.id}.terms.order`, { [bucketPath]: 'desc' });
+        _.set(doc, `aggs.${series.id}.terms.order`, { [bucketPath]: direction });
         _.set(doc, `aggs.${series.id}.aggs`, {
           [sortAggKey]: {
             filter: {
@@ -40,6 +42,10 @@ export default function splitByTerm(req, panel, series) {
             aggs: { SORT: fn(metric) }
           }
         });
+      } else if (['_term', '_count'].includes(series.terms_order_by)) {
+        _.set(doc, `aggs.${series.id}.terms.order`, { [series.terms_order_by]: direction });
+      } else {
+        _.set(doc, `aggs.${series.id}.terms.order`, { _count: direction });
       }
     }
     return next(doc);


### PR DESCRIPTION
This PR adds the option to sort by terms as well as change the direction of the terms `asc` and `desc`, for the terms split

![image](https://user-images.githubusercontent.com/41702/31198371-e67b8032-a908-11e7-89fc-480336745883.png)
