### PR TITLE
Removes noreferrer on explicit elastic.co domains

### DIFF
--- a/src/legacy/core_plugins/kibana/public/home/components/tutorial/__snapshots__/introduction.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/home/components/tutorial/__snapshots__/introduction.test.js.snap
@@ -50,7 +50,7 @@ exports[`props exportedFieldsUrl 1`] = `
         fill={false}
         href="exported_fields_url"
         iconSide="left"
-        rel="noopener noreferrer"
+        rel="noopener"
         target="_blank"
         type="button"
       >

--- a/src/legacy/core_plugins/kibana/public/home/components/tutorial/introduction.js
+++ b/src/legacy/core_plugins/kibana/public/home/components/tutorial/introduction.js
@@ -58,7 +58,7 @@ function IntroductionUI({ description, previewUrl, title, exportedFieldsUrl, ico
         <EuiButton
           href={exportedFieldsUrl}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           <FormattedMessage id="kbn.home.tutorial.introduction.viewButtonLabel" defaultMessage="View exported fields"/>
         </EuiButton>

--- a/src/legacy/core_plugins/kibana/ui_setting_defaults.js
+++ b/src/legacy/core_plugins/kibana/ui_setting_defaults.js
@@ -47,7 +47,7 @@ export function getUiSettingDefaults() {
                        'kbn.advancedSettings.query.queryStringOptionsText',
           values: {
             optionsLink:
-              '<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html" target="_blank" rel="noopener noreferrer">' +
+              '<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html" target="_blank" rel="noopener">' +
               i18n.translate('kbn.advancedSettings.query.queryStringOptions.optionsLinkText', {
                 defaultMessage: 'Options',
               }) +
@@ -94,7 +94,7 @@ export function getUiSettingDefaults() {
                      'kbn.advancedSettings.sortOptionsText',
         values: {
           optionsLink:
-            '<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html" target="_blank" rel="noopener noreferrer">' +
+            '<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html" target="_blank" rel="noopener">' +
             i18n.translate('kbn.advancedSettings.sortOptions.optionsLinkText', {
               defaultMessage: 'Options',
             }) +
@@ -332,7 +332,7 @@ export function getUiSettingDefaults() {
           setRequestReferenceSetting: '<strong>courier:setRequestPreference</strong>',
           customSettingValue: '"custom"',
           requestPreferenceLink:
-            '<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-preference.html" target="_blank" rel="noopener noreferrer">' +
+            '<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-preference.html" target="_blank" rel="noopener">' +
             i18n.translate('kbn.advancedSettings.courier.customRequestPreference.requestPreferenceLinkText', {
               defaultMessage: 'Request Preference',
             }) +
@@ -354,7 +354,7 @@ export function getUiSettingDefaults() {
         values: {
           maxRequestsLink:
             `<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
-            target="_blank" rel="noopener noreferrer" >max_concurrent_shard_requests</a>`
+            target="_blank" rel="noopener" >max_concurrent_shard_requests</a>`
         },
       }),
       category: ['search'],
@@ -362,7 +362,7 @@ export function getUiSettingDefaults() {
     'search:includeFrozen': {
       name: 'Search in frozen indices',
       description: `Will include <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen-indices.html"
-        target="_blank" rel="noopener noreferrer">frozen indices</a> in results if enabled. Searching through frozen indices
+        target="_blank" rel="noopener">frozen indices</a> in results if enabled. Searching through frozen indices
         might increase the search time.`,
       value: false,
       category: ['search'],
@@ -422,7 +422,7 @@ export function getUiSettingDefaults() {
         values: {
           cellDimensionsLink:
             `<a href="http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html#_cell_dimensions_at_the_equator"
-            target="_blank" rel="noopener noreferrer">` +
+            target="_blank" rel="noopener">` +
             i18n.translate('kbn.advancedSettings.visualization.tileMap.maxPrecision.cellDimensionsLinkText', {
               defaultMessage: 'Explanation of cell dimensions',
             }) +
@@ -819,7 +819,7 @@ export function getUiSettingDefaults() {
         values: {
           acceptedFormatsLink:
             `<a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math"
-            target="_blank" rel="noopener noreferrer">` +
+            target="_blank" rel="noopener">` +
             i18n.translate('kbn.advancedSettings.timepicker.quickRanges.acceptedFormatsLinkText', {
               defaultMessage: 'accepted formats',
             }) +
@@ -869,7 +869,7 @@ export function getUiSettingDefaults() {
         values: {
           markdownLink:
             `<a href="https://help.github.com/articles/basic-writing-and-formatting-syntax/"
-            target="_blank" rel="noopener noreferrer">` +
+            target="_blank" rel="noopener">` +
             i18n.translate('kbn.advancedSettings.notifications.banner.markdownLinkText', {
               defaultMessage: 'Markdown supported',
             }) +

--- a/src/legacy/core_plugins/region_map/public/region_map_vis_params.html
+++ b/src/legacy/core_plugins/region_map/public/region_map_vis_params.html
@@ -29,7 +29,7 @@
       <a
         class="rgmEMSLink pull-right"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noopener"
         ng-href="{{editorState.params.emsHotLink}}"
         target="_blank"
         title="{{'regionMap.visParams.previewOnEMSLinkTitle' | i18n: {

--- a/src/legacy/core_plugins/timelion/public/directives/timelion_help/timelion_help.html
+++ b/src/legacy/core_plugins/timelion/public/directives/timelion_help/timelion_help.html
@@ -278,7 +278,7 @@
         <a
           href="https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#query-string-syntax"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           i18n-id="timelion.help.querying.luceneQueryLinkText"
           i18n-default-message="Lucene query string"
           i18n-description="Part of composite text
@@ -334,7 +334,7 @@
         <a
           href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics.html"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           i18n-id="timelion.help.querying.countMetricAggregationLinkText"
           i18n-default-message="Elasticsearch metric aggregation"
           i18n-description="Part of composite text

--- a/src/legacy/core_plugins/vega/public/vega_editor_template.html
+++ b/src/legacy/core_plugins/vega/public/vega_editor_template.html
@@ -36,7 +36,7 @@
         <li role="menuitem">
           <a
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href="https://www.elastic.co/guide/en/kibana/master/vega-graph.html"
             i18n-id="vega.editor.vegaHelpLinkText"
             i18n-default-message="Kibana Vega Help"

--- a/src/legacy/ui/public/agg_types/controls/date_ranges.html
+++ b/src/legacy/ui/public/agg_types/controls/date_ranges.html
@@ -53,7 +53,7 @@
               class="kuiLink"
               documentation-href="date.dateMath"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               i18n-id="common.ui.aggTypes.dateRanges.acceptedDateFormatsLinkText"
               i18n-default-message="Accepted date formats"
             ></a>

--- a/src/legacy/ui/public/vis/editors/default/agg_select.html
+++ b/src/legacy/ui/public/vis/editors/default/agg_select.html
@@ -19,7 +19,7 @@
       href="{{aggHelpLink}}"
       class="pull-right visEditorAggSelect__helpLink"
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       i18n-id="common.ui.vis.editors.aggSelect.helpLinkLabel"
       i18n-default-message="{aggTitle} help"
       i18n-values="{ aggTitle: agg.type.title }"

--- a/x-pack/plugins/apm/public/components/shared/PropertiesTable/__test__/__snapshots__/PropertiesTable.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/PropertiesTable/__test__/__snapshots__/PropertiesTable.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`PropertiesTable AgentFeatureTipMessage component should render when doc
     type="iInCircle"
   />
   You can configure your agent to add contextual information about your users.
-
+   
   <EuiLink
     color="primary"
     href="mock-url"

--- a/x-pack/plugins/apm/public/components/shared/PropertiesTable/__test__/__snapshots__/PropertiesTable.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/shared/PropertiesTable/__test__/__snapshots__/PropertiesTable.test.tsx.snap
@@ -8,11 +8,11 @@ exports[`PropertiesTable AgentFeatureTipMessage component should render when doc
     type="iInCircle"
   />
   You can configure your agent to add contextual information about your users.
-   
+
   <EuiLink
     color="primary"
     href="mock-url"
-    rel="noopener noreferrer"
+    rel="noopener"
     target="_blank"
     type="button"
   >

--- a/x-pack/plugins/apm/public/components/shared/PropertiesTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/PropertiesTable/index.tsx
@@ -91,7 +91,7 @@ export function AgentFeatureTipMessage({
     <TableInfo>
       <EuiIconWithSpace type="iInCircle" />
       {getAgentFeatureText(featureName)}{' '}
-      <EuiLink target="_blank" rel="noopener noreferrer" href={docsUrl}>
+      <EuiLink target="_blank" rel="noopener" href={docsUrl}>
         {i18n.translate(
           'xpack.apm.propertiesTable.agentFeature.learnMoreLinkLabel',
           { defaultMessage: 'Learn more in the documentation.' }

--- a/x-pack/plugins/index_management/public/sections/index_list/components/detail_panel/edit_settings_json/edit_settings_json.js
+++ b/x-pack/plugins/index_management/public/sections/index_list/components/detail_panel/edit_settings_json/edit_settings_json.js
@@ -145,7 +145,7 @@ export class EditSettingsJson extends React.PureComponent {
         <EuiLink
           href={settingsDocumentationLink}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           <FormattedMessage
             id="xpack.idxMgmt.editSettingsJSON.settingsReferenceLinkText"

--- a/x-pack/plugins/infra/public/components/header_feedback_link.tsx
+++ b/x-pack/plugins/infra/public/components/header_feedback_link.tsx
@@ -15,7 +15,7 @@ interface InfraHeaderFeedbackLinkProps {
 
 export const InfraHeaderFeedbackLink: React.SFC<InfraHeaderFeedbackLinkProps> = ({ url }) => (
   <VerticallyCenteredHeaderSection side="right">
-    <EuiLink href={url} target="_blank" rel="noopener noreferrer">
+    <EuiLink href={url} target="_blank" rel="noopener">
       <FormattedMessage
         id="xpack.infra.headerFeedbackLink.feedbackText"
         defaultMessage="Feedback"

--- a/x-pack/plugins/ml/public/components/documentation_help_link/__snapshots__/documentation_help_link_view.test.js.snap
+++ b/x-pack/plugins/ml/public/components/documentation_help_link/__snapshots__/documentation_help_link_view.test.js.snap
@@ -8,7 +8,7 @@ exports[`DocumentationHelpLink renders the link 1`] = `
   target="_blank"
 >
   Label Text
-
+  
   <EuiIcon
     size="m"
     type="popout"

--- a/x-pack/plugins/ml/public/components/documentation_help_link/__snapshots__/documentation_help_link_view.test.js.snap
+++ b/x-pack/plugins/ml/public/components/documentation_help_link/__snapshots__/documentation_help_link_view.test.js.snap
@@ -8,7 +8,7 @@ exports[`DocumentationHelpLink renders the link 1`] = `
   target="_blank"
 >
   Label Text
-  
+   
   <EuiIcon
     size="m"
     type="popout"

--- a/x-pack/plugins/ml/public/components/documentation_help_link/__snapshots__/documentation_help_link_view.test.js.snap
+++ b/x-pack/plugins/ml/public/components/documentation_help_link/__snapshots__/documentation_help_link_view.test.js.snap
@@ -4,11 +4,11 @@ exports[`DocumentationHelpLink renders the link 1`] = `
 <a
   className="documentation-help-link"
   href="http://fullUrl"
-  rel="noopener noreferrer"
+  rel="noopener"
   target="_blank"
 >
   Label Text
-   
+
   <EuiIcon
     size="m"
     type="popout"

--- a/x-pack/plugins/ml/public/components/documentation_help_link/documentation_help_link_view.js
+++ b/x-pack/plugins/ml/public/components/documentation_help_link/documentation_help_link_view.js
@@ -12,7 +12,7 @@ export function DocumentationHelpLink({ fullUrl, label }) {
   return (
     <a
       href={fullUrl}
-      rel="noopener noreferrer"
+      rel="noopener"
       target="_blank"
       className="documentation-help-link"
     >

--- a/x-pack/plugins/searchprofiler/public/templates/index.html
+++ b/x-pack/plugins/searchprofiler/public/templates/index.html
@@ -41,7 +41,7 @@
             i18n-id="xpack.searchProfiler.registerLicenseDescription"
             i18n-default-message="Please {registerLicenseLink} to continue using the Search Profiler"
             i18n-values="{
-              html_registerLicenseLink: '<a class=\'kuiLink\' href=\'https://www.elastic.co/subscriptions\' rel=\'noopener noreferrer\'>' + registerLicenseLinkLabel + '</a>',
+              html_registerLicenseLink: '<a class=\'kuiLink\' href=\'https://www.elastic.co/subscriptions\' rel=\'noopener\'>' + registerLicenseLinkLabel + '</a>',
             }"
           ></p>
         </div>

--- a/x-pack/plugins/watcher/public/sections/watch_edit/components/watch_edit_detail/watch_edit_detail.html
+++ b/x-pack/plugins/watcher/public/sections/watch_edit/components/watch_edit_detail/watch_edit_detail.html
@@ -59,7 +59,7 @@
       <a
         href="{{ watchEditDetail.documentationLinks.watcher.putWatchApi }}"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noopener"
         data-test-subj="lnkPutWatchApiDoc"
         i18n-id="xpack.watcher.sections.watchEdit.detail.syntaxLinkLabel"
         i18n-default-message="Syntax"


### PR DESCRIPTION
## Summary

This remove the `noreferrer` attribute on docsite links that are "known" elastic.co links. Here's the methodology I went through:

- Did a search of `noreferrer` in Kibana.
- Filtered out anything with `snap` in them (snapshots).
- Filtered out x-pack, but then added them in since it was easy enough.
- Links that either had explicit references, or implied, to `elastic.co` were whitelisted. I used my best judgement for the "implied" ones, so feel free to say "no" to them!

I'm anticipating some test failures, and will follow up accordingly, but wanted to get this out for review prior to investing more time in stability.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

