### PR TITLE
[APM] Move Http and DB context elements up in Span flyout

### DIFF
--- a/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
+++ b/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
@@ -75,11 +75,6 @@ describe('Span', () => {
     service: {
       name: 'service name'
     },
-    context: {
-      db: {
-        statement: 'db statement'
-      }
-    },
     parent: {
       id: 'parentId'
     },
@@ -90,7 +85,10 @@ describe('Span', () => {
       name: 'span name',
       subtype: 'my subtype',
       sync: false,
-      type: 'span type'
+      type: 'span type',
+      db: {
+        statement: 'db statement'
+      }
     },
     transaction: {
       id: 'transaction id'
@@ -140,7 +138,6 @@ describe('Error', () => {
         version: 'v1337'
       }
     },
-    context: {},
     parent: {
       id: 'parentId'
     },

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
@@ -22,6 +22,7 @@ import { Span } from 'x-pack/plugins/apm/typings/es_schemas/Span';
 import {
   borderRadius,
   fontFamilyCode,
+  fontSize,
   px,
   unit,
   units
@@ -35,6 +36,7 @@ const DatabaseStatement = styled.div`
   border-radius: ${borderRadius};
   border: 1px solid ${theme.euiColorLightShade};
   font-family: ${fontFamilyCode};
+  font-size: ${fontSize};
 `;
 
 interface Props {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
@@ -38,7 +38,7 @@ const DatabaseStatement = styled.div`
 `;
 
 interface Props {
-  dbContext?: NonNullable<Span['context']>['db'];
+  dbContext?: NonNullable<Span['span']>['db'];
 }
 
 export function DatabaseContext({ dbContext }: Props) {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/HttpContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/HttpContext.tsx
@@ -16,6 +16,7 @@ import {
 
 import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { idx } from 'x-pack/plugins/apm/common/idx';
 import { Span } from 'x-pack/plugins/apm/typings/es_schemas/Span';
 
 const ContextUrl = styled.div`
@@ -27,11 +28,13 @@ const ContextUrl = styled.div`
 `;
 
 interface Props {
-  httpContext: NonNullable<Span['context']>['http'];
+  httpContext: NonNullable<Span['span']>['http'];
 }
 
 export function HttpContext({ httpContext }: Props) {
-  if (!httpContext || !httpContext.url) {
+  const url = idx(httpContext, _ => _.url.original);
+
+  if (!url) {
     return null;
   }
 
@@ -41,7 +44,7 @@ export function HttpContext({ httpContext }: Props) {
         <h3>HTTP URL</h3>
       </EuiTitle>
       <EuiSpacer size="m" />
-      <ContextUrl>{httpContext.url}</ContextUrl>
+      <ContextUrl>{url}</ContextUrl>
       <EuiSpacer size="l" />
     </Fragment>
   );

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/HttpContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/HttpContext.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import {
   borderRadius,
   fontFamilyCode,
+  fontSize,
   px,
   unit,
   units
@@ -25,6 +26,7 @@ const ContextUrl = styled.div`
   border-radius: ${borderRadius};
   border: 1px solid ${theme.euiColorLightShade};
   font-family: ${fontFamilyCode};
+  font-size: ${fontSize};
 `;
 
 interface Props {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -55,8 +55,8 @@ export function SpanFlyout({
 
   const stackframes = span.span.stacktrace;
   const codeLanguage = idx(parentTransaction, _ => _.service.language.name);
-  const dbContext = idx(span, _ => _.context.db);
-  const httpContext = idx(span, _ => _.context.http);
+  const dbContext = idx(span, _ => _.span.db);
+  const httpContext = idx(span, _ => _.span.http);
   const labels = span.labels;
   const tags = keys(labels).map(key => ({
     key,
@@ -100,6 +100,8 @@ export function SpanFlyout({
           <EuiHorizontalRule />
           <StickySpanProperties span={span} totalDuration={totalDuration} />
           <EuiHorizontalRule />
+          <HttpContext httpContext={httpContext} />
+          <DatabaseContext dbContext={dbContext} />
           <EuiTabbedContent
             tabs={[
               {
@@ -113,8 +115,6 @@ export function SpanFlyout({
                 content: (
                   <Fragment>
                     <EuiSpacer size="l" />
-                    <HttpContext httpContext={httpContext} />
-                    <DatabaseContext dbContext={dbContext} />
                     <Stacktrace
                       stackframes={stackframes}
                       codeLanguage={codeLanguage}

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
@@ -60,11 +60,10 @@ export function Stacktrace({ stackframes = [], codeLanguage }: Props) {
 
         // non-library frame
         return group.stackframes.map((stackframe, idx) => (
-          <Stackframe
-            key={`${i}-${idx}`}
-            codeLanguage={codeLanguage}
-            stackframe={stackframe}
-          />
+          <Fragment key={`${i}-${idx}`}>
+            {idx > 0 && <EuiSpacer size="m" />}
+            <Stackframe codeLanguage={codeLanguage} stackframe={stackframe} />
+          </Fragment>
         ));
       })}
       <EuiSpacer size="m" />

--- a/x-pack/plugins/apm/typings/es_schemas/Span.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/Span.ts
@@ -39,6 +39,15 @@ export interface Span extends APMDoc {
     subtype: string;
     sync: boolean;
     type: string;
+    http?: {
+      url: {
+        original: string;
+      };
+    };
+    db?: {
+      statement: string;
+      type?: string;
+    };
   };
   transaction: { id: string };
 }

--- a/x-pack/plugins/apm/typings/es_schemas/Span.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/Span.ts
@@ -12,23 +12,8 @@ interface Processor {
   event: 'span';
 }
 
-interface SpanContext {
-  db?: {
-    instance?: string;
-    statement?: string;
-    type?: string;
-    user?: string;
-  };
-  http?: {
-    method?: string;
-    status_code?: number;
-    url?: string;
-  };
-}
-
 export interface Span extends APMDoc {
   processor: Processor;
-  context?: SpanContext;
   service: { name: string };
   span: {
     action: string;
@@ -40,13 +25,21 @@ export interface Span extends APMDoc {
     sync: boolean;
     type: string;
     http?: {
-      url: {
-        original: string;
+      url?: {
+        original?: string;
       };
+      response?: {
+        status_code?: number;
+      };
+      method?: string;
     };
     db?: {
-      statement: string;
+      instance?: string;
+      statement?: string;
       type?: string;
+      user?: {
+        name?: string;
+      };
     };
   };
   transaction: { id: string };


### PR DESCRIPTION
Closes #29697 by moving the Http and DB context elements up above the tabbed content/stacktrace. 
Also fixed some bugs:
	- was expecting pre-ecs context data in HttpContext and DatabaseContext
	- style issue with missing spacer between stackframes
![span-flyout-move-http-db-up](https://user-images.githubusercontent.com/1967266/52756443-361e0080-2fb6-11e9-9bcf-85969c94dcf9.gif)
