### PR TITLE
[Infra UI] Add check to make sure EuiContextMenu popover needs to be closed

### DIFF
--- a/x-pack/plugins/infra/public/components/nodes_overview/table.tsx
+++ b/x-pack/plugins/infra/public/components/nodes_overview/table.tsx
@@ -159,9 +159,13 @@ export const TableView = injectI18n(
     };
 
     private closePopoverFor = (id: string) => () => {
-      this.setState(prevState => ({
-        isPopoverOpen: prevState.isPopoverOpen.filter(subject => subject !== id),
-      }));
+      if (this.state.isPopoverOpen.includes(id)) {
+        this.setState(prevState => {
+          return {
+            isPopoverOpen: prevState.isPopoverOpen.filter(subject => subject !== id),
+          };
+        });
+      }
     };
   }
 );

--- a/x-pack/plugins/infra/public/components/waffle/node.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node.tsx
@@ -90,7 +90,9 @@ export class Node extends React.PureComponent<Props, State> {
   };
 
   private closePopover = () => {
-    this.setState({ isPopoverOpen: false });
+    if (this.state.isPopoverOpen) {
+      this.setState({ isPopoverOpen: false });
+    }
   };
 }
 


### PR DESCRIPTION
This PR adds check to the on close handlers for `EuiContextMenu` to ensure they are handling an actual open context menu. The is necessary because the `EuiOutsideClickDetector` calls ALL `onClose` handlers globally. If the checks are not in place ALL the `setState` calls will trigger a `render`.