### PR TITLE
[Infra UI] Use metric indices when displaying metrics in the waffle map

### DIFF
--- a/x-pack/plugins/infra/server/lib/adapters/nodes/lib/create_partition_bodies.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/nodes/lib/create_partition_bodies.ts
@@ -28,7 +28,7 @@ export function createPartitionBodies(
   const indices =
     nodeOptions.metric.type === InfraMetricType.logRate
       ? [sourceConfiguration.logAlias]
-      : [sourceConfiguration.logAlias, sourceConfiguration.metricAlias];
+      : [sourceConfiguration.metricAlias];
   times(
     numberOfPartitions,
     (partitionId: number): void => {


### PR DESCRIPTION
This PR uses only the metrics indices for metrics that are not log based. This came up because the waffle map would show hosts that didn't have metric data which could be confusing to the user.