### PR TITLE
EUI 6.10.0 & Background color fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "6.9.0",
+    "@elastic/eui": "6.10.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "8.1.1-kibana2",
     "@elastic/numeral": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "6.8.0",
+    "@elastic/eui": "6.9.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "8.1.1-kibana2",
     "@elastic/numeral": "2.3.2",

--- a/src/legacy/core_plugins/console/public/_app.scss
+++ b/src/legacy/core_plugins/console/public/_app.scss
@@ -3,7 +3,6 @@
   flex: 1 1 auto;
   position: relative;
   padding: $euiSizeS;
-  background-color: $euiPageBackgroundColor;
   // Make sure the editor actions don't create scrollbars on this container
   // SASSTODO: Uncomment when tooltips are EUI-ified (inside portals)
   // overflow: hidden;

--- a/src/legacy/core_plugins/console/public/_app.scss
+++ b/src/legacy/core_plugins/console/public/_app.scss
@@ -3,7 +3,7 @@
   flex: 1 1 auto;
   position: relative;
   padding: $euiSizeS;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   // Make sure the editor actions don't create scrollbars on this container
   // SASSTODO: Uncomment when tooltips are EUI-ified (inside portals)
   // overflow: hidden;

--- a/src/legacy/core_plugins/kibana/public/dashboard/_dashboard_app.scss
+++ b/src/legacy/core_plugins/kibana/public/dashboard/_dashboard_app.scss
@@ -2,11 +2,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  background-color: $euiColorEmptyShade;
-}
-
-.dshAppContainer--withMargins {
-  background-color: $euiColorLightestShade;
 }
 
 .dshStartScreen {

--- a/src/legacy/core_plugins/kibana/public/dashboard/_hacks.scss
+++ b/src/legacy/core_plugins/kibana/public/dashboard/_hacks.scss
@@ -4,7 +4,7 @@
  * Mimics EuiPageBackground
  */
 dashboard-listing {
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   min-height: 100vh;
 }
 

--- a/src/legacy/core_plugins/kibana/public/dashboard/_hacks.scss
+++ b/src/legacy/core_plugins/kibana/public/dashboard/_hacks.scss
@@ -1,14 +1,6 @@
 // ANGULAR SELECTOR HACKS
 
 /**
- * Mimics EuiPageBackground
- */
-dashboard-listing {
-  background-color: $euiPageBackgroundColor;
-  min-height: 100vh;
-}
-
-/**
  * Needs to correspond with the react root nested inside angular.
  */
  dashboard-viewport-provider {

--- a/src/legacy/core_plugins/kibana/public/dashboard/viewport/_dashboard_viewport.scss
+++ b/src/legacy/core_plugins/kibana/public/dashboard/viewport/_dashboard_viewport.scss
@@ -5,5 +5,4 @@
 
 .dshDashboardViewport-withMargins {
   width: 100%;
-  background-color: $euiPageBackgroundColor;
 }

--- a/src/legacy/core_plugins/kibana/public/discover/_discover.scss
+++ b/src/legacy/core_plugins/kibana/public/discover/_discover.scss
@@ -1,3 +1,7 @@
+discover-app {
+  background-color: $euiColorEmptyShade;
+}
+
 // SASSTODO: replace the margin-top value with a variable
 .dscSidebar__listHeader {
   margin-top: 5px;
@@ -175,6 +179,7 @@
 }
 
 .dscResults {
+
   h3 {
     margin: -20px 0 10px 0;
     text-align: center;

--- a/src/legacy/core_plugins/kibana/public/home/_home.scss
+++ b/src/legacy/core_plugins/kibana/public/home/_home.scss
@@ -1,5 +1,5 @@
 home-app {
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 }
 
 .homPage {

--- a/src/legacy/core_plugins/kibana/public/home/_home.scss
+++ b/src/legacy/core_plugins/kibana/public/home/_home.scss
@@ -1,7 +1,3 @@
-home-app {
-  background-color: $euiPageBackgroundColor;
-}
-
 .homPage {
   min-height: 100vh;
   max-width: 1200px;

--- a/src/legacy/core_plugins/kibana/public/home/_home.scss
+++ b/src/legacy/core_plugins/kibana/public/home/_home.scss
@@ -1,5 +1,4 @@
 .homPage {
-  min-height: 100vh;
   max-width: 1200px;
   margin: auto;
 }

--- a/src/legacy/core_plugins/kibana/public/home/components/tutorial/__snapshots__/saved_objects_installer.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/home/components/tutorial/__snapshots__/saved_objects_installer.test.js.snap
@@ -195,8 +195,13 @@ exports[`bulkCreate should display error message when bulkCreate request fails 1
             <span
               className="euiScreenReaderOnly"
             >
-              Incomplete
-               Step 
+              <EuiI18n
+                default="Incomplete Step"
+                token="euiStep.incompleteStep"
+              >
+                Incomplete Step
+              </EuiI18n>
+               
             </span>
           </EuiScreenReaderOnly>
           <EuiStepNumber
@@ -524,7 +529,13 @@ exports[`bulkCreate should display success message when bulkCreate is successful
             <span
               className="euiScreenReaderOnly"
             >
-               Step 
+              <EuiI18n
+                default="Step"
+                token="euiStep.completeStep"
+              >
+                Step
+              </EuiI18n>
+               
             </span>
           </EuiScreenReaderOnly>
           <EuiStepNumber
@@ -536,23 +547,17 @@ exports[`bulkCreate should display success message when bulkCreate is successful
             <div
               className="euiStepNumber euiStepNumber--complete euiStep__circle"
             >
-              <EuiIcon
-                className="euiStepNumber__icon"
-                size="m"
-                title="complete"
-                type="check"
+              <EuiI18n
+                default="complete"
+                token="euiStepNumber.isComplete"
               >
-                <check
-                  className="euiIcon euiIcon--medium euiStepNumber__icon"
-                  focusable="false"
-                  height="16"
-                  style={null}
+                <EuiIcon
+                  className="euiStepNumber__icon"
+                  size="m"
                   title="complete"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
+                  type="check"
                 >
-                  <svg
+                  <check
                     className="euiIcon euiIcon--medium euiStepNumber__icon"
                     focusable="false"
                     height="16"
@@ -562,13 +567,24 @@ exports[`bulkCreate should display success message when bulkCreate is successful
                     width="16"
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </check>
-              </EuiIcon>
+                    <svg
+                      className="euiIcon euiIcon--medium euiStepNumber__icon"
+                      focusable="false"
+                      height="16"
+                      style={null}
+                      title="complete"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </check>
+                </EuiIcon>
+              </EuiI18n>
             </div>
           </EuiStepNumber>
           <EuiTitle

--- a/src/legacy/core_plugins/kibana/public/management/_hacks.scss
+++ b/src/legacy/core_plugins/kibana/public/management/_hacks.scss
@@ -12,7 +12,6 @@ kbn-management-objects-view {
 
 // SASSTODO: Remove when Kibana has a proper background color
 kbn-management-objects, kbn-management-app, .tab-management {
-  background: $euiPageBackgroundColor;
   flex-grow: 1;
 }
 

--- a/src/legacy/core_plugins/kibana/public/management/_hacks.scss
+++ b/src/legacy/core_plugins/kibana/public/management/_hacks.scss
@@ -10,11 +10,6 @@ kbn-management-objects-view {
   display: block;
 }
 
-// SASSTODO: Remove when Kibana has a proper background color
-kbn-management-objects, kbn-management-app, .tab-management {
-  flex-grow: 1;
-}
-
 #management-landing {
   display: flex;
 }

--- a/src/legacy/core_plugins/kibana/public/management/_hacks.scss
+++ b/src/legacy/core_plugins/kibana/public/management/_hacks.scss
@@ -12,7 +12,7 @@ kbn-management-objects-view {
 
 // SASSTODO: Remove when Kibana has a proper background color
 kbn-management-objects, kbn-management-app, .tab-management {
-  background: $euiColorLightestShade;
+  background: $euiPageBackgroundColor;
   flex-grow: 1;
 }
 

--- a/src/legacy/core_plugins/kibana/public/visualize/wizard/__snapshots__/new_vis_modal.test.tsx.snap
+++ b/src/legacy/core_plugins/kibana/public/visualize/wizard/__snapshots__/new_vis_modal.test.tsx.snap
@@ -387,38 +387,32 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
               }
               tabIndex={0}
             >
-              <EuiButtonIcon
-                aria-label="Closes this modal window"
-                className="euiModal__closeIcon"
-                color="text"
-                iconSize="m"
-                iconType="cross"
-                onClick={[Function]}
-                type="button"
+              <EuiI18n
+                default="Closes this modal window"
+                token="euiModal.closeModal"
               >
-                <button
+                <EuiButtonIcon
                   aria-label="Closes this modal window"
-                  className="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+                  className="euiModal__closeIcon"
+                  color="text"
+                  iconSize="m"
+                  iconType="cross"
                   onClick={[Function]}
                   type="button"
                 >
-                  <EuiIcon
-                    aria-hidden="true"
-                    className="euiButtonIcon__icon"
-                    size="m"
-                    type="cross"
+                  <button
+                    aria-label="Closes this modal window"
+                    className="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <cross
+                    <EuiIcon
                       aria-hidden="true"
-                      className="euiIcon euiIcon--medium euiButtonIcon__icon"
-                      focusable="false"
-                      height="16"
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="euiButtonIcon__icon"
+                      size="m"
+                      type="cross"
                     >
-                      <svg
+                      <cross
                         aria-hidden="true"
                         className="euiIcon euiIcon--medium euiButtonIcon__icon"
                         focusable="false"
@@ -428,14 +422,25 @@ exports[`NewVisModal filter for visualization types should render as expected 1`
                         width="16"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M7.293 8L3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8z"
-                        />
-                      </svg>
-                    </cross>
-                  </EuiIcon>
-                </button>
-              </EuiButtonIcon>
+                        <svg
+                          aria-hidden="true"
+                          className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.293 8L3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8z"
+                          />
+                        </svg>
+                      </cross>
+                    </EuiIcon>
+                  </button>
+                </EuiButtonIcon>
+              </EuiI18n>
               <div
                 className="euiModal__flex"
               >
@@ -1325,38 +1330,32 @@ exports[`NewVisModal should render as expected 1`] = `
               }
               tabIndex={0}
             >
-              <EuiButtonIcon
-                aria-label="Closes this modal window"
-                className="euiModal__closeIcon"
-                color="text"
-                iconSize="m"
-                iconType="cross"
-                onClick={[Function]}
-                type="button"
+              <EuiI18n
+                default="Closes this modal window"
+                token="euiModal.closeModal"
               >
-                <button
+                <EuiButtonIcon
                   aria-label="Closes this modal window"
-                  className="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+                  className="euiModal__closeIcon"
+                  color="text"
+                  iconSize="m"
+                  iconType="cross"
                   onClick={[Function]}
                   type="button"
                 >
-                  <EuiIcon
-                    aria-hidden="true"
-                    className="euiButtonIcon__icon"
-                    size="m"
-                    type="cross"
+                  <button
+                    aria-label="Closes this modal window"
+                    className="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <cross
+                    <EuiIcon
                       aria-hidden="true"
-                      className="euiIcon euiIcon--medium euiButtonIcon__icon"
-                      focusable="false"
-                      height="16"
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
+                      className="euiButtonIcon__icon"
+                      size="m"
+                      type="cross"
                     >
-                      <svg
+                      <cross
                         aria-hidden="true"
                         className="euiIcon euiIcon--medium euiButtonIcon__icon"
                         focusable="false"
@@ -1366,14 +1365,25 @@ exports[`NewVisModal should render as expected 1`] = `
                         width="16"
                         xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M7.293 8L3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8z"
-                        />
-                      </svg>
-                    </cross>
-                  </EuiIcon>
-                </button>
-              </EuiButtonIcon>
+                        <svg
+                          aria-hidden="true"
+                          className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.293 8L3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8z"
+                          />
+                        </svg>
+                      </cross>
+                    </EuiIcon>
+                  </button>
+                </EuiButtonIcon>
+              </EuiI18n>
               <div
                 className="euiModal__flex"
               >

--- a/src/legacy/core_plugins/kibana/public/visualize/wizard/_wizard.scss
+++ b/src/legacy/core_plugins/kibana/public/visualize/wizard/_wizard.scss
@@ -11,7 +11,7 @@
 
   .visWizard__row {
     flex: 1;
-    background-color: $euiColorLightestShade;
+    background-color: $euiColorEmptyShade;
   }
 
   .visWizard__column--small {

--- a/src/legacy/core_plugins/metrics/public/components/_series_editor.scss
+++ b/src/legacy/core_plugins/metrics/public/components/_series_editor.scss
@@ -2,7 +2,6 @@
 
 .tvbSeriesEditor__container {
   padding: $euiSize;
-  background-color: $euiColorLightestShade;
 }
 
 @include euiPanel('tvbSeriesEditor');

--- a/src/legacy/core_plugins/metrics/public/components/_vis_editor.scss
+++ b/src/legacy/core_plugins/metrics/public/components/_vis_editor.scss
@@ -1,4 +1,3 @@
 .tvbEditor {
   flex: 1;
-  background: $euiPageBackgroundColor;
 }

--- a/src/legacy/core_plugins/metrics/public/components/_vis_editor.scss
+++ b/src/legacy/core_plugins/metrics/public/components/_vis_editor.scss
@@ -1,4 +1,4 @@
 .tvbEditor {
   flex: 1;
-  background: $euiColorLightestShade;
+  background: $euiPageBackgroundColor;
 }

--- a/src/legacy/core_plugins/metrics/public/components/panel_config/_panel_config.scss
+++ b/src/legacy/core_plugins/metrics/public/components/panel_config/_panel_config.scss
@@ -1,4 +1,3 @@
 .tvbPanelConfig__container {
   padding: $euiSize;
-  background-color: $euiColorLightestShade;
 }

--- a/src/legacy/core_plugins/status_page/public/index.scss
+++ b/src/legacy/core_plugins/status_page/public/index.scss
@@ -1,6 +1,1 @@
 @import 'ui/public/styles/styling_constants';
-
-// SASSTODO: Remove when K7 applies background color to body
-#status_page-app .stsPage {
-  min-height: 100vh;
-}

--- a/src/legacy/core_plugins/timelion/public/_app.scss
+++ b/src/legacy/core_plugins/timelion/public/_app.scss
@@ -1,7 +1,9 @@
-
+@import '@elastic/eui/src/components/header/variables';
 
 .timApp {
   position: relative;
+  min-height: calc(100vh - #{$euiHeaderChildSize});
+  background: $euiColorEmptyShade;
 
   [ng-click] {
     cursor: pointer;

--- a/src/ui/public/doc_viewer/_doc_viewer.scss
+++ b/src/ui/public/doc_viewer/_doc_viewer.scss
@@ -18,7 +18,8 @@
 }
 
 .kbnDocViewer__content {
-  margin: $euiSizeS 0 0 0;
+  background-color: $euiColorEmptyShade;
+  padding: $euiSizeS 0 0 0;
 }
 
 .kbnDocViewer__buttons,

--- a/src/ui/public/inspector/ui/__snapshots__/inspector_panel.test.js.snap
+++ b/src/ui/public/inspector/ui/__snapshots__/inspector_panel.test.js.snap
@@ -243,6 +243,7 @@ exports[`InspectorPanel should render as expected 1`] = `
                   repositionOnScroll={true}
                 >
                   <EuiOutsideClickDetector
+                    isDisabled={true}
                     onOutsideClick={[Function]}
                   >
                     <div

--- a/src/ui/public/kbn_top_nav/_kbn_top_nav.scss
+++ b/src/ui/public/kbn_top_nav/_kbn_top_nav.scss
@@ -3,7 +3,7 @@
  */
 
 .kbnTopNav {
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   border-bottom: $euiBorderThin;
 }
 

--- a/src/ui/public/styles/_legacy/_base.scss
+++ b/src/ui/public/styles/_legacy/_base.scss
@@ -70,7 +70,6 @@ input[type="checkbox"],
 }
 
 .application {
-  background-color: $euiColorEmptyShade;
   position: relative;
   z-index: 0;
   display: flex;

--- a/src/ui/public/styles/_legacy/components/_config.scss
+++ b/src/ui/public/styles/_legacy/components/_config.scss
@@ -5,7 +5,7 @@
   border-bottom: 1px solid transparent;
 
   .container-fluid {
-    background-color: $euiColorLightestShade;
+    background-color: $euiPageBackgroundColor;
     padding: $euiSizeS;
   }
 }

--- a/src/ui/public/styles/_mixins.scss
+++ b/src/ui/public/styles/_mixins.scss
@@ -26,7 +26,7 @@
 @mixin kibana-resizer($size: ($euiSizeM + 2px), $direction: horizontal) {
   display: flex;
   flex: 0 0 $size;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   align-items: center;
   justify-content: center;
   margin: 0;

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -120,7 +120,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "6.8.0",
+    "@elastic/eui": "6.9.0",
     "@elastic/node-crypto": "0.1.2",
     "@elastic/numeral": "2.3.2",
     "@kbn/babel-preset": "1.0.0",

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -120,7 +120,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "6.9.0",
+    "@elastic/eui": "6.10.0",
     "@elastic/node-crypto": "0.1.2",
     "@elastic/numeral": "2.3.2",
     "@kbn/babel-preset": "1.0.0",

--- a/x-pack/plugins/apm/index.js
+++ b/x-pack/plugins/apm/index.js
@@ -34,6 +34,7 @@ export function apm(kibana) {
         euiIconType: 'apmApp',
         order: 8100
       },
+      styleSheetPaths: resolve(__dirname, 'public/index.scss'),
       home: ['plugins/apm/register_feature'],
       injectDefaultVars(server) {
         const config = server.config();

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -70,9 +70,7 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
         className="euiScreenReaderOnly"
         role="status"
       >
-        Below is a table of 
-        0
-         items.
+        Below is a table of 0 items.
       </caption>
       <thead>
         <tr>
@@ -387,9 +385,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
         className="euiScreenReaderOnly"
         role="status"
       >
-        Below is a table of 
-        4
-         items.
+        Below is a table of 4 items.
       </caption>
       <thead>
         <tr>

--- a/x-pack/plugins/apm/public/index.scss
+++ b/x-pack/plugins/apm/public/index.scss
@@ -1,7 +1,7 @@
 // Import the EUI global scope so we can use EUI constants
 @import 'ui/public/styles/_styling_constants';
 
-/* Graph plugin styles */
+/* APM plugin styles */
 
 // Prefix all styles with "apm" to avoid conflicts.
 // Examples

--- a/x-pack/plugins/apm/public/index.scss
+++ b/x-pack/plugins/apm/public/index.scss
@@ -1,0 +1,16 @@
+// Import the EUI global scope so we can use EUI constants
+@import 'ui/public/styles/_styling_constants';
+
+/* Graph plugin styles */
+
+// Prefix all styles with "apm" to avoid conflicts.
+// Examples
+//   apmChart
+//   apmChart__legend
+//   apmChart__legend--small
+//   apmChart__legend-isLoading
+
+.apmReactRoot {
+  background-color: $euiColorEmptyShade;
+  overflow-x: auto;
+}

--- a/x-pack/plugins/apm/public/templates/index.html
+++ b/x-pack/plugins/apm/public/templates/index.html
@@ -2,4 +2,4 @@
   <kbn-top-nav name="apm" config="topNavMenu"></kbn-top-nav>
 </div>
 
-<div id="react-apm-root" class="apmReactRoot" style="overflow-x: auto;"></div>
+<div id="react-apm-root" class="apmReactRoot"></div>

--- a/x-pack/plugins/apm/public/templates/index.html
+++ b/x-pack/plugins/apm/public/templates/index.html
@@ -2,4 +2,4 @@
   <kbn-top-nav name="apm" config="topNavMenu"></kbn-top-nav>
 </div>
 
-<div id="react-apm-root" style="overflow-x: auto;"></div>
+<div id="react-apm-root" class="apmReactRoot" style="overflow-x: auto;"></div>

--- a/x-pack/plugins/beats_management/public/components/layouts/background.tsx
+++ b/x-pack/plugins/beats_management/public/components/layouts/background.tsx
@@ -8,5 +8,4 @@ import styled from 'styled-components';
 
 export const Background = styled.div`
   flex-grow: 1;
-  height: 100vh;
 `;

--- a/x-pack/plugins/beats_management/public/components/layouts/background.tsx
+++ b/x-pack/plugins/beats_management/public/components/layouts/background.tsx
@@ -9,5 +9,4 @@ import styled from 'styled-components';
 export const Background = styled.div`
   flex-grow: 1;
   height: 100vh;
-  background: #f5f7fa;
 `;

--- a/x-pack/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
+++ b/x-pack/plugins/canvas/public/apps/workpad/workpad_app/workpad_app.scss
@@ -1,6 +1,6 @@
 .canvasLayout {
   display: flex;
-  background: $euiColorLightestShade;
+  background: $euiPageBackgroundColor;
   flex-grow: 1;
   overflow: hidden;
 }
@@ -54,7 +54,7 @@
   flex-grow: 0;
   flex-basis: auto;
   width: 350px;
-  background: darken($euiColorLightestShade, 2%);
+  background: $euiColorLightestShade;
   display: flex;
   position: relative;
 
@@ -67,6 +67,6 @@
   flex-grow: 0;
   flex-basis: auto;
   width: 100%;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   z-index: $euiZNavigation;
 }

--- a/x-pack/plugins/canvas/public/components/toolbar/tray/tray.scss
+++ b/x-pack/plugins/canvas/public/components/toolbar/tray/tray.scss
@@ -5,6 +5,6 @@
 }
 
 .canvasTray__panel {
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   border-radius: 0;
 }

--- a/x-pack/plugins/canvas/public/style/main.scss
+++ b/x-pack/plugins/canvas/public/style/main.scss
@@ -1,7 +1,7 @@
 .canvas.canvasContainer {
   display: flex;
   flex-grow: 1;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 }
 
 .canvasContainer--loading {

--- a/x-pack/plugins/graph/public/templates/_graph.scss
+++ b/x-pack/plugins/graph/public/templates/_graph.scss
@@ -14,6 +14,7 @@
  */
 
 .gphGraph__container {
+  background: $euiColorEmptyShade;
   position: fixed;
   height: 100%;
   width: calc(100% - #{$kbnGlobalNavClosedWidth}); /* 1 */

--- a/x-pack/plugins/index_lifecycle_management/__jest__/__snapshots__/extend_index_management.test.js.snap
+++ b/x-pack/plugins/index_lifecycle_management/__jest__/__snapshots__/extend_index_management.test.js.snap
@@ -536,6 +536,7 @@ exports[`ilm summary extension should return extension when index has lifecycle 
                 withTitle={true}
               >
                 <EuiOutsideClickDetector
+                  isDisabled={true}
                   onOutsideClick={[Function]}
                 >
                   <div

--- a/x-pack/plugins/index_management/public/_index_management.scss
+++ b/x-pack/plugins/index_management/public/_index_management.scss
@@ -1,5 +1,5 @@
 #indReactRoot, #indexManagementReactRoot {
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 }
 
 .indTable {

--- a/x-pack/plugins/index_management/public/_index_management.scss
+++ b/x-pack/plugins/index_management/public/_index_management.scss
@@ -1,9 +1,4 @@
-#indReactRoot, #indexManagementReactRoot {
-  background-color: $euiPageBackgroundColor;
-}
-
 .indTable {
-
   // The index table is a bespoke table and can't make use of EuiBasicTable's width settings
   thead th.indTable__header--name {
     width: 25%;

--- a/x-pack/plugins/infra/index.ts
+++ b/x-pack/plugins/infra/index.ts
@@ -37,6 +37,7 @@ export function infra(kibana: any) {
         listed: false,
         url: `/app/${APP_ID}#/home`,
       },
+      styleSheetPaths: resolve(__dirname, 'public/index.scss'),
       home: ['plugins/infra/register_feature'],
       links: [
         {

--- a/x-pack/plugins/infra/public/index.scss
+++ b/x-pack/plugins/infra/public/index.scss
@@ -1,0 +1,20 @@
+// Import the EUI global scope so we can use EUI constants
+@import 'ui/public/styles/_styling_constants';
+
+/* Graph plugin styles */
+
+// Prefix all styles with "inf" to avoid conflicts.
+// Examples
+//   infChart
+//   infChart__legend
+//   infChart__legend--small
+//   infChart__legend-isLoading
+
+.infReactRoot {
+  background-color: $euiColorEmptyShade;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex: 1 0 0%;
+  overflow: hidden;
+}

--- a/x-pack/plugins/infra/public/index.scss
+++ b/x-pack/plugins/infra/public/index.scss
@@ -1,7 +1,7 @@
 // Import the EUI global scope so we can use EUI constants
 @import 'ui/public/styles/_styling_constants';
 
-/* Graph plugin styles */
+/* Infra plugin styles */
 
 // Prefix all styles with "inf" to avoid conflicts.
 // Examples

--- a/x-pack/plugins/infra/public/lib/adapters/framework/kibana_framework_adapter.ts
+++ b/x-pack/plugins/infra/public/lib/adapters/framework/kibana_framework_adapter.ts
@@ -118,7 +118,7 @@ export class InfraKibanaFrameworkAdapter implements InfraFrameworkAdapter {
       template: `
         <div
           id="${ROOT_ELEMENT_ID}"
-          style="display: flex; flex-direction: column; align-items: stretch; flex: 1 0 0%; overflow: hidden;"
+          class="infReactRoot"
         ></div>
       `,
     }));

--- a/x-pack/plugins/license_management/__jest__/__snapshots__/telemetry_opt_in.test.js.snap
+++ b/x-pack/plugins/license_management/__jest__/__snapshots__/telemetry_opt_in.test.js.snap
@@ -333,6 +333,7 @@ exports[`TelemetryOptIn should display when telemetry not opted in 1`] = `
               panelPaddingSize="m"
             >
               <EuiOutsideClickDetector
+                isDisabled={true}
                 onOutsideClick={[Function]}
               >
                 <div

--- a/x-pack/plugins/license_management/__jest__/__snapshots__/upload_license.test.js.snap
+++ b/x-pack/plugins/license_management/__jest__/__snapshots__/upload_license.test.js.snap
@@ -327,38 +327,32 @@ exports[`UploadLicense should display a modal when license requires acknowledgem
                               onKeyDown={[Function]}
                               tabIndex={0}
                             >
-                              <EuiButtonIcon
-                                aria-label="Closes this modal window"
-                                className="euiModal__closeIcon"
-                                color="text"
-                                iconSize="m"
-                                iconType="cross"
-                                onClick={[Function]}
-                                type="button"
+                              <EuiI18n
+                                default="Closes this modal window"
+                                token="euiModal.closeModal"
                               >
-                                <button
+                                <EuiButtonIcon
                                   aria-label="Closes this modal window"
-                                  className="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+                                  className="euiModal__closeIcon"
+                                  color="text"
+                                  iconSize="m"
+                                  iconType="cross"
                                   onClick={[Function]}
                                   type="button"
                                 >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiButtonIcon__icon"
-                                    size="m"
-                                    type="cross"
+                                  <button
+                                    aria-label="Closes this modal window"
+                                    className="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"
+                                    onClick={[Function]}
+                                    type="button"
                                   >
-                                    <cross
+                                    <EuiIcon
                                       aria-hidden="true"
-                                      className="euiIcon euiIcon--medium euiButtonIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      style={null}
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
+                                      className="euiButtonIcon__icon"
+                                      size="m"
+                                      type="cross"
                                     >
-                                      <svg
+                                      <cross
                                         aria-hidden="true"
                                         className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                         focusable="false"
@@ -368,14 +362,25 @@ exports[`UploadLicense should display a modal when license requires acknowledgem
                                         width="16"
                                         xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M7.293 8L3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8z"
-                                        />
-                                      </svg>
-                                    </cross>
-                                  </EuiIcon>
-                                </button>
-                              </EuiButtonIcon>
+                                        <svg
+                                          aria-hidden="true"
+                                          className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M7.293 8L3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8z"
+                                          />
+                                        </svg>
+                                      </cross>
+                                    </EuiIcon>
+                                  </button>
+                                </EuiButtonIcon>
+                              </EuiI18n>
                               <div
                                 className="euiModal__flex"
                               >

--- a/x-pack/plugins/maps/public/components/gis_map/_gis_map.scss
+++ b/x-pack/plugins/maps/public/components/gis_map/_gis_map.scss
@@ -1,9 +1,10 @@
 .mapMapWrapper {
+  background-color: $euiColorEmptyShade;
   position: relative;
 }
 
 .mapMapLayerPanel {
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   width: 0;
   overflow: hidden;
 

--- a/x-pack/plugins/maps/public/shared/components/_index.scss
+++ b/x-pack/plugins/maps/public/shared/components/_index.scss
@@ -1,1 +1,0 @@
-@import './map_listing';

--- a/x-pack/plugins/maps/public/shared/components/_map_listing.scss
+++ b/x-pack/plugins/maps/public/shared/components/_map_listing.scss
@@ -1,5 +1,0 @@
-// Makes sure the listing page is full height with proper background
-map-listing, {
-  min-height: 100vh;
-  background-color: $euiPageBackgroundColor;
-}

--- a/x-pack/plugins/maps/public/shared/components/_map_listing.scss
+++ b/x-pack/plugins/maps/public/shared/components/_map_listing.scss
@@ -1,5 +1,5 @@
 // Makes sure the listing page is full height with proper background
 map-listing, {
   min-height: 100vh;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 }

--- a/x-pack/plugins/ml/public/_hacks.scss
+++ b/x-pack/plugins/ml/public/_hacks.scss
@@ -1,3 +1,12 @@
+.tab-settings,
+.tab-datavisualizer,
+.tab-timeseriesexplorer,
+.tab-explorer,
+.tab-jobs {
+  // Make all page background white until More of the pages use EuiPage to wrap in panel-like components
+  background-color: $euiColorEmptyShade;
+}
+
 // These are hacks that were near ML's root. Unsure if they still need to be here.
 .tab-jobs,
 .edit-job-modal,

--- a/x-pack/plugins/ml/public/datavisualizer/_datavisualizer.scss
+++ b/x-pack/plugins/ml/public/datavisualizer/_datavisualizer.scss
@@ -3,7 +3,6 @@
   margin-right: auto;
   margin-left: auto;
   padding: $euiSizeS $euiSize;
-  background-color: $euiColorLightestShade;
   flex: 1 0 auto;
 
   .flexGroup__filler {

--- a/x-pack/plugins/ml/public/datavisualizer/selector/_selector.scss
+++ b/x-pack/plugins/ml/public/datavisualizer/selector/_selector.scss
@@ -1,5 +1,5 @@
 .ml-datavisualizer-selector {
   flex-grow: 1;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   min-height: 100vh;
 }

--- a/x-pack/plugins/ml/public/file_datavisualizer/_file_datavisualizer.scss
+++ b/x-pack/plugins/ml/public/file_datavisualizer/_file_datavisualizer.scss
@@ -2,6 +2,6 @@
 
 .file-datavisualizer-container {
   padding: 20px;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
   min-height: calc(100vh - 70px);
 }

--- a/x-pack/plugins/ml/public/settings/_settings.scss
+++ b/x-pack/plugins/ml/public/settings/_settings.scss
@@ -1,7 +1,7 @@
 .mlSettingsPage {
 
   .mlSettingsPage__body {
-    background: $euiColorLightestShade;
+    background: $euiPageBackgroundColor;
     min-height: 100vh;
   }
 

--- a/x-pack/plugins/ml/public/settings/calendars/_calendars.scss
+++ b/x-pack/plugins/ml/public/settings/calendars/_calendars.scss
@@ -1,4 +1,4 @@
 .mlCalendarManagement {
-  background: $euiColorLightestShade;
+  background: $euiPageBackgroundColor;
   min-height: 100vh;
 }

--- a/x-pack/plugins/ml/public/settings/filter_lists/_filter_lists.scss
+++ b/x-pack/plugins/ml/public/settings/filter_lists/_filter_lists.scss
@@ -1,5 +1,5 @@
 .ml-filter-lists {
-  background: $euiColorLightestShade;
+  background: $euiPageBackgroundColor;
   min-height: 100vh;
 }
 

--- a/x-pack/plugins/monitoring/public/_hacks.scss
+++ b/x-pack/plugins/monitoring/public/_hacks.scss
@@ -1,12 +1,6 @@
 @import '@elastic/eui/src/components/header/variables';
 
 #monitoring-app {
-  // SASSTODO: We need background colors till more of Kibana is converted
-  monitoring-main {
-    background: $euiColorLightestShade;
-    height: calc(100vh - #{$euiHeaderChildSize});
-  }
-
   // SASSTODO: PUI tooltips can be replaced with EuiToolTip
   .pui-tooltip-inner {
     font-size: $euiFontSizeXS;

--- a/x-pack/plugins/spaces/public/index.scss
+++ b/x-pack/plugins/spaces/public/index.scss
@@ -1,7 +1,7 @@
 // Import the EUI global scope so we can use EUI constants
 @import 'ui/public/styles/_styling_constants';
 
-/* Graph plugin styles */
+/* Spaces plugin styles */
 
 // Prefix all styles with "spc" to avoid conflicts.
 // Examples

--- a/x-pack/plugins/spaces/public/views/management/_manage_spaces.scss
+++ b/x-pack/plugins/spaces/public/views/management/_manage_spaces.scss
@@ -1,8 +1,3 @@
-#manageSpacesReactRoot {
-  background: $euiPageBackgroundColor;
-  flex-grow: 1;
-}
-
 .spcManagePage__content {
   max-width: 640px;
   margin-left: auto;

--- a/x-pack/plugins/spaces/public/views/management/_manage_spaces.scss
+++ b/x-pack/plugins/spaces/public/views/management/_manage_spaces.scss
@@ -1,5 +1,5 @@
 #manageSpacesReactRoot {
-  background: $euiColorLightestShade;
+  background: $euiPageBackgroundColor;
   flex-grow: 1;
 }
 

--- a/x-pack/plugins/upgrade_assistant/public/_app.scss
+++ b/x-pack/plugins/upgrade_assistant/public/_app.scss
@@ -1,4 +1,4 @@
 upgrade-assistant {
   flex-grow: 1;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 }

--- a/x-pack/plugins/upgrade_assistant/public/_app.scss
+++ b/x-pack/plugins/upgrade_assistant/public/_app.scss
@@ -1,4 +1,0 @@
-upgrade-assistant {
-  flex-grow: 1;
-  background-color: $euiPageBackgroundColor;
-}

--- a/x-pack/plugins/upgrade_assistant/public/index.scss
+++ b/x-pack/plugins/upgrade_assistant/public/index.scss
@@ -1,4 +1,3 @@
 @import 'ui/public/styles/_styling_constants';
 
-@import './app';
 @import './components/index';

--- a/x-pack/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/_threshold_watch_edit.scss
+++ b/x-pack/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/_threshold_watch_edit.scss
@@ -1,6 +1,6 @@
 threshold-watch-edit {
   flex: 1 0 auto;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 
   .thresholdWatchEditButtons {
     flex-direction:row-reverse;

--- a/x-pack/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/_threshold_watch_edit.scss
+++ b/x-pack/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/_threshold_watch_edit.scss
@@ -1,7 +1,4 @@
 threshold-watch-edit {
-  flex: 1 0 auto;
-  background-color: $euiPageBackgroundColor;
-
   .thresholdWatchEditButtons {
     flex-direction:row-reverse;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,10 +871,10 @@
     tabbable "^1.1.0"
     uuid "^3.1.0"
 
-"@elastic/eui@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-6.9.0.tgz#baada76820e8e5a7efccfd327234ef05ce105ee3"
-  integrity sha512-wvJY1hQsKukOIlhJihif7s0qvDb52xv+0nMS27UBqmiwSD4rLwomhlFaZ/DauesLbUvCd1wVl0CHW34uwA9RAQ==
+"@elastic/eui@6.10.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-6.10.0.tgz#4255e53c7481dd5170072a0bdf45eb796817c0b0"
+  integrity sha512-yWEt/wbG3BtqaDAcPOS9Hkm8G2BftmP31wzr2Q/Dm+jpNhTA/fUs++1WFgaVvX/Vj9RsTgi8yx8PZHth8Metog==
   dependencies:
     "@types/lodash" "^4.14.116"
     "@types/numeral" "^0.0.25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,10 +871,10 @@
     tabbable "^1.1.0"
     uuid "^3.1.0"
 
-"@elastic/eui@6.8.0":
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-6.8.0.tgz#16152cb2b04ddc756bed5cadb525d27a8904ec42"
-  integrity sha512-AnBgIpcEzpKrdbqYRIitU0kPN0fTgO2olOSaQqoKz8LUQButYLE9+ghV6c48K12UuuMQUK7m+qvyXt2z/5xCGQ==
+"@elastic/eui@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-6.9.0.tgz#baada76820e8e5a7efccfd327234ef05ce105ee3"
+  integrity sha512-wvJY1hQsKukOIlhJihif7s0qvDb52xv+0nMS27UBqmiwSD4rLwomhlFaZ/DauesLbUvCd1wVl0CHW34uwA9RAQ==
   dependencies:
     "@types/lodash" "^4.14.116"
     "@types/numeral" "^0.0.25"


### PR DESCRIPTION
## [`6.10.0`](https://github.com/elastic/eui/tree/v6.10.0)

- Adjust dark mode background color ([#1530](https://github.com/elastic/eui/pull/1530))
- TypeScript are now formatted with Prettier ([#1529](https://github.com/elastic/eui/pull/1529))
- Updated `EuiPopover` and `EuiColorPicker` to pause `EuiOutsideClickDetector` in when not open ([#1527](https://github.com/elastic/eui/pull/1527))

## [`6.9.0`](https://github.com/elastic/eui/tree/v6.9.0)

- Changed animation settings for `EuiNavDrawer` ([#1524](https://github.com/elastic/eui/pull/1524))
- Converted a number of components to support text localization ([#1504](https://github.com/elastic/eui/pull/1504))
- Updated `app_ems.svg` ([#1517](https://github.com/elastic/eui/pull/1517))

**Bug fixes**

- Updated `EuiPage` background color to match body background color ([#1513](https://github.com/elastic/eui/pull/1513))
- Fixed React key usage in `EuiPagination` ([#1514](https://github.com/elastic/eui/pull/1514))
- Fixed bug which prevented `EuiSwitch` with generated ID from having its label announced by VoiceOver ([#1519](https://github.com/elastic/eui/pull/1519))
- Fixed `EuiFilterButton` handling `numFilters` when `0` was specified ([#1510](https://github.com/elastic/eui/pull/1510))

---

## Background fixes

This PR removes the white background placed on `.application` and now allows the background color from the `html` element to show through.

This means that most of the background hacks we put on can be taken off. However, we now have the opposite hacks where some apps need the full white background so these were added. 

I'd like to get a thumbs up from the following plugins (tagging people I know instead of whole teams)

- [ ] [Infra](https://github.com/elastic/kibana/compare/master...cchaos:background-color?expand=1#diff-72cc793ea143ca258604ba512a227964) @simianhacker 
- [x] [APM](https://github.com/elastic/kibana/compare/master...cchaos:background-color?expand=1#diff-ccb6171f32f24e31a48385e83d40539f) @jasonrhodes 
- [x] [Canvas](https://github.com/elastic/kibana/compare/master...cchaos:background-color?expand=1#diff-b9a89b5efd9a7f48bca41d5ec8da1f13) @ryankeairns (I think there might be some more adjustments you'll want to make here)
- [x] [ML](https://github.com/elastic/kibana/compare/master...cchaos:background-color?expand=1#diff-e370fdc76628963a160ab4079476947c) @peteharverson 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~

