### PR TITLE
[APM] Removes call to disable the angular encoding fix

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/FilterBar/DatePicker.tsx
+++ b/x-pack/plugins/apm/public/components/shared/FilterBar/DatePicker.tsx
@@ -49,12 +49,8 @@ class DatePickerComponent extends React.Component<Props> {
   public componentDidUpdate(prevProps: Props) {
     const currentParams = this.getParamsFromSearch(this.props.location.search);
     const previousParams = this.getParamsFromSearch(prevProps.location.search);
-    if (
-      currentParams.rangeFrom !== previousParams.rangeFrom ||
-      currentParams.rangeTo !== previousParams.rangeTo
-    ) {
-      this.dispatchTimeRangeUpdate();
-    }
+
+    this.dispatchTimeRangeUpdate();
 
     if (
       currentParams.refreshPaused !== previousParams.refreshPaused ||

--- a/x-pack/plugins/apm/public/index.tsx
+++ b/x-pack/plugins/apm/public/index.tsx
@@ -38,7 +38,6 @@ type PromiseResolver = (value?: {} | PromiseLike<{}> | undefined) => void;
 
 // @ts-ignore
 chrome.setRootTemplate(template);
-chrome.disableAutoAngularUrlEncodingFix();
 const store = configureStore();
 const checkForRoot = (resolve: PromiseResolver) => {
   const ready = !!document.getElementById(REACT_APP_ROOT_ID);


### PR DESCRIPTION
Fixes #33109 
Related to #32732

UPDATE: Also fixes problem where refreshing a relative range did nothing. This had been fixed earlier but may have been lost to a merge or something? Relative range refreshes should now work, while absolute date refreshes should not trigger any additional requests.

## Summary

We want the fix from #32732 turned on for us to solve our back button encoding problems, so I've removed our call to disable it.

Check:
* [ ] Absolute dates in date picker, navigate around, back button should work and the URL should not be mangled by clicking "Refresh" (but no extra calls should be made)
* [ ] Relative dates in date picker, navigate around, back button should work, Refresh should cause a new call to be made with new calculated range
* [ ] Navigate to transaction pages with a "/" in the transaction name and it should load with no problem, back button should work