### PR TITLE
[InfraOps] Fix Potential Color Bugs

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/index.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/index.tsx
@@ -86,6 +86,10 @@ const extractValuesFromMap = (groups: InfraWaffleMapGroup[], values: number[] = 
 
 const calculateBoundsFromMap = (map: InfraWaffleData): InfraWaffleMapBounds => {
   const values = extractValuesFromMap(map);
+  // if there is only one value then we need to set the bottom range to zero
+  if (values.length === 1) {
+    values.unshift(0);
+  }
   return { min: min(values), max: max(values) };
 };
 

--- a/x-pack/plugins/infra/public/components/waffle/lib/color_from_value.ts
+++ b/x-pack/plugins/infra/public/components/waffle/lib/color_from_value.ts
@@ -5,7 +5,7 @@
  */
 
 import { eq, first, gt, gte, last, lt, lte, sortBy } from 'lodash';
-import { mix } from 'polished';
+import { mix, parseToRgb, toColorString } from 'polished';
 import {
   InfraWaffleMapBounds,
   InfraWaffleMapGradientLegend,
@@ -23,19 +23,27 @@ const OPERATOR_TO_FN = {
   [InfraWaffleMapRuleOperator.gt]: gt,
 };
 
+const convertToRgbString = (color: string) => {
+  return toColorString(parseToRgb(color));
+};
+
 export const colorFromValue = (
   legend: InfraWaffleMapLegend,
   value: number | string,
   bounds: InfraWaffleMapBounds,
-  defaultColor = 'rgba(0, 179, 164, 1)'
+  defaultColor = 'rgba(217, 217, 217, 1)'
 ): string => {
-  if (isInfraWaffleMapStepLegend(legend)) {
-    return calculateStepColor(legend, value, defaultColor);
+  try {
+    if (isInfraWaffleMapStepLegend(legend)) {
+      return convertToRgbString(calculateStepColor(legend, value, defaultColor));
+    }
+    if (isInfraWaffleMapGradientLegend(legend)) {
+      return convertToRgbString(calculateGradientColor(legend, value, bounds, defaultColor));
+    }
+    return defaultColor;
+  } catch (error) {
+    return defaultColor;
   }
-  if (isInfraWaffleMapGradientLegend(legend)) {
-    return calculateGradientColor(legend, value, bounds, defaultColor);
-  }
-  return defaultColor;
 };
 
 const normalizeValue = (min: number, max: number, value: number): number => {
@@ -45,7 +53,7 @@ const normalizeValue = (min: number, max: number, value: number): number => {
 export const calculateStepColor = (
   legend: InfraWaffleMapStepLegend,
   value: number | string,
-  defaultColor = 'rgba(0, 179, 164, 1)'
+  defaultColor = 'rgba(217, 217, 217, 1)'
 ): string => {
   return sortBy(legend.rules, 'sortBy').reduce((color: string, rule) => {
     const operatorFn = OPERATOR_TO_FN[rule.operator];


### PR DESCRIPTION
- Fixes 25707 by parsing the colors generated for the node and adding a
try/catch to prevent an errors by returning the default color
- Set the min bounds to zero when there is only one data point

![image](https://user-images.githubusercontent.com/41702/49108205-d2045f80-f244-11e8-88bd-e5873ed413f9.png)

REVIEWERS: We only need one.