### PR TITLE
Updates error message when creating ML job

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout.tsx
@@ -101,8 +101,8 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
       title: 'Job creation failed',
       text: (
         <p>
-          You may not have adequate permissions to create a machine learning
-          job, or this job may already exist.
+          Your current license may not allow for creating machine learning jobs,
+          or this job may already exist.
         </p>
       )
     });

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout.tsx
@@ -90,26 +90,19 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
   };
 
   public addErrorToast = () => {
-    const { location, urlParams } = this.props;
-    const { serviceName = 'unknown', transactionType } = urlParams;
+    const { urlParams } = this.props;
+    const { serviceName = 'unknown' } = urlParams;
 
     if (!serviceName) {
       return;
     }
 
     toastNotifications.addWarning({
-      title: 'Job already exists',
+      title: 'Job creation failed',
       text: (
         <p>
-          There&apos;s already a job running for anomaly detection on{' '}
-          {serviceName} ({transactionType}).{' '}
-          <ViewMLJob
-            serviceName={serviceName}
-            transactionType={transactionType}
-            location={location}
-          >
-            View existing job
-          </ViewMLJob>
+          You may not have adequate permissions to create a machine learning
+          job, or this job may already exist.
         </p>
       )
     });


### PR DESCRIPTION
## Summary

I've updated the error message when a user tries to create a machine learning job and that create fails. Before, we were assuming this failure was always because the job already existed, so we showed a title that said as much, and included in the message a link to the existing job.

- First, this is a problem because the create now fails if you don't have permissions to create a job. Before, this only happened if your license didn't include ML, but now you can have ML "available", it seems, but without the "Create Job" permission. We don't currently have a good way to check these granular privileges. See more here: https://github.com/elastic/kibana/issues/24486#issuecomment-451470484

- Second, it doesn't seem very likely that any users would ever get this error because a job already exists, as we are already checking if the job exists when they open the flyout and disabling the button if it does. (Possibly a user could open the flyout, and then the job could be created by another user on their cluster, creating a race condition if the first user tries to create it, but this seems like a rare edge case.)

For these reasons, I've updated the error to say "Job creation failed" and have the first listed reason mention permissions, with a note about "or the job may already exist" tacked to the end of the error message since this case is unlikely (see above). 

<img width="325" alt="screen shot 2019-01-04 at 10 24 44 am" src="https://user-images.githubusercontent.com/159370/50696126-98c1cb00-100c-11e9-8b42-0cccd15edaf8.png">
