### PR TITLE
[TSVB] Introducing Timerange Data Mode for Metric Style Visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@elastic/eui": "4.0.1",
+    "@elastic/datemath": "4.0.2",
     "@elastic/filesaver": "1.1.2",
     "@elastic/numeral": "2.3.2",
     "@elastic/ui-ace": "0.2.3",

--- a/src/core_plugins/metrics/common/metric_types.js
+++ b/src/core_plugins/metrics/common/metric_types.js
@@ -1,0 +1,5 @@
+export const metricTypes = ['gauge', 'table', 'metric', 'top_n'];
+
+export function isMetric(panelType) {
+  return metricTypes.includes(panelType);
+}

--- a/src/core_plugins/metrics/common/metric_types.js
+++ b/src/core_plugins/metrics/common/metric_types.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export const metricTypes = ['gauge', 'table', 'metric', 'top_n'];
 
 export function isMetric(panelType) {

--- a/src/core_plugins/metrics/public/components/aggs/agg_select.js
+++ b/src/core_plugins/metrics/public/components/aggs/agg_select.js
@@ -80,8 +80,12 @@ function filterByPanelType(panelType) {
   };
 }
 
+function includeCalculation() {
+  return agg => agg.value === 'calculation';
+}
+
 function AggSelect(props) {
-  const { siblings, panelType, value, timerangeMode } = props;
+  const { siblings, panelType, value, timerangeMode, metricsOnly } = props;
 
   const selectedOption = allAggOptions.find(option => {
     return value === option.value;
@@ -94,7 +98,7 @@ function AggSelect(props) {
   if (siblings.length <= 1) enablePipelines = false;
 
   let options;
-  if (panelType === 'metrics') {
+  if (metricsOnly) {
     options = metricAggs;
   } else if (isMetric(panelType) && timerangeMode === 'all') {
     options = [
@@ -102,7 +106,7 @@ function AggSelect(props) {
       ...metricAggs,
       { label: 'Parent Pipeline Aggregations', value: null, pipeline: true, heading: true, disabled: true },
       ...pipelineAggs.filter(filterByPanelType(panelType))
-        .filter(agg => agg.value === 'calculation')
+        .filter(includeCalculation())
         .map(agg => ({ ...agg, disabled: !enablePipelines })),
     ];
   } else {
@@ -147,12 +151,17 @@ function AggSelect(props) {
   );
 }
 
+AggSelect.defaultProps = {
+  metricsOnly: false
+};
+
 AggSelect.propTypes = {
   onChange: PropTypes.func,
   panelType: PropTypes.string,
   siblings: PropTypes.array,
   value: PropTypes.string,
   timerangeMode: PropTypes.oneOf(['all', 'last']),
+  metricsOnly: PropTypes.boolean
 };
 
 export default AggSelect;

--- a/src/core_plugins/metrics/public/components/aggs/agg_select.js
+++ b/src/core_plugins/metrics/public/components/aggs/agg_select.js
@@ -161,7 +161,7 @@ AggSelect.propTypes = {
   siblings: PropTypes.array,
   value: PropTypes.string,
   timerangeMode: PropTypes.oneOf(['all', 'last']),
-  metricsOnly: PropTypes.boolean
+  metricsOnly: PropTypes.bool
 };
 
 export default AggSelect;

--- a/src/core_plugins/metrics/public/components/aggs/agg_select.js
+++ b/src/core_plugins/metrics/public/components/aggs/agg_select.js
@@ -22,6 +22,7 @@ import React from 'react';
 import {
   EuiComboBox,
 } from '@elastic/eui';
+import { isMetric } from '../../../common/metric_types';
 
 const metricAggs = [
   { label: 'Average', value: 'avg' },
@@ -80,7 +81,7 @@ function filterByPanelType(panelType) {
 }
 
 function AggSelect(props) {
-  const { siblings, panelType, value } = props;
+  const { siblings, panelType, value, timerangeMode } = props;
 
   const selectedOption = allAggOptions.find(option => {
     return value === option.value;
@@ -95,6 +96,15 @@ function AggSelect(props) {
   let options;
   if (panelType === 'metrics') {
     options = metricAggs;
+  } else if (isMetric(panelType) && timerangeMode === 'all') {
+    options = [
+      { label: 'Metric Aggregations', value: null, heading: true, disabled: true },
+      ...metricAggs,
+      { label: 'Parent Pipeline Aggregations', value: null, pipeline: true, heading: true, disabled: true },
+      ...pipelineAggs.filter(filterByPanelType(panelType))
+        .filter(agg => agg.value === 'calculation')
+        .map(agg => ({ ...agg, disabled: !enablePipelines })),
+    ];
   } else {
     options = [
       {
@@ -142,6 +152,7 @@ AggSelect.propTypes = {
   panelType: PropTypes.string,
   siblings: PropTypes.array,
   value: PropTypes.string,
+  timerangeMode: PropTypes.oneOf(['all', 'last']),
 };
 
 export default AggSelect;

--- a/src/core_plugins/metrics/public/components/aggs/calculation.js
+++ b/src/core_plugins/metrics/public/components/aggs/calculation.js
@@ -32,12 +32,13 @@ import Vars from './vars';
 import { htmlIdGenerator } from '@elastic/eui';
 
 class CalculationAgg extends Component {
-
   componentWillMount() {
     if (!this.props.model.variables) {
-      this.props.onChange(_.assign({}, this.props.model, {
-        variables: [{ id: uuid.v1() }]
-      }));
+      this.props.onChange(
+        _.assign({}, this.props.model, {
+          variables: [{ id: uuid.v1() }],
+        })
+      );
     }
   }
 
@@ -66,6 +67,7 @@ class CalculationAgg extends Component {
             <div className="vis_editor__label">Aggregation</div>
             <AggSelect
               panelType={this.props.panel.type}
+              timerangeMode={this.props.panel.timerange_mode}
               siblings={this.props.siblings}
               value={model.type}
               onChange={handleSelectChange('type')}
@@ -82,8 +84,9 @@ class CalculationAgg extends Component {
             <div className="vis_editor__row_item">
               <label className="vis_editor__label" htmlFor={htmlId('painless')}>
                 Painless Script - Variables are keys on the <code>params</code>
-                object, i.e. <code>params.&lt;name&gt;</code>.
-                To access the bucket interval (in milliseconds) use <code>params._interval</code>.
+                object, i.e. <code>params.&lt;name&gt;</code>. To access the
+                bucket interval (in milliseconds) use{' '}
+                <code>params._interval</code>.
               </label>
               <input
                 id={htmlId('painless')}
@@ -98,7 +101,6 @@ class CalculationAgg extends Component {
       </AggRow>
     );
   }
-
 }
 
 CalculationAgg.propTypes = {

--- a/src/core_plugins/metrics/public/components/aggs/cumulative_sum.js
+++ b/src/core_plugins/metrics/public/components/aggs/cumulative_sum.js
@@ -40,6 +40,7 @@ function CumulativeSumAgg(props) {
       <div className="vis_editor__row_item">
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
+          timerangeMode={props.panel.timerange_mode}
           panelType={props.panel.type}
           siblings={props.siblings}
           value={model.type}
@@ -57,7 +58,6 @@ function CumulativeSumAgg(props) {
       </div>
     </AggRow>
   );
-
 }
 
 CumulativeSumAgg.propTypes = {

--- a/src/core_plugins/metrics/public/components/aggs/derivative.js
+++ b/src/core_plugins/metrics/public/components/aggs/derivative.js
@@ -51,6 +51,7 @@ export const DerivativeAgg = props => {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerange_mode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}

--- a/src/core_plugins/metrics/public/components/aggs/field_select.js
+++ b/src/core_plugins/metrics/public/components/aggs/field_select.js
@@ -41,14 +41,16 @@ function FieldSelect(props) {
   const selectedOptions = selectedOption ? [selectedOption] : [];
 
   return (
-    <EuiComboBox
-      placeholder="Select field..."
-      isDisabled={disabled}
-      options={options}
-      selectedOptions={selectedOptions}
-      onChange={onChange}
-      singleSelection={true}
-    />
+    <div data-test-subj="fieldSelector" className="vis_editor__row_item">
+      <EuiComboBox
+        placeholder="Select field..."
+        isDisabled={disabled}
+        options={options}
+        selectedOptions={selectedOptions}
+        onChange={onChange}
+        singleSelection={true}
+      />
+    </div>
   );
 }
 

--- a/src/core_plugins/metrics/public/components/aggs/filter_ratio.js
+++ b/src/core_plugins/metrics/public/components/aggs/filter_ratio.js
@@ -28,21 +28,19 @@ import createTextHandler from '../lib/create_text_handler';
 import { htmlIdGenerator } from '@elastic/eui';
 
 export const FilterRatioAgg = props => {
-  const {
-    series,
-    fields,
-    panel
-  } = props;
+  const { series, fields, panel } = props;
 
   const handleChange = createChangeHandler(props.onChange, props.model);
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
-  const indexPattern = series.override_index_pattern && series.series_index_pattern || panel.index_pattern;
+  const indexPattern =
+    (series.override_index_pattern && series.series_index_pattern) ||
+    panel.index_pattern;
 
   const defaults = {
     numerator: '*',
     denominator: '*',
-    metric_agg: 'count'
+    metric_agg: 'count',
   };
 
   const model = { ...defaults, ...props.model };
@@ -63,6 +61,7 @@ export const FilterRatioAgg = props => {
           <div className="vis_editor__row_item">
             <div className="vis_editor__label">Aggregation</div>
             <AggSelect
+              timerangeMode={props.panel.timerange_mode}
               panelType={props.panel.type}
               siblings={props.siblings}
               value={model.type}
@@ -82,7 +81,10 @@ export const FilterRatioAgg = props => {
             />
           </div>
           <div className="vis_editor__row_item">
-            <label className="vis_editor__label" htmlFor={htmlId('denominator')}>
+            <label
+              className="vis_editor__label"
+              htmlFor={htmlId('denominator')}
+            >
               Denominator
             </label>
             <input
@@ -100,11 +102,12 @@ export const FilterRatioAgg = props => {
             <AggSelect
               siblings={props.siblings}
               panelType="metrics"
+              timerangeMode={props.panel.timerange_mode}
               value={model.metric_agg}
               onChange={handleSelectChange('metric_agg')}
             />
           </div>
-          { model.metric_agg !== 'count' ? (
+          {model.metric_agg !== 'count' ? (
             <div className="vis_editor__row_item">
               <label className="vis_editor__label" htmlFor={htmlId('aggField')}>
                 Field
@@ -118,7 +121,8 @@ export const FilterRatioAgg = props => {
                 value={model.field}
                 onChange={handleSelectChange('field')}
               />
-            </div>) : null }
+            </div>
+          ) : null}
         </div>
       </div>
     </AggRow>

--- a/src/core_plugins/metrics/public/components/aggs/filter_ratio.js
+++ b/src/core_plugins/metrics/public/components/aggs/filter_ratio.js
@@ -74,6 +74,7 @@ export const FilterRatioAgg = props => {
             </label>
             <input
               id={htmlId('numerator')}
+              data-test-subj="filterRatioNumerator"
               className="vis_editor__input-grows-100"
               onChange={handleTextChange('numerator')}
               value={model.numerator}
@@ -89,6 +90,7 @@ export const FilterRatioAgg = props => {
             </label>
             <input
               id={htmlId('denominator')}
+              data-test-subj="filterRatioDenominator"
               className="vis_editor__input-grows-100"
               onChange={handleTextChange('denominator')}
               value={model.denominator}
@@ -97,7 +99,7 @@ export const FilterRatioAgg = props => {
           </div>
         </div>
         <div style={{ flex: '1 0 auto', display: 'flex', marginTop: '10px' }}>
-          <div className="vis_editor__row_item">
+          <div className="vis_editor__row_item" data-test-subj="filterRatioMetricAgg">
             <div className="vis_editor__label">Metric Aggregation</div>
             <AggSelect
               siblings={props.siblings}

--- a/src/core_plugins/metrics/public/components/aggs/filter_ratio.js
+++ b/src/core_plugins/metrics/public/components/aggs/filter_ratio.js
@@ -101,7 +101,7 @@ export const FilterRatioAgg = props => {
             <div className="vis_editor__label">Metric Aggregation</div>
             <AggSelect
               siblings={props.siblings}
-              panelType="metrics"
+              metricsOnly={true}
               timerangeMode={props.panel.timerange_mode}
               value={model.metric_agg}
               onChange={handleSelectChange('metric_agg')}

--- a/src/core_plugins/metrics/public/components/aggs/moving_average.js
+++ b/src/core_plugins/metrics/public/components/aggs/moving_average.js
@@ -76,7 +76,6 @@ export const MovingAverageAgg = props => {
           <div className="vis_editor__row_item">
             <div className="vis_editor__label">Aggregation</div>
             <AggSelect
-              panel={props.panel}
               panelType={props.panel.type}
               siblings={props.siblings}
               value={model.type}

--- a/src/core_plugins/metrics/public/components/aggs/moving_average.js
+++ b/src/core_plugins/metrics/public/components/aggs/moving_average.js
@@ -76,6 +76,7 @@ export const MovingAverageAgg = props => {
           <div className="vis_editor__row_item">
             <div className="vis_editor__label">Aggregation</div>
             <AggSelect
+              panel={props.panel}
               panelType={props.panel.type}
               siblings={props.siblings}
               value={model.type}

--- a/src/core_plugins/metrics/public/components/aggs/percentile.js
+++ b/src/core_plugins/metrics/public/components/aggs/percentile.js
@@ -28,6 +28,7 @@ import AddDeleteButtons from '../add_delete_buttons';
 import uuid from 'uuid';
 import createChangeHandler from '../lib/create_change_handler';
 import createSelectHandler from '../lib/create_select_handler';
+import { createNewPercentile } from '../lib/create_new_percentile';
 import {
   htmlIdGenerator,
   EuiComboBox,
@@ -69,7 +70,7 @@ class Percentiles extends Component {
     const selectedModeOption = modeOptions.find(option => {
       return model.mode === option.value;
     });
-    return  (
+    return (
       <div className="vis_editor__percentiles-row" key={model.id}>
         <div className="vis_editor__percentiles-content">
           <input
@@ -128,12 +129,12 @@ class Percentiles extends Component {
 
   render() {
     const { model, name } = this.props;
-    if (!model[name]) return (<div/>);
+    if (!model[name]) return (<div />);
 
     const rows = model[name].map(this.renderRow);
     return (
       <div className="vis_editor__percentiles">
-        { rows }
+        {rows}
       </div>
     );
   }
@@ -154,9 +155,11 @@ class PercentileAgg extends Component { // eslint-disable-line react/no-multi-co
 
   componentWillMount() {
     if (!this.props.model.percentiles) {
-      this.props.onChange(_.assign({}, this.props.model, {
-        percentiles: [newPercentile({ value: 50 })]
-      }));
+      this.props.onChange(
+        _.assign({}, this.props.model, {
+          percentiles: [createNewPercentile({ value: 50 })],
+        })
+      );
     }
   }
 
@@ -165,7 +168,9 @@ class PercentileAgg extends Component { // eslint-disable-line react/no-multi-co
 
     const handleChange = createChangeHandler(this.props.onChange, model);
     const handleSelectChange = createSelectHandler(handleChange);
-    const indexPattern = series.override_index_pattern && series.series_index_pattern || panel.index_pattern;
+    const indexPattern =
+      (series.override_index_pattern && series.series_index_pattern) ||
+      panel.index_pattern;
 
     return (
       <AggRow
@@ -181,6 +186,7 @@ class PercentileAgg extends Component { // eslint-disable-line react/no-multi-co
               <div className="vis_editor__label">Aggregation</div>
               <AggSelect
                 panelType={this.props.panel.type}
+                timerangeMode={this.props.panel.timerangeMode}
                 siblings={this.props.siblings}
                 value={model.type}
                 onChange={handleSelectChange('type')}
@@ -207,7 +213,6 @@ class PercentileAgg extends Component { // eslint-disable-line react/no-multi-co
       </AggRow>
     );
   }
-
 }
 
 PercentileAgg.propTypes = {

--- a/src/core_plugins/metrics/public/components/aggs/percentile_rank.js
+++ b/src/core_plugins/metrics/public/components/aggs/percentile_rank.js
@@ -36,7 +36,9 @@ export const PercentileRankAgg = props => {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
 
-  const indexPattern = series.override_index_pattern && series.series_index_pattern || panel.index_pattern;
+  const indexPattern =
+    (series.override_index_pattern && series.series_index_pattern) ||
+    panel.index_pattern;
   const htmlId = htmlIdGenerator();
 
   return (
@@ -51,13 +53,16 @@ export const PercentileRankAgg = props => {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerange_mode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}
         />
       </div>
       <div className="vis_editor__row_item">
-        <label className="vis_editor__label" htmlFor={htmlId('field')}>Field</label>
+        <label className="vis_editor__label" htmlFor={htmlId('field')}>
+          Field
+        </label>
         <FieldSelect
           id={htmlId('field')}
           fields={fields}
@@ -69,7 +74,9 @@ export const PercentileRankAgg = props => {
         />
       </div>
       <div className="vis_editor__percentile_rank_value">
-        <label className="vis_editor__label" htmlFor={htmlId('value')}>Value</label>
+        <label className="vis_editor__label" htmlFor={htmlId('value')}>
+          Value
+        </label>
         <input
           id={htmlId('value')}
           className="vis_editor__input-grows"

--- a/src/core_plugins/metrics/public/components/aggs/percentiles.js
+++ b/src/core_plugins/metrics/public/components/aggs/percentiles.js
@@ -1,0 +1,133 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import _ from 'lodash';
+import * as collectionActions from '../lib/collection_actions';
+import AddDeleteButtons from '../add_delete_buttons';
+import Select from 'react-select';
+import { htmlIdGenerator } from '@elastic/eui';
+import { createNewPercentile } from '../lib/create_new_percentile';
+
+export class Percentiles extends Component {
+  constructor(props) {
+    super(props);
+    this.renderRow = this.renderRow.bind(this);
+  }
+
+  handleTextChange(item, name) {
+    return e => {
+      const handleChange = collectionActions.handleChange.bind(
+        null,
+        this.props
+      );
+      const part = {};
+      part[name] = _.get(e, 'value', _.get(e, 'target.value'));
+      handleChange(_.assign({}, item, part));
+    };
+  }
+
+  renderRow(row, i, items) {
+    const defaults = { value: '', percentile: '', shade: '' };
+    const model = { ...defaults, ...row };
+    const handleAdd = collectionActions.handleAdd.bind(
+      null,
+      this.props,
+      createNewPercentile
+    );
+    const handleDelete = collectionActions.handleDelete.bind(
+      null,
+      this.props,
+      model
+    );
+    const modeOptions = [
+      { label: 'Line', value: 'line' },
+      { label: 'Band', value: 'band' },
+    ];
+    const optionsStyle = {};
+    if (model.mode === 'line') {
+      optionsStyle.display = 'none';
+    }
+    const htmlId = htmlIdGenerator(model.id);
+    return (
+      <div className="vis_editor__percentiles-row" key={model.id}>
+        <div className="vis_editor__percentiles-content">
+          <input
+            aria-label="Percentile"
+            placeholder="Percentile"
+            className="vis_editor__input-grows"
+            type="number"
+            step="1"
+            onChange={this.handleTextChange(model, 'value')}
+            value={model.value}
+          />
+          <label className="vis_editor__label" htmlFor={htmlId('mode')}>
+            Mode
+          </label>
+          <div className="vis_editor__row_item">
+            <Select
+              inputProps={{ id: htmlId('mode') }}
+              clearable={false}
+              onChange={this.handleTextChange(model, 'mode')}
+              options={modeOptions}
+              value={model.mode}
+            />
+          </div>
+          <label
+            style={optionsStyle}
+            className="vis_editor__label"
+            htmlFor={htmlId('fillTo')}
+          >
+            Fill To
+          </label>
+          <input
+            id={htmlId('fillTo')}
+            style={optionsStyle}
+            className="vis_editor__input-grows"
+            type="number"
+            step="1"
+            onChange={this.handleTextChange(model, 'percentile')}
+            value={model.percentile}
+          />
+          <label
+            style={optionsStyle}
+            className="vis_editor__label"
+            htmlFor={htmlId('shade')}
+          >
+            Shade (0 to 1)
+          </label>
+          <input
+            id={htmlId('shade')}
+            style={optionsStyle}
+            className="vis_editor__input-grows"
+            type="number"
+            step="0.1"
+            onChange={this.handleTextChange(model, 'shade')}
+            value={model.shade}
+          />
+        </div>
+        <AddDeleteButtons
+          onAdd={handleAdd}
+          onDelete={handleDelete}
+          disableDelete={items.length < 2}
+        />
+      </div>
+    );
+  }
+
+  render() {
+    const { model, name } = this.props;
+    if (!model[name]) return <div />;
+
+    const rows = model[name].map(this.renderRow);
+    return <div className="vis_editor__percentiles">{rows}</div>;
+  }
+}
+
+Percentiles.defaultProps = {
+  name: 'percentile',
+};
+
+Percentiles.propTypes = {
+  name: PropTypes.string,
+  model: PropTypes.object,
+  onChange: PropTypes.func,
+};

--- a/src/core_plugins/metrics/public/components/aggs/percentiles.js
+++ b/src/core_plugins/metrics/public/components/aggs/percentiles.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import _ from 'lodash';
@@ -60,7 +79,7 @@ export class Percentiles extends Component {
             value={model.value}
           />
           <label className="vis_editor__label" htmlFor={htmlId('mode')}>
-            Mode
+                        Mode
           </label>
           <div className="vis_editor__row_item">
             <Select
@@ -76,7 +95,7 @@ export class Percentiles extends Component {
             className="vis_editor__label"
             htmlFor={htmlId('fillTo')}
           >
-            Fill To
+                        Fill To
           </label>
           <input
             id={htmlId('fillTo')}
@@ -92,7 +111,7 @@ export class Percentiles extends Component {
             className="vis_editor__label"
             htmlFor={htmlId('shade')}
           >
-            Shade (0 to 1)
+                        Shade (0 to 1)
           </label>
           <input
             id={htmlId('shade')}

--- a/src/core_plugins/metrics/public/components/aggs/positive_only.js
+++ b/src/core_plugins/metrics/public/components/aggs/positive_only.js
@@ -46,6 +46,7 @@ export const PositiveOnlyAgg = props => {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerangeMode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}

--- a/src/core_plugins/metrics/public/components/aggs/serial_diff.js
+++ b/src/core_plugins/metrics/public/components/aggs/serial_diff.js
@@ -50,6 +50,7 @@ export const SerialDiffAgg = props => {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerange_mode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}
@@ -65,7 +66,9 @@ export const SerialDiffAgg = props => {
         />
       </div>
       <div>
-        <label className="vis_editor__label" htmlFor={htmlId('lag')}>Lag</label>
+        <label className="vis_editor__label" htmlFor={htmlId('lag')}>
+          Lag
+        </label>
         <input
           id={htmlId('lag')}
           className="vis_editor__input"

--- a/src/core_plugins/metrics/public/components/aggs/series_agg.js
+++ b/src/core_plugins/metrics/public/components/aggs/series_agg.js
@@ -81,6 +81,7 @@ function SeriesAgg(props) {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={panel.type}
+          timerangeMode={panel.timerange_mode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}
@@ -98,7 +99,6 @@ function SeriesAgg(props) {
       </div>
     </AggRow>
   );
-
 }
 
 SeriesAgg.propTypes = {

--- a/src/core_plugins/metrics/public/components/aggs/static.js
+++ b/src/core_plugins/metrics/public/components/aggs/static.js
@@ -34,7 +34,7 @@ export const Static = props => {
   const defaults = {
     numerator: '*',
     denominator: '*',
-    metric_agg: 'count'
+    metric_agg: 'count',
   };
 
   const model = { ...defaults, ...props.model };
@@ -54,13 +54,17 @@ export const Static = props => {
             <div className="vis_editor__label">Aggregation</div>
             <AggSelect
               panelType={props.panel.type}
+              timerangeMode={props.panel.timerange_mode}
               siblings={props.siblings}
               value={model.type}
               onChange={handleSelectChange('type')}
             />
           </div>
           <div className="vis_editor__row_item">
-            <label className="vis_editor__label" htmlFor={htmlId('staticValue')}>
+            <label
+              className="vis_editor__label"
+              htmlFor={htmlId('staticValue')}
+            >
               Static Value
             </label>
             <input

--- a/src/core_plugins/metrics/public/components/aggs/std_agg.js
+++ b/src/core_plugins/metrics/public/components/aggs/std_agg.js
@@ -36,7 +36,9 @@ function StandardAgg(props) {
     restrict = 'none';
   }
 
-  const indexPattern = series.override_index_pattern && series.series_index_pattern || panel.index_pattern;
+  const indexPattern =
+    (series.override_index_pattern && series.series_index_pattern) ||
+    panel.index_pattern;
   const htmlId = htmlIdGenerator();
 
   return (
@@ -51,31 +53,30 @@ function StandardAgg(props) {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerange_mode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}
         />
       </div>
-      {
-        model.type !== 'count'
-          ? (
-            <div className="vis_editor__item">
-              <label className="vis_editor__label" htmlFor={htmlId('field')}>Field</label>
-              <FieldSelect
-                id={htmlId('field')}
-                fields={fields}
-                type={model.type}
-                restrict={restrict}
-                indexPattern={indexPattern}
-                value={model.field}
-                onChange={handleSelectChange('field')}
-              />
-            </div>
-          ) : null
-      }
+      {model.type !== 'count' ? (
+        <div className="vis_editor__item">
+          <label className="vis_editor__label" htmlFor={htmlId('field')}>
+            Field
+          </label>
+          <FieldSelect
+            id={htmlId('field')}
+            fields={fields}
+            type={model.type}
+            restrict={restrict}
+            indexPattern={indexPattern}
+            value={model.field}
+            onChange={handleSelectChange('field')}
+          />
+        </div>
+      ) : null}
     </AggRow>
   );
-
 }
 
 StandardAgg.propTypes = {

--- a/src/core_plugins/metrics/public/components/aggs/std_deviation.js
+++ b/src/core_plugins/metrics/public/components/aggs/std_deviation.js
@@ -49,7 +49,9 @@ export const StandardDeviationAgg = props => {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
 
-  const indexPattern = series.override_index_pattern && series.series_index_pattern || panel.index_pattern;
+  const indexPattern =
+    (series.override_index_pattern && series.series_index_pattern) ||
+    panel.index_pattern;
   const htmlId = htmlIdGenerator();
   const selectedModeOption = modeOptions.find(option => {
     return model.mode === option.value;
@@ -67,13 +69,16 @@ export const StandardDeviationAgg = props => {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerangeMode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}
         />
       </div>
       <div className="vis_editor__std_deviation-field">
-        <label className="vis_editor__label" htmlFor={htmlId('field')}>Field</label>
+        <label className="vis_editor__label" htmlFor={htmlId('field')}>
+          Field
+        </label>
         <FieldSelect
           id={htmlId('field')}
           fields={fields}
@@ -85,7 +90,9 @@ export const StandardDeviationAgg = props => {
         />
       </div>
       <div className="vis_editor__std_deviation-sigma_item">
-        <label className="vis_editor__label" htmlFor={htmlId('sigma')}>Sigma</label>
+        <label className="vis_editor__label" htmlFor={htmlId('sigma')}>
+          Sigma
+        </label>
         <input
           id={htmlId('sigma')}
           className="vis_editor__std_deviation-sigma"

--- a/src/core_plugins/metrics/public/components/aggs/std_sibling.js
+++ b/src/core_plugins/metrics/public/components/aggs/std_sibling.js
@@ -44,7 +44,9 @@ export const StandardSiblingAgg = props => {
   if (model.type === 'std_deviation_bucket') {
     stdDev.sigma = (
       <div className="vis_editor__std_deviation-sigma_item">
-        <label className="vis_editor__label" htmlFor={htmlId('sigma')}>Sigma</label>
+        <label className="vis_editor__label" htmlFor={htmlId('sigma')}>
+          Sigma
+        </label>
         <input
           id={htmlId('sigma')}
           className="vis_editor__std_deviation-sigma"
@@ -58,7 +60,7 @@ export const StandardSiblingAgg = props => {
       { label: 'Raw', value: 'raw' },
       { label: 'Upper Bound', value: 'upper' },
       { label: 'Lower Bound', value: 'lower' },
-      { label: 'Bounds Band', value: 'band' }
+      { label: 'Bounds Band', value: 'band' },
     ];
     const selectedModeOption = modeOptions.find(option => {
       return model.mode === option.value;
@@ -90,6 +92,7 @@ export const StandardSiblingAgg = props => {
         <div className="vis_editor__label">Aggregation</div>
         <AggSelect
           panelType={props.panel.type}
+          timerangeMode={props.panel.timerange_mode}
           siblings={props.siblings}
           value={model.type}
           onChange={handleSelectChange('type')}
@@ -105,8 +108,8 @@ export const StandardSiblingAgg = props => {
           value={model.field}
         />
       </div>
-      { stdDev.sigma }
-      { stdDev.mode }
+      {stdDev.sigma}
+      {stdDev.mode}
     </AggRow>
   );
 };

--- a/src/core_plugins/metrics/public/components/aggs/top_hit.js
+++ b/src/core_plugins/metrics/public/components/aggs/top_hit.js
@@ -78,6 +78,7 @@ export const TopHitAgg = props => {
             <div className="vis_editor__label">Aggregation</div>
             <AggSelect
               panelType={props.panel.type}
+              timerangeMode={props.panel.timerange_mode}
               siblings={props.siblings}
               value={model.type}
               onChange={handleSelectChange('type')}

--- a/src/core_plugins/metrics/public/components/code.js
+++ b/src/core_plugins/metrics/public/components/code.js
@@ -1,0 +1,5 @@
+import { EuiCode } from '@elastic/eui';
+import React from 'react';
+export function Code({ children }) {
+  return <EuiCode>{children}</EuiCode>;
+}

--- a/src/core_plugins/metrics/public/components/code.js
+++ b/src/core_plugins/metrics/public/components/code.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { EuiCode } from '@elastic/eui';
 import React from 'react';
 export function Code({ children }) {

--- a/src/core_plugins/metrics/public/components/data_config.js
+++ b/src/core_plugins/metrics/public/components/data_config.js
@@ -94,7 +94,7 @@ export function DataConfig({ onChange, model, fields }) {
           </label>
         ) : null}
         {model.type !== 'timeseries' ? (
-          <div className="vis_editor__row_item">
+          <div className="vis_editor__row_item" data-test-subj="dataTimeRange">
             <EuiComboBox
               options={timerangeModes}
               isClearable={false}
@@ -112,6 +112,7 @@ export function DataConfig({ onChange, model, fields }) {
         {model.type !== 'timeseries' && model.timerange_mode === 'last' && (
           <input
             id={htmlId('timerange_mode_interval')}
+            data-test-subj="timeRangeInterval"
             className="vis_editor__input-grows"
             type="text"
             onChange={handleTextChange('timerange_mode_interval')}

--- a/src/core_plugins/metrics/public/components/data_config.js
+++ b/src/core_plugins/metrics/public/components/data_config.js
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import createTextHandler from './lib/create_text_handler';
+import createSelectHandler from './lib/create_select_handler';
+import { Code } from './code';
+import { Note } from './note';
+import { Info } from './info';
+import { htmlIdGenerator, EuiComboBox } from '@elastic/eui';
+import FieldSelect from './aggs/field_select';
+
+export function DataConfig({ onChange, model, fields }) {
+  const handleSelectChange = createSelectHandler(onChange);
+  const handleTextChange = createTextHandler(onChange);
+  const htmlId = htmlIdGenerator();
+  const timerangeModes = [
+    { label: 'Entire timerange', value: 'all' },
+    { label: 'Last value', value: 'last' }
+  ];
+  const timerangeModeHelp = (
+    <Note style={{ width: '300px' }}>
+      This setting controls the timespan used for matching documents.{' '}
+      <Code>Entire timerange</Code> will match all the documents selected
+      in the timepicker. <Code>Last value</Code> will match only the documents
+      for the specified interval from the end of the timerange.
+    </Note>
+  );
+
+  const selectedOption = timerangeModes.find(option => {
+    return option.value === model.timerange_mode;
+  });
+  const selectedOptions = selectedOption ? [selectedOption] : [];
+
+  return (
+
+    <div className="vis_editor__container">
+      <div className="vis_editor__vis_config-row">
+        <label className="vis_editor__label" htmlFor={htmlId('index_pattern')}>
+          Index pattern
+        </label>
+        <input
+          id={htmlId('index_pattern')}
+          className="vis_editor__input-grows"
+          type="text"
+          onChange={handleTextChange('index_pattern')}
+          value={model.index_pattern}
+        />
+        <label className="vis_editor__label" htmlFor={htmlId('time_field')}>
+          Time Field
+        </label>
+        <div className="vis_editor__row_item">
+          <FieldSelect
+            id={htmlId('time_field')}
+            restrict="date"
+            value={model.time_field}
+            onChange={handleSelectChange('time_field')}
+            indexPattern={model.index_pattern}
+            fields={fields}
+          />
+        </div>
+        {model.type === 'timeseries' ? (
+          <label className="vis_editor__label" htmlFor={htmlId('interval')}>
+            Interval (auto, 1m, 1d, 7d, 1y, &gt;=1m)
+          </label>
+        ) : null}
+        {model.type === 'timeseries' ? (
+          <input
+            id={htmlId('interval')}
+            className="vis_editor__input"
+            onChange={handleTextChange('interval', 'auto')}
+            value={model.interval}
+          />
+        ) : null}
+        {model.type !== 'timeseries' ? (
+          <label className="vis_editor__label" htmlFor={htmlId('timerange_mode')}>
+            Timerange mode <Info message={timerangeModeHelp} />
+          </label>
+        ) : null}
+        {model.type !== 'timeseries' ? (
+          <div className="vis_editor__row_item">
+            <EuiComboBox
+              options={timerangeModes}
+              isClearable={false}
+              onChange={handleSelectChange('timerange_mode')}
+              selectedOptions={selectedOptions}
+              singleSelection={true}
+            />
+          </div>
+        ) : null}
+        {model.type !== 'timeseries' && model.timerange_mode === 'last' && (
+          <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
+            Interval (1s, 1m, 1h, 1d, &gt;=1m)
+          </label>
+        ) || null}
+        {model.type !== 'timeseries' && model.timerange_mode === 'last' && (
+          <input
+            id={htmlId('timerange_mode_interval')}
+            className="vis_editor__input-grows"
+            type="text"
+            onChange={handleTextChange('timerange_mode_interval')}
+            value={model.timerange_mode_interval}
+          />
+        ) || null}
+      </div>
+    </div>
+  );
+
+}

--- a/src/core_plugins/metrics/public/components/data_config.js
+++ b/src/core_plugins/metrics/public/components/data_config.js
@@ -47,6 +47,8 @@ export function DataConfig({ onChange, model, fields }) {
     return option.value === model.timerange_mode;
   });
   const selectedOptions = selectedOption ? [selectedOption] : [];
+  const isTimeseries = model.type === 'timeseries';
+  const isLastValue = model.timerange_mode === 'last';
 
   return (
 
@@ -75,12 +77,12 @@ export function DataConfig({ onChange, model, fields }) {
             fields={fields}
           />
         </div>
-        {model.type === 'timeseries' ? (
+        {isTimeseries ? (
           <label className="vis_editor__label" htmlFor={htmlId('interval')}>
             Interval (auto, 1m, 1d, 7d, 1y, &gt;=1m)
           </label>
         ) : null}
-        {model.type === 'timeseries' ? (
+        {isTimeseries ? (
           <input
             id={htmlId('interval')}
             className="vis_editor__input"
@@ -88,12 +90,12 @@ export function DataConfig({ onChange, model, fields }) {
             value={model.interval}
           />
         ) : null}
-        {model.type !== 'timeseries' ? (
+        {!isTimeseries ? (
           <label className="vis_editor__label" htmlFor={htmlId('timerange_mode')}>
             Timerange mode <Info message={timerangeModeHelp} />
           </label>
         ) : null}
-        {model.type !== 'timeseries' ? (
+        {!isTimeseries ? (
           <div className="vis_editor__row_item" data-test-subj="dataTimeRange">
             <EuiComboBox
               options={timerangeModes}
@@ -104,21 +106,18 @@ export function DataConfig({ onChange, model, fields }) {
             />
           </div>
         ) : null}
-        {model.type !== 'timeseries' && model.timerange_mode === 'last' && (
-          <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
-            Interval (1s, 1m, 1h, 1d, &gt;=1m)
-          </label>
-        ) || null}
-        {model.type !== 'timeseries' && model.timerange_mode === 'last' && (
-          <input
-            id={htmlId('timerange_mode_interval')}
-            data-test-subj="timeRangeInterval"
-            className="vis_editor__input-grows"
-            type="text"
-            onChange={handleTextChange('timerange_mode_interval')}
-            value={model.timerange_mode_interval}
-          />
-        ) || null}
+        <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
+          Interval (auto, 1s, 1m, 1h, 1d, &gt;=1m)
+        </label>
+        <input
+          disabled={!isTimeseries && !isLastValue}
+          id={htmlId('timerange_mode_interval')}
+          data-test-subj="timeRangeInterval"
+          className="vis_editor__input-grows"
+          type="text"
+          onChange={handleTextChange('timerange_mode_interval')}
+          value={model.timerange_mode_interval}
+        />
       </div>
     </div>
   );

--- a/src/core_plugins/metrics/public/components/data_config.js
+++ b/src/core_plugins/metrics/public/components/data_config.js
@@ -78,46 +78,46 @@ export function DataConfig({ onChange, model, fields }) {
           />
         </div>
         {isTimeseries ? (
-          <label className="vis_editor__label" htmlFor={htmlId('interval')}>
-            Interval (auto, 1m, 1d, 7d, 1y, &gt;=1m)
-          </label>
-        ) : null}
-        {isTimeseries ? (
-          <input
-            id={htmlId('interval')}
-            className="vis_editor__input"
-            onChange={handleTextChange('interval', 'auto')}
-            value={model.interval}
-          />
-        ) : null}
-        {!isTimeseries ? (
-          <label className="vis_editor__label" htmlFor={htmlId('timerange_mode')}>
-            Timerange mode <Info message={timerangeModeHelp} />
-          </label>
-        ) : null}
-        {!isTimeseries ? (
-          <div className="vis_editor__row_item" data-test-subj="dataTimeRange">
-            <EuiComboBox
-              options={timerangeModes}
-              isClearable={false}
-              onChange={handleSelectChange('timerange_mode')}
-              selectedOptions={selectedOptions}
-              singleSelection={true}
+          <React.Fragment>
+            <label className="vis_editor__label" htmlFor={htmlId('interval')}>
+              Interval (auto, 1m, 1d, 7d, 1y, &gt;=1m)
+            </label>
+            <input
+              id={htmlId('interval')}
+              className="vis_editor__input"
+              onChange={handleTextChange('interval', 'auto')}
+              value={model.interval}
             />
-          </div>
+          </React.Fragment>
         ) : null}
-        <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
-          Interval (auto, 1s, 1m, 1h, 1d, &gt;=1m)
-        </label>
-        <input
-          disabled={!isTimeseries && !isLastValue}
-          id={htmlId('timerange_mode_interval')}
-          data-test-subj="timeRangeInterval"
-          className="vis_editor__input-grows"
-          type="text"
-          onChange={handleTextChange('timerange_mode_interval')}
-          value={model.timerange_mode_interval}
-        />
+        {!isTimeseries ? (
+          <React.Fragment>
+            <label className="vis_editor__label" htmlFor={htmlId('timerange_mode')}>
+              Timerange mode <Info message={timerangeModeHelp} />
+            </label>
+            <div className="vis_editor__row_item" data-test-subj="dataTimeRange">
+              <EuiComboBox
+                options={timerangeModes}
+                isClearable={false}
+                onChange={handleSelectChange('timerange_mode')}
+                selectedOptions={selectedOptions}
+                singleSelection={true}
+              />
+            </div>
+            <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
+              Interval (auto, 1s, 1m, 1h, 1d, &gt;=1m)
+            </label>
+            <input
+              disabled={!isTimeseries && !isLastValue}
+              id={htmlId('timerange_mode_interval')}
+              data-test-subj="timeRangeInterval"
+              className="vis_editor__input-grows"
+              type="text"
+              onChange={handleTextChange('timerange_mode_interval')}
+              value={model.timerange_mode_interval}
+            />
+          </React.Fragment>
+        ) : null}
       </div>
     </div>
   );

--- a/src/core_plugins/metrics/public/components/data_format_picker.js
+++ b/src/core_plugins/metrics/public/components/data_format_picker.js
@@ -120,7 +120,9 @@ class DataFormatPicker extends Component {
         return to === option.value;
       });
       return (
-        <div className="vis_editor__data_format_picker-container">
+        <div
+          className="vis_editor__data_format_picker-container"
+        >
           <div className="vis_editor__label">
             {this.props.label}
           </div>

--- a/src/core_plugins/metrics/public/components/index_pattern.js
+++ b/src/core_plugins/metrics/public/components/index_pattern.js
@@ -22,7 +22,6 @@ import React from 'react';
 import FieldSelect from './aggs/field_select';
 import createSelectHandler from './lib/create_select_handler';
 import createTextHandler from './lib/create_text_handler';
-import YesNo from './yes_no';
 import { htmlIdGenerator } from '@elastic/eui';
 
 export const IndexPattern = props => {
@@ -69,22 +68,6 @@ export const IndexPattern = props => {
           fields={fields}
         />
       </div>
-      <label className="vis_editor__label" htmlFor={htmlId('interval')}>
-        Interval (auto, 1m, 1d, 7d, 1y, &gt;=1m)
-      </label>
-      <input
-        id={htmlId('interval')}
-        className="vis_editor__input"
-        disabled={props.disabled}
-        onChange={handleTextChange(intervalName, 'auto')}
-        value={model[intervalName]}
-      />
-      <div className="vis_editor__label">Drop Last Bucket</div>
-      <YesNo
-        value={model[dropBucketName]}
-        name={dropBucketName}
-        onChange={props.onChange}
-      />
     </div>
   );
 };

--- a/src/core_plugins/metrics/public/components/info.js
+++ b/src/core_plugins/metrics/public/components/info.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import React, { Component } from 'react';
 import {
   EuiPopover,
@@ -11,37 +30,37 @@ export class Info extends Component {
     this.state = { show: false };
   }
 
-  closePopover = () => {
-    this.setState({ show: false });
-  }
+    closePopover = () => {
+      this.setState({ show: false });
+    }
 
-  showPopover = () => {
-    this.setState({ show: true });
-  }
+    showPopover = () => {
+      this.setState({ show: true });
+    }
 
-  render() {
-    const { message } = this.props;
-    const button = (
-      <EuiButtonIcon
-        onClick={this.showPopover}
-        size="s"
-        iconType="iInCircle"
-        color="text"
-        aria-label="help"
-      />
-    );
-    return (
-      <EuiPopover
-        id="help-popover"
-        ownFocus
-        button={button}
-        isOpen={this.state.show}
-        closePopover={this.closePopover}
-        anchorPosition="upCenter"
-      >
-        {message}
-      </EuiPopover>
-    );
-  }
+    render() {
+      const { message } = this.props;
+      const button = (
+        <EuiButtonIcon
+          onClick={this.showPopover}
+          size="s"
+          iconType="iInCircle"
+          color="text"
+          aria-label="help"
+        />
+      );
+      return (
+        <EuiPopover
+          id="help-popover"
+          ownFocus
+          button={button}
+          isOpen={this.state.show}
+          closePopover={this.closePopover}
+          anchorPosition="upCenter"
+        >
+          {message}
+        </EuiPopover>
+      );
+    }
 
 }

--- a/src/core_plugins/metrics/public/components/info.js
+++ b/src/core_plugins/metrics/public/components/info.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import {
+  EuiPopover,
+  EuiButtonIcon
+} from '@elastic/eui';
+
+export class Info extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { show: false };
+  }
+
+  closePopover = () => {
+    this.setState({ show: false });
+  }
+
+  showPopover = () => {
+    this.setState({ show: true });
+  }
+
+  render() {
+    const { message } = this.props;
+    const button = (
+      <EuiButtonIcon
+        onClick={this.showPopover}
+        size="s"
+        iconType="iInCircle"
+        color="text"
+        aria-label="help"
+      />
+    );
+    return (
+      <EuiPopover
+        id="help-popover"
+        ownFocus
+        button={button}
+        isOpen={this.state.show}
+        closePopover={this.closePopover}
+        anchorPosition="upCenter"
+      >
+        {message}
+      </EuiPopover>
+    );
+  }
+
+}

--- a/src/core_plugins/metrics/public/components/lib/check_timeseries_pipelines.js
+++ b/src/core_plugins/metrics/public/components/lib/check_timeseries_pipelines.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export const timeseriesPipelineAggs = [
   'cumulative_sum',
   'derivative',

--- a/src/core_plugins/metrics/public/components/lib/check_timeseries_pipelines.js
+++ b/src/core_plugins/metrics/public/components/lib/check_timeseries_pipelines.js
@@ -1,0 +1,18 @@
+export const timeseriesPipelineAggs = [
+  'cumulative_sum',
+  'derivative',
+  'moving_average',
+  'positive_only',
+  'serial_diff',
+  'series_agg',
+];
+
+export function isValidTimeseriesMetric(metric) {
+  return (
+    /_bucket$/.test(metric.type) || timeseriesPipelineAggs.includes(metric.type)
+  );
+}
+
+export function hasPipelineAggregation(series) {
+  return series.metrics.some(isValidTimeseriesMetric);
+}

--- a/src/core_plugins/metrics/public/components/lib/create_new_percentile.js
+++ b/src/core_plugins/metrics/public/components/lib/create_new_percentile.js
@@ -1,0 +1,4 @@
+import uuid from 'uuid';
+export function createNewPercentile(opts) {
+  return { id: uuid.v1(), mode: 'line', shade: 0.2, ...opts };
+}

--- a/src/core_plugins/metrics/public/components/lib/create_new_percentile.js
+++ b/src/core_plugins/metrics/public/components/lib/create_new_percentile.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import uuid from 'uuid';
 export function createNewPercentile(opts) {
   return { id: uuid.v1(), mode: 'line', shade: 0.2, ...opts };

--- a/src/core_plugins/metrics/public/components/lib/remove_timeseries_metrics.js
+++ b/src/core_plugins/metrics/public/components/lib/remove_timeseries_metrics.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { isValidTimeseriesMetric } from './check_timeseries_pipelines';
 export function removeTimeseriesMetrics(series) {
   return series.map(item => {

--- a/src/core_plugins/metrics/public/components/lib/remove_timeseries_metrics.js
+++ b/src/core_plugins/metrics/public/components/lib/remove_timeseries_metrics.js
@@ -1,0 +1,9 @@
+import { isValidTimeseriesMetric } from './check_timeseries_pipelines';
+export function removeTimeseriesMetrics(series) {
+  return series.map(item => {
+    return {
+      ...item,
+      metrics: item.metrics.filter(metric => !isValidTimeseriesMetric(metric)),
+    };
+  });
+}

--- a/src/core_plugins/metrics/public/components/modal_confirm.js
+++ b/src/core_plugins/metrics/public/components/modal_confirm.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+  EuiConfirmModal as ConfirmModal,
+  EuiOverlayMask as ModalOverlay,
+  EUI_MODAL_CONFIRM_BUTTON as MODAL_CONFIRM_BUTTON,
+} from '@elastic/eui';
+export function ModalConfirm({
+  title = 'Are you sure?',
+  show = false,
+  message,
+  onCancel,
+  onConfirm,
+  confirmButtonText = 'Yes',
+  cancelButtonText = 'No',
+}) {
+  if (!show) return null;
+  return (
+    <ModalOverlay>
+      <ConfirmModal
+        title={title}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        cancelButtonText={cancelButtonText}
+        confirmButtonText={confirmButtonText}
+        defaultFocusedButton={MODAL_CONFIRM_BUTTON}
+      >
+        {message}
+      </ConfirmModal>
+    </ModalOverlay>
+  );
+}

--- a/src/core_plugins/metrics/public/components/modal_confirm.js
+++ b/src/core_plugins/metrics/public/components/modal_confirm.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import React from 'react';
 import {
   EuiConfirmModal as ConfirmModal,

--- a/src/core_plugins/metrics/public/components/note.js
+++ b/src/core_plugins/metrics/public/components/note.js
@@ -1,0 +1,12 @@
+import React from 'react';
+export function Note({ children, style = {} }) {
+  return (
+    <div
+      style={style}
+      className="vis_editor__descNote"
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/src/core_plugins/metrics/public/components/note.js
+++ b/src/core_plugins/metrics/public/components/note.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import React from 'react';
 export function Note({ children, style = {} }) {
   return (

--- a/src/core_plugins/metrics/public/components/panel_config/gauge.js
+++ b/src/core_plugins/metrics/public/components/panel_config/gauge.js
@@ -20,7 +20,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import SeriesEditor from '../series_editor';
-import { IndexPattern } from '../index_pattern';
 import createSelectHandler from '../lib/create_select_handler';
 import createTextHandler from '../lib/create_text_handler';
 import ColorRules from '../color_rules';
@@ -91,11 +90,6 @@ class GaugePanelConfig extends Component {
     } else {
       view = (
         <div className="vis_editor__container">
-          <IndexPattern
-            fields={this.props.fields}
-            model={this.props.model}
-            onChange={this.props.onChange}
-          />
           <div className="vis_editor__vis_config-row">
             <label className="vis_editor__label" htmlFor={htmlId('panelFilter')}>
               Panel Filter
@@ -111,6 +105,12 @@ class GaugePanelConfig extends Component {
             <YesNo
               value={model.ignore_global_filter}
               name="ignore_global_filter"
+              onChange={this.props.onChange}
+            />
+            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <YesNo
+              value={model.drop_last_bucket}
+              name="drop_last_bucket"
               onChange={this.props.onChange}
             />
           </div>

--- a/src/core_plugins/metrics/public/components/panel_config/gauge.js
+++ b/src/core_plugins/metrics/public/components/panel_config/gauge.js
@@ -107,7 +107,7 @@ class GaugePanelConfig extends Component {
               name="ignore_global_filter"
               onChange={this.props.onChange}
             />
-            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <div className="vis_editor__label">Drop Partial Buckets</div>
             <YesNo
               value={model.drop_last_bucket}
               name="drop_last_bucket"

--- a/src/core_plugins/metrics/public/components/panel_config/markdown.js
+++ b/src/core_plugins/metrics/public/components/panel_config/markdown.js
@@ -116,7 +116,7 @@ class MarkdownPanelConfig extends Component {
               name="ignore_global_filter"
               onChange={this.props.onChange}
             />
-            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <div className="vis_editor__label">Drop Partial Buckets</div>
             <YesNo
               value={model.drop_last_bucket}
               name="drop_last_bucket"

--- a/src/core_plugins/metrics/public/components/panel_config/markdown.js
+++ b/src/core_plugins/metrics/public/components/panel_config/markdown.js
@@ -20,7 +20,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import SeriesEditor from '../series_editor';
-import { IndexPattern } from '../index_pattern';
 import 'brace/mode/less';
 import createSelectHandler from '../lib/create_select_handler';
 import createTextHandler from '../lib/create_text_handler';
@@ -94,11 +93,6 @@ class MarkdownPanelConfig extends Component {
     } else {
       view = (
         <div className="vis_editor__container">
-          <IndexPattern
-            fields={this.props.fields}
-            model={this.props.model}
-            onChange={this.props.onChange}
-          />
           <div className="vis_editor__vis_config-row">
             <div className="vis_editor__label">Background Color</div>
             <ColorPicker
@@ -120,6 +114,12 @@ class MarkdownPanelConfig extends Component {
             <YesNo
               value={model.ignore_global_filter}
               name="ignore_global_filter"
+              onChange={this.props.onChange}
+            />
+            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <YesNo
+              value={model.drop_last_bucket}
+              name="drop_last_bucket"
               onChange={this.props.onChange}
             />
           </div>

--- a/src/core_plugins/metrics/public/components/panel_config/metric.js
+++ b/src/core_plugins/metrics/public/components/panel_config/metric.js
@@ -20,7 +20,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import SeriesEditor from '../series_editor';
-import { IndexPattern } from '../index_pattern';
 import createTextHandler from '../lib/create_text_handler';
 import ColorRules from '../color_rules';
 import YesNo from '../yes_no';
@@ -68,11 +67,6 @@ class MetricPanelConfig extends Component {
     } else {
       view = (
         <div className="vis_editor__container">
-          <IndexPattern
-            fields={this.props.fields}
-            model={this.props.model}
-            onChange={this.props.onChange}
-          />
           <div className="vis_editor__vis_config-row">
             <label className="vis_editor__label" htmlFor={htmlId('panelFilter')}>
               Panel Filter
@@ -88,6 +82,12 @@ class MetricPanelConfig extends Component {
             <YesNo
               value={model.ignore_global_filter}
               name="ignore_global_filter"
+              onChange={this.props.onChange}
+            />
+            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <YesNo
+              value={model.drop_last_bucket}
+              name="drop_last_bucket"
               onChange={this.props.onChange}
             />
           </div>

--- a/src/core_plugins/metrics/public/components/panel_config/metric.js
+++ b/src/core_plugins/metrics/public/components/panel_config/metric.js
@@ -84,7 +84,7 @@ class MetricPanelConfig extends Component {
               name="ignore_global_filter"
               onChange={this.props.onChange}
             />
-            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <div className="vis_editor__label">Drop Partial Buckets</div>
             <YesNo
               value={model.drop_last_bucket}
               name="drop_last_bucket"

--- a/src/core_plugins/metrics/public/components/panel_config/table.js
+++ b/src/core_plugins/metrics/public/components/panel_config/table.js
@@ -26,10 +26,7 @@ import createSelectHandler from '../lib/create_select_handler';
 import uuid from 'uuid';
 import YesNo from '../yes_no';
 import { htmlIdGenerator } from '@elastic/eui';
-import Select from 'react-select';
-import { Code } from '../code';
-import { Note } from '../note';
-import { Info } from '../info';
+import { DataConfig } from '../data_config';
 
 class TablePanelConfig extends Component {
 
@@ -58,18 +55,6 @@ class TablePanelConfig extends Component {
     const handleSelectChange = createSelectHandler(this.props.onChange);
     const handleTextChange = createTextHandler(this.props.onChange);
     const htmlId = htmlIdGenerator();
-    const timerangeModes = [
-      { label: 'Entire timerange', value: 'all' },
-      { label: 'Last value', value: 'last' }
-    ];
-    const timerangeModeHelp = (
-      <Note style={{ width: '300px' }}>
-        This setting controls the timespan used for matching documents.{' '}
-        <Code>Entire timerange</Code> will match all the documents selected
-        in the timepicker. <Code>Last value</Code> will match only the documents
-        for the specified interval from the end of the timerange.
-      </Note>
-    );
     let view;
     if (selectedTab === 'data') {
       view = (
@@ -112,54 +97,7 @@ class TablePanelConfig extends Component {
                 />
               </div>
               <div className="vis_editor__vis_config-row">
-                <label className="vis_editor__label" htmlFor={htmlId('index_pattern')}>
-                  Index pattern
-                </label>
-                <input
-                  id={htmlId('index_pattern')}
-                  className="vis_editor__input-grows"
-                  type="text"
-                  onChange={handleTextChange('index_pattern')}
-                  value={model.index_pattern}
-                />
-                <label className="vis_editor__label" htmlFor={htmlId('time_field')}>
-                  Time Field
-                </label>
-                <div className="vis_editor__row_item">
-                  <FieldSelect
-                    id={htmlId('time_field')}
-                    restrict="date"
-                    value={model.time_field}
-                    onChange={handleSelectChange('time_field')}
-                    indexPattern={model.index_pattern}
-                    fields={this.props.fields}
-                  />
-                </div>
-                <label className="vis_editor__label" htmlFor={htmlId('timerange_mode')}>
-                  Data timerange mode <Info message={timerangeModeHelp} />
-                </label>
-                <div className="vis_editor__row_item">
-                  <Select
-                    options={timerangeModes}
-                    clearable={false}
-                    onChange={handleSelectChange('timerange_mode')}
-                    value={model.timerange_mode}
-                  />
-                </div>
-                {model.timerange_mode === 'last' && (
-                  <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
-                    Interval (1s, 1m, 1h, 1d)
-                  </label>
-                ) || null}
-                {model.timerange_mode === 'last' && (
-                  <input
-                    id={htmlId('timerange_mode_interval')}
-                    className="vis_editor__input-grows"
-                    type="text"
-                    onChange={handleTextChange('timerange_mode_interval')}
-                    value={model.timerange_mode_interval}
-                  />
-                ) || null}
+                <DataConfig model={model} fields={this.props.fields} onChange={this.props.onChange} />
               </div>
             </div>
           </div>

--- a/src/core_plugins/metrics/public/components/panel_config/table.js
+++ b/src/core_plugins/metrics/public/components/panel_config/table.js
@@ -139,7 +139,7 @@ class TablePanelConfig extends Component {
               name="ignore_global_filter"
               onChange={this.props.onChange}
             />
-            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <div className="vis_editor__label">Drop Partial Buckets</div>
             <YesNo
               value={model.drop_last_bucket}
               name="drop_last_bucket"

--- a/src/core_plugins/metrics/public/components/panel_config/table.js
+++ b/src/core_plugins/metrics/public/components/panel_config/table.js
@@ -21,12 +21,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FieldSelect from '../aggs/field_select';
 import SeriesEditor from '../series_editor';
-import { IndexPattern } from '../index_pattern';
 import createTextHandler from '../lib/create_text_handler';
 import createSelectHandler from '../lib/create_select_handler';
 import uuid from 'uuid';
 import YesNo from '../yes_no';
 import { htmlIdGenerator } from '@elastic/eui';
+import Select from 'react-select';
+import { Code } from '../code';
+import { Note } from '../note';
+import { Info } from '../info';
 
 class TablePanelConfig extends Component {
 
@@ -55,6 +58,18 @@ class TablePanelConfig extends Component {
     const handleSelectChange = createSelectHandler(this.props.onChange);
     const handleTextChange = createTextHandler(this.props.onChange);
     const htmlId = htmlIdGenerator();
+    const timerangeModes = [
+      { label: 'Entire timerange', value: 'all' },
+      { label: 'Last value', value: 'last' }
+    ];
+    const timerangeModeHelp = (
+      <Note style={{ width: '300px' }}>
+        This setting controls the timespan used for matching documents.{' '}
+        <Code>Entire timerange</Code> will match all the documents selected
+        in the timepicker. <Code>Last value</Code> will match only the documents
+        for the specified interval from the end of the timerange.
+      </Note>
+    );
     let view;
     if (selectedTab === 'data') {
       view = (
@@ -96,6 +111,56 @@ class TablePanelConfig extends Component {
                   value={model.pivot_rows}
                 />
               </div>
+              <div className="vis_editor__vis_config-row">
+                <label className="vis_editor__label" htmlFor={htmlId('index_pattern')}>
+                  Index pattern
+                </label>
+                <input
+                  id={htmlId('index_pattern')}
+                  className="vis_editor__input-grows"
+                  type="text"
+                  onChange={handleTextChange('index_pattern')}
+                  value={model.index_pattern}
+                />
+                <label className="vis_editor__label" htmlFor={htmlId('time_field')}>
+                  Time Field
+                </label>
+                <div className="vis_editor__row_item">
+                  <FieldSelect
+                    id={htmlId('time_field')}
+                    restrict="date"
+                    value={model.time_field}
+                    onChange={handleSelectChange('time_field')}
+                    indexPattern={model.index_pattern}
+                    fields={this.props.fields}
+                  />
+                </div>
+                <label className="vis_editor__label" htmlFor={htmlId('timerange_mode')}>
+                  Data timerange mode <Info message={timerangeModeHelp} />
+                </label>
+                <div className="vis_editor__row_item">
+                  <Select
+                    options={timerangeModes}
+                    clearable={false}
+                    onChange={handleSelectChange('timerange_mode')}
+                    value={model.timerange_mode}
+                  />
+                </div>
+                {model.timerange_mode === 'last' && (
+                  <label className="vis_editor__label" htmlFor={htmlId('timerange_mode_interval')}>
+                    Interval (1s, 1m, 1h, 1d)
+                  </label>
+                ) || null}
+                {model.timerange_mode === 'last' && (
+                  <input
+                    id={htmlId('timerange_mode_interval')}
+                    className="vis_editor__input-grows"
+                    type="text"
+                    onChange={handleTextChange('timerange_mode_interval')}
+                    value={model.timerange_mode_interval}
+                  />
+                ) || null}
+              </div>
             </div>
           </div>
           <SeriesEditor
@@ -120,11 +185,6 @@ class TablePanelConfig extends Component {
               value={model.drilldown_url}
             />
           </div>
-          <IndexPattern
-            fields={this.props.fields}
-            model={this.props.model}
-            onChange={this.props.onChange}
-          />
           <div className="vis_editor__vis_config-row">
             <label className="vis_editor__label" htmlFor={htmlId('panelFilterInput')}>Panel Filter</label>
             <input
@@ -139,6 +199,12 @@ class TablePanelConfig extends Component {
               id={htmlId('globalFilterOption')}
               value={model.ignore_global_filter}
               name="ignore_global_filter"
+              onChange={this.props.onChange}
+            />
+            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <YesNo
+              value={model.drop_last_bucket}
+              name="drop_last_bucket"
               onChange={this.props.onChange}
             />
           </div>

--- a/src/core_plugins/metrics/public/components/panel_config/timeseries.js
+++ b/src/core_plugins/metrics/public/components/panel_config/timeseries.js
@@ -21,7 +21,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import SeriesEditor from '../series_editor';
 import AnnotationsEditor from '../annotations_editor';
-import { IndexPattern } from '../index_pattern';
 import createSelectHandler from '../lib/create_select_handler';
 import createTextHandler from '../lib/create_text_handler';
 import ColorPicker from '../color_picker';
@@ -100,11 +99,6 @@ class TimeseriesPanelConfig extends Component {
     } else {
       view = (
         <div className="vis_editor__container">
-          <IndexPattern
-            fields={this.props.fields}
-            model={this.props.model}
-            onChange={this.props.onChange}
-          />
           <div className="vis_editor__vis_config-row">
             <label className="vis_editor__label" htmlFor={htmlId('axisMin')}>Axis Min</label>
             <input
@@ -144,6 +138,12 @@ class TimeseriesPanelConfig extends Component {
                 singleSelection={true}
               />
             </div>
+            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <YesNo
+              value={model.drop_last_bucket}
+              name="drop_last_bucket"
+              onChange={this.props.onChange}
+            />
           </div>
           <div className="vis_editor__vis_config-row">
             <div className="vis_editor__label">Background Color</div>

--- a/src/core_plugins/metrics/public/components/panel_config/timeseries.js
+++ b/src/core_plugins/metrics/public/components/panel_config/timeseries.js
@@ -138,7 +138,7 @@ class TimeseriesPanelConfig extends Component {
                 singleSelection={true}
               />
             </div>
-            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <div className="vis_editor__label">Drop Partial Buckets</div>
             <YesNo
               value={model.drop_last_bucket}
               name="drop_last_bucket"

--- a/src/core_plugins/metrics/public/components/panel_config/top_n.js
+++ b/src/core_plugins/metrics/public/components/panel_config/top_n.js
@@ -20,7 +20,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import SeriesEditor from '../series_editor';
-import { IndexPattern } from '../index_pattern';
 import createTextHandler from '../lib/create_text_handler';
 import ColorRules from '../color_rules';
 import ColorPicker from '../color_picker';
@@ -80,11 +79,6 @@ class TopNPanelConfig extends Component {
               value={model.drilldown_url}
             />
           </div>
-          <IndexPattern
-            fields={this.props.fields}
-            model={this.props.model}
-            onChange={this.props.onChange}
-          />
           <div className="vis_editor__vis_config-row">
             <div className="vis_editor__label">Background Color</div>
             <ColorPicker
@@ -106,6 +100,12 @@ class TopNPanelConfig extends Component {
             <YesNo
               value={model.ignore_global_filter}
               name="ignore_global_filter"
+              onChange={this.props.onChange}
+            />
+            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <YesNo
+              value={model.drop_last_bucket}
+              name="drop_last_bucket"
               onChange={this.props.onChange}
             />
           </div>

--- a/src/core_plugins/metrics/public/components/panel_config/top_n.js
+++ b/src/core_plugins/metrics/public/components/panel_config/top_n.js
@@ -102,7 +102,7 @@ class TopNPanelConfig extends Component {
               name="ignore_global_filter"
               onChange={this.props.onChange}
             />
-            <div className="vis_editor__label">Drop Partial Bucket</div>
+            <div className="vis_editor__label">Drop Partial Buckets</div>
             <YesNo
               value={model.drop_last_bucket}
               name="drop_last_bucket"

--- a/src/core_plugins/metrics/public/components/series_editor.js
+++ b/src/core_plugins/metrics/public/components/series_editor.js
@@ -28,6 +28,7 @@ import {
 } from './lib/collection_actions';
 import newSeriesFn from './lib/new_series_fn';
 import Sortable from 'react-anything-sortable';
+import { DataConfig } from './data_config';
 
 class SeriesEditor extends Component {
 
@@ -79,7 +80,7 @@ class SeriesEditor extends Component {
   }
 
   render() {
-    const { limit, model, name } = this.props;
+    const { limit, model, name, fields } = this.props;
     const series = model[name]
       .filter((val, index) => index < (limit || Infinity))
       .map(this.renderRow);
@@ -88,15 +89,22 @@ class SeriesEditor extends Component {
       this.props.onChange({ series });
     };
     return (
-      <div className="vis_editor__series_editor-container">
-        <Sortable
-          dynamic={true}
-          direction="vertical"
-          onSort={handleSort}
-          sortHandle="vis_editor__sort"
-        >
-          { series }
-        </Sortable>
+      <div>
+        {model.type !== 'table' ? (
+          <div className="vis_editor__dataRangeSelect">
+            <DataConfig model={model} fields={fields} onChange={this.props.onChange} />
+          </div>
+        ) : null }
+        <div className="vis_editor__series_editor-container">
+          <Sortable
+            dynamic={true}
+            direction="vertical"
+            onSort={handleSort}
+            sortHandle="vis_editor__sort"
+          >
+            { series }
+          </Sortable>
+        </div>
       </div>
     );
   }

--- a/src/core_plugins/metrics/public/components/vis_editor.js
+++ b/src/core_plugins/metrics/public/components/vis_editor.js
@@ -28,7 +28,7 @@ import { get } from 'lodash';
 import { hasPipelineAggregation } from './lib/check_timeseries_pipelines';
 import { ModalConfirm } from './modal_confirm';
 import { removeTimeseriesMetrics } from './lib/remove_timeseries_metrics';
-import { metricTypes } from '../../common/metric_types';
+import { isMetric } from '../../common/metric_types';
 
 class VisEditor extends Component {
   constructor(props) {
@@ -75,7 +75,7 @@ class VisEditor extends Component {
     const timerangeMode = part.timerange_mode || model.timerange_mode;
     const type = part.type || model.type;
     const modeIsAll =
-      timerangeMode && timerangeMode === 'all' && metricTypes.includes(type);
+      timerangeMode && timerangeMode === 'all' && isMetric(type);
     const series = part.series || model.series;
     const containsPipelines = series.some(hasPipelineAggregation);
     if (modeIsAll && containsPipelines) {

--- a/src/core_plugins/metrics/public/components/vis_editor.js
+++ b/src/core_plugins/metrics/public/components/vis_editor.js
@@ -25,6 +25,10 @@ import VisPicker from './vis_picker';
 import PanelConfig from './panel_config';
 import brushHandler from '../lib/create_brush_handler';
 import { get } from 'lodash';
+import { hasPipelineAggregation } from './lib/check_timeseries_pipelines';
+import { ModalConfirm } from './modal_confirm';
+import { removeTimeseriesMetrics } from './lib/remove_timeseries_metrics';
+import { metricTypes } from '../../common/metric_types';
 
 class VisEditor extends Component {
   constructor(props) {
@@ -32,7 +36,13 @@ class VisEditor extends Component {
     const { vis } = props;
     this.appState = vis.API.getAppState();
     const reversed = get(this.appState, 'options.darkTheme', false);
-    this.state = { model: props.vis.params, dirty: false, autoApply: true, reversed };
+    this.state = {
+      model: props.vis.params,
+      dirty: false,
+      autoApply: true,
+      reversed,
+      showConfirm: false,
+    };
     this.onBrush = brushHandler(props.vis.API.timeFilter);
     this.handleUiState = this.handleUiState.bind(this, props.vis);
     this.handleAppStateChange = this.handleAppStateChange.bind(this);
@@ -60,27 +70,55 @@ class VisEditor extends Component {
     }
   }
 
-  render() {
-    const handleChange = (part) => {
-      const nextModel = { ...this.state.model, ...part };
+  testTimespanMode = part => {
+    const { model } = this.state;
+    const timerangeMode = part.timerange_mode || model.timerange_mode;
+    const type = part.type || model.type;
+    const modeIsAll =
+      timerangeMode && timerangeMode === 'all' && metricTypes.includes(type);
+    const series = part.series || model.series;
+    const containsPipelines = series.some(hasPipelineAggregation);
+    if (modeIsAll && containsPipelines) {
+      this.setState({ showConfirm: true, nextPart: part });
+      return false;
+    }
+    return true;
+  };
 
+  handleChange = part => {
+    if (this.testTimespanMode(part)) {
+      const nextModel = { ...this.state.model, ...part };
       this.props.vis.params = nextModel;
       if (this.state.autoApply) {
         this.props.vis.updateState();
       }
-
       this.setState({ model: nextModel, dirty: !this.state.autoApply });
-    };
+    }
+  };
 
-    const handleAutoApplyToggle = (part) => {
-      this.setState({ autoApply: part.target.checked });
-    };
+  handleAutoApplyToggle = part => {
+    this.setState({ autoApply: part.target.checked });
+  };
 
-    const handleCommit = () => {
-      this.props.vis.updateState();
-      this.setState({ dirty: false });
-    };
+  handleCommit = () => {
+    this.props.vis.updateState();
+    this.setState({ dirty: false });
+  };
 
+  handleCancel = () => {
+    this.handleChange(this.state.nextPart);
+    this.setState({ showConfirm: false, nextPart: {} });
+  };
+
+  handleConfirm = () => {
+    const nextPart = {
+      series: removeTimeseriesMetrics(this.state.model.series),
+      ...this.state.nextPart,
+    };
+    this.handleChange(nextPart);
+    this.setState({ showConfirm: false, nextPart: {} });
+  };
+  render() {
     if (!this.props.isEditorMode) {
       if (!this.props.vis.params || !this.props.visData) return null;
       const reversed = this.state.reversed;
@@ -105,7 +143,7 @@ class VisEditor extends Component {
       return (
         <div className="vis_editor">
           <div className="vis-editor-hide-for-reporting">
-            <VisPicker model={model} onChange={handleChange} />
+            <VisPicker model={model} onChange={this.handleChange} />
           </div>
           <VisEditorVisualization
             dirty={this.state.dirty}
@@ -117,9 +155,9 @@ class VisEditor extends Component {
             onUiState={this.handleUiState}
             uiState={this.props.vis.getUiState()}
             onBrush={this.onBrush}
-            onCommit={handleCommit}
-            onToggleAutoApply={handleAutoApplyToggle}
-            onChange={handleChange}
+            onCommit={this.handleCommit}
+            onToggleAutoApply={this.handleAutoApplyToggle}
+            onChange={this.handleChange}
             title={this.props.vis.title}
             description={this.props.vis.description}
             dateFormat={this.props.config.get('dateFormat')}
@@ -130,10 +168,28 @@ class VisEditor extends Component {
               model={model}
               visData={this.props.visData}
               dateFormat={this.props.config.get('dateFormat')}
-              onChange={handleChange}
               getConfig={this.getConfig}
+              onChange={this.handleChange}
             />
           </div>
+          <ModalConfirm
+            show={this.state.showConfirm}
+            onConfirm={this.handleConfirm}
+            onCancel={this.handleCancel}
+            title="Incompatible Metrics"
+            confirmButtonText="Remove Metrics"
+            cancelButtonText="Keep"
+            message={
+              <div>
+                <p>
+                  The <strong>data timerange mode</strong> you have chosen is
+                  not compatible with some of the metrics you have configured.
+                  If you proceed the incompatible metrics will be removed.
+                </p>
+                <p>Remove incompatible metrics?</p>
+              </div>
+            }
+          />
         </div>
       );
     }
@@ -151,7 +207,7 @@ class VisEditor extends Component {
 }
 
 VisEditor.defaultProps = {
-  visData: {}
+  visData: {},
 };
 
 VisEditor.propTypes = {

--- a/src/core_plugins/metrics/public/components/vis_types/metric/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/metric/vis.js
@@ -57,7 +57,11 @@ function MetricVisualization(props) {
         newProps.formatter = tickFormatter(seriesDef.formatter, seriesDef.value_template, props.getConfig);
       }
       if (i === 0 && colors.color) newProps.color = colors.color;
-      return _.assign({}, _.pick(row, ['label', 'data']), newProps);
+      return {
+        data: row.data,
+        label: row.label,
+        ...newProps
+      };
     });
   const params = {
     metric: series[0],
@@ -76,7 +80,7 @@ function MetricVisualization(props) {
   const style = { backgroundColor: panelBackgroundColor };
   return (
     <div className="dashboard__visualization" style={style}>
-      <Metric {...params}/>
+      <Metric {...params} />
     </div>
   );
 

--- a/src/core_plugins/metrics/public/components/vis_types/table/series.js
+++ b/src/core_plugins/metrics/public/components/vis_types/table/series.js
@@ -27,7 +27,7 @@ import createTextHandler from '../../lib/create_text_handler';
 import createAggRowRender from '../../lib/create_agg_row_render';
 import { createUpDownHandler } from '../../lib/sort_keyhandler';
 
-function TopNSeries(props) {
+function TableSeries(props) {
   const {
     model,
     onAdd,
@@ -156,7 +156,7 @@ function TopNSeries(props) {
   );
 }
 
-TopNSeries.propTypes = {
+TableSeries.propTypes = {
   className: PropTypes.string,
   disableAdd: PropTypes.bool,
   disableDelete: PropTypes.bool,
@@ -180,4 +180,4 @@ TopNSeries.propTypes = {
   visible: PropTypes.bool
 };
 
-export default TopNSeries;
+export default TableSeries;

--- a/src/core_plugins/metrics/public/components/vis_types/table/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/table/vis.js
@@ -158,7 +158,7 @@ class TableVis extends Component {
     };
     return (
       <tr>
-        <th scope="col" onClick={handleSortClick}>{label} {sortComponent}</th>
+        <th scope="col" style={{ textAlign: 'left' }} onClick={handleSortClick}>{label} {sortComponent}</th>
         { columns }
       </tr>
     );

--- a/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
@@ -50,9 +50,9 @@ class TimeseriesVisualization extends Component {
   }
 
   xaxisFormatter = (val) => {
-    const { scaledDataFormat, dateFormat } = this.props.visData;
-    if (!scaledDataFormat || !dateFormat) return val;
-    const formatter = createXaxisFormatter(this.getInterval(), scaledDataFormat, dateFormat);
+    const { visData } = this.props;
+    if (!visData.scaledDataFormat || !visData.dateFormat) return val;
+    const formatter = createXaxisFormatter(this.getInterval(), visData.scaledDataFormat, visData.dateFormat);
     return formatter(val);
   }
 

--- a/src/core_plugins/metrics/public/components/vis_with_splits.js
+++ b/src/core_plugins/metrics/public/components/vis_with_splits.js
@@ -20,10 +20,10 @@
 import React from 'react';
 import { getDisplayName } from './lib/get_display_name';
 import { last, findIndex, first } from 'lodash';
-import calculateLabel  from '../../common/calculate_label';
+import calculateLabel from '../../common/calculate_label';
 export function visWithSplits(WrappedComponent) {
   function SplitVisComponent(props) {
-    const { model, visData } = props;
+    const { model, visData, getConfig } = props;
     if (!model || !visData || !visData[model.id]) return (<WrappedComponent {...props} />);
     if (visData[model.id].series.every(s => s.id.split(':').length === 1)) {
       return (<WrappedComponent {...props} />);
@@ -57,17 +57,18 @@ export function visWithSplits(WrappedComponent) {
     const rows = Object.keys(splitsVisData).map(key => {
       const splitData = splitsVisData[key];
       const { series, label } = splitData;
-      const newSeries = (indexOfNonSplit != null && indexOfNonSplit > 0) ?  [...series, nonSplitSeries] : [nonSplitSeries, ...series];
+      const newSeries = (indexOfNonSplit != null && indexOfNonSplit > 0) ? [...series, nonSplitSeries] : [nonSplitSeries, ...series];
       const newVisData = {
         [model.id]: {
           id: model.id,
-          series: newSeries || series
+          series: (newSeries || series).filter(s => s != null)
         }
       };
       return (
         <div key={key} className="splitVis_split">
           <div className="splitVis_visualization">
             <WrappedComponent
+              getConfig={getConfig}
               model={model}
               visData={newVisData}
               onBrush={props.onBrush}

--- a/src/core_plugins/metrics/public/kbn_vis_types/index.js
+++ b/src/core_plugins/metrics/public/kbn_vis_types/index.js
@@ -66,13 +66,16 @@ export default function MetricsVisProvider(Private) {
             stacked: 'none'
           }],
         time_field: '@timestamp',
+        timerange_mode: 'last',
+        timerange_mode_interval: 'auto',
         index_pattern: '',
         interval: 'auto',
         axis_position: 'left',
         axis_formatter: 'number',
         axis_scale: 'normal',
         show_legend: 1,
-        show_grid: 1
+        show_grid: 1,
+        drop_last_bucket: 1
       },
       component: require('../components/vis_editor')
     },

--- a/src/core_plugins/metrics/public/less/editor.less
+++ b/src/core_plugins/metrics/public/less/editor.less
@@ -63,6 +63,12 @@
   .vis_editor__label;
   font-style: italic;
 }
+
+.vis_editor__descNote {
+  font-size: 0.9em;
+  line-height: 1.2;
+}
+
 .vis_editor__input {
   padding: 8px 10px;
   border-radius: @borderRadius;
@@ -603,5 +609,9 @@
 }
 
 .vis_editor__table-pivot-fields {
+  border-bottom: 2px solid @lineColor;
+}
+
+.vis_editor__dataRangeSelect {
   border-bottom: 2px solid @lineColor;
 }

--- a/src/core_plugins/metrics/public/less/editor.less
+++ b/src/core_plugins/metrics/public/less/editor.less
@@ -71,8 +71,9 @@
 
 .vis_editor__input {
   padding: 8px 10px;
-  border-radius: @borderRadius;
-  border: 1px solid @grayLight;
+  // border-radius: @borderRadius;
+  border: 1px solid @grayLighter;
+  border-bottom: 2px solid @grayLighter;
   font-size: 1.1em;
 }
 .vis_editor__input-grows {
@@ -119,6 +120,7 @@
   display: flex;
   align-items: center;
   position: relative;
+  z-index: 2010;
 }
 .vis_editor__color_picker-swatch {
   border: 1px solid @grayDark;

--- a/src/core_plugins/metrics/public/less/split_vis.less
+++ b/src/core_plugins/metrics/public/less/split_vis.less
@@ -13,4 +13,5 @@
 .splitVis_visualization {
   position: relative;
   flex: 1 0 auto;
+  display: flex;
 }

--- a/src/core_plugins/metrics/public/visualizations/less/includes/top_n.less
+++ b/src/core_plugins/metrics/public/visualizations/less/includes/top_n.less
@@ -7,7 +7,7 @@
   tr:hover { td { background-color: rgba(0,0,0,0.1) } }
 }
 
-.rhythm_top_n__labels,
+.rhythm_top_n__label,
 .rhythm_top_n__value {
   text-align: right;
   white-space: nowrap;

--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_bucket_offset.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_bucket_offset.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { expect } from 'chai';
 import { getBucketKey, getBucketOffset } from '../../helpers/get_bucket_offset';
 

--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_bucket_offset.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_bucket_offset.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { getBucketKey, getBucketOffset } from '../../helpers/get_bucket_offset';
+
+
+describe('getBucketOffset(end, interval)', () => {
+
+  describe('getBucketKey(value, interval, offset)', () => {
+    it('should return 30 for bucket key for 32 with an offset of 5', () => {
+      expect(getBucketKey(32, 5))
+        .to.equal(30);
+    });
+
+    it('should return 30 for bucket key for 30 with an offset of 5', () => {
+      expect(getBucketKey(30, 5))
+        .to.equal(30);
+    });
+
+  });
+
+  it('should return an offset of -3', () => {
+    expect(getBucketOffset(32, 5))
+      .to.equal(-3);
+  });
+
+  it('should return an offset of -5', () => {
+    expect(getBucketOffset(30, 5))
+      .to.equal(-5);
+  });
+
+});

--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_splits.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_splits.js
@@ -50,7 +50,6 @@ describe('getSplits(resp, panel, series)', () => {
         meta: { bucketSize: 10 },
         color: '#FF0000',
         timeseries: { buckets: [] },
-        meta: { bucketSize: 10000 },
         SIBAGG: { value: 1 }
       }
     ]);
@@ -96,7 +95,6 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-01',
         meta: { bucketSize: 10 },
         color: '#FF0000',
-        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 1 }
       },
@@ -106,7 +104,6 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-02',
         meta: { bucketSize: 10 },
         color: '#FF0000',
-        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 2 }
       }
@@ -153,7 +150,6 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-01',
         meta: { bucketSize: 10 },
         color: '#FF0000',
-        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 1 }
       },
@@ -163,7 +159,6 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-02',
         meta: { bucketSize: 10 },
         color: '#930000',
-        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 2 }
       }
@@ -205,7 +200,7 @@ describe('getSplits(resp, panel, series)', () => {
         id: 'SERIES:filter-1',
         key: 'filter-1',
         label: '200s',
-        meta: { bucketSize: 10000 },
+        meta: { bucketSize: 10 },
         color: '#F00',
         timeseries: { buckets: [] },
       },
@@ -213,7 +208,7 @@ describe('getSplits(resp, panel, series)', () => {
         id: 'SERIES:filter-2',
         key: 'filter-2',
         label: '300s',
-        meta: { bucketSize: 10000 },
+        meta: { bucketSize: 10 },
         color: '#0F0',
         timeseries: { buckets: [] },
       }

--- a/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_splits.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/__tests__/helpers/get_splits.js
@@ -26,6 +26,7 @@ describe('getSplits(resp, panel, series)', () => {
     const resp = {
       aggregations: {
         SERIES: {
+          meta: { bucketSize: 10000 },
           timeseries: { buckets: [] },
           SIBAGG: { value: 1 },
           meta: { bucketSize: 10 }
@@ -49,6 +50,7 @@ describe('getSplits(resp, panel, series)', () => {
         meta: { bucketSize: 10 },
         color: '#FF0000',
         timeseries: { buckets: [] },
+        meta: { bucketSize: 10000 },
         SIBAGG: { value: 1 }
       }
     ]);
@@ -58,6 +60,7 @@ describe('getSplits(resp, panel, series)', () => {
     const resp = {
       aggregations: {
         SERIES: {
+          meta: { bucketSize: 10000 },
           buckets: [
             {
               key: 'example-01',
@@ -93,6 +96,7 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-01',
         meta: { bucketSize: 10 },
         color: '#FF0000',
+        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 1 }
       },
@@ -102,6 +106,7 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-02',
         meta: { bucketSize: 10 },
         color: '#FF0000',
+        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 2 }
       }
@@ -112,6 +117,7 @@ describe('getSplits(resp, panel, series)', () => {
     const resp = {
       aggregations: {
         SERIES: {
+          meta: { bucketSize: 10000 },
           buckets: [
             {
               key: 'example-01',
@@ -147,6 +153,7 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-01',
         meta: { bucketSize: 10 },
         color: '#FF0000',
+        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 1 }
       },
@@ -156,6 +163,7 @@ describe('getSplits(resp, panel, series)', () => {
         label: 'example-02',
         meta: { bucketSize: 10 },
         color: '#930000',
+        meta: { bucketSize: 10000 },
         timeseries: { buckets: [] },
         SIBAGG: { value: 2 }
       }
@@ -166,6 +174,7 @@ describe('getSplits(resp, panel, series)', () => {
     const resp = {
       aggregations: {
         SERIES: {
+          meta: { bucketSize: 10000 },
           buckets: {
             'filter-1': {
               timeseries: { buckets: [] },
@@ -196,7 +205,7 @@ describe('getSplits(resp, panel, series)', () => {
         id: 'SERIES:filter-1',
         key: 'filter-1',
         label: '200s',
-        meta: { bucketSize: 10 },
+        meta: { bucketSize: 10000 },
         color: '#F00',
         timeseries: { buckets: [] },
       },
@@ -204,7 +213,7 @@ describe('getSplits(resp, panel, series)', () => {
         id: 'SERIES:filter-2',
         key: 'filter-2',
         label: '300s',
-        meta: { bucketSize: 10 },
+        meta: { bucketSize: 10000 },
         color: '#0F0',
         timeseries: { buckets: [] },
       }

--- a/src/core_plugins/metrics/server/lib/vis_data/get_interval_and_timefield.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/get_interval_and_timefield.js
@@ -36,14 +36,14 @@ t * Licensed to Elasticsearch B.V. under one or more contributor
  * under the License.
  */
 
-import { metricTypes } from '../../../common/metric_types';
+import { isMetric } from '../../../common/metric_types';
 export default function getIntervalAndTimefield(panel, series = {}) {
   const timeField =
     (series.override_index_pattern && series.series_time_field) ||
     panel.time_field;
   const interval =
     (series.override_index_pattern && series.series_interval) || panel.interval;
-  if (metricTypes.includes(panel.type) && panel.timerange_mode === 'last') {
+  if (isMetric(panel.type) && panel.timerange_mode === 'last') {
     return { timeField, interval: panel.timerange_mode_interval || interval };
   }
   return { timeField, interval };

--- a/src/core_plugins/metrics/server/lib/vis_data/get_interval_and_timefield.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/get_interval_and_timefield.js
@@ -17,8 +17,34 @@
  * under the License.
  */
 
+/*
+t * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { metricTypes } from '../../../common/metric_types';
 export default function getIntervalAndTimefield(panel, series = {}) {
-  const timeField = series.override_index_pattern && series.series_time_field || panel.time_field;
-  const interval = series.override_index_pattern && series.series_interval || panel.interval;
+  const timeField =
+    (series.override_index_pattern && series.series_time_field) ||
+    panel.time_field;
+  const interval =
+    (series.override_index_pattern && series.series_interval) || panel.interval;
+  if (metricTypes.includes(panel.type) && panel.timerange_mode === 'last') {
+    return { timeField, interval: panel.timerange_mode_interval || interval };
+  }
   return { timeField, interval };
 }

--- a/src/core_plugins/metrics/server/lib/vis_data/get_series_data.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/get_series_data.js
@@ -21,6 +21,7 @@ import getRequestParams from './series/get_request_params';
 import handleResponseBody from './series/handle_response_body';
 import handleErrorResponse from './handle_error_response';
 import getAnnotations from './get_annotations';
+import { set } from 'lodash';
 export function getSeriesData(req, panel) {
   const { callWithRequest } = req.server.plugins.elasticsearch.getCluster('data');
   const bodies = panel.series.map(series => getRequestParams(req, panel, series));
@@ -34,7 +35,8 @@ export function getSeriesData(req, panel) {
         [panel.id]: {
           id: panel.id,
           series: series.reduce((acc, series) => acc.concat(series), [])
-        }
+        },
+        meta: { response: resp }
       };
     })
     .then(resp => {
@@ -45,9 +47,10 @@ export function getSeriesData(req, panel) {
       });
     })
     .then(resp => {
-      resp.type = panel.type;
+      set(resp, 'type', panel.type);
+      set(resp, 'meta.request', bodies);
       return resp;
     })
-    .catch(handleErrorResponse(panel));
+    .catch(handleErrorResponse(panel, bodies));
 }
 

--- a/src/core_plugins/metrics/server/lib/vis_data/get_table_data.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/get_table_data.js
@@ -30,11 +30,11 @@ export async function getTableData(req, panel) {
   try {
     const resp = await callWithRequest(req, 'search', params);
     const buckets = get(resp, 'aggregations.pivot.buckets', []);
-    return { type: 'table', series: buckets.map(processBucket(panel)) };
+    return { type: 'table', series: buckets.map(processBucket(panel)), meta: { request: params.body, response: resp } };
   } catch (err) {
     if (err.body) {
       err.response = err.body;
-      return { type: 'table', ...handleErrorResponse(panel)(err) };
+      return { type: 'table', ...handleErrorResponse(panel)(err), meta: { request: params.body } };
     }
   }
 }

--- a/src/core_plugins/metrics/server/lib/vis_data/handle_error_response.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/handle_error_response.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export default panel => error => {
+export default (panel, request) => error => {
   if (error.isBoom && error.status === 401) throw error;
   const result = {};
   let errorResponse;
@@ -38,5 +38,6 @@ export default panel => error => {
     error: errorResponse,
     series: []
   };
+  if (request) result.meta = { request };
   return result;
 };

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/get_bucket_offset.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/get_bucket_offset.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export function getBucketKey(value, interval, offset = 0) {
   return Math.floor((value - offset) / interval) * interval + offset;
 }

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/get_bucket_offset.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/get_bucket_offset.js
@@ -1,0 +1,8 @@
+export function getBucketKey(value, interval, offset = 0) {
+  return Math.floor((value - offset) / interval) * interval + offset;
+}
+
+export function getBucketOffset(end, interval) {
+  const bucketKey = getBucketKey(end, interval);
+  return Math.floor((end - interval) - bucketKey);
+}

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/get_splits.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/get_splits.js
@@ -23,7 +23,7 @@ import _ from 'lodash';
 import getLastMetric from './get_last_metric';
 import getSplitColors from './get_split_colors';
 import { formatKey } from './format_key';
-import { metricTypes } from '../../../../common/metric_types';
+import { isMetric } from '../../../../common/metric_types';
 export default function getSplits(resp, panel, series) {
   const meta = _.get(resp, `aggregations.${series.id}.meta`);
   const color = new Color(series.color);
@@ -38,7 +38,7 @@ export default function getSplits(resp, panel, series) {
         bucket.label = formatKey(bucket.key, series);
         bucket.color = panel.type === 'top_n' ? color.hex() : colors.shift();
         bucket.meta = meta;
-        if (metricTypes.includes(panel.type) && panel.timerange_mode === 'all') {
+        if (isMetric(panel.type) && panel.timerange_mode === 'all') {
           bucket.timeseries = {
             buckets: [
               { key: Date.now(), ...bucket.timeseries.buckets._all },
@@ -58,7 +58,7 @@ export default function getSplits(resp, panel, series) {
         bucket.color = filter.color;
         bucket.label = filter.label || filter.filter || '*';
         bucket.meta = meta;
-        if (metricTypes.includes(panel.type) && panel.timerange_mode === 'all') {
+        if (isMetric(panel.type) && panel.timerange_mode === 'all') {
           bucket.timeseries = {
             buckets: [
               { key: Date.now(), ...bucket.timeseries.buckets._all },
@@ -74,7 +74,7 @@ export default function getSplits(resp, panel, series) {
   const timeseries = _.get(resp, `aggregations.${series.id}.timeseries`);
   const mergeObj = {
     meta,
-    timeseries: metricTypes.includes(panel.type) && panel.timerange_mode === 'all' ?
+    timeseries: isMetric(panel.type) && panel.timerange_mode === 'all' ?
       {
         buckets: [
           { key: Date.now(), ...timeseries.buckets._all },

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/has_sibling_aggs.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/has_sibling_aggs.js
@@ -1,0 +1,6 @@
+export function hasSiblingAggs(series) {
+  return series.metrics.some(
+    metric => /_bucket$/.test(metric.type)
+  );
+}
+

--- a/src/core_plugins/metrics/server/lib/vis_data/helpers/has_sibling_aggs.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/helpers/has_sibling_aggs.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export function hasSiblingAggs(series) {
   return series.metrics.some(
     metric => /_bucket$/.test(metric.type)

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
@@ -69,7 +69,6 @@ describe('dateHistogram(req, panel, series)', () => {
                 field: '@timestamp',
                 interval: '10s',
                 min_doc_count: 0,
-                time_zone: 'UTC',
                 offset: '-10s',
                 extended_bounds: {
                   min: 1483228800000,
@@ -111,7 +110,6 @@ describe('dateHistogram(req, panel, series)', () => {
                 field: '@timestamp',
                 interval: '10s',
                 min_doc_count: 0,
-                time_zone: 'UTC',
                 offset: '-10s',
                 extended_bounds: {
                   min: 1483225200000,
@@ -156,7 +154,6 @@ describe('dateHistogram(req, panel, series)', () => {
                 field: 'timestamp',
                 interval: '20s',
                 min_doc_count: 0,
-                time_zone: 'UTC',
                 offset: '-20s',
                 extended_bounds: {
                   min: 1483228800000,

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
@@ -80,7 +80,9 @@ describe('dateHistogram(req, panel, series)', () => {
           meta: {
             bucketSize: 10,
             intervalString: '10s',
-            timeField: '@timestamp'
+            timeField: '@timestamp',
+            to: '2017-01-01T01:00:00.000Z',
+            from: '2017-01-01T00:00:00.000Z'
           }
         }
       }
@@ -118,7 +120,9 @@ describe('dateHistogram(req, panel, series)', () => {
           meta: {
             bucketSize: 10,
             intervalString: '10s',
-            timeField: '@timestamp'
+            timeField: '@timestamp',
+            to: '2017-01-01T00:00:00.000Z',
+            from: '2016-12-31T23:00:00.000Z'
           }
         }
       }
@@ -159,7 +163,9 @@ describe('dateHistogram(req, panel, series)', () => {
           meta: {
             bucketSize: 20,
             intervalString: '20s',
-            timeField: 'timestamp'
+            timeField: 'timestamp',
+            to: '2017-01-01T01:00:00.000Z',
+            from: '2017-01-01T00:00:00.000Z'
           }
         }
       }

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
@@ -70,6 +70,7 @@ describe('dateHistogram(req, panel, series)', () => {
                 interval: '10s',
                 min_doc_count: 0,
                 time_zone: 'UTC',
+                offset: '-10s',
                 extended_bounds: {
                   min: 1483228800000,
                   max: 1483232400000
@@ -82,7 +83,8 @@ describe('dateHistogram(req, panel, series)', () => {
             intervalString: '10s',
             timeField: '@timestamp',
             to: '2017-01-01T01:00:00.000Z',
-            from: '2017-01-01T00:00:00.000Z'
+            from: '2017-01-01T00:00:00.000Z',
+            offset: '-10s'
           }
         }
       }
@@ -110,6 +112,7 @@ describe('dateHistogram(req, panel, series)', () => {
                 interval: '10s',
                 min_doc_count: 0,
                 time_zone: 'UTC',
+                offset: '-10s',
                 extended_bounds: {
                   min: 1483225200000,
                   max: 1483228800000
@@ -122,7 +125,8 @@ describe('dateHistogram(req, panel, series)', () => {
             intervalString: '10s',
             timeField: '@timestamp',
             to: '2017-01-01T00:00:00.000Z',
-            from: '2016-12-31T23:00:00.000Z'
+            from: '2016-12-31T23:00:00.000Z',
+            offset: '-10s'
           }
         }
       }
@@ -153,6 +157,7 @@ describe('dateHistogram(req, panel, series)', () => {
                 interval: '20s',
                 min_doc_count: 0,
                 time_zone: 'UTC',
+                offset: '-20s',
                 extended_bounds: {
                   min: 1483228800000,
                   max: 1483232400000
@@ -163,6 +168,7 @@ describe('dateHistogram(req, panel, series)', () => {
           meta: {
             bucketSize: 20,
             intervalString: '20s',
+            offset: '-20s',
             timeField: 'timestamp',
             to: '2017-01-01T01:00:00.000Z',
             from: '2017-01-01T00:00:00.000Z'

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/__tests__/date_histogram.js
@@ -56,6 +56,13 @@ describe('dateHistogram(req, panel, series)', () => {
     expect(doc).to.eql({
       aggs: {
         test: {
+          meta: {
+            bucketSize: 10,
+            to: '2017-01-01T01:00:00.000Z',
+            from: '2017-01-01T00:00:00.000Z',
+            intervalString: '10s',
+            timeField: '@timestamp'
+          },
           aggs: {
             timeseries: {
               date_histogram: {
@@ -87,6 +94,13 @@ describe('dateHistogram(req, panel, series)', () => {
     expect(doc).to.eql({
       aggs: {
         test: {
+          meta: {
+            bucketSize: 10,
+            to: '2017-01-01T00:00:00.000Z',
+            from: '2016-12-31T23:00:00.000Z',
+            intervalString: '10s',
+            timeField: '@timestamp'
+          },
           aggs: {
             timeseries: {
               date_histogram: {
@@ -121,6 +135,13 @@ describe('dateHistogram(req, panel, series)', () => {
     expect(doc).to.eql({
       aggs: {
         test: {
+          meta: {
+            bucketSize: 20,
+            to: '2017-01-01T01:00:00.000Z',
+            from: '2017-01-01T00:00:00.000Z',
+            intervalString: '20s',
+            timeField: 'timestamp'
+          },
           aggs: {
             timeseries: {
               date_histogram: {

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -21,7 +21,7 @@ import getBucketSize from '../../helpers/get_bucket_size';
 import offsetTime from '../../offset_time';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 import { set } from 'lodash';
-import { metricTypes } from '../../../../../common/metric_types';
+import { isMetric } from '../../../../../common/metric_types';
 import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
 
 export default function dateHistogram(req, panel, series) {
@@ -31,10 +31,10 @@ export default function dateHistogram(req, panel, series) {
     const { from, to }  = offsetTime(req, series.offset_time, panel);
     const { timezone } = req.payload.timerange;
 
-    if (metricTypes.includes(panel.type) && panel.timerange_mode === 'all') {
+    if (isMetric(panel.type) && panel.timerange_mode === 'all') {
       set(doc, `aggs.${series.id}.aggs.timeseries.filters`, { filters: { _all: { match_all: {} } } });
     } else {
-      const useTruncatedTimerange = metricTypes.includes(panel.type) && !hasSiblingAggs(series);
+      const useTruncatedTimerange = isMetric(panel.type) && !hasSiblingAggs(series);
       const boundsMin = useTruncatedTimerange ? to.clone().subtract(5 * bucketSize, 's') : from;
 
       set(doc, `aggs.${series.id}.aggs.timeseries.date_histogram`, {

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -21,22 +21,39 @@ import getBucketSize from '../../helpers/get_bucket_size';
 import offsetTime from '../../offset_time';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 import { set } from 'lodash';
+import { metricTypes } from '../../../../../common/metric_types';
+import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
+
 export default function dateHistogram(req, panel, series) {
   return next => doc => {
     const { timeField, interval } = getIntervalAndTimefield(panel, series);
     const { bucketSize, intervalString } = getBucketSize(req, interval);
-    const { from, to }  = offsetTime(req, series.offset_time);
+    const { from, to }  = offsetTime(req, series.offset_time, panel);
     const { timezone } = req.payload.timerange;
 
-    set(doc, `aggs.${series.id}.aggs.timeseries.date_histogram`, {
-      field: timeField,
-      interval: intervalString,
-      min_doc_count: 0,
-      time_zone: timezone,
-      extended_bounds: {
-        min: from.valueOf(),
-        max: to.valueOf()
-      }
+    if (metricTypes.includes(panel.type) && panel.timerange_mode === 'all') {
+      set(doc, `aggs.${series.id}.aggs.timeseries.filters`, { filters: { _all: { match_all: {} } } });
+    } else {
+      const useTruncatedTimerange = metricTypes.includes(panel.type) && !hasSiblingAggs(series);
+      const boundsMin = useTruncatedTimerange ? to.clone().subtract(5 * bucketSize, 's') : from;
+
+      set(doc, `aggs.${series.id}.aggs.timeseries.date_histogram`, {
+        field: timeField,
+        interval: intervalString,
+        min_doc_count: 0,
+        time_zone: timezone,
+        extended_bounds: {
+          min: boundsMin.valueOf(),
+          max: to.valueOf()
+        }
+      });
+    }
+    set(doc, `aggs.${series.id}.meta`, {
+      to: to.toISOString(),
+      from: from.toISOString(),
+      timeField,
+      intervalString,
+      bucketSize
     });
     set(doc, `aggs.${series.id}.meta`, {
       timeField,

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -55,11 +55,6 @@ export default function dateHistogram(req, panel, series) {
       intervalString,
       bucketSize
     });
-    set(doc, `aggs.${series.id}.meta`, {
-      timeField,
-      intervalString,
-      bucketSize
-    });
     return next(doc);
   };
 }

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/date_histogram.js
@@ -30,7 +30,6 @@ export default function dateHistogram(req, panel, series) {
     const { timeField, interval } = getIntervalAndTimefield(panel, series);
     const { bucketSize, intervalString } = getBucketSize(req, interval);
     const { from, to }  = offsetTime(req, series.offset_time, panel);
-    const { timezone } = req.payload.timerange;
 
     const offset = getBucketOffset(from.valueOf(), bucketSize * 1000);
     const offsetString = `${Math.floor(offset / 1000)}s`;
@@ -45,7 +44,6 @@ export default function dateHistogram(req, panel, series) {
         field: timeField,
         interval: intervalString,
         min_doc_count: 0,
-        time_zone: timezone,
         offset: offsetString,
         extended_bounds: {
           min: boundsMin.valueOf(),

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/query.js
@@ -19,10 +19,19 @@
 
 import offsetTime from '../../offset_time';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
+import getBucketSize from '../../helpers/get_bucket_size';
+import { metricTypes } from '../../../../../common/metric_types';
+import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
+
 export default function query(req, panel, series) {
   return next => doc => {
-    const { timeField } = getIntervalAndTimefield(panel, series);
+    const { timeField, interval } = getIntervalAndTimefield(panel, series);
+    const { bucketSize } = getBucketSize(req, interval);
     const { from, to } = offsetTime(req, series.offset_time);
+
+    const boundsMin = metricTypes.includes(panel.type) && !hasSiblingAggs(series) ?
+      to.clone().subtract(5 * bucketSize, 's') :
+      from;
 
     doc.size = 0;
     doc.query = {
@@ -34,7 +43,7 @@ export default function query(req, panel, series) {
     const timerange = {
       range: {
         [timeField]: {
-          gte: from.valueOf(),
+          gte: panel.timerange_mode === 'all' ? from.valueOf() : boundsMin.valueOf(),
           lte: to.valueOf(),
           format: 'epoch_millis',
         }

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/series/query.js
@@ -20,7 +20,7 @@
 import offsetTime from '../../offset_time';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 import getBucketSize from '../../helpers/get_bucket_size';
-import { metricTypes } from '../../../../../common/metric_types';
+import { isMetric } from '../../../../../common/metric_types';
 import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
 
 export default function query(req, panel, series) {
@@ -29,7 +29,7 @@ export default function query(req, panel, series) {
     const { bucketSize } = getBucketSize(req, interval);
     const { from, to } = offsetTime(req, series.offset_time);
 
-    const boundsMin = metricTypes.includes(panel.type) && !hasSiblingAggs(series) ?
+    const boundsMin = isMetric(panel.type) && !hasSiblingAggs(series) ?
       to.clone().subtract(5 * bucketSize, 's') :
       from;
 

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/date_histogram.js
@@ -22,6 +22,8 @@ import getBucketSize from '../../helpers/get_bucket_size';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 import getTimerange from '../../helpers/get_timerange';
 import { calculateAggRoot } from './calculate_agg_root';
+import { metricTypes } from '../../../../../common/metric_types';
+import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
 
 export default function dateHistogram(req, panel) {
   return next => doc => {
@@ -30,14 +32,28 @@ export default function dateHistogram(req, panel) {
     const { from, to }  = getTimerange(req);
     panel.series.forEach(column => {
       const aggRoot = calculateAggRoot(doc, column);
-      set(doc, `${aggRoot}.timeseries.date_histogram`, {
-        field: timeField,
-        interval: intervalString,
-        min_doc_count: 0,
-        extended_bounds: {
-          min: from.valueOf(),
-          max: to.valueOf()
-        }
+      if (metricTypes.includes(panel.type) && panel.timerange_mode === 'all') {
+        set(doc, `${aggRoot}.timeseries.filters`, { filters: { _all: { match_all: {} } } });
+      } else {
+        const useTruncatedTimerange = metricTypes.includes(panel.type) && !panel.series.some(hasSiblingAggs);
+        const boundsMin = useTruncatedTimerange ? to.clone().subtract(5 * bucketSize, 's') : from;
+
+        set(doc, `${aggRoot}.timeseries.date_histogram`, {
+          field: timeField,
+          interval: intervalString,
+          min_doc_count: 0,
+          extended_bounds: {
+            min: boundsMin.valueOf(),
+            max: to.valueOf()
+          }
+        });
+      }
+      set(doc, aggRoot.replace(/\.aggs$/, '.meta'), {
+        to: to.toISOString(),
+        from: from.toISOString(),
+        timeField,
+        intervalString,
+        bucketSize
       });
       set(doc, aggRoot.replace(/\.aggs$/, '.meta'), {
         timeField,

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/date_histogram.js
@@ -55,11 +55,6 @@ export default function dateHistogram(req, panel) {
         intervalString,
         bucketSize
       });
-      set(doc, aggRoot.replace(/\.aggs$/, '.meta'), {
-        timeField,
-        intervalString,
-        bucketSize
-      });
     });
     return next(doc);
   };

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/date_histogram.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/date_histogram.js
@@ -22,7 +22,7 @@ import getBucketSize from '../../helpers/get_bucket_size';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 import getTimerange from '../../helpers/get_timerange';
 import { calculateAggRoot } from './calculate_agg_root';
-import { metricTypes } from '../../../../../common/metric_types';
+import { isMetric } from '../../../../../common/metric_types';
 import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
 
 export default function dateHistogram(req, panel) {
@@ -32,10 +32,10 @@ export default function dateHistogram(req, panel) {
     const { from, to }  = getTimerange(req);
     panel.series.forEach(column => {
       const aggRoot = calculateAggRoot(doc, column);
-      if (metricTypes.includes(panel.type) && panel.timerange_mode === 'all') {
+      if (isMetric(panel.type) && panel.timerange_mode === 'all') {
         set(doc, `${aggRoot}.timeseries.filters`, { filters: { _all: { match_all: {} } } });
       } else {
-        const useTruncatedTimerange = metricTypes.includes(panel.type) && !panel.series.some(hasSiblingAggs);
+        const useTruncatedTimerange = isMetric(panel.type) && !panel.series.some(hasSiblingAggs);
         const boundsMin = useTruncatedTimerange ? to.clone().subtract(5 * bucketSize, 's') : from;
 
         set(doc, `${aggRoot}.timeseries.date_histogram`, {

--- a/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/query.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/request_processors/table/query.js
@@ -20,7 +20,7 @@
 import getTimerange from '../../helpers/get_timerange';
 import getIntervalAndTimefield from '../../get_interval_and_timefield';
 import getBucketSize from '../../helpers/get_bucket_size';
-import { metricTypes } from '../../../../../common/metric_types';
+import { isMetric } from '../../../../../common/metric_types';
 import { hasSiblingAggs } from '../../helpers/has_sibling_aggs';
 export default function query(req, panel) {
   return next => doc => {
@@ -28,7 +28,7 @@ export default function query(req, panel) {
     const { bucketSize } = getBucketSize(req, interval);
     const { from, to } = getTimerange(req);
 
-    const boundsMin = metricTypes.includes(panel.type) && !panel.series.some(hasSiblingAggs) ?
+    const boundsMin = isMetric(panel.type) && !panel.series.some(hasSiblingAggs) ?
       to.clone().subtract(5 * bucketSize, 's') :
       from;
 

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/__tests__/drop_last_bucket.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/__tests__/drop_last_bucket.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import { dropLastBucket } from '../drop_last_bucket';
+
+describe('dropLastBucket(resp, panel, series)', () => {
+  let panel;
+  let series;
+  let resp;
+
+  beforeEach(() => {
+    panel = {
+      time_field: 'timestamp',
+      mode: 'last',
+      interval: '1m'
+    };
+    series = {
+      id: 'test',
+      chart_type: 'line',
+      stacked: false,
+      line_width: 1,
+      point_size: 1,
+      fill: 0,
+      color: '#F00',
+      split_mode: 'everything',
+      metrics: [{
+        id: 'stddev',
+        mode: 'raw',
+        type: 'std_deviation',
+        field: 'cpu'
+      }]
+    };
+    resp = {
+      aggregations: {
+        test: {
+          meta: {
+            bucketSize: 60,
+            from: '2018-01-01T07:26:00.000Z',
+            intervalString: '1m',
+            timeField: '@timestamp',
+            to: '2018-01-01T07:31:00.000Z',
+          }
+        }
+      }
+    };
+  });
+
+
+  it('should drop the last partial buckte', () => {
+    const next = value => value;
+    const results = [
+      {
+        data: [
+          [ 1514791560000, 0 ],
+          [ 1514791620000, 0 ],
+          [ 1514791680000, 0 ],
+          [ 1514791740000, 0 ],
+          [ 1514791800000, 0 ],
+          [ 1514791860000, 0 ]
+        ]
+      }
+    ];
+    const data = dropLastBucket(resp, panel, series)(next)(results);
+    expect(data).to.eql([
+      {
+        data: [
+          [ 1514791560000, 0 ],
+          [ 1514791620000, 0 ],
+          [ 1514791680000, 0 ],
+          [ 1514791740000, 0 ],
+          [ 1514791800000, 0 ]
+        ]
+      }
+    ]);
+  });
+
+});
+

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/__tests__/drop_last_bucket.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/__tests__/drop_last_bucket.js
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { expect } from 'chai';
 import { dropLastBucket } from '../drop_last_bucket';
 

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/__tests__/drop_last_bucket.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/__tests__/drop_last_bucket.js
@@ -44,11 +44,12 @@ describe('dropLastBucket(resp, panel, series)', () => {
   });
 
 
-  it('should drop the last partial buckte', () => {
+  it('should drop the last partial bucktet', () => {
     const next = value => value;
     const results = [
       {
         data: [
+          [ 1514791500000, 0 ],
           [ 1514791560000, 0 ],
           [ 1514791620000, 0 ],
           [ 1514791680000, 0 ],

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/drop_last_bucket.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/drop_last_bucket.js
@@ -18,15 +18,26 @@
  */
 
 import { get } from 'lodash';
+import moment from 'moment';
 export function dropLastBucket(resp, panel, series) {
   return next => results => {
+    const bucketSize = get(resp, `aggregations.${series.id}.meta.bucketSize`);
+    const maxString = get(resp, `aggregations.${series.id}.meta.to`);
+    const max = moment.utc(maxString);
     const seriesDropLastBucket = get(series, 'override_drop_last_bucket', 1);
     const dropLastBucket = get(panel, 'drop_last_bucket', seriesDropLastBucket);
-    if (dropLastBucket) {
+
+    const isCompatibleRequest = panel.timerange_mode !== 'all' || panel.type === 'timeseries';
+    if (dropLastBucket && isCompatibleRequest) {
       results.forEach(item => {
-        item.data = item.data.slice(0, item.data.length - 1);
+        const lastIndex = item.data.reduceRight((acc, row) => {
+          const date = moment.utc(row[0] + bucketSize);
+          return date.isAfter(max) ? --acc : acc;
+        }, item.data.length);
+        item.data = item.data.slice(0, lastIndex);
       });
     }
+
     return next(results);
   };
 }

--- a/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/drop_last_bucket.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/response_processors/series/drop_last_bucket.js
@@ -21,6 +21,7 @@ import { get } from 'lodash';
 import moment from 'moment';
 export function dropLastBucket(resp, panel, series) {
   return next => results => {
+    if (panel.timerange_mode === 'all') return next(results);
     const bucketSize = get(resp, `aggregations.${series.id}.meta.bucketSize`);
     const maxString = get(resp, `aggregations.${series.id}.meta.to`);
     const max = moment.utc(maxString);

--- a/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
@@ -120,6 +120,8 @@ describe('buildRequestBody(req)', () => {
           },
           meta: {
             timeField: '@timestamp',
+            from: '2017-01-26T20:37:35.881Z',
+            to: '2017-01-26T20:52:35.881Z',
             bucketSize: 10,
             intervalString: '10s'
           },

--- a/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
@@ -123,7 +123,8 @@ describe('buildRequestBody(req)', () => {
             bucketSize: 10,
             intervalString: '10s',
             to: '2017-01-26T20:52:35.881Z',
-            from: '2017-01-26T20:37:35.881Z'
+            from: '2017-01-26T20:37:35.881Z',
+            offset: '-5s'
           },
           aggs: {
             timeseries: {
@@ -132,6 +133,7 @@ describe('buildRequestBody(req)', () => {
                 interval: '10s',
                 min_doc_count: 0,
                 time_zone: 'UTC',
+                offset: '-5s',
                 extended_bounds: {
                   min: 1485463055881,
                   max: 1485463955881

--- a/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
@@ -120,8 +120,6 @@ describe('buildRequestBody(req)', () => {
           },
           meta: {
             timeField: '@timestamp',
-            from: '2017-01-26T20:37:35.881Z',
-            to: '2017-01-26T20:52:35.881Z',
             bucketSize: 10,
             intervalString: '10s'
           },

--- a/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
@@ -132,7 +132,6 @@ describe('buildRequestBody(req)', () => {
                 field: '@timestamp',
                 interval: '10s',
                 min_doc_count: 0,
-                time_zone: 'UTC',
                 offset: '-5s',
                 extended_bounds: {
                   min: 1485463055881,

--- a/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
+++ b/src/core_plugins/metrics/server/lib/vis_data/series/__tests__/build_request_body.js
@@ -121,7 +121,9 @@ describe('buildRequestBody(req)', () => {
           meta: {
             timeField: '@timestamp',
             bucketSize: 10,
-            intervalString: '10s'
+            intervalString: '10s',
+            to: '2017-01-26T20:52:35.881Z',
+            from: '2017-01-26T20:37:35.881Z'
           },
           aggs: {
             timeseries: {

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -33,7 +33,7 @@ export default function ({ getService, getPageObjects }) {
 
       it('should show the correct count in the legend', async function () {
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('156');
+        expect(actualCount).to.be('56');
       });
 
       it('should show the correct count in the legend with 2h offset', async function () {
@@ -41,14 +41,14 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualBuilder.enterOffsetSeries('2h');
         await PageObjects.header.waitUntilLoadingHasFinished();
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('293');
+        expect(actualCount).to.be('379');
       });
 
       it('should show the correct count in the legend with -2h offset', async function () {
         await PageObjects.visualBuilder.enterOffsetSeries('-2h');
         await PageObjects.header.waitUntilLoadingHasFinished();
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('53');
+        expect(actualCount).to.be('31');
       });
 
       after(async () => {
@@ -74,7 +74,7 @@ export default function ({ getService, getPageObjects }) {
       });
 
       it('should show correct data', async function () {
-        const expectedMetricValue =  '157';
+        const expectedMetricValue = '57';
         const value = await PageObjects.visualBuilder.getMetricValue();
         log.debug(`metric value: ${JSON.stringify(value)}`);
         log.debug(`metric value: ${value}`);
@@ -95,7 +95,7 @@ export default function ({ getService, getPageObjects }) {
       });
 
       it('should show correct data', async function () {
-        const expectedMetricValue =  '156';
+        const expectedMetricValue = '56';
         const value = await PageObjects.visualBuilder.getMetricValue();
         log.debug(`metric value: ${value}`);
         expect(value).to.eql(expectedMetricValue);
@@ -116,7 +116,7 @@ export default function ({ getService, getPageObjects }) {
           const labelString = await PageObjects.visualBuilder.getGaugeLabel();
           expect(labelString).to.be('Count');
           const gaugeCount = await PageObjects.visualBuilder.getGaugeCount();
-          expect(gaugeCount).to.be('156');
+          expect(gaugeCount).to.be('56');
         });
       });
     });
@@ -133,7 +133,7 @@ export default function ({ getService, getPageObjects }) {
         const labelString = await PageObjects.visualBuilder.getTopNLabel();
         expect(labelString).to.be('Count');
         const gaugeCount = await PageObjects.visualBuilder.getTopNCount();
-        expect(gaugeCount).to.be('156');
+        expect(gaugeCount).to.be('56');
       });
     });
 
@@ -205,7 +205,7 @@ export default function ({ getService, getPageObjects }) {
       it('should be able verify that values are displayed in the table', async () => {
         const tableData = await PageObjects.visualBuilder.getViewTable();
         log.debug(`Values on ${tableData}`);
-        const expectedData = 'OS Count\nwin 8 13\nwin xp 10\nwin 7 12\nios 5\nosx 3';
+        const expectedData = 'OS Count\nwin 8 13\nwin 7 12\nwin xp 10\nios 5\nosx 3';
         expect(tableData).to.be(expectedData);
       });
 

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -83,6 +83,37 @@ export default function ({ getService, getPageObjects }) {
 
     });
 
+    describe('Data Timerange', () => {
+      beforeEach(async () => {
+        await PageObjects.visualBuilder.resetPage();
+        await PageObjects.visualBuilder.clickMetric();
+      });
+
+      it('should display the correct value for entire timerange', async function () {
+        await PageObjects.visualBuilder.selectDataTimeRange('all');
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        const expectedMetricValue =  '13,830';
+        return PageObjects.visualBuilder.getMetricValue()
+          .then(function (value) {
+            log.debug(`metric value: ${value}`);
+            expect(value).to.eql(expectedMetricValue);
+          });
+      });
+
+      it('should display the correct value for last value', async function () {
+        await PageObjects.visualBuilder.selectDataTimeRange('last');
+        await PageObjects.visualBuilder.setTimeRangeInterval('1d');
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        const expectedMetricValue =  '4,459';
+        return PageObjects.visualBuilder.getMetricValue()
+          .then(function (value) {
+            log.debug(`metric value: ${value}`);
+            expect(value).to.eql(expectedMetricValue);
+          });
+      });
+
+    });
+
     describe('metric', () => {
       before(async () => {
         await PageObjects.visualBuilder.resetPage();

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -33,7 +33,7 @@ export default function ({ getService, getPageObjects }) {
 
       it('should show the correct count in the legend', async function () {
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('56');
+        expect(actualCount).to.be('116');
       });
 
       it('should show the correct count in the legend with 2h offset', async function () {
@@ -41,14 +41,14 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualBuilder.enterOffsetSeries('2h');
         await PageObjects.header.waitUntilLoadingHasFinished();
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('379');
+        expect(actualCount).to.be('403');
       });
 
       it('should show the correct count in the legend with -2h offset', async function () {
         await PageObjects.visualBuilder.enterOffsetSeries('-2h');
         await PageObjects.header.waitUntilLoadingHasFinished();
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('31');
+        expect(actualCount).to.be('68');
       });
 
       after(async () => {
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualBuilder.clickSeriesOption();
         await PageObjects.visualBuilder.selectDataFormat('percent');
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('75.08%');
+        expect(actualCount).to.be('98.68%');
       });
 
     });
@@ -182,7 +182,7 @@ export default function ({ getService, getPageObjects }) {
         const labelString = await PageObjects.visualBuilder.getTopNLabel();
         expect(labelString).to.be('Count');
         const gaugeCount = await PageObjects.visualBuilder.getTopNCount();
-        expect(gaugeCount).to.be('56');
+        expect(gaugeCount).to.be('116');
       });
     });
 
@@ -220,8 +220,8 @@ export default function ({ getService, getPageObjects }) {
           await PageObjects.header.waitUntilLoadingHasFinished();
           const text = await PageObjects.visualBuilder.getMarkdownText();
           const [timestamp, value] = text.split('#');
-          expect(timestamp).to.be('1442901600000');
-          expect(value).to.be('3');
+          expect(timestamp).to.be('1442901300000');
+          expect(value).to.be('0');
         });
 
         it('allow negative time offsets', async () => {
@@ -229,8 +229,8 @@ export default function ({ getService, getPageObjects }) {
           await PageObjects.header.waitUntilLoadingHasFinished();
           const text = await PageObjects.visualBuilder.getMarkdownText();
           const [timestamp, value] = text.split('#');
-          expect(timestamp).to.be('1442901600000');
-          expect(value).to.be('23');
+          expect(timestamp).to.be('1442908800000');
+          expect(value).to.be('40');
         });
       });
 

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -41,7 +41,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualBuilder.enterOffsetSeries('2h');
         await PageObjects.header.waitUntilLoadingHasFinished();
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('157');
+        expect(actualCount).to.be('379');
       });
 
       it('should show the correct count in the legend with -2h offset', async function () {

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -58,6 +58,24 @@ export default function ({ getService, getPageObjects }) {
 
     });
 
+    describe('Filter Ratio', () => {
+      before(async () => {
+        await PageObjects.visualBuilder.resetPage();
+      });
+
+      it('should show the correct value for a filter ratio', async () => {
+        await PageObjects.visualBuilder.selectAggType('filter_ratio');
+        await PageObjects.visualBuilder.setFilterRatioNumerator('machine.os.raw:\'win xp\'');
+        await PageObjects.visualBuilder.selectAggType('avg', 1);
+        await PageObjects.visualBuilder.selectField('bytes', 1);
+        await PageObjects.visualBuilder.clickSeriesOption();
+        await PageObjects.visualBuilder.selectDataFormat('percent');
+        const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
+        expect(actualCount).to.be('75.08%');
+      });
+
+    });
+
     describe('Math Aggregation', () => {
       before(async () => {
         await PageObjects.visualBuilder.resetPage();

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -41,7 +41,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualBuilder.enterOffsetSeries('2h');
         await PageObjects.header.waitUntilLoadingHasFinished();
         const actualCount = await PageObjects.visualBuilder.getRhythmChartLegendValue();
-        expect(actualCount).to.be('379');
+        expect(actualCount).to.be('157');
       });
 
       it('should show the correct count in the legend with -2h offset', async function () {

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -92,7 +92,7 @@ export default function ({ getService, getPageObjects }) {
       it('should display the correct value for entire timerange', async function () {
         await PageObjects.visualBuilder.selectDataTimeRange('all');
         await PageObjects.header.waitUntilLoadingHasFinished();
-        const expectedMetricValue =  '13,830';
+        const expectedMetricValue = '13,830';
         return PageObjects.visualBuilder.getMetricValue()
           .then(function (value) {
             log.debug(`metric value: ${value}`);
@@ -104,7 +104,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualBuilder.selectDataTimeRange('last');
         await PageObjects.visualBuilder.setTimeRangeInterval('1d');
         await PageObjects.header.waitUntilLoadingHasFinished();
-        const expectedMetricValue =  '4,459';
+        const expectedMetricValue = '4,459';
         return PageObjects.visualBuilder.getMetricValue()
           .then(function (value) {
             log.debug(`metric value: ${value}`);

--- a/test/functional/page_objects/visual_builder_page.js
+++ b/test/functional/page_objects/visual_builder_page.js
@@ -182,6 +182,21 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
       await comboBox.set('groupByField', fieldName);
     }
 
+    async selectDataTimeRange(fieldName) {
+      const element = await testSubjects.find('dataTimeRange');
+      const input = await element.findByCssSelector('.Select-input input');
+      await input.type(fieldName);
+      const option = await element.findByCssSelector('.Select-option');
+      await option.click();
+    }
+
+    async setTimeRangeInterval(value, nth = 0) {
+      const expressions = await testSubjects.findAll('timeRangeInterval');
+      await expressions[nth].clearValue();
+      await expressions[nth].type(value);
+      return await PageObjects.header.waitUntilLoadingHasFinished();
+    }
+
     async setLabelValue(value) {
       const el = await testSubjects.find('columnLabelName');
       await el.clearValue();

--- a/test/functional/page_objects/visual_builder_page.js
+++ b/test/functional/page_objects/visual_builder_page.js
@@ -162,6 +162,15 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
       return await PageObjects.header.waitUntilLoadingHasFinished();
     }
 
+    async selectField(type, nth = 0) {
+      const elements = await testSubjects.findAll('fieldSelector');
+      const input = await elements[nth].findByCssSelector('.Select-input input');
+      await input.type(type);
+      const option = await elements[nth].findByCssSelector('.Select-option');
+      await option.click();
+      return await PageObjects.header.waitUntilLoadingHasFinished();
+    }
+
     async fillInExpression(expression, nth = 0) {
       const expressions = await testSubjects.findAll('mathExpression');
       await expressions[nth].type(expression);
@@ -188,6 +197,21 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
       await input.type(fieldName);
       const option = await element.findByCssSelector('.Select-option');
       await option.click();
+    }
+
+    async selectDataFormat(format) {
+      const prefix = '.vis_editor__data_format_picker-container';
+      const input = await find.byCssSelector(`${prefix} .Select-input input`);
+      await input.type(format);
+      const option = await find.byCssSelector(`${prefix} .Select-option`);
+      await option.click();
+    }
+
+    async setFilterRatioNumerator(value, nth = 0) {
+      const el = await testSubjects.findAll('filterRatioNumerator');
+      await el[nth].clearValue();
+      await el[nth].type(value);
+      await PageObjects.header.waitUntilLoadingHasFinished();
     }
 
     async setTimeRangeInterval(value, nth = 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,7 +101,7 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@elastic/datemath@^4.0.2":
+"@elastic/datemath@4.0.2", "@elastic/datemath@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@elastic/datemath/-/datemath-4.0.2.tgz#91417763fa4ec93ad1426cb69aaf2de2e9914a68"
   dependencies:


### PR DESCRIPTION
This PR attempts to fix a common usability issue with the metric style visualizations by adding a new setting that controls the time range used for matching documents. There are two options:

- `Entire time range` will match all the documents selected in the time picker. 
- `Last value` will match only the documents for the specified interval from the end of the time range.

Before this setting users would often try to use the TSVB metric visualization to display a number for the entire time range not realizing that it was the last bucket. In some instances, users would add an "overall average" then scratch their heads wondering why the average would not match up to the raw values they calculated by hand. This PR is an attempt to try and alleviate that confusion by introducing this new concept up front. 

This PR includes the following:

- Adds time range data mode for table, gauge, metric and top n
- Changes query for metric style vis to only query last 5 buckets unless
there is a sibling agg
- Request and response are now included in api response
- Fixed table header EUI upgrade
- Fixed wrapping for top n

Last Value Mode

![image](https://user-images.githubusercontent.com/41702/34313432-2ec83742-e728-11e7-9b3a-da19a7c288bf.png)

Entire Timerange Mode

![image](https://user-images.githubusercontent.com/41702/34313435-3aeaa62c-e728-11e7-92dc-9f7a1d5be34c.png)

When a user switches from "Last Value" mode to "Entire Timerange" mode and they have incompatible pipeline aggs

![image](https://user-images.githubusercontent.com/41702/34313604-93a4640a-e729-11e7-9cae-189fb7e8f0b8.png)


Merry Xmas @alexfrancoeur !
