### PR TITLE
Add data rendering count for visualisation

### DIFF
--- a/src/ui/public/visualize/loader/embedded_visualize_handler.ts
+++ b/src/ui/public/visualize/loader/embedded_visualize_handler.ts
@@ -45,6 +45,7 @@ interface EmbeddedVisualizeHandlerParams extends VisualizeLoaderParams {
 
 const RENDER_COMPLETE_EVENT = 'render_complete';
 const LOADING_ATTRIBUTE = 'data-loading';
+const RENDERING_COUNT_ATTRIBUTE = 'data-rendering-count';
 
 /**
  * A handler to the embedded visualization. It offers several methods to interact
@@ -115,6 +116,7 @@ export class EmbeddedVisualizeHandler {
     });
 
     element.setAttribute(LOADING_ATTRIBUTE, '');
+    element.setAttribute(RENDERING_COUNT_ATTRIBUTE, '0');
     element.addEventListener('renderComplete', this.onRenderCompleteListener);
 
     this.appState = appState;
@@ -304,9 +306,15 @@ export class EmbeddedVisualizeHandler {
     this.fetchAndRender(true);
   };
 
+  private incrementRenderingCount = () => {
+    const renderingCount = Number(this.element.getAttribute(RENDERING_COUNT_ATTRIBUTE) || 0);
+    this.element.setAttribute(RENDERING_COUNT_ATTRIBUTE, `${renderingCount + 1}`);
+  };
+
   private onRenderCompleteListener = () => {
     this.listeners.emit(RENDER_COMPLETE_EVENT);
     this.element.removeAttribute(LOADING_ATTRIBUTE);
+    this.incrementRenderingCount();
   };
 
   private onUiStateChange = () => {

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -26,7 +26,7 @@ export default function ({ getService, getPageObjects }) {
   const browser = getService('browser');
   const kibanaServer = getService('kibanaServer');
   const filterBar = getService('filterBar');
-  const PageObjects = getPageObjects(['common', 'discover', 'header']);
+  const PageObjects = getPageObjects(['common', 'discover', 'header', 'visualize']);
   const defaultSettings = {
     'dateFormat:tz': 'UTC',
     defaultIndex: 'logstash-*',

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -132,14 +132,18 @@ export default function ({ getService, getPageObjects }) {
 
       it('should modify the time range when a bar is clicked', async function () {
         await PageObjects.header.setAbsoluteRange(fromTime, toTime);
+        await PageObjects.visualize.waitForVisualization();
         await PageObjects.discover.clickHistogramBar(0);
+        await PageObjects.visualize.waitForVisualization();
         const actualTimeString = await PageObjects.header.getPrettyDuration();
         expect(actualTimeString).to.be('September 20th 2015, 00:00:00.000 to September 20th 2015, 03:00:00.000');
       });
 
       it('should modify the time range when the histogram is brushed', async function () {
         await PageObjects.header.setAbsoluteRange(fromTime, toTime);
+        await PageObjects.visualize.waitForVisualization();
         await PageObjects.discover.brushHistogram(0, 1);
+        await PageObjects.visualize.waitForVisualization();
         const actualTimeString = await PageObjects.header.getPrettyDuration();
         expect(actualTimeString).to.be('September 19th 2015, 23:52:17.080 to September 20th 2015, 02:59:51.112');
       });

--- a/test/functional/apps/getting_started/_shakespeare.js
+++ b/test/functional/apps/getting_started/_shakespeare.js
@@ -86,7 +86,6 @@ export default function ({ getService, getPageObjects }) {
       // then increment the aggIndex for the next one we create
       aggIndex = aggIndex + 1;
       await PageObjects.visualize.clickGo();
-      await PageObjects.visualize.waitForVisualization();
       const expectedChartValues = [935];
       await retry.try(async () => {
         const data = await PageObjects.visualize.getBarChartData('Speaking Parts');

--- a/test/functional/apps/visualize/_heatmap_chart.js
+++ b/test/functional/apps/visualize/_heatmap_chart.js
@@ -45,7 +45,6 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.visualize.selectField('@timestamp');
       // leaving Interval set to Auto
       await PageObjects.visualize.clickGo();
-      await PageObjects.visualize.waitForVisualization();
     });
 
     it('should save and load', async function () {
@@ -65,7 +64,6 @@ export default function ({ getService, getPageObjects }) {
       expect(pageTitle).to.contain(vizName1);
       await PageObjects.visualize.waitForVisualizationSavedToastGone();
       await PageObjects.visualize.loadSavedVisualization(vizName1);
-      await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.visualize.waitForVisualization();
     });
 

--- a/test/functional/apps/visualize/_pie_chart.js
+++ b/test/functional/apps/visualize/_pie_chart.js
@@ -149,9 +149,7 @@ export default function ({ getService, getPageObjects }) {
     describe('disabled aggs', () => {
       before(async () => {
         await PageObjects.visualize.loadSavedVisualization(vizName1);
-        await PageObjects.visualize.waitForVisualization();
-        // sleep a bit before trying to get the pie chart data below
-        await PageObjects.common.sleep(2000);
+        await PageObjects.visualize.waitForRenderingCount();
       });
 
       it('should show correct result with one agg disabled', async () => {
@@ -174,7 +172,7 @@ export default function ({ getService, getPageObjects }) {
         expect(pageTitle).to.contain(vizName1);
         await PageObjects.visualize.waitForVisualizationSavedToastGone();
         await PageObjects.visualize.loadSavedVisualization(vizName1);
-        await PageObjects.visualize.waitForVisualization();
+        await PageObjects.visualize.waitForRenderingCount();
 
         const expectedTableData =  [ 'win 8', 'win xp', 'win 7', 'ios', 'osx'  ];
         await pieChart.expectPieChartLabels(expectedTableData);

--- a/test/functional/apps/visualize/_pie_chart.js
+++ b/test/functional/apps/visualize/_pie_chart.js
@@ -270,7 +270,6 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.visualize.selectAggregation('Terms');
         await PageObjects.visualize.selectField('geo.src');
         await PageObjects.visualize.clickGo();
-        await PageObjects.visualize.waitForVisualization();
       });
 
       it ('shows correct split chart', async () => {

--- a/test/functional/apps/visualize/_tile_map.js
+++ b/test/functional/apps/visualize/_tile_map.js
@@ -34,7 +34,7 @@ export default function ({ getService, getPageObjects }) {
     describe('incomplete config', function describeIndexTests() {
 
       before(async function () {
-        browser.setWindowSize(1280, 1000);
+        await browser.setWindowSize(1280, 1000);
 
         const fromTime = '2015-09-19 06:31:44.000';
         const toTime = '2015-09-23 18:31:44.000';
@@ -60,7 +60,7 @@ export default function ({ getService, getPageObjects }) {
 
     describe('complete config', function describeIndexTests() {
       before(async function () {
-        browser.setWindowSize(1280, 1000);
+        await browser.setWindowSize(1280, 1000);
 
         const fromTime = '2015-09-19 06:31:44.000';
         const toTime = '2015-09-23 18:31:44.000';
@@ -224,7 +224,7 @@ export default function ({ getService, getPageObjects }) {
       const toastDefaultLife = 6000;
 
       before(async function () {
-        browser.setWindowSize(1280, 1000);
+        await browser.setWindowSize(1280, 1000);
 
         log.debug('navigateToApp visualize');
         await PageObjects.visualize.navigateToNewVisualization();
@@ -243,7 +243,6 @@ export default function ({ getService, getPageObjects }) {
       });
 
       beforeEach(async function () {
-        await PageObjects.common.sleep(2000);
         await PageObjects.visualize.clickMapZoomIn(waitForLoading);
       });
 
@@ -256,25 +255,24 @@ export default function ({ getService, getPageObjects }) {
 
       it('should show warning at zoom 10',
         async () => {
-          testSubjects.existOrFail('maxZoomWarning');
+          await testSubjects.existOrFail('maxZoomWarning');
         });
 
       it('should continue providing zoom warning if left alone',
         async () => {
-          testSubjects.existOrFail('maxZoomWarning');
+          await testSubjects.existOrFail('maxZoomWarning');
         });
 
       it('should suppress zoom warning if suppress warnings button clicked',
         async () => {
           last = true;
+          await PageObjects.visualize.waitForVisualization();
           await find.clickByCssSelector('[data-test-subj="suppressZoomWarnings"]');
-
-          await PageObjects.common.sleep(toastDefaultLife + 2000);
           await PageObjects.visualize.clickMapZoomOut(waitForLoading);
-          await PageObjects.common.sleep(1000);
+          await testSubjects.waitForDeleted('suppressZoomWarnings');
           await PageObjects.visualize.clickMapZoomIn(waitForLoading);
 
-          testSubjects.missingOrFail('maxZoomWarning');
+          await testSubjects.missingOrFail('maxZoomWarning');
         });
     });
   });

--- a/test/functional/apps/visualize/_tsvb_chart.js
+++ b/test/functional/apps/visualize/_tsvb_chart.js
@@ -96,6 +96,7 @@ export default function ({ getService, getPageObjects }) {
 
       it('should show correct data', async function () {
         const expectedMetricValue =  '156';
+        await PageObjects.visualize.waitForVisualization();
         const value = await PageObjects.visualBuilder.getMetricValue();
         log.debug(`metric value: ${value}`);
         expect(value).to.eql(expectedMetricValue);
@@ -113,6 +114,7 @@ export default function ({ getService, getPageObjects }) {
 
       it('should verify gauge label and count display', async function () {
         await retry.try(async () => {
+          await PageObjects.visualize.waitForVisualization();
           const labelString = await PageObjects.visualBuilder.getGaugeLabel();
           expect(labelString).to.be('Count');
           const gaugeCount = await PageObjects.visualBuilder.getGaugeCount();
@@ -130,6 +132,7 @@ export default function ({ getService, getPageObjects }) {
       });
 
       it('should verify topN label and count display', async function () {
+        await PageObjects.visualize.waitForVisualization();
         const labelString = await PageObjects.visualBuilder.getTopNLabel();
         expect(labelString).to.be('Count');
         const gaugeCount = await PageObjects.visualBuilder.getTopNCount();

--- a/test/functional/apps/visualize/_vertical_bar_chart.js
+++ b/test/functional/apps/visualize/_vertical_bar_chart.js
@@ -46,8 +46,6 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.visualize.selectField('@timestamp');
       // leaving Interval set to Auto
       await PageObjects.visualize.clickGo();
-      await PageObjects.header.waitUntilLoadingHasFinished();
-      await PageObjects.visualize.waitForVisualization();
     };
 
 
@@ -60,7 +58,6 @@ export default function ({ getService, getPageObjects }) {
       expect(pageTitle).to.contain(vizName1);
       await PageObjects.visualize.waitForVisualizationSavedToastGone();
       await PageObjects.visualize.loadSavedVisualization(vizName1);
-      await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.visualize.waitForVisualization();
     });
 

--- a/test/functional/apps/visualize/_vertical_bar_chart_nontimeindex.js
+++ b/test/functional/apps/visualize/_vertical_bar_chart_nontimeindex.js
@@ -43,8 +43,6 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.visualize.selectField('@timestamp');
       await PageObjects.visualize.setCustomInterval('3h');
       await PageObjects.visualize.clickGo();
-      await PageObjects.header.waitUntilLoadingHasFinished();
-      await PageObjects.visualize.waitForVisualization();
     };
 
 
@@ -57,7 +55,6 @@ export default function ({ getService, getPageObjects }) {
       expect(pageTitle).to.contain(vizName1);
       await PageObjects.visualize.waitForVisualizationSavedToastGone();
       await PageObjects.visualize.loadSavedVisualization(vizName1);
-      await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.visualize.waitForVisualization();
     });
 

--- a/test/functional/page_objects/discover_page.js
+++ b/test/functional/page_objects/discover_page.js
@@ -113,25 +113,17 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
       await testSubjects.click('discoverOpenButton');
     }
 
-    async waitVisualisationLoaded() {
-      await testSubjects.waitForAttributeToChange('visualizationLoader', 'data-render-complete', 'true');
-    }
-
     async clickHistogramBar(i) {
-      await this.waitVisualisationLoaded();
       const bars = await find.allByCssSelector(`.series.histogram rect`);
       await bars[i].click();
-      await this.waitVisualisationLoaded();
     }
 
     async brushHistogram(from, to) {
-      await this.waitVisualisationLoaded();
       const bars = await find.allByCssSelector('.series.histogram rect');
       await browser.dragAndDrop(
         { element: bars[from], xOffset: 0, yOffset: -5 },
         { element: bars[to], xOffset: 0, yOffset: -5 }
       );
-      await this.waitVisualisationLoaded();
     }
 
     async getCurrentQueryName() {

--- a/test/functional/page_objects/visualize_page.js
+++ b/test/functional/page_objects/visualize_page.js
@@ -129,6 +129,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
     }
 
     async getTextTag() {
+      await this.waitForVisualization();
       const elements = await find.allByCssSelector('text');
       return await Promise.all(elements.map(async element => await element.getVisibleText()));
     }

--- a/test/functional/page_objects/visualize_page.js
+++ b/test/functional/page_objects/visualize_page.js
@@ -931,7 +931,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
       });
     }
 
-    async waitForVisualizationRenderingCompleted() {
+    async waitForVisualizationRenderingStabilized() {
       //assuming rendering is done when data-rendering-count is constant within 1000 ms
       await retry.try(async () => {
         const previousCount = await this.getVisualizationRenderingCount();
@@ -943,7 +943,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
     }
 
     async waitForVisualization() {
-      await this.waitForVisualizationRenderingCompleted();
+      await this.waitForVisualizationRenderingStabilized();
       return await find.byCssSelector('.visualization');
     }
 
@@ -1060,12 +1060,12 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
     }
 
     async openLegendOptionColors(name) {
-      await this.waitForVisualizationRenderingCompleted();
+      await this.waitForVisualizationRenderingStabilized();
       await retry.try(async () => {
         // This click has been flaky in opening the legend, hence the retry.  See
         // https://github.com/elastic/kibana/issues/17468
         await testSubjects.click(`legend-${name}`);
-        await this.waitForVisualizationRenderingCompleted();
+        await this.waitForVisualizationRenderingStabilized();
         // arbitrary color chosen, any available would do
         const isOpen = await this.doesLegendColorChoiceExist('#EF843C');
         if (!isOpen) {
@@ -1097,7 +1097,7 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
       await this.toggleLegend();
       await testSubjects.click(`legend-${name}`);
       await testSubjects.click(`legend-${name}-filterIn`);
-      await this.waitForVisualizationRenderingCompleted();
+      await this.waitForVisualizationRenderingStabilized();
     }
 
     async doesLegendColorChoiceExist(color) {


### PR DESCRIPTION
## Summary

While working on WebDriver migration we faced many `visualize app` tests been flaky. Further investigation showed that `data-render-complete` attribute is not a reliable way to check if visualization is loaded:

The value can change from `true` to `false` **multiple times** as it depends on the number of renderings in happening each case, it can be 1 or it can be 3 of them. It is important to wait properly for loading done to avoid StaleElement exceptions. 

@markov00 pointed me to his PR **Adding data-rendering-count attribute to detect rendering cycles** #22420, that I used as POC.

It proved to be a robust and reliable way to handle visualizations being loaded, I haven't seen a better solution so far.

With this PR we have:
- `waitForRenderingCount(previousCount = 0, increment = 1)` that waits for specific number of renderings to be completed; Should be used when renderings increment is contant (e.g. +1 when `visualizeEditorRenderButton` is clicked)
- `waitForVisualization()` is waiting until `data-rendering-count` number is constant within 1000 ms; there are cases when final number of renderings cannot be predicted (changing from 1 to 3 each test run), e.g. after `filterBar.removeFilter` is called in `pie chart` tests


### Checklist

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

~~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
~~- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

