### PR TITLE
[APM] Switch to visualization colour palette for histogram

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/Histogram/__test__/__snapshots__/Histogram.test.js.snap
+++ b/x-pack/plugins/apm/public/components/shared/charts/Histogram/__test__/__snapshots__/Histogram.test.js.snap
@@ -422,11 +422,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -441,11 +441,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -460,11 +460,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857142}
@@ -479,11 +479,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -498,11 +498,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571405}
@@ -517,11 +517,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857142}
@@ -536,11 +536,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571405}
@@ -555,11 +555,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571405}
@@ -574,11 +574,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571377}
@@ -593,11 +593,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571462}
@@ -612,11 +612,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -631,11 +631,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -650,11 +650,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -669,11 +669,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -688,11 +688,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -707,11 +707,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -726,11 +726,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571547}
@@ -745,11 +745,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -764,11 +764,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571547}
@@ -783,11 +783,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -802,11 +802,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571433}
@@ -821,11 +821,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571377}
@@ -840,11 +840,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -859,11 +859,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -878,11 +878,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571604}
@@ -897,11 +897,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -916,11 +916,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.62857142857149}
@@ -935,11 +935,11 @@ exports[`Histogram Initially should have default markup 1`] = `
           onMouseOver={[Function]}
           style={
             Object {
-              "fill": "#7fb5d9",
+              "fill": "#98c2fd",
               "opacity": 1,
               "rx": "0px",
               "ry": "0px",
-              "stroke": "#7fb5d9",
+              "stroke": "#98c2fd",
             }
           }
           width={22.628571428571377}

--- a/x-pack/plugins/apm/public/components/shared/charts/Histogram/index.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/Histogram/index.js
@@ -72,8 +72,8 @@ export class HistogramInner extends PureComponent {
         ...item,
         color:
           item === selectedItem
-            ? theme.euiColorPrimary
-            : tint(0.5, theme.euiColorPrimary),
+            ? theme.euiColorVis1
+            : tint(0.5, theme.euiColorVis1),
         x0: item.x0 + padding,
         x: item.x - padding,
         y: item.y > 0 ? Math.max(item.y, MINIMUM_BUCKET_SIZE) : 0

--- a/x-pack/plugins/apm/public/components/shared/charts/Histogram/index.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/Histogram/index.js
@@ -181,7 +181,7 @@ export class HistogramInner extends PureComponent {
               width={x(bucketSize) - x(0)}
               style={{
                 fill: 'transparent',
-                stroke: theme.euiColorPrimary,
+                stroke: theme.euiColorVis1,
                 rx: '0px',
                 ry: '0px'
               }}


### PR DESCRIPTION
## Summary

In order to better support custom theming in Kibana, it makes sense to consider converting our only chart that doesn't utilize EUI visualization colours. The histogram which is used for interactively selecting sample from response time distribution and showing error occurrences over time has been using the `euiColorPrimary`. The issue that might occur is that a theme replaces that `euiColorPrimary` with a green, orange or similar to match with customer branding or similar, and that immediately changes the way our charts are rendered in this specific case.

One added benefit is that the blue viz colour typically aligns with the assigned colour for the service in the Timeline view.

![kapture 2019-02-21 at 14 43 52](https://user-images.githubusercontent.com/4104278/53173387-da6ffa80-35e7-11e9-81be-bd36726366b3.gif)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

