### PR TITLE
[Infra UI] Change waffle map node to button for accessibility

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/node.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node.tsx
@@ -66,13 +66,13 @@ export class Node extends React.PureComponent<Props, State> {
             <SquareOuter color={color}>
               <SquareInner color={color}>
                 {valueMode ? (
-                  <ValueInner>
+                  <ValueInner aria-label={`${node.name}, click to open menu`}>
                     <Label color={color}>{node.name}</Label>
                     <Value color={color}>{value}</Value>
                   </ValueInner>
                 ) : (
                   ellipsisMode && (
-                    <ValueInner>
+                    <ValueInner aria-label={`${node.name}, click to open menu`}>
                       <Label color={color}>...</Label>
                     </ValueInner>
                   )
@@ -126,7 +126,7 @@ const SquareInner = styled<ColorProps, 'div'>('div')`
   background-color: ${props => props.color};
 `;
 
-const ValueInner = styled.div`
+const ValueInner = styled.button`
   position: absolute;
   top: 0;
   left: 0;
@@ -139,6 +139,13 @@ const ValueInner = styled.div`
   padding: 1em;
   overflow: hidden;
   flex-wrap: wrap;
+  width: 100%;
+  border: none;
+  &:focus {
+    outline: none !important;
+    border: 3px solid ${params => params.theme.eui.euiFocusRingColor};
+    box-shadow: none;
+  }
 `;
 
 const Value = styled<ColorProps, 'div'>('div')`

--- a/x-pack/plugins/infra/public/components/waffle/node.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/node.tsx
@@ -10,6 +10,7 @@ import { darken, readableColor } from 'polished';
 import React from 'react';
 import styled from 'styled-components';
 
+import { InjectedIntl, injectI18n } from '@kbn/i18n/react';
 import { InfraNodeType } from '../../../server/lib/adapters/nodes';
 import { InfraTimerangeInput } from '../../graphql/types';
 import { InfraWaffleMapBounds, InfraWaffleMapNode, InfraWaffleMapOptions } from '../../lib/lib';
@@ -30,71 +31,90 @@ interface Props {
   bounds: InfraWaffleMapBounds;
   nodeType: InfraNodeType;
   timeRange: InfraTimerangeInput;
+  intl: InjectedIntl;
 }
 
-export class Node extends React.PureComponent<Props, State> {
-  public readonly state: State = initialState;
-  public render() {
-    const { nodeType, node, options, squareSize, bounds, formatter, timeRange } = this.props;
-    const { isPopoverOpen } = this.state;
-    const { metric } = node;
-    const valueMode = squareSize > 70;
-    const ellipsisMode = squareSize > 30;
-    const rawValue = (metric && metric.value) || 0;
-    const color = colorFromValue(options.legend, rawValue, bounds);
-    const value = formatter(rawValue);
-    const newTimerange = {
-      ...timeRange,
-      from: moment(timeRange.to)
-        .subtract(1, 'hour')
-        .valueOf(),
-    };
-    return (
-      <NodeContextMenu
-        node={node}
-        nodeType={nodeType}
-        isPopoverOpen={isPopoverOpen}
-        closePopover={this.closePopover}
-        options={options}
-        timeRange={newTimerange}
-      >
-        <EuiToolTip position="top" content={`${node.name} | ${value}`}>
-          <NodeContainer
-            style={{ width: squareSize || 0, height: squareSize || 0 }}
-            onClick={this.togglePopover}
-          >
-            <SquareOuter color={color}>
-              <SquareInner color={color}>
-                {valueMode ? (
-                  <ValueInner aria-label={`${node.name}, click to open menu`}>
-                    <Label color={color}>{node.name}</Label>
-                    <Value color={color}>{value}</Value>
-                  </ValueInner>
-                ) : (
-                  ellipsisMode && (
-                    <ValueInner aria-label={`${node.name}, click to open menu`}>
-                      <Label color={color}>...</Label>
+export const Node = injectI18n(
+  class extends React.PureComponent<Props, State> {
+    public readonly state: State = initialState;
+    public render() {
+      const {
+        nodeType,
+        node,
+        options,
+        squareSize,
+        bounds,
+        formatter,
+        timeRange,
+        intl,
+      } = this.props;
+      const { isPopoverOpen } = this.state;
+      const { metric } = node;
+      const valueMode = squareSize > 70;
+      const ellipsisMode = squareSize > 30;
+      const rawValue = (metric && metric.value) || 0;
+      const color = colorFromValue(options.legend, rawValue, bounds);
+      const value = formatter(rawValue);
+      const newTimerange = {
+        ...timeRange,
+        from: moment(timeRange.to)
+          .subtract(1, 'hour')
+          .valueOf(),
+      };
+      const nodeAriaLabel = intl.formatMessage(
+        {
+          id: 'xpack.infra.node.ariaLabel',
+          defaultMessage: '{nodeName}, click to open menu',
+        },
+        { nodeName: node.name }
+      );
+      return (
+        <NodeContextMenu
+          node={node}
+          nodeType={nodeType}
+          isPopoverOpen={isPopoverOpen}
+          closePopover={this.closePopover}
+          options={options}
+          timeRange={newTimerange}
+        >
+          <EuiToolTip position="top" content={`${node.name} | ${value}`}>
+            <NodeContainer
+              style={{ width: squareSize || 0, height: squareSize || 0 }}
+              onClick={this.togglePopover}
+            >
+              <SquareOuter color={color}>
+                <SquareInner color={color}>
+                  {valueMode ? (
+                    <ValueInner aria-label={nodeAriaLabel}>
+                      <Label color={color}>{node.name}</Label>
+                      <Value color={color}>{value}</Value>
                     </ValueInner>
-                  )
-                )}
-              </SquareInner>
-            </SquareOuter>
-          </NodeContainer>
-        </EuiToolTip>
-      </NodeContextMenu>
-    );
-  }
-
-  private togglePopover = () => {
-    this.setState(prevState => ({ isPopoverOpen: !prevState.isPopoverOpen }));
-  };
-
-  private closePopover = () => {
-    if (this.state.isPopoverOpen) {
-      this.setState({ isPopoverOpen: false });
+                  ) : (
+                    ellipsisMode && (
+                      <ValueInner aria-label={nodeAriaLabel}>
+                        <Label color={color}>...</Label>
+                      </ValueInner>
+                    )
+                  )}
+                </SquareInner>
+              </SquareOuter>
+            </NodeContainer>
+          </EuiToolTip>
+        </NodeContextMenu>
+      );
     }
-  };
-}
+
+    private togglePopover = () => {
+      this.setState(prevState => ({ isPopoverOpen: !prevState.isPopoverOpen }));
+    };
+
+    private closePopover = () => {
+      if (this.state.isPopoverOpen) {
+        this.setState({ isPopoverOpen: false });
+      }
+    };
+  }
+);
 
 const NodeContainer = styled.div`
   position: relative;
@@ -143,7 +163,8 @@ const ValueInner = styled.button`
   border: none;
   &:focus {
     outline: none !important;
-    border: 3px solid ${params => params.theme.eui.euiFocusRingColor};
+    border: ${params => params.theme.eui.euiFocusRingSize} solid
+      ${params => params.theme.eui.euiFocusRingColor};
     box-shadow: none;
   }
 `;


### PR DESCRIPTION
## Summary

This PR fixes elastic/kibana#28158 by changing the `ValueInner` div to a button for the `Node` component

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

