### PR TITLE
[APM] Fix migrate assistant label and copy

### DIFF
--- a/x-pack/plugins/apm/public/components/app/GlobalHelpExtension/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/GlobalHelpExtension/index.tsx
@@ -37,8 +37,8 @@ export const GlobalHelpExtension: React.SFC = () => {
             hash: '/management/elasticsearch/upgrade_assistant'
           })}
         >
-          {i18n.translate('xpack.apm.helpMenu.migrationAssistantLink', {
-            defaultMessage: 'Migration assistant'
+          {i18n.translate('xpack.apm.helpMenu.upgradeAssistantLink', {
+            defaultMessage: 'Upgrade assistant'
           })}
         </EuiLink>
       </Container>

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/NoServicesMessage.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/NoServicesMessage.tsx
@@ -61,10 +61,10 @@ export function NoServicesMessage({ historicalDataFound }: Props) {
                 hash="/management/elasticsearch/upgrade_assistant"
               >
                 {i18n.translate(
-                  'xpack.apm.servicesTable.MigrationAssistantLink',
+                  'xpack.apm.servicesTable.UpgradeAssistantLink',
                   {
                     defaultMessage:
-                      'Learn more by visiting the Kibana Migration Assistant'
+                      'Learn more by visiting the Kibana Upgrade Assistant'
                   }
                 )}
               </KibanaLink>

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/__test__/NoServicesMessage.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/__test__/NoServicesMessage.test.tsx
@@ -14,7 +14,7 @@ describe('NoServicesMessage', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should show a "no services installed" message, a link to the set up instructions page, a message about upgrading APM server, and a link to the migration assistant when NO historical data is found', () => {
+  it('should show a "no services installed" message, a link to the set up instructions page, a message about upgrading APM server, and a link to the upgrade assistant when NO historical data is found', () => {
     const wrapper = shallow(<NoServicesMessage historicalDataFound={false} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/NoServicesMessage.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/NoServicesMessage.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NoServicesMessage should show a "no services installed" message, a link to the set up instructions page, a message about upgrading APM server, and a link to the migration assistant when NO historical data is found 1`] = `
+exports[`NoServicesMessage should show a "no services installed" message, a link to the set up instructions page, a message about upgrading APM server, and a link to the upgrade assistant when NO historical data is found 1`] = `
 <EuiEmptyPrompt
   actions={
     <SetupInstructionsLink
@@ -20,7 +20,7 @@ exports[`NoServicesMessage should show a "no services installed" message, a link
           hash="/management/elasticsearch/upgrade_assistant"
           pathname="/app/kibana"
         >
-          Learn more by visiting the Kibana Migration Assistant
+          Learn more by visiting the Kibana Upgrade Assistant
         </Connect(UnconnectedKibanaLink)>
         .
       </p>


### PR DESCRIPTION
## Summary

A small oversight (probably on my part), but I've been calling it the Migration Assistant throughout, when it's actually called Upgrade assistant in Kibana. I'm rectifying my mistake to make it consistent with Kibana terminology. Otherwise it'd be rather confusing to users.

- [x] Updated help menu copy
<img width="367" alt="screenshot 2019-02-21 at 22 38 58" src="https://user-images.githubusercontent.com/4104278/53203679-1af06800-362a-11e9-9ef8-a51687f16ad2.png">

- [x] Updated "No services" empty state copy on Services list 
![image.png](https://zube.io/files/elastic/2e18790a0fc0c403957572cb4f55060c-image.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~