### PR TITLE
[APM] Rename APM Kibana configs

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -21,7 +21,7 @@ xpack.apm.ui.enabled:: Set to `false` to hide the APM plugin {kib} from the menu
 
 xpack.apm.ui.transactionGroupBucketSize:: Number of top transaction groups displayed in APM plugin in Kibana. Defaults to `100`.
 
-apm_oss.indexPattern:: Index pattern is used for integrations with Machine Learning and Kuery Bar. It must match all apm indices. Defaults to `apm-*`.
+apm_oss.indexPatternTitle:: Index pattern is used for integrations with Machine Learning and Kuery Bar. It must match all apm indices. Defaults to `apm-*`.
 
 apm_oss.errorIndices:: Matcher for indices containing error documents. Defaults to `apm-*`.
 
@@ -30,3 +30,5 @@ apm_oss.onboardingIndices:: Matcher for indices containing onboarding documents.
 apm_oss.spanIndices:: Matcher for indices containing span documents. Defaults to `apm-*`.
 
 apm_oss.transactionIndices:: Matcher for indices containing transaction documents. Defaults to `apm-*`.
+
+apm_oss.metricIndices:: Matcher for indices containing metric documents. Defaults to `apm-*`.

--- a/src/legacy/core_plugins/apm_oss/index.js
+++ b/src/legacy/core_plugins/apm_oss/index.js
@@ -36,7 +36,7 @@ export default function apmOss(kibana) {
         errorIndices: Joi.string().default('apm-*'),
         transactionIndices: Joi.string().default('apm-*'),
         spanIndices: Joi.string().default('apm-*'),
-        metricsIndices: Joi.string().default('apm-*'),
+        metricIndices: Joi.string().default('apm-*'),
         onboardingIndices: Joi.string().default('apm-*'),
       }).default();
     },
@@ -47,7 +47,7 @@ export default function apmOss(kibana) {
         'errorIndices',
         'transactionIndices',
         'spanIndices',
-        'metricsIndices',
+        'metricIndices',
         'onboardingIndices'
       ].map(type => server.config().get(`apm_oss.${type}`))));
     }

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/index.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/index.js
@@ -38,7 +38,7 @@ function isEnabled(config) {
 
 export function apmSpecProvider(server) {
   const config = server.config();
-  const apmIndexPatternTitle = config.get('apm_oss.indexPattern');
+  const apmIndexPatternTitle = config.get('apm_oss.indexPatternTitle');
 
   const artifacts = {
     dashboards: [

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/saved_objects/get_saved_objects.test.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/saved_objects/get_saved_objects.test.js
@@ -22,7 +22,7 @@ import { getSavedObjects } from './get_saved_objects';
 
 const indexPatternTitle = 'dynamic index pattern title';
 
-test('should dynamically set index title to "apm_oss.indexPattern" yaml config value', () => {
+test('should dynamically set index title to "apm_oss.indexPatternTitle" yaml config value', () => {
   const savedObjects = getSavedObjects(indexPatternTitle);
   const indexPattern = savedObjects[0];
   expect(indexPattern.type).to.be('index-pattern');

--- a/x-pack/plugins/apm/index.js
+++ b/x-pack/plugins/apm/index.js
@@ -40,7 +40,7 @@ export function apm(kibana) {
         const config = server.config();
         return {
           apmUiEnabled: config.get('xpack.apm.ui.enabled'),
-          apmIndexPatternTitle: config.get('apm_oss.indexPattern') // TODO: rename to apm_oss.indexPatternTitle in 7.0 (breaking change)
+          apmIndexPatternTitle: config.get('apm_oss.indexPatternTitle')
         };
       },
       hacks: ['plugins/apm/hacks/toggle_app_link_in_nav'],

--- a/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/fetcher.ts
@@ -51,7 +51,7 @@ export async function fetch({
   }
 
   const params = {
-    index: config.get<string>('apm_oss.metricsIndices'),
+    index: config.get<string>('apm_oss.metricIndices'),
     body: {
       size: 0,
       query: { bool: { filter: filters } },

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
@@ -54,7 +54,7 @@ export async function fetch({
   };
 
   const params = {
-    index: config.get<string>('apm_oss.metricsIndices'),
+    index: config.get<string>('apm_oss.metricIndices'),
     body: {
       size: 0,
       query: { bool: { filter: filters } },

--- a/x-pack/plugins/apm/server/lib/services/get_services.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services.ts
@@ -34,6 +34,7 @@ export async function getServices(
     {
       bool: {
         should: [
+          { term: { [PROCESSOR_EVENT]: 'metric' } },
           { term: { [PROCESSOR_EVENT]: 'transaction' } },
           { term: { [PROCESSOR_EVENT]: 'error' } }
         ]
@@ -56,6 +57,7 @@ export async function getServices(
 
   const params = {
     index: [
+      config.get<string>('apm_oss.metricsIndices'),
       config.get<string>('apm_oss.errorIndices'),
       config.get<string>('apm_oss.transactionIndices')
     ],

--- a/x-pack/plugins/apm/server/lib/services/get_services.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services.ts
@@ -57,7 +57,7 @@ export async function getServices(
 
   const params = {
     index: [
-      config.get<string>('apm_oss.metricsIndices'),
+      config.get<string>('apm_oss.metricIndices'),
       config.get<string>('apm_oss.errorIndices'),
       config.get<string>('apm_oss.transactionIndices')
     ],


### PR DESCRIPTION
A few of the APM names in the Kibana config are a bit inconsistent, and 7.0 being a major version allows us to make these kinds of breaking changes.

**indexPattern -> indexPatternTitle**
`indexPattern` can both be a string to match indices, and a saved object of type "indexPattern". 
In this case we use it as the title for the index pattern that is imported in the Getting Started guide, and I wanted to make that explicit:
https://github.com/elastic/kibana/blob/26a35e4f035ddae1bd78f4910f78c58eb57db2ec/src/legacy/core_plugins/kibana/server/tutorials/apm/saved_objects/get_saved_objects.js#L22-L25

**metricsIndices -> metricIndices**
We have 5 index matchers:
- errorIndices
- onboardingIndices
- spanIndices
- transactionIndices
- metric**s**Indices

`metricIndices` is the only one in plural. APM Server also has identifiers for documents:
 - error
 - onboarding
 - span
 - transaction
 - metric

Here the singular version is used consistently

I couldn't find any other usages of `metricsIndices` (plural) in Kibana. However Infra also uses `metricIndices` (singular): https://github.com/elastic/kibana/blob/26a35e4f035ddae1bd78f4910f78c58eb57db2ec/x-pack/plugins/infra/common/graphql/types.ts#L80-L81