### PR TITLE
add 'doc_table:hideTimeColumn' advanced setting

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -39,6 +39,7 @@ document.
 `discover:sort:defaultOrder`:: Controls the default sort direction for time based index patterns in the Discover app.
 `doc_table:highlight`:: Highlight results in Discover and Saved Searches Dashboard. Highlighting makes request slow when
 working on big documents. Set this property to `false` to disable highlighting.
+`doc_table:hideTimeColumn`:: Hide the 'Time' column in Discover and in all Saved Searches on Dashboards.
 `search:includeFrozen`:: Will include {ref}/frozen-indices.html[frozen indices] in results if enabled. Searching through frozen indices
 might increase the search time.
 `courier:maxSegmentCount`:: Kibana splits requests in the Discover app into segments to limit the size of requests sent to

--- a/src/legacy/core_plugins/kibana/public/discover/controllers/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/controllers/discover.js
@@ -380,7 +380,8 @@ function discoverController(
     }
 
     const timeFieldName = $scope.indexPattern.timeFieldName;
-    const fields = timeFieldName ? [timeFieldName, ...selectedFields] : selectedFields;
+    const hideTimeColumn = config.get('doc_table:hideTimeColumn');
+    const fields = (timeFieldName && !hideTimeColumn) ? [timeFieldName, ...selectedFields] : selectedFields;
     return {
       searchFields: fields,
       selectFields: fields

--- a/src/legacy/core_plugins/kibana/ui_setting_defaults.js
+++ b/src/legacy/core_plugins/kibana/ui_setting_defaults.js
@@ -269,6 +269,16 @@ export function getUiSettingDefaults() {
       }),
       category: ['discover'],
     },
+    'doc_table:hideTimeColumn': {
+      name: i18n.translate('kbn.advancedSettings.docTableHideTimeColumnTitle', {
+        defaultMessage: 'Hide \'Time\' column',
+      }),
+      value: false,
+      description: i18n.translate('kbn.advancedSettings.docTableHideTimeColumnText', {
+        defaultMessage: 'Hide \'Time\' column in Discover and Saved Searches Dashboard.',
+      }),
+      category: ['discover'],
+    },
     'courier:maxSegmentCount': {
       name: i18n.translate('kbn.advancedSettings.courier.maxSegmentCountTitle', {
         defaultMessage: 'Maximum segment count',

--- a/src/legacy/core_plugins/kibana/ui_setting_defaults.js
+++ b/src/legacy/core_plugins/kibana/ui_setting_defaults.js
@@ -275,7 +275,7 @@ export function getUiSettingDefaults() {
       }),
       value: false,
       description: i18n.translate('kbn.advancedSettings.docTableHideTimeColumnText', {
-        defaultMessage: 'Hide \'Time\' column in Discover and Saved Searches Dashboard.',
+        defaultMessage: 'Hide the \'Time\' column in Discover and in all Saved Searches on Dashboards.',
       }),
       category: ['discover'],
     },

--- a/src/ui/public/doc_table/components/table_header.html
+++ b/src/ui/public/doc_table/components/table_header.html
@@ -1,7 +1,7 @@
 <tr>
   <td width="1%"></td>
   <th
-    ng-if="indexPattern.timeFieldName"
+    ng-if="indexPattern.timeFieldName && !hideTimeColumn"
     data-test-subj="docTableHeaderField"
     scope="col"
   >

--- a/src/ui/public/doc_table/components/table_header.js
+++ b/src/ui/public/doc_table/components/table_header.js
@@ -36,7 +36,9 @@ module.directive('kbnTableHeader', function (shortDotsFilter) {
       onMoveColumn: '=?',
     },
     template: headerHtml,
-    controller: function ($scope) {
+    controller: function ($scope, config) {
+      $scope.hideTimeColumn = config.get('doc_table:hideTimeColumn');
+
       $scope.isSortableColumn = function isSortableColumn(columnName) {
         return (
           !!$scope.indexPattern

--- a/src/ui/public/doc_table/components/table_row.js
+++ b/src/ui/public/doc_table/components/table_row.js
@@ -45,7 +45,7 @@ const MIN_LINE_LENGTH = 20;
  * <tr ng-repeat="row in rows" kbn-table-row="row"></tr>
  * ```
  */
-module.directive('kbnTableRow', function ($compile, $httpParamSerializer, kbnUrl) {
+module.directive('kbnTableRow', function ($compile, $httpParamSerializer, kbnUrl, config) {
   const cellTemplate = _.template(noWhiteSpace(require('ui/doc_table/components/table_row/cell.html')));
   const truncateByHeightTemplate = _.template(noWhiteSpace(require('ui/partials/truncate_by_height.html')));
 
@@ -139,7 +139,8 @@ module.directive('kbnTableRow', function ($compile, $httpParamSerializer, kbnUrl
         ];
 
         const mapping = indexPattern.fields.byName;
-        if (indexPattern.timeFieldName) {
+        const hideTimeColumn = config.get('doc_table:hideTimeColumn');
+        if (indexPattern.timeFieldName && !hideTimeColumn) {
           newHtmls.push(cellTemplate({
             timefield: true,
             formatted: _displayField(row, indexPattern.timeFieldName),


### PR DESCRIPTION
Related to #3319 

This PR adds a new advanced setting : `'doc_table:hideTimeColumn'`

Behavior: When this advanced setting (boolean) is enabled, on discover app and saved searches on Dashboard app, the first 'Time' column is not displayed.

This is useful for every user who have a timeseries based index-pattern and does not want 'timestamp' column on every doc table.
I think particularly about 'saved searches' that are displayed on a dashboard. On some cases, timestamp is not an interesting information.
Despite this setting is enabled, users can still add '@timestamp' field manually on some saved searches.

Release Summary: Kibana now offers an advanced setting (doc_table.hideTimeColumn) which will hide the 'Time' column from the UI for Discover and Saved Searches. Enabling this setting will affect all Saved Searches in all Dashboards within the current Space.