### PR TITLE
Switched tabs to render to avoid unnecessary mount cycles

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Main/Home.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/Home.tsx
@@ -20,12 +20,12 @@ const homeTabs: IHistoryTab[] = [
   {
     path: '/services',
     name: 'Services',
-    component: ServiceOverview
+    render: props => <ServiceOverview {...props} />
   },
   {
     path: '/traces',
     name: 'Traces',
-    component: TraceOverview
+    render: props => <TraceOverview {...props} />
   }
 ];
 

--- a/x-pack/plugins/apm/public/components/app/Main/__test__/__snapshots__/Home.test.js.snap
+++ b/x-pack/plugins/apm/public/components/app/Main/__test__/__snapshots__/Home.test.js.snap
@@ -39,14 +39,14 @@ exports[`Home component should render 1`] = `
     tabs={
       Array [
         Object {
-          "component": [Function],
           "name": "Services",
           "path": "/services",
+          "render": [Function],
         },
         Object {
-          "component": [Function],
           "name": "Traces",
           "path": "/traces",
+          "render": [Function],
         },
       ]
     }

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceDetailTabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceDetailTabs.tsx
@@ -26,7 +26,7 @@ export class ServiceDetailTabs extends React.Component<TabsProps> {
         name: 'Transactions',
         path: `/${serviceName}/transactions/${transactionTypes[0]}`,
         routePath: `/${serviceName}/transactions/:transactionType?`,
-        component: () => (
+        render: () => (
           <TransactionOverview
             urlParams={urlParams}
             serviceTransactionTypes={transactionTypes}
@@ -36,7 +36,7 @@ export class ServiceDetailTabs extends React.Component<TabsProps> {
       {
         name: 'Errors',
         path: `/${serviceName}/errors`,
-        component: () => {
+        render: () => {
           return (
             <ErrorGroupOverview urlParams={urlParams} location={location} />
           );
@@ -45,7 +45,7 @@ export class ServiceDetailTabs extends React.Component<TabsProps> {
       {
         name: 'Metrics',
         path: `/${serviceName}/metrics`,
-        component: () => <ServiceMetrics urlParams={urlParams} />
+        render: () => <ServiceMetrics urlParams={urlParams} />
       }
     ];
 

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -70,12 +70,13 @@ const traceListColumns: ITableColumn[] = [
 ];
 
 export function TraceList({ items = [], noItemsMessage, isLoading }: Props) {
-  return isLoading ? null : (
+  const noItems = isLoading ? null : noItemsMessage;
+  return (
     <ManagedTable
       columns={traceListColumns}
       items={items}
       initialSort={{ field: 'impact', direction: 'desc' }}
-      noItemsMessage={noItemsMessage}
+      noItemsMessage={noItems}
       initialPageSize={25}
     />
   );

--- a/x-pack/plugins/apm/public/components/shared/HistoryTabs/__test__/HistoryTabs.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/HistoryTabs/__test__/HistoryTabs.test.tsx
@@ -40,17 +40,17 @@ describe('HistoryTabs', () => {
       {
         name: 'One',
         path: '/one',
-        component: () => <Content name="one" />
+        render: props => <Content {...props} name="one" />
       },
       {
         name: 'Two',
         path: '/two',
-        component: () => <Content name="two" />
+        render: () => <Content name="two" />
       },
       {
         name: 'Three',
         path: '/three',
-        component: () => <Content name="three" />
+        render: () => <Content name="three" />
       }
     ];
 

--- a/x-pack/plugins/apm/public/components/shared/HistoryTabs/__test__/__snapshots__/HistoryTabs.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/HistoryTabs/__test__/__snapshots__/HistoryTabs.test.tsx.snap
@@ -55,19 +55,19 @@ exports[`HistoryTabs should render correctly 1`] = `
     size="l"
   />
   <Route
-    component={[Function]}
     key="/one"
     path="/one"
+    render={[Function]}
   />
   <Route
-    component={[Function]}
     key="/two"
     path="/two"
+    render={[Function]}
   />
   <Route
-    component={[Function]}
     key="/three"
     path="/three"
+    render={[Function]}
   />
 </React.Fragment>
 `;

--- a/x-pack/plugins/apm/public/components/shared/HistoryTabs/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/HistoryTabs/index.tsx
@@ -17,7 +17,7 @@ export interface IHistoryTab {
   path: string;
   routePath?: string;
   name: React.ReactNode;
-  component?: React.SFC | React.ComponentClass;
+  render?: (props: RouteComponentProps) => React.ReactNode;
 }
 
 export interface HistoryTabsProps extends RouteComponentProps {
@@ -51,10 +51,10 @@ const HistoryTabsWithoutRouter = ({
       </EuiTabs>
       <EuiSpacer />
       {tabs.map(tab =>
-        tab.component ? (
+        tab.render ? (
           <Route
             path={tab.routePath || tab.path}
-            component={tab.component}
+            render={tab.render}
             key={tab.path}
           />
         ) : null


### PR DESCRIPTION
Fixes #27883 
Fixes #28371 

## Summary

We were previously using the 'component' prop for React Router routes inside of our history tabs component, which causes lots of extra mount cycles. Using the 'render' prop avoids that.

I also decided to *only* allow the render prop instead of allowing `component` or `render`. This keeps the history tabs component simpler and prevents accidental usage of `component`, which causes massive remounts throughout the nested tree. This unfortunately means using a straight component is a little more verbose b/c you have to pass down props from the render method, but I think that's an ok trade-off. (e.g. you used to be able to do `component: MyComponent` if you didn't have any props to pass it, but now you have to do `render: props => <MyComponent {...props} />`)

## What this PR fixes

* Visit the transaction overview page and turn on auto-refresh, set it to something fast (5 sec or less). The charts and the list of transaction groups should not disappear or "flicker" at all as the data refreshes.
* Open the dev tools Network panel. On each auto refresh, or on each manual time picker change, or on each manual drag selection of a time window (dragging on one of the graphs left to right), each of these should only produce a single charts request. Filter network requests by "charts" to see this. (On "master" currently, this produced 3 or more charts requests each.)
* Click on one or more of the chart series to hide them, then adjust the time window. The hidden series should persist across time range changes.

* The "traces" tab on the APM home page no longer "flickers" while loading data, either. If you go to that tab and turn on the auto refresh, there should be no flicker or glitch as data loads. In addition, on initial load, you still won't get a "no traces found" message while the data is loading.


**More info**

To see how the Route component's `render` prop works vs `component`, you can open Redux dev tools on master while you have auto-refresh on and you'll see a ton of REACT_REDUX_REQUEST:DID_UNMOUNT actions.
<img width="344" alt="screen shot 2019-01-09 at 12 47 12 pm" src="https://user-images.githubusercontent.com/159370/50918435-3999f700-140e-11e9-8ac6-966be333973b.png">

On this branch, you just see what you expect:
<img width="356" alt="screen shot 2019-01-09 at 12 45 01 pm" src="https://user-images.githubusercontent.com/159370/50917819-8ed50900-140c-11e9-848a-6208e609f25b.png">


For more, see: https://reacttraining.com/react-router/web/api/Route

Specifically:

>When you use component (instead of render or children, below) the router uses React.createElement to create a new React element from the given component. That means if you provide an inline function to the component prop, you would create a new component every render. This results in the existing component unmounting and the new component mounting instead of just updating the existing component. When using an inline function for inline rendering, use the render or the children prop (below).