### PR TITLE
[Infra UI] Use link-to service for detail links

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
@@ -8,7 +8,14 @@ import { EuiContextMenu, EuiContextMenuPanelDescriptor, EuiPopover } from '@elas
 import React from 'react';
 import { InfraNodeType } from '../../../common/graphql/types';
 import { InfraWaffleMapNode, InfraWaffleMapOptions } from '../../lib/lib';
-import { getContainerLogsUrl, getHostLogsUrl, getPodLogsUrl } from '../../pages/link_to';
+import {
+  getContainerDetailUrl,
+  getContainerLogsUrl,
+  getHostDetailUrl,
+  getHostLogsUrl,
+  getPodDetailUrl,
+  getPodLogsUrl,
+} from '../../pages/link_to';
 
 interface Props {
   options: InfraWaffleMapOptions;
@@ -27,6 +34,7 @@ export const NodeContextMenu: React.SFC<Props> = ({
   nodeType,
 }) => {
   const nodeLogsUrl = getNodeLogsUrl(nodeType, node);
+  const nodeDetailUrl = getNodeDetailUrl(nodeType, node);
   const nodeField = options.fields ? options.fields[nodeType] : null;
   const panels: EuiContextMenuPanelDescriptor[] = [
     {
@@ -41,10 +49,14 @@ export const NodeContextMenu: React.SFC<Props> = ({
               },
             ]
           : []),
-        {
-          name: `View metrics`,
-          href: `#/metrics/${nodeType}/${node.name}`,
-        },
+        ...(nodeDetailUrl
+          ? [
+              {
+                name: `View metrics`,
+                href: nodeDetailUrl,
+              },
+            ]
+          : []),
         ...(nodeField
           ? [
               {
@@ -87,6 +99,28 @@ const getNodeLogsUrl = (
       return getContainerLogsUrl({ containerId: lastPathSegment.value });
     case 'pod':
       return getPodLogsUrl({ podId: lastPathSegment.value });
+    default:
+      return undefined;
+  }
+};
+
+const getNodeDetailUrl = (
+  nodeType: 'host' | 'container' | 'pod',
+  { path }: InfraWaffleMapNode
+): string | undefined => {
+  if (path.length <= 0) {
+    return undefined;
+  }
+
+  const lastPathSegment = path[path.length - 1];
+
+  switch (nodeType) {
+    case 'host':
+      return getHostDetailUrl({ name: lastPathSegment.value });
+    case 'container':
+      return getContainerDetailUrl({ name: lastPathSegment.value });
+    case 'pod':
+      return getPodDetailUrl({ name: lastPathSegment.value });
     default:
       return undefined;
   }

--- a/x-pack/plugins/infra/public/pages/link_to/index.ts
+++ b/x-pack/plugins/infra/public/pages/link_to/index.ts
@@ -8,3 +8,6 @@ export { LinkToPage } from './link_to';
 export { getContainerLogsUrl, RedirectToContainerLogs } from './redirect_to_container_logs';
 export { getHostLogsUrl, RedirectToHostLogs } from './redirect_to_host_logs';
 export { getPodLogsUrl, RedirectToPodLogs } from './redirect_to_pod_logs';
+export { getHostDetailUrl, RedirectToHostDetail } from './redirect_to_host_detail';
+export { getContainerDetailUrl, RedirectToContainerDetail } from './redirect_to_container_detail';
+export { getPodDetailUrl, RedirectToPodDetail } from './redirect_to_pod_detail';

--- a/x-pack/plugins/infra/public/pages/link_to/link_to.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/link_to.tsx
@@ -7,8 +7,11 @@
 import React from 'react';
 import { match as RouteMatch, Redirect, Route, Switch } from 'react-router-dom';
 
+import { RedirectToContainerDetail } from './redirect_to_container_detail';
 import { RedirectToContainerLogs } from './redirect_to_container_logs';
+import { RedirectToHostDetail } from './redirect_to_host_detail';
 import { RedirectToHostLogs } from './redirect_to_host_logs';
+import { RedirectToPodDetail } from './redirect_to_pod_detail';
 import { RedirectToPodLogs } from './redirect_to_pod_logs';
 
 interface LinkToPageProps {
@@ -27,6 +30,9 @@ export class LinkToPage extends React.Component<LinkToPageProps> {
         />
         <Route path={`${match.url}/host-logs/:hostname`} component={RedirectToHostLogs} />
         <Route path={`${match.url}/pod-logs/:podId`} component={RedirectToPodLogs} />
+        <Route path={`${match.url}/host-detail/:name`} component={RedirectToHostDetail} />
+        <Route path={`${match.url}/pod-detail/:name`} component={RedirectToPodDetail} />
+        <Route path={`${match.url}/container-detail/:name`} component={RedirectToContainerDetail} />
         <Redirect to="/home" />
       </Switch>
     );

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_container_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_container_detail.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+import { LoadingPage } from '../../components/loading_page';
+import { WithSource } from '../../containers/with_source';
+
+export const RedirectToContainerDetail = ({
+  match,
+  location,
+}: RouteComponentProps<{ name: string }>) => (
+  <WithSource>
+    {({ configuredFields }) => {
+      if (!configuredFields) {
+        return <LoadingPage message="Loading container details" />;
+      }
+
+      return <Redirect to={`/metrics/container/${match.params.name}`} />;
+    }}
+  </WithSource>
+);
+
+export const getContainerDetailUrl = ({ name }: { name: string }) =>
+  `#/link-to/container-detail/${name}`;

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_container_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_container_detail.tsx
@@ -7,22 +7,8 @@
 import React from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
 
-import { LoadingPage } from '../../components/loading_page';
-import { WithSource } from '../../containers/with_source';
-
-export const RedirectToContainerDetail = ({
-  match,
-  location,
-}: RouteComponentProps<{ name: string }>) => (
-  <WithSource>
-    {({ configuredFields }) => {
-      if (!configuredFields) {
-        return <LoadingPage message="Loading container details" />;
-      }
-
-      return <Redirect to={`/metrics/container/${match.params.name}`} />;
-    }}
-  </WithSource>
+export const RedirectToContainerDetail = ({ match }: RouteComponentProps<{ name: string }>) => (
+  <Redirect to={`/metrics/container/${match.params.name}`} />
 );
 
 export const getContainerDetailUrl = ({ name }: { name: string }) =>

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_host_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_host_detail.tsx
@@ -7,22 +7,8 @@
 import React from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
 
-import { LoadingPage } from '../../components/loading_page';
-import { WithSource } from '../../containers/with_source';
-
-export const RedirectToHostDetail = ({
-  match,
-  location,
-}: RouteComponentProps<{ name: string }>) => (
-  <WithSource>
-    {({ configuredFields }) => {
-      if (!configuredFields) {
-        return <LoadingPage message="Loading host details" />;
-      }
-
-      return <Redirect to={`/metrics/host/${match.params.name}`} />;
-    }}
-  </WithSource>
+export const RedirectToHostDetail = ({ match }: RouteComponentProps<{ name: string }>) => (
+  <Redirect to={`/metrics/host/${match.params.name}`} />
 );
 
 export const getHostDetailUrl = ({ name }: { name: string }) => `#/link-to/host-detail/${name}`;

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_host_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_host_detail.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+import { LoadingPage } from '../../components/loading_page';
+import { WithSource } from '../../containers/with_source';
+
+export const RedirectToHostDetail = ({
+  match,
+  location,
+}: RouteComponentProps<{ name: string }>) => (
+  <WithSource>
+    {({ configuredFields }) => {
+      if (!configuredFields) {
+        return <LoadingPage message="Loading host details" />;
+      }
+
+      return <Redirect to={`/metrics/host/${match.params.name}`} />;
+    }}
+  </WithSource>
+);
+
+export const getHostDetailUrl = ({ name }: { name: string }) => `#/link-to/host-detail/${name}`;

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_pod_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_pod_detail.tsx
@@ -7,19 +7,8 @@
 import React from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
 
-import { LoadingPage } from '../../components/loading_page';
-import { WithSource } from '../../containers/with_source';
-
-export const RedirectToPodDetail = ({ match, location }: RouteComponentProps<{ name: string }>) => (
-  <WithSource>
-    {({ configuredFields }) => {
-      if (!configuredFields) {
-        return <LoadingPage message="Loading pod details" />;
-      }
-
-      return <Redirect to={`/metrics/pod/${match.params.name}`} />;
-    }}
-  </WithSource>
+export const RedirectToPodDetail = ({ match }: RouteComponentProps<{ name: string }>) => (
+  <Redirect to={`/metrics/pod/${match.params.name}`} />
 );
 
 export const getPodDetailUrl = ({ name }: { name: string }) => `#/link-to/pod-detail/${name}`;

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_pod_detail.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_pod_detail.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+
+import { LoadingPage } from '../../components/loading_page';
+import { WithSource } from '../../containers/with_source';
+
+export const RedirectToPodDetail = ({ match, location }: RouteComponentProps<{ name: string }>) => (
+  <WithSource>
+    {({ configuredFields }) => {
+      if (!configuredFields) {
+        return <LoadingPage message="Loading pod details" />;
+      }
+
+      return <Redirect to={`/metrics/pod/${match.params.name}`} />;
+    }}
+  </WithSource>
+);
+
+export const getPodDetailUrl = ({ name }: { name: string }) => `#/link-to/pod-detail/${name}`;


### PR DESCRIPTION
This PR used the link-to route for the detail page links for hosts, pods
and containers. The URLs are as follows:
```
/link-to/host-detail/:name
/link-to/container-detail/:name
/link-to/pod-detail/:name
```
