### PR TITLE
[APM] Fixes various bugs with date picker implementation

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -553,7 +553,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             >
               <a
                 className="euiLink euiLink--primary c0"
-                href="#/opbeans-python/errors/a0ce2c8978ef92cdf2ff163ae28576ee?"
+                href="#/opbeans-python/errors/a0ce2c8978ef92cdf2ff163ae28576ee?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
               >
                 a0ce2
               </a>
@@ -582,7 +582,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   <a
                     aria-describedby="error-message-tooltip"
                     className="euiLink euiLink--primary c2"
-                    href="#/opbeans-python/errors/a0ce2c8978ef92cdf2ff163ae28576ee?"
+                    href="#/opbeans-python/errors/a0ce2c8978ef92cdf2ff163ae28576ee?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
                     onBlur={[Function]}
                     onFocus={[Function]}
                   >
@@ -660,7 +660,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             >
               <a
                 className="euiLink euiLink--primary c0"
-                href="#/opbeans-python/errors/f3ac95493913cc7a3cfec30a19d2120a?"
+                href="#/opbeans-python/errors/f3ac95493913cc7a3cfec30a19d2120a?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
               >
                 f3ac9
               </a>
@@ -689,7 +689,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   <a
                     aria-describedby="error-message-tooltip"
                     className="euiLink euiLink--primary c2"
-                    href="#/opbeans-python/errors/f3ac95493913cc7a3cfec30a19d2120a?"
+                    href="#/opbeans-python/errors/f3ac95493913cc7a3cfec30a19d2120a?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
                     onBlur={[Function]}
                     onFocus={[Function]}
                   >
@@ -767,7 +767,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             >
               <a
                 className="euiLink euiLink--primary c0"
-                href="#/opbeans-python/errors/e90863d04b7a692435305f09bbe8c840?"
+                href="#/opbeans-python/errors/e90863d04b7a692435305f09bbe8c840?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
               >
                 e9086
               </a>
@@ -796,7 +796,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   <a
                     aria-describedby="error-message-tooltip"
                     className="euiLink euiLink--primary c2"
-                    href="#/opbeans-python/errors/e90863d04b7a692435305f09bbe8c840?"
+                    href="#/opbeans-python/errors/e90863d04b7a692435305f09bbe8c840?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
                     onBlur={[Function]}
                     onFocus={[Function]}
                   >
@@ -874,7 +874,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             >
               <a
                 className="euiLink euiLink--primary c0"
-                href="#/opbeans-python/errors/8673d8bf7a032e387c101bafbab0d2bc?"
+                href="#/opbeans-python/errors/8673d8bf7a032e387c101bafbab0d2bc?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
               >
                 8673d
               </a>
@@ -903,7 +903,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   <a
                     aria-describedby="error-message-tooltip"
                     className="euiLink euiLink--primary c2"
-                    href="#/opbeans-python/errors/8673d8bf7a032e387c101bafbab0d2bc?"
+                    href="#/opbeans-python/errors/8673d8bf7a032e387c101bafbab0d2bc?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0"
                     onBlur={[Function]}
                     onFocus={[Function]}
                   >

--- a/x-pack/plugins/apm/public/components/shared/FilterBar/DatePicker.tsx
+++ b/x-pack/plugins/apm/public/components/shared/FilterBar/DatePicker.tsx
@@ -121,7 +121,7 @@ class DatePickerComponent extends React.Component<Props> {
   }) {
     const currentSearch = toQuery(this.props.location.search);
 
-    this.props.history.replace({
+    this.props.history.push({
       ...this.props.location,
       search: fromQuery({
         ...currentSearch,

--- a/x-pack/plugins/apm/public/components/shared/Links/KibanaLink.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/KibanaLink.test.tsx
@@ -44,7 +44,7 @@ describe('UnconnectedKibanaLink', () => {
       search: '?rangeFrom=now-5w&rangeTo=now-2w'
     });
     expect(wrapper.find('EuiLink').props().href).toEqual(
-      `/app/apm#/something?rangeFrom=now-5w&rangeTo=now-2w`
+      `/app/apm#/something?rangeFrom=now-5w&rangeTo=now-2w&refreshPaused=true&refreshInterval=0`
     );
   });
 
@@ -54,7 +54,7 @@ describe('UnconnectedKibanaLink', () => {
       search: '?rangeFrom=now-5w&rangeTo=now-2w'
     });
     expect(wrapper.find('EuiLink').props().href).toEqual(
-      `#/something?rangeFrom=now-5w&rangeTo=now-2w`
+      `#/something?rangeFrom=now-5w&rangeTo=now-2w&refreshPaused=true&refreshInterval=0`
     );
   });
 

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.test.tsx
@@ -29,7 +29,7 @@ describe('fromQuery', () => {
     ).toEqual('traceId=bar&transactionId=john%20doe');
   });
 
-  it('should not encode range params', () => {
+  it('should encode range params', () => {
     expect(
       fromQuery({
         traceId: 'b/c',
@@ -37,7 +37,7 @@ describe('fromQuery', () => {
         rangeTo: '2019-03-05T12:00:00.000Z'
       })
     ).toEqual(
-      'traceId=b%2Fc&rangeFrom=2019-03-03T12:00:00.000Z&rangeTo=2019-03-05T12:00:00.000Z'
+      'traceId=b%2Fc&rangeFrom=2019-03-03T12%3A00%3A00.000Z&rangeTo=2019-03-05T12%3A00%3A00.000Z'
     );
   });
 
@@ -53,14 +53,14 @@ describe('fromQuery', () => {
 });
 
 describe('getKibanaHref', () => {
-  it('should build correct URL for APM paths, include existing date range params', () => {
+  it('should build correct URL for APM paths, merging in existing date range params', () => {
     const location = { search: '?rangeFrom=now/w&rangeTo=now-24h' } as Location;
     const pathname = '/app/apm';
     const hash = '/services/x/transactions';
     const query = { transactionId: 'something' };
     const href = getKibanaHref({ location, pathname, hash, query });
     expect(href).toEqual(
-      '/app/apm#/services/x/transactions?rangeFrom=now/w&rangeTo=now-24h&transactionId=something'
+      '/app/apm#/services/x/transactions?rangeFrom=now%2Fw&rangeTo=now-24h&refreshPaused=true&refreshInterval=0&transactionId=something'
     );
   });
 

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.test.tsx
@@ -40,6 +40,16 @@ describe('fromQuery', () => {
       'traceId=b%2Fc&rangeFrom=2019-03-03T12:00:00.000Z&rangeTo=2019-03-05T12:00:00.000Z'
     );
   });
+
+  it('should handle undefined, boolean, and number values without throwing errors', () => {
+    expect(
+      fromQuery({
+        flyoutDetailTab: undefined,
+        refreshPaused: true,
+        refreshInterval: 5000
+      })
+    ).toEqual('flyoutDetailTab=&refreshPaused=true&refreshInterval=5000');
+  });
 });
 
 describe('getKibanaHref', () => {

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -6,7 +6,7 @@
 
 import { Location } from 'history';
 import createHistory from 'history/createHashHistory';
-import { mapValues, pick } from 'lodash';
+import { pick } from 'lodash';
 import qs from 'querystring';
 import chrome from 'ui/chrome';
 import url from 'url';
@@ -17,22 +17,7 @@ export function toQuery(search?: string): APMQueryParamsRaw {
 }
 
 export function fromQuery(query: APMQueryParams) {
-  // we have to avoid encoding range params because they cause
-  // Kibana angular to decode them and append them to the existing
-  // URL as an encoded hash /shrug
-  const encoded = mapValues(query, (value, key) => {
-    if (['rangeFrom', 'rangeTo'].includes(key!)) {
-      return value;
-    }
-    if (value === undefined) {
-      return undefined;
-    }
-    return qs.escape(String(value));
-  });
-
-  return qs.stringify(encoded, '&', '=', {
-    encodeURIComponent: (value: string) => value
-  });
+  return qs.stringify(query);
 }
 
 export const PERSISTENT_APM_PARAMS = [

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -23,7 +23,10 @@ export function fromQuery(query: APMQueryParams) {
     if (['rangeFrom', 'rangeTo'].includes(key!)) {
       return value;
     }
-    return qs.escape(value.toString());
+    if (value === undefined) {
+      return undefined;
+    }
+    return qs.escape(String(value));
   });
 
   return qs.stringify(encoded, '&', '=', {

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -10,6 +10,7 @@ import { mapValues, pick } from 'lodash';
 import qs from 'querystring';
 import chrome from 'ui/chrome';
 import url from 'url';
+import { TIMEPICKER_DEFAULTS } from 'x-pack/plugins/apm/public/store/urlParams';
 
 export function toQuery(search?: string): APMQueryParamsRaw {
   return search ? qs.parse(search.slice(1)) : {};
@@ -53,6 +54,7 @@ function getSearchString(
   const isApmLink = pathname.includes('app/apm') || pathname === '';
   if (isApmLink) {
     const nextQuery = {
+      ...TIMEPICKER_DEFAULTS,
       ...pick(currentQuery, PERSISTENT_APM_PARAMS),
       ...query
     };

--- a/x-pack/plugins/apm/public/components/shared/charts/SyncChartGroup/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/SyncChartGroup/index.tsx
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import moment from 'moment';
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import {

--- a/x-pack/plugins/apm/public/components/shared/charts/SyncChartGroup/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/SyncChartGroup/index.tsx
@@ -6,7 +6,11 @@
 
 import moment from 'moment';
 import React from 'react';
-import { timefilter } from 'ui/timefilter';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import {
+  fromQuery,
+  toQuery
+} from 'x-pack/plugins/apm/public/components/shared/Links/url_helpers';
 
 export interface RangeSelection {
   start: number;
@@ -25,7 +29,7 @@ export interface HoverXHandlers {
   hoverX: HoverX | null;
 }
 
-interface SyncChartGroupProps {
+interface SyncChartGroupProps extends RouteComponentProps {
   render: (props: HoverXHandlers) => React.ReactNode;
 }
 
@@ -33,7 +37,7 @@ interface SyncChartState {
   hoverX: HoverX | null;
 }
 
-export class SyncChartGroup extends React.Component<
+class SyncChartGroupComponent extends React.Component<
   SyncChartGroupProps,
   SyncChartState
 > {
@@ -44,12 +48,22 @@ export class SyncChartGroup extends React.Component<
     this.setState({ hoverX: null });
   public onSelectionEnd: OnSelectionEndHandler = range => {
     this.setState({ hoverX: null });
-    timefilter.setTime({
-      from: moment(range.start).toISOString(),
-      to: moment(range.end).toISOString(),
-      mode: 'absolute'
+
+    const currentSearch = toQuery(this.props.location.search);
+    const nextSearch = {
+      rangeFrom: new Date(range.start).toISOString(),
+      rangeTo: new Date(range.end).toISOString()
+    };
+
+    this.props.history.push({
+      ...this.props.location,
+      search: fromQuery({
+        ...currentSearch,
+        ...nextSearch
+      })
     });
   };
+
   public render() {
     return this.props.render({
       onHover: this.onHover,
@@ -59,3 +73,5 @@ export class SyncChartGroup extends React.Component<
     });
   }
 }
+
+export const SyncChartGroup = withRouter(SyncChartGroupComponent);


### PR DESCRIPTION
Fixes #32752
Blocked by #32732 

## Summary

Fixes included in this PR:

* 53d8c6bdb3395cf61caafa10c88d4efc5291154e Reverts our changes to `fromQuery` so that it now just returns the straight result of `qs.stringify()`
  * Things to test here: relative ranges shouldn't mangle the URL, clicking "refresh" while on an absolute range shouldn't mangle the URL
  * This only works right now because I've shadowed the changes in #32732 with this commit: 9d213ea4e5b0bd2f4f55dfb23af0de054679fd6f ... I can revert this before merging or leave it as it is the same changes.
  * This change depends on #32732 but simplifies our code a lot and also fixes the bug in #32752 
* 9ebc12b9b26095bdb82dd1fd4c5fb1b77d9a3e79 Changes "replace" to "push" so that clicking "back" after changing date ranges will cycle through previous date ranges because each one is pushed onto the pushstate stack
* 15b4af58ebd29f852a327811fc54e8abb4933395 `KibanaLink` will now include the default time picker options even when there are no currently selected time picker options, which is the behavior we had before when it was in rison. Removing this behavior caused links to end up with a trailing `?` in this case, which seemed to break the back button functionality.
* 3ab353560bd713598ebe5a884bd020538953343e Chart selection (drag) will now do a URL update to the range query params because the URL is now the source of truth for the APM date picker. This update triggers all of the expected state updates for the date picker state and our redux store. The legacy timefilter has been removed.
  * Also did a search through APM for `timefilter` to make sure we aren't relying on it anywhere else. I did not find any other cases.
