### PR TITLE
[6.x] Fixing #29778 - Disable add button when field select is empty (#29779)

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/custom_field_panel.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/custom_field_panel.tsx
@@ -59,7 +59,13 @@ export const CustomFieldPanel = injectI18n(
                 isClearable={false}
               />
             </EuiFormRow>
-            <EuiButton type="submit" size="s" fill onClick={this.handleSubmit}>
+            <EuiButton
+              disabled={!this.state.selectedOptions.length}
+              type="submit"
+              size="s"
+              fill
+              onClick={this.handleSubmit}
+            >
               Add
             </EuiButton>
           </EuiForm>


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fixing #29778 - Disable add button when field select is empty  (#29779)