### PR TITLE
[i18n] APM translate for Feedback menu

### DIFF
--- a/x-pack/plugins/apm/public/templates/feedback_menu.html
+++ b/x-pack/plugins/apm/public/templates/feedback_menu.html
@@ -1,9 +1,14 @@
 <div style="padding: 16px;">
     <div class="euiText">
-        <h2>Provide APM feedback</h2>
-        <p>Please send us feedback by starting a new thread in our forum.
-            <br>Comments and suggestions are much appreciated. Thanks!
-        </p>
+        <h2
+          i18n-id="xpack.apm.feedbackMenu.provideFeedbackTitle"
+          i18n-default-message="Provide APM feedback"
+        ></h2>
+        <p
+          i18n-id="xpack.apm.feedbackMenu.provideFeedbackDescription"
+          i18n-default-message="Please send us feedback by starting a new thread in our forum.{br}Comments and suggestions are much appreciated. Thanks!"
+          i18n-values="{ html_br: '<br>' }"
+        ></p>
     </div>
     <br>
     <a
@@ -14,7 +19,10 @@
     >
         <span class="euiButton__content">
             <i class="fa fa-external-link" aria-hidden="true" style="margin-right: 5px;"></i>
-            <span>Submit feedback</span>
+            <span
+              i18n-id="xpack.apm.feedbackMenu.submitFeedbackButtonLabel"
+              i18n-default-message="Submit feedback"
+            ></span>
         </span>
     </a>
 </div>


### PR DESCRIPTION
APM translations for `x-pack/plugins/apm/public/templates/feedback_menu.html`

Issue: https://github.com/elastic/kibana/issues/27283

i18n Guideline: https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/GUIDELINE.md
i18n Readme: https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md
i18n tool Readme: https://github.com/elastic/kibana/blob/master/src/dev/i18n/README.md

To test localized labels run Kibana with enabled pseudo-locale (either pass `--i18n.locale=en-xa` as a command-line argument or add it to the `kibana.yml`). Example: `Hello World!` -> `Ĥéļļļô ŴŴôŕļļð!`

