### PR TITLE
[Infra UI] Log Rules for Nginx Errors

### DIFF
--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.test.ts
@@ -23,7 +23,7 @@ describe('Filebeat Rules', () => {
     const message = format(event);
     expect(message).toEqual([
       {
-        constant: '[Nginx] ',
+        constant: '[Nginx][access] ',
       },
       {
         field: 'nginx.access.remote_ip',
@@ -84,11 +84,23 @@ describe('Filebeat Rules', () => {
     const event = {
       'nginx.error.message':
         'connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: localhost, request: "GET /php-status?json= HTTP/1.1", upstream: "fastcgi://[::1]:9000", host: "localhost"',
+      'nginx.error.level': 'error',
     };
     const message = format(event);
     expect(message).toEqual([
       {
-        constant: '[Nginx Error] ',
+        constant: '[Nginx]',
+      },
+      {
+        constant: '[',
+      },
+      {
+        field: 'nginx.error.level',
+        highlights: [],
+        value: 'error',
+      },
+      {
+        constant: '] ',
       },
       {
         field: 'nginx.error.message',

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { compileFormattingRules } from '../message';
+import { filebeatNginxRules } from './filebeat_nginx';
+
+const { format } = compileFormattingRules(filebeatNginxRules);
+describe('Filebeat Rules', () => {
+  test('Nginx Access Rule', () => {
+    const event = {
+      'nginx.access': true,
+      'nginx.access.remote_ip': '192.168.1.42',
+      'nginx.access.user_name': 'admin',
+      'nginx.access.method': 'GET',
+      'nginx.access.url': '/faq',
+      'nginx.access.http_version': '1.1',
+      'nginx.access.body_sent.bytes': 1024,
+      'nginx.access.response_code': 200,
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      {
+        constant: '[Nginx] ',
+      },
+      {
+        field: 'nginx.access.remote_ip',
+        highlights: [],
+        value: '192.168.1.42',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'nginx.access.user_name',
+        highlights: [],
+        value: 'admin',
+      },
+      {
+        constant: ' "',
+      },
+      {
+        field: 'nginx.access.method',
+        highlights: [],
+        value: 'GET',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'nginx.access.url',
+        highlights: [],
+        value: '/faq',
+      },
+      {
+        constant: ' HTTP/',
+      },
+      {
+        field: 'nginx.access.http_version',
+        highlights: [],
+        value: '1.1',
+      },
+      {
+        constant: '" ',
+      },
+      {
+        field: 'nginx.access.response_code',
+        highlights: [],
+        value: '200',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'nginx.access.body_sent.bytes',
+        highlights: [],
+        value: '1024',
+      },
+    ]);
+  });
+  test('Nginx Access Rule', () => {
+    const event = {
+      'nginx.error.message':
+        'connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: localhost, request: "GET /php-status?json= HTTP/1.1", upstream: "fastcgi://[::1]:9000", host: "localhost"',
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      {
+        constant: '[Nginx Error] ',
+      },
+      {
+        field: 'nginx.error.message',
+        highlights: [],
+        value:
+          'connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: localhost, request: "GET /php-status?json= HTTP/1.1", upstream: "fastcgi://[::1]:9000", host: "localhost"',
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.ts
@@ -11,7 +11,7 @@ export const filebeatNginxRules = [
     },
     format: [
       {
-        constant: '[Nginx] ',
+        constant: '[Nginx][access] ',
       },
       {
         field: 'nginx.access.remote_ip',
@@ -60,7 +60,16 @@ export const filebeatNginxRules = [
     },
     format: [
       {
-        constant: '[Nginx Error] ',
+        constant: '[Nginx]',
+      },
+      {
+        constant: '[',
+      },
+      {
+        field: 'nginx.error.level',
+      },
+      {
+        constant: '] ',
       },
       {
         field: 'nginx.error.message',

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_nginx.ts
@@ -11,10 +11,7 @@ export const filebeatNginxRules = [
     },
     format: [
       {
-        constant: 'nginx',
-      },
-      {
-        constant: ' ',
+        constant: '[Nginx] ',
       },
       {
         field: 'nginx.access.remote_ip',
@@ -54,6 +51,19 @@ export const filebeatNginxRules = [
       },
       {
         field: 'nginx.access.body_sent.bytes',
+      },
+    ],
+  },
+  {
+    when: {
+      exists: ['nginx.error.message'],
+    },
+    format: [
+      {
+        constant: '[Nginx Error] ',
+      },
+      {
+        field: 'nginx.error.message',
       },
     ],
   },


### PR DESCRIPTION
This PR adds a rule for Nginx error messages I also changed the prefix for the access logs to match.

![image](https://user-images.githubusercontent.com/41702/50923038-2fc1c500-1409-11e9-929d-6205401bab8c.png)
