### PR TITLE
Requires fields necessary for percent calculation

### DIFF
--- a/x-pack/plugins/apm/public/utils/__test__/formatters.test.ts
+++ b/x-pack/plugins/apm/public/utils/__test__/formatters.test.ts
@@ -43,7 +43,11 @@ describe('formatters', () => {
 
     it('should return fallback when denominator is 0 ', () => {
       expect(asPercent(3725, 0, 'n/a')).toEqual('n/a');
-      expect(asPercent(3725, 0)).toEqual('');
+    });
+
+    it('should return fallback when numerator or denominator is NaN', () => {
+      expect(asPercent(3725, NaN, 'n/a')).toEqual('n/a');
+      expect(asPercent(NaN, 10000, 'n/a')).toEqual('n/a');
     });
   });
 });

--- a/x-pack/plugins/apm/public/utils/formatters.ts
+++ b/x-pack/plugins/apm/public/utils/formatters.ts
@@ -134,7 +134,7 @@ export function asPercent(
   denominator: number | undefined,
   fallbackResult = ''
 ) {
-  if (!denominator) {
+  if (!denominator || isNaN(numerator)) {
     return fallbackResult;
   }
 

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/__tests__/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/__tests__/__snapshots__/fetcher.test.ts.snap
@@ -81,6 +81,18 @@ Array [
                 },
               },
             ],
+            "must": Array [
+              Object {
+                "exists": Object {
+                  "field": "system.memory.total",
+                },
+              },
+              Object {
+                "exists": Object {
+                  "field": "system.memory.actual.free",
+                },
+              },
+            ],
           },
         },
         "size": 0,

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
@@ -36,6 +36,20 @@ const percentSystemMemoryUsedScript = {
 export async function fetch(args: MetricsRequestArgs) {
   return fetchMetrics<Aggs>({
     ...args,
+    bool: {
+      must: [
+        {
+          exists: {
+            field: METRIC_SYSTEM_TOTAL_MEMORY
+          }
+        },
+        {
+          exists: {
+            field: METRIC_SYSTEM_FREE_MEMORY
+          }
+        }
+      ]
+    },
     timeseriesBucketAggregations: {
       averagePercentMemoryUsed: { avg: percentSystemMemoryUsedScript },
       maximumPercentMemoryUsed: { max: percentSystemMemoryUsedScript }

--- a/x-pack/plugins/apm/server/lib/metrics/metricsFetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/metricsFetcher.ts
@@ -12,7 +12,8 @@ export async function fetchMetrics<T = void>({
   serviceName,
   setup,
   timeseriesBucketAggregations = {},
-  totalAggregations = {}
+  totalAggregations = {},
+  bool = {}
 }: MetricsRequestArgs) {
   const { start, end, esFilterQuery, client, config } = setup;
   const { intervalString } = getBucketSize(start, end, 'auto');
@@ -41,6 +42,7 @@ export async function fetchMetrics<T = void>({
       size: 0,
       query: {
         bool: {
+          ...bool,
           filter: filters
         }
       },

--- a/x-pack/plugins/apm/server/lib/metrics/query_types.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/query_types.ts
@@ -11,6 +11,7 @@ export interface MetricsRequestArgs {
   setup: Setup;
   timeseriesBucketAggregations?: StringMap<any>;
   totalAggregations?: StringMap<any>;
+  bool?: StringMap<any>;
 }
 
 export interface AggValue {


### PR DESCRIPTION
Fixes #29015 

## Summary

To test this change with our typical mock opbeans data set up, you'll need to be running the latest opbeans-java. Without this commit, the metrics tab for the opbeans-java service will blow up, and with this change it should be fine.