### PR TITLE
[APM] fixes the margin spaces in Span flyout

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiTitle } from '@elastic/eui';
+import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import React, { Fragment } from 'react';
 // @ts-ignore
 import sql from 'react-syntax-highlighter/dist/languages/sql';
@@ -28,7 +28,6 @@ import {
 registerLanguage('sql', sql);
 
 const DatabaseStatement = styled.div`
-  margin-top: ${px(unit)};
   padding: ${px(units.half)} ${px(unit)};
   background: ${colors.yellow};
   border-radius: ${borderRadius};
@@ -54,6 +53,7 @@ export function DatabaseContext({ dbContext }: Props) {
       <EuiTitle size="xs">
         <h3>Database statement</h3>
       </EuiTitle>
+      <EuiSpacer size="m" />
       <DatabaseStatement>
         <SyntaxHighlighter
           language={'sql'}
@@ -70,6 +70,7 @@ export function DatabaseContext({ dbContext }: Props) {
           {dbContext.statement}
         </SyntaxHighlighter>
       </DatabaseStatement>
+      <EuiSpacer size="l" />
     </Fragment>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/HttpContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/HttpContext.tsx
@@ -15,11 +15,10 @@ import {
   units
 } from '../../../../../../../style/variables';
 
-import { EuiTitle } from '@elastic/eui';
+import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import { Span } from 'x-pack/plugins/apm/typings/es_schemas/Span';
 
-const DatabaseStatement = styled.div`
-  margin-top: ${px(unit)};
+const ContextUrl = styled.div`
   padding: ${px(units.half)} ${px(unit)};
   background: ${colors.gray5};
   border-radius: ${borderRadius};
@@ -41,7 +40,9 @@ export function HttpContext({ httpContext }: Props) {
       <EuiTitle size="xs">
         <h3>HTTP URL</h3>
       </EuiTitle>
-      <DatabaseStatement>{httpContext.url}</DatabaseStatement>
+      <EuiSpacer size="m" />
+      <ContextUrl>{httpContext.url}</ContextUrl>
+      <EuiSpacer size="l" />
     </Fragment>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlyoutHeader,
   EuiHorizontalRule,
   EuiPortal,
+  EuiSpacer,
   EuiTabbedContent,
   EuiTitle
 } from '@elastic/eui';
@@ -35,7 +36,7 @@ import { Span } from '../../../../../../../../typings/es_schemas/Span';
 import { FlyoutTopLevelProperties } from '../FlyoutTopLevelProperties';
 
 const StackTraceContainer = styled.div`
-  margin-top: ${px(unit)};
+  //margin-top: ${px(unit)};
 `;
 
 const TagName = styled.div`
@@ -100,6 +101,7 @@ export function SpanFlyout({
                 name: 'Stack Trace',
                 content: (
                   <Fragment>
+                    <EuiSpacer size="l" />
                     <HttpContext httpContext={httpContext} />
                     <DatabaseContext dbContext={dbContext} />
                     <StackTraceContainer>

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -23,7 +23,6 @@ import React, { Fragment } from 'react';
 import styled from 'styled-components';
 
 import { SERVICE_LANGUAGE_NAME } from '../../../../../../../../common/constants';
-import { px, unit } from '../../../../../../../style/variables';
 
 import { DatabaseContext } from './DatabaseContext';
 import { HttpContext } from './HttpContext';
@@ -34,10 +33,6 @@ import { Stacktrace } from 'x-pack/plugins/apm/public/components/shared/Stacktra
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import { Span } from '../../../../../../../../typings/es_schemas/Span';
 import { FlyoutTopLevelProperties } from '../FlyoutTopLevelProperties';
-
-const StackTraceContainer = styled.div`
-  //margin-top: ${px(unit)};
-`;
 
 const TagName = styled.div`
   font-weight: bold;
@@ -104,12 +99,10 @@ export function SpanFlyout({
                     <EuiSpacer size="l" />
                     <HttpContext httpContext={httpContext} />
                     <DatabaseContext dbContext={dbContext} />
-                    <StackTraceContainer>
-                      <Stacktrace
-                        stackframes={stackframes}
-                        codeLanguage={codeLanguage}
-                      />
-                    </StackTraceContainer>
+                    <Stacktrace
+                      stackframes={stackframes}
+                      codeLanguage={codeLanguage}
+                    />
                   </Fragment>
                 )
               },

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/LibraryStackFrames.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/LibraryStackFrames.tsx
@@ -4,18 +4,17 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiLink } from '@elastic/eui';
+import { EuiLink, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import { IStackframe } from 'x-pack/plugins/apm/typings/es_schemas/Stackframe';
-import { px, units } from '../../../style/variables';
+import { units } from '../../../style/variables';
 // @ts-ignore
 import { Ellipsis } from '../../shared/Icons';
 import { Stackframe } from './Stackframe';
 
 const LibraryFrameToggle = styled.div`
-  margin: 0 0 ${px(units.plus)} 0;
   user-select: none;
 `;
 
@@ -74,15 +73,19 @@ export class LibraryStackFrames extends React.Component<Props, State> {
         </LibraryFrameToggle>
 
         <div>
-          {isVisible &&
-            stackframes.map((stackframe, i) => (
-              <Stackframe
-                key={i}
-                isLibraryFrame
-                codeLanguage={codeLanguage}
-                stackframe={stackframe}
-              />
-            ))}
+          {isVisible && (
+            <Fragment>
+              <EuiSpacer size="m" />
+              {stackframes.map((stackframe, i) => (
+                <Stackframe
+                  key={i}
+                  isLibraryFrame
+                  codeLanguage={codeLanguage}
+                  stackframe={stackframe}
+                />
+              ))}
+            </Fragment>
+          )}
         </div>
       </div>
     );

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/Stackframe.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/Stackframe.tsx
@@ -10,13 +10,7 @@ import {
   IStackframe,
   IStackframeWithLineContext
 } from '../../../../typings/es_schemas/Stackframe';
-import {
-  borderRadius,
-  colors,
-  fontFamilyCode,
-  px,
-  units
-} from '../../../style/variables';
+import { borderRadius, colors, fontFamilyCode } from '../../../style/variables';
 import { FrameHeading } from '../Stacktrace/FrameHeading';
 import { Context } from './Context';
 import { Variables } from './Variables';
@@ -27,7 +21,6 @@ const CodeHeader = styled.div`
 `;
 
 const Container = styled.div<{ isLibraryFrame: boolean }>`
-  margin: 0 0 ${px(units.plus)} 0;
   position: relative;
   font-family: ${fontFamilyCode};
   border: 1px solid ${colors.gray4};

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/__test__/__snapshots__/Stackframe.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/__test__/__snapshots__/Stackframe.test.tsx.snap
@@ -101,7 +101,6 @@ exports[`Stackframe when stackframe has source lines should render correctly 1`]
 }
 
 .c0 {
-  margin: 0 0 24px 0;
   position: relative;
   font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
   border: 1px solid #D3DAE6;

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEmpty, last } from 'lodash';
 import React, { Fragment } from 'react';
@@ -42,12 +43,22 @@ export function Stacktrace({ stackframes = [], codeLanguage }: Props) {
         if (group.isLibraryFrame) {
           const initialVisiblity = groups.length === 1; // if there is only a single group it should be visible initially
           return (
-            <LibraryStackFrames
-              key={i}
-              initialVisiblity={initialVisiblity}
-              stackframes={group.stackframes}
-              codeLanguage={codeLanguage}
-            />
+            <Fragment>
+              {group.stackframes.length > 1 && i !== 0 && (
+                <EuiSpacer size="m" />
+              ) // render a leading spacer if LibraryStackFrames is collapsible and it's not the first item
+              }
+              <LibraryStackFrames
+                key={i}
+                initialVisiblity={initialVisiblity}
+                stackframes={group.stackframes}
+                codeLanguage={codeLanguage}
+              />
+              {group.stackframes.length > 1 && i !== groups.length - 1 && (
+                <EuiSpacer size="m" />
+              ) // render a trailing spacer if LibraryStackFrames is collapsible and it's not the last item
+              }
+            </Fragment>
           );
         }
 
@@ -60,6 +71,7 @@ export function Stacktrace({ stackframes = [], codeLanguage }: Props) {
           />
         ));
       })}
+      <EuiSpacer size="m" />
     </Fragment>
   );
 }

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
@@ -41,23 +41,20 @@ export function Stacktrace({ stackframes = [], codeLanguage }: Props) {
       {groups.map((group, i) => {
         // library frame
         if (group.isLibraryFrame) {
-          const initialVisiblity = groups.length === 1; // if there is only a single group it should be visible initially
+          const hasMultipleStackframes = group.stackframes.length > 1;
+          const hasLeadingSpacer = hasMultipleStackframes && i !== 0;
+          const hasTrailingSpacer =
+            hasMultipleStackframes && i !== groups.length - 1;
           return (
             <Fragment>
-              {group.stackframes.length > 1 && i !== 0 && (
-                <EuiSpacer size="m" />
-              ) // render a leading spacer if LibraryStackFrames is collapsible and it's not the first item
-              }
+              {hasLeadingSpacer && <EuiSpacer size="m" />}
               <LibraryStackFrames
                 key={i}
-                initialVisiblity={initialVisiblity}
+                initialVisiblity={!hasMultipleStackframes}
                 stackframes={group.stackframes}
                 codeLanguage={codeLanguage}
               />
-              {group.stackframes.length > 1 && i !== groups.length - 1 && (
-                <EuiSpacer size="m" />
-              ) // render a trailing spacer if LibraryStackFrames is collapsible and it's not the last item
-              }
+              {hasTrailingSpacer && <EuiSpacer size="m" />}
             </Fragment>
           );
         }


### PR DESCRIPTION
fixes #28071 by using EuiSpacers of the appropriate sizes to match the expected layout margins
<img width="700" alt="screen shot 2019-01-16 at 10 44 09 pm" src="https://user-images.githubusercontent.com/1967266/51301789-48bc0e80-19e5-11e9-946b-947cfab34a97.png">

