### PR TITLE
[APM] fixes selecting edges of charts

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/VoronoiPlot.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/VoronoiPlot.js
@@ -52,7 +52,7 @@ VoronoiPlot.propTypes = {
   onHover: PropTypes.func.isRequired,
   onMouseDown: PropTypes.func.isRequired,
   onMouseLeave: PropTypes.func.isRequired,
-  onMouseUp: PropTypes.func.isRequired,
+  onMouseUp: PropTypes.func,
   series: PropTypes.array.isRequired,
   plotValues: PropTypes.object.isRequired
 };

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/index.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/index.js
@@ -75,9 +75,6 @@ export class InnerCustomPlot extends PureComponent {
   };
 
   onMouseLeave = (...args) => {
-    if (this.state.isDrawing) {
-      this.setState({ isDrawing: false });
-    }
     this.props.onMouseLeave(...args);
   };
 
@@ -89,7 +86,7 @@ export class InnerCustomPlot extends PureComponent {
     });
 
   onMouseUp = () => {
-    if (this.state.selectionEnd !== null) {
+    if (this.state.isDrawing && this.state.selectionEnd !== null) {
       const [start, end] = [
         this.state.selectionStart,
         this.state.selectionEnd
@@ -106,6 +103,14 @@ export class InnerCustomPlot extends PureComponent {
       this.setState({ selectionEnd: node.x });
     }
   };
+
+  componentDidMount() {
+    document.body.addEventListener('mouseup', this.onMouseUp);
+  }
+
+  componentWillUnmount() {
+    document.body.removeEventListener('mouseup', this.onMouseUp);
+  }
 
   render() {
     const { series, truncateLegends, noHits, width } = this.props;
@@ -163,7 +168,6 @@ export class InnerCustomPlot extends PureComponent {
             onHover={this.onHover}
             onMouseLeave={this.onMouseLeave}
             onMouseDown={this.onMouseDown}
-            onMouseUp={this.onMouseUp}
           />
         </div>
         <Legends

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
@@ -243,8 +243,8 @@ describe('when response has data', () => {
       wrapper
         .find('.rv-voronoi__cell')
         .at(20)
-        .simulate('mouseOver')
-        .simulate('mouseUp');
+        .simulate('mouseOver');
+      document.body.dispatchEvent(new Event('mouseup'));
     });
 
     it('should call onSelectionEnd', () => {
@@ -265,8 +265,8 @@ describe('when response has data', () => {
       wrapper
         .find('.rv-voronoi__cell')
         .at(10)
-        .simulate('mouseOver')
-        .simulate('mouseUp');
+        .simulate('mouseOver');
+      document.body.dispatchEvent(new Event('mouseup'));
     });
 
     it('should call onSelectionEnd', () => {


### PR DESCRIPTION
fixes elastic/kibana#26529 by making the mouseup event handler global

![chart-edge-selection](https://user-images.githubusercontent.com/1967266/51898847-ab5ac600-2366-11e9-8782-c53f3971966c.gif)
