### PR TITLE
[APM] Guard saved objects against JSON.parse of undefined

### DIFF
--- a/src/legacy/ui/public/index_patterns/static_utils/index.js
+++ b/src/legacy/ui/public/index_patterns/static_utils/index.js
@@ -18,6 +18,7 @@
  */
 
 import { KBN_FIELD_TYPES } from '../../../../utils/kbn_field_types';
+import { get } from 'lodash';
 
 const filterableTypes = KBN_FIELD_TYPES.filter(type => type.filterable).map(type => type.name);
 
@@ -26,7 +27,7 @@ export function isFilterable(field) {
 }
 
 export function getFromSavedObject(savedObject) {
-  if (!savedObject) {
+  if (get(savedObject, 'attributes.fields') === undefined) {
     return null;
   }
 

--- a/x-pack/plugins/apm/public/services/kuery.ts
+++ b/x-pack/plugins/apm/public/services/kuery.ts
@@ -7,7 +7,6 @@
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { getAutocompleteProvider } from 'ui/autocomplete_providers';
 import { StaticIndexPattern } from 'ui/index_patterns';
-// @ts-ignore
 import { getFromSavedObject } from 'ui/index_patterns/static_utils';
 import { getAPMIndexPattern } from './rest/savedObjects';
 

--- a/x-pack/plugins/apm/public/services/rest/savedObjects.ts
+++ b/x-pack/plugins/apm/public/services/rest/savedObjects.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { first, isEmpty, memoize } from 'lodash';
+import { memoize } from 'lodash';
 import chrome from 'ui/chrome';
 import { callApi } from './callApi';
 
@@ -34,15 +34,7 @@ export const getAPMIndexPattern = memoize(async () => {
     }
   });
 
-  if (isEmpty(res.saved_objects)) {
-    return;
-  }
-
-  const apmSavedObject = first(
-    res.saved_objects.filter(
-      savedObject => savedObject.attributes.title === apmIndexPatternTitle
-    )
+  return res.saved_objects.find(
+    savedObject => savedObject.attributes.title === apmIndexPatternTitle
   );
-
-  return apmSavedObject;
 });


### PR DESCRIPTION
Closes #32077

When calling `getFromSavedObject(savedObject)` the fields will still be attempted parse (with `JSON.parse`) even if the saved objects is empty and doesn't contain any fields.
This results in the exception: `Unexpected token u in JSON at position 0 at JSON.parse ()`.

This PR adds a guard to empty objects will not be attempted parsed.