### PR TITLE
Normalizing CPU usage for waffle map

### DIFF
--- a/x-pack/plugins/infra/server/lib/adapters/nodes/adapter_types.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/nodes/adapter_types.ts
@@ -228,7 +228,8 @@ export type InfraAgg =
   | InfraDerivativeAgg
   | InfraAvgAgg
   | InfraMaxAgg
-  | InfraCumulativeSumAgg;
+  | InfraCumulativeSumAgg
+  | undefined;
 export interface InfraNodeMetricAgg {
   [key: string]: InfraAgg;
 }

--- a/x-pack/plugins/infra/server/lib/adapters/nodes/metric_aggregation_creators/cpu.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/nodes/metric_aggregation_creators/cpu.ts
@@ -9,7 +9,7 @@ import { InfraNodeMetricFn, InfraNodeType } from '../adapter_types';
 const FIELDS = {
   [InfraNodeType.host]: 'system.cpu.user.pct',
   [InfraNodeType.pod]: 'kubernetes.pod.cpu.usage.node.pct',
-  [InfraNodeType.container]: 'docker.cpu.user.pct',
+  [InfraNodeType.container]: 'docker.cpu.total.pct',
 };
 
 export const cpu: InfraNodeMetricFn = (nodeType: InfraNodeType) => {

--- a/x-pack/plugins/infra/server/lib/adapters/nodes/metric_aggregation_creators/cpu.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/nodes/metric_aggregation_creators/cpu.ts
@@ -13,6 +13,46 @@ const FIELDS = {
 };
 
 export const cpu: InfraNodeMetricFn = (nodeType: InfraNodeType) => {
+  if (nodeType === InfraNodeType.host) {
+    return {
+      cpu_user: {
+        avg: {
+          field: 'system.cpu.user.pct',
+        },
+      },
+      cpu_system: {
+        avg: {
+          field: 'system.cpu.system.pct',
+        },
+      },
+      cpu_cores: {
+        max: {
+          field: 'system.cpu.cores',
+        },
+      },
+      cpu: {
+        bucket_script: {
+          buckets_path: {
+            user: 'cpu_user',
+            system: 'cpu_system',
+            cores: 'cpu_cores',
+          },
+          script: {
+            source: '(params.user + params.system) / params.cores',
+            lang: 'painless',
+          },
+          gap_policy: 'skip',
+        },
+      },
+    };
+  }
+
   const field = FIELDS[nodeType];
-  return { cpu: { avg: { field } } };
+  return {
+    cpu: {
+      avg: {
+        field,
+      },
+    },
+  };
 };

--- a/x-pack/test/api_integration/apis/infra/waffle.ts
+++ b/x-pack/test/api_integration/apis/infra/waffle.ts
@@ -46,7 +46,7 @@ const waffleTests: KbnTestProvider = ({ getService }) => {
             expect(firstNode).to.have.property('metric');
             expect(firstNode.metric).to.eql({
               name: 'cpu',
-              value: 0.005833333333333334,
+              value: 0.011,
               __typename: 'InfraNodeMetric',
             });
           }


### PR DESCRIPTION
This PR changes the aggregation for calculating the CPU usage for hosts to match the metrics overview calculation by adding both system and user together then dividing it by the number of cores. This PR also includes a fix for the Docker cpu field.