### PR TITLE
[Infra UI] Log Rules for AuditD Filebeat Module

### DIFF
--- a/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
@@ -266,7 +266,7 @@ const convertHitToLogEntryDocument = (fields: string[]) => (
             [fieldName]: get(fieldName, hit._source),
           }
         : flattenedFields,
-    {} as { [fieldName: string]: string | number | null }
+    {} as { [fieldName: string]: string | number | boolean | null }
   ),
   key: {
     time: hit.sort[0],

--- a/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
@@ -266,7 +266,7 @@ const convertHitToLogEntryDocument = (fields: string[]) => (
             [fieldName]: get(fieldName, hit._source),
           }
         : flattenedFields,
-    {} as { [fieldName: string]: string | number | boolean | null }
+    {} as { [fieldName: string]: string | number | null }
   ),
   key: {
     time: hit.sort[0],

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { compileFormattingRules } from '../message';
+import { filebeatAuditdRules } from './filebeat_auditd';
+
+const { format } = compileFormattingRules(filebeatAuditdRules);
+
+describe('Filebeat Rules', () => {
+  test('auditd IPSEC event', () => {
+    const event = {
+      '@timestamp': '2017-01-31T20:17:14.891Z',
+      'auditd.log.auid': '4294967295',
+      'auditd.log.dst': '192.168.0.0',
+      'auditd.log.dst_prefixlen': '16',
+      'auditd.log.op': 'SPD-delete',
+      'auditd.log.record_type': 'MAC_IPSEC_EVENT',
+      'auditd.log.res': '1',
+      'auditd.log.sequence': 18877201,
+      'auditd.log.ses': '4294967295',
+      'auditd.log.src': '192.168.2.0',
+      'auditd.log.src_prefixlen': '24',
+      'ecs.version': '1.0.0-beta2',
+      'event.dataset': 'auditd.log',
+      'event.module': 'auditd',
+      'fileset.name': 'log',
+      'input.type': 'log',
+      'log.offset': 0,
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type', highlights: [], value: 'MAC_IPSEC_EVENT' },
+      { constant: ' auid:' },
+      { field: 'auditd.log.auid', highlights: [], value: '4294967295' },
+      { constant: ' src:' },
+      { field: 'auditd.log.src', highlights: [], value: '192.168.2.0' },
+      { constant: ' dst:' },
+      { field: 'auditd.log.dst', highlights: [], value: '192.168.0.0' },
+      { constant: ' op:' },
+      { field: 'auditd.log.op', highlights: [], value: 'SPD-delete' },
+    ]);
+  });
+
+  test('AuditD SYSCALL event', () => {
+    const event = {
+      '@timestamp': '2017-01-31T20:17:14.891Z',
+      'auditd.log.a0': '9',
+      'auditd.log.a1': '7f564b2672a0',
+      'auditd.log.a2': 'b8',
+      'auditd.log.a3': '0',
+      'auditd.log.arch': 'x86_64',
+      'auditd.log.auid': '4294967295',
+      'auditd.log.comm': 'charon',
+      'auditd.log.egid': '0',
+      'auditd.log.euid': '0',
+      'auditd.log.exe': '/usr/libexec/strongswan/charon (deleted)',
+      'auditd.log.exit': '184',
+      'auditd.log.fsgid': '0',
+      'auditd.log.fsuid': '0',
+      'auditd.log.gid': '0',
+      'auditd.log.items': '0',
+      'auditd.log.pid': '1281',
+      'auditd.log.ppid': '1240',
+      'auditd.log.record_type': 'SYSCALL',
+      'auditd.log.sequence': 18877199,
+      'auditd.log.ses': '4294967295',
+      'auditd.log.sgid': '0',
+      'auditd.log.success': 'yes',
+      'auditd.log.suid': '0',
+      'auditd.log.syscall': '44',
+      'auditd.log.tty': '(none)',
+      'auditd.log.uid': '0',
+      'ecs.version': '1.0.0-beta2',
+      'event.dataset': 'auditd.log',
+      'event.module': 'auditd',
+      'fileset.name': 'log',
+      'input.type': 'log',
+      'log.offset': 174,
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type', highlights: [], value: 'SYSCALL' },
+      { constant: ' auid:' },
+      { field: 'auditd.log.auid', highlights: [], value: '4294967295' },
+      { constant: ' exe:' },
+      {
+        field: 'auditd.log.exe',
+        highlights: [],
+        value: '/usr/libexec/strongswan/charon (deleted)',
+      },
+      { constant: ' gid:' },
+      { field: 'auditd.log.gid', highlights: [], value: '0' },
+      { constant: ' uid:' },
+      { field: 'auditd.log.uid', highlights: [], value: '0' },
+      { constant: ' tty:' },
+      { field: 'auditd.log.tty', highlights: [], value: '(none)' },
+      { constant: ' pid:' },
+      { field: 'auditd.log.pid', highlights: [], value: '1281' },
+      { constant: ' ppid:' },
+      { field: 'auditd.log.ppid', highlights: [], value: '1240' },
+    ]);
+  });
+});

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
@@ -32,9 +32,9 @@ describe('Filebeat Rules', () => {
     };
     const message = format(event);
     expect(message).toEqual([
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type', highlights: [], value: 'MAC_IPSEC_EVENT' },
-      { constant: ' src:' },
+      { constant: '] src:' },
       { field: 'auditd.log.src', highlights: [], value: '192.168.2.0' },
       { constant: ' dst:' },
       { field: 'auditd.log.dst', highlights: [], value: '192.168.0.0' },
@@ -81,9 +81,9 @@ describe('Filebeat Rules', () => {
     };
     const message = format(event);
     expect(message).toEqual([
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type', highlights: [], value: 'SYSCALL' },
-      { constant: ' exe:' },
+      { constant: '] exe:' },
       {
         field: 'auditd.log.exe',
         highlights: [],
@@ -117,9 +117,9 @@ describe('Filebeat Rules', () => {
     };
     const message = format(event);
     expect(message).toEqual([
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type', highlights: [], value: 'EXAMPLE' },
-      { constant: ' msg:' },
+      { constant: '] ' },
       {
         field: 'auditd.log.msg',
         highlights: [],
@@ -142,9 +142,9 @@ describe('Filebeat Rules', () => {
     };
     const message = format(event);
     expect(message).toEqual([
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type', highlights: [], value: 'EXAMPLE' },
-      { constant: ' event without message.' },
+      { constant: '] Event without message.' },
     ]);
   });
 });

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
@@ -102,7 +102,7 @@ describe('Filebeat Rules', () => {
     ]);
   });
 
-  test('AuditD catchall rule', () => {
+  test('AuditD events with msg rule', () => {
     const event = {
       '@timestamp': '2017-01-31T20:17:14.891Z',
       'auditd.log.auid': '4294967295',
@@ -125,6 +125,26 @@ describe('Filebeat Rules', () => {
         highlights: [],
         value: 'some kind of message',
       },
+    ]);
+  });
+
+  test('AuditD catchall rule', () => {
+    const event = {
+      '@timestamp': '2017-01-31T20:17:14.891Z',
+      'auditd.log.auid': '4294967295',
+      'auditd.log.record_type': 'EXAMPLE',
+      'ecs.version': '1.0.0-beta2',
+      'event.dataset': 'auditd.log',
+      'event.module': 'auditd',
+      'fileset.name': 'log',
+      'input.type': 'log',
+      'log.offset': 174,
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type', highlights: [], value: 'EXAMPLE' },
+      { constant: ' event without message.' },
     ]);
   });
 });

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.test.ts
@@ -10,7 +10,7 @@ import { filebeatAuditdRules } from './filebeat_auditd';
 const { format } = compileFormattingRules(filebeatAuditdRules);
 
 describe('Filebeat Rules', () => {
-  test('auditd IPSEC event', () => {
+  test('auditd IPSEC rule', () => {
     const event = {
       '@timestamp': '2017-01-31T20:17:14.891Z',
       'auditd.log.auid': '4294967295',
@@ -34,8 +34,6 @@ describe('Filebeat Rules', () => {
     expect(message).toEqual([
       { constant: '[AuditD] ' },
       { field: 'auditd.log.record_type', highlights: [], value: 'MAC_IPSEC_EVENT' },
-      { constant: ' auid:' },
-      { field: 'auditd.log.auid', highlights: [], value: '4294967295' },
       { constant: ' src:' },
       { field: 'auditd.log.src', highlights: [], value: '192.168.2.0' },
       { constant: ' dst:' },
@@ -45,7 +43,7 @@ describe('Filebeat Rules', () => {
     ]);
   });
 
-  test('AuditD SYSCALL event', () => {
+  test('AuditD SYSCALL rule', () => {
     const event = {
       '@timestamp': '2017-01-31T20:17:14.891Z',
       'auditd.log.a0': '9',
@@ -85,8 +83,6 @@ describe('Filebeat Rules', () => {
     expect(message).toEqual([
       { constant: '[AuditD] ' },
       { field: 'auditd.log.record_type', highlights: [], value: 'SYSCALL' },
-      { constant: ' auid:' },
-      { field: 'auditd.log.auid', highlights: [], value: '4294967295' },
       { constant: ' exe:' },
       {
         field: 'auditd.log.exe',
@@ -103,6 +99,32 @@ describe('Filebeat Rules', () => {
       { field: 'auditd.log.pid', highlights: [], value: '1281' },
       { constant: ' ppid:' },
       { field: 'auditd.log.ppid', highlights: [], value: '1240' },
+    ]);
+  });
+
+  test('AuditD catchall rule', () => {
+    const event = {
+      '@timestamp': '2017-01-31T20:17:14.891Z',
+      'auditd.log.auid': '4294967295',
+      'auditd.log.record_type': 'EXAMPLE',
+      'auditd.log.msg': 'some kind of message',
+      'ecs.version': '1.0.0-beta2',
+      'event.dataset': 'auditd.log',
+      'event.module': 'auditd',
+      'fileset.name': 'log',
+      'input.type': 'log',
+      'log.offset': 174,
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type', highlights: [], value: 'EXAMPLE' },
+      { constant: ' msg:' },
+      {
+        field: 'auditd.log.msg',
+        highlights: [],
+        value: 'some kind of message',
+      },
     ]);
   });
 });

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
@@ -13,9 +13,9 @@ export const filebeatAuditdRules = [
       },
     },
     format: [
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type' },
-      { constant: ' src:' },
+      { constant: '] src:' },
       { field: 'auditd.log.src' },
       { constant: ' dst:' },
       { field: 'auditd.log.dst' },
@@ -40,9 +40,9 @@ export const filebeatAuditdRules = [
       },
     },
     format: [
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type' },
-      { constant: ' exe:' },
+      { constant: '] exe:' },
       { field: 'auditd.log.exe' },
       { constant: ' gid:' },
       { field: 'auditd.log.gid' },
@@ -62,9 +62,9 @@ export const filebeatAuditdRules = [
       exists: ['auditd.log.record_type', 'auditd.log.msg'],
     },
     format: [
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type' },
-      { constant: ' msg:' },
+      { constant: '] ' },
       { field: 'auditd.log.msg' },
     ],
   },
@@ -74,9 +74,9 @@ export const filebeatAuditdRules = [
       exists: ['auditd.log.record_type'],
     },
     format: [
-      { constant: '[AuditD] ' },
+      { constant: '[AuditD][' },
       { field: 'auditd.log.record_type' },
-      { constant: ' event without message.' },
+      { constant: '] Event without message.' },
     ],
   },
 ];

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
@@ -56,7 +56,7 @@ export const filebeatAuditdRules = [
       { field: 'auditd.log.ppid' },
     ],
   },
-  // CATCHALL Rule
+  // Events with `msg` Rule
   {
     when: {
       exists: ['auditd.log.record_type', 'auditd.log.msg'],
@@ -66,6 +66,17 @@ export const filebeatAuditdRules = [
       { field: 'auditd.log.record_type' },
       { constant: ' msg:' },
       { field: 'auditd.log.msg' },
+    ],
+  },
+  // Events with `msg` Rule
+  {
+    when: {
+      exists: ['auditd.log.record_type'],
+    },
+    format: [
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type' },
+      { constant: ' event without message.' },
     ],
   },
 ];

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
@@ -4,16 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 export const filebeatAuditdRules = [
-  // IPSEC_EVENT
+  // IPSEC_EVENT Rule
   {
     when: {
-      exists: [
-        'auditd.log.record_type',
-        'auditd.log.auid',
-        'auditd.log.src',
-        'auditd.log.dst',
-        'auditd.log.op',
-      ],
+      exists: ['auditd.log.record_type', 'auditd.log.src', 'auditd.log.dst', 'auditd.log.op'],
       values: {
         'auditd.log.record_type': 'MAC_IPSEC_EVENT',
       },
@@ -21,8 +15,6 @@ export const filebeatAuditdRules = [
     format: [
       { constant: '[AuditD] ' },
       { field: 'auditd.log.record_type' },
-      { constant: ' auid:' },
-      { field: 'auditd.log.auid' },
       { constant: ' src:' },
       { field: 'auditd.log.src' },
       { constant: ' dst:' },
@@ -31,12 +23,11 @@ export const filebeatAuditdRules = [
       { field: 'auditd.log.op' },
     ],
   },
-  // SYSCALL
+  // SYSCALL Rule
   {
     when: {
       exists: [
         'auditd.log.record_type',
-        'auditd.log.auid',
         'auditd.log.exe',
         'auditd.log.gid',
         'auditd.log.uid',
@@ -51,8 +42,6 @@ export const filebeatAuditdRules = [
     format: [
       { constant: '[AuditD] ' },
       { field: 'auditd.log.record_type' },
-      { constant: ' auid:' },
-      { field: 'auditd.log.auid' },
       { constant: ' exe:' },
       { field: 'auditd.log.exe' },
       { constant: ' gid:' },
@@ -65,6 +54,18 @@ export const filebeatAuditdRules = [
       { field: 'auditd.log.pid' },
       { constant: ' ppid:' },
       { field: 'auditd.log.ppid' },
+    ],
+  },
+  // CATCHALL Rule
+  {
+    when: {
+      exists: ['auditd.log.record_type', 'auditd.log.msg'],
+    },
+    format: [
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type' },
+      { constant: ' msg:' },
+      { field: 'auditd.log.msg' },
     ],
   },
 ];

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_auditd.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+export const filebeatAuditdRules = [
+  // IPSEC_EVENT
+  {
+    when: {
+      exists: [
+        'auditd.log.record_type',
+        'auditd.log.auid',
+        'auditd.log.src',
+        'auditd.log.dst',
+        'auditd.log.op',
+      ],
+      values: {
+        'auditd.log.record_type': 'MAC_IPSEC_EVENT',
+      },
+    },
+    format: [
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type' },
+      { constant: ' auid:' },
+      { field: 'auditd.log.auid' },
+      { constant: ' src:' },
+      { field: 'auditd.log.src' },
+      { constant: ' dst:' },
+      { field: 'auditd.log.dst' },
+      { constant: ' op:' },
+      { field: 'auditd.log.op' },
+    ],
+  },
+  // SYSCALL
+  {
+    when: {
+      exists: [
+        'auditd.log.record_type',
+        'auditd.log.auid',
+        'auditd.log.exe',
+        'auditd.log.gid',
+        'auditd.log.uid',
+        'auditd.log.tty',
+        'auditd.log.pid',
+        'auditd.log.ppid',
+      ],
+      values: {
+        'auditd.log.record_type': 'SYSCALL',
+      },
+    },
+    format: [
+      { constant: '[AuditD] ' },
+      { field: 'auditd.log.record_type' },
+      { constant: ' auid:' },
+      { field: 'auditd.log.auid' },
+      { constant: ' exe:' },
+      { field: 'auditd.log.exe' },
+      { constant: ' gid:' },
+      { field: 'auditd.log.gid' },
+      { constant: ' uid:' },
+      { field: 'auditd.log.uid' },
+      { constant: ' tty:' },
+      { field: 'auditd.log.tty' },
+      { constant: ' pid:' },
+      { field: 'auditd.log.pid' },
+      { constant: ' ppid:' },
+      { field: 'auditd.log.ppid' },
+    ],
+  },
+];

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/index.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { filebeatApache2Rules } from './filebeat_apache2';
+import { filebeatAuditdRules } from './filebeat_auditd';
 import { filebeatNginxRules } from './filebeat_nginx';
 import { filebeatRedisRules } from './filebeat_redis';
 import { filebeatSystemRules } from './filebeat_system';
@@ -15,6 +16,7 @@ export const builtinRules = [
   ...filebeatNginxRules,
   ...filebeatRedisRules,
   ...filebeatSystemRules,
+  ...filebeatAuditdRules,
   ...genericRules,
   {
     when: {

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/log_entries_domain.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/log_entries_domain.ts
@@ -164,7 +164,7 @@ export interface LogEntryDocument {
 }
 
 export interface LogEntryDocumentFields {
-  [fieldName: string]: string | number | null;
+  [fieldName: string]: string | number | boolean | null;
 }
 
 const convertLogDocumentToEntry = (


### PR DESCRIPTION
This PR adds rules for the AuditD Filebeat module. There are custom rules for the `SYSCALL` and `MAC_IPSEC_EVENT` events. For everything else there is a catch all for everything else as long as it has an `auditd.log.msg` field.

@makwarth For additional AuditD rules we are going to need some example events. The event in this PR were taken from the Filebeat tests (https://github.com/elastic/beats/blob/master/filebeat/module/auditd/log/test/test.log-expected.json). Maybe someone from @elastic/beats could weigh in on which events we should support.