### PR TITLE
[APM] Replace `any` with `unknown`

### DIFF
--- a/src/server/saved_objects/service/saved_objects_client.d.ts
+++ b/src/server/saved_objects/service/saved_objects_client.d.ts
@@ -25,7 +25,7 @@ export interface BaseOptions {
 
 export interface CreateOptions extends BaseOptions {
   id?: string;
-  override?: boolean;
+  overwrite?: boolean;
   references?: SavedObjectReference[];
 }
 

--- a/x-pack/plugins/apm/common/ml_job_constants.test.ts
+++ b/x-pack/plugins/apm/common/ml_job_constants.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { getMlIndex, getMlJobId, getMlPrefix } from './ml_job_constants';
+
+describe('ml_job_constants', () => {
+  it('getMlPrefix', () => {
+    expect(getMlPrefix('myServiceName')).toBe('myservicename-');
+    expect(getMlPrefix('myServiceName', 'myTransactionType')).toBe(
+      'myservicename-mytransactiontype-'
+    );
+  });
+
+  it('getMlJobId', () => {
+    expect(getMlJobId('myServiceName')).toBe(
+      'myservicename-high_mean_response_time'
+    );
+    expect(getMlJobId('myServiceName', 'myTransactionType')).toBe(
+      'myservicename-mytransactiontype-high_mean_response_time'
+    );
+  });
+
+  it('getMlIndex', () => {
+    expect(getMlIndex('myServiceName')).toBe(
+      '.ml-anomalies-myservicename-high_mean_response_time'
+    );
+
+    expect(getMlIndex('myServiceName', 'myTransactionType')).toBe(
+      '.ml-anomalies-myservicename-mytransactiontype-high_mean_response_time'
+    );
+  });
+});

--- a/x-pack/plugins/apm/common/ml_job_constants.ts
+++ b/x-pack/plugins/apm/common/ml_job_constants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export function getMlPrefix(serviceName: string, transactionType?: string) {
+  const maybeTransactionType = transactionType ? `${transactionType}-` : '';
+  return `${serviceName}-${maybeTransactionType}`.toLowerCase();
+}
+
+export function getMlJobId(serviceName: string, transactionType?: string) {
+  return `${getMlPrefix(serviceName, transactionType)}high_mean_response_time`;
+}
+
+export function getMlIndex(serviceName: string, transactionType?: string) {
+  return `.ml-anomalies-${getMlJobId(serviceName, transactionType)}`;
+}

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout.tsx
@@ -23,12 +23,10 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { Location } from 'history';
 import React, { Component } from 'react';
 import { toastNotifications } from 'ui/notify';
+import { getMlJobId } from 'x-pack/plugins/apm/common/ml_job_constants';
 import { KibanaLink } from 'x-pack/plugins/apm/public/components/shared/Links/KibanaLink';
 import { MLJobLink } from 'x-pack/plugins/apm/public/components/shared/Links/MLJobLink';
-import {
-  getMlPrefix,
-  startMLJob
-} from 'x-pack/plugins/apm/public/services/rest/ml';
+import { startMLJob } from 'x-pack/plugins/apm/public/services/rest/ml';
 import { getAPMIndexPattern } from 'x-pack/plugins/apm/public/services/rest/savedObjects';
 import { MLJobsRequest } from 'x-pack/plugins/apm/public/store/reactReduxRequest/machineLearningJobs';
 import { IUrlParams } from 'x-pack/plugins/apm/public/store/urlParams';
@@ -62,6 +60,7 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
     this.setState({ hasIndexPattern: !!indexPattern });
   }
 
+  // TODO: This should use `getDerivedStateFromProps`
   public componentDidUpdate(prevProps: FlyoutProps) {
     if (
       prevProps.urlParams.transactionType !==
@@ -98,7 +97,7 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
 
   public addErrorToast = () => {
     const { urlParams } = this.props;
-    const { serviceName = 'unknown' } = urlParams;
+    const { serviceName } = urlParams;
 
     if (!serviceName) {
       return;
@@ -127,7 +126,11 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
 
   public addSuccessToast = () => {
     const { location, urlParams } = this.props;
-    const { serviceName = 'unknown', transactionType } = urlParams;
+    const { serviceName, transactionType } = urlParams;
+
+    if (!serviceName) {
+      return;
+    }
 
     toastNotifications.addSuccess({
       title: i18n.translate(
@@ -185,10 +188,7 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
 
           const hasMLJob = data.jobs.some(
             job =>
-              job.jobId &&
-              job.jobId.startsWith(
-                getMlPrefix(serviceName, selectedTransactionType)
-              )
+              job.job_id === getMlJobId(serviceName, selectedTransactionType)
           );
 
           return (
@@ -345,7 +345,8 @@ export class MachineLearningFlyout extends Component<FlyoutProps, FlyoutState> {
                   <EuiFlexItem>
                     {this.props.serviceTransactionTypes.length > 1 ? (
                       <TransactionSelect
-                        types={this.props.serviceTransactionTypes}
+                        serviceName={serviceName}
+                        transactionTypes={this.props.serviceTransactionTypes}
                         selected={this.state.selectedTransactionType}
                         existingJobs={data.jobs}
                         onChange={value =>

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/TransactionSelect.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/TransactionSelect.tsx
@@ -16,21 +16,24 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import { getMlJobId } from 'x-pack/plugins/apm/common/ml_job_constants';
 import { MLJobApiResponse } from 'x-pack/plugins/apm/public/services/rest/ml';
 
 interface TransactionSelectProps {
+  serviceName: string;
   existingJobs: MLJobApiResponse['jobs'];
-  types: string[];
+  transactionTypes: string[];
   selected?: string;
   onChange: (value: string) => void;
 }
 
-export const TransactionSelect: React.SFC<TransactionSelectProps> = ({
+export function TransactionSelect({
+  serviceName,
   existingJobs,
-  types,
+  transactionTypes,
   selected,
   onChange
-}) => {
+}: TransactionSelectProps) {
   return (
     <EuiFormRow
       label={i18n.translate(
@@ -43,38 +46,39 @@ export const TransactionSelect: React.SFC<TransactionSelectProps> = ({
       <EuiSuperSelect
         valueOfSelected={selected}
         onChange={onChange}
-        options={types.map((type, i) => ({
-          value: type,
-          inputDisplay: type,
-          dropdownDisplay: (
-            <EuiFlexGroup justifyContent="spaceBetween">
-              <EuiFlexItem>
-                <EuiText>{type}</EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                {Boolean(
-                  existingJobs.find(
-                    job => job.jobId && job.jobId.includes(type)
-                  )
-                ) ? (
-                  <EuiToolTip
-                    content={i18n.translate(
-                      'xpack.apm.serviceDetails.enableAnomalyDetectionPanel.existedJobTooltip',
-                      {
-                        defaultMessage: 'ML job exists for this type'
-                      }
-                    )}
-                  >
-                    <EuiIcon type="machineLearningApp" />
-                  </EuiToolTip>
-                ) : (
-                  <EuiIcon type="empty" />
-                )}
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          )
-        }))}
+        options={transactionTypes.map(transactionType => {
+          const hasMlJobs = existingJobs.some(
+            job => job.job_id === getMlJobId(serviceName, transactionType)
+          );
+          return {
+            value: transactionType,
+            inputDisplay: transactionType,
+            dropdownDisplay: (
+              <EuiFlexGroup justifyContent="spaceBetween">
+                <EuiFlexItem>
+                  <EuiText>{transactionType}</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  {hasMlJobs ? (
+                    <EuiToolTip
+                      content={i18n.translate(
+                        'xpack.apm.serviceDetails.enableAnomalyDetectionPanel.existedJobTooltip',
+                        {
+                          defaultMessage: 'ML job exists for this type'
+                        }
+                      )}
+                    >
+                      <EuiIcon type="machineLearningApp" />
+                    </EuiToolTip>
+                  ) : (
+                    <EuiIcon type="empty" />
+                  )}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            )
+          };
+        })}
       />
     </EuiFormRow>
   );
-};
+}

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
@@ -9,6 +9,7 @@ import { isEmpty } from 'lodash';
 import chrome from 'ui/chrome';
 import url from 'url';
 import uuid from 'uuid';
+import { StringMap } from 'x-pack/plugins/apm/typings/common';
 import {
   ERROR_CULPRIT,
   ERROR_EXC_HANDLED,
@@ -49,8 +50,8 @@ interface Arguments {
 
 interface Actions {
   log_error: { logging: { text: string } };
-  slack_webhook?: { [key: string]: any };
-  email?: { [key: string]: any };
+  slack_webhook?: StringMap;
+  email?: StringMap;
 }
 
 export async function createErrorGroupWatch({

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
@@ -13,7 +13,7 @@ import { KibanaLink } from 'x-pack/plugins/apm/public/components/shared/Links/Ki
 import { IServiceListItem } from 'x-pack/plugins/apm/server/lib/services/get_services';
 import { fontSizes, truncate } from '../../../../style/variables';
 import { asDecimal, asMillis } from '../../../../utils/formatters';
-import { ManagedTable } from '../../../shared/ManagedTable';
+import { ITableColumn, ManagedTable } from '../../../shared/ManagedTable';
 
 interface Props {
   items: IServiceListItem[];
@@ -39,7 +39,7 @@ const AppLink = styled(KibanaLink)`
   ${truncate('100%')};
 `;
 
-export const SERVICE_COLUMNS = [
+export const SERVICE_COLUMNS: Array<ITableColumn<IServiceListItem>> = [
   {
     field: 'serviceName',
     name: i18n.translate('xpack.apm.servicesTable.nameColumnLabel', {

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -34,7 +34,7 @@ const traceListColumns: Array<ITableColumn<ITransactionGroup>> = [
     }),
     width: '40%',
     sortable: true,
-    render: (name, group: ITransactionGroup) => (
+    render: (name: string, group: ITransactionGroup) => (
       <EuiToolTip id="trace-transaction-link-tooltip" content={name}>
         <StyledTransactionLink transaction={group.sample}>
           {name}

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -26,7 +26,7 @@ interface Props {
   isLoading: boolean;
 }
 
-const traceListColumns: ITableColumn[] = [
+const traceListColumns: Array<ITableColumn<ITransactionGroup>> = [
   {
     field: 'name',
     name: i18n.translate('xpack.apm.tracesTable.nameColumnLabel', {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/WaterfallItem.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/WaterfallItem.tsx
@@ -80,7 +80,7 @@ interface IWaterfallItemProps {
   item: IWaterfallItem;
   color: string;
   isSelected: boolean;
-  onClick: () => any;
+  onClick: () => unknown;
 }
 
 function PrefixIcon({ item }: { item: IWaterfallItem }) {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -15,6 +15,7 @@ import {
   uniq,
   zipObject
 } from 'lodash';
+import { StringMap } from 'x-pack/plugins/apm/typings/common';
 import { Span } from '../../../../../../../../typings/es_schemas/Span';
 import { Transaction } from '../../../../../../../../typings/es_schemas/Transaction';
 
@@ -191,9 +192,7 @@ function getServices(items: IWaterfallItem[]) {
   return uniq(serviceNames);
 }
 
-export interface IServiceColors {
-  [key: string]: string;
-}
+export type IServiceColors = StringMap<string>;
 
 function getServiceColors(services: string[]) {
   const assignedColors = [

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export function TransactionList({ items, serviceName, ...rest }: Props) {
-  const columns: ITableColumn[] = [
+  const columns: Array<ITableColumn<ITransactionGroup>> = [
     {
       field: 'name',
       name: i18n.translate('xpack.apm.transactionsTable.nameColumnLabel', {

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -36,7 +36,7 @@ export function TransactionList({ items, serviceName, ...rest }: Props) {
       }),
       width: '50%',
       sortable: true,
-      render: (transactionName, data) => {
+      render: (transactionName: string, data) => {
         const encodedType = legacyEncodeURIComponent(
           data.sample.transaction.type
         );
@@ -65,7 +65,7 @@ export function TransactionList({ items, serviceName, ...rest }: Props) {
       ),
       sortable: true,
       dataType: 'number',
-      render: value => asMillis(value)
+      render: (value: number) => asMillis(value)
     },
     {
       field: 'p95',
@@ -77,7 +77,7 @@ export function TransactionList({ items, serviceName, ...rest }: Props) {
       ),
       sortable: true,
       dataType: 'number',
-      render: value => asMillis(value)
+      render: (value: number) => asMillis(value)
     },
     {
       field: 'transactionsPerMinute',
@@ -89,7 +89,7 @@ export function TransactionList({ items, serviceName, ...rest }: Props) {
       ),
       sortable: true,
       dataType: 'number',
-      render: value =>
+      render: (value: number) =>
         `${asDecimal(value)} ${i18n.translate(
           'xpack.apm.transactionsTable.transactionsPerMinuteUnitLabel',
           {
@@ -104,7 +104,7 @@ export function TransactionList({ items, serviceName, ...rest }: Props) {
       }),
       sortable: true,
       dataType: 'number',
-      render: value => <ImpactBar value={value} />
+      render: (value: number) => <ImpactBar value={value} />
     }
   ];
 

--- a/x-pack/plugins/apm/public/components/shared/ImpactBar/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ImpactBar/index.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { StringMap } from '../../../../typings/common';
 
 // TODO: extend from EUI's EuiProgress prop interface
-export interface ImpactBarProps extends StringMap<any> {
+export interface ImpactBarProps extends StringMap {
   value: number;
   max?: number;
 }

--- a/x-pack/plugins/apm/public/components/shared/Links/DiscoverLinks/QueryWithIndexPattern.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/DiscoverLinks/QueryWithIndexPattern.tsx
@@ -32,7 +32,7 @@ export function getQueryWithIndexPattern(
 
 interface Props {
   query: QueryParamsDecoded;
-  children: (query: QueryParamsDecoded) => ReactElement<any>;
+  children: (query: QueryParamsDecoded) => ReactElement<unknown>;
 }
 
 interface State {

--- a/x-pack/plugins/apm/public/components/shared/Links/MLJobLink.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/MLJobLink.test.tsx
@@ -34,7 +34,7 @@ describe('MLJobLink', () => {
     );
 
     expect(wrapper.prop('href')).toBe(
-      '/app/ml#/timeseriesexplorer?_g=(ml:(jobIds:!(myServiceName-myTransactionType-high_mean_response_time)),time:(from:now-24h,mode:quick,to:now))'
+      '/app/ml#/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),time:(from:now-24h,mode:quick,to:now))'
     );
   });
 });

--- a/x-pack/plugins/apm/public/components/shared/Links/MLJobLink.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/MLJobLink.tsx
@@ -7,6 +7,7 @@
 import { EuiLink } from '@elastic/eui';
 import { Location } from 'history';
 import React from 'react';
+import { getMlJobId } from 'x-pack/plugins/apm/common/ml_job_constants';
 import { getKibanaHref } from './url_helpers';
 
 interface Props {
@@ -23,8 +24,7 @@ export const MLJobLink: React.SFC<Props> = ({
 }) => {
   const pathname = '/app/ml';
   const hash = '/timeseriesexplorer';
-  const maybeTransactionType = transactionType ? transactionType + '-' : '';
-  const jobId = `${serviceName}-${maybeTransactionType}high_mean_response_time`;
+  const jobId = getMlJobId(serviceName, transactionType);
   const query = {
     _g: { ml: { jobIds: [jobId] } }
   };

--- a/x-pack/plugins/apm/public/components/shared/Links/__snapshots__/MLJobLink.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/Links/__snapshots__/MLJobLink.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`MLJobLink should render component 1`] = `
 <EuiLink
   color="primary"
-  href="/app/ml#/timeseriesexplorer?_g=(ml:(jobIds:!(myServiceName-myTransactionType-high_mean_response_time)),time:(from:now-24h,mode:quick,to:now))"
+  href="/app/ml#/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),time:(from:now-24h,mode:quick,to:now))"
   type="button"
 />
 `;

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -135,8 +135,8 @@ interface RisonEncoded {
 }
 
 interface RisonDecoded {
-  _g?: StringMap;
-  _a?: StringMap;
+  _g?: StringMap<any>;
+  _a?: StringMap<any>;
 }
 
 export type QueryParams = APMQueryParams & RisonEncoded;

--- a/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -11,7 +11,7 @@ import { idx } from 'x-pack/plugins/apm/common/idx';
 
 // TODO: this should really be imported from EUI
 export interface ITableColumn<T> {
-  field: string;
+  field: keyof T;
   name: string;
   dataType?: string;
   align?: string;
@@ -35,7 +35,7 @@ interface Props<T> {
   initialPageSize?: number;
   hidePerPageOptions?: boolean;
   initialSort?: {
-    field: string;
+    field: keyof T;
     direction: 'asc' | 'desc';
   };
   noItemsMessage?: React.ReactNode;

--- a/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -11,7 +11,7 @@ import { idx } from 'x-pack/plugins/apm/common/idx';
 
 // TODO: this should really be imported from EUI
 export interface ITableColumn<T> {
-  field: keyof T;
+  field: string;
   name: string;
   dataType?: string;
   align?: string;

--- a/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -8,22 +8,29 @@ import { EuiBasicTable } from '@elastic/eui';
 import { sortByOrder } from 'lodash';
 import React, { Component } from 'react';
 import { idx } from 'x-pack/plugins/apm/common/idx';
-import { StringMap } from '../../../../typings/common';
 
 // TODO: this should really be imported from EUI
-export interface ITableColumn {
+export interface ITableColumn<T> {
   field: string;
   name: string;
   dataType?: string;
   align?: string;
   width?: string;
   sortable?: boolean;
-  render?: (value: any, item?: any) => unknown;
+  render?: (value: any, item: T) => unknown;
 }
 
-export interface IManagedTableProps {
-  items: Array<StringMap<any>>;
-  columns: ITableColumn[];
+interface IState {
+  page: { index: number; size: number };
+  sort: {
+    field: string;
+    direction: string;
+  };
+}
+
+interface Props<T> {
+  items: T[];
+  columns: Array<ITableColumn<T>>;
   initialPageIndex?: number;
   initialPageSize?: number;
   hidePerPageOptions?: boolean;
@@ -34,8 +41,8 @@ export interface IManagedTableProps {
   noItemsMessage?: React.ReactNode;
 }
 
-export class ManagedTable extends Component<IManagedTableProps, any> {
-  constructor(props: IManagedTableProps) {
+export class ManagedTable<T> extends Component<Props<T>, IState> {
+  constructor(props: Props<T>) {
     super(props);
 
     const defaultSort = {
@@ -55,13 +62,13 @@ export class ManagedTable extends Component<IManagedTableProps, any> {
     };
   }
 
-  public onTableChange = ({ page = {}, sort = {} }) => {
+  public onTableChange = ({ page, sort }: IState) => {
     this.setState({ page, sort });
   };
 
   public getCurrentItems() {
     const { items } = this.props;
-    const { sort = {}, page = {} } = this.state;
+    const { sort, page } = this.state;
     // TODO: Use _.orderBy once we upgrade to lodash 4+
     const sorted = sortByOrder(items, sort.field, sort.direction);
     return sorted.slice(page.index * page.size, (page.index + 1) * page.size);

--- a/x-pack/plugins/apm/public/components/shared/PropertiesTable/NestedKeyValueTable.tsx
+++ b/x-pack/plugins/apm/public/components/shared/PropertiesTable/NestedKeyValueTable.tsx
@@ -82,7 +82,7 @@ export function NestedValue({
   depth,
   keySorter
 }: {
-  value: StringMap;
+  value: unknown;
   depth: number;
   parentKey?: string;
   keySorter?: KeySorter;
@@ -90,7 +90,7 @@ export function NestedValue({
   if (depth > 0 && isObject(value)) {
     return (
       <NestedKeyValueTable
-        data={value}
+        data={value as StringMap}
         parentKey={parentKey}
         keySorter={keySorter}
         depth={depth - 1}
@@ -107,7 +107,7 @@ export function NestedKeyValueTable({
   keySorter = Object.keys,
   depth = 0
 }: {
-  data: StringMap<any>;
+  data: StringMap;
   parentKey?: string;
   keySorter?: KeySorter;
   depth?: number;

--- a/x-pack/plugins/apm/public/components/shared/PropertiesTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/PropertiesTable/index.tsx
@@ -116,7 +116,7 @@ export function PropertiesTable({
   propKey,
   agentName
 }: {
-  propData?: StringMap<any>;
+  propData?: StringMap;
   propKey: string;
   agentName?: string;
 }) {

--- a/x-pack/plugins/apm/public/services/kuery.ts
+++ b/x-pack/plugins/apm/public/services/kuery.ts
@@ -6,11 +6,15 @@
 
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { getAutocompleteProvider } from 'ui/autocomplete_providers';
+import { StaticIndexPattern } from 'ui/index_patterns';
 // @ts-ignore
 import { getFromSavedObject } from 'ui/index_patterns/static_utils';
 import { getAPMIndexPattern } from './rest/savedObjects';
 
-export function convertKueryToEsQuery(kuery: string, indexPattern: any) {
+export function convertKueryToEsQuery(
+  kuery: string,
+  indexPattern: StaticIndexPattern
+) {
   const ast = fromKueryExpression(kuery);
   return toElasticsearchQuery(ast, indexPattern);
 }
@@ -18,8 +22,8 @@ export function convertKueryToEsQuery(kuery: string, indexPattern: any) {
 export async function getSuggestions(
   query: string,
   selectionStart: number,
-  apmIndexPattern: any,
-  boolFilter: any
+  apmIndexPattern: StaticIndexPattern,
+  boolFilter: unknown
 ) {
   const autocompleteProvider = getAutocompleteProvider('kuery');
   if (!autocompleteProvider) {
@@ -41,13 +45,8 @@ export async function getSuggestions(
   });
 }
 
-interface IIndexPatternForKuery {
-  title: string;
-  fields: any[];
-}
-
 export async function getAPMIndexPatternForKuery(): Promise<
-  IIndexPatternForKuery | undefined
+  StaticIndexPattern | undefined
 > {
   const apmIndexPattern = await getAPMIndexPattern();
   if (!apmIndexPattern) {

--- a/x-pack/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/plugins/apm/public/services/rest/ml.ts
@@ -7,17 +7,15 @@
 import { ESFilter } from 'elasticsearch';
 import chrome from 'ui/chrome';
 import {
+  getMlJobId,
+  getMlPrefix
+} from 'x-pack/plugins/apm/common/ml_job_constants';
+import {
   PROCESSOR_EVENT,
   SERVICE_NAME,
   TRANSACTION_TYPE
 } from '../../../common/elasticsearch_fieldnames';
 import { callApi } from './callApi';
-
-export function getMlPrefix(serviceName: string, transactionType?: string) {
-  return `${serviceName}-${
-    transactionType ? transactionType + '-' : ''
-  }`.toLowerCase();
-}
 
 interface MlResponseItem {
   id: string;
@@ -73,14 +71,12 @@ export interface MLJobApiResponse {
   count: number;
   jobs: Array<{
     job_id: string;
-    [key: string]: any;
   }>;
 }
 
 export async function getMLJob({
   serviceName,
-  transactionType,
-  anomalyName = 'high_mean_response_time'
+  transactionType
 }: {
   serviceName: string;
   transactionType?: string;
@@ -88,9 +84,9 @@ export async function getMLJob({
 }) {
   return callApi<MLJobApiResponse>({
     method: 'GET',
-    pathname: `/api/ml/anomaly_detectors/${getMlPrefix(
+    pathname: `/api/ml/anomaly_detectors/${getMlJobId(
       serviceName,
       transactionType
-    )}${anomalyName}`
+    )}`
   });
 }

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/__test__/apm_telemetry.test.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/__test__/apm_telemetry.test.ts
@@ -4,10 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { SavedObjectAttributes } from 'src/server/saved_objects/service/saved_objects_client';
 import {
   AgentName,
   APM_TELEMETRY_DOC_ID,
-  ApmTelemetry,
   createApmTelementry,
   getSavedObjectsClient,
   storeApmTelemetry
@@ -48,7 +48,7 @@ describe('apm_telemetry', () => {
 
   describe('storeApmTelemetry', () => {
     let server: any;
-    let apmTelemetry: ApmTelemetry;
+    let apmTelemetry: SavedObjectAttributes;
     let savedObjectsClientInstance: any;
 
     beforeEach(() => {

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/apm_telemetry.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/apm_telemetry.ts
@@ -6,6 +6,7 @@
 
 import { Server } from 'hapi';
 import { countBy } from 'lodash';
+import { SavedObjectAttributes } from 'src/server/saved_objects/service/saved_objects_client';
 
 // Support telemetry for additional agent types by appending definitions in
 // mappings.json and the AgentName enum.
@@ -19,16 +20,11 @@ export enum AgentName {
   GoLang = 'go'
 }
 
-export interface ApmTelemetry {
-  has_any_services: boolean;
-  services_per_agent: { [agentName in AgentName]?: number };
-}
-
 export const APM_TELEMETRY_DOC_ID = 'apm-telemetry';
 
 export function createApmTelementry(
   agentNames: AgentName[] = []
-): ApmTelemetry {
+): SavedObjectAttributes {
   const validAgentNames = agentNames.filter(agentName =>
     Object.values(AgentName).includes(agentName)
   );
@@ -40,7 +36,7 @@ export function createApmTelementry(
 
 export function storeApmTelemetry(
   server: Server,
-  apmTelemetry: ApmTelemetry
+  apmTelemetry: SavedObjectAttributes
 ): void {
   const savedObjectsClient = getSavedObjectsClient(server);
   savedObjectsClient.create('apm-telemetry', apmTelemetry, {
@@ -49,7 +45,7 @@ export function storeApmTelemetry(
   });
 }
 
-export function getSavedObjectsClient(server: Server): any {
+export function getSavedObjectsClient(server: Server) {
   const { SavedObjectsClient, getSavedObjectsRepository } = server.savedObjects;
   const { callWithInternalUser } = server.plugins.elasticsearch.getCluster(
     'admin'

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
@@ -5,7 +5,6 @@
  */
 
 export {
-  ApmTelemetry,
   AgentName,
   storeApmTelemetry,
   createApmTelementry,

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/make_apm_usage_collector.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/make_apm_usage_collector.ts
@@ -7,7 +7,6 @@
 import { Server } from 'hapi';
 import {
   APM_TELEMETRY_DOC_ID,
-  ApmTelemetry,
   createApmTelementry,
   getSavedObjectsClient
 } from './apm_telemetry';
@@ -16,8 +15,8 @@ import {
 interface KibanaHapiServer extends Server {
   usage: {
     collectorSet: {
-      makeUsageCollector: any;
-      register: any;
+      makeUsageCollector: (options: unknown) => unknown;
+      register: (options: unknown) => unknown;
     };
   };
 }
@@ -25,7 +24,7 @@ interface KibanaHapiServer extends Server {
 export function makeApmUsageCollector(server: KibanaHapiServer): void {
   const apmUsageCollector = server.usage.collectorSet.makeUsageCollector({
     type: 'apm',
-    fetch: async (): Promise<ApmTelemetry> => {
+    fetch: async () => {
       const savedObjectsClient = getSavedObjectsClient(server);
       try {
         const apmTelemetrySavedObject = await savedObjectsClient.get(

--- a/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { SearchParams } from 'elasticsearch';
 import { idx } from 'x-pack/plugins/apm/common/idx';
 import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import {
@@ -41,7 +42,7 @@ export async function getErrorGroups({
 }): Promise<ErrorGroupListAPIResponse> {
   const { start, end, esFilterQuery, client, config } = setup;
 
-  const params: any = {
+  const params: SearchParams = {
     index: config.get<string>('apm_oss.errorIndices'),
     body: {
       size: 0,

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { AggregationSearchResponse } from 'elasticsearch';
+import { AggregationSearchResponse, SearchParams } from 'elasticsearch';
 import { StringMap } from 'x-pack/plugins/apm/typings/common';
 import {
   TRANSACTION_DURATION,
@@ -43,7 +43,7 @@ export function transactionGroupsFetcher(
   bodyQuery: StringMap
 ): Promise<ESResponse> {
   const { esFilterQuery, client, config } = setup;
-  const params = {
+  const params: SearchParams = {
     index: config.get<string>('apm_oss.transactionIndices'),
     body: {
       size: 0,

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/fetcher.ts
@@ -5,6 +5,7 @@
  */
 
 import { AggregationSearchResponse } from 'elasticsearch';
+import { getMlIndex } from 'x-pack/plugins/apm/common/ml_job_constants';
 import { Setup } from '../../../helpers/setup_request';
 
 export interface ESBucket {
@@ -50,7 +51,7 @@ export async function anomalySeriesFetcher({
   const newStart = start - mlBucketSize * 1000;
 
   const params = {
-    index: `.ml-anomalies-${serviceName}-${transactionType}-high_mean_response_time`.toLowerCase(),
+    index: getMlIndex(serviceName, transactionType),
     body: {
       size: 0,
       query: {

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/get_ml_bucket_size.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/get_ml_bucket_size.ts
@@ -5,6 +5,7 @@
  */
 
 import { idx } from 'x-pack/plugins/apm/common/idx';
+import { getMlIndex } from 'x-pack/plugins/apm/common/ml_job_constants';
 import { Setup } from '../../../helpers/setup_request';
 
 interface IOptions {
@@ -24,7 +25,7 @@ export async function getMlBucketSize({
 }: IOptions): Promise<number> {
   const { client, start, end } = setup;
   const params = {
-    index: `.ml-anomalies-${serviceName}-${transactionType}-high_mean_response_time`.toLowerCase(),
+    index: getMlIndex(serviceName, transactionType),
     body: {
       _source: 'bucket_span',
       size: 1,

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
@@ -4,7 +4,11 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { AggregationSearchResponse, ESFilter } from 'elasticsearch';
+import {
+  AggregationSearchResponse,
+  ESFilter,
+  SearchParams
+} from 'elasticsearch';
 import {
   PROCESSOR_EVENT,
   SERVICE_NAME,
@@ -101,7 +105,7 @@ export function timeseriesFetcher({
     filter.push(esFilterQuery);
   }
 
-  const params: any = {
+  const params: SearchParams = {
     index: config.get('apm_oss.transactionIndices'),
     body: {
       size: 0,

--- a/x-pack/plugins/apm/typings/common.ts
+++ b/x-pack/plugins/apm/typings/common.ts
@@ -4,6 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export interface StringMap<T = any> {
+export interface StringMap<T = unknown> {
   [key: string]: T;
 }


### PR DESCRIPTION
`any` is an escape hatch and should almost never be used. `unknown` is mostly a better, safer alternative.
While converting `any` to `unknown` I uncovered 1 production bug related to ML integration, and a typo in a shared interface.