### PR TITLE
[APM] Reset height in transaction details on transaction change

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionTabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionTabs.tsx
@@ -61,7 +61,9 @@ export function TransactionTabs({
   const agentName = transaction.agent.name;
 
   return (
-    <HeightRetainer>
+    <HeightRetainer
+      key={`${transaction.trace.id}:${transaction.transaction.id}`}
+    >
       <EuiTabs>
         {tabs.map(({ key, label }) => {
           return (


### PR DESCRIPTION
Closes #32626 by setting a unique key on the HeightRetainer element per transaction.