### PR TITLE
[APM] Missing handled value is displayed as `undefined`

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/DetailView.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/DetailView.test.tsx
@@ -13,6 +13,7 @@ import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
 // @ts-ignore
 import { mockMoment } from '../../../../../utils/testHelpers';
+import { IStickyProperty } from '../../../../shared/StickyProperties';
 import { DetailView } from '../index';
 
 describe('DetailView', () => {
@@ -34,7 +35,6 @@ describe('DetailView', () => {
 
   it('should render Discover button', () => {
     const errorGroup: RRRRenderResponse<ErrorGroupAPIResponse> = {
-      args: [],
       status: 'SUCCESS',
       data: {
         occurrencesCount: 10,
@@ -61,50 +61,8 @@ describe('DetailView', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render StickyProperties', () => {
-    const errorGroup: RRRRenderResponse<ErrorGroupAPIResponse> = {
-      args: [],
-      status: 'SUCCESS',
-      data: {
-        occurrencesCount: 10,
-        transaction: {
-          http: { request: { method: 'GET' } },
-          url: { full: 'myUrl' },
-          trace: { id: 'traceId' },
-          transaction: {
-            type: 'myTransactionType',
-            name: 'myTransactionName',
-            id: 'myTransactionName'
-          },
-          service: { name: 'myService' },
-          user: { id: 'myUserId' }
-        } as Transaction,
-        error: {
-          '@timestamp': 'myTimestamp',
-          http: { request: { method: 'GET' } },
-          url: { full: 'myUrl' },
-          service: { name: 'myService' },
-          user: { id: 'myUserId' },
-          error: { exception: [{ handled: true }] },
-          transaction: { id: 'myTransactionId', sampled: true }
-        } as APMError
-      }
-    };
-    const wrapper = shallow(
-      <DetailView
-        errorGroup={errorGroup}
-        urlParams={{}}
-        location={{} as Location}
-      />
-    ).find('StickyProperties');
-
-    expect(wrapper.exists()).toBe(true);
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it('should render tabs', () => {
     const errorGroup: RRRRenderResponse<ErrorGroupAPIResponse> = {
-      args: [],
       status: 'SUCCESS',
       data: {
         occurrencesCount: 10,
@@ -129,7 +87,6 @@ describe('DetailView', () => {
 
   it('should render TabContent', () => {
     const errorGroup: RRRRenderResponse<ErrorGroupAPIResponse> = {
-      args: [],
       status: 'SUCCESS',
       data: {
         occurrencesCount: 10,
@@ -149,5 +106,71 @@ describe('DetailView', () => {
 
     expect(wrapper.exists()).toBe(true);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('StickyProperties', () => {
+    it('should render correctly with data', () => {
+      const errorGroup: RRRRenderResponse<ErrorGroupAPIResponse> = {
+        status: 'SUCCESS',
+        data: {
+          occurrencesCount: 10,
+          transaction: {
+            http: { request: { method: 'GET' } },
+            url: { full: 'myUrl' },
+            trace: { id: 'traceId' },
+            transaction: {
+              type: 'myTransactionType',
+              name: 'myTransactionName',
+              id: 'myTransactionName'
+            },
+            service: { name: 'myService' },
+            user: { id: 'myUserId' }
+          } as Transaction,
+          error: {
+            '@timestamp': 'myTimestamp',
+            http: { request: { method: 'GET' } },
+            url: { full: 'myUrl' },
+            service: { name: 'myService' },
+            user: { id: 'myUserId' },
+            error: { exception: [{ handled: true }] },
+            transaction: { id: 'myTransactionId', sampled: true }
+          } as APMError
+        }
+      };
+      const wrapper = shallow(
+        <DetailView
+          errorGroup={errorGroup}
+          urlParams={{}}
+          location={{} as Location}
+        />
+      ).find('StickyProperties');
+
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render handled as `N/A` if it is `undefined`', () => {
+      const errorGroup: RRRRenderResponse<ErrorGroupAPIResponse> = {
+        status: 'SUCCESS',
+        data: {
+          occurrencesCount: 10,
+          error: {} as APMError
+        }
+      };
+      const wrapper = shallow(
+        <DetailView
+          errorGroup={errorGroup}
+          urlParams={{}}
+          location={{} as Location}
+        />
+      ).find('StickyProperties');
+
+      const stickyProps = wrapper.prop('stickyProperties') as IStickyProperty[];
+      const handledProp = stickyProps.find(
+        prop => prop.fieldName === 'error.exception.handled'
+      ) as IStickyProperty;
+
+      expect(handledProp.val).toBe('N/A');
+    });
   });
 });

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/__snapshots__/DetailView.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__test__/__snapshots__/DetailView.test.tsx.snap
@@ -1,48 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DetailView should render Discover button 1`] = `
-<DiscoverErrorLink
-  error={
-    Object {
-      "@timestamp": "myTimestamp",
-      "error": Object {
-        "exception": Object {
-          "handled": true,
-        },
-      },
-      "http": Object {
-        "request": Object {
-          "method": "GET",
-        },
-      },
-      "service": Object {
-        "name": "myService",
-      },
-      "transaction": Object {
-        "id": "myTransactionId",
-        "sampled": true,
-      },
-      "url": Object {
-        "full": "myUrl",
-      },
-      "user": Object {
-        "id": "myUserId",
-      },
-    }
-  }
->
-  <EuiButtonEmpty
-    color="primary"
-    iconSide="left"
-    iconType="discoverApp"
-    type="button"
-  >
-    View 10 occurrences in Discover
-  </EuiButtonEmpty>
-</DiscoverErrorLink>
-`;
-
-exports[`DetailView should render StickyProperties 1`] = `
+exports[`DetailView StickyProperties should render correctly with data 1`] = `
 <StickyProperties
   stickyProperties={
     Array [
@@ -143,6 +101,48 @@ exports[`DetailView should render StickyProperties 1`] = `
     ]
   }
 />
+`;
+
+exports[`DetailView should render Discover button 1`] = `
+<DiscoverErrorLink
+  error={
+    Object {
+      "@timestamp": "myTimestamp",
+      "error": Object {
+        "exception": Object {
+          "handled": true,
+        },
+      },
+      "http": Object {
+        "request": Object {
+          "method": "GET",
+        },
+      },
+      "service": Object {
+        "name": "myService",
+      },
+      "transaction": Object {
+        "id": "myTransactionId",
+        "sampled": true,
+      },
+      "url": Object {
+        "full": "myUrl",
+      },
+      "user": Object {
+        "id": "myUserId",
+      },
+    }
+  }
+>
+  <EuiButtonEmpty
+    color="primary"
+    iconSide="left"
+    iconType="discoverApp"
+    type="button"
+  >
+    View 10 occurrences in Discover
+  </EuiButtonEmpty>
+</DiscoverErrorLink>
 `;
 
 exports[`DetailView should render TabContent 1`] = `

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
@@ -132,9 +132,9 @@ export function DetailView({ errorGroup, urlParams, location }: Props) {
       label: i18n.translate('xpack.apm.errorGroupDetails.handledLabel', {
         defaultMessage: 'Handled'
       }),
-      val:
-        String(idx(error, _ => _.error.exception[0].handled)) ||
-        NOT_AVAILABLE_LABEL,
+      val: String(
+        idx(error, _ => _.error.exception[0].handled) || NOT_AVAILABLE_LABEL
+      ),
       width: '25%'
     },
     {


### PR DESCRIPTION
When `error.exception.handled` is not set it should be displayed as "N/A". Currently it shows up as `undefined`

<img width="1537" alt="screenshot 2019-03-04 at 10 38 00" src="https://user-images.githubusercontent.com/209966/53724319-eb333280-3e69-11e9-954e-7707065c9c21.png">
