### PR TITLE
Filters transaction and error queries by processor.event

### DIFF
--- a/x-pack/plugins/apm/server/lib/errors/distribution/__tests__/__snapshots__/get_buckets.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/__tests__/__snapshots__/get_buckets.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`timeseriesFetcher should make the correct query 1`] = `
+Array [
+  Array [
+    "search",
+    Object {
+      "body": Object {
+        "aggs": Object {
+          "distribution": Object {
+            "histogram": Object {
+              "extended_bounds": Object {
+                "max": 1528977600000,
+                "min": 1528113600000,
+              },
+              "field": "@timestamp",
+              "interval": 10,
+              "min_doc_count": 0,
+            },
+          },
+        },
+        "query": Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "term": Object {
+                  "processor.event": "error",
+                },
+              },
+              Object {
+                "term": Object {
+                  "context.service.name": "myServiceName",
+                },
+              },
+              Object {
+                "range": Object {
+                  "@timestamp": Object {
+                    "format": "epoch_millis",
+                    "gte": 1528113600000,
+                    "lte": 1528977600000,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        "size": 0,
+      },
+      "index": "myIndex",
+    },
+  ],
+]
+`;

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_buckets.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_buckets.ts
@@ -5,7 +5,11 @@
  */
 
 import { BucketAgg, ESFilter } from 'elasticsearch';
-import { ERROR_GROUP_ID, SERVICE_NAME } from '../../../../common/constants';
+import {
+  ERROR_GROUP_ID,
+  PROCESSOR_EVENT,
+  SERVICE_NAME
+} from '../../../../common/constants';
 import { Setup } from '../../helpers/setup_request';
 
 export async function getBuckets({
@@ -15,12 +19,13 @@ export async function getBuckets({
   setup
 }: {
   serviceName: string;
-  groupId: string;
+  groupId?: string;
   bucketSize: number;
   setup: Setup;
 }) {
   const { start, end, esFilterQuery, client, config } = setup;
   const filter: ESFilter[] = [
+    { term: { [PROCESSOR_EVENT]: 'error' } },
     { term: { [SERVICE_NAME]: serviceName } },
     {
       range: {

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
@@ -27,7 +27,7 @@ export async function getDistribution({
   setup
 }: {
   serviceName: string;
-  groupId: string;
+  groupId?: string;
   setup: Setup;
 }): Promise<ErrorDistributionAPIResponse> {
   const bucketSize = getBucketSize(setup);

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/__snapshots__/fetcher.test.ts.snap
@@ -64,6 +64,11 @@ Array [
             "filter": Array [
               Object {
                 "term": Object {
+                  "processor.event": "transaction",
+                },
+              },
+              Object {
+                "term": Object {
                   "context.service.name": "myServiceName",
                 },
               },

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
@@ -6,6 +6,7 @@
 
 import { AggregationSearchResponse, ESFilter } from 'elasticsearch';
 import {
+  PROCESSOR_EVENT,
   SERVICE_NAME,
   TRANSACTION_DURATION,
   TRANSACTION_NAME,
@@ -79,6 +80,7 @@ export function timeseriesFetcher({
   const { intervalString } = getBucketSize(start, end, 'auto');
 
   const filter: ESFilter[] = [
+    { term: { [PROCESSOR_EVENT]: 'transaction' } },
     { term: { [SERVICE_NAME]: serviceName } },
     {
       range: {


### PR DESCRIPTION
Closes #28827

## Summary

There were two queries that used to rely on transaction type and error group ID to make sure the results were only including the document types that contained those values. This PR changes those queries so they use `processor.event` to do that filtering instead.

A test has been added for each of these, as well.

### To test

You can test this query change in the console. For instance, the previous query (minus the aggregations, for brevity):
```
GET apm-*/_search
{
    "size": 0,
    "query": {
        "bool": {
            "filter": [

                {
                    "term": {
                        "context.service.name": "opbeans-go"
                    }
                },
                {
                    "range": {
                        "@timestamp": {
                            "gte": 1547557777300,
                            "lte": 1547644177300,
                            "format": "epoch_millis"
                        }
                    }
                }
            ]
        }
    }
}
```
produces `251799` total hits.

Adding the event filter like so:
```
GET apm-*/_search
{
    "size": 0,
    "query": {
        "bool": {
            "filter": [
                {
                    "term": {
                        "processor.event": "transaction"
                    }
                },
                {
                    "term": {
                        "context.service.name": "opbeans-go"
                    }
                },
                {
                    "range": {
                        "@timestamp": {
                            "gte": 1547557777300,
                            "lte": 1547644177300,
                            "format": "epoch_millis"
                        }
                    }
                }
            ]
        }
    }
}
```
produces only `127807` hits.
