### PR TITLE
[APM] fixes vertical clipping bug in StickyProperties

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
@@ -16,7 +16,6 @@ import {
   fontSizes,
   px,
   truncate,
-  unit,
   units
 } from '../../../style/variables';
 
@@ -47,16 +46,16 @@ const PropertyValueDimmed = styled.span`
   color: ${theme.euiColorMediumShade};
 `;
 
+const propertyValueLineHeight = 1.2;
 const PropertyValue = styled.div`
   display: inline-block;
-  line-height: ${px(unit)};
+  line-height: ${propertyValueLineHeight};
 `;
 PropertyValue.displayName = 'PropertyValue';
 
 const PropertyValueTruncated = styled.span`
   display: inline-block;
-  line-height: ${px(unit)};
-  padding-bottom: ${px(units.eighth)};
+  line-height: ${propertyValueLineHeight};
   ${truncate('100%')};
 `;
 

--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
@@ -56,6 +56,7 @@ PropertyValue.displayName = 'PropertyValue';
 const PropertyValueTruncated = styled.span`
   display: inline-block;
   line-height: ${px(unit)};
+  padding-bottom: ${px(units.eighth)};
   ${truncate('100%')};
 `;
 


### PR DESCRIPTION
[APM] fixes vertical clipping bug in StickyProperties by adding extra bottom padding to the property value

<img width="545" alt="screen shot 2019-03-01 at 11 55 44 am" src="https://user-images.githubusercontent.com/1967266/53673606-6f54a280-3c3d-11e9-808b-a3a2f6d36881.png">

