### PR TITLE
[APM] Fix schema issues

### DIFF
--- a/x-pack/plugins/apm/typings/es_schemas/raw/APMBaseDoc.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/APMBaseDoc.ts
@@ -6,17 +6,16 @@
 
 // all documents types extend APMBaseDoc and inherit all properties
 export interface APMBaseDoc {
-  '@metadata': unknown;
   '@timestamp': string;
   agent: {
     name: string;
     version: string;
   };
-  observer: unknown;
   timestamp: { us: number };
   parent?: { id: string }; // parent ID is not available on root transactions
   trace?: { id: string };
   labels?: {
     [key: string]: string | number | boolean;
   };
+  [key: string]: unknown;
 }


### PR DESCRIPTION
`ecs` property was added to spans, which now causes the contract test between APM Server and Kibana to break. This should fix it.

Error:
```
[2019-03-26T04:52:39.383Z] tmp/apm-server-docs/SpanRawDocs.ts(120,5): error TS2322: Type '{ '@metadata': { beat: string; type: string; version: string; }; '@timestamp': string; agent: { name: string; version: string; }; ecs: { version: string; }; observer: { ephemeral_id: string; hostname: string; id: string; type: string; version: string; version_major: number; }; ... 5 more ...; trace: { ...; }; }' is not assignable to type 'SpanRaw'.

[2019-03-26T04:52:39.384Z]   Object literal may only specify known properties, and 'ecs' does not exist in type 'SpanRaw'.
```