### PR TITLE
[APM] fix object path for request url in sample transaction

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -33,7 +33,7 @@ export function StickyTransactionProperties({
 
   const url =
     idx(transaction, _ => _.context.page.url) ||
-    idx(transaction, _ => _.context.request.url) ||
+    idx(transaction, _ => _.context.request.url.full) ||
     'N/A';
   const duration = transaction.transaction.duration.us;
   const stickyProperties: IStickyProperty[] = [

--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../../style/variables';
 
 export interface IStickyProperty {
-  val: React.ReactNode | Date;
+  val: JSX.Element | string | Date;
   label: string;
   fieldName?: string;
   width?: 0 | string;


### PR DESCRIPTION
fixes #28899 by using the correct object path to the url `transaction context.request.url.full`

<img width="1172" alt="screen shot 2019-01-16 at 11 59 33 pm" src="https://user-images.githubusercontent.com/1967266/51303634-cafb0180-19ea-11e9-9124-9ef6d732482b.png">
