### PR TITLE
[6.x] [page_objects/visual_builder_page] fixes #29670 with proper wait for visualization loaded (#29741)

### DIFF
--- a/test/functional/page_objects/visual_builder_page.js
+++ b/test/functional/page_objects/visual_builder_page.js
@@ -60,6 +60,7 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
     }
 
     async enterMarkdown(markdown) {
+      const prevRenderingCount = await PageObjects.visualize.getVisualizationRenderingCount();
       const input = await find.byCssSelector('.tvbMarkdownEditor__editor textarea');
       // Since we use ACE editor and that isn't really storing its value inside
       // a textarea we must really select all text and remove it, and cannot use
@@ -72,7 +73,7 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }) {
       await browser.pressKeys(Keys.NULL); // Release modifier keys
       await browser.pressKeys(Keys.BACKSPACE); // Delete all content
       await input.type(markdown);
-      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.visualize.waitForRenderingCount(prevRenderingCount + 1);
     }
 
     async getMarkdownText() {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - [page_objects/visual_builder_page] fixes #29670 with proper wait for visualization loaded  (#29741)