### PR TITLE
[Infra UI] Changed EuiKeyPadMenuItem to EuiKeyPadMenuItemButton to support accessibility

### DIFF
--- a/x-pack/plugins/infra/public/components/waffle/waffle_node_type_switcher.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/waffle_node_type_switcher.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiKeyPadMenu, EuiKeyPadMenuItem } from '@elastic/eui';
+import { EuiKeyPadMenu, EuiKeyPadMenuItemButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
 import {
@@ -25,7 +25,7 @@ export class WaffleNodeTypeSwitcher extends React.PureComponent<Props> {
   public render() {
     return (
       <EuiKeyPadMenu>
-        <EuiKeyPadMenuItem
+        <EuiKeyPadMenuItemButton
           label={
             <FormattedMessage
               id="xpack.infra.waffle.nodeTypeSwitcher.hostsLabel"
@@ -40,23 +40,23 @@ export class WaffleNodeTypeSwitcher extends React.PureComponent<Props> {
             alt=""
             className="euiIcon euiIcon--large"
           />
-        </EuiKeyPadMenuItem>
-        <EuiKeyPadMenuItem label="Kubernetes" onClick={this.handleClick(InfraNodeType.pod)}>
+        </EuiKeyPadMenuItemButton>
+        <EuiKeyPadMenuItemButton label="Kubernetes" onClick={this.handleClick(InfraNodeType.pod)}>
           <img
             src="../plugins/infra/images/k8.svg"
             role="presentation"
             alt=""
             className="euiIcon euiIcon--large"
           />
-        </EuiKeyPadMenuItem>
-        <EuiKeyPadMenuItem label="Docker" onClick={this.handleClick(InfraNodeType.container)}>
+        </EuiKeyPadMenuItemButton>
+        <EuiKeyPadMenuItemButton label="Docker" onClick={this.handleClick(InfraNodeType.container)}>
           <img
             src="../plugins/infra/images/docker.svg"
             role="presentation"
             alt=""
             className="euiIcon euiIcon--large"
           />
-        </EuiKeyPadMenuItem>
+        </EuiKeyPadMenuItemButton>
       </EuiKeyPadMenu>
     );
   }


### PR DESCRIPTION
## Summary

This PR fixes elastic/kibana#28155 by changing the EuiKeyPadMenuItem to EuiKeyPadMenuItemButton. Since this put a button on the page the menu is now part of the tab order.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [X] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

