### PR TITLE
[6.7] [Infra UI] Clean up Docker and Kubernetes fields for ECS (#31175)

### DIFF
--- a/docs/settings/general-infra-logs-ui-settings.asciidoc
+++ b/docs/settings/general-infra-logs-ui-settings.asciidoc
@@ -10,8 +10,8 @@
 
 `xpack.infra.sources.default.fields.tiebreaker`:: Field used to break ties between two entries with the same timestamp. Defaults to `_doc`.
 
-`xpack.infra.sources.default.fields.host`:: Field used to identify hosts. Defaults to `beat.hostname`.
+`xpack.infra.sources.default.fields.host`:: Field used to identify hosts. Defaults to `host.name`.
 
-`xpack.infra.sources.default.fields.container`:: Field used to identify Docker containers. Defaults to `docker.container.name`.
+`xpack.infra.sources.default.fields.container`:: Field used to identify Docker containers. Defaults to `container.id`.
 
-`xpack.infra.sources.default.fields.pod`:: Field used to identify Kubernetes pods. Defaults to `kubernetes.pod.name`.
+`xpack.infra.sources.default.fields.pod`:: Field used to identify Kubernetes pods. Defaults to `kubernetes.pod.uid`.

--- a/x-pack/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
+++ b/x-pack/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
@@ -94,7 +94,7 @@ export const FieldsConfigurationPanel = ({
           id="xpack.infra.sourceConfiguration.containerFieldDescription"
           defaultMessage="Field used to identify Docker containers. The recommended value is {defaultValue}."
           values={{
-            defaultValue: <EuiCode>docker.container.id</EuiCode>,
+            defaultValue: <EuiCode>container.id</EuiCode>,
           }}
         />
       }

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_overview.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_overview.ts
@@ -122,7 +122,7 @@ export const hostK8sOverview: InfraMetricModelCreator = (timeField, indexPattern
           type: InfraMetricModelMetricType.max,
         },
         {
-          field: 'kubernetes.pod.name',
+          field: 'kubernetes.pod.uid',
           id: 'card-pod-name',
           type: InfraMetricModelMetricType.cardinality,
         },

--- a/x-pack/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_pod_cap.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_pod_cap.ts
@@ -31,7 +31,7 @@ export const hostK8sPodCap: InfraMetricModelCreator = (timeField, indexPattern, 
       id: 'used',
       metrics: [
         {
-          field: 'kubernetes.pod.name',
+          field: 'kubernetes.pod.uid',
           id: 'avg-pod',
           type: InfraMetricModelMetricType.cardinality,
         },

--- a/x-pack/plugins/infra/server/lib/sources/defaults.ts
+++ b/x-pack/plugins/infra/server/lib/sources/defaults.ts
@@ -10,7 +10,7 @@ export const defaultSourceConfiguration = {
   metricAlias: 'metricbeat-*',
   logAlias: 'filebeat-*,kibana_sample_data_logs*',
   fields: {
-    container: 'docker.container.id',
+    container: 'container.id',
     host: 'host.name',
     pod: 'kubernetes.pod.uid',
     tiebreaker: '_doc',

--- a/x-pack/test/api_integration/apis/infra/sources.ts
+++ b/x-pack/test/api_integration/apis/infra/sources.ts
@@ -37,7 +37,7 @@ const sourcesTests: KbnTestProvider = ({ getService }) => {
         expect(sourceConfiguration.name).to.be('Default');
         expect(sourceConfiguration.metricAlias).to.be('metricbeat-*');
         expect(sourceConfiguration.logAlias).to.be('filebeat-*,kibana_sample_data_logs*');
-        expect(sourceConfiguration.fields.container).to.be('docker.container.id');
+        expect(sourceConfiguration.fields.container).to.be('container.id');
         expect(sourceConfiguration.fields.host).to.be('host.name');
         expect(sourceConfiguration.fields.pod).to.be('kubernetes.pod.uid');
 
@@ -108,7 +108,7 @@ const sourcesTests: KbnTestProvider = ({ getService }) => {
         expect(configuration.description).to.be('');
         expect(configuration.metricAlias).to.be('metricbeat-*');
         expect(configuration.logAlias).to.be('filebeat-*,kibana_sample_data_logs*');
-        expect(configuration.fields.container).to.be('docker.container.id');
+        expect(configuration.fields.container).to.be('container.id');
         expect(configuration.fields.host).to.be('host.name');
         expect(configuration.fields.pod).to.be('kubernetes.pod.uid');
         expect(configuration.fields.tiebreaker).to.be('_doc');


### PR DESCRIPTION
Backports the following commits to 6.7:
 - [Infra UI] Clean up Docker and Kubernetes fields for ECS  (#31175)