### PR TITLE
[Infra UI] Fix Image Paths for Node Type Switcher

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/waffle_node_type_switcher.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/waffle_node_type_switcher.tsx
@@ -25,13 +25,13 @@ export class WaffleNodeTypeSwitcher extends React.PureComponent<Props> {
     return (
       <EuiKeyPadMenu>
         <EuiKeyPadMenuItem label="Hosts" onClick={this.handleClick(InfraNodeType.host)}>
-          <img src="/plugins/infra/images/hosts.svg" className="euiIcon euiIcon--large" />
+          <img src="../plugins/infra/images/hosts.svg" className="euiIcon euiIcon--large" />
         </EuiKeyPadMenuItem>
         <EuiKeyPadMenuItem label="Kubernetes" onClick={this.handleClick(InfraNodeType.pod)}>
-          <img src="/plugins/infra/images/k8.svg" className="euiIcon euiIcon--large" />
+          <img src="../plugins/infra/images/k8.svg" className="euiIcon euiIcon--large" />
         </EuiKeyPadMenuItem>
         <EuiKeyPadMenuItem label="Docker" onClick={this.handleClick(InfraNodeType.container)}>
-          <img src="/plugins/infra/images/docker.svg" className="euiIcon euiIcon--large" />
+          <img src="../plugins/infra/images/docker.svg" className="euiIcon euiIcon--large" />
         </EuiKeyPadMenuItem>
       </EuiKeyPadMenu>
     );


### PR DESCRIPTION
This PR fixes the images on the node switch to be relative instead of absolute (so it will work with a base path defined).