### PR TITLE
[APM] Fix asPercent

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/CPUUsageChart.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/CPUUsageChart.tsx
@@ -37,7 +37,7 @@ export function CPUUsageChart({ data, hoverXHandlers }: Props) {
         noHits={data.totalHits === 0}
         series={data.series}
         tickFormatY={(y: number | null) => `${(y || 0) * 100}%`}
-        formatTooltipValue={(c: Coordinate) => asPercent(c.y || 0)}
+        formatTooltipValue={(c: Coordinate) => asPercent(c.y || 0, 1)}
         yMax={1}
       />
     </React.Fragment>

--- a/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
+++ b/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
@@ -137,28 +137,28 @@ export function getCPUSeries(CPUChartResponse: MetricsChartAPIResponse['cpu']) {
       data: series.systemCPUMax,
       type: 'linemark',
       color: colors.apmBlue,
-      legendValue: asPercent(overallValues.systemCPUMax || 0)
+      legendValue: asPercent(overallValues.systemCPUMax || 0, 1)
     },
     {
       title: 'System average',
       data: series.systemCPUAverage,
       type: 'linemark',
       color: colors.apmGreen,
-      legendValue: asPercent(overallValues.systemCPUAverage || 0)
+      legendValue: asPercent(overallValues.systemCPUAverage || 0, 1)
     },
     {
       title: 'Process max',
       data: series.processCPUMax,
       type: 'linemark',
       color: colors.apmOrange,
-      legendValue: asPercent(overallValues.processCPUMax || 0)
+      legendValue: asPercent(overallValues.processCPUMax || 0, 1)
     },
     {
       title: 'Process average',
       data: series.processCPUAverage,
       type: 'linemark',
       color: colors.apmYellow,
-      legendValue: asPercent(overallValues.processCPUAverage || 0)
+      legendValue: asPercent(overallValues.processCPUAverage || 0, 1)
     }
   ];
 

--- a/x-pack/plugins/apm/public/utils/__test__/formatters.test.ts
+++ b/x-pack/plugins/apm/public/utils/__test__/formatters.test.ts
@@ -33,8 +33,12 @@ describe('formatters', () => {
       expect(asPercent(3725, 10000, 'n/a')).toEqual('37.25%');
     });
 
-    it('should format given number as percent when only one argument given', () => {
-      expect(asPercent(0.3725)).toEqual('37.25%');
+    it('should format when numerator is 0', () => {
+      expect(asPercent(0, 1, 'n/a')).toEqual('0.00%');
+    });
+
+    it('should return fallback when denominator is undefined', () => {
+      expect(asPercent(3725, undefined, 'n/a')).toEqual('n/a');
     });
 
     it('should return fallback when denominator is 0 ', () => {

--- a/x-pack/plugins/apm/public/utils/formatters.ts
+++ b/x-pack/plugins/apm/public/utils/formatters.ts
@@ -139,11 +139,10 @@ export function asPercent(
   denominator?: number,
   fallbackResult = ''
 ) {
-  if (denominator === 0) {
+  if (!denominator) {
     return fallbackResult;
   }
 
-  const decimal = denominator ? numerator / denominator : numerator;
-
+  const decimal = numerator / denominator;
   return numeral(decimal).format('0.00%');
 }


### PR DESCRIPTION
In elastic/kibana#26608 `asPercent` was changed to support formatting a decimal number without supplying a denominator. If the denominator was missing `asPercent` would treat the numerator as if it was a decimal number.
This causes problems everywhere the numerator is not a decimal number, and where the denominator is potentially `undefined`, like on the timeline:

![screen shot 2019-01-16 at 11 12 04 am](https://user-images.githubusercontent.com/209966/51247922-d7ea0780-198e-11e9-8e5f-3403701f6cd0.png)

"% of trace" is calculated like `asPercent(entryTransactionDuration, rootTransactionDuration)`.
Sometimes the root transaction cannot be found, so to calculation will be `asPercent(1337, undefined)` and will therefore return "133700.00%". 

To fix this I've reverted the changes to `asPercent`, and added `1` as the denominator for the decimal numbers.