### PR TITLE
[6.x] Updating legend to use gray/blue gradient (#28206)

### DIFF
--- a/x-pack/plugins/infra/public/containers/with_options.tsx
+++ b/x-pack/plugins/infra/public/containers/with_options.tsx
@@ -59,16 +59,8 @@ const initialState = {
             color: '#D3DAE6',
           },
           {
-            value: 0.65,
-            color: '#00B3A4',
-          },
-          {
-            value: 0.8,
-            color: '#E6C220',
-          },
-          {
             value: 1,
-            color: '#DB1374',
+            color: '#3185FC',
           },
         ],
       },
@@ -82,7 +74,7 @@ interface WithOptionsProps {
 
 type State = Readonly<typeof initialState>;
 
-export const withOptions = <P extends InfraOptions>(WrappedComponent: React.ComponentType<P>) => (
+export const withOptions = (WrappedComponent: React.ComponentType<InfraOptions>) => (
   <WithOptions>{args => <WrappedComponent {...args} />}</WithOptions>
 );
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Updating legend to use gray/blue gradient  (#28206)