### PR TITLE
[TSVB] Fixes #14470 - Remove field restriction on cardinality agg

### DIFF
--- a/src/core_plugins/metrics/public/components/aggs/std_agg.js
+++ b/src/core_plugins/metrics/public/components/aggs/std_agg.js
@@ -14,7 +14,7 @@ function StandardAgg(props) {
   const handleSelectChange = createSelectHandler(handleChange);
   let restrict = 'numeric';
   if (model.type === 'cardinality') {
-    restrict = 'string';
+    restrict = 'none';
   }
 
   const indexPattern = series.override_index_pattern && series.series_index_pattern || panel.index_pattern;


### PR DESCRIPTION
This PR fixes #14470 by removing the field constraints from the cardinality agg for TSVB.