### PR TITLE
[APM] fixes missing key warning in Stacktrace

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
@@ -46,10 +46,9 @@ export function Stacktrace({ stackframes = [], codeLanguage }: Props) {
           const hasTrailingSpacer =
             hasMultipleStackframes && i !== groups.length - 1;
           return (
-            <Fragment>
+            <Fragment key={i}>
               {hasLeadingSpacer && <EuiSpacer size="m" />}
               <LibraryStackFrames
-                key={i}
                 initialVisiblity={!hasMultipleStackframes}
                 stackframes={group.stackframes}
                 codeLanguage={codeLanguage}


### PR DESCRIPTION
[APM] fixes #29037 by applying a key prop to <Fragment> within a render loop.