### PR TITLE
[6.x] Fixes #23821 - Change link to traces (#29972)

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
@@ -59,7 +59,7 @@ export const NodeContextMenu = injectI18n(
         },
         { nodeType }
       ),
-      href: `../app/apm#/services?_g=()&kuery=${APM_FIELDS[nodeType]}~20~3A~20~22${node.id}~22`,
+      href: `../app/apm#/traces?_g=()&kuery=${APM_FIELDS[nodeType]}~20~3A~20~22${node.id}~22`,
     };
 
     const panels: EuiContextMenuPanelDescriptor[] = [


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fixes #23821 - Change link to traces  (#29972)