### PR TITLE
[APM] Fix Stackframe fontsizes

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/FrameHeading.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/FrameHeading.tsx
@@ -9,12 +9,13 @@ import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import { idx } from 'x-pack/plugins/apm/common/idx';
 import { IStackframe } from 'x-pack/plugins/apm/typings/es_schemas/fields/Stackframe';
-import { fontFamilyCode, px, units } from '../../../style/variables';
+import { fontFamilyCode, fontSize, px, units } from '../../../style/variables';
 
 const FileDetails = styled.div`
   color: ${theme.euiColorMediumShade};
   padding: ${px(units.half)};
   font-family: ${fontFamilyCode};
+  font-size: ${fontSize};
 `;
 const LibraryFrameFileDetail = styled.span`
   color: ${theme.euiColorDarkShade};

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/Stackframe.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/Stackframe.tsx
@@ -11,7 +11,11 @@ import {
   IStackframe,
   IStackframeWithLineContext
 } from 'x-pack/plugins/apm/typings/es_schemas/fields/Stackframe';
-import { borderRadius, fontFamilyCode } from '../../../style/variables';
+import {
+  borderRadius,
+  fontFamilyCode,
+  fontSize
+} from '../../../style/variables';
 import { FrameHeading } from '../Stacktrace/FrameHeading';
 import { Context } from './Context';
 import { Variables } from './Variables';
@@ -24,6 +28,7 @@ const CodeHeader = styled.div`
 const Container = styled.div<{ isLibraryFrame: boolean }>`
   position: relative;
   font-family: ${fontFamilyCode};
+  font-size: ${fontSize};
   border: 1px solid ${theme.euiColorLightShade};
   border-radius: ${borderRadius};
   background: ${props =>

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/__test__/__snapshots__/Stackframe.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/__test__/__snapshots__/Stackframe.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Stackframe when stackframe has source lines should render correctly 1`]
   color: rgb(152,162,179);
   padding: 8px;
   font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-size: 14px;
 }
 
 .c3 {
@@ -103,6 +104,7 @@ exports[`Stackframe when stackframe has source lines should render correctly 1`]
 .c0 {
   position: relative;
   font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-size: 14px;
   border: 1px solid rgb(211,218,230);
   border-radius: 5px;
   background: rgb(245,247,250);


### PR DESCRIPTION
## Summary

Decreased the default font size to improve legibility in the code box.

_Before_

<img width="825" alt="screenshot 2019-02-08 at 10 34 57" src="https://user-images.githubusercontent.com/4104278/52473706-ca432e80-2b96-11e9-83fc-762f2bc401e0.png">

_After_

<img width="833" alt="screenshot 2019-02-08 at 10 34 36" src="https://user-images.githubusercontent.com/4104278/52473740-d202d300-2b96-11e9-9f61-d5ec1cb11dcd.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

