### PR TITLE
[Infra UI] Fix Typo in Nginx Layout for Metrics Detail page

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/layouts/nginx.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/layouts/nginx.ts
@@ -48,7 +48,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
             defaultMessage: 'Request Rate',
           }
         ),
-        requires: ['nginx.statusstub'],
+        requires: ['nginx.stubstatus'],
         type: InfraMetricLayoutSectionType.chart,
         visConfig: {
           formatter: InfraFormatterType.abbreviatedNumber,
@@ -66,7 +66,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
             defaultMessage: 'Active Connections',
           }
         ),
-        requires: ['nginx.statusstub'],
+        requires: ['nginx.stubstatus'],
         type: InfraMetricLayoutSectionType.chart,
         visConfig: {
           formatter: InfraFormatterType.abbreviatedNumber,
@@ -86,7 +86,7 @@ export const nginxLayoutCreator: InfraMetricLayoutCreator = theme => [
             defaultMessage: 'Requests per Connections',
           }
         ),
-        requires: ['nginx.statusstub'],
+        requires: ['nginx.stubstatus'],
         type: InfraMetricLayoutSectionType.chart,
         visConfig: {
           formatter: InfraFormatterType.abbreviatedNumber,


### PR DESCRIPTION
This PR fixes elastic/kibana#28591 by fixing a typo in the Nginx layout definition file.

![image](https://user-images.githubusercontent.com/41702/51051595-7cd0a300-1591-11e9-83a8-375043a243e1.png)
