### PR TITLE
[APM] Also show metric-only services in service overview

### DIFF
--- a/x-pack/plugins/apm/server/lib/services/get_services.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services.ts
@@ -34,6 +34,7 @@ export async function getServices(
     {
       bool: {
         should: [
+          { term: { [PROCESSOR_EVENT]: 'metric' } },
           { term: { [PROCESSOR_EVENT]: 'transaction' } },
           { term: { [PROCESSOR_EVENT]: 'error' } }
         ]
@@ -56,6 +57,7 @@ export async function getServices(
 
   const params = {
     index: [
+      config.get<string>('apm_oss.metricsIndices'),
       config.get<string>('apm_oss.errorIndices'),
       config.get<string>('apm_oss.transactionIndices')
     ],


### PR DESCRIPTION
Closes #27558

Below screenshots are taken for services that only have metric data

**3 rightmost columns expect transaction and error data to be available**
![screenshot 2019-02-07 at 16 06 52](https://user-images.githubusercontent.com/209966/52421514-7d0e8080-2af4-11e9-96d5-7c41cce058c2.png)

**No transactions data is available (a "bug" causes the empty states to not show)**
![screenshot 2019-02-07 at 16 06 58](https://user-images.githubusercontent.com/209966/52421513-7d0e8080-2af4-11e9-8feb-d3f52be2da94.png)

**Metrics charts are displayed correctly**
![screenshot 2019-02-07 at 16 07 25](https://user-images.githubusercontent.com/209966/52421512-7c75ea00-2af4-11e9-9ba0-163cd7cf4dcb.png)

