### PR TITLE
[APM] Add fallback for missing `handled` value

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.test.tsx
@@ -4,10 +4,11 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 import React from 'react';
 import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
+import { IStickyProperty } from '../../../shared/StickyProperties';
 import { StickyErrorProperties } from './StickyErrorProperties';
 
 describe('StickyErrorProperties', () => {
@@ -40,5 +41,45 @@ describe('StickyErrorProperties', () => {
     );
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('error.exception.handled', () => {
+    function getIsHandledValue(error: APMError) {
+      const wrapper = shallow(
+        <StickyErrorProperties error={error} transaction={undefined} />
+      );
+
+      const stickyProps = wrapper.prop('stickyProperties') as IStickyProperty[];
+      const handledProp = stickyProps.find(
+        prop => prop.fieldName === 'error.exception.handled'
+      ) as IStickyProperty;
+
+      return handledProp.val;
+    }
+
+    it('should should render "true"', () => {
+      const error = {
+        error: { exception: [{ handled: true }] }
+      } as APMError;
+
+      const isHandledValue = getIsHandledValue(error);
+      expect(isHandledValue).toBe('true');
+    });
+
+    it('should should render "false"', () => {
+      const error = {
+        error: { exception: [{ handled: false }] }
+      } as APMError;
+
+      const isHandledValue = getIsHandledValue(error);
+      expect(isHandledValue).toBe('false');
+    });
+
+    it('should should render "N/A"', () => {
+      const error = {} as APMError;
+
+      const isHandledValue = getIsHandledValue(error);
+      expect(isHandledValue).toBe('N/A');
+    });
   });
 });

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.test.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { shallow, ShallowWrapper } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import { APMError } from 'x-pack/plugins/apm/typings/es_schemas/Error';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/Transaction';
@@ -52,32 +52,25 @@ describe('StickyErrorProperties', () => {
       const stickyProps = wrapper.prop('stickyProperties') as IStickyProperty[];
       const handledProp = stickyProps.find(
         prop => prop.fieldName === 'error.exception.handled'
-      ) as IStickyProperty;
+      );
 
-      return handledProp.val;
+      return handledProp && handledProp.val;
     }
 
     it('should should render "true"', () => {
-      const error = {
-        error: { exception: [{ handled: true }] }
-      } as APMError;
-
+      const error = { error: { exception: [{ handled: true }] } } as APMError;
       const isHandledValue = getIsHandledValue(error);
       expect(isHandledValue).toBe('true');
     });
 
     it('should should render "false"', () => {
-      const error = {
-        error: { exception: [{ handled: false }] }
-      } as APMError;
-
+      const error = { error: { exception: [{ handled: false }] } } as APMError;
       const isHandledValue = getIsHandledValue(error);
       expect(isHandledValue).toBe('false');
     });
 
     it('should should render "N/A"', () => {
       const error = {} as APMError;
-
       const isHandledValue = getIsHandledValue(error);
       expect(isHandledValue).toBe('N/A');
     });

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.tsx
@@ -5,6 +5,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { isBoolean } from 'lodash';
 import React, { Fragment } from 'react';
 import {
   ERROR_EXC_HANDLED,
@@ -56,6 +57,7 @@ function TransactionLink({ error, transaction }: Props) {
 }
 
 export function StickyErrorProperties({ error, transaction }: Props) {
+  const isHandled = idx(error, _ => _.error.exception[0].handled);
   const stickyProperties = [
     {
       fieldName: '@timestamp',
@@ -88,9 +90,7 @@ export function StickyErrorProperties({ error, transaction }: Props) {
       label: i18n.translate('xpack.apm.errorGroupDetails.handledLabel', {
         defaultMessage: 'Handled'
       }),
-      val:
-        String(idx(error, _ => _.error.exception[0].handled)) ||
-        NOT_AVAILABLE_LABEL,
+      val: isBoolean(isHandled) ? String(isHandled) : NOT_AVAILABLE_LABEL,
       width: '25%'
     },
     {


### PR DESCRIPTION
When `error.exception.handled` is not set it should be displayed as "N/A". Currently it shows up as `undefined`

<img width="1537" alt="screenshot 2019-03-04 at 10 38 00" src="https://user-images.githubusercontent.com/209966/53724319-eb333280-3e69-11e9-954e-7707065c9c21.png">
