### PR TITLE
[APM] Context Tabs jumping height fix

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionPropertiesTable.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionPropertiesTable.tsx
@@ -8,7 +8,7 @@ import { EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Location } from 'history';
 import { first, get } from 'lodash';
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import {
   fromQuery,
@@ -18,6 +18,7 @@ import {
 import { Transaction } from '../../../../../typings/es_schemas/Transaction';
 import { IUrlParams } from '../../../../store/urlParams';
 import { px, units } from '../../../../style/variables';
+import { HeightRetainer } from '../../../shared/HeightRetainer';
 import {
   getPropertyTabNames,
   PropertiesTable
@@ -54,28 +55,6 @@ interface TransactionPropertiesTableProps {
   urlParams: IUrlParams;
   waterfall: IWaterfall;
 }
-
-const HeightRetainer: React.SFC = props => {
-  const containerElement = useRef<HTMLDivElement>(null);
-  const minHeight = useRef<number>(0);
-
-  useEffect(() => {
-    if (containerElement.current) {
-      const currentHeight = containerElement.current.clientHeight;
-      if (minHeight.current < currentHeight) {
-        minHeight.current = currentHeight;
-      }
-    }
-  });
-
-  return (
-    <div
-      {...props}
-      ref={containerElement}
-      style={{ minHeight: minHeight.current }}
-    />
-  );
-};
 
 export function TransactionPropertiesTable({
   location,

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionPropertiesTable.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionPropertiesTable.tsx
@@ -8,7 +8,7 @@ import { EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Location } from 'history';
 import { first, get } from 'lodash';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import {
   fromQuery,
@@ -55,6 +55,28 @@ interface TransactionPropertiesTableProps {
   waterfall: IWaterfall;
 }
 
+const HeightRetainer: React.SFC = props => {
+  const containerElement = useRef<HTMLDivElement>(null);
+  const minHeight = useRef<number>(0);
+
+  useEffect(() => {
+    if (containerElement.current) {
+      const currentHeight = containerElement.current.clientHeight;
+      if (minHeight.current < currentHeight) {
+        minHeight.current = currentHeight;
+      }
+    }
+  });
+
+  return (
+    <div
+      {...props}
+      ref={containerElement}
+      style={{ minHeight: minHeight.current }}
+    />
+  );
+};
+
 export function TransactionPropertiesTable({
   location,
   transaction,
@@ -67,7 +89,7 @@ export function TransactionPropertiesTable({
   const isTimelineTab = currentTab.key === timelineTab.key;
 
   return (
-    <div>
+    <HeightRetainer>
       <EuiTabs>
         {tabs.map(({ key, label }) => {
           return (
@@ -108,6 +130,6 @@ export function TransactionPropertiesTable({
           />
         </TableContainer>
       )}
-    </div>
+    </HeightRetainer>
   );
 }

--- a/x-pack/plugins/apm/public/components/shared/HeightRetainer/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/HeightRetainer/index.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useEffect, useRef } from 'react';
+
+export const HeightRetainer: React.SFC = props => {
+  const containerElement = useRef<HTMLDivElement>(null);
+  const minHeight = useRef<number>(0);
+
+  useEffect(() => {
+    if (containerElement.current) {
+      const currentHeight = containerElement.current.clientHeight;
+      if (minHeight.current < currentHeight) {
+        minHeight.current = currentHeight;
+      }
+    }
+  });
+
+  return (
+    <div
+      {...props}
+      ref={containerElement}
+      style={{ minHeight: minHeight.current }}
+    />
+  );
+};


### PR DESCRIPTION
[APM] fixes #18144 by setting the container min-height to the tab with the largest rendered height

![jumping-context-tabs-fix-min-height](https://user-images.githubusercontent.com/1967266/53671171-159aab00-3c32-11e9-85b1-c35a25000205.gif)
