### PR TITLE
whitelist (MIT OR GPL-3.0) for jszip in selenium-webdriver

### DIFF
--- a/src/dev/license_checker/config.js
+++ b/src/dev/license_checker/config.js
@@ -27,6 +27,7 @@ export const LICENSE_WHITELIST = [
   '(MIT AND CC-BY-3.0)',
   '(MIT AND Zlib)',
   '(MIT OR Apache-2.0)',
+  '(MIT OR GPL-3.0)',
   '(WTFPL OR MIT)',
   'AFLv2.1',
   'Apache 2.0',


### PR DESCRIPTION
While working on #26477 that will replace `Leadfoot` with `WebDriver` test library we noticed [kibana-intake job](https://kibana-ci.elastic.co/job/elastic+kibana+pull-request/5826/JOB=kibana-intake,node=immutable/console) is failing with:
```
Fatal error: Non-conforming licenses: 
15:03:11   jszip
15:03:11     version: 3.1.5
15:03:11     all licenses: (MIT OR GPL-3.0)
15:03:11     invalid licenses: (MIT OR GPL-3.0)
15:03:11     path: node_modules/selenium-webdriver/node_modules/jszip
``` 
WebDriver has `jszip` dependency, which is  `dual-licensed. You may use it under the MIT license or the GPLv3 license.`

This PR whitelists **(MIT OR GPL-3.0)** license

