### PR TITLE
[6.7] Fixes #32022 - Fix table to display name instead of ID (#32051)

### DIFF
--- a/x-pack/plugins/infra/public/components/nodes_overview/table.tsx
+++ b/x-pack/plugins/infra/public/components/nodes_overview/table.tsx
@@ -124,7 +124,7 @@ export const TableView = injectI18n(
       const items = nodes.map(node => {
         const name = last(node.path);
         return {
-          name: (name && name.value) || 'unknown',
+          name: (name && name.label) || 'unknown',
           ...getGroupPaths(node.path).reduce(
             (acc, path, index) => ({
               ...acc,


### PR DESCRIPTION
Backports the following commits to 6.7:
 - Fixes #32022 - Fix table to display name instead of ID  (#32051)