### PR TITLE
[APM] Use `idx` everywhere for picking deeply nested properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,6 @@
     "topojson-client": "3.0.0",
     "trunc-html": "1.0.2",
     "trunc-text": "1.0.2",
-    "ts-optchain": "^0.1.1",
     "tslib": "^1.9.3",
     "type-detect": "^4.0.8",
     "ui-select": "0.19.6",

--- a/x-pack/plugins/apm/common/__snapshots__/constants.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/constants.test.ts.snap
@@ -14,6 +14,8 @@ exports[`Error ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Error ERROR_LOG_STACKTRACE 1`] = `undefined`;
 
+exports[`Error HTTP_REQUEST_METHOD 1`] = `undefined`;
+
 exports[`Error METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
 
 exports[`Error METRIC_PROCESS_MEMORY_RSS 1`] = `undefined`;
@@ -33,10 +35,6 @@ exports[`Error PARENT_ID 1`] = `"parentId"`;
 exports[`Error PROCESSOR_EVENT 1`] = `"error"`;
 
 exports[`Error PROCESSOR_NAME 1`] = `"error"`;
-
-exports[`Error REQUEST_METHOD 1`] = `undefined`;
-
-exports[`Error REQUEST_URL_FULL 1`] = `undefined`;
 
 exports[`Error SERVICE_AGENT_NAME 1`] = `"agent name"`;
 
@@ -70,6 +68,8 @@ exports[`Error TRANSACTION_SAMPLED 1`] = `undefined`;
 
 exports[`Error TRANSACTION_TYPE 1`] = `undefined`;
 
+exports[`Error URL_FULL 1`] = `undefined`;
+
 exports[`Error USER_ID 1`] = `undefined`;
 
 exports[`Span ERROR_CULPRIT 1`] = `undefined`;
@@ -85,6 +85,8 @@ exports[`Span ERROR_GROUP_ID 1`] = `undefined`;
 exports[`Span ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Span ERROR_LOG_STACKTRACE 1`] = `undefined`;
+
+exports[`Span HTTP_REQUEST_METHOD 1`] = `undefined`;
 
 exports[`Span METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
 
@@ -105,10 +107,6 @@ exports[`Span PARENT_ID 1`] = `"parentId"`;
 exports[`Span PROCESSOR_EVENT 1`] = `"span"`;
 
 exports[`Span PROCESSOR_NAME 1`] = `"transaction"`;
-
-exports[`Span REQUEST_METHOD 1`] = `undefined`;
-
-exports[`Span REQUEST_URL_FULL 1`] = `undefined`;
 
 exports[`Span SERVICE_AGENT_NAME 1`] = `"agent name"`;
 
@@ -142,6 +140,8 @@ exports[`Span TRANSACTION_SAMPLED 1`] = `undefined`;
 
 exports[`Span TRANSACTION_TYPE 1`] = `undefined`;
 
+exports[`Span URL_FULL 1`] = `undefined`;
+
 exports[`Span USER_ID 1`] = `undefined`;
 
 exports[`Transaction ERROR_CULPRIT 1`] = `undefined`;
@@ -157,6 +157,8 @@ exports[`Transaction ERROR_GROUP_ID 1`] = `undefined`;
 exports[`Transaction ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Transaction ERROR_LOG_STACKTRACE 1`] = `undefined`;
+
+exports[`Transaction HTTP_REQUEST_METHOD 1`] = `"GET"`;
 
 exports[`Transaction METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
 
@@ -177,10 +179,6 @@ exports[`Transaction PARENT_ID 1`] = `"parentId"`;
 exports[`Transaction PROCESSOR_EVENT 1`] = `"transaction"`;
 
 exports[`Transaction PROCESSOR_NAME 1`] = `"transaction"`;
-
-exports[`Transaction REQUEST_METHOD 1`] = `"GET"`;
-
-exports[`Transaction REQUEST_URL_FULL 1`] = `"http://www.elastic.co"`;
 
 exports[`Transaction SERVICE_AGENT_NAME 1`] = `"agent name"`;
 
@@ -213,5 +211,7 @@ exports[`Transaction TRANSACTION_RESULT 1`] = `"transaction result"`;
 exports[`Transaction TRANSACTION_SAMPLED 1`] = `true`;
 
 exports[`Transaction TRANSACTION_TYPE 1`] = `"transaction type"`;
+
+exports[`Transaction URL_FULL 1`] = `"http://www.elastic.co"`;
 
 exports[`Transaction USER_ID 1`] = `"1337"`;

--- a/x-pack/plugins/apm/common/constants.ts
+++ b/x-pack/plugins/apm/common/constants.ts
@@ -6,8 +6,8 @@
 export const SERVICE_NAME = 'service.name';
 export const SERVICE_AGENT_NAME = 'agent.name';
 export const SERVICE_LANGUAGE_NAME = 'service.language.name';
-export const REQUEST_URL_FULL = 'url.full';
-export const REQUEST_METHOD = 'http.request.method';
+export const URL_FULL = 'url.full';
+export const HTTP_REQUEST_METHOD = 'http.request.method';
 export const USER_ID = 'user.id';
 
 export const OBSERVER_LISTENING = 'observer.listening';

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/DetailView.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/DetailView.test.tsx
@@ -67,7 +67,7 @@ describe('DetailView', () => {
       status: 'SUCCESS',
       data: {
         occurrencesCount: 10,
-        transaction: ({
+        transaction: {
           http: { request: { method: 'GET' } },
           url: { full: 'myUrl' },
           trace: { id: 'traceId' },
@@ -78,8 +78,8 @@ describe('DetailView', () => {
           },
           service: { name: 'myService' },
           user: { id: 'myUserId' }
-        } as unknown) as Transaction,
-        error: ({
+        } as Transaction,
+        error: {
           '@timestamp': 'myTimestamp',
           http: { request: { method: 'GET' } },
           url: { full: 'myUrl' },
@@ -87,7 +87,7 @@ describe('DetailView', () => {
           user: { id: 'myUserId' },
           error: { exception: { handled: true } },
           transaction: { id: 'myTransactionId', sampled: true }
-        } as unknown) as APMError
+        } as APMError
       }
     };
     const wrapper = shallow(

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/__snapshots__/DetailView.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/__snapshots__/DetailView.test.tsx.snap
@@ -74,17 +74,62 @@ exports[`DetailView should render StickyProperties 1`] = `
       Object {
         "fieldName": "transaction.id",
         "label": "Transaction sample ID",
-        "val": <Connect(UnconnectedKibanaLink)
-          hash="/myService/transactions/myTransactionType/myTransactionName"
-          query={
+        "val": <TransactionLink
+          error={
             Object {
-              "traceId": "traceId",
-              "transactionId": "myTransactionName",
+              "@timestamp": "myTimestamp",
+              "error": Object {
+                "exception": Object {
+                  "handled": true,
+                },
+              },
+              "http": Object {
+                "request": Object {
+                  "method": "GET",
+                },
+              },
+              "service": Object {
+                "name": "myService",
+              },
+              "transaction": Object {
+                "id": "myTransactionId",
+                "sampled": true,
+              },
+              "url": Object {
+                "full": "myUrl",
+              },
+              "user": Object {
+                "id": "myUserId",
+              },
             }
           }
-        >
-          myTransactionName
-        </Connect(UnconnectedKibanaLink)>,
+          transaction={
+            Object {
+              "http": Object {
+                "request": Object {
+                  "method": "GET",
+                },
+              },
+              "service": Object {
+                "name": "myService",
+              },
+              "trace": Object {
+                "id": "traceId",
+              },
+              "transaction": Object {
+                "id": "myTransactionName",
+                "name": "myTransactionName",
+                "type": "myTransactionType",
+              },
+              "url": Object {
+                "full": "myUrl",
+              },
+              "user": Object {
+                "id": "myUserId",
+              },
+            }
+          }
+        />,
         "width": "25%",
       },
       Object {

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
@@ -13,37 +13,33 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Location } from 'history';
-import { first, get } from 'lodash';
-import React from 'react';
+import { first, get, isEmpty } from 'lodash';
+import React, { Fragment } from 'react';
 import { RRRRenderResponse } from 'react-redux-request';
 import styled from 'styled-components';
 import {
-  ERROR_EXC_STACKTRACE,
-  ERROR_LOG_STACKTRACE
+  ERROR_EXC_HANDLED,
+  HTTP_REQUEST_METHOD,
+  TRANSACTION_ID,
+  URL_FULL,
+  USER_ID
 } from 'x-pack/plugins/apm/common/constants';
 import { idx } from 'x-pack/plugins/apm/common/idx';
 import { KibanaLink } from 'x-pack/plugins/apm/public/components/shared/Links/KibanaLink';
-import { legacyEncodeURIComponent } from 'x-pack/plugins/apm/public/components/shared/Links/url_helpers';
 import {
   fromQuery,
   history,
   toQuery
 } from 'x-pack/plugins/apm/public/components/shared/Links/url_helpers';
-import { NOT_AVAILABLE_LABEL } from 'x-pack/plugins/apm/public/constants';
+import { legacyEncodeURIComponent } from 'x-pack/plugins/apm/public/components/shared/Links/url_helpers';
+import {
+  NOT_AVAILABLE_LABEL,
+  STATUS
+} from 'x-pack/plugins/apm/public/constants';
 import { IUrlParams } from 'x-pack/plugins/apm/public/store/urlParams';
 import { ErrorGroupAPIResponse } from 'x-pack/plugins/apm/server/lib/errors/get_error_group';
 import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
-import { IStackframe } from 'x-pack/plugins/apm/typings/es_schemas/fields/Stackframe';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
-import {
-  ERROR_EXC_HANDLED,
-  REQUEST_METHOD,
-  REQUEST_URL_FULL,
-  TRACE_ID,
-  TRANSACTION_ID,
-  USER_ID
-} from '../../../../../common/constants';
-import { STATUS } from '../../../../constants';
 import {
   borderRadius,
   colors,
@@ -111,7 +107,6 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
     return null;
   }
 
-  const transactionLink = getTransactionLink(error, transaction);
   const stickyProperties = [
     {
       fieldName: '@timestamp',
@@ -122,21 +117,21 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
       width: '50%'
     },
     {
-      fieldName: REQUEST_URL_FULL,
+      fieldName: URL_FULL,
       label: 'URL',
       val:
         idx(error, _ => _.context.page.url) ||
-        idx(transaction, _ => _.url.full) ||
+        idx(error, _ => _.url.full) ||
         NOT_AVAILABLE_LABEL,
       truncated: true,
       width: '50%'
     },
     {
-      fieldName: REQUEST_METHOD,
+      fieldName: HTTP_REQUEST_METHOD,
       label: i18n.translate('xpack.apm.errorGroupDetails.requestMethodLabel', {
         defaultMessage: 'Request method'
       }),
-      val: get(error, REQUEST_METHOD, NOT_AVAILABLE_LABEL),
+      val: idx(error, _ => _.http.request.method) || NOT_AVAILABLE_LABEL,
       width: '25%'
     },
     {
@@ -144,7 +139,9 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
       label: i18n.translate('xpack.apm.errorGroupDetails.handledLabel', {
         defaultMessage: 'Handled'
       }),
-      val: String(get(error, ERROR_EXC_HANDLED, NOT_AVAILABLE_LABEL)),
+      val:
+        String(idx(error, _ => _.error.exception.handled)) ||
+        NOT_AVAILABLE_LABEL,
       width: '25%'
     },
     {
@@ -155,7 +152,7 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
           defaultMessage: 'Transaction sample ID'
         }
       ),
-      val: transactionLink || NOT_AVAILABLE_LABEL,
+      val: <TransactionLink transaction={transaction} error={error} />,
       width: '25%'
     },
     {
@@ -163,7 +160,7 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
       label: i18n.translate('xpack.apm.errorGroupDetails.userIdLabel', {
         defaultMessage: 'User ID'
       }),
-      val: get(error, USER_ID, NOT_AVAILABLE_LABEL),
+      val: idx(error, _ => _.user.id) || NOT_AVAILABLE_LABEL,
       width: '25%'
     }
   ];
@@ -233,9 +230,19 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
   );
 }
 
-function getTransactionLink(error: APMError, transaction?: Transaction) {
-  if (!transaction || !get(error, 'transaction.sampled')) {
-    return;
+interface TransactionLinkProps {
+  error: APMError;
+  transaction?: Transaction;
+}
+
+function TransactionLink({ error, transaction }: TransactionLinkProps) {
+  if (!transaction) {
+    return <Fragment>{NOT_AVAILABLE_LABEL}</Fragment>;
+  }
+
+  const isSampled = idx(error, _ => _.transaction.sampled);
+  if (!isSampled) {
+    return <Fragment>{transaction.transaction.id}</Fragment>;
   }
 
   const path = `/${
@@ -249,15 +256,13 @@ function getTransactionLink(error: APMError, transaction?: Transaction) {
       hash={path}
       query={{
         transactionId: transaction.transaction.id,
-        traceId: get(transaction, TRACE_ID)
+        traceId: idx(transaction, _ => _.trace.id)
       }}
     >
       {transaction.transaction.id}
     </KibanaLink>
   );
 }
-
-type MaybeStackframes = IStackframe[] | undefined;
 
 export function TabContent({
   error,
@@ -268,8 +273,8 @@ export function TabContent({
 }) {
   const codeLanguage = error.service.name;
   const agentName = error.agent.name;
-  const excStackframes: MaybeStackframes = get(error, ERROR_EXC_STACKTRACE);
-  const logStackframes: MaybeStackframes = get(error, ERROR_LOG_STACKTRACE);
+  const excStackframes = idx(error, _ => _.error.exception.stacktrace);
+  const logStackframes = idx(error, _ => _.error.exception.stacktrace);
 
   switch (currentTab.key) {
     case logStacktraceTab.key:
@@ -281,7 +286,7 @@ export function TabContent({
         <Stacktrace stackframes={excStackframes} codeLanguage={codeLanguage} />
       );
     default:
-      const propData = get(error, currentTab);
+      const propData = get(error, currentTab.key);
       return (
         <PropertiesTable
           propData={propData}
@@ -299,7 +304,7 @@ export function getCurrentTab(tabs: Tab[] = [], selectedTabKey?: string) {
 }
 
 export function getTabs(error: APMError) {
-  const hasLogStacktrace = get(error, ERROR_LOG_STACKTRACE, []).length > 0;
+  const hasLogStacktrace = !isEmpty(idx(error, _ => _.error.log.stacktrace));
   return [
     ...(hasLogStacktrace ? [logStacktraceTab] : []),
     exceptionStacktraceTab,

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/view.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/view.tsx
@@ -7,15 +7,9 @@
 import { EuiBadge, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Location } from 'history';
-import { get } from 'lodash';
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import {
-  ERROR_CULPRIT,
-  ERROR_EXC_HANDLED,
-  ERROR_EXC_MESSAGE,
-  ERROR_LOG_MESSAGE
-} from '../../../../common/constants';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { NOT_AVAILABLE_LABEL } from '../../../constants';
 import { ErrorDistributionRequest } from '../../../store/reactReduxRequest/errorDistribution';
 import { ErrorGroupDetailsRequest } from '../../../store/reactReduxRequest/errorGroup';
@@ -80,11 +74,14 @@ export function ErrorGroupDetails({ urlParams, location }: Props) {
       render={errorGroup => {
         // If there are 0 occurrences, show only distribution chart w. empty message
         const showDetails = errorGroup.data.occurrencesCount !== 0;
-        const logMessage = get(errorGroup.data.error, ERROR_LOG_MESSAGE);
-        const excMessage = get(errorGroup.data.error, ERROR_EXC_MESSAGE);
-        const culprit = get(errorGroup.data.error, ERROR_CULPRIT);
+        const logMessage = idx(errorGroup, _ => _.data.error.error.log.message);
+        const excMessage = idx(
+          errorGroup,
+          _ => _.data.error.error.exception.message
+        );
+        const culprit = idx(errorGroup, _ => _.data.error.error.culprit);
         const isUnhandled =
-          get(errorGroup.data.error, ERROR_EXC_HANDLED) === false;
+          idx(errorGroup, _ => _.data.error.error.exception.handled) === false;
 
         return (
           <div>

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -5,13 +5,12 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { get } from 'lodash';
 import React from 'react';
 import { idx } from 'x-pack/plugins/apm/common/idx';
 import {
-  REQUEST_URL_FULL,
   TRANSACTION_DURATION,
   TRANSACTION_RESULT,
+  URL_FULL,
   USER_ID
 } from '../../../../../common/constants';
 import { Transaction } from '../../../../../typings/es_schemas/Transaction';
@@ -48,7 +47,7 @@ export function StickyTransactionProperties({
       width: '50%'
     },
     {
-      fieldName: REQUEST_URL_FULL,
+      fieldName: URL_FULL,
       label: 'URL',
       val: url,
       truncated: true,
@@ -77,7 +76,7 @@ export function StickyTransactionProperties({
         defaultMessage: 'Result'
       }),
       fieldName: TRANSACTION_RESULT,
-      val: get(transaction, TRANSACTION_RESULT, NOT_AVAILABLE_LABEL),
+      val: idx(transaction, _ => _.transaction.result) || NOT_AVAILABLE_LABEL,
       width: '25%'
     },
     {
@@ -85,7 +84,7 @@ export function StickyTransactionProperties({
         defaultMessage: 'User ID'
       }),
       fieldName: USER_ID,
-      val: get(transaction, USER_ID, NOT_AVAILABLE_LABEL),
+      val: idx(transaction, _ => _.user.id) || NOT_AVAILABLE_LABEL,
       truncated: true,
       width: '25%'
     }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -26,7 +26,6 @@ import { idx } from 'x-pack/plugins/apm/common/idx';
 import { DiscoverSpanLink } from 'x-pack/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverSpanLink';
 import { Stacktrace } from 'x-pack/plugins/apm/public/components/shared/Stacktrace';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
-import { SERVICE_LANGUAGE_NAME } from '../../../../../../../../common/constants';
 import { Span } from '../../../../../../../../typings/es_schemas/Span';
 import { FlyoutTopLevelProperties } from '../FlyoutTopLevelProperties';
 import { DatabaseContext } from './DatabaseContext';
@@ -55,7 +54,7 @@ export function SpanFlyout({
   }
 
   const stackframes = span.span.stacktrace;
-  const codeLanguage: string = get(span, SERVICE_LANGUAGE_NAME);
+  const codeLanguage = idx(span, _ => _.service.language.name);
   const dbContext = idx(span, _ => _.context.db);
   const httpContext = idx(span, _ => _.context.http);
   const labels = span.labels;

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -54,7 +54,7 @@ export function SpanFlyout({
   }
 
   const stackframes = span.span.stacktrace;
-  const codeLanguage = idx(span, _ => _.service.language.name);
+  const codeLanguage = idx(parentTransaction, _ => _.service.language.name);
   const dbContext = idx(span, _ => _.context.db);
   const httpContext = idx(span, _ => _.context.http);
   const labels = span.labels;

--- a/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -5,8 +5,9 @@
  */
 
 import { EuiBasicTable } from '@elastic/eui';
-import { get, sortByOrder } from 'lodash';
+import { sortByOrder } from 'lodash';
 import React, { Component } from 'react';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { StringMap } from '../../../../typings/common';
 
 // TODO: this should really be imported from EUI
@@ -38,7 +39,7 @@ export class ManagedTable extends Component<IManagedTableProps, any> {
     super(props);
 
     const defaultSort = {
-      field: get(props, 'columns[0].field', ''),
+      field: idx(props, _ => _.columns[0].field) || '',
       direction: 'asc'
     };
 

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/Context.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/Context.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { get, size } from 'lodash';
+import { size } from 'lodash';
 import React from 'react';
 // TODO add dependency for @types/react-syntax-highlighter
 // @ts-ignore
@@ -20,6 +20,7 @@ import { registerLanguage } from 'react-syntax-highlighter/dist/light';
 // @ts-ignore
 import { xcode } from 'react-syntax-highlighter/dist/styles';
 import styled from 'styled-components';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { IStackframeWithLineContext } from 'x-pack/plugins/apm/typings/es_schemas/fields/Stackframe';
 import {
   borderRadius,
@@ -105,13 +106,13 @@ const Code = styled.code`
 
 function getStackframeLines(stackframe: IStackframeWithLineContext) {
   const line = stackframe.line.context;
-  const preLines: string[] = get(stackframe, 'context.pre', []);
-  const postLines: string[] = get(stackframe, 'context.post', []);
+  const preLines = idx(stackframe, _ => _.context.pre) || [];
+  const postLines = idx(stackframe, _ => _.context.post) || [];
   return [...preLines, line, ...postLines];
 }
 
 function getStartLineNumber(stackframe: IStackframeWithLineContext) {
-  const preLines = size(get(stackframe, 'context.pre', []));
+  const preLines = size(idx(stackframe, _ => _.context.pre) || []);
   return stackframe.line.number - preLines;
 }
 
@@ -124,7 +125,7 @@ interface Props {
 export function Context({ stackframe, codeLanguage, isLibraryFrame }: Props) {
   const lines = getStackframeLines(stackframe);
   const startLineNumber = getStartLineNumber(stackframe);
-  const highlightedLineIndex = size(get(stackframe, 'context.pre', []));
+  const highlightedLineIndex = size(idx(stackframe, _ => _.context.pre) || []);
   const language = codeLanguage || 'javascript'; // TODO: Add support for more languages
 
   return (

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/FrameHeading.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/FrameHeading.tsx
@@ -4,10 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { get } from 'lodash';
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import { IStackframe } from '../../../../typings/es_schemas/fields/Stackframe';
+import { idx } from 'x-pack/plugins/apm/common/idx';
+import { IStackframe } from 'x-pack/plugins/apm/typings/es_schemas/fields/Stackframe';
 import { colors, fontFamilyCode, px, units } from '../../../style/variables';
 
 const FileDetails = styled.div`
@@ -32,7 +32,7 @@ const FrameHeading: React.SFC<Props> = ({ stackframe, isLibraryFrame }) => {
   const FileDetail = isLibraryFrame
     ? LibraryFrameFileDetail
     : AppFrameFileDetail;
-  const lineNumber: number = get(stackframe, 'line.number');
+  const lineNumber = idx(stackframe, _ => _.line.number) || 0;
   return (
     <FileDetails>
       <FileDetail>{stackframe.filename}</FileDetail> in{' '}

--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/StickyProperties.test.js
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/StickyProperties.test.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { StickyProperties } from './index';
 import { shallow } from 'enzyme';
-import { USER_ID, REQUEST_URL_FULL } from '../../../../common/constants';
+import { USER_ID, URL_FULL } from '../../../../common/constants';
 import { mockMoment } from '../../../utils/testHelpers';
 
 describe('StickyProperties', () => {
@@ -21,7 +21,7 @@ describe('StickyProperties', () => {
         val: 1536405447640
       },
       {
-        fieldName: REQUEST_URL_FULL,
+        fieldName: URL_FULL,
         label: 'URL',
         val: 'https://www.elastic.co/test',
         truncated: true

--- a/x-pack/plugins/apm/public/store/reactReduxRequest/waterfall.tsx
+++ b/x-pack/plugins/apm/public/store/reactReduxRequest/waterfall.tsx
@@ -4,10 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { get } from 'lodash';
 import React from 'react';
 import { Request, RRRRender } from 'react-redux-request';
-import { TRACE_ID } from 'x-pack/plugins/apm/common/constants';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { TraceAPIResponse } from 'x-pack/plugins/apm/server/lib/traces/get_trace';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import {
@@ -29,7 +28,7 @@ interface Props {
 
 export function WaterfallRequest({ urlParams, transaction, render }: Props) {
   const { start, end } = urlParams;
-  const traceId: string = get(transaction, TRACE_ID);
+  const traceId = idx(transaction, _ => _.trace.id);
 
   if (!(traceId && start && end)) {
     return null;

--- a/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
@@ -5,7 +5,7 @@
  */
 
 import { ESFilter } from 'elasticsearch';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import {
@@ -69,9 +69,9 @@ export async function getErrorGroup({
   };
 
   const resp = await client<APMError>('search', params);
-  const error = oc(resp).hits.hits[0]._source();
-  const transactionId = oc(error).transaction.id();
-  const traceId = oc(error).trace.id();
+  const error = idx(resp, _ => _.hits.hits[0]._source);
+  const transactionId = idx(error, _ => _.transaction.id);
+  const traceId = idx(error, _ => _.trace.id);
 
   let transaction;
   if (transactionId) {

--- a/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import {
   ERROR_CULPRIT,
@@ -141,22 +141,23 @@ export async function getErrorGroups({
   }
 
   const resp = await client<void, Aggs>('search', params);
-  const hits = oc(resp)
-    .aggregations.error_groups.buckets([])
-    .map(bucket => {
-      const source = bucket.sample.hits.hits[0]._source;
-      const message =
-        oc(source).error.log.message() || oc(source).error.exception.message();
+  const buckets = idx(resp, _ => _.aggregations.error_groups.buckets) || [];
 
-      return {
-        message,
-        occurrenceCount: bucket.doc_count,
-        culprit: oc(source).error.culprit(),
-        groupId: oc(source).error.grouping_key(),
-        latestOccurrenceAt: source['@timestamp'],
-        handled: oc(source).error.exception.handled()
-      };
-    });
+  const hits = buckets.map(bucket => {
+    const source = bucket.sample.hits.hits[0]._source;
+    const message =
+      idx(source, _ => _.error.log.message) ||
+      idx(source, _ => _.error.exception.message);
+
+    return {
+      message,
+      occurrenceCount: bucket.doc_count,
+      culprit: idx(source, _ => _.error.culprit),
+      groupId: idx(source, _ => _.error.grouping_key),
+      latestOccurrenceAt: source['@timestamp'],
+      handled: idx(source, _ => _.error.exception.handled)
+    };
+  });
 
   return hits;
 }

--- a/x-pack/plugins/apm/server/lib/services/get_service.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service.ts
@@ -6,7 +6,7 @@
 
 import { BucketAgg } from 'elasticsearch';
 import { ESFilter } from 'elasticsearch';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import {
   SERVICE_AGENT_NAME,
   SERVICE_NAME,
@@ -76,11 +76,12 @@ export async function getService(
   }
 
   const { aggregations } = await client<void, Aggs>('search', params);
+  const buckets = idx(aggregations, _ => _.types.buckets) || [];
+  const types = buckets.map(bucket => bucket.key);
+  const agentName = idx(aggregations, _ => _.agents.buckets[0].key);
   return {
     serviceName,
-    types: oc(aggregations)
-      .types.buckets([])
-      .map(bucket => bucket.key),
-    agentName: oc(aggregations).agents.buckets[0].key()
+    types,
+    agentName
   };
 }

--- a/x-pack/plugins/apm/server/lib/services/get_services.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services.ts
@@ -124,7 +124,7 @@ export async function getServices(
 
     return {
       serviceName: bucket.key,
-      agentName: idx(bucket, _ => _.agents.buckets[0].key) || undefined, // TODO: get rid of unneeded undefined
+      agentName: idx(bucket, _ => _.agents.buckets[0].key),
       transactionsPerMinute,
       errorsPerMinute,
       avgResponseTime: bucket.avg.value

--- a/x-pack/plugins/apm/server/lib/services/get_services.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services.ts
@@ -6,7 +6,7 @@
 
 import { BucketAgg } from 'elasticsearch';
 import { ESFilter } from 'elasticsearch';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import {
   PROCESSOR_EVENT,
   SERVICE_AGENT_NAME,
@@ -108,15 +108,15 @@ export async function getServices(
 
   const resp = await client<void, Aggs>('search', params);
   const aggs = resp.aggregations;
-  const serviceBuckets = oc(aggs).services.buckets([]);
+  const serviceBuckets = idx(aggs, _ => _.services.buckets) || [];
 
   return serviceBuckets.map(bucket => {
     const eventTypes = bucket.events.buckets;
     const transactions = eventTypes.find(e => e.key === 'transaction');
-    const totalTransactions = oc(transactions).doc_count(0);
+    const totalTransactions = idx(transactions, _ => _.doc_count) || 0;
 
     const errors = eventTypes.find(e => e.key === 'error');
-    const totalErrors = oc(errors).doc_count(0);
+    const totalErrors = idx(errors, _ => _.doc_count) || 0;
 
     const deltaAsMinutes = (end - start) / 1000 / 60;
     const transactionsPerMinute = totalTransactions / deltaAsMinutes;
@@ -124,7 +124,7 @@ export async function getServices(
 
     return {
       serviceName: bucket.key,
-      agentName: oc(bucket).agents.buckets[0].key(),
+      agentName: idx(bucket, _ => _.agents.buckets[0].key) || undefined, // TODO: get rid of unneeded undefined
       transactionsPerMinute,
       errorsPerMinute,
       avgResponseTime: bucket.avg.value

--- a/x-pack/plugins/apm/server/lib/transaction_groups/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/transform.ts
@@ -5,7 +5,7 @@
  */
 
 import moment from 'moment';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import { ESResponse } from './fetcher';
 
@@ -38,7 +38,7 @@ export function transactionGroupsTransformer({
   start: number;
   end: number;
 }): ITransactionGroup[] {
-  const buckets = oc(response).aggregations.transactions.buckets([]);
+  const buckets = idx(response, _ => _.aggregations.transactions.buckets) || [];
   const duration = moment.duration(end - start);
   const minutes = duration.asMinutes();
   const results = buckets.map(bucket => {

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/get_ml_bucket_size.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/get_ml_bucket_size.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { Setup } from '../../../helpers/setup_request';
 
 interface IOptions {
@@ -53,7 +53,7 @@ export async function getMlBucketSize({
 
   try {
     const resp = await client<ESResponse>('search', params);
-    return oc(resp).hits.hits[0]._source.bucket_span(0);
+    return idx(resp, _ => _.hits.hits[0]._source.bucket_span) || 0;
   } catch (err) {
     const isHttpError = 'statusCode' in err;
     if (isHttpError) {

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.test.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { ESBucket, ESResponse } from './fetcher';
 import { mlAnomalyResponse } from './mock-responses/mlAnomalyResponse';
 import { anomalySeriesTransform, replaceFirstAndLastBucket } from './transform';
@@ -291,9 +291,11 @@ function getESResponse(buckets: ESBucket[]): ESResponse {
         buckets: buckets.map(bucket => {
           return {
             ...bucket,
-            lower: { value: oc(bucket).lower.value(null) },
-            upper: { value: oc(bucket).upper.value(null) },
-            anomaly_score: { value: oc(bucket).anomaly_score.value(null) }
+            lower: { value: idx(bucket, _ => _.lower.value) || null },
+            upper: { value: idx(bucket, _ => _.upper.value) || null },
+            anomaly_score: {
+              value: idx(bucket, _ => _.anomaly_score.value) || null
+            }
           };
         })
       }

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.ts
@@ -5,7 +5,7 @@
  */
 
 import { first, last } from 'lodash';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import {
   Coordinate,
   RectCoordinate
@@ -34,16 +34,16 @@ export function anomalySeriesTransform(
     return;
   }
 
-  const buckets = oc(response)
-    .aggregations.ml_avg_response_times.buckets([])
-    .map(bucket => {
-      return {
-        x: bucket.key,
-        anomalyScore: bucket.anomaly_score.value,
-        lower: bucket.lower.value,
-        upper: bucket.upper.value
-      };
-    });
+  const buckets = (
+    idx(response, _ => _.aggregations.ml_avg_response_times.buckets) || []
+  ).map(bucket => {
+    return {
+      x: bucket.key,
+      anomalyScore: bucket.anomaly_score.value,
+      lower: bucket.lower.value,
+      upper: bucket.upper.value
+    };
+  });
 
   const bucketSizeInMillis = Math.max(bucketSize, mlBucketSize) * 1000;
 

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/transform.ts
@@ -5,7 +5,7 @@
  */
 
 import { isNumber, round, sortBy } from 'lodash';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { Coordinate } from 'x-pack/plugins/apm/typings/timeseries';
 import { ESResponse } from './fetcher';
 
@@ -31,13 +31,13 @@ export function timeseriesTransformer({
   bucketSize: number;
 }): ApmTimeSeriesResponse {
   const aggs = timeseriesResponse.aggregations;
-  const overallAvgDuration = oc(aggs).overall_avg_duration.value();
-
-  const responseTimeBuckets = oc(aggs)
-    .response_times.buckets([])
-    .slice(1, -1);
+  const overallAvgDuration = idx(aggs, _ => _.overall_avg_duration.value);
+  const responseTimeBuckets = idx(aggs, _ => _.response_times.buckets);
   const { avg, p95, p99 } = getResponseTime(responseTimeBuckets);
-  const transactionResultBuckets = oc(aggs).transaction_results.buckets([]);
+  const transactionResultBuckets = idx(
+    aggs,
+    _ => _.transaction_results.buckets
+  );
   const tpmBuckets = getTpmBuckets(transactionResultBuckets, bucketSize);
 
   return {
@@ -53,7 +53,7 @@ export function timeseriesTransformer({
 }
 
 export function getTpmBuckets(
-  transactionResultBuckets: ESResponse['aggregations']['transaction_results']['buckets'],
+  transactionResultBuckets: ESResponse['aggregations']['transaction_results']['buckets'] = [],
   bucketSize: number
 ) {
   const buckets = transactionResultBuckets.map(({ key, timeseries }) => {
@@ -74,9 +74,9 @@ export function getTpmBuckets(
 }
 
 function getResponseTime(
-  responseTimeBuckets: ESResponse['aggregations']['response_times']['buckets']
+  responseTimeBuckets: ESResponse['aggregations']['response_times']['buckets'] = []
 ) {
-  return responseTimeBuckets.reduce(
+  return responseTimeBuckets.slice(1, -1).reduce(
     (acc, bucket) => {
       const { '95.0': p95, '99.0': p99 } = bucket.pct.values;
 

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
@@ -5,7 +5,7 @@
  */
 
 import { isEmpty } from 'lodash';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { ESResponse } from './fetcher';
 
 export interface IBucket {
@@ -40,11 +40,11 @@ function getDefaultSample(buckets: IBucket[]) {
 
 export function bucketTransformer(response: ESResponse): IBucketsResponse {
   const buckets = response.aggregations.distribution.buckets.map(bucket => {
-    const sampleSource = oc(bucket).sample.hits.hits[0]._source();
-    const isSampled = oc(sampleSource).transaction.sampled(false);
+    const sampleSource = idx(bucket, _ => _.sample.hits.hits[0]._source);
+    const isSampled = idx(sampleSource, _ => _.transaction.sampled);
     const sample = {
-      traceId: oc(sampleSource).trace.id(),
-      transactionId: oc(sampleSource).transaction.id()
+      traceId: idx(sampleSource, _ => _.trace.id),
+      transactionId: idx(sampleSource, _ => _.transaction.id)
     };
 
     return {

--- a/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { ESFilter } from 'elasticsearch';
-import { oc } from 'ts-optchain';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import {
   PROCESSOR_EVENT,
@@ -58,5 +58,5 @@ export async function getTransaction(
   };
 
   const resp = await client<Transaction>('search', params);
-  return oc(resp).hits.hits[0]._source();
+  return idx(resp, _ => _.hits.hits[0]._source);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21230,11 +21230,6 @@ ts-node@^7.0.1:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-ts-optchain@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ts-optchain/-/ts-optchain-0.1.1.tgz#9d45e2c3fc6201c2f9be82edad4c76fefb2a36d9"
-  integrity sha512-WWNaATI+rtNm6C3550HbLzvu32zIg0I0gBkvJZpOQnyeGIoGxg2RZOt96U7bi90ZlQ7bFiI5PCRaXScv4+4Y4A==
-
 tslib@1.9.3, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"


### PR DESCRIPTION
Closes #28933
This is a follow-up to the ECS changes, and makes ensures that we actually use the new ECS fields.