### PR TITLE
[APM] Distribution histogram - Replaced custom tooltip with EuiIconTip

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -139,7 +139,13 @@ export class TransactionDistribution extends Component<Props> {
               }
             )}{' '}
             <EuiIconTip
-              content="Each bucket will show a sample transaction. If there's no sample available, it's most likely because of the sampling limit set in the agent configuration."
+              content={i18n.translate(
+                'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingDescription',
+                {
+                  defaultMessage:
+                    "Each bucket will show a sample transaction. If there's no sample available, it's most likely because of the sampling limit set in the agent configuration."
+                }
+              )}
               position="top"
             />
           </h5>

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiIcon, EuiText, EuiTitle, EuiToolTip } from '@elastic/eui';
+import { EuiIconTip, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import d3 from 'd3';
 import { Location } from 'history';
@@ -138,32 +138,10 @@ export class TransactionDistribution extends Component<Props> {
                 defaultMessage: 'Transactions duration distribution'
               }
             )}{' '}
-            <EuiToolTip
-              content={
-                <div>
-                  <EuiText>
-                    <strong>
-                      {i18n.translate(
-                        'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingLabel',
-                        {
-                          defaultMessage: 'Sampling'
-                        }
-                      )}
-                    </strong>
-                  </EuiText>
-                  <EuiText>
-                    {i18n.translate(
-                      'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingDescription',
-                      {
-                        defaultMessage: `Each bucket will show a sample transaction. If there's no sample available, it's most likely because of the sampling limit set in the agent configuration.`
-                      }
-                    )}
-                  </EuiText>
-                </div>
-              }
-            >
-              <EuiIcon type="questionInCircle" />
-            </EuiToolTip>
+            <EuiIconTip
+              content="Each bucket will show a sample transaction. If there's no sample available, it's most likely because of the sampling limit set in the agent configuration."
+              position="top"
+            />
           </h5>
         </EuiTitle>
 

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -139,6 +139,12 @@ export class TransactionDistribution extends Component<Props> {
               }
             )}{' '}
             <EuiIconTip
+              title={i18n.translate(
+                'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingLabel',
+                {
+                  defaultMessage: 'Sampling'
+                }
+              )}
               content={i18n.translate(
                 'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingDescription',
                 {


### PR DESCRIPTION
## Summary

First I noticed that the content size was too large, then saw that we originally had implemented a custom icon and tooltip solution for displaying messaging around sampling. Now that EUI supports this scenario with the `EuiIconTip`, I've converted it.

_Old tooltip_
<img width="748" alt="screenshot 2019-03-08 at 12 53 07" src="https://user-images.githubusercontent.com/4104278/54027447-dd4f1b80-41a1-11e9-92fb-f002e150cae2.png">

_New tooltip_
<img width="555" alt="screenshot 2019-03-08 at 13 06 10" src="https://user-images.githubusercontent.com/4104278/54027792-fc01e200-41a2-11e9-96f6-c5948482323c.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

