### PR TITLE
[6.x] Fixes AutoRefresh button on node detail page (#26426)

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/index.tsx
@@ -170,6 +170,8 @@ export const MetricDetail = withTheme(
                                                       currentTimeRange={currentTimeRange}
                                                       isLiveStreaming={isAutoReloading}
                                                       onChangeRangeTime={setRangeTime}
+                                                      startLiveStreaming={startMetricsAutoReload}
+                                                      stopLiveStreaming={stopMetricsAutoReload}
                                                     />
                                                   </MetricsTitleTimeRangeContainer>
                                                 </EuiPageHeaderSection>


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fixes AutoRefresh button on node detail page  (#26426)