### PR TITLE
Adding InfraOps and Logs to homepage

### DIFF
--- a/src/ui/public/registry/feature_catalogue.d.ts
+++ b/src/ui/public/registry/feature_catalogue.d.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export enum FeatureCatalogueCategory {
+  ADMIN = 'admin',
+  DATA = 'data',
+  OTHER = 'other',
+}
+
+interface FeatureCatalogueObject {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  path: string;
+  showOnHomePage: boolean;
+  category: FeatureCatalogueCategory;
+}
+
+type FeatureCatalogueRegistryFunction = () => FeatureCatalogueObject;
+
+export const FeatureCatalogueRegistryProvider: {
+  register: (fn: FeatureCatalogueRegistryFunction) => void;
+};

--- a/x-pack/plugins/infra/index.ts
+++ b/x-pack/plugins/infra/index.ts
@@ -27,6 +27,7 @@ export function infra(kibana: any) {
         listed: false,
         url: `/app/${APP_ID}#/home`,
       },
+      home: ['plugins/infra/register_feature'],
       links: [
         {
           description: 'Explore your infrastructure',

--- a/x-pack/plugins/infra/public/register_feature.ts
+++ b/x-pack/plugins/infra/public/register_feature.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  FeatureCatalogueCategory,
+  FeatureCatalogueRegistryProvider,
+} from 'ui/registry/feature_catalogue';
+
+const APP_ID = 'infra';
+
+FeatureCatalogueRegistryProvider.register(() => ({
+  id: 'infraops',
+  title: 'InfraOps',
+  description:
+    'Explore infrastructure metrics and logs for common servers, containers, and services.',
+  icon: 'infraApp',
+  path: `/app/${APP_ID}#home`,
+  showOnHomePage: true,
+  category: FeatureCatalogueCategory.DATA,
+}));
+
+FeatureCatalogueRegistryProvider.register(() => ({
+  id: 'infralogging',
+  title: 'Logs',
+  description:
+    'Stream logs in real time or scroll through historical views in a console-like experience.',
+  icon: 'loggingApp',
+  path: `/app/${APP_ID}#logs`,
+  showOnHomePage: true,
+  category: FeatureCatalogueCategory.DATA,
+}));


### PR DESCRIPTION
This PR adds InfraOps and Logs to the Kibana home page.

![image](https://user-images.githubusercontent.com/41702/46981192-2637f380-d08c-11e8-8309-034975897a41.png)

Closes #23468
