### PR TITLE
[7.x] Fixes #30090 - Change context.system.hostname to host.hostname for contextual menu. (#30884)

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node_context_menu.tsx
@@ -30,7 +30,7 @@ export const NodeContextMenu = injectI18n(
     // #26620 for the details for these fields.
     // TODO: This is tech debt, remove it after 7.0 & ECS migration.
     const APM_FIELDS = {
-      [InfraNodeType.host]: 'context.system.hostname',
+      [InfraNodeType.host]: 'host.hostname',
       [InfraNodeType.container]: 'container.id',
       [InfraNodeType.pod]: 'kubernetes.pod.uid',
     };


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixes #30090 - Change context.system.hostname to host.hostname for contextual menu.  (#30884)