### PR TITLE
[InfraOps] Fix for AutoRefresh button on node detail page

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/index.tsx
@@ -170,6 +170,8 @@ export const MetricDetail = withTheme(
                                                       currentTimeRange={currentTimeRange}
                                                       isLiveStreaming={isAutoReloading}
                                                       onChangeRangeTime={setRangeTime}
+                                                      startLiveStreaming={startMetricsAutoReload}
+                                                      stopLiveStreaming={stopMetricsAutoReload}
                                                     />
                                                   </MetricsTitleTimeRangeContainer>
                                                 </EuiPageHeaderSection>


### PR DESCRIPTION
This PR fixes the Auto Refresh button on the node detail page. Looks like we just forgot to pass down the start/stop function to the controls.

REVIEWERS: First Come First Serve!