### PR TITLE
[APM] Fix agent status check

### DIFF
--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
@@ -158,11 +158,10 @@ export function onPremInstructions(apmIndexPattern) {
             index: apmIndexPattern,
             query: {
               bool: {
-                filter: {
-                  exists: {
-                    field: 'processor.name',
-                  },
-                },
+                should: [
+                  { term: { 'processor.name': 'error' } },
+                  { term: { 'processor.name': 'transaction' } },
+                ],
               },
             },
           },

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
@@ -161,6 +161,8 @@ export function onPremInstructions(apmIndexPattern) {
                 should: [
                   { term: { 'processor.name': 'error' } },
                   { term: { 'processor.name': 'transaction' } },
+                  { term: { 'processor.name': 'metric' } },
+                  { term: { 'processor.name': 'sourcemap' } },
                 ],
               },
             },

--- a/x-pack/plugins/apm/server/lib/status_check/agent_check.js
+++ b/x-pack/plugins/apm/server/lib/status_check/agent_check.js
@@ -21,7 +21,9 @@ export async function getAgentStatus({ setup }) {
         bool: {
           should: [
             { term: { [PROCESSOR_NAME]: 'error' } },
-            { term: { [PROCESSOR_NAME]: 'transaction' } }
+            { term: { [PROCESSOR_NAME]: 'transaction' } },
+            { term: { [PROCESSOR_NAME]: 'metric' } },
+            { term: { [PROCESSOR_NAME]: 'sourcemap' } }
           ]
         }
       }

--- a/x-pack/plugins/apm/server/lib/status_check/agent_check.js
+++ b/x-pack/plugins/apm/server/lib/status_check/agent_check.js
@@ -6,6 +6,7 @@
 
 import { PROCESSOR_NAME } from '../../../common/constants';
 
+// Note: this logic is duplicated in tutorials/apm/envs/on_prem
 export async function getAgentStatus({ setup }) {
   const { client, config } = setup;
 
@@ -18,11 +19,10 @@ export async function getAgentStatus({ setup }) {
       size: 0,
       query: {
         bool: {
-          filter: {
-            exists: {
-              field: PROCESSOR_NAME
-            }
-          }
+          should: [
+            { term: { [PROCESSOR_NAME]: 'error' } },
+            { term: { [PROCESSOR_NAME]: 'transaction' } }
+          ]
         }
       }
     }

--- a/x-pack/plugins/apm/server/lib/status_check/server_check.js
+++ b/x-pack/plugins/apm/server/lib/status_check/server_check.js
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+// Note: this logic is duplicated in tutorials/apm/envs/on_prem
 export async function getServerStatus({ setup }) {
   const { client, config } = setup;
 


### PR DESCRIPTION
Closes #26490

Can be tested locally by deleting all APM documents (via Kibana Dev Tools):
```
DELETE apm*
```

and then starting the stack without any agents:
```
./compose.py start master --no-kibana --no-apm-server-self-instrument
```

**Results**:
✅ APM Server
❌ Agent

Afterwards start the stack with one agent:
```
./compose.py start master --no-kibana --no-apm-server-self-instrument
```

**Results:**
✅ APM Server
✅ Agent