### PR TITLE
[7.0] [Infra UI] Fixing group by labels by fixing the field names (post ECS migration) (#30416)

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/lib/field_to_display_name.ts
+++ b/x-pack/plugins/infra/public/components/waffle/lib/field_to_display_name.ts
@@ -24,19 +24,19 @@ export const fieldToName = (field: string, intl: InjectedIntl) => {
       id: 'xpack.infra.groupByDisplayNames.hostName',
       defaultMessage: 'Host',
     }),
-    'meta.cloud.availability_zone': intl.formatMessage({
+    'cloud.availability_zone': intl.formatMessage({
       id: 'xpack.infra.groupByDisplayNames.availabilityZone',
       defaultMessage: 'Availability Zone',
     }),
-    'meta.cloud.machine_type': intl.formatMessage({
+    'cloud.machine.type': intl.formatMessage({
       id: 'xpack.infra.groupByDisplayNames.machineType',
       defaultMessage: 'Machine Type',
     }),
-    'meta.cloud.project_id': intl.formatMessage({
+    'cloud.project.id': intl.formatMessage({
       id: 'xpack.infra.groupByDisplayNames.projectID',
       defaultMessage: 'Project ID',
     }),
-    'meta.cloud.provider': intl.formatMessage({
+    'cloud.provider': intl.formatMessage({
       id: 'xpack.infra.groupByDisplayNames.provider',
       defaultMessage: 'Cloud Provider',
     }),

--- a/x-pack/plugins/infra/public/components/waffle/waffle_group_by_controls.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/waffle_group_by_controls.tsx
@@ -48,14 +48,14 @@ const getOptions = (
       [InfraNodeType.container]: [
         'host.name',
         'cloud.availability_zone',
-        'cloud.machine_type',
-        'cloud.project_id',
+        'cloud.machine.type',
+        'cloud.project.id',
         'cloud.provider',
       ].map(mapFieldToOption),
       [InfraNodeType.host]: [
         'cloud.availability_zone',
-        'cloud.machine_type',
-        'cloud.project_id',
+        'cloud.machine.type',
+        'cloud.project.id',
         'cloud.provider',
       ].map(mapFieldToOption),
     };


### PR DESCRIPTION
Backports the following commits to 7.0:
 - [Infra UI] Fixing group by labels by fixing the field names (post ECS migration)  (#30416)