### PR TITLE
[TSVB] Make form font-sizes consistent (after EUI upgrade)

### DIFF
--- a/src/core_plugins/metrics/public/less/editor.less
+++ b/src/core_plugins/metrics/public/less/editor.less
@@ -67,6 +67,7 @@
   padding: 8px 10px;
   border-radius: @borderRadius;
   border: 1px solid @grayLight;
+  font-size: 1.1em;
 }
 .vis_editor__input-grows {
   .vis_editor__input;


### PR DESCRIPTION
This PR fixes the form font sizes which where messed up by the new EUI style sheet.

Before:
![image](https://user-images.githubusercontent.com/41702/34696460-28db841c-f48c-11e7-8aa2-36dafae6a818.png)

After:

![image](https://user-images.githubusercontent.com/41702/34696402-e9d7426a-f48b-11e7-826c-519425bdf736.png)
