### PR TITLE
[APM] use context.page.url when displaying error/transaction url if set

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiTitle
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import idx from 'idx';
 import { first, get } from 'lodash';
 import React from 'react';
 import { RRRRenderResponse } from 'react-redux-request';
@@ -122,7 +123,10 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
     {
       fieldName: REQUEST_URL_FULL,
       label: 'URL',
-      val: get(error, REQUEST_URL_FULL, notAvailableLabel),
+      val:
+        idx(error, _ => _.context.page.url) ||
+        idx(transaction, _ => _.context.request.url.full) ||
+        notAvailableLabel,
       truncated: true,
       width: '50%'
     },

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import idx from 'idx';
 import { get } from 'lodash';
 import React from 'react';
 import {
@@ -29,7 +30,11 @@ export function StickyTransactionProperties({
   totalDuration
 }: Props) {
   const timestamp = transaction['@timestamp'];
-  const url = get(transaction, REQUEST_URL_FULL, 'N/A');
+
+  const url =
+    idx(transaction, _ => _.context.page.url) ||
+    idx(transaction, _ => _.context.request.url) ||
+    'N/A';
   const duration = transaction.transaction.duration.us;
   const stickyProperties: IStickyProperty[] = [
     {

--- a/x-pack/plugins/apm/typings/es_schemas/Error.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/Error.ts
@@ -29,6 +29,9 @@ interface Context {
   service: ContextService;
   system?: ContextSystem;
   request?: ContextRequest;
+  page?: {
+    url: string;
+  };
   [key: string]: unknown;
 }
 

--- a/x-pack/plugins/apm/typings/es_schemas/Transaction.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/Transaction.ts
@@ -27,6 +27,9 @@ interface Context {
     username?: string;
     email?: string;
   };
+  page?: {
+    url: string;
+  };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
fixes #20147 by displaying context.page.url if available on the transaction or error object, otherwise display context.request.url.full or the default message 

<img width="1122" alt="screen shot 2019-01-12 at 1 06 39 am" src="https://user-images.githubusercontent.com/1967266/51071484-67499080-1606-11e9-8be8-ac14dfeb1797.png">
