### PR TITLE
[6.x] Use metric indices when displaying metrics in the waffle map (#24251)

### DIFF
--- a/x-pack/plugins/infra/server/lib/adapters/nodes/lib/create_partition_bodies.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/nodes/lib/create_partition_bodies.ts
@@ -28,7 +28,7 @@ export function createPartitionBodies(
   const indices =
     nodeOptions.metric.type === InfraMetricType.logRate
       ? [sourceConfiguration.logAlias]
-      : [sourceConfiguration.logAlias, sourceConfiguration.metricAlias];
+      : [sourceConfiguration.metricAlias];
   times(
     numberOfPartitions,
     (partitionId: number): void => {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Use metric indices when displaying metrics in the waffle map  (#24251)