### PR TITLE
[APM] Flip transaction.name to keyword by default

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/KueryBar/get_bool_filter.js
+++ b/x-pack/plugins/apm/public/components/shared/KueryBar/get_bool_filter.js
@@ -39,7 +39,7 @@ export function getBoolFilter(urlParams) {
 
       if (urlParams.transactionName) {
         boolFilter.push({
-          term: { [`${TRANSACTION_NAME}.keyword`]: urlParams.transactionName }
+          term: { [TRANSACTION_NAME]: urlParams.transactionName }
         });
       }
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/fetcher.test.ts.snap
@@ -44,7 +44,7 @@ Array [
               },
             },
             "terms": Object {
-              "field": "transaction.name.keyword",
+              "field": "transaction.name",
               "order": Object {
                 "sum": "desc",
               },

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -51,7 +51,7 @@ export function transactionGroupsFetcher(
       aggs: {
         transactions: {
           terms: {
-            field: `${TRANSACTION_NAME}.keyword`,
+            field: TRANSACTION_NAME,
             order: { sum: 'desc' },
             size: config.get<number>('xpack.apm.ui.transactionGroupBucketSize')
           },

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
@@ -141,7 +141,7 @@ export function timeseriesFetcher({
 
   if (transactionName) {
     params.body.query.bool.must = [
-      { term: { [`${TRANSACTION_NAME}.keyword`]: transactionName } }
+      { term: { [TRANSACTION_NAME]: transactionName } }
     ];
   }
 

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/calculate_bucket_size.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/calculate_bucket_size.ts
@@ -30,7 +30,7 @@ export async function calculateBucketSize(
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
             { term: { [TRANSACTION_TYPE]: transactionType } },
-            { term: { [`${TRANSACTION_NAME}.keyword`]: transactionName } },
+            { term: { [TRANSACTION_NAME]: transactionName } },
             {
               range: {
                 '@timestamp': {

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
@@ -54,7 +54,7 @@ export function bucketFetcher(
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
     { term: { [TRANSACTION_TYPE]: transactionType } },
-    { term: { [`${TRANSACTION_NAME}.keyword`]: transactionName } },
+    { term: { [TRANSACTION_NAME]: transactionName } },
     {
       range: {
         '@timestamp': {


### PR DESCRIPTION
Closes #29574 

Required by https://github.com/elastic/apm-server/pull/1859