### PR TITLE
[intepreter][Canvas] Dedupe server functions in batched requests

### DIFF
--- a/packages/kbn-interpreter/src/public/interpreter.test.js
+++ b/packages/kbn-interpreter/src/public/interpreter.test.js
@@ -41,7 +41,7 @@ describe('kbn-interpreter/interpreter', () => {
       kfetch,
       ajaxStream,
       typesRegistry: { toJS: () => ({}) },
-      functionsRegistry: ({ register: () => {} }),
+      functionsRegistry: { register: () => {} },
     });
 
     expect(kfetch).toHaveBeenCalledTimes(1);
@@ -65,12 +65,12 @@ describe('kbn-interpreter/interpreter', () => {
       kfetch,
       ajaxStream,
       typesRegistry: { toJS: () => ({}) },
-      functionsRegistry: ({ register }),
+      functionsRegistry: { register },
     });
 
     expect(register).toHaveBeenCalledTimes(2);
 
-    const [ hello, world ] = register.mock.calls.map(([fn]) => fn());
+    const [hello, world] = register.mock.calls.map(([fn]) => fn());
 
     expect(hello.name).toEqual('hello');
     expect(typeof hello.fn).toEqual('function');
@@ -88,14 +88,15 @@ describe('kbn-interpreter/interpreter', () => {
       url: FUNCTIONS_URL,
       onResponse: expect.any(Function),
       body: JSON.stringify({
-        functions: [{
-          id: 1,
-          functionName: 'hello',
-          args,
-          context,
-        }]
+        functions: [
+          {
+            functionName: 'hello',
+            args,
+            context,
+            id: 1,
+          },
+        ],
       }),
     });
   });
-
 });


### PR DESCRIPTION
## Summary

Currently, if a set of batched function calls are identical, they are all called.  For example, if a page calls for `demodata` in a number of elements, `demodata` is requested and returned for each element, (ballooning the size of the response).

This PR dedupes the server calls, greatly reducing the payload size.

Before:

<img width="1287" alt="screen shot 2019-03-07 at 4 00 00 pm" src="https://user-images.githubusercontent.com/297604/53992305-234ca680-40f2-11e9-94e6-68ad50ce13a8.png">
<img width="713" alt="screen shot 2019-03-07 at 4 00 07 pm" src="https://user-images.githubusercontent.com/297604/53992311-25166a00-40f2-11e9-816a-9522b4a93e35.png">

After:

<img width="1287" alt="screen shot 2019-03-07 at 3 57 26 pm" src="https://user-images.githubusercontent.com/297604/53992326-29428780-40f2-11e9-8281-adce22c9d82d.png">
<img width="966" alt="screen shot 2019-03-07 at 3 57 34 pm" src="https://user-images.githubusercontent.com/297604/53992331-2a73b480-40f2-11e9-94d7-1c34d596b45d.png">
