### PR TITLE
[6.x] Fixes #27525 - Change diskio bytes and ops for Docker to use derivative (#28182)

### DIFF
--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/container/container_disk_io_bytes.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/container/container_disk_io_bytes.ts
@@ -24,8 +24,20 @@ export const containerDiskIOBytes: InfraMetricModelCreator = (
       metrics: [
         {
           field: 'docker.diskio.read.bytes',
-          id: 'avg-diskio-bytes',
-          type: InfraMetricModelMetricType.avg,
+          id: 'max-diskio-read-bytes',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          field: 'max-diskio-read-bytes',
+          id: 'deriv-max-diskio-read-bytes',
+          type: InfraMetricModelMetricType.derivative,
+          unit: '1s',
+        },
+        {
+          id: 'posonly-deriv-max-diskio-read-bytes',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [{ id: 'var-rate', name: 'rate', field: 'deriv-max-diskio-read-bytes' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
         },
       ],
     },
@@ -35,8 +47,32 @@ export const containerDiskIOBytes: InfraMetricModelCreator = (
       metrics: [
         {
           field: 'docker.diskio.write.bytes',
-          id: 'avg-diskio-bytes',
-          type: InfraMetricModelMetricType.avg,
+          id: 'max-diskio-write-bytes',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          field: 'max-diskio-write-bytes',
+          id: 'deriv-max-diskio-write-bytes',
+          type: InfraMetricModelMetricType.derivative,
+          unit: '1s',
+        },
+        {
+          id: 'posonly-deriv-max-diskio-write-bytes',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [{ id: 'var-rate', name: 'rate', field: 'deriv-max-diskio-write-bytes' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
+        },
+        {
+          id: 'calc-invert-rate',
+          script: 'params.rate * -1',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [
+            {
+              field: 'posonly-deriv-max-diskio-write-bytes',
+              id: 'var-rate',
+              name: 'rate',
+            },
+          ],
         },
       ],
     },

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/container/container_diskio_ops.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/container/container_diskio_ops.ts
@@ -20,8 +20,20 @@ export const containerDiskIOOps: InfraMetricModelCreator = (timeField, indexPatt
       metrics: [
         {
           field: 'docker.diskio.read.ops',
-          id: 'avg-diskio-ops',
-          type: InfraMetricModelMetricType.avg,
+          id: 'max-diskio-read-ops',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          field: 'max-diskio-read-ops',
+          id: 'deriv-max-diskio-read-ops',
+          type: InfraMetricModelMetricType.derivative,
+          unit: '1s',
+        },
+        {
+          id: 'posonly-deriv-max-diskio-read-ops',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [{ id: 'var-rate', name: 'rate', field: 'deriv-max-diskio-read-ops' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
         },
       ],
     },
@@ -31,8 +43,32 @@ export const containerDiskIOOps: InfraMetricModelCreator = (timeField, indexPatt
       metrics: [
         {
           field: 'docker.diskio.write.ops',
-          id: 'avg-diskio-ops',
-          type: InfraMetricModelMetricType.avg,
+          id: 'max-diskio-write-ops',
+          type: InfraMetricModelMetricType.max,
+        },
+        {
+          field: 'max-diskio-write-ops',
+          id: 'deriv-max-diskio-write-ops',
+          type: InfraMetricModelMetricType.derivative,
+          unit: '1s',
+        },
+        {
+          id: 'posonly-deriv-max-diskio-write-ops',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [{ id: 'var-rate', name: 'rate', field: 'deriv-max-diskio-write-ops' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
+        },
+        {
+          id: 'calc-invert-rate',
+          script: 'params.rate * -1',
+          type: InfraMetricModelMetricType.calculation,
+          variables: [
+            {
+              field: 'posonly-deriv-max-diskio-write-ops',
+              id: 'var-rate',
+              name: 'rate',
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fixes #27525 - Change diskio bytes and ops for Docker to use derivative  (#28182)