### PR TITLE
wrap leadfoot/keys in browser, pressKeys on elementWrapper

### DIFF
--- a/test/functional/page_objects/common_page.js
+++ b/test/functional/page_objects/common_page.js
@@ -249,7 +249,7 @@ export function CommonPageProvider({ getService, getPageObjects }) {
     }
 
     async pressEnterKey() {
-      await browser.pressKeys('\uE007');
+      await browser.pressKeys(browser.keys.ENTER);
     }
 
     // pass in true if your test will show multiple modals

--- a/test/functional/page_objects/visual_builder_page.js
+++ b/test/functional/page_objects/visual_builder_page.js
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import Keys from 'leadfoot/keys';
-
 export function VisualBuilderPageProvider({ getService, getPageObjects }) {
   const find = getService('find');
   const retry = getService('retry');
@@ -65,12 +63,12 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
       // a textarea we must really select all text and remove it, and cannot use
       // clearValue().
       if (process.platform === 'darwin') {
-        await browser.pressKeys([Keys.COMMAND, 'a']); // Select all Mac
+        await input.pressKeys([browser.keys.COMMAND, 'a']); // Select all Mac
       } else {
-        await browser.pressKeys([Keys.CONTROL, 'a']); // Select all for everything else
+        await input.pressKeys([browser.keys.CONTROL, 'a']); // Select all for everything else
       }
-      await browser.pressKeys(Keys.NULL); // Release modifier keys
-      await browser.pressKeys(Keys.BACKSPACE); // Delete all content
+      await input.pressKeys(browser.keys.NULL); // Release modifier keys
+      await input.pressKeys(browser.keys.BACKSPACE); // Delete all content
       await input.type(markdown);
       await PageObjects.header.waitUntilLoadingHasFinished();
     }
@@ -208,7 +206,7 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
       const el = await testSubjects.find('comboBoxSearchInput');
       await el.clearValue();
       await el.type(timeField);
-      await browser.pressKeys(Keys.RETURN);
+      await el.pressKeys(browser.keys.RETURN);
       await PageObjects.header.waitUntilLoadingHasFinished();
     }
   }

--- a/test/functional/page_objects/visualize_page.js
+++ b/test/functional/page_objects/visualize_page.js
@@ -20,7 +20,6 @@
 import { VisualizeConstants } from '../../../src/legacy/core_plugins/kibana/public/visualize/visualize_constants';
 import Bluebird from 'bluebird';
 import expect from 'expect.js';
-import Keys from 'leadfoot/keys';
 
 export function VisualizePageProvider({ getService, getPageObjects }) {
   const browser = getService('browser');
@@ -399,7 +398,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
         await find.clickByCssSelector(selector);
         const input = await find.byCssSelector(`${selector} input.ui-select-search`);
         await input.type(myString);
-        await browser.pressKeys(Keys.RETURN);
+        await input.pressKeys(browser.keys.RETURN);
       });
       await PageObjects.common.sleep(500);
     }
@@ -508,7 +507,8 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
       `;
       await find.clickByCssSelector(selector);
       await find.setValue(`${selector} input.ui-select-search`, fieldValue);
-      await browser.pressKeys(Keys.RETURN);
+      const input = await find.byCssSelector(`${selector} input.ui-select-search`);
+      await input.pressKeys(browser.keys.RETURN);
     }
 
     async selectFieldById(fieldValue, id) {
@@ -546,7 +546,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
       // was a long enough gap from the typing above to the space click.  Hence the
       // need for the sleep.
       await PageObjects.common.sleep(500);
-      await browser.pressKeys(Keys.SPACE);
+      await input.pressKeys(browser.keys.SPACE);
     }
 
     async setCustomInterval(newValue) {
@@ -612,7 +612,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
 
     async sizeUpEditor() {
       await testSubjects.click('visualizeEditorResizer');
-      await browser.pressKeys(Keys.ARROW_RIGHT);
+      await browser.pressKeys(browser.keys.ARROW_RIGHT);
     }
 
     async clickOptions() {

--- a/test/functional/services/browser.js
+++ b/test/functional/services/browser.js
@@ -18,11 +18,18 @@
  */
 
 import { modifyUrl } from '../../../src/core/utils';
+import Keys from 'leadfoot/keys';
 
 export function BrowserProvider({ getService }) {
   const leadfoot = getService('__leadfoot__');
 
-  return new class BrowserService {
+  class BrowserService {
+
+    /**
+     * Keyboard events
+     */
+    keys = Keys;
+
     /**
      * Gets the dimensions of a window.
      * https://theintern.io/leadfoot/module-leadfoot_Session.html#getWindowSize
@@ -33,7 +40,6 @@ export function BrowserProvider({ getService }) {
     async getWindowSize(...args) {
       return await leadfoot.getWindowSize(...args);
     }
-
 
     /**
      * Sets the dimensions of a window.
@@ -245,5 +251,7 @@ export function BrowserProvider({ getService }) {
     async execute(...args) {
       return await leadfoot.execute(...args);
     }
-  };
+  }
+
+  return  new BrowserService();
 }

--- a/test/functional/services/filter_bar.js
+++ b/test/functional/services/filter_bar.js
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import Keys from 'leadfoot/keys';
-
 export function FilterBarProvider({ getService, getPageObjects }) {
   const browser = getService('browser');
   const testSubjects = getService('testSubjects');
@@ -92,7 +90,7 @@ export function FilterBarProvider({ getService, getPageObjects }) {
         }
         for (let j = 0; j < fieldValues.length; j++) {
           await paramFields[i].type(fieldValues[j]);
-          await browser.pressKeys(Keys.RETURN);
+          await paramFields[i].pressKeys(browser.keys.RETURN);
         }
       }
       await testSubjects.click('saveFilter');

--- a/test/functional/services/lib/leadfoot_element_wrapper.js
+++ b/test/functional/services/lib/leadfoot_element_wrapper.js
@@ -313,4 +313,15 @@ export class LeadfootElementWrapper {
   async findByXpath(xpath) {
     return this._wrap(await this._leadfootElement.findByXpath(xpath));
   }
+
+  /**
+   * Sends key event into element.
+   * https://theintern.io/leadfoot/module-leadfoot_Session.html#pressKeys
+   *
+   * @param  {string|string[]} keys
+   * @return {Promise<void>}
+   */
+  async pressKeys(...args) {
+    await this._leadfoot.pressKeys(...args);
+  }
 }

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -5,7 +5,6 @@
  */
 
 import testSubjSelector from '@kbn/test-subj-selector';
-import Keys from 'leadfoot/keys';
 import moment from 'moment';
 
 import { KibanaFunctionalTestDefaultProviders } from '../../types/providers';
@@ -13,6 +12,7 @@ import { KibanaFunctionalTestDefaultProviders } from '../../types/providers';
 export function InfraHomePageProvider({ getService }: KibanaFunctionalTestDefaultProviders) {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
+  const browser = getService('browser');
 
   return {
     async goToTime(time: number) {
@@ -20,8 +20,8 @@ export function InfraHomePageProvider({ getService }: KibanaFunctionalTestDefaul
         `${testSubjSelector('waffleDatePicker')} .euiDatePicker.euiFieldText`
       );
 
-      await datePickerInput.type(Array(30).fill(Keys.BACKSPACE));
-      await datePickerInput.type([moment(time).format('L LTS'), Keys.RETURN]);
+      await datePickerInput.type(Array(30).fill(browser.keys.BACKSPACE));
+      await datePickerInput.type([moment(time).format('L LTS'), browser.keys.RETURN]);
     },
 
     async getWaffleMap() {


### PR DESCRIPTION
## Summary

- Before migration, we need to remove direct Leadfoot imports: `leadfoot/Keys` moved into `browser.keys` property

- While interacting with inputs, WebDriver usually requires sending keyboard events [directly to specific input element](https://stackoverflow.com/a/41438121/4103101)
I tried alternative with Actions API (similar to leadfoot approach) and it did not work (nothing happens) for Kibana input fields, so this PR does `browser` -> `input` switch prio migration.

### Checklist

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

~~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
~~- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

