### PR TITLE
[TSVB] Fix CSS Bug with Top N Values

### DIFF
--- a/src/core_plugins/metrics/public/visualizations/less/includes/top_n.less
+++ b/src/core_plugins/metrics/public/visualizations/less/includes/top_n.less
@@ -8,38 +8,24 @@
 }
 
 .rhythm_top_n__labels,
-.rhythm_top_n__values {
-  // flex: 0 0 auto;
+.rhythm_top_n__value {
   text-align: right;
-}
-.rhythm_top_n__bars {
-  // flex: 1 0 auto;
+  white-space: nowrap;
+  line-height: 0;
+  vertical-align: middle;
 }
 
 .rhythm_top_n__label {
-  // margin: 4px 10px 4px 0;
   color: @textColor;
-  white-space: nowrap;
-  text-align: right;
-  line-height: 0;
   padding: 4px 0;
-  vertical-align: middle;
-  // height: 18px;
 }
 
 .rhythm_top_n__value {
-  // margin: 4px 0 4px 10px;
   color: @valueColor;
-  text-align: right;
-  line-height: 0;
   padding: 4px 4px 4px 0;
-  vertical-align: middle;
-  // height: 18px;
 }
 
 .rhythm_top_n__bar {
-  // height: 16px;
-  // margin: 4px 0;
   padding: 4px 10px;
   vertical-align: middle;
 }


### PR DESCRIPTION
This PR fixes a bug with the Top N visualization in TSVB. There should be a `white-space: nowrap` on the value to prevent the value from wrapping when the user adds spaces to the value template.

Before:

![image](https://user-images.githubusercontent.com/41702/31103229-b28a3694-a78a-11e7-8ff2-5bd01cbd7a11.png)


After

![image](https://user-images.githubusercontent.com/41702/31103207-9f155242-a78a-11e7-83ec-7d5f4c080098.png)
