### PR TITLE
[APM] Trunctating DB statements in span flyout

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
@@ -69,7 +69,7 @@ export function DatabaseContext({ dbContext }: Props) {
       </EuiTitle>
       <EuiSpacer size="m" />
       <DatabaseStatement>
-        <TruncateHeightSection previewHeight={px(10 * dbSyntaxLineHeight)}>
+        <TruncateHeightSection previewHeight={10 * dbSyntaxLineHeight}>
           <SyntaxHighlighter
             language={'sql'}
             style={xcode}

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/DatabaseContext.tsx
@@ -27,6 +27,7 @@ import {
   unit,
   units
 } from '../../../../../../../style/variables';
+import { TruncateHeightSection } from './TruncateHeightSection';
 
 registerLanguage('sql', sql);
 
@@ -38,6 +39,8 @@ const DatabaseStatement = styled.div`
   font-family: ${fontFamilyCode};
   font-size: ${fontSize};
 `;
+
+const dbSyntaxLineHeight = unit * 1.5;
 
 interface Props {
   dbContext?: NonNullable<Span['span']>['db'];
@@ -66,20 +69,22 @@ export function DatabaseContext({ dbContext }: Props) {
       </EuiTitle>
       <EuiSpacer size="m" />
       <DatabaseStatement>
-        <SyntaxHighlighter
-          language={'sql'}
-          style={xcode}
-          customStyle={{
-            color: null,
-            background: null,
-            padding: null,
-            lineHeight: px(unit * 1.5),
-            whiteSpace: 'pre-wrap',
-            overflowX: 'scroll'
-          }}
-        >
-          {dbContext.statement}
-        </SyntaxHighlighter>
+        <TruncateHeightSection previewHeight={px(10 * dbSyntaxLineHeight)}>
+          <SyntaxHighlighter
+            language={'sql'}
+            style={xcode}
+            customStyle={{
+              color: null,
+              background: null,
+              padding: null,
+              lineHeight: px(dbSyntaxLineHeight),
+              whiteSpace: 'pre-wrap',
+              overflowX: 'scroll'
+            }}
+          >
+            {dbContext.statement}
+          </SyntaxHighlighter>
+        </TruncateHeightSection>
       </DatabaseStatement>
       <EuiSpacer size="l" />
     </Fragment>

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/TruncateHeightSection.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/TruncateHeightSection.tsx
@@ -18,38 +18,27 @@ const ToggleButtonContainer = styled.div`
 `;
 
 interface Props {
-  previewHeight: string;
+  previewHeight: number;
 }
 
 export const TruncateHeightSection: React.SFC<Props> = ({
   children,
   previewHeight
 }) => {
-  const [isTruncated, setIsTruncated] = useState(true);
-  const [isContentClipping, setIsContentClipping] = useState(true);
-  const [forcedStaticHeight, setForcedStaticHeight] = useState(true);
   const contentContainerEl = useRef<HTMLDivElement>(null);
 
-  useEffect(
-    () => {
-      setForcedStaticHeight(true);
-    },
-    [children, previewHeight]
-  );
+  const [showToggle, setShowToggle] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(
     () => {
-      if (forcedStaticHeight) {
-        if (contentContainerEl.current) {
-          setIsContentClipping(
-            contentContainerEl.current.scrollHeight >
-              contentContainerEl.current.clientHeight
-          );
-        }
-        setForcedStaticHeight(false);
+      if (contentContainerEl.current) {
+        const shouldShow =
+          contentContainerEl.current.scrollHeight > previewHeight;
+        setShowToggle(shouldShow);
       }
     },
-    [forcedStaticHeight]
+    [children, previewHeight]
   );
 
   return (
@@ -58,26 +47,23 @@ export const TruncateHeightSection: React.SFC<Props> = ({
         ref={contentContainerEl}
         style={{
           overflow: 'hidden',
-          height:
-            forcedStaticHeight || (isContentClipping && isTruncated)
-              ? previewHeight
-              : 'auto'
+          maxHeight: isOpen ? 'initial' : px(previewHeight)
         }}
       >
         {children}
       </div>
-      {isContentClipping ? (
+      {showToggle ? (
         <ToggleButtonContainer>
           <EuiLink
             onClick={() => {
-              setIsTruncated(!isTruncated);
+              setIsOpen(!isOpen);
             }}
           >
             <Ellipsis
-              horizontal={!isTruncated}
+              horizontal={!isOpen}
               style={{ marginRight: units.half }}
             />{' '}
-            {isTruncated
+            {isOpen
               ? i18n.translate('xpack.apm.toggleHeight.showMoreButtonLabel', {
                   defaultMessage: 'Show more lines'
                 })

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/TruncateHeightSection.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/TruncateHeightSection.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { Fragment, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { idx } from 'x-pack/plugins/apm/common/idx';
+import { px, units } from '../../../../../../../style/variables';
+// @ts-ignore
+import { Ellipsis } from '../../../../../../shared/Icons';
+
+const ToggleButtonContainer = styled.div`
+  margin-top: ${px(units.half)};
+  user-select: none;
+`;
+
+const ContentContainer = styled.div`
+  overflow: hidden;
+`;
+
+interface Props {
+  previewHeight: string;
+}
+
+export const TruncateHeightSection: React.SFC<Props> = props => {
+  const [isTruncated, setIsTruncated] = useState(true);
+  const [showToggle, setShowToggle] = useState(false);
+  const contentContainerEl = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scrollHeight =
+      idx(contentContainerEl, _ => _.current.scrollHeight) || 0;
+    const clientHeight =
+      idx(contentContainerEl, _ => _.current.clientHeight) || 0;
+    if (scrollHeight > clientHeight) {
+      setShowToggle(true);
+    } else {
+      setIsTruncated(false);
+    }
+  });
+
+  return (
+    <Fragment>
+      <ContentContainer
+        innerRef={contentContainerEl}
+        style={{
+          height: isTruncated ? props.previewHeight : 'auto'
+        }}
+      >
+        {props.children}
+      </ContentContainer>
+      {showToggle ? (
+        <ToggleButtonContainer>
+          <EuiLink
+            onClick={() => {
+              setIsTruncated(!isTruncated);
+            }}
+          >
+            <Ellipsis
+              horizontal={!isTruncated}
+              style={{ marginRight: units.half }}
+            />{' '}
+            {isTruncated
+              ? i18n.translate('xpack.apm.toggleHeight.showMoreButtonLabel', {
+                  defaultMessage: 'Show more lines'
+                })
+              : i18n.translate('xpack.apm.toggleHeight.showLessButtonLabel', {
+                  defaultMessage: 'Show fewer lines'
+                })}
+          </EuiLink>
+        </ToggleButtonContainer>
+      ) : null}
+    </Fragment>
+  );
+};


### PR DESCRIPTION
[APM] closes #18114 by trunctating db statements in span flyout by default but allowing toggle between preview and full content.
![db-statement-truncation](https://user-images.githubusercontent.com/1967266/53157796-2767b880-3577-11e9-9c29-53cea9508fec.gif)
