### PR TITLE
[Logs UI] Fix row height glitch on mouse over

### DIFF
--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_item_view.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_item_view.tsx
@@ -125,6 +125,7 @@ const LogTextStreamIconDiv = styled<IconProps, 'div'>('div')`
       : 'transparent'};
   text-align: center;
   user-select: none;
+  font-size: 0.9em;
 `;
 
 const LogTextStreamLogEntryItemDiv = styled.div`


### PR DESCRIPTION
This PR fixes elastic/kibana#30185 by changing the `font-size` to `0.9em`. I originally tried to change the `iconSize` per EUI documentation but it didn't seem to have any effect.

![icon-size-demo](https://user-images.githubusercontent.com/41702/52599742-bc034580-2e16-11e9-8f8c-6e3cffa8170e.gif)
 