### PR TITLE
[TSVB] Add checks for scaledDataFormat and dateFormat in xaxisFormatter

### DIFF
--- a/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
+++ b/src/core_plugins/metrics/public/components/vis_types/timeseries/vis.js
@@ -31,8 +31,9 @@ class TimeseriesVisualization extends Component {
   }
 
   xaxisFormatter = (val) => {
-    const { visData } = this.props;
-    const formatter = createXaxisFormatter(this.getInterval(), visData.scaledDataFormat, visData.dateFormat);
+    const { scaledDataFormat, dateFormat } = this.props.visData;
+    if (!scaledDataFormat || !dateFormat) return val;
+    const formatter = createXaxisFormatter(this.getInterval(), scaledDataFormat, dateFormat);
     return formatter(val);
   }
 


### PR DESCRIPTION
This PR fixes a bug that was introduced in #15512. When the user switches from any other visualization to "Time Series" an exception is thrown because there isn't a check for the `scaledDataFormat` rules or `dateFormat`. This can be tested by creating a TSVB vis, switching to "Metric" then switching back to "Time Series".