### PR TITLE
[APM] Always render collapsible library stackframes

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/LibraryStackFrames.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/LibraryStackFrames.tsx
@@ -44,16 +44,6 @@ export class LibraryStackFrames extends React.Component<Props, State> {
       return null;
     }
 
-    if (stackframes.length === 1) {
-      return (
-        <Stackframe
-          isLibraryFrame
-          codeLanguage={codeLanguage}
-          stackframe={stackframes[0]}
-        />
-      );
-    }
-
     return (
       <div>
         <LibraryFrameToggle>

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/LibraryStackFrames.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/LibraryStackFrames.tsx
@@ -55,8 +55,9 @@ export class LibraryStackFrames extends React.Component<Props, State> {
             {i18n.translate(
               'xpack.apm.stacktraceTab.libraryFramesToogleButtonLabel',
               {
-                defaultMessage: '{stackframesLength} library frames',
-                values: { stackframesLength: stackframes.length }
+                defaultMessage:
+                  '{count, plural, one {# library frame} other {# library frames}}',
+                values: { count: stackframes.length }
               }
             )}
           </EuiLink>

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/index.tsx
@@ -41,19 +41,15 @@ export function Stacktrace({ stackframes = [], codeLanguage }: Props) {
       {groups.map((group, i) => {
         // library frame
         if (group.isLibraryFrame) {
-          const hasMultipleStackframes = group.stackframes.length > 1;
-          const hasLeadingSpacer = hasMultipleStackframes && i !== 0;
-          const hasTrailingSpacer =
-            hasMultipleStackframes && i !== groups.length - 1;
           return (
             <Fragment key={i}>
-              {hasLeadingSpacer && <EuiSpacer size="m" />}
+              <EuiSpacer size="m" />
               <LibraryStackFrames
-                initialVisiblity={!hasMultipleStackframes}
+                initialVisiblity={false}
                 stackframes={group.stackframes}
                 codeLanguage={codeLanguage}
               />
-              {hasTrailingSpacer && <EuiSpacer size="m" />}
+              <EuiSpacer size="m" />
             </Fragment>
           );
         }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3458,7 +3458,7 @@
     "xpack.apm.servicesTable.transactionsPerMinuteColumnLabel": "每分钟事务数",
     "xpack.apm.servicesTable.transactionsPerMinuteUnitLabel": "tpm",
     "xpack.apm.setupInstructionsButtonLabel": "设置说明",
-    "xpack.apm.stacktraceTab.libraryFramesToogleButtonLabel": "{stackframesLength} 库框架",
+    "xpack.apm.stacktraceTab.libraryFramesToogleButtonLabel": "{count} 库框架",
     "xpack.apm.stacktraceTab.localVariablesToogleButtonLabel": "本地变量",
     "xpack.apm.stacktraceTab.noStacktraceAvailableLabel": "没有可用的堆栈追溯信息。",
     "xpack.apm.topNav.apmFeedbackDescription": "APM 反馈",


### PR DESCRIPTION
[APM] closes #28919 by always rendering library stackframes as collapsible, even when there's only 1

<img width="524" alt="screen shot 2019-02-20 at 12 28 16 am" src="https://user-images.githubusercontent.com/1967266/53077288-86a9c800-34a6-11e9-87a6-588bb35228c5.png">
<img width="525" alt="screen shot 2019-02-20 at 12 28 48 am" src="https://user-images.githubusercontent.com/1967266/53077290-86a9c800-34a6-11e9-9738-e08b82759dbd.png">
