### PR TITLE
[APM] fixes infinite recursion for multiple waterfall item references

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/__snapshots__/waterfall_helpers.test.ts.snap
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/__snapshots__/waterfall_helpers.test.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`waterfall_helpers getWaterfallItems should handle cyclic references 1`] = `
+Array [
+  Object {
+    "childIds": Array [
+      "a",
+    ],
+    "id": "a",
+    "offset": 0,
+    "skew": 0,
+    "timestamp": 10,
+  },
+  Object {
+    "childIds": Array [
+      "a",
+    ],
+    "id": "a",
+    "offset": 10,
+    "parentId": "a",
+    "skew": undefined,
+    "timestamp": 20,
+  },
+]
+`;
+
 exports[`waterfall_helpers getWaterfallItems should order items correctly 1`] = `
 Array [
   Object {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -98,6 +98,20 @@ describe('waterfall_helpers', () => {
         getWaterfallItems(childrenByParentId, entryTransactionItem)
       ).toMatchSnapshot();
     });
+
+    it('should handle cyclic references', () => {
+      const items = [
+        { id: 'a', timestamp: 10 } as IWaterfallItem,
+        { id: 'a', parentId: 'a', timestamp: 20 } as IWaterfallItem
+      ];
+      const childrenByParentId = groupBy(items, hit =>
+        hit.parentId ? hit.parentId : 'root'
+      );
+      const entryTransactionItem = childrenByParentId.root[0];
+      expect(
+        getWaterfallItems(childrenByParentId, entryTransactionItem)
+      ).toMatchSnapshot();
+    });
   });
 
   describe('getClockSkew', () => {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -155,10 +155,15 @@ export function getWaterfallItems(
   childrenByParentId: IWaterfallGroup,
   entryTransactionItem: IWaterfallItem
 ) {
+  const visitedWaterfallItemSet = new Set();
   function getSortedChildren(
     item: IWaterfallItem,
     parentItem?: IWaterfallItem
   ): IWaterfallItem[] {
+    if (visitedWaterfallItemSet.has(item)) {
+      return [];
+    }
+    visitedWaterfallItemSet.add(item);
     const children = sortBy(childrenByParentId[item.id] || [], 'timestamp');
 
     item.childIds = children.map(child => child.id);


### PR DESCRIPTION
[APM] fixes #29564 by bailing out of recursion when multiple references of the same object are detected