### PR TITLE
[7.x] Updates TPM buckets with a missing result key to default to 'n/a' (#29331)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/props.json
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/props.json
@@ -1,5 +1,4 @@
 {
-  "location": {},
   "urlParams": {
     "page": 0,
     "serviceName": "opbeans-python",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Updates TPM buckets with a missing result key to default to 'n/a'  (#29331)