### PR TITLE
[TSVB] Stacked series should not contain null values

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
@@ -59,6 +59,16 @@ function TimeseriesVisualization(props) {
         .filter(r => _.startsWith(r.id, s.id))
         .forEach(r => delete r.label);
     }
+    if (s.stacked !== 'none') {
+      series
+        .filter(r => _.startsWith(r.id, s.id))
+        .forEach(row => {
+          row.data = row.data.map(point => {
+            if (!point[1]) return [point[0], 0];
+            return point;
+          });
+        });
+    }
     if (s.stacked === 'percent') {
       s.seperate_axis = true;
       s.axisFormatter = 'percent';


### PR DESCRIPTION
This PR fixes stacking in TSVB by replacing the null values with zero for stacked series.

Before:

![image](https://user-images.githubusercontent.com/41702/32746517-21f083b8-c873-11e7-89c5-a4b583926db8.png)


After:

![image](https://user-images.githubusercontent.com/41702/32746498-0b173d80-c873-11e7-9b83-4df535bd413b.png)
