### PR TITLE
[Ingest UI] Add Nginx Metrics to Detail Pages

### DIFF
--- a/x-pack/plugins/infra/common/graphql/introspection.json
+++ b/x-pack/plugins/infra/common/graphql/introspection.json
@@ -1789,6 +1789,30 @@
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "nginxHits",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nginxRequestRate",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nginxActiveConnections",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nginxRequestsPerConnection",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null

--- a/x-pack/plugins/infra/common/graphql/types.ts
+++ b/x-pack/plugins/infra/common/graphql/types.ts
@@ -597,6 +597,10 @@ export enum InfraMetric {
   containerDiskIOBytes = 'containerDiskIOBytes',
   containerMemory = 'containerMemory',
   containerNetworkTraffic = 'containerNetworkTraffic',
+  nginxHits = 'nginxHits',
+  nginxRequestRate = 'nginxRequestRate',
+  nginxActiveConnections = 'nginxActiveConnections',
+  nginxRequestsPerConnection = 'nginxRequestsPerConnection',
 }
 
 export enum InfraOperator {

--- a/x-pack/plugins/infra/public/pages/metrics/layouts/container.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/container.ts
@@ -6,6 +6,7 @@
 
 import { InfraMetric } from '../../../../common/graphql/types';
 import { InfraFormatterType } from '../../../lib/lib';
+import { nginxLayoutCreator } from './nginx';
 import {
   InfraMetricLayoutCreator,
   InfraMetricLayoutSectionType,
@@ -127,4 +128,5 @@ export const containerLayoutCreator: InfraMetricLayoutCreator = theme => [
       },
     ],
   },
+  ...nginxLayoutCreator(theme),
 ];

--- a/x-pack/plugins/infra/public/pages/metrics/layouts/host.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/host.ts
@@ -216,4 +216,71 @@ export const hostLayoutCreator: InfraMetricLayoutCreator = theme => [
       },
     ],
   },
+  {
+    id: 'nginxOverview',
+    label: 'Nginx',
+    requires: ['nginx'],
+    sections: [
+      {
+        id: InfraMetric.nginxHits,
+        label: 'Hits',
+        requires: ['nginx.access'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          stacked: true,
+          seriesOverrides: {
+            '200s': { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.bar },
+            '300s': { color: theme.eui.euiColorVis5, type: InfraMetricLayoutVisualizationType.bar },
+            '400s': { color: theme.eui.euiColorVis2, type: InfraMetricLayoutVisualizationType.bar },
+            '500s': { color: theme.eui.euiColorVis9, type: InfraMetricLayoutVisualizationType.bar },
+          },
+        },
+      },
+      {
+        id: InfraMetric.nginxRequestRate,
+        label: 'Request Rate',
+        requires: ['nginx.statusstub'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          formatterTemplate: '{{value}}/s',
+          seriesOverrides: {
+            rate: { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.area },
+          },
+        },
+      },
+      {
+        id: InfraMetric.nginxActiveConnections,
+        label: 'Active Connections',
+        requires: ['nginx.statusstub'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          seriesOverrides: {
+            connections: {
+              color: theme.eui.euiColorVis0,
+              type: InfraMetricLayoutVisualizationType.bar,
+            },
+          },
+        },
+      },
+      {
+        id: InfraMetric.nginxRequestsPerConnection,
+        label: 'Requests per Connections',
+        requires: ['nginx.statusstub'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          seriesOverrides: {
+            reqPerConns: {
+              color: theme.eui.euiColorVis0,
+              type: InfraMetricLayoutVisualizationType.bar,
+              name: 'reqs per conn',
+            },
+          },
+        },
+      },
+    ],
+  },
 ];

--- a/x-pack/plugins/infra/public/pages/metrics/layouts/host.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/host.ts
@@ -6,6 +6,7 @@
 
 import { InfraMetric } from '../../../../common/graphql/types';
 import { InfraFormatterType } from '../../../lib/lib';
+import { nginxLayoutCreator } from './nginx';
 import {
   InfraMetricLayoutCreator,
   InfraMetricLayoutSectionType,
@@ -216,71 +217,5 @@ export const hostLayoutCreator: InfraMetricLayoutCreator = theme => [
       },
     ],
   },
-  {
-    id: 'nginxOverview',
-    label: 'Nginx',
-    requires: ['nginx'],
-    sections: [
-      {
-        id: InfraMetric.nginxHits,
-        label: 'Hits',
-        requires: ['nginx.access'],
-        type: InfraMetricLayoutSectionType.chart,
-        visConfig: {
-          formatter: InfraFormatterType.abvNumber,
-          stacked: true,
-          seriesOverrides: {
-            '200s': { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.bar },
-            '300s': { color: theme.eui.euiColorVis5, type: InfraMetricLayoutVisualizationType.bar },
-            '400s': { color: theme.eui.euiColorVis2, type: InfraMetricLayoutVisualizationType.bar },
-            '500s': { color: theme.eui.euiColorVis9, type: InfraMetricLayoutVisualizationType.bar },
-          },
-        },
-      },
-      {
-        id: InfraMetric.nginxRequestRate,
-        label: 'Request Rate',
-        requires: ['nginx.statusstub'],
-        type: InfraMetricLayoutSectionType.chart,
-        visConfig: {
-          formatter: InfraFormatterType.abvNumber,
-          formatterTemplate: '{{value}}/s',
-          seriesOverrides: {
-            rate: { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.area },
-          },
-        },
-      },
-      {
-        id: InfraMetric.nginxActiveConnections,
-        label: 'Active Connections',
-        requires: ['nginx.statusstub'],
-        type: InfraMetricLayoutSectionType.chart,
-        visConfig: {
-          formatter: InfraFormatterType.abvNumber,
-          seriesOverrides: {
-            connections: {
-              color: theme.eui.euiColorVis0,
-              type: InfraMetricLayoutVisualizationType.bar,
-            },
-          },
-        },
-      },
-      {
-        id: InfraMetric.nginxRequestsPerConnection,
-        label: 'Requests per Connections',
-        requires: ['nginx.statusstub'],
-        type: InfraMetricLayoutSectionType.chart,
-        visConfig: {
-          formatter: InfraFormatterType.abvNumber,
-          seriesOverrides: {
-            reqPerConns: {
-              color: theme.eui.euiColorVis0,
-              type: InfraMetricLayoutVisualizationType.bar,
-              name: 'reqs per conn',
-            },
-          },
-        },
-      },
-    ],
-  },
+  ...nginxLayoutCreator(theme),
 ];

--- a/x-pack/plugins/infra/public/pages/metrics/layouts/nginx.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/nginx.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraMetric } from '../../../../common/graphql/types';
+import { InfraFormatterType } from '../../../lib/lib';
+import {
+  InfraMetricLayoutCreator,
+  InfraMetricLayoutSectionType,
+  InfraMetricLayoutVisualizationType,
+} from './types';
+
+export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
+  {
+    id: 'nginxOverview',
+    label: 'Nginx',
+    requires: ['nginx'],
+    sections: [
+      {
+        id: InfraMetric.nginxHits,
+        label: 'Hits',
+        requires: ['nginx.access'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          stacked: true,
+          seriesOverrides: {
+            '200s': { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.bar },
+            '300s': { color: theme.eui.euiColorVis5, type: InfraMetricLayoutVisualizationType.bar },
+            '400s': { color: theme.eui.euiColorVis2, type: InfraMetricLayoutVisualizationType.bar },
+            '500s': { color: theme.eui.euiColorVis9, type: InfraMetricLayoutVisualizationType.bar },
+          },
+        },
+      },
+      {
+        id: InfraMetric.nginxRequestRate,
+        label: 'Request Rate',
+        requires: ['nginx.statusstub'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          formatterTemplate: '{{value}}/s',
+          seriesOverrides: {
+            rate: { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.area },
+          },
+        },
+      },
+      {
+        id: InfraMetric.nginxActiveConnections,
+        label: 'Active Connections',
+        requires: ['nginx.statusstub'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          seriesOverrides: {
+            connections: {
+              color: theme.eui.euiColorVis0,
+              type: InfraMetricLayoutVisualizationType.bar,
+            },
+          },
+        },
+      },
+      {
+        id: InfraMetric.nginxRequestsPerConnection,
+        label: 'Requests per Connections',
+        requires: ['nginx.statusstub'],
+        type: InfraMetricLayoutSectionType.chart,
+        visConfig: {
+          formatter: InfraFormatterType.abvNumber,
+          seriesOverrides: {
+            reqPerConns: {
+              color: theme.eui.euiColorVis0,
+              type: InfraMetricLayoutVisualizationType.bar,
+              name: 'reqs per conn',
+            },
+          },
+        },
+      },
+    ],
+  },
+];

--- a/x-pack/plugins/infra/public/pages/metrics/layouts/nginx.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/nginx.ts
@@ -27,7 +27,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
           formatter: InfraFormatterType.abvNumber,
           stacked: true,
           seriesOverrides: {
-            '200s': { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.bar },
+            '200s': { color: theme.eui.euiColorVis1, type: InfraMetricLayoutVisualizationType.bar },
             '300s': { color: theme.eui.euiColorVis5, type: InfraMetricLayoutVisualizationType.bar },
             '400s': { color: theme.eui.euiColorVis2, type: InfraMetricLayoutVisualizationType.bar },
             '500s': { color: theme.eui.euiColorVis9, type: InfraMetricLayoutVisualizationType.bar },
@@ -43,7 +43,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
           formatter: InfraFormatterType.abvNumber,
           formatterTemplate: '{{value}}/s',
           seriesOverrides: {
-            rate: { color: theme.eui.euiColorVis0, type: InfraMetricLayoutVisualizationType.area },
+            rate: { color: theme.eui.euiColorVis1, type: InfraMetricLayoutVisualizationType.area },
           },
         },
       },
@@ -56,7 +56,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
           formatter: InfraFormatterType.abvNumber,
           seriesOverrides: {
             connections: {
-              color: theme.eui.euiColorVis0,
+              color: theme.eui.euiColorVis1,
               type: InfraMetricLayoutVisualizationType.bar,
             },
           },
@@ -71,7 +71,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
           formatter: InfraFormatterType.abvNumber,
           seriesOverrides: {
             reqPerConns: {
-              color: theme.eui.euiColorVis0,
+              color: theme.eui.euiColorVis1,
               type: InfraMetricLayoutVisualizationType.bar,
               name: 'reqs per conn',
             },

--- a/x-pack/plugins/infra/public/pages/metrics/layouts/pod.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/pod.ts
@@ -6,6 +6,7 @@
 
 import { InfraMetric } from '../../../../common/graphql/types';
 import { InfraFormatterType } from '../../../lib/lib';
+import { nginxLayoutCreator } from './nginx';
 import {
   InfraMetricLayoutCreator,
   InfraMetricLayoutSectionType,
@@ -96,4 +97,5 @@ export const podLayoutCreator: InfraMetricLayoutCreator = theme => [
       },
     ],
   },
+  ...nginxLayoutCreator(theme),
 ];

--- a/x-pack/plugins/infra/server/graphql/metrics/schema.gql.ts
+++ b/x-pack/plugins/infra/server/graphql/metrics/schema.gql.ts
@@ -31,6 +31,10 @@ export const metricsSchema: any = gql`
     containerDiskIOBytes
     containerMemory
     containerNetworkTraffic
+    nginxHits
+    nginxRequestRate
+    nginxActiveConnections
+    nginxRequestsPerConnection
   }
 
   type InfraMetricData {

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
@@ -7,6 +7,7 @@
 import {
   InfraMetric,
   InfraMetricData,
+  InfraMetricType,
   InfraNodeType,
   InfraTimerangeInput,
 } from '../../../../common/graphql/types';
@@ -38,12 +39,13 @@ export enum InfraMetricModelMetricType {
   series_agg = 'series_agg',
   positive_only = 'positive_only',
   derivative = 'derivative',
+  count = 'count',
 }
 
 export interface InfraMetricModel {
   id: string;
   requires: string[];
-  index_pattern: string;
+  index_pattern: string | string[];
   interval: string;
   time_field: string;
   type: string;
@@ -86,6 +88,11 @@ export interface InfraMetricModelBucketScriptVariable {
   name: string;
 }
 
+export interface InfraMetricModelCount {
+  id: string;
+  type: InfraMetricModelMetricType.count;
+}
+
 export interface InfraMetricModelBucketScript {
   id: string;
   script: string;
@@ -94,6 +101,7 @@ export interface InfraMetricModelBucketScript {
 }
 
 export type InfraMetricModelMetric =
+  | InfraMetricModelCount
   | InfraMetricModelBasicMetric
   | InfraMetricModelBucketScript
   | InfraMetricModelDerivative
@@ -101,6 +109,6 @@ export type InfraMetricModelMetric =
 
 export type InfraMetricModelCreator = (
   timeField: string,
-  indexPattern: string,
+  indexPattern: string | string[],
   interval: string
 ) => InfraMetricModel;

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
@@ -7,7 +7,6 @@
 import {
   InfraMetric,
   InfraMetricData,
-  InfraMetricType,
   InfraNodeType,
   InfraTimerangeInput,
 } from '../../../../common/graphql/types';

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/kibana_metrics_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/kibana_metrics_adapter.ts
@@ -27,7 +27,10 @@ export class KibanaMetricsAdapter implements InfraMetricsAdapter {
       [InfraNodeType.container]: options.sourceConfiguration.fields.container,
       [InfraNodeType.pod]: options.sourceConfiguration.fields.pod,
     };
-    const indexPattern = options.sourceConfiguration.metricAlias;
+    const indexPattern = [
+      options.sourceConfiguration.metricAlias,
+      options.sourceConfiguration.logAlias,
+    ];
     const timeField = options.sourceConfiguration.fields.timestamp;
     const interval = options.timerange.interval;
     const nodeField = fields[options.nodeType];

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/lib/check_valid_node.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/lib/check_valid_node.ts
@@ -8,7 +8,7 @@ import { InfraDatabaseSearchResponse } from '../../framework';
 
 export const checkValidNode = async (
   search: <Aggregation>(options: object) => Promise<InfraDatabaseSearchResponse<{}, Aggregation>>,
-  indexPattern: string,
+  indexPattern: string | string[],
   field: string,
   id: string
 ): Promise<boolean> => {

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/index.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/index.ts
@@ -32,6 +32,10 @@ import { containerDiskIOOps } from './container/container_diskio_ops';
 import { containerMemory } from './container/container_memory';
 import { containerNetworkTraffic } from './container/container_network_traffic';
 import { containerOverview } from './container/container_overview';
+import { nginxActiveConnections } from './nginx/nginx_active_connections';
+import { nginxHits } from './nginx/nginx_hits';
+import { nginxRequestRate } from './nginx/nginx_request_rate';
+import { nginxRequestsPerConnection } from './nginx/nginx_requests_per_connection';
 
 interface InfraMetricModels {
   [key: string]: InfraMetricModelCreator;
@@ -63,4 +67,8 @@ export const metricModels: InfraMetricModels = {
   [InfraMetric.containerNetworkTraffic]: containerNetworkTraffic,
   [InfraMetric.containerMemory]: containerMemory,
   [InfraMetric.containerOverview]: containerOverview,
+  [InfraMetric.nginxHits]: nginxHits,
+  [InfraMetric.nginxRequestRate]: nginxRequestRate,
+  [InfraMetric.nginxActiveConnections]: nginxActiveConnections,
+  [InfraMetric.nginxRequestsPerConnection]: nginxRequestsPerConnection,
 };

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_active_connections.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_active_connections.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+
+export const nginxActiveConnections: InfraMetricModelCreator = (
+  timeField,
+  indexPattern,
+  interval
+) => ({
+  id: 'nginxActiveConnections',
+  requires: ['nginx.stubstatus'],
+  index_pattern: indexPattern,
+  interval,
+  time_field: timeField,
+  type: 'timeseries',
+  series: [
+    {
+      id: 'connections',
+      metrics: [
+        {
+          field: 'nginx.stubstatus.active',
+          id: 'avg-active',
+          type: InfraMetricModelMetricType.avg,
+        },
+      ],
+      split_mode: 'everything',
+    },
+  ],
+});

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_hits.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_hits.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+
+export const nginxHits: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
+  id: 'nginxHits',
+  requires: ['nginx.access'],
+  index_pattern: indexPattern,
+  interval,
+  time_field: timeField,
+  type: 'timeseries',
+  series: [
+    {
+      id: '200s',
+      metrics: [
+        {
+          id: 'count-200',
+          type: InfraMetricModelMetricType.count,
+        },
+      ],
+      split_mode: 'filter',
+      filter: 'nginx.access.response_code:[200 TO 299]',
+    },
+    {
+      id: '300s',
+      metrics: [
+        {
+          id: 'count-300',
+          type: InfraMetricModelMetricType.count,
+        },
+      ],
+      split_mode: 'filter',
+      filter: 'nginx.access.response_code:[300 TO 399]',
+    },
+    {
+      id: '400s',
+      metrics: [
+        {
+          id: 'count-400',
+          type: InfraMetricModelMetricType.count,
+        },
+      ],
+      split_mode: 'filter',
+      filter: 'nginx.access.response_code:[400 TO 499]',
+    },
+    {
+      id: '500s',
+      metrics: [
+        {
+          id: 'count-500',
+          type: InfraMetricModelMetricType.count,
+        },
+      ],
+      split_mode: 'filter',
+      filter: 'nginx.access.response_code:[500 TO 599]',
+    },
+  ],
+});

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_request_rate.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_request_rate.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+
+export const nginxRequestRate: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
+  id: 'nginxRequestRate',
+  requires: ['nginx.stubstatus'],
+  index_pattern: indexPattern,
+  interval,
+  time_field: timeField,
+  type: 'timeseries',
+  series: [
+    {
+      id: 'rate',
+      metrics: [
+        {
+          field: 'nginx.stubstatus.requests',
+          id: 'max-requests',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          field: 'max-requests',
+          id: 'derv-max-requests',
+          type: InfraMetricModelMetricType.derivative,
+          unit: '1s',
+        },
+        {
+          id: 'posonly-derv-max-requests',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [{ id: 'var-rate', name: 'rate', field: 'derv-max-requests' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
+        },
+      ],
+      split_mode: 'everything',
+    },
+  ],
+});

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_requests_per_connection.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_requests_per_connection.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+
+export const nginxRequestsPerConnection: InfraMetricModelCreator = (
+  timeField,
+  indexPattern,
+  interval
+) => ({
+  id: 'nginxRequestsPerConnection',
+  requires: ['nginx.stubstatus'],
+  index_pattern: indexPattern,
+  interval,
+  time_field: timeField,
+  type: 'timeseries',
+  series: [
+    {
+      id: 'reqPerConns',
+      metrics: [
+        {
+          field: 'nginx.stubstatus.handled',
+          id: 'max-handled',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          field: 'nginx.stubstatus.requests',
+          id: 'max-requests',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          id: 'reqs-per-connection',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [
+            { id: 'var-handled', name: 'handled', field: 'max-handled' },
+            { id: 'var-requests', name: 'requests', field: 'max-requests' },
+          ],
+          script:
+            'params.handled > 0.0 && params.requests > 0.0 ? params.handled / params.requests : 0.0',
+        },
+      ],
+      split_mode: 'everything',
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds Nginx metrics to the detail pages. There will be a follow up PR that will add and hide the Nginx sections to the nodes that have those capabilities. For now it will show up on all the pages with empty data.

![image](https://user-images.githubusercontent.com/41702/46725699-a4535f00-cc74-11e8-86ef-3a9caf5c400e.png)
