### PR TITLE
[7.x] Fixing font size for icon div (#30744)

### DIFF
--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_item_view.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_item_view.tsx
@@ -125,6 +125,7 @@ const LogTextStreamIconDiv = styled<IconProps, 'div'>('div')`
       : 'transparent'};
   text-align: center;
   user-select: none;
+  font-size: 0.9em;
 `;
 
 const LogTextStreamLogEntryItemDiv = styled.div`


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixing font size for icon div  (#30744)