### PR TITLE
[APM] Fix warning in Span flyout for bad columns definition

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -120,10 +120,14 @@ export function SpanFlyout({
                     <EuiBasicTable
                       columns={[
                         {
+                          name: '',
                           field: 'key',
                           render: (key: string) => <TagName>{key}</TagName>
                         },
-                        { field: 'value' }
+                        {
+                          name: '',
+                          field: 'value'
+                        }
                       ]}
                       items={tags}
                     />


### PR DESCRIPTION
Fixes #27117 by setting `name` property when defining table columns