### PR TITLE
[Vis Editor] Fix geohash checkbox group spacing

### DIFF
--- a/src/legacy/core_plugins/region_map/public/_region_map.scss
+++ b/src/legacy/core_plugins/region_map/public/_region_map.scss
@@ -1,3 +1,4 @@
 .rgmEMSLink {
+  margin-top: $euiSizeXS;
   font-size: $euiFontSizeXS;
 }

--- a/src/legacy/ui/public/agg_types/controls/precision.html
+++ b/src/legacy/ui/public/agg_types/controls/precision.html
@@ -1,3 +1,17 @@
+<div class="form-group">
+  <label>
+    <input
+      type="checkbox"
+      name="autoPrecision"
+      ng-model="agg.params.autoPrecision"
+    >
+    <span
+      i18n-id="common.ui.aggTypes.changePrecisionLabel"
+      i18n-default-message="Change precision on map zoom"
+    ></span>
+  </label>
+</div>
+
 <div class="visEditorAgg__formRow--flex" ng-controller="agg.type.params.byName.precision.controller">
   <div ng-if="!agg.params.autoPrecision" class="form-group">
     <label
@@ -23,21 +37,7 @@
   </div>
 </div>
 
-<div>
-  <label>
-    <input
-      type="checkbox"
-      name="autoPrecision"
-      ng-model="agg.params.autoPrecision"
-    >
-    <span
-      i18n-id="common.ui.aggTypes.changePrecisionLabel"
-      i18n-default-message="Change precision on map zoom"
-    ></span>
-  </label>
-</div>
-
-<div>
+<div class="form-group">
   <label>
     <input
       type="checkbox"
@@ -51,7 +51,7 @@
   </label>
 </div>
 
-<div>
+<div class="form-group">
   <label>
     <input
       type="checkbox"

--- a/src/legacy/ui/public/vis/editors/default/_sidebar.scss
+++ b/src/legacy/ui/public/vis/editors/default/_sidebar.scss
@@ -136,7 +136,6 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  line-height: 1.5;
   white-space: nowrap;
 
   + * {
@@ -158,6 +157,7 @@
   display: flex;
   align-items: center;
   margin-right: $euiSizeXS;
+  line-height: $euiLineHeight;
 }
 
 .visEditorSidebar__collapsibleTitleText {

--- a/src/legacy/ui/public/vis/editors/default/advanced_toggle.html
+++ b/src/legacy/ui/public/vis/editors/default/advanced_toggle.html
@@ -2,10 +2,9 @@
   <a ng-click="advancedToggled = !advancedToggled">
     <icon ng-show="advancedToggled" type="'arrowDown'" size="'s'"></icon>
     <icon ng-show="!advancedToggled" type="'arrowRight'" size="'s'"></icon>
-    <small><span
+    <small
     i18n-id="common.ui.vis.editors.advancedToggle.advancedLinkLabel"
     i18n-default-message="Advanced"
-    >
-    </span></small>
+    ></small>
   </a>
 </div>

--- a/src/legacy/ui/public/vis/editors/default/advanced_toggle.html
+++ b/src/legacy/ui/public/vis/editors/default/advanced_toggle.html
@@ -1,10 +1,11 @@
 <div class="eui-textRight">
   <a ng-click="advancedToggled = !advancedToggled">
-    <i aria-hidden="true" class="fa fa-caret-down" ng-class="{'fa-caret-down': advancedToggled, 'fa-caret-left': !advancedToggled}"></i>
-    <span
-      i18n-id="common.ui.vis.editors.advancedToggle.advancedLinkLabel"
-      i18n-default-message="Advanced"
+    <icon ng-show="advancedToggled" type="'arrowDown'" size="'s'"></icon>
+    <icon ng-show="!advancedToggled" type="'arrowRight'" size="'s'"></icon>
+    <small><span
+    i18n-id="common.ui.vis.editors.advancedToggle.advancedLinkLabel"
+    i18n-default-message="Advanced"
     >
-    </span>
+    </span></small>
   </a>
 </div>


### PR DESCRIPTION
Fixes #32659

- And alignment of text in visEditorSidebar__collapsibleTitle
- And size of advanced toggle text

## Before

<img width="294" alt="screen shot 2019-03-07 at 11 27 52 am" src="https://user-images.githubusercontent.com/549577/53972043-1321d080-40cc-11e9-8b25-c1d0ddbad0a6.png">


## After

<img width="318" alt="screen shot 2019-03-07 at 11 19 50 am" src="https://user-images.githubusercontent.com/549577/53971943-e2419b80-40cb-11e9-9446-6dd010c426f4.png">

<img width="321" alt="screen shot 2019-03-07 at 11 19 58 am" src="https://user-images.githubusercontent.com/549577/53971951-e53c8c00-40cb-11e9-868d-952ee57c0772.png">

^^ I also moved the precision slider to be **after** the checkbox since it's visibility is directly related to the checked state of the checkbox.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
- ~[ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~

