### PR TITLE
Frozen indices support

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
@@ -43,8 +43,11 @@ export function setupRequest(req: Legacy.Request): Setup {
   const uiSettings = req.getUiSettingsService();
 
   const client: ESClient = async (type, params) => {
+    const includeFrozen = await uiSettings.get('search:includeFrozen');
+
     if (query._debug) {
       console.log(`DEBUG ES QUERY:`);
+      console.log({ includeFrozen });
       console.log(
         `${req.method.toUpperCase()} ${req.url.pathname} ${JSON.stringify(
           query
@@ -53,8 +56,6 @@ export function setupRequest(req: Legacy.Request): Setup {
       console.log(`GET ${params.index}/_search`);
       console.log(JSON.stringify(params.body, null, 4));
     }
-
-    const includeFrozen = await uiSettings.get('search:includeFrozen');
 
     const nextParams = {
       ...params,

--- a/x-pack/plugins/apm/server/routes/__test__/routeFailures.test.ts
+++ b/x-pack/plugins/apm/server/routes/__test__/routeFailures.test.ts
@@ -35,7 +35,10 @@ describe('route handlers should fail with a Boom error', () => {
             getCluster: () => mockCluster
           }
         }
-      }
+      },
+      getUiSettingsService: jest.fn(() => ({
+        get: jest.fn()
+      }))
     };
 
     const routes = flatten(mockServer.route.mock.calls);


### PR DESCRIPTION
Closes elastic/kibana#27730 

## Summary

Reads in the ui advaned setting for "include frozen indices" and translates that value to the ES option called "ignore_throttled", which is now attached to every ES query we make from the server.

**UPDATE**: This PR was replaced by elastic/kibana#29970 due to strange problems with CI which started because my fork of ES had a very old branch in it with the same name as this branch. The copy PR had a different branch name, which passed CI fine. 🤷‍♂️ 