### PR TITLE
[APM] Fix icon for View trace button

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
@@ -34,7 +34,7 @@ function MaybeViewTraceLink({
     return (
       <EuiFlexItem grow={false}>
         <EuiToolTip content="The trace parent cannot be found">
-          <EuiButton iconType="apmApp" disabled={true}>
+          <EuiButton iconType="apmTrace" disabled={true}>
             View full trace
           </EuiButton>
         </EuiToolTip>
@@ -50,7 +50,7 @@ function MaybeViewTraceLink({
     return (
       <EuiFlexItem grow={false}>
         <EuiToolTip content="Currently viewing the full trace">
-          <EuiButton iconType="apmApp" disabled={true}>
+          <EuiButton iconType="apmTrace" disabled={true}>
             View full trace
           </EuiButton>
         </EuiToolTip>
@@ -62,7 +62,7 @@ function MaybeViewTraceLink({
     return (
       <EuiFlexItem grow={false}>
         <TransactionLink transaction={waterfall.traceRoot}>
-          <EuiButton iconType="apmApp">View full trace</EuiButton>
+          <EuiButton iconType="apmTrace">View full trace</EuiButton>
         </TransactionLink>
       </EuiFlexItem>
     );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/28906

Replacing the APM logo with a dedicated APM trace icon for the View trace button in the Transactions view.

_Before_
<img width="318" alt="screenshot 2019-01-17 at 11 10 58" src="https://user-images.githubusercontent.com/4104278/51311987-84d58a80-1a4a-11e9-81fb-7ca810994289.png">

_After_
<img width="339" alt="screenshot 2019-01-17 at 11 15 36" src="https://user-images.githubusercontent.com/4104278/51311977-7d15e600-1a4a-11e9-9782-26dba268c913.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~