### PR TITLE
[6.x] Fixes #24261 - Add unable to render message for data less then 2 points (#24291)

### DIFF
--- a/x-pack/plugins/infra/public/components/metrics/sections/chart_section.tsx
+++ b/x-pack/plugins/infra/public/components/metrics/sections/chart_section.tsx
@@ -111,6 +111,10 @@ const createItemsFormatter = (
   });
 };
 
+const seriesHasLessThen2DataPoints = (series: InfraDataSeries): boolean => {
+  return series.data.length < 2;
+};
+
 export class ChartSection extends React.PureComponent<Props> {
   public render() {
     const { crosshairValue, section, metric, onCrosshairUpdate } = this.props;
@@ -136,6 +140,10 @@ export class ChartSection extends React.PureComponent<Props> {
     }
     if (!metric) {
       chartProps.statusText = 'Missing data';
+    }
+    if (metric.series.some(seriesHasLessThen2DataPoints)) {
+      chartProps.statusText =
+        'Not enough data points to render chart, try increasing the time range.';
     }
     const formatter = get(visConfig, 'formatter', InfraFormatterType.number);
     const formatterTemplate = get(visConfig, 'formatterTemplate', '{{value}}');
@@ -164,7 +172,7 @@ export class ChartSection extends React.PureComponent<Props> {
             />
             {metric &&
               metric.series.map(series => {
-                if (!series) {
+                if (!series || series.data.length < 2) {
                   return null;
                 }
                 const data = series.data.map(d => {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fixes #24261 - Add unable to render message for data less then 2 points  (#24291)