### PR TITLE
[Infra UI] Disable add button on custom group by when field is empty

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/custom_field_panel.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/custom_field_panel.tsx
@@ -59,7 +59,13 @@ export const CustomFieldPanel = injectI18n(
                 isClearable={false}
               />
             </EuiFormRow>
-            <EuiButton type="submit" size="s" fill onClick={this.handleSubmit}>
+            <EuiButton
+              disabled={!this.state.selectedOptions.length}
+              type="submit"
+              size="s"
+              fill
+              onClick={this.handleSubmit}
+            >
               Add
             </EuiButton>
           </EuiForm>


### PR DESCRIPTION
This PR fixes elastic/kibana#29778 by disabling the add button on the custom group by form when the user hasn't selected a field.

![image](https://user-images.githubusercontent.com/41702/52093364-2646fb00-2578-11e9-9b16-b32b77e134d1.png)
