### PR TITLE
Updates load object text now that we do not load visualizations

### DIFF
--- a/src/legacy/core_plugins/kibana/server/tutorials/apm/index.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/apm/index.js
@@ -91,9 +91,7 @@ It allows you to monitor the performance of thousands of applications in real ti
     savedObjectsInstallMsg: i18n.translate(
       'kbn.server.tutorials.apm.specProvider.savedObjectsInstallMsg',
       {
-        defaultMessage:
-          'Load index pattern, visualizations, and pre-defined dashboards. \
-An index pattern is required for some features in the APM UI.',
+        defaultMessage: 'An APM index pattern is required for some features in the APM UI.',
       }
     ),
   };


### PR DESCRIPTION
Closes #29245

## Summary

Removes message about loading dashboards and visualizations now that we no longer load those from the set up instructions page.

Note: "Load Kibana Objects" is the title here and cannot be changed.

Before:
<img width="1153" alt="screen shot 2019-02-12 at 9 03 27 am" src="https://user-images.githubusercontent.com/159370/52641939-fc5ed400-2ea7-11e9-9576-e2132b8fb16b.png">

Now:
<img width="1152" alt="screen shot 2019-02-12 at 9 08 12 am" src="https://user-images.githubusercontent.com/159370/52641950-01238800-2ea8-11e9-89de-3f5a95ce1ac3.png">


