### PR TITLE
[7.0] Improving way to check if pipelines list is loaded (#32370)

### DIFF
--- a/x-pack/plugins/logstash/public/components/pipeline_list/pipeline_list.js
+++ b/x-pack/plugins/logstash/public/components/pipeline_list/pipeline_list.js
@@ -95,7 +95,7 @@ class PipelineListUi extends React.Component {
 
     this.setState({
       message: (
-        <div>
+        <div data-test-subj="loadingPipelines">
           <EuiLoadingSpinner size="m" />
           &nbsp; <FormattedMessage
             id="xpack.logstash.pipelineList.pipelinesLoadingMessage"

--- a/x-pack/test/functional/services/pipeline_list.js
+++ b/x-pack/test/functional/services/pipeline_list.js
@@ -163,7 +163,8 @@ export function PipelineListProvider({ getService }) {
       await retry.waitFor('pipline list visible on screen', async () => {
         const container = await testSubjects.find(SUBJ_CONTAINER);
         const found = await container.findAllByCssSelector('table tbody');
-        return found.length > 0;
+        const isLoading = await testSubjects.exists('loadingPipelines');
+        return (found.length > 0) && (isLoading === false);
       });
     }
 


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Improving way to check if pipelines list is loaded  (#32370)