### PR TITLE
[Infra UI] Add URL State to Waffle Map

### DIFF
--- a/x-pack/plugins/infra/public/containers/waffle/with_waffle_options.tsx
+++ b/x-pack/plugins/infra/public/containers/waffle/with_waffle_options.tsx
@@ -53,7 +53,7 @@ interface WaffleOptionsUrlState {
   nodeType?: ReturnType<typeof waffleOptionsSelectors.selectNodeType>;
 }
 
-export const WithWaffleMetricsUrlState = () => (
+export const WithWaffleOptionsUrlState = () => (
   <WithWaffleOptions>
     {({ changeMetrics, urlState }) => (
       <UrlStateContainer

--- a/x-pack/plugins/infra/public/containers/waffle/with_waffle_options.tsx
+++ b/x-pack/plugins/infra/public/containers/waffle/with_waffle_options.tsx
@@ -10,7 +10,6 @@ import { createSelector } from 'reselect';
 import { InfraMetricInput, InfraMetricType, InfraPathType } from '../../../common/graphql/types';
 import { InfraNodeType } from '../../../server/lib/adapters/nodes';
 import { State, waffleOptionsActions, waffleOptionsSelectors } from '../../store';
-import { changeGroupBy, changeNodeType } from '../../store/local/waffle_options/actions';
 import { initialWaffleOptionsState } from '../../store/local/waffle_options/reducer';
 import { asChildFunctionRenderer } from '../../utils/typed_react';
 import { bindPlainActionCreators } from '../../utils/typed_redux';
@@ -55,7 +54,7 @@ interface WaffleOptionsUrlState {
 
 export const WithWaffleOptionsUrlState = () => (
   <WithWaffleOptions>
-    {({ changeMetrics, urlState }) => (
+    {({ changeMetrics, urlState, changeGroupBy, changeNodeType }) => (
       <UrlStateContainer
         urlState={urlState}
         urlStateKey="waffleOptions"

--- a/x-pack/plugins/infra/public/pages/home/index.tsx
+++ b/x-pack/plugins/infra/public/pages/home/index.tsx
@@ -14,6 +14,7 @@ import { Header } from '../../components/header';
 import { ColumnarPage } from '../../components/page';
 
 import { WithWaffleFilterUrlState } from '../../containers/waffle/with_waffle_filters';
+import { WithWaffleOptionsUrlState } from '../../containers/waffle/with_waffle_options';
 import { WithWaffleTimeUrlState } from '../../containers/waffle/with_waffle_time';
 import { WithKibanaChrome } from '../../containers/with_kibana_chrome';
 import { WithSource } from '../../containers/with_source';
@@ -28,6 +29,7 @@ export class HomePage extends React.PureComponent {
               <>
                 <WithWaffleTimeUrlState />
                 <WithWaffleFilterUrlState />
+                <WithWaffleOptionsUrlState />
                 <Header />
                 <HomeToolbar />
                 <HomePageContent />


### PR DESCRIPTION
This PR fixes the name `WithWaffleOptionsUrlState` and adds it to the home page so the URL will serialize the state.