### PR TITLE
Removes 'privileges' from the feature definition

### DIFF
--- a/src/legacy/core_plugins/kibana/public/management/index.js
+++ b/src/legacy/core_plugins/kibana/public/management/index.js
@@ -142,7 +142,7 @@ uiModules
       link: function ($scope) {
         timefilter.disableAutoRefreshSelector();
         timefilter.disableTimeRangeSelector();
-        $scope.sections = management.items.inOrder;
+        $scope.sections = management.visibleItems;
         $scope.section = management.getSection($scope.sectionName) || management;
 
         if ($scope.section) {
@@ -153,7 +153,7 @@ uiModules
 
         updateSidebar($scope.sections, $scope.section.id);
         $scope.$on('$destroy', () => destroyReact(SIDENAV_ID));
-        management.addListener(() => updateSidebar(management.items.inOrder, $scope.section.id));
+        management.addListener(() => updateSidebar(management.visibleItems, $scope.section.id));
 
         updateLandingPage($scope.$root.chrome.getKibanaVersion());
         $scope.$on('$destroy', () => destroyReact(LANDING_ID));
@@ -167,8 +167,9 @@ uiModules
     return {
       restrict: 'E',
       link: function ($scope) {
-        $scope.sections = management.items.inOrder;
+        $scope.sections = management.visibleItems;
         $scope.kbnVersion = kbnVersion;
+
       }
     };
   });

--- a/src/ui/public/management/components/sidebar_nav.tsx
+++ b/src/ui/public/management/components/sidebar_nav.tsx
@@ -31,7 +31,7 @@ interface Subsection {
   icon?: IconType;
 }
 interface Section extends Subsection {
-  items: IndexedArray<Subsection>;
+  visibleItems: IndexedArray<Subsection>;
 }
 
 const sectionVisible = (section: Subsection) => !section.disabled && section.visible;
@@ -47,9 +47,9 @@ const sectionToNav = (selectedId: string) => ({ display, id, url, icon }: Subsec
 export const sideNavItems = (sections: Section[], selectedId: string) =>
   sections
     .filter(sectionVisible)
-    .filter(section => section.items.filter(sectionVisible).length)
+    .filter(section => section.visibleItems.filter(sectionVisible).length)
     .map(section => ({
-      items: section.items.inOrder.filter(sectionVisible).map(sectionToNav(selectedId)),
+      items: section.visibleItems.filter(sectionVisible).map(sectionToNav(selectedId)),
       ...sectionToNav(selectedId)(section),
     }));
 

--- a/x-pack/plugins/apm/index.js
+++ b/x-pack/plugins/apm/index.js
@@ -74,17 +74,7 @@ export function apm(kibana) {
         name: 'APM',
         icon: 'apmApp',
         navLinkId: 'apm',
-        privileges: {
-          all: {
-            app: ['apm', 'kibana'],
-            catalogue: ['apm'],
-            savedObject: {
-              all: [],
-              read: ['config']
-            },
-            ui: []
-          }
-        }
+        catalogue: ['apm']
       });
 
       initTransactionsApi(server);

--- a/x-pack/plugins/canvas/init.js
+++ b/x-pack/plugins/canvas/init.js
@@ -40,26 +40,7 @@ export default async function(server /*options*/) {
     name: 'Canvas',
     icon: 'canvasApp',
     navLinkId: 'canvas',
-    privileges: {
-      all: {
-        catalogue: ['canvas'],
-        app: ['canvas', 'kibana'],
-        savedObject: {
-          all: ['canvas'],
-          read: ['config', 'index-pattern'],
-        },
-        ui: [],
-      },
-      read: {
-        catalogue: ['canvas'],
-        app: ['canvas', 'kibana'],
-        savedObject: {
-          all: [],
-          read: ['config', 'index-pattern', 'canvas'],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['canvas'],
   });
 
   // There are some common functions that use private APIs, load them here

--- a/x-pack/plugins/gis/index.js
+++ b/x-pack/plugins/gis/index.js
@@ -55,24 +55,6 @@ export function gis(kibana) {
           name: 'Maps',
           icon: 'gisApp',
           navLinkId: 'gis',
-          privileges: {
-            all: {
-              app: ['gis', 'kibana'],
-              savedObject: {
-                all: ['gis-map'],
-                read: ['config']
-              },
-              ui: [],
-            },
-            read: {
-              app: ['gis', 'kibana'],
-              savedObject: {
-                all: [],
-                read: ['gis-map', 'config']
-              },
-              ui: [],
-            },
-          }
         });
 
         server.addSavedObjectsToSampleDataset('logs', webLogsSavedObjects);

--- a/x-pack/plugins/graph/index.js
+++ b/x-pack/plugins/graph/index.js
@@ -55,26 +55,7 @@ export function graph(kibana) {
         name: 'Graph',
         icon: 'graphApp',
         navLinkId: 'graph',
-        privileges: {
-          all: {
-            catalogue: ['graph'],
-            app: ['graph', 'kibana'],
-            savedObject: {
-              all: ['graph-workspace'],
-              read: ['config', 'index-pattern'],
-            },
-            ui: [],
-          },
-          read: {
-            catalogue: ['graph'],
-            app: ['graph', 'kibana'],
-            savedObject: {
-              all: [],
-              read: ['config', 'index-pattern', 'graph-workspace'],
-            },
-            ui: [],
-          }
-        }
+        catalogue: ['graph'],
       });
 
       initServer(server);

--- a/x-pack/plugins/infra/server/kibana.index.ts
+++ b/x-pack/plugins/infra/server/kibana.index.ts
@@ -37,17 +37,7 @@ export const initServerWithKibana = (kbnServer: KbnServer) => {
       defaultMessage: 'Infrastructure',
     }),
     navLinkId: 'infra:home',
-    privileges: {
-      all: {
-        catalogue: ['infraops'],
-        app: ['infra', 'kibana'],
-        savedObject: {
-          all: [],
-          read: ['config'],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['infraops'],
   });
 
   xpackMainPlugin.registerFeature({
@@ -56,17 +46,7 @@ export const initServerWithKibana = (kbnServer: KbnServer) => {
       defaultMessage: 'Logs',
     }),
     navLinkId: 'infra:logs',
-    privileges: {
-      all: {
-        catalogue: ['infralogging'],
-        app: ['infra', 'kibana'],
-        savedObject: {
-          all: [],
-          read: ['config'],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['infralogging'],
   });
 };
 

--- a/x-pack/plugins/ml/index.js
+++ b/x-pack/plugins/ml/index.js
@@ -75,22 +75,7 @@ export const ml = (kibana) => {
         name: 'Machine Learning',
         icon: 'machineLearningApp',
         navLinkId: 'ml',
-        privileges: {
-          all: {
-            metadata: {
-              tooltip: i18n.translate('xpack.ml.privileges.tooltip', {
-                defaultMessage: 'The machine_learning_user or machine_learning_admin role should be assigned to grant access'
-              })
-            },
-            catalogue: ['ml'],
-            app: ['ml', 'kibana'],
-            savedObject: {
-              all: [],
-              read: ['config']
-            },
-            ui: [],
-          },
-        }
+        catalogue: ['ml'],
       });
 
       // Add server routes and initialize the plugin here

--- a/x-pack/plugins/monitoring/init.js
+++ b/x-pack/plugins/monitoring/init.js
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { i18n } from '@kbn/i18n';
 import { LOGGING_TAG, KIBANA_MONITORING_LOGGING_TAG } from './common/constants';
 import { requireUIRoutes } from './server/routes';
 import { instantiateClient } from './server/es_client/instantiate_client';
@@ -60,22 +59,7 @@ export const init = (monitoringPlugin, server) => {
     name: 'Monitoring',
     icon: 'monitoringApp',
     navLinkId: 'monitoring',
-    privileges: {
-      all: {
-        metadata: {
-          tooltip: i18n.translate('xpack.monitoring.privileges.tooltip', {
-            defaultMessage: 'The monitoring_user role should be assigned to grant access'
-          })
-        },
-        catalogue: ['monitoring'],
-        app: ['monitoring', 'kibana'],
-        savedObject: {
-          all: [],
-          read: ['config'],
-        },
-        ui: [],
-      },
-    }
+    catalogue: ['monitoring'],
   });
 
   const bulkUploader = initBulkUploader(kbnServer, server);

--- a/x-pack/plugins/spaces/server/lib/toggle_ui_capabilities.test.ts
+++ b/x-pack/plugins/spaces/server/lib/toggle_ui_capabilities.test.ts
@@ -13,44 +13,23 @@ const features: Feature[] = [
   {
     id: 'feature_1',
     name: 'Feature 1',
-    privileges: {},
   },
   {
     id: 'feature_2',
     name: 'Feature 2',
     navLinkId: 'feature2',
-    privileges: {
-      all: {
-        catalogue: ['feature2Entry'],
-        management: {
-          kibana: ['somethingElse'],
-        },
-        app: [],
-        ui: [],
-        savedObject: {
-          all: [],
-          read: [],
-        },
-      },
+    catalogue: ['feature2Entry'],
+    management: {
+      kibana: ['somethingElse'],
     },
   },
   {
     id: 'feature_3',
     name: 'Feature 3',
     navLinkId: 'feature3',
-    privileges: {
-      all: {
-        catalogue: ['feature3Entry'],
-        management: {
-          kibana: ['indices'],
-        },
-        app: [],
-        ui: [],
-        savedObject: {
-          all: [],
-          read: [],
-        },
-      },
+    catalogue: ['feature3Entry'],
+    management: {
+      kibana: ['indices'],
     },
   },
 ];

--- a/x-pack/plugins/spaces/server/lib/toggle_ui_capabilities.ts
+++ b/x-pack/plugins/spaces/server/lib/toggle_ui_capabilities.ts
@@ -41,24 +41,22 @@ function toggleDisabledFeatures(
       navLinks[feature.navLinkId] = false;
     }
 
-    Object.values(feature.privileges).forEach(privilege => {
-      // Disable associated catalogue entries
-      const privilegeCatalogueEntries: string[] = privilege.catalogue || [];
-      privilegeCatalogueEntries.forEach(catalogueEntryId => {
-        catalogueEntries[catalogueEntryId] = false;
-      });
+    // Disable associated catalogue entries
+    const privilegeCatalogueEntries: string[] = feature.catalogue || [];
+    privilegeCatalogueEntries.forEach(catalogueEntryId => {
+      catalogueEntries[catalogueEntryId] = false;
+    });
 
-      // Disable associated management items
-      const privilegeManagementSections: Record<string, string[]> = privilege.management || {};
-      Object.entries(privilegeManagementSections).forEach(([sectionId, sectionItems]) => {
-        sectionItems.forEach(item => {
-          if (
-            managementItems.hasOwnProperty(sectionId) &&
-            managementItems[sectionId].hasOwnProperty(item)
-          ) {
-            managementItems[sectionId][item] = false;
-          }
-        });
+    // Disable associated management items
+    const privilegeManagementSections: Record<string, string[]> = feature.management || {};
+    Object.entries(privilegeManagementSections).forEach(([sectionId, sectionItems]) => {
+      sectionItems.forEach(item => {
+        if (
+          managementItems.hasOwnProperty(sectionId) &&
+          managementItems[sectionId].hasOwnProperty(item)
+        ) {
+          managementItems[sectionId][item] = false;
+        }
       });
     });
 

--- a/x-pack/plugins/xpack_main/server/lib/__tests__/replace_injected_vars.js
+++ b/x-pack/plugins/xpack_main/server/lib/__tests__/replace_injected_vars.js
@@ -48,10 +48,7 @@ describe('replaceInjectedVars uiExport', () => {
         b: 1
       },
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
 
@@ -73,10 +70,7 @@ describe('replaceInjectedVars uiExport', () => {
         b: 1
       },
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -95,10 +89,7 @@ describe('replaceInjectedVars uiExport', () => {
         b: 1
       },
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -117,10 +108,7 @@ describe('replaceInjectedVars uiExport', () => {
         b: 1
       },
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -139,10 +127,7 @@ describe('replaceInjectedVars uiExport', () => {
         b: 1
       },
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -161,10 +146,7 @@ describe('replaceInjectedVars uiExport', () => {
         b: 1
       },
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -179,10 +161,7 @@ describe('replaceInjectedVars uiExport', () => {
     expect(newVars).to.eql({
       ...originalInjectedVars,
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -197,10 +176,7 @@ describe('replaceInjectedVars uiExport', () => {
     expect(newVars).to.eql({
       ...originalInjectedVars,
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -220,11 +196,9 @@ describe('replaceInjectedVars uiExport', () => {
       uiCapabilities: {
         navLinks: { foo: true },
         bar: { baz: true },
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
         catalogue: {
           cfoo: true,
+          myCatalogueEntry: true,
         }
       },
     });
@@ -240,10 +214,7 @@ describe('replaceInjectedVars uiExport', () => {
     expect(newVars).to.eql({
       ...originalInjectedVars,
       uiCapabilities: {
-        mockFeature: {
-          mockFeatureCapability: true,
-        },
-        catalogue: {}
+        catalogue: { myCatalogueEntry: true }
       },
     });
   });
@@ -262,16 +233,7 @@ function mockServer() {
         getFeatures: () => [{
           id: 'mockFeature',
           name: 'Mock Feature',
-          privileges: {
-            all: {
-              app: [],
-              savedObject: {
-                all: [],
-                read: [],
-              },
-              ui: ['mockFeatureCapability']
-            }
-          }
+          catalogue: ['myCatalogueEntry']
         }],
         info: {
           isAvailable: sinon.stub().returns(true),

--- a/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.test.ts
+++ b/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.test.ts
@@ -17,7 +17,6 @@ describe('registerFeature', () => {
     const feature: Feature = {
       id: 'test-feature',
       name: 'Test Feature',
-      privileges: {},
     };
 
     registerFeature(feature);
@@ -37,20 +36,6 @@ describe('registerFeature', () => {
       icon: 'addDataApp',
       navLinkId: 'someNavLink',
       validLicenses: ['standard', 'basic', 'gold', 'platinum'],
-      privileges: {
-        all: {
-          metadata: {
-            tooltip: 'some fancy tooltip',
-          },
-          app: ['app1', 'app2'],
-          savedObject: {
-            all: ['config', 'space', 'etc'],
-            read: ['canvas'],
-          },
-          api: ['someApiEndpointTag', 'anotherEndpointTag'],
-          ui: ['allowsFoo', 'showBar', 'showBaz'],
-        },
-      },
     };
 
     registerFeature(feature);
@@ -66,13 +51,11 @@ describe('registerFeature', () => {
     const feature: Feature = {
       id: 'test-feature',
       name: 'Test Feature',
-      privileges: {},
     };
 
     const duplicateFeature: Feature = {
       id: 'test-feature',
       name: 'Duplicate Test Feature',
-      privileges: {},
     };
 
     registerFeature(feature);
@@ -88,34 +71,8 @@ describe('registerFeature', () => {
         registerFeature({
           id: prohibitedId,
           name: 'some feature',
-          privileges: {},
         })
       ).toThrowErrorMatchingSnapshot();
     });
-  });
-
-  it('prevents features from being registered with invalid privileges', () => {
-    const feature: Feature = {
-      id: 'test-feature',
-      name: 'Test Feature',
-      privileges: {
-        ['some invalid key']: {
-          metadata: {
-            tooltip: 'some fancy tooltip',
-          },
-          app: ['app1', 'app2'],
-          savedObject: {
-            all: ['config', 'space', 'etc'],
-            read: ['canvas'],
-          },
-          api: ['someApiEndpointTag', 'anotherEndpointTag'],
-          ui: ['allowsFoo', 'showBar', 'showBaz'],
-        },
-      },
-    };
-
-    expect(() => registerFeature(feature)).toThrowErrorMatchingInlineSnapshot(
-      `"child \\"privileges\\" fails because [\\"some invalid key\\" is not allowed]"`
-    );
   });
 });

--- a/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.ts
+++ b/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.ts
@@ -9,23 +9,6 @@ import Joi from 'joi';
 import _ from 'lodash';
 import { UICapabilities } from 'ui/capabilities';
 
-export interface FeaturePrivilegeDefinition {
-  metadata?: {
-    tooltip?: string;
-  };
-  management?: {
-    [sectionId: string]: string[];
-  };
-  catalogue?: string[];
-  api?: string[];
-  app: string[];
-  savedObject: {
-    all: string[];
-    read: string[];
-  };
-  ui: string[];
-}
-
 export interface Feature {
   id: string;
   name: string;
@@ -33,9 +16,11 @@ export interface Feature {
   icon?: IconType;
   description?: string;
   navLinkId?: string;
-  privileges: {
-    [key: string]: FeaturePrivilegeDefinition;
+  ui?: string[];
+  management?: {
+    [sectionId: string]: string[];
   };
+  catalogue?: string[];
 }
 
 // Each feature gets its own property on the UICapabilities object,
@@ -56,33 +41,8 @@ const schema = Joi.object({
   icon: Joi.string(),
   description: Joi.string(),
   navLinkId: Joi.string(),
-  privileges: Joi.object()
-    .pattern(
-      featurePrivilegePartRegex,
-      Joi.object({
-        metadata: Joi.object({
-          tooltip: Joi.string(),
-        }),
-        management: Joi.object().pattern(managementSectionIdRegex, Joi.array().items(Joi.string())),
-        catalogue: Joi.array().items(Joi.string()),
-        api: Joi.array().items(Joi.string()),
-        app: Joi.array()
-          .items(Joi.string())
-          .required(),
-        savedObject: Joi.object({
-          all: Joi.array()
-            .items(Joi.string())
-            .required(),
-          read: Joi.array()
-            .items(Joi.string())
-            .required(),
-        }).required(),
-        ui: Joi.array()
-          .items(Joi.string().regex(uiCapabilitiesRegex))
-          .required(),
-      })
-    )
-    .required(),
+  management: Joi.object().pattern(managementSectionIdRegex, Joi.array().items(Joi.string())),
+  catalogue: Joi.array().items(Joi.string()),
 });
 
 const features: Record<string, Feature> = {};

--- a/x-pack/plugins/xpack_main/server/lib/populate_ui_capabilities.ts
+++ b/x-pack/plugins/xpack_main/server/lib/populate_ui_capabilities.ts
@@ -28,7 +28,6 @@ export function populateUICapabilities(
 function getCapabilitiesFromFeature(feature: Feature): FeatureCapabilities {
   const UIFeatureCapabilities: FeatureCapabilities = {
     catalogue: {},
-    [feature.id]: {},
   };
 
   if (feature.catalogue) {

--- a/x-pack/plugins/xpack_main/server/lib/populate_ui_capabilities.ts
+++ b/x-pack/plugins/xpack_main/server/lib/populate_ui_capabilities.ts
@@ -31,10 +31,10 @@ function getCapabilitiesFromFeature(feature: Feature): FeatureCapabilities {
     [feature.id]: {},
   };
 
-  Object.values(feature.privileges).forEach(privilege => {
-    UIFeatureCapabilities[feature.id] = {
-      ...UIFeatureCapabilities[feature.id],
-      ...privilege.ui.reduce(
+  if (feature.catalogue) {
+    UIFeatureCapabilities.catalogue = {
+      ...UIFeatureCapabilities.catalogue,
+      ...feature.catalogue.reduce(
         (privilegeAcc, capability) => ({
           ...privilegeAcc,
           [capability]: true,
@@ -42,20 +42,7 @@ function getCapabilitiesFromFeature(feature: Feature): FeatureCapabilities {
         {}
       ),
     };
-
-    if (privilege.catalogue) {
-      UIFeatureCapabilities.catalogue = {
-        ...UIFeatureCapabilities.catalogue,
-        ...privilege.catalogue.reduce(
-          (privilegeAcc, capability) => ({
-            ...privilegeAcc,
-            [capability]: true,
-          }),
-          {}
-        ),
-      };
-    }
-  });
+  }
 
   return UIFeatureCapabilities;
 }

--- a/x-pack/plugins/xpack_main/server/lib/register_oss_features.ts
+++ b/x-pack/plugins/xpack_main/server/lib/register_oss_features.ts
@@ -12,141 +12,45 @@ const kibanaFeatures: Feature[] = [
     name: 'Discover',
     icon: 'discoverApp',
     navLinkId: 'kibana:discover',
-    privileges: {
-      all: {
-        catalogue: ['discover'],
-        app: ['kibana'],
-        savedObject: {
-          all: ['search'],
-          read: ['config', 'index-pattern'],
-        },
-        ui: ['show', 'showWriteControls'],
-      },
-      read: {
-        catalogue: ['discover'],
-        app: ['kibana'],
-        savedObject: {
-          all: [],
-          read: ['config', 'index-pattern', 'search'],
-        },
-        ui: ['show'],
-      },
-    },
+    catalogue: ['discover'],
   },
   {
     id: 'visualize',
     name: 'Visualize',
     icon: 'visualizeApp',
     navLinkId: 'kibana:visualize',
-    privileges: {
-      all: {
-        catalogue: ['visualize'],
-        app: ['kibana'],
-        savedObject: {
-          all: ['visualization'],
-          read: ['config', 'index-pattern', 'search'],
-        },
-        ui: [],
-      },
-      read: {
-        catalogue: ['visualize'],
-        app: ['kibana'],
-        savedObject: {
-          all: [],
-          read: ['config', 'index-pattern', 'search', 'visualization'],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['visualize'],
   },
   {
     id: 'dashboard',
     name: 'Dashboard',
     icon: 'dashboardApp',
     navLinkId: 'kibana:dashboard',
-    privileges: {
-      all: {
-        catalogue: ['dashboard'],
-        app: ['kibana'],
-        savedObject: {
-          all: ['dashboard'],
-          read: ['config', 'index-pattern', 'search', 'visualization', 'timelion', 'canvas'],
-        },
-        ui: [],
-      },
-      read: {
-        catalogue: ['dashboard'],
-        app: ['kibana'],
-        savedObject: {
-          all: [],
-          read: [
-            'config',
-            'index-pattern',
-            'search',
-            'visualization',
-            'timelion',
-            'canvas',
-            'dashboard',
-          ],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['dashboard'],
   },
   {
     id: 'dev_tools',
     name: 'Dev Tools',
     icon: 'devToolsApp',
     navLinkId: 'kibana:dev_tools',
-    privileges: {
-      all: {
-        catalogue: ['console', 'searchprofiler', 'grokdebugger'],
-        api: ['console/execute'],
-        app: ['kibana'],
-        savedObject: {
-          all: [],
-          read: ['config'],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['console', 'searchprofiler', 'grokdebugger'],
   },
   {
     id: 'advancedSettings',
     name: 'Advanced Settings',
     icon: 'advancedSettingsApp',
-    privileges: {
-      all: {
-        catalogue: ['advanced_settings'],
-        management: {
-          kibana: ['settings'],
-        },
-        app: ['kibana'],
-        savedObject: {
-          all: ['config'],
-          read: [],
-        },
-        ui: [],
-      },
+    catalogue: ['advanced_settings'],
+    management: {
+      kibana: ['settings'],
     },
   },
   {
     id: 'indexPatterns',
     name: 'Index Pattern Management',
     icon: 'indexPatternApp',
-    privileges: {
-      all: {
-        catalogue: ['index_patterns'],
-        management: {
-          kibana: ['indices'],
-        },
-        app: ['kibana'],
-        savedObject: {
-          all: ['index-pattern'],
-          read: ['config'],
-        },
-        ui: [],
-      },
+    catalogue: ['index_patterns'],
+    management: {
+      kibana: ['indices'],
     },
   },
 ];
@@ -157,26 +61,7 @@ const timelionFeatures: Feature[] = [
     name: 'Timelion',
     icon: 'timelionApp',
     navLinkId: 'timelion',
-    privileges: {
-      all: {
-        catalogue: ['timelion'],
-        app: ['timelion', 'kibana'],
-        savedObject: {
-          all: ['timelion'],
-          read: ['config', 'index-pattern'],
-        },
-        ui: [],
-      },
-      read: {
-        catalogue: ['timelion'],
-        app: ['timelion', 'kibana'],
-        savedObject: {
-          all: [],
-          read: ['config', 'index-pattern', 'timelion'],
-        },
-        ui: [],
-      },
-    },
+    catalogue: ['timelion'],
   },
 ];
 

--- a/x-pack/plugins/xpack_main/server/routes/api/v1/features/__snapshots__/features.test.ts.snap
+++ b/x-pack/plugins/xpack_main/server/routes/api/v1/features/__snapshots__/features.test.ts.snap
@@ -5,7 +5,6 @@ Array [
   Object {
     "id": "feature_1",
     "name": "Feature 1",
-    "privileges": Object {},
   },
 ]
 `;
@@ -15,12 +14,10 @@ Array [
   Object {
     "id": "feature_1",
     "name": "Feature 1",
-    "privileges": Object {},
   },
   Object {
     "id": "licensed_feature",
     "name": "Licensed Feature",
-    "privileges": Object {},
     "validLicenses": Array [
       "gold",
     ],

--- a/x-pack/plugins/xpack_main/server/routes/api/v1/features/features.test.ts
+++ b/x-pack/plugins/xpack_main/server/routes/api/v1/features/features.test.ts
@@ -45,14 +45,12 @@ describe('GET /api/features/v1', () => {
     registerFeature({
       id: 'feature_1',
       name: 'Feature 1',
-      privileges: {},
     });
 
     registerFeature({
       id: 'licensed_feature',
       name: 'Licensed Feature',
       validLicenses: ['gold'],
-      privileges: {},
     });
   });
 


### PR DESCRIPTION
**ATTN Pinged teams**: Ignore this PR

## Summary

Removes the `privileges` property from the feature definition. In doing so, the `management` and `catalogue` entries were moved from within the privilege definition to the root feature definition.

**Awaiting https://github.com/elastic/kibana/pull/28271**

Related: https://github.com/elastic/kibana/issues/28184