### PR TITLE
[Infra UI] Log Rules for Apache2 errors

### DIFF
--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.test.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { compileFormattingRules } from '../message';
+import { filebeatApache2Rules } from './filebeat_apache2';
+
+const { format } = compileFormattingRules(filebeatApache2Rules);
+describe('Filebeat Rules', () => {
+  test('Apache2 Access', () => {
+    const event = {
+      'apache2.access': true,
+      'apache2.access.remote_ip': '192.168.1.42',
+      'apache2.access.user_name': 'admin',
+      'apache2.access.method': 'GET',
+      'apache2.access.url': '/faqs',
+      'apache2.access.http_version': '1.1',
+      'apache2.access.response_code': '200',
+      'apache2.access.body_sent.bytes': 1024,
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      {
+        constant: '[Apache][access] ',
+      },
+      {
+        field: 'apache2.access.remote_ip',
+        highlights: [],
+        value: '192.168.1.42',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'apache2.access.user_name',
+        highlights: [],
+        value: 'admin',
+      },
+      {
+        constant: ' "',
+      },
+      {
+        field: 'apache2.access.method',
+        highlights: [],
+        value: 'GET',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'apache2.access.url',
+        highlights: [],
+        value: '/faqs',
+      },
+      {
+        constant: ' HTTP/',
+      },
+      {
+        field: 'apache2.access.http_version',
+        highlights: [],
+        value: '1.1',
+      },
+      {
+        constant: '" ',
+      },
+      {
+        field: 'apache2.access.response_code',
+        highlights: [],
+        value: '200',
+      },
+      {
+        constant: ' ',
+      },
+      {
+        field: 'apache2.access.body_sent.bytes',
+        highlights: [],
+        value: '1024',
+      },
+    ]);
+  });
+  test('Apache2 Error', () => {
+    const event = {
+      'apache2.error.message':
+        'AH00489: Apache/2.4.18 (Ubuntu) configured -- resuming normal operations',
+      'apache2.error.level': 'notice',
+    };
+    const message = format(event);
+    expect(message).toEqual([
+      {
+        constant: '[Apache][',
+      },
+      {
+        field: 'apache2.error.level',
+        highlights: [],
+        value: 'notice',
+      },
+      {
+        constant: '] ',
+      },
+      {
+        field: 'apache2.error.message',
+        highlights: [],
+        value: 'AH00489: Apache/2.4.18 (Ubuntu) configured -- resuming normal operations',
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/builtin_rules/filebeat_apache2.ts
@@ -11,10 +11,7 @@ export const filebeatApache2Rules = [
     },
     format: [
       {
-        constant: 'apache2',
-      },
-      {
-        constant: ' ',
+        constant: '[Apache][access] ',
       },
       {
         field: 'apache2.access.remote_ip',
@@ -54,6 +51,25 @@ export const filebeatApache2Rules = [
       },
       {
         field: 'apache2.access.body_sent.bytes',
+      },
+    ],
+  },
+  {
+    when: {
+      exists: ['apache2.error.message'],
+    },
+    format: [
+      {
+        constant: '[Apache][',
+      },
+      {
+        field: 'apache2.error.level',
+      },
+      {
+        constant: '] ',
+      },
+      {
+        field: 'apache2.error.message',
       },
     ],
   },


### PR DESCRIPTION
This PR add rules for Apache 2 Error Logs

![image](https://user-images.githubusercontent.com/41702/50922426-bc6b8380-1407-11e9-9adc-f2cb928bdea5.png)

It also contains a reformat of the access logs:

![image](https://user-images.githubusercontent.com/41702/50922492-defd9c80-1407-11e9-9223-9b0ea253cf69.png)
