### PR TITLE
[APM] Cleanup of ES queries

### DIFF
--- a/x-pack/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
@@ -6,21 +6,13 @@ exports[`Error ERROR_EXC_HANDLED 1`] = `undefined`;
 
 exports[`Error ERROR_EXC_MESSAGE 1`] = `undefined`;
 
-exports[`Error ERROR_EXC_STACKTRACE 1`] = `undefined`;
-
 exports[`Error ERROR_GROUP_ID 1`] = `"grouping key"`;
 
 exports[`Error ERROR_LOG_MESSAGE 1`] = `undefined`;
 
-exports[`Error ERROR_LOG_STACKTRACE 1`] = `undefined`;
-
 exports[`Error HTTP_REQUEST_METHOD 1`] = `undefined`;
 
 exports[`Error METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
-
-exports[`Error METRIC_PROCESS_MEMORY_RSS 1`] = `undefined`;
-
-exports[`Error METRIC_PROCESS_MEMORY_SIZE 1`] = `undefined`;
 
 exports[`Error METRIC_SYSTEM_CPU_PERCENT 1`] = `undefined`;
 
@@ -34,11 +26,7 @@ exports[`Error PARENT_ID 1`] = `"parentId"`;
 
 exports[`Error PROCESSOR_EVENT 1`] = `"error"`;
 
-exports[`Error PROCESSOR_NAME 1`] = `"error"`;
-
 exports[`Error SERVICE_AGENT_NAME 1`] = `"agent name"`;
-
-exports[`Error SERVICE_LANGUAGE_NAME 1`] = `"nodejs"`;
 
 exports[`Error SERVICE_NAME 1`] = `"service name"`;
 
@@ -49,10 +37,6 @@ exports[`Error SPAN_DURATION 1`] = `undefined`;
 exports[`Error SPAN_ID 1`] = `undefined`;
 
 exports[`Error SPAN_NAME 1`] = `undefined`;
-
-exports[`Error SPAN_SQL 1`] = `undefined`;
-
-exports[`Error SPAN_START 1`] = `undefined`;
 
 exports[`Error SPAN_SUBTYPE 1`] = `undefined`;
 
@@ -82,21 +66,13 @@ exports[`Span ERROR_EXC_HANDLED 1`] = `undefined`;
 
 exports[`Span ERROR_EXC_MESSAGE 1`] = `undefined`;
 
-exports[`Span ERROR_EXC_STACKTRACE 1`] = `undefined`;
-
 exports[`Span ERROR_GROUP_ID 1`] = `undefined`;
 
 exports[`Span ERROR_LOG_MESSAGE 1`] = `undefined`;
 
-exports[`Span ERROR_LOG_STACKTRACE 1`] = `undefined`;
-
 exports[`Span HTTP_REQUEST_METHOD 1`] = `undefined`;
 
 exports[`Span METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
-
-exports[`Span METRIC_PROCESS_MEMORY_RSS 1`] = `undefined`;
-
-exports[`Span METRIC_PROCESS_MEMORY_SIZE 1`] = `undefined`;
 
 exports[`Span METRIC_SYSTEM_CPU_PERCENT 1`] = `undefined`;
 
@@ -110,11 +86,7 @@ exports[`Span PARENT_ID 1`] = `"parentId"`;
 
 exports[`Span PROCESSOR_EVENT 1`] = `"span"`;
 
-exports[`Span PROCESSOR_NAME 1`] = `"transaction"`;
-
 exports[`Span SERVICE_AGENT_NAME 1`] = `"agent name"`;
-
-exports[`Span SERVICE_LANGUAGE_NAME 1`] = `undefined`;
 
 exports[`Span SERVICE_NAME 1`] = `"service name"`;
 
@@ -125,10 +97,6 @@ exports[`Span SPAN_DURATION 1`] = `1337`;
 exports[`Span SPAN_ID 1`] = `"span id"`;
 
 exports[`Span SPAN_NAME 1`] = `"span name"`;
-
-exports[`Span SPAN_SQL 1`] = `"db statement"`;
-
-exports[`Span SPAN_START 1`] = `undefined`;
 
 exports[`Span SPAN_SUBTYPE 1`] = `"my subtype"`;
 
@@ -158,21 +126,13 @@ exports[`Transaction ERROR_EXC_HANDLED 1`] = `undefined`;
 
 exports[`Transaction ERROR_EXC_MESSAGE 1`] = `undefined`;
 
-exports[`Transaction ERROR_EXC_STACKTRACE 1`] = `undefined`;
-
 exports[`Transaction ERROR_GROUP_ID 1`] = `undefined`;
 
 exports[`Transaction ERROR_LOG_MESSAGE 1`] = `undefined`;
 
-exports[`Transaction ERROR_LOG_STACKTRACE 1`] = `undefined`;
-
 exports[`Transaction HTTP_REQUEST_METHOD 1`] = `"GET"`;
 
 exports[`Transaction METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
-
-exports[`Transaction METRIC_PROCESS_MEMORY_RSS 1`] = `undefined`;
-
-exports[`Transaction METRIC_PROCESS_MEMORY_SIZE 1`] = `undefined`;
 
 exports[`Transaction METRIC_SYSTEM_CPU_PERCENT 1`] = `undefined`;
 
@@ -186,11 +146,7 @@ exports[`Transaction PARENT_ID 1`] = `"parentId"`;
 
 exports[`Transaction PROCESSOR_EVENT 1`] = `"transaction"`;
 
-exports[`Transaction PROCESSOR_NAME 1`] = `"transaction"`;
-
 exports[`Transaction SERVICE_AGENT_NAME 1`] = `"agent name"`;
-
-exports[`Transaction SERVICE_LANGUAGE_NAME 1`] = `"nodejs"`;
 
 exports[`Transaction SERVICE_NAME 1`] = `"service name"`;
 
@@ -201,10 +157,6 @@ exports[`Transaction SPAN_DURATION 1`] = `undefined`;
 exports[`Transaction SPAN_ID 1`] = `undefined`;
 
 exports[`Transaction SPAN_NAME 1`] = `undefined`;
-
-exports[`Transaction SPAN_SQL 1`] = `undefined`;
-
-exports[`Transaction SPAN_START 1`] = `undefined`;
 
 exports[`Transaction SPAN_SUBTYPE 1`] = `undefined`;
 

--- a/x-pack/plugins/apm/common/elasticsearch_fieldnames.ts
+++ b/x-pack/plugins/apm/common/elasticsearch_fieldnames.ts
@@ -5,14 +5,11 @@
  */
 export const SERVICE_NAME = 'service.name';
 export const SERVICE_AGENT_NAME = 'agent.name';
-export const SERVICE_LANGUAGE_NAME = 'service.language.name';
 export const URL_FULL = 'url.full';
 export const HTTP_REQUEST_METHOD = 'http.request.method';
 export const USER_ID = 'user.id';
 
 export const OBSERVER_LISTENING = 'observer.listening';
-
-export const PROCESSOR_NAME = 'processor.name';
 export const PROCESSOR_EVENT = 'processor.event';
 
 export const TRANSACTION_DURATION = 'transaction.duration.us';
@@ -24,14 +21,12 @@ export const TRANSACTION_SAMPLED = 'transaction.sampled';
 
 export const TRACE_ID = 'trace.id';
 
-export const SPAN_START = 'span.start.us';
 export const SPAN_DURATION = 'span.duration.us';
 export const SPAN_TYPE = 'span.type';
 export const SPAN_SUBTYPE = 'span.subtype';
 export const SPAN_ACTION = 'span.action';
 export const SPAN_NAME = 'span.name';
 export const SPAN_ID = 'span.id';
-export const SPAN_SQL = 'context.db.statement';
 
 // Parent ID for a transaction or span
 export const PARENT_ID = 'parent.id';
@@ -39,16 +34,11 @@ export const PARENT_ID = 'parent.id';
 export const ERROR_GROUP_ID = 'error.grouping_key';
 export const ERROR_CULPRIT = 'error.culprit';
 export const ERROR_LOG_MESSAGE = 'error.log.message';
-export const ERROR_LOG_STACKTRACE = 'error.log.stacktrace';
 export const ERROR_EXC_MESSAGE = 'error.exception.message'; // only to be used in es queries, since error.exception is now an array
-export const ERROR_EXC_STACKTRACE = 'error.exception.stacktrace'; // only to be used in es queries, since error.exception is now an array
 export const ERROR_EXC_HANDLED = 'error.exception.handled'; // only to be used in es queries, since error.exception is now an array
 
 // METRICS
 export const METRIC_SYSTEM_FREE_MEMORY = 'system.memory.actual.free';
 export const METRIC_SYSTEM_TOTAL_MEMORY = 'system.memory.total';
-export const METRIC_PROCESS_MEMORY_SIZE = 'system.process.memory.size';
-export const METRIC_PROCESS_MEMORY_RSS = 'system.process.memory.rss.bytes';
-
 export const METRIC_SYSTEM_CPU_PERCENT = 'system.cpu.total.norm.pct';
 export const METRIC_PROCESS_CPU_PERCENT = 'system.process.cpu.total.norm.pct';

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_buckets.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_buckets.ts
@@ -10,6 +10,7 @@ import {
   PROCESSOR_EVENT,
   SERVICE_NAME
 } from '../../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../../helpers/range_filter';
 import { Setup } from '../../helpers/setup_request';
 
 export async function getBuckets({
@@ -27,15 +28,7 @@ export async function getBuckets({
   const filter: ESFilter[] = [
     { term: { [PROCESSOR_EVENT]: 'error' } },
     { term: { [SERVICE_NAME]: serviceName } },
-    {
-      range: {
-        '@timestamp': {
-          gte: start,
-          lte: end,
-          format: 'epoch_millis'
-        }
-      }
-    }
+    { range: rangeFilter(start, end) }
   ];
 
   if (groupId) {

--- a/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
@@ -10,9 +10,11 @@ import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 import {
   ERROR_GROUP_ID,
+  PROCESSOR_EVENT,
   SERVICE_NAME,
   TRANSACTION_SAMPLED
 } from '../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 import { getTransaction } from '../transactions/get_transaction';
 
@@ -35,16 +37,9 @@ export async function getErrorGroup({
   const { start, end, esFilterQuery, client, config } = setup;
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
+    { term: { [PROCESSOR_EVENT]: 'error' } },
     { term: { [ERROR_GROUP_ID]: groupId } },
-    {
-      range: {
-        '@timestamp': {
-          gte: start,
-          lte: end,
-          format: 'epoch_millis'
-        }
-      }
-    }
+    { range: rangeFilter(start, end) }
   ];
 
   if (esFilterQuery) {

--- a/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
@@ -16,6 +16,7 @@ import {
   PROCESSOR_EVENT,
   SERVICE_NAME
 } from '../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
 interface ErrorResponseItems {
@@ -51,15 +52,7 @@ export async function getErrorGroups({
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
             { term: { [PROCESSOR_EVENT]: 'error' } },
-            {
-              range: {
-                '@timestamp': {
-                  gte: start,
-                  lte: end,
-                  format: 'epoch_millis'
-                }
-              }
-            }
+            { range: rangeFilter(start, end) }
           ]
         }
       },

--- a/x-pack/plugins/apm/server/lib/helpers/range_filter.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/range_filter.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export function rangeFilter(start: number, end: number) {
+  return {
+    '@timestamp': {
+      gte: start,
+      lte: end,
+      format: 'epoch_millis'
+    }
+  };
+}

--- a/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/__tests__/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/__tests__/__snapshots__/fetcher.test.ts.snap
@@ -71,7 +71,7 @@ Array [
               },
               Object {
                 "term": Object {
-                  "processor.name": "metric",
+                  "processor.event": "metric",
                 },
               },
               Object {

--- a/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/fetcher.ts
@@ -7,7 +7,7 @@ import { AggregationSearchResponse, ESFilter } from 'elasticsearch';
 import {
   METRIC_PROCESS_CPU_PERCENT,
   METRIC_SYSTEM_CPU_PERCENT,
-  PROCESSOR_NAME,
+  PROCESSOR_EVENT,
   SERVICE_NAME
 } from 'x-pack/plugins/apm/common/elasticsearch_fieldnames';
 import { getBucketSize } from '../../helpers/get_bucket_size';
@@ -40,7 +40,7 @@ export async function fetch({
   const { intervalString } = getBucketSize(start, end, 'auto');
   const filters: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
-    { term: { [PROCESSOR_NAME]: 'metric' } },
+    { term: { [PROCESSOR_EVENT]: 'metric' } },
     {
       range: { '@timestamp': { gte: start, lte: end, format: 'epoch_millis' } }
     }

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/__tests__/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/__tests__/__snapshots__/fetcher.test.ts.snap
@@ -63,7 +63,7 @@ Array [
               },
               Object {
                 "term": Object {
-                  "processor.name": "metric",
+                  "processor.event": "metric",
                 },
               },
               Object {

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
@@ -7,7 +7,7 @@ import { AggregationSearchResponse, ESFilter } from 'elasticsearch';
 import {
   METRIC_SYSTEM_FREE_MEMORY,
   METRIC_SYSTEM_TOTAL_MEMORY,
-  PROCESSOR_NAME,
+  PROCESSOR_EVENT,
   SERVICE_NAME
 } from 'x-pack/plugins/apm/common/elasticsearch_fieldnames';
 import { getBucketSize } from '../../helpers/get_bucket_size';
@@ -36,7 +36,7 @@ export async function fetch({
   const { intervalString } = getBucketSize(start, end, 'auto');
   const filters: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
-    { term: { [PROCESSOR_NAME]: 'metric' } },
+    { term: { [PROCESSOR_EVENT]: 'metric' } },
     {
       range: { '@timestamp': { gte: start, lte: end, format: 'epoch_millis' } }
     },

--- a/x-pack/plugins/apm/server/lib/services/get_service.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service.ts
@@ -8,10 +8,12 @@ import { BucketAgg } from 'elasticsearch';
 import { ESFilter } from 'elasticsearch';
 import { idx } from 'x-pack/plugins/apm/common/idx';
 import {
+  PROCESSOR_EVENT,
   SERVICE_AGENT_NAME,
   SERVICE_NAME,
   TRANSACTION_TYPE
 } from '../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
 export interface ServiceAPIResponse {
@@ -28,15 +30,8 @@ export async function getService(
 
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
-    {
-      range: {
-        '@timestamp': {
-          gte: start,
-          lte: end,
-          format: 'epoch_millis'
-        }
-      }
-    }
+    { terms: { [PROCESSOR_EVENT]: ['error', 'transaction'] } },
+    { range: rangeFilter(start, end) }
   ];
 
   if (esFilterQuery) {

--- a/x-pack/plugins/apm/server/lib/services/get_services.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services.ts
@@ -13,6 +13,7 @@ import {
   SERVICE_NAME,
   TRANSACTION_DURATION
 } from '../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
 export interface IServiceListItem {
@@ -31,24 +32,8 @@ export async function getServices(
   const { start, end, esFilterQuery, client, config } = setup;
 
   const filter: ESFilter[] = [
-    {
-      bool: {
-        should: [
-          { term: { [PROCESSOR_EVENT]: 'metric' } },
-          { term: { [PROCESSOR_EVENT]: 'transaction' } },
-          { term: { [PROCESSOR_EVENT]: 'error' } }
-        ]
-      }
-    },
-    {
-      range: {
-        '@timestamp': {
-          gte: start,
-          lte: end,
-          format: 'epoch_millis'
-        }
-      }
-    }
+    { terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] } },
+    { range: rangeFilter(start, end) }
   ];
 
   if (esFilterQuery) {

--- a/x-pack/plugins/apm/server/lib/traces/get_top_traces.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_top_traces.ts
@@ -7,9 +7,9 @@
 import {
   PARENT_ID,
   PROCESSOR_EVENT,
-  TRACE_ID,
   TRANSACTION_SAMPLED
 } from '../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 import { getTransactionGroups } from '../transaction_groups';
 import { ITransactionGroup } from '../transaction_groups/transform';
@@ -23,31 +23,10 @@ export async function getTopTraces(
 
   const bodyQuery = {
     bool: {
-      must: {
-        // this criterion safeguards against data that lacks a transaction
-        // parent ID but still is not a "trace" by way of not having a
-        // trace ID (e.g. old data before parent ID was implemented, etc)
-        exists: {
-          field: TRACE_ID
-        }
-      },
-      must_not: {
-        // no parent ID alongside a trace ID means this transaction is a
-        // "root" transaction, i.e. a trace
-        exists: {
-          field: PARENT_ID
-        }
-      },
+      // no parent ID means this transaction is a "root" transaction, i.e. a trace
+      must_not: { exists: { field: PARENT_ID } },
       filter: [
-        {
-          range: {
-            '@timestamp': {
-              gte: start,
-              lte: end,
-              format: 'epoch_millis'
-            }
-          }
-        },
+        { range: rangeFilter(start, end) },
         { term: { [PROCESSOR_EVENT]: 'transaction' } }
       ],
       should: [{ term: { [TRANSACTION_SAMPLED]: true } }]

--- a/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -9,9 +9,9 @@ import {
   PROCESSOR_EVENT,
   TRACE_ID
 } from 'x-pack/plugins/apm/common/elasticsearch_fieldnames';
-
 import { Span } from '../../../typings/es_schemas/Span';
 import { Transaction } from '../../../typings/es_schemas/Transaction';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
 export type TraceItem = Transaction | Span;
@@ -34,15 +34,7 @@ export async function getTraceItems(
           filter: [
             { term: { [TRACE_ID]: traceId } },
             { terms: { [PROCESSOR_EVENT]: ['span', 'transaction'] } },
-            {
-              range: {
-                '@timestamp': {
-                  gte: start,
-                  lte: end,
-                  format: 'epoch_millis'
-                }
-              }
-            }
+            { range: rangeFilter(start, end) }
           ]
         }
       }

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/__snapshots__/fetcher.test.ts.snap
@@ -40,6 +40,11 @@ Array [
           "bool": Object {
             "filter": Array [
               Object {
+                "exists": Object {
+                  "field": "bucket_span",
+                },
+              },
+              Object {
                 "range": Object {
                   "timestamp": Object {
                     "format": "epoch_millis",
@@ -49,11 +54,6 @@ Array [
                 },
               },
             ],
-            "must": Object {
-              "exists": Object {
-                "field": "bucket_span",
-              },
-            },
           },
         },
         "size": 0,

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/fetcher.ts
@@ -56,12 +56,8 @@ export async function anomalySeriesFetcher({
       size: 0,
       query: {
         bool: {
-          must: {
-            exists: {
-              field: 'bucket_span'
-            }
-          },
           filter: [
+            { exists: { field: 'bucket_span' } },
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/get_ml_bucket_size.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/get_ml_bucket_size.ts
@@ -31,12 +31,8 @@ export async function getMlBucketSize({
       size: 1,
       query: {
         bool: {
-          must: {
-            exists: {
-              field: 'bucket_span'
-            }
-          },
           filter: [
+            { exists: { field: 'bucket_span' } },
             {
               range: {
                 timestamp: {

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/calculate_bucket_size.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/calculate_bucket_size.ts
@@ -6,6 +6,7 @@
 
 import { SearchParams } from 'elasticsearch';
 import {
+  PROCESSOR_EVENT,
   SERVICE_NAME,
   TRANSACTION_DURATION,
   TRANSACTION_NAME,
@@ -29,6 +30,7 @@ export async function calculateBucketSize(
         bool: {
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
+            { term: { [PROCESSOR_EVENT]: 'transaction' } },
             { term: { [TRANSACTION_TYPE]: transactionType } },
             { term: { [TRANSACTION_NAME]: transactionName } },
             {

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
@@ -10,6 +10,7 @@ import {
   SearchResponse
 } from 'elasticsearch';
 import {
+  PROCESSOR_EVENT,
   SERVICE_NAME,
   TRACE_ID,
   TRANSACTION_DURATION,
@@ -20,6 +21,7 @@ import {
 } from 'x-pack/plugins/apm/common/elasticsearch_fieldnames';
 import { Setup } from 'x-pack/plugins/apm/server/lib/helpers/setup_request';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
+import { rangeFilter } from '../../../helpers/range_filter';
 
 interface Bucket {
   key: number;
@@ -53,17 +55,10 @@ export function bucketFetcher(
   const bucketTargetCount = config.get<number>('xpack.apm.bucketTargetCount');
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
+    { term: { [PROCESSOR_EVENT]: 'transaction' } },
     { term: { [TRANSACTION_TYPE]: transactionType } },
     { term: { [TRANSACTION_NAME]: transactionName } },
-    {
-      range: {
-        '@timestamp': {
-          gte: start,
-          lte: end,
-          format: 'epoch_millis'
-        }
-      }
-    }
+    { range: rangeFilter(start, end) }
   ];
 
   if (esFilterQuery) {

--- a/x-pack/plugins/apm/server/lib/transactions/get_top_transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_top_transactions/index.ts
@@ -12,6 +12,7 @@ import {
 } from 'x-pack/plugins/apm/common/elasticsearch_fieldnames';
 import { Setup } from 'x-pack/plugins/apm/server/lib/helpers/setup_request';
 
+import { rangeFilter } from '../../helpers/range_filter';
 import { getTransactionGroups } from '../../transaction_groups';
 import { ITransactionGroup } from '../../transaction_groups/transform';
 
@@ -32,11 +33,7 @@ export async function getTopTransactions({
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
     { term: { [PROCESSOR_EVENT]: 'transaction' } },
-    {
-      range: {
-        '@timestamp': { gte: start, lte: end, format: 'epoch_millis' }
-      }
-    }
+    { range: rangeFilter(start, end) }
   ];
 
   if (transactionType) {

--- a/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
@@ -12,6 +12,7 @@ import {
 } from 'x-pack/plugins/apm/common/elasticsearch_fieldnames';
 import { idx } from 'x-pack/plugins/apm/common/idx';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
+import { rangeFilter } from '../../helpers/range_filter';
 import { Setup } from '../../helpers/setup_request';
 
 export type TransactionAPIResponse = Transaction | undefined;
@@ -32,15 +33,7 @@ export async function getTransaction(
     { term: { [PROCESSOR_EVENT]: 'transaction' } },
     { term: { [TRANSACTION_ID]: transactionId } },
     { term: { [TRACE_ID]: traceId } },
-    {
-      range: {
-        '@timestamp': {
-          gte: start,
-          lte: end,
-          format: 'epoch_millis'
-        }
-      }
-    }
+    { range: rangeFilter(start, end) }
   ];
 
   if (esFilterQuery) {


### PR DESCRIPTION
 - Ensure all queries specify `processor.event` (and replace usages of `processor.name`)
 - Remove unused fieldnames in `elasticsearch_fieldnames.ts`
 - Add `rangeFilter` helper to simplify ES queries that queries `@timestamp` by a start and end date