### PR TITLE
[APM] Rename "Tags" -> "Labels" in span flyout

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/SpanFlyout/index.tsx
@@ -57,10 +57,10 @@ export function SpanFlyout({
   const codeLanguage = idx(parentTransaction, _ => _.service.language.name);
   const dbContext = idx(span, _ => _.span.db);
   const httpContext = idx(span, _ => _.span.http);
-  const labels = span.labels;
-  const tags = keys(labels).map(key => ({
+  const spanLabels = span.labels;
+  const labels = keys(spanLabels).map(key => ({
     key,
-    value: get(labels, key)
+    value: get(spanLabels, key)
   }));
 
   return (
@@ -123,11 +123,11 @@ export function SpanFlyout({
                 )
               },
               {
-                id: 'tags',
+                id: 'labels',
                 name: i18n.translate(
-                  'xpack.apm.transactionDetails.spanFlyout.tagsTabLabel',
+                  'xpack.apm.propertiesTable.tabs.labelsLabel',
                   {
-                    defaultMessage: 'Tags'
+                    defaultMessage: 'Labels'
                   }
                 ),
                 content: (
@@ -144,7 +144,7 @@ export function SpanFlyout({
                           field: 'value'
                         }
                       ]}
-                      items={tags}
+                      items={labels}
                     />
                   </Fragment>
                 )

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3442,7 +3442,6 @@
     "xpack.apm.transactionDetails.spanFlyout.spanDetailsTitle": "跨度详情",
     "xpack.apm.transactionDetails.spanFlyout.spanType.navigationTimingLabel": "导航定时",
     "xpack.apm.transactionDetails.spanFlyout.stackTraceTabLabel": "堆栈追溯",
-    "xpack.apm.transactionDetails.spanFlyout.tagsTabLabel": "标记",
     "xpack.apm.transactionDetails.spanFlyout.typeLabel": "类型",
     "xpack.apm.transactionDetails.spanFlyout.viewSpanInDiscoverButtonLabel": "在 Discover 中查看跨度",
     "xpack.apm.transactionDetails.timestampLabel": "时间戳",


### PR DESCRIPTION
Closes #33486. Rename "Tags" -> "Labels" in span flyout.

<img width="572" alt="Screen Shot 2019-03-21 at 10 06 35 PM" src="https://user-images.githubusercontent.com/1967266/54801981-9b54b980-4c26-11e9-9b8a-9c8f8bf16056.png">
