### PR TITLE
Fixing typo where OPERATORS was created as an array instead of an object

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/top_n/vis.js
@@ -6,7 +6,7 @@ import replaceVars from '../../lib/replace_vars';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { sortBy, first, get, gt, gte, lt, lte } from 'lodash';
-const OPPERATORS = [ gt, gte, lt, lte ];
+const OPPERATORS = { gt, gte, lt, lte };
 
 function sortByDirection(data, direction, fn) {
   if (direction === 'desc') {


### PR DESCRIPTION
This PR fixes a typo where OPERATORS was created as an array instead of an object.