### PR TITLE
[page_objects/time_picker] fix getTimeDurationInHours returning NaN

### DIFF
--- a/test/functional/page_objects/time_picker.js
+++ b/test/functional/page_objects/time_picker.js
@@ -188,10 +188,11 @@ export function TimePickerPageProvider({ getService, getPageObjects }) {
     }
 
     async getTimeDurationInHours() {
+      const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
       const { start, end } = await this.getTimeConfigAsAbsoluteTimes();
 
-      const startMoment = moment(Date.parse(start));
-      const endMoment = moment(Date.parse(end));
+      const startMoment = moment(start, DEFAULT_DATE_FORMAT);
+      const endMoment = moment(end, DEFAULT_DATE_FORMAT);
 
       return moment.duration(moment(endMoment) - moment(startMoment)).asHours();
     }

--- a/test/functional/page_objects/time_picker.js
+++ b/test/functional/page_objects/time_picker.js
@@ -188,11 +188,10 @@ export function TimePickerPageProvider({ getService, getPageObjects }) {
     }
 
     async getTimeDurationInHours() {
-      const DEFAULT_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
       const { start, end } = await this.getTimeConfigAsAbsoluteTimes();
 
-      const startMoment = moment(start, DEFAULT_DATE_FORMAT);
-      const endMoment = moment(end, DEFAULT_DATE_FORMAT);
+      const startMoment = moment(Date.parse(start));
+      const endMoment = moment(Date.parse(end));
 
       return moment.duration(moment(endMoment) - moment(startMoment)).asHours();
     }


### PR DESCRIPTION
## Summary

I recently noticed that `discover app query should modify the time range when the histogram is brushed` test is passing even when dragAndDrop is not executed.

It is caused by `{start, end}` values have format diffrent from `DEFAULT_DATE_FORMAT`

<img width="910" alt="DevTools - Node js 2019-03-14 17-21-11" src="https://user-images.githubusercontent.com/10977896/54374361-4261b000-467f-11e9-8997-f9c116889adc.png">

As a result, `getTimeDurationInHours` always return `NaN`.

<img width="948" alt="DevTools - Node js 2019-03-14 17-22-54" src="https://user-images.githubusercontent.com/10977896/54374520-9076b380-467f-11e9-9b3c-15070c82a1d8.png">


After the fix it returns valid value:

<img width="788" alt="DevTools - Node js 2019-03-14 17-27-11" src="https://user-images.githubusercontent.com/10977896/54374564-ad12eb80-467f-11e9-82c6-14502432f94d.png">