### PR TITLE
[7.0] [page_objects/time_picker] fix getTimeDurationInHours returning NaN (#33255)

### DIFF
--- a/test/functional/page_objects/time_picker.js
+++ b/test/functional/page_objects/time_picker.js
@@ -188,7 +188,7 @@ export function TimePickerPageProvider({ getService, getPageObjects }) {
     }
 
     async getTimeDurationInHours() {
-      const DEFAULT_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
+      const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
       const { start, end } = await this.getTimeConfigAsAbsoluteTimes();
 
       const startMoment = moment(start, DEFAULT_DATE_FORMAT);


### PR DESCRIPTION
Backports the following commits to 7.0:
 - [page_objects/time_picker] fix getTimeDurationInHours returning NaN  (#33255)