### PR TITLE
[6.x] Fixes #26052 - Change time range for waffle map from last hour to last 5 minutes (#26278)

### DIFF
--- a/x-pack/plugins/infra/public/store/local/waffle_time/selectors.ts
+++ b/x-pack/plugins/infra/public/store/local/waffle_time/selectors.ts
@@ -17,7 +17,7 @@ export const selectTimeUpdatePolicyInterval = (state: WaffleTimeState) =>
   state.updatePolicy.policy === 'interval' ? state.updatePolicy.interval : null;
 
 export const selectCurrentTimeRange = createSelector(selectCurrentTime, currentTime => ({
-  from: currentTime - 1000 * 60 * 60,
+  from: currentTime - 1000 * 60 * 5,
   interval: '1m',
   to: currentTime,
 }));


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fixes #26052 - Change time range for waffle map from last hour to last 5 minutes  (#26278)