### PR TITLE
Fixes #23821 - Change link to traces

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
@@ -59,7 +59,7 @@ export const NodeContextMenu = injectI18n(
         },
         { nodeType }
       ),
-      href: `../app/apm#/services?_g=()&kuery=${APM_FIELDS[nodeType]}~20~3A~20~22${node.id}~22`,
+      href: `../app/apm#/traces?_g=()&kuery=${APM_FIELDS[nodeType]}~20~3A~20~22${node.id}~22`,
     };
 
     const panels: EuiContextMenuPanelDescriptor[] = [


### PR DESCRIPTION
Fixes elastic/kibana#23821 by changing the link from `../app/apm#/services` to `../app/apm#/traces`

@makwarth I tested this in my env and it seems to work. I just need you to double check that everything works as expected on the APM side.