### PR TITLE
[APM] fix action menu infra link for docker.container.id

### DIFF
--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -181,6 +181,7 @@
     "history-extra": "^4.0.2",
     "humps": "2.0.1",
     "icalendar": "0.7.1",
+    "idx": "^2.5.2",
     "inline-style": "^2.0.0",
     "intl": "^1.2.5",
     "io-ts": "^1.4.2",

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -17,7 +17,10 @@ import {
 import idx from 'idx';
 import React from 'react';
 import { getKibanaHref } from 'x-pack/plugins/apm/public/utils/url';
-import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
+import {
+  Transaction,
+  TransactionV2
+} from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import { getDiscoverQuery } from '../DiscoverButtons/DiscoverTransactionButton';
 import { QueryWithIndexPattern } from '../DiscoverButtons/QueryWithIndexPattern';
 
@@ -66,8 +69,11 @@ export class TransactionActionMenu extends React.Component<Props, State> {
 
   public getInfraActions(transaction: Transaction) {
     const hostName = idx(transaction, _ => _.context.system.hostname);
-    const podId = idx(transaction, _ => _.kubernetes.pod.uid);
-    const containerId = idx(transaction, _ => _.docker.container.id);
+    const podId = idx(transaction as TransactionV2, _ => _.kubernetes.pod.uid);
+    const containerId = idx(
+      transaction as TransactionV2,
+      _ => _.docker.container.id
+    );
     const pathname = '/app/infra';
     const time = new Date(transaction['@timestamp']).getTime();
     const infraMetricsQuery = getInfraMetricsQuery(transaction);

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -14,7 +14,7 @@ import {
   EuiLink,
   EuiPopover
 } from '@elastic/eui';
-import { get } from 'lodash';
+import idx from 'idx';
 import React from 'react';
 import { getKibanaHref } from 'x-pack/plugins/apm/public/utils/url';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
@@ -65,9 +65,9 @@ export class TransactionActionMenu extends React.Component<Props, State> {
   };
 
   public getInfraActions(transaction: Transaction) {
-    const hostName = get(transaction, 'context.system.hostname');
-    const podId = get(transaction, 'kubernetes.pod.uid');
-    const containerId = get(transaction, 'docker.container.id');
+    const hostName = idx(transaction, _ => _.context.system.hostname);
+    const podId = idx(transaction, _ => _.kubernetes.pod.uid);
+    const containerId = idx(transaction, _ => _.docker.container.id);
     const pathname = '/app/infra';
     const time = new Date(transaction['@timestamp']).getTime();
     const infraMetricsQuery = getInfraMetricsQuery(transaction);

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -67,7 +67,7 @@ export class TransactionActionMenu extends React.Component<Props, State> {
   public getInfraActions(transaction: Transaction) {
     const hostName = get(transaction, 'context.system.hostname');
     const podId = get(transaction, 'kubernetes.pod.uid');
-    const containerId = get(transaction, 'container.id');
+    const containerId = get(transaction, 'docker.container.id');
     const pathname = '/app/infra';
     const time = new Date(transaction['@timestamp']).getTime();
     const infraMetricsQuery = getInfraMetricsQuery(transaction);

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/__test__/transactionActionMenuProps.json
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/__test__/transactionActionMenuProps.json
@@ -106,8 +106,10 @@
         "uid": "pod123456abcdef"
       }
     },
-    "container": {
-      "id": "container123456abcdef"
+    "docker": {
+      "container": {
+        "id": "container123456abcdef"
+      }
     },
     "timestamp": {
       "us": 1545092070952472

--- a/x-pack/plugins/apm/typings/es_schemas/Transaction.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/Transaction.ts
@@ -56,6 +56,16 @@ export interface TransactionV1 extends APMDocV1 {
     };
     type: string;
   };
+  kubernetes?: {
+    pod: {
+      uid: string;
+    };
+  };
+  docker?: {
+    container: {
+      id: string;
+    };
+  };
 }
 
 export interface TransactionV2 extends APMDocV2 {
@@ -80,9 +90,14 @@ export interface TransactionV2 extends APMDocV2 {
     };
     type: string;
   };
-  kubernetes: {
+  kubernetes?: {
     pod: {
       uid: string;
+    };
+  };
+  docker?: {
+    container: {
+      id: string;
     };
   };
   container: {

--- a/x-pack/plugins/apm/typings/es_schemas/Transaction.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/Transaction.ts
@@ -56,16 +56,6 @@ export interface TransactionV1 extends APMDocV1 {
     };
     type: string;
   };
-  kubernetes?: {
-    pod: {
-      uid: string;
-    };
-  };
-  docker?: {
-    container: {
-      id: string;
-    };
-  };
 }
 
 export interface TransactionV2 extends APMDocV2 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11158,6 +11158,11 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
+idx@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/idx/-/idx-2.5.2.tgz#4b405c2e6d68d04136e0a368a7ab35b9caa0595f"
+  integrity sha512-MLoGF4lQU5q/RqJJjRsuid52emu7tPVtSSZaYXsqRvSjvXdBEmIwk2urvbNvPBRU9Ox9I4WYnxiz2GjhU34Lrw==
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"


### PR DESCRIPTION
Fixes #27573 by targeting `docker.container.id` to populate the action menu