### PR TITLE
Update securing-spaces.asciidoc

### DIFF
--- a/docs/spaces/securing-spaces.asciidoc
+++ b/docs/spaces/securing-spaces.asciidoc
@@ -5,3 +5,5 @@
 With security enabled, you can control who has access to specific spaces. You can manage access in **Management > Roles**.
 
 image::spaces/images/securing-spaces.png["Securing spaces"]
+
+Note that kibana ships with a built-in role called ```kibana_user``` which grants the **all** privilege as minimum access to all spaces. In order to restrict a user to only a subset of spaces, remember to not give the ```kibana_user``` role but but instead to create a custom scheme where new roles grant both Index Privileges **manage, read, index, delete** to the pattern ```.kibana*``` and the intended access to the correct subset of spaces.


### PR DESCRIPTION
## Summary

Users following the instructions will be surprised to find that kibana_user gives blanket "all" access to spaces.  kibana_user is a default role and cannot be modified so a new scheme will have to be created.  Hopefully this notice will help people understand why users can still see and modify all roles until something is taken away from a user that was unrelated to spaces in version 6.4 and before.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

 - ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
 - ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
 - ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
 - ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

