### PR TITLE
[APM] Unconditional callout regarding migration for Getting Started Guide

### DIFF
--- a/src/legacy/core_plugins/kibana/common/tutorials/tutorial_schema.js
+++ b/src/legacy/core_plugins/kibana/common/tutorials/tutorial_schema.js
@@ -72,7 +72,11 @@ const instructionVariantSchema = Joi.object({
 
 const instructionSetSchema = Joi.object({
   title: Joi.string(),
-  callOut: Joi.object(),
+  callOut: Joi.object({
+    title: Joi.string().required(),
+    message: Joi.string(),
+    iconType: Joi.string()
+  }),
   // Variants (OSes, languages, etc.) for which tutorial instructions are specified.
   instructionVariants: Joi.array().items(instructionVariantSchema).required(),
   statusCheck: statusCheckSchema,

--- a/src/legacy/core_plugins/kibana/common/tutorials/tutorial_schema.js
+++ b/src/legacy/core_plugins/kibana/common/tutorials/tutorial_schema.js
@@ -70,6 +70,7 @@ const instructionVariantSchema = Joi.object({
 
 const instructionSetSchema = Joi.object({
   title: Joi.string(),
+  callOut: Joi.object(),
   // Variants (OSes, languages, etc.) for which tutorial instructions are specified.
   instructionVariants: Joi.array().items(instructionVariantSchema).required(),
   statusCheck: statusCheckSchema,

--- a/src/legacy/core_plugins/kibana/common/tutorials/tutorial_schema.js
+++ b/src/legacy/core_plugins/kibana/common/tutorials/tutorial_schema.js
@@ -51,7 +51,9 @@ const statusCheckSchema = Joi.object({
   success: Joi.string(),
   error: Joi.string(),
   esHitsCheck: Joi.object({
-    index: Joi.string().required(),
+    index: Joi.alternatives()
+      .try(Joi.string(), Joi.array().items(Joi.string()))
+      .required(),
     query: Joi.object().required(),
   }).required(),
 });

--- a/src/legacy/core_plugins/kibana/public/home/components/tutorial/instruction_set.js
+++ b/src/legacy/core_plugins/kibana/public/home/components/tutorial/instruction_set.js
@@ -253,6 +253,14 @@ class InstructionSetUi extends React.Component {
     );
   };
 
+  renderCallOut = () => {
+    if(!this.props.callOut) {
+      return null;
+    }
+
+    return <EuiCallOut {...this.props.callOut} />;
+  }
+
   render() {
     let paramsForm;
     if (this.props.params && this.state.isParamFormVisible) {
@@ -269,6 +277,8 @@ class InstructionSetUi extends React.Component {
       <div>
 
         {this.renderHeader()}
+
+        {this.renderCallOut()}
 
         {paramsForm}
 
@@ -307,6 +317,7 @@ const statusCheckConfigShape = PropTypes.shape({
 
 InstructionSetUi.propTypes = {
   title: PropTypes.string.isRequired,
+  callOut: PropTypes.object,
   instructionVariants: PropTypes.arrayOf(instructionVariantShape).isRequired,
   statusCheckConfig: statusCheckConfigShape,
   statusCheckState: PropTypes.oneOf([

--- a/src/legacy/core_plugins/kibana/public/home/components/tutorial/instruction_set.js
+++ b/src/legacy/core_plugins/kibana/public/home/components/tutorial/instruction_set.js
@@ -258,7 +258,7 @@ class InstructionSetUi extends React.Component {
       return null;
     }
 
-    return <EuiCallOut {...this.props.callOut} />;
+    return <EuiCallOut title={this.props.callOut.title} children={this.props.callOut.message} iconType={this.props.callOut.iconType} />;
   }
 
   render() {

--- a/src/legacy/core_plugins/kibana/public/home/components/tutorial/tutorial.js
+++ b/src/legacy/core_plugins/kibana/public/home/components/tutorial/tutorial.js
@@ -261,6 +261,7 @@ class TutorialUi extends React.Component {
       return (
         <InstructionSet
           title={instructionSet.title}
+          callOut={instructionSet.callOut}
           instructionVariants={instructionSet.instructionVariants}
           statusCheckConfig={instructionSet.statusCheck}
           statusCheckState={this.state.statusCheckStates[index]}

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
@@ -39,7 +39,7 @@ import {
   createJavaAgentInstructions,
 } from '../instructions/apm_agent_instructions';
 
-export function onPremInstructions(apmIndexPattern) {
+export function onPremInstructions(config) {
   const EDIT_CONFIG = createEditConfig();
   const START_SERVER_UNIX = createStartServerUnix();
   const START_SERVER_UNIX_SYSV = createStartServerUnixSysv();
@@ -89,14 +89,15 @@ export function onPremInstructions(apmIndexPattern) {
             defaultMessage: 'You have correctly setup APM Server',
           }),
           error: i18n.translate('kbn.server.tutorials.apm.apmServer.statusCheck.errorMessage', {
-            defaultMessage: 'No APM Server detected. Please make sure it is running and you have updated to 7.0 or higher.',
+            defaultMessage:
+              'No APM Server detected. Please make sure it is running and you have updated to 7.0 or higher.',
           }),
           esHitsCheck: {
-            index: apmIndexPattern,
+            index: config.get('apm_oss.onboardingIndices'),
             query: {
               bool: {
                 filter: [
-                  { exists: { field: 'observer.listening' } },
+                  { term: { 'processor.event': 'onboarding' } },
                   { range: { 'observer.version_major': { gte: 7 } } },
                 ],
               },
@@ -160,11 +161,16 @@ export function onPremInstructions(apmIndexPattern) {
             defaultMessage: 'No data has been received from agents yet',
           }),
           esHitsCheck: {
-            index: apmIndexPattern,
+            index: [
+              config.get('apm_oss.errorIndices'),
+              config.get('apm_oss.transactionIndices'),
+              config.get('apm_oss.metricsIndices'),
+              config.get('apm_oss.sourcemapIndices'),
+            ],
             query: {
               bool: {
                 filter: [
-                  { terms: { 'processor.name': ['error', 'transaction', 'metric', 'sourcemap'] } },
+                  { terms: { 'processor.event': ['error', 'transaction', 'metric', 'sourcemap'] } },
                   { range: { 'observer.version_major': { gte: 7 } } },
                 ],
               },

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
@@ -51,10 +51,14 @@ export function onPremInstructions(config) {
           defaultMessage: 'APM Server',
         }),
         callOut: {
-          title: 'Important: Updating to 7.0 or higher',
-          children:
-            'Please make sure your APM Server is updated to 7.0 or \
-             higher. You can also migrate your 6.x data with the Migration Assistant.',
+          title: i18n.translate('kbn.server.tutorials.apm.apmServer.callOut.title', {
+            defaultMessage: 'Important: Updating to 7.0 or higher',
+          }),
+          message: i18n.translate('kbn.server.tutorials.apm.apmServer.callOut.message', {
+            defaultMessage: `Please make sure your APM Server is updated to 7.0 or higher. \
+            You can also migrate your 6.x data with the migration assistant found in Kibana's management section.`,
+          }),
+          iconType: 'alert'
         },
         instructionVariants: [
           {

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
@@ -89,17 +89,16 @@ export function onPremInstructions(apmIndexPattern) {
             defaultMessage: 'You have correctly setup APM Server',
           }),
           error: i18n.translate('kbn.server.tutorials.apm.apmServer.statusCheck.errorMessage', {
-            defaultMessage: 'APM Server has still not connected to Elasticsearch',
+            defaultMessage: 'No APM Server detected. Please make sure it is running and you have updated to 7.0 or higher.',
           }),
           esHitsCheck: {
             index: apmIndexPattern,
             query: {
               bool: {
-                filter: {
-                  exists: {
-                    field: 'observer.listening',
-                  },
-                },
+                filter: [
+                  { exists: { field: 'observer.listening' } },
+                  { range: { 'observer.version_major': { gte: 7 } } },
+                ],
               },
             },
           },
@@ -164,11 +163,9 @@ export function onPremInstructions(apmIndexPattern) {
             index: apmIndexPattern,
             query: {
               bool: {
-                should: [
-                  { term: { 'processor.name': 'error' } },
-                  { term: { 'processor.name': 'transaction' } },
-                  { term: { 'processor.name': 'metric' } },
-                  { term: { 'processor.name': 'sourcemap' } },
+                filter: [
+                  { terms: { 'processor.name': ['error', 'transaction', 'metric', 'sourcemap'] } },
+                  { range: { 'observer.version_major': { gte: 7 } } },
                 ],
               },
             },

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/envs/on_prem.js
@@ -50,6 +50,12 @@ export function onPremInstructions(apmIndexPattern) {
         title: i18n.translate('kbn.server.tutorials.apm.apmServer.title', {
           defaultMessage: 'APM Server',
         }),
+        callOut: {
+          title: 'Important: Updating to 7.0 or higher',
+          children:
+            'Please make sure your APM Server is updated to 7.0 or \
+             higher. You can also migrate your 6.x data with the Migration Assistant.',
+        },
         instructionVariants: [
           {
             id: INSTRUCTION_VARIANT.OSX,

--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/index.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/index.js
@@ -84,7 +84,7 @@ It allows you to monitor the performance of thousands of applications in real ti
     }),
     euiIconType: 'apmApp',
     artifacts: artifacts,
-    onPrem: onPremInstructions(apmIndexPatternTitle),
+    onPrem: onPremInstructions(config),
     elasticCloud: createElasticCloudInstructions(config),
     previewImagePath: '/plugins/kibana/home/tutorial_resources/apm/apm.png',
     savedObjects: getSavedObjects(apmIndexPatternTitle),


### PR DESCRIPTION
Closes #30274

 - Adds the uncondtional callout to the Getting Started Guide
 - Updated the logic for the status checks, so it only considers 7.x+ data, and updated the status message to reflect this

<img width="1270" alt="screenshot 2019-02-12 at 12 55 59" src="https://user-images.githubusercontent.com/209966/52633772-b6186d80-2ec5-11e9-8b9c-7c7adafcc98b.png">

<img width="1283" alt="screenshot 2019-02-12 at 12 56 49" src="https://user-images.githubusercontent.com/209966/52633771-b6186d80-2ec5-11e9-9454-31ca29dba4ea.png">

cc @jasonrhodes 