### PR TITLE
[APM] Update documentation links

### DIFF
--- a/x-pack/plugins/apm/public/utils/documentation/agents.ts
+++ b/x-pack/plugins/apm/public/utils/documentation/agents.ts
@@ -14,32 +14,32 @@ type DocUrls = {
 };
 
 const customUrls = {
-  'js-base': `${AGENT_URL_ROOT}/js-base/0.x/api.html#apm-set-custom-context`,
-  'rum-js': `${AGENT_URL_ROOT}/js-base/0.x/api.html#apm-set-custom-context`,
+  'js-base': `${AGENT_URL_ROOT}/js-base/4.x/api.html#apm-set-custom-context`,
+  'rum-js': `${AGENT_URL_ROOT}/js-base/4.x/api.html#apm-set-custom-context`,
   java: undefined,
-  nodejs: `${AGENT_URL_ROOT}/nodejs/1.x/agent-api.html#apm-set-custom-context`,
-  python: `${AGENT_URL_ROOT}/python/2.x/api.html#api-set-custom-context`,
-  ruby: `${AGENT_URL_ROOT}/ruby/1.x/advanced.html#_adding_custom_context`,
+  nodejs: `${AGENT_URL_ROOT}/nodejs/2.x/agent-api.html#apm-set-custom-context`,
+  python: `${AGENT_URL_ROOT}/python/4.x/api.html#api-set-custom-context`,
+  ruby: `${AGENT_URL_ROOT}/ruby/2.x/context.html#_adding_custom_context`,
   go: undefined
 };
 
 const AGENT_DOC_URLS: DocUrls = {
   user: {
-    'js-base': `${AGENT_URL_ROOT}/js-base/0.x/api.html#apm-set-user-context`,
-    'rum-js': `${AGENT_URL_ROOT}/js-base/0.x/api.html#apm-set-user-context`,
-    java: `${AGENT_URL_ROOT}/java/0.7/public-api.html#api-transaction-set-user`,
-    nodejs: `${AGENT_URL_ROOT}/nodejs/1.x/agent-api.html#apm-set-user-context`,
-    python: `${AGENT_URL_ROOT}/python/2.x/api.html#api-set-user-context`,
-    ruby: `${AGENT_URL_ROOT}/ruby/1.x/advanced.html#_providing_info_about_the_user`,
+    'js-base': `${AGENT_URL_ROOT}/js-base/4.x/api.html#apm-set-user-context`,
+    'rum-js': `${AGENT_URL_ROOT}/js-base/4.x/api.html#apm-set-user-context`,
+    java: `${AGENT_URL_ROOT}/java/1.x/public-api.html#api-transaction-set-user`,
+    nodejs: `${AGENT_URL_ROOT}/nodejs/2.x/agent-api.html#apm-set-user-context`,
+    python: `${AGENT_URL_ROOT}/python/4.x/api.html#api-set-user-context`,
+    ruby: `${AGENT_URL_ROOT}/ruby/2.x/context.html#_providing_info_about_the_user`,
     go: undefined
   },
   labels: {
-    'js-base': `${AGENT_URL_ROOT}/js-base/0.x/api.html#apm-set-tags`,
-    'rum-js': `${AGENT_URL_ROOT}/js-base/0.x/api.html#apm-set-tags`,
-    java: `${AGENT_URL_ROOT}/java/0.7/public-api.html#api-transaction-add-tag`,
-    nodejs: `${AGENT_URL_ROOT}/nodejs/1.x/agent-api.html#apm-set-tag`,
-    python: `${AGENT_URL_ROOT}/python/2.x/api.html#api-tag`,
-    ruby: `${AGENT_URL_ROOT}/ruby/1.x/advanced.html#_adding_tags`,
+    'js-base': `${AGENT_URL_ROOT}/js-base/4.x/api.html#apm-add-tags`,
+    'rum-js': `${AGENT_URL_ROOT}/js-base/4.x/api.html#apm-add-tags`,
+    java: `${AGENT_URL_ROOT}/java/1.x/public-api.html#api-transaction-add-tag`,
+    nodejs: `${AGENT_URL_ROOT}/nodejs/2.x/agent-api.html#apm-set-tag`,
+    python: `${AGENT_URL_ROOT}/python/4.x/api.html#api-tag`,
+    ruby: `${AGENT_URL_ROOT}/ruby/2.x/context.html#_adding_tags`,
     go: undefined
   },
   'transaction.custom': customUrls,


### PR DESCRIPTION
Was doing `7.0` testing and noticed links to documentation are very out of date:
<img width="1283" alt="Screen Shot 2019-03-18 at 10 29 24 AM" src="https://user-images.githubusercontent.com/5618806/54550484-4df7f400-4969-11e9-81ed-a221883e4842.png">

Unfortunately, we can't really use `current` here as then older versions of Kibana will link to newer, perhaps incompatible, versions of the agents.

I also noticed that there aren't any docs links for go, which might be helpful:
<img width="1295" alt="Screen Shot 2019-03-18 at 10 54 51 AM" src="https://user-images.githubusercontent.com/5618806/54551982-50a81880-496c-11e9-8b27-c163b0387fd8.png">
