### PR TITLE
[APM] Infer ReturnType from functions instead of declaring it explicitly

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.test.tsx
@@ -7,7 +7,6 @@
 import { shallow } from 'enzyme';
 import { Location } from 'history';
 import React from 'react';
-import { APMError } from '../../../../../typings/es_schemas/ui/APMError';
 import { mockMoment } from '../../../../utils/testHelpers';
 import { DetailView } from './index';
 
@@ -31,7 +30,8 @@ describe('DetailView', () => {
   it('should render Discover button', () => {
     const errorGroup = {
       occurrencesCount: 10,
-      error: ({
+      transaction: undefined,
+      error: {
         '@timestamp': 'myTimestamp',
         http: { request: { method: 'GET' } },
         url: { full: 'myUrl' },
@@ -39,8 +39,9 @@ describe('DetailView', () => {
         user: { id: 'myUserId' },
         error: { exception: { handled: true } },
         transaction: { id: 'myTransactionId', sampled: true }
-      } as unknown) as APMError
+      } as any
     };
+
     const wrapper = shallow(
       <DetailView
         errorGroup={errorGroup}
@@ -56,7 +57,8 @@ describe('DetailView', () => {
   it('should render StickyProperties', () => {
     const errorGroup = {
       occurrencesCount: 10,
-      error: {} as APMError
+      error: {} as any,
+      transaction: undefined
     };
     const wrapper = shallow(
       <DetailView
@@ -72,11 +74,12 @@ describe('DetailView', () => {
   it('should render tabs', () => {
     const errorGroup = {
       occurrencesCount: 10,
-      error: ({
+      transaction: undefined,
+      error: {
         '@timestamp': 'myTimestamp',
         service: {},
         user: {}
-      } as unknown) as APMError
+      } as any
     };
     const wrapper = shallow(
       <DetailView
@@ -93,10 +96,11 @@ describe('DetailView', () => {
   it('should render TabContent', () => {
     const errorGroup = {
       occurrencesCount: 10,
-      error: ({
+      transaction: undefined,
+      error: {
         '@timestamp': 'myTimestamp',
         context: {}
-      } as unknown) as APMError
+      } as any
     };
     const wrapper = shallow(
       <DetailView

--- a/x-pack/plugins/apm/public/components/app/Main/ProvideBreadcrumbs.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/ProvideBreadcrumbs.tsx
@@ -19,7 +19,7 @@ type LocationMatch = Pick<
   'location' | 'match'
 >;
 
-export type BreadcrumbFunction = (props: LocationMatch) => string;
+type BreadcrumbFunction = (props: LocationMatch) => string;
 
 export interface BreadcrumbRoute extends RouteProps {
   breadcrumb: string | BreadcrumbFunction | null;
@@ -29,11 +29,11 @@ export interface Breadcrumb extends LocationMatch {
   value: string;
 }
 
-export interface RenderProps extends RouteComponentProps {
+interface RenderProps extends RouteComponentProps {
   breadcrumbs: Breadcrumb[];
 }
 
-export interface ProvideBreadcrumbsProps extends RouteComponentProps {
+interface ProvideBreadcrumbsProps extends RouteComponentProps {
   routes: BreadcrumbRoute[];
   render: (props: RenderProps) => React.ReactElement<any> | null;
 }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -21,11 +21,11 @@ import { StringMap } from '../../../../../../../../typings/common';
 import { Span } from '../../../../../../../../typings/es_schemas/ui/Span';
 import { Transaction } from '../../../../../../../../typings/es_schemas/ui/Transaction';
 
-export interface IWaterfallIndex {
+interface IWaterfallIndex {
   [key: string]: IWaterfallItem;
 }
 
-export interface IWaterfallGroup {
+interface IWaterfallGroup {
   [key: string]: IWaterfallItem[];
 }
 

--- a/x-pack/plugins/apm/public/components/shared/FilterBar/DatePicker.tsx
+++ b/x-pack/plugins/apm/public/components/shared/FilterBar/DatePicker.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../store/urlParams';
 import { fromQuery, toQuery } from '../Links/url_helpers';
 
-export interface DatePickerProps extends RouteComponentProps {
+interface DatePickerProps extends RouteComponentProps {
   dispatchRefreshTimeRange: typeof refreshTimeRange;
   urlParams: IUrlParams;
 }

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
@@ -29,7 +29,7 @@ describe('when response has data', () => {
   let onSelectionEnd;
 
   beforeEach(() => {
-    const series = getResponseTimeSeries(responseWithData);
+    const series = getResponseTimeSeries({ apmTimeseries: responseWithData });
     onHover = jest.fn();
     onMouseLeave = jest.fn();
     onSelectionEnd = jest.fn();

--- a/x-pack/plugins/apm/public/hooks/useTransactionDistribution.ts
+++ b/x-pack/plugins/apm/public/hooks/useTransactionDistribution.ts
@@ -8,7 +8,12 @@ import { loadTransactionDistribution } from '../services/rest/apm/transaction_gr
 import { IUrlParams } from '../store/urlParams';
 import { useFetcher } from './useFetcher';
 
-const INITIAL_DATA = { buckets: [], totalHits: 0, bucketSize: 0 };
+const INITIAL_DATA = {
+  buckets: [],
+  totalHits: 0,
+  bucketSize: 0,
+  defaultSample: undefined
+};
 
 export function useTransactionDistribution(urlParams: IUrlParams) {
   const {

--- a/x-pack/plugins/apm/public/store/selectors/__tests__/chartSelectors.test.ts
+++ b/x-pack/plugins/apm/public/store/selectors/__tests__/chartSelectors.test.ts
@@ -38,7 +38,9 @@ describe('chartSelectors', () => {
     } as ApmTimeSeriesResponse;
 
     it('should produce correct series', () => {
-      expect(getResponseTimeSeries(apmTimeseries)).toEqual([
+      expect(
+        getResponseTimeSeries({ apmTimeseries, anomalyTimeseries: undefined })
+      ).toEqual([
         {
           color: '#3185fc',
           data: [{ x: 0, y: 100 }, { x: 1000, y: 200 }],
@@ -64,7 +66,10 @@ describe('chartSelectors', () => {
     });
 
     it('should return 3 series', () => {
-      expect(getResponseTimeSeries(apmTimeseries).length).toBe(3);
+      expect(
+        getResponseTimeSeries({ apmTimeseries, anomalyTimeseries: undefined })
+          .length
+      ).toBe(3);
     });
   });
 

--- a/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
+++ b/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
@@ -12,7 +12,6 @@ import mean from 'lodash.mean';
 import { rgba } from 'polished';
 import { MetricsChartAPIResponse } from '../../../server/lib/metrics/get_all_metrics_chart_data';
 import { TimeSeriesAPIResponse } from '../../../server/lib/transactions/charts';
-import { AnomalyTimeSeriesResponse } from '../../../server/lib/transactions/charts/get_anomaly_data/transform';
 import { ApmTimeSeriesResponse } from '../../../server/lib/transactions/charts/get_timeseries_data/transform';
 import { StringMap } from '../../../typings/common';
 import { Coordinate, RectCoordinate } from '../../../typings/timeseries';
@@ -81,9 +80,8 @@ const INITIAL_DATA = {
 
 export function getTransactionCharts(
   { start, end, transactionType }: IUrlParams,
-  timeseriesResponse: TimeSeriesAPIResponse = INITIAL_DATA
+  { apmTimeseries, anomalyTimeseries }: TimeSeriesAPIResponse = INITIAL_DATA
 ): ITransactionChartData {
-  const { apmTimeseries, anomalyTimeseries } = timeseriesResponse;
   const noHits = apmTimeseries.totalHits === 0;
   const tpmSeries = noHits
     ? getEmptySerie(start, end)
@@ -91,13 +89,13 @@ export function getTransactionCharts(
 
   const responseTimeSeries = noHits
     ? getEmptySerie(start, end)
-    : getResponseTimeSeries(apmTimeseries, anomalyTimeseries);
+    : getResponseTimeSeries({ apmTimeseries, anomalyTimeseries });
 
   return {
     noHits,
     tpmSeries,
     responseTimeSeries,
-    hasMLJob: timeseriesResponse.anomalyTimeseries !== undefined
+    hasMLJob: anomalyTimeseries !== undefined
   };
 }
 
@@ -203,10 +201,10 @@ interface TimeSerie {
   areaColor?: string;
 }
 
-export function getResponseTimeSeries(
-  apmTimeseries: ApmTimeSeriesResponse,
-  anomalyTimeseries?: AnomalyTimeSeriesResponse
-) {
+export function getResponseTimeSeries({
+  apmTimeseries,
+  anomalyTimeseries
+}: TimeSeriesAPIResponse) {
   const { overallAvgDuration } = apmTimeseries;
   const { avg, p95, p99 } = apmTimeseries.responseTimes;
 

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { PromiseReturnType } from '../../../../typings/common';
 import { Setup } from '../../helpers/setup_request';
 import { getBuckets } from './get_buckets';
 
@@ -12,14 +13,9 @@ function getBucketSize({ start, end, config }: Setup) {
   return Math.floor((end - start) / bucketTargetCount);
 }
 
-export interface ErrorDistributionAPIResponse {
-  totalHits: number;
-  buckets: Array<{
-    key: number;
-    count: number;
-  }>;
-  bucketSize: number;
-}
+export type ErrorDistributionAPIResponse = PromiseReturnType<
+  typeof getDistribution
+>;
 
 export async function getDistribution({
   serviceName,
@@ -29,7 +25,7 @@ export async function getDistribution({
   serviceName: string;
   groupId?: string;
   setup: Setup;
-}): Promise<ErrorDistributionAPIResponse> {
+}) {
   const bucketSize = getBucketSize(setup);
   const { buckets, totalHits } = await getBuckets({
     serviceName,

--- a/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
@@ -12,17 +12,13 @@ import {
   TRANSACTION_SAMPLED
 } from '../../../common/elasticsearch_fieldnames';
 import { idx } from '../../../common/idx';
+import { PromiseReturnType } from '../../../typings/common';
 import { APMError } from '../../../typings/es_schemas/ui/APMError';
-import { Transaction } from '../../../typings/es_schemas/ui/Transaction';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 import { getTransaction } from '../transactions/get_transaction';
 
-export interface ErrorGroupAPIResponse {
-  transaction?: Transaction;
-  error?: APMError;
-  occurrencesCount: number;
-}
+export type ErrorGroupAPIResponse = PromiseReturnType<typeof getErrorGroup>;
 
 // TODO: rename from "getErrorGroup"  to "getErrorGroupSample" (since a single error is returned, not an errorGroup)
 export async function getErrorGroup({
@@ -33,7 +29,7 @@ export async function getErrorGroup({
   serviceName: string;
   groupId: string;
   setup: Setup;
-}): Promise<ErrorGroupAPIResponse> {
+}) {
   const { start, end, esFilterQuery, client, config } = setup;
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },

--- a/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
@@ -15,20 +15,14 @@ import {
   SERVICE_NAME
 } from '../../../common/elasticsearch_fieldnames';
 import { idx } from '../../../common/idx';
+import { PromiseReturnType } from '../../../typings/common';
 import { APMError } from '../../../typings/es_schemas/ui/APMError';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
-interface ErrorResponseItems {
-  message?: string;
-  occurrenceCount: number;
-  culprit?: string;
-  groupId?: string;
-  latestOccurrenceAt: string;
-  handled?: boolean;
-}
-
-export type ErrorGroupListAPIResponse = ErrorResponseItems[];
+export type ErrorGroupListAPIResponse = PromiseReturnType<
+  typeof getErrorGroups
+>;
 
 export async function getErrorGroups({
   serviceName,
@@ -40,7 +34,7 @@ export async function getErrorGroups({
   sortField: string;
   sortDirection: string;
   setup: Setup;
-}): Promise<ErrorGroupListAPIResponse> {
+}) {
   const { start, end, esFilterQuery, client, config } = setup;
 
   const params: SearchParams = {

--- a/x-pack/plugins/apm/server/lib/metrics/get_all_metrics_chart_data.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_all_metrics_chart_data.ts
@@ -4,21 +4,15 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { CPUChartAPIResponse, getCPUChartData } from './get_cpu_chart_data';
-import {
-  getMemoryChartData,
-  MemoryChartAPIResponse
-} from './get_memory_chart_data';
+import { PromiseReturnType } from '../../../typings/common';
+import { getCPUChartData } from './get_cpu_chart_data';
+import { getMemoryChartData } from './get_memory_chart_data';
 import { MetricsRequestArgs } from './query_types';
 
-export interface MetricsChartAPIResponse {
-  memory: MemoryChartAPIResponse;
-  cpu: CPUChartAPIResponse;
-}
-
-export async function getAllMetricsChartData(
-  args: MetricsRequestArgs
-): Promise<MetricsChartAPIResponse> {
+export type MetricsChartAPIResponse = PromiseReturnType<
+  typeof getAllMetricsChartData
+>;
+export async function getAllMetricsChartData(args: MetricsRequestArgs) {
   const [memoryChartData, cpuChartData] = await Promise.all([
     getMemoryChartData(args),
     getCPUChartData(args)

--- a/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/fetcher.ts
@@ -3,13 +3,14 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { AggregationSearchResponse, ESFilter } from 'elasticsearch';
+import { ESFilter } from 'elasticsearch';
 import {
   METRIC_PROCESS_CPU_PERCENT,
   METRIC_SYSTEM_CPU_PERCENT,
   PROCESSOR_EVENT,
   SERVICE_NAME
 } from '../../../../common/elasticsearch_fieldnames';
+import { PromiseReturnType } from '../../../../typings/common';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { AggValue, MetricsRequestArgs, TimeSeriesBucket } from '../query_types';
 
@@ -30,12 +31,8 @@ interface Aggs {
   processCPUMax: AggValue;
 }
 
-export type ESResponse = AggregationSearchResponse<void, Aggs>;
-
-export async function fetch({
-  serviceName,
-  setup
-}: MetricsRequestArgs): Promise<ESResponse> {
+export type ESResponse = PromiseReturnType<typeof fetch>;
+export async function fetch({ serviceName, setup }: MetricsRequestArgs) {
   const { start, end, esFilterQuery, client, config } = setup;
   const { intervalString } = getBucketSize(start, end, 'auto');
   const filters: ESFilter[] = [

--- a/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/transformer.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_cpu_chart_data/transformer.ts
@@ -6,24 +6,7 @@
 import { Coordinate } from '../../../../typings/timeseries';
 import { ESResponse } from './fetcher';
 
-export interface CPUChartAPIResponse {
-  series: {
-    systemCPUAverage: Coordinate[];
-    systemCPUMax: Coordinate[];
-    processCPUAverage: Coordinate[];
-    processCPUMax: Coordinate[];
-  };
-  // overall totals for the whole time range
-  overallValues: {
-    systemCPUAverage: number | null;
-    systemCPUMax: number | null;
-    processCPUAverage: number | null;
-    processCPUMax: number | null;
-  };
-  totalHits: number;
-}
-
-export type CPUMetricName =
+type CPUMetricName =
   | 'systemCPUAverage'
   | 'systemCPUMax'
   | 'processCPUAverage'
@@ -36,7 +19,9 @@ const CPU_METRIC_NAMES: CPUMetricName[] = [
   'processCPUMax'
 ];
 
-export function transform(result: ESResponse): CPUChartAPIResponse {
+export type CPUChartAPIResponse = ReturnType<typeof transform>;
+
+export function transform(result: ESResponse) {
   const { aggregations, hits } = result;
   const {
     timeseriesData,
@@ -46,11 +31,11 @@ export function transform(result: ESResponse): CPUChartAPIResponse {
     processCPUMax
   } = aggregations;
 
-  const series: CPUChartAPIResponse['series'] = {
-    systemCPUAverage: [],
-    systemCPUMax: [],
-    processCPUAverage: [],
-    processCPUMax: []
+  const series = {
+    systemCPUAverage: [] as Coordinate[],
+    systemCPUMax: [] as Coordinate[],
+    processCPUAverage: [] as Coordinate[],
+    processCPUMax: [] as Coordinate[]
   };
 
   // using forEach here to avoid looping over the entire dataset

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/fetcher.ts
@@ -3,13 +3,14 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { AggregationSearchResponse, ESFilter } from 'elasticsearch';
+import { ESFilter } from 'elasticsearch';
 import {
   METRIC_SYSTEM_FREE_MEMORY,
   METRIC_SYSTEM_TOTAL_MEMORY,
   PROCESSOR_EVENT,
   SERVICE_NAME
 } from '../../../../common/elasticsearch_fieldnames';
+import { PromiseReturnType } from '../../../../typings/common';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { AggValue, MetricsRequestArgs, TimeSeriesBucket } from '../query_types';
 
@@ -26,12 +27,8 @@ interface Aggs {
   memoryUsedMax: AggValue;
 }
 
-export type ESResponse = AggregationSearchResponse<void, Aggs>;
-
-export async function fetch({
-  serviceName,
-  setup
-}: MetricsRequestArgs): Promise<ESResponse> {
+export type ESResponse = PromiseReturnType<typeof fetch>;
+export async function fetch({ serviceName, setup }: MetricsRequestArgs) {
   const { start, end, esFilterQuery, client, config } = setup;
   const { intervalString } = getBucketSize(start, end, 'auto');
   const filters: ESFilter[] = [

--- a/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/transformer.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/get_memory_chart_data/transformer.ts
@@ -6,33 +6,20 @@
 import { Coordinate } from '../../../../typings/timeseries';
 import { ESResponse } from './fetcher';
 
-export interface MemoryChartAPIResponse {
-  series: {
-    memoryUsedAvg: Coordinate[];
-    memoryUsedMax: Coordinate[];
-  };
-  // overall totals for the whole time range
-  overallValues: {
-    memoryUsedAvg: number | null;
-    memoryUsedMax: number | null;
-  };
-  totalHits: number;
-}
-
-export type MemoryMetricName = 'memoryUsedAvg' | 'memoryUsedMax';
-
+type MemoryMetricName = 'memoryUsedAvg' | 'memoryUsedMax';
 const MEMORY_METRIC_NAMES: MemoryMetricName[] = [
   'memoryUsedAvg',
   'memoryUsedMax'
 ];
 
-export function transform(result: ESResponse): MemoryChartAPIResponse {
+export type MemoryChartAPIResponse = ReturnType<typeof transform>;
+export function transform(result: ESResponse) {
   const { aggregations, hits } = result;
   const { timeseriesData, memoryUsedAvg, memoryUsedMax } = aggregations;
 
-  const series: MemoryChartAPIResponse['series'] = {
-    memoryUsedAvg: [],
-    memoryUsedMax: []
+  const series = {
+    memoryUsedAvg: [] as Coordinate[],
+    memoryUsedMax: [] as Coordinate[]
   };
 
   // using forEach here to avoid looping over the entire dataset

--- a/x-pack/plugins/apm/server/lib/services/get_service.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service.ts
@@ -4,8 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { BucketAgg } from 'elasticsearch';
-import { ESFilter } from 'elasticsearch';
+import { BucketAgg, ESFilter } from 'elasticsearch';
 import {
   PROCESSOR_EVENT,
   SERVICE_AGENT_NAME,
@@ -13,19 +12,12 @@ import {
   TRANSACTION_TYPE
 } from '../../../common/elasticsearch_fieldnames';
 import { idx } from '../../../common/idx';
+import { PromiseReturnType } from '../../../typings/common';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
-export interface ServiceAPIResponse {
-  serviceName: string;
-  types: string[];
-  agentName?: string;
-}
-
-export async function getService(
-  serviceName: string,
-  setup: Setup
-): Promise<ServiceAPIResponse> {
+export type ServiceAPIResponse = PromiseReturnType<typeof getService>;
+export async function getService(serviceName: string, setup: Setup) {
   const { start, end, esFilterQuery, client, config } = setup;
 
   const filter: ESFilter[] = [

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_services_items.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_services_items.ts
@@ -4,8 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { BucketAgg } from 'elasticsearch';
-import { ESFilter } from 'elasticsearch';
+import { BucketAgg, ESFilter } from 'elasticsearch';
 import {
   PROCESSOR_EVENT,
   SERVICE_AGENT_NAME,
@@ -13,9 +12,11 @@ import {
   TRANSACTION_DURATION
 } from '../../../../common/elasticsearch_fieldnames';
 import { idx } from '../../../../common/idx';
+import { PromiseReturnType } from '../../../../typings/common';
 import { rangeFilter } from '../../helpers/range_filter';
 import { Setup } from '../../helpers/setup_request';
 
+export type ServiceListAPIResponse = PromiseReturnType<typeof getServicesItems>;
 export async function getServicesItems(setup: Setup) {
   const { start, end, esFilterQuery, client, config } = setup;
 

--- a/x-pack/plugins/apm/server/lib/traces/get_top_traces.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_top_traces.ts
@@ -9,16 +9,13 @@ import {
   PROCESSOR_EVENT,
   TRANSACTION_SAMPLED
 } from '../../../common/elasticsearch_fieldnames';
+import { PromiseReturnType } from '../../../typings/common';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 import { getTransactionGroups } from '../transaction_groups';
-import { ITransactionGroup } from '../transaction_groups/transform';
 
-export type TraceListAPIResponse = ITransactionGroup[];
-
-export async function getTopTraces(
-  setup: Setup
-): Promise<TraceListAPIResponse> {
+export type TraceListAPIResponse = PromiseReturnType<typeof getTopTraces>;
+export async function getTopTraces(setup: Setup) {
   const { start, end } = setup;
 
   const bodyQuery = {

--- a/x-pack/plugins/apm/server/lib/traces/get_trace.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_trace.ts
@@ -4,27 +4,20 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import {
-  ErrorsPerTransaction,
-  getTraceErrorsPerTransaction
-} from '../errors/get_trace_errors_per_transaction';
+import { PromiseReturnType } from '../../../typings/common';
+import { getTraceErrorsPerTransaction } from '../errors/get_trace_errors_per_transaction';
 import { Setup } from '../helpers/setup_request';
-import { getTraceItems, TraceItem } from './get_trace_items';
+import { getTraceItems } from './get_trace_items';
 
-export interface TraceAPIResponse {
-  trace: TraceItem[];
-  errorsPerTransaction: ErrorsPerTransaction;
-}
-
-export async function getTrace(
-  traceId: string,
-  setup: Setup
-): Promise<TraceAPIResponse> {
-  return Promise.all([
+export type TraceAPIResponse = PromiseReturnType<typeof getTrace>;
+export async function getTrace(traceId: string, setup: Setup) {
+  const [trace, errorsPerTransaction] = await Promise.all([
     getTraceItems(traceId, setup),
     getTraceErrorsPerTransaction(traceId, setup)
-  ]).then(([trace, errorsPerTransaction]) => ({
+  ]);
+
+  return {
     trace,
     errorsPerTransaction
-  }));
+  };
 }

--- a/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -14,12 +14,7 @@ import { Transaction } from '../../../typings/es_schemas/ui/Transaction';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup } from '../helpers/setup_request';
 
-export type TraceItem = Transaction | Span;
-
-export async function getTraceItems(
-  traceId: string,
-  setup: Setup
-): Promise<TraceItem[]> {
+export async function getTraceItems(traceId: string, setup: Setup) {
   const { start, end, client, config } = setup;
 
   const params: SearchParams = {
@@ -41,6 +36,6 @@ export async function getTraceItems(
     }
   };
 
-  const resp = await client<TraceItem>('search', params);
+  const resp = await client<Transaction | Span>('search', params);
   return resp.hits.hits.map(hit => hit._source);
 }

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -4,12 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { AggregationSearchResponse, SearchParams } from 'elasticsearch';
+import { SearchParams } from 'elasticsearch';
 import {
   TRANSACTION_DURATION,
   TRANSACTION_NAME
 } from '../../../common/elasticsearch_fieldnames';
-import { StringMap } from '../../../typings/common';
+import { PromiseReturnType, StringMap } from '../../../typings/common';
 import { Transaction } from '../../../typings/es_schemas/ui/Transaction';
 import { Setup } from '../helpers/setup_request';
 
@@ -36,12 +36,8 @@ interface Aggs {
   };
 }
 
-export type ESResponse = AggregationSearchResponse<void, Aggs>;
-
-export function transactionGroupsFetcher(
-  setup: Setup,
-  bodyQuery: StringMap
-): Promise<ESResponse> {
+export type ESResponse = PromiseReturnType<typeof transactionGroupsFetcher>;
+export function transactionGroupsFetcher(setup: Setup, bodyQuery: StringMap) {
   const { esFilterQuery, client, config } = setup;
   const params: SearchParams = {
     index: config.get<string>('apm_oss.transactionIndices'),

--- a/x-pack/plugins/apm/server/lib/transaction_groups/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/transform.ts
@@ -6,27 +6,37 @@
 
 import moment from 'moment';
 import { idx } from '../../../common/idx';
-import { Transaction } from '../../../typings/es_schemas/ui/Transaction';
 import { ESResponse } from './fetcher';
 
-export interface ITransactionGroup {
-  name: string;
-  sample: Transaction;
-  p95: number;
-  averageResponseTime: number;
-  transactionsPerMinute: number;
-  impact: number;
-}
-
-function calculateRelativeImpacts(results: ITransactionGroup[]) {
-  const values = results.map(({ impact }) => impact);
+function calculateRelativeImpacts(transactionGroups: ITransactionGroup[]) {
+  const values = transactionGroups.map(({ impact }) => impact);
   const max = Math.max(...values);
   const min = Math.min(...values);
 
-  return results.map(bucket => ({
+  return transactionGroups.map(bucket => ({
     ...bucket,
     impact: ((bucket.impact - min) / (max - min)) * 100 || 0
   }));
+}
+
+export type ITransactionGroup = ReturnType<typeof getTransactionGroup>;
+function getTransactionGroup(
+  bucket: ESResponse['aggregations']['transactions']['buckets'][0],
+  minutes: number
+) {
+  const averageResponseTime = bucket.avg.value;
+  const transactionsPerMinute = bucket.doc_count / minutes;
+  const impact = bucket.sum.value;
+  const sample = bucket.sample.hits.hits[0]._source;
+
+  return {
+    name: bucket.key,
+    sample,
+    p95: bucket.p95.values['95.0'],
+    averageResponseTime,
+    transactionsPerMinute,
+    impact
+  };
 }
 
 export function transactionGroupsTransformer({
@@ -41,21 +51,9 @@ export function transactionGroupsTransformer({
   const buckets = idx(response, _ => _.aggregations.transactions.buckets) || [];
   const duration = moment.duration(end - start);
   const minutes = duration.asMinutes();
-  const results = buckets.map(bucket => {
-    const averageResponseTime = bucket.avg.value;
-    const transactionsPerMinute = bucket.doc_count / minutes;
-    const impact = bucket.sum.value;
-    const sample = bucket.sample.hits.hits[0]._source;
+  const transactionGroups = buckets.map(bucket =>
+    getTransactionGroup(bucket, minutes)
+  );
 
-    return {
-      name: bucket.key,
-      sample,
-      p95: bucket.p95.values['95.0'],
-      averageResponseTime,
-      transactionsPerMinute,
-      impact
-    };
-  });
-
-  return calculateRelativeImpacts(results);
+  return calculateRelativeImpacts(transactionGroups);
 }

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/fetcher.ts
@@ -4,8 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { AggregationSearchResponse } from 'elasticsearch';
 import { getMlIndex } from '../../../../../common/ml_job_constants';
+import { PromiseReturnType } from '../../../../../typings/common';
 import { Setup } from '../../../helpers/setup_request';
 
 export interface ESBucket {
@@ -29,8 +29,7 @@ interface Aggs {
   };
 }
 
-export type ESResponse = AggregationSearchResponse<void, Aggs>;
-
+export type ESResponse = PromiseReturnType<typeof anomalySeriesFetcher>;
 export async function anomalySeriesFetcher({
   serviceName,
   transactionType,
@@ -43,7 +42,7 @@ export async function anomalySeriesFetcher({
   intervalString: string;
   mlBucketSize: number;
   setup: Setup;
-}): Promise<ESResponse | undefined> {
+}) {
   const { client, start, end } = setup;
 
   // move the start back with one bucket size, to ensure to get anomaly data in the beginning

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/index.test.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/index.test.ts
@@ -10,14 +10,14 @@ import { mlBucketSpanResponse } from './mock-responses/mlBucketSpanResponse';
 import { AnomalyTimeSeriesResponse } from './transform';
 
 describe('getAnomalySeries', () => {
-  let avgAnomalies: AnomalyTimeSeriesResponse;
+  let avgAnomalies: Required<AnomalyTimeSeriesResponse>;
   beforeEach(async () => {
     const clientSpy = jest
       .fn()
       .mockResolvedValueOnce(mlBucketSpanResponse)
       .mockResolvedValueOnce(mlAnomalyResponse);
 
-    avgAnomalies = (await getAnomalySeries({
+    avgAnomalies = await getAnomalySeries({
       serviceName: 'myServiceName',
       transactionType: 'myTransactionType',
       timeSeriesDates: [100, 100000],
@@ -30,11 +30,11 @@ describe('getAnomalySeries', () => {
           has: () => true
         }
       }
-    })) as AnomalyTimeSeriesResponse;
+    });
   });
 
   it('should remove buckets lower than threshold and outside date range from anomalyScore', () => {
-    expect(avgAnomalies.anomalyScore).toEqual([
+    expect(avgAnomalies!.anomalyScore).toEqual([
       { x0: 15000, x: 25000 },
       { x0: 25000, x: 35000 }
     ]);
@@ -42,7 +42,7 @@ describe('getAnomalySeries', () => {
 
   it('should remove buckets outside date range from anomalyBoundaries', () => {
     expect(
-      avgAnomalies.anomalyBoundaries.filter(
+      avgAnomalies!.anomalyBoundaries.filter(
         bucket => bucket.x < 100 || bucket.x > 100000
       ).length
     ).toBe(0);
@@ -50,7 +50,7 @@ describe('getAnomalySeries', () => {
 
   it('should remove buckets with null from anomalyBoundaries', () => {
     expect(
-      avgAnomalies.anomalyBoundaries.filter(p => p.y === null).length
+      avgAnomalies!.anomalyBoundaries.filter(p => p.y === null).length
     ).toBe(0);
   });
 

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.ts
@@ -7,40 +7,34 @@
 import { first, last } from 'lodash';
 import { idx } from '../../../../../common/idx';
 import { Coordinate, RectCoordinate } from '../../../../../typings/timeseries';
-import { ESResponse } from './fetcher';
+import { ESBucket, ESResponse } from './fetcher';
 
-interface IBucket {
-  x: number;
-  anomalyScore: number | null;
-  lower: number | null;
-  upper: number | null;
+type IBucket = ReturnType<typeof getBucket>;
+function getBucket(bucket: ESBucket) {
+  return {
+    x: bucket.key,
+    anomalyScore: bucket.anomaly_score.value,
+    lower: bucket.lower.value,
+    upper: bucket.upper.value
+  };
 }
 
-export interface AnomalyTimeSeriesResponse {
-  anomalyScore: RectCoordinate[];
-  anomalyBoundaries: Coordinate[];
-}
-
+export type AnomalyTimeSeriesResponse = ReturnType<
+  typeof anomalySeriesTransform
+>;
 export function anomalySeriesTransform(
-  response: ESResponse | undefined,
+  response: ESResponse,
   mlBucketSize: number,
   bucketSize: number,
   timeSeriesDates: number[]
-): AnomalyTimeSeriesResponse | undefined {
+) {
   if (!response) {
     return;
   }
 
   const buckets = (
     idx(response, _ => _.aggregations.ml_avg_response_times.buckets) || []
-  ).map(bucket => {
-    return {
-      x: bucket.key,
-      anomalyScore: bucket.anomaly_score.value,
-      lower: bucket.lower.value,
-      upper: bucket.upper.value
-    };
-  });
+  ).map(getBucket);
 
   const bucketSizeInMillis = Math.max(bucketSize, mlBucketSize) * 1000;
 

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
@@ -4,11 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import {
-  AggregationSearchResponse,
-  ESFilter,
-  SearchParams
-} from 'elasticsearch';
+import { ESFilter, SearchParams } from 'elasticsearch';
 import {
   PROCESSOR_EVENT,
   SERVICE_NAME,
@@ -17,6 +13,7 @@ import {
   TRANSACTION_RESULT,
   TRANSACTION_TYPE
 } from '../../../../../common/elasticsearch_fieldnames';
+import { PromiseReturnType } from '../../../../../typings/common';
 import { getBucketSize } from '../../../helpers/get_bucket_size';
 import { rangeFilter } from '../../../helpers/range_filter';
 import { Setup } from '../../../helpers/setup_request';
@@ -68,8 +65,7 @@ interface Aggs {
   };
 }
 
-export type ESResponse = AggregationSearchResponse<void, Aggs>;
-
+export type ESResponse = PromiseReturnType<typeof timeseriesFetcher>;
 export function timeseriesFetcher({
   serviceName,
   transactionType,
@@ -80,7 +76,7 @@ export function timeseriesFetcher({
   transactionType?: string;
   transactionName?: string;
   setup: Setup;
-}): Promise<ESResponse> {
+}) {
   const { start, end, esFilterQuery, client, config } = setup;
   const { intervalString } = getBucketSize(start, end, 'auto');
 

--- a/x-pack/plugins/apm/server/lib/transactions/charts/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/index.ts
@@ -4,27 +4,23 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { PromiseReturnType } from '../../../../typings/common';
 import { Setup } from '../../helpers/setup_request';
 import { getAnomalySeries } from './get_anomaly_data';
-import { AnomalyTimeSeriesResponse } from './get_anomaly_data/transform';
 import { getApmTimeseriesData } from './get_timeseries_data';
 import { ApmTimeSeriesResponse } from './get_timeseries_data/transform';
-
-export interface TimeSeriesAPIResponse {
-  apmTimeseries: ApmTimeSeriesResponse;
-  anomalyTimeseries?: AnomalyTimeSeriesResponse;
-}
 
 function getDates(apmTimeseries: ApmTimeSeriesResponse) {
   return apmTimeseries.responseTimes.avg.map(p => p.x);
 }
 
+export type TimeSeriesAPIResponse = PromiseReturnType<typeof getChartsData>;
 export async function getChartsData(options: {
   serviceName: string;
   transactionType?: string;
   transactionName?: string;
   setup: Setup;
-}): Promise<TimeSeriesAPIResponse> {
+}) {
   const apmTimeseries = await getApmTimeseriesData(options);
   const anomalyTimeseries = await getAnomalySeries({
     ...options,

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
@@ -4,11 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import {
-  AggregationSearchResponse,
-  ESFilter,
-  SearchResponse
-} from 'elasticsearch';
+import { ESFilter, SearchResponse } from 'elasticsearch';
 import {
   PROCESSOR_EVENT,
   SERVICE_NAME,
@@ -19,6 +15,7 @@ import {
   TRANSACTION_SAMPLED,
   TRANSACTION_TYPE
 } from '../../../../../common/elasticsearch_fieldnames';
+import { PromiseReturnType } from '../../../../../typings/common';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import { rangeFilter } from '../../../helpers/range_filter';
 import { Setup } from '../../../helpers/setup_request';
@@ -40,8 +37,7 @@ interface Aggs {
   };
 }
 
-export type ESResponse = AggregationSearchResponse<void, Aggs>;
-
+export type ESResponse = PromiseReturnType<typeof bucketFetcher>;
 export function bucketFetcher(
   serviceName: string,
   transactionName: string,
@@ -50,7 +46,7 @@ export function bucketFetcher(
   traceId: string,
   bucketSize: number,
   setup: Setup
-): Promise<ESResponse> {
+) {
   const { start, end, esFilterQuery, client, config } = setup;
   const bucketTargetCount = config.get<number>('xpack.apm.bucketTargetCount');
   const filter: ESFilter[] = [

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
@@ -8,23 +8,6 @@ import { isEmpty } from 'lodash';
 import { idx } from '../../../../../common/idx';
 import { ESResponse } from './fetcher';
 
-export interface IBucket {
-  key: number;
-  count: number;
-  sample?: IBucketSample;
-}
-
-interface IBucketSample {
-  traceId?: string;
-  transactionId?: string;
-}
-
-interface IBucketsResponse {
-  totalHits: number;
-  buckets: IBucket[];
-  defaultSample?: IBucketSample;
-}
-
 function getDefaultSample(buckets: IBucket[]) {
   const samples = buckets
     .filter(bucket => bucket.count > 0 && bucket.sample)
@@ -38,21 +21,26 @@ function getDefaultSample(buckets: IBucket[]) {
   return samples[middleIndex];
 }
 
-export function bucketTransformer(response: ESResponse): IBucketsResponse {
-  const buckets = response.aggregations.distribution.buckets.map(bucket => {
-    const sampleSource = idx(bucket, _ => _.sample.hits.hits[0]._source);
-    const isSampled = idx(sampleSource, _ => _.transaction.sampled);
-    const sample = {
-      traceId: idx(sampleSource, _ => _.trace.id),
-      transactionId: idx(sampleSource, _ => _.transaction.id)
-    };
+export type IBucket = ReturnType<typeof getBucket>;
+function getBucket(
+  bucket: ESResponse['aggregations']['distribution']['buckets'][0]
+) {
+  const sampleSource = idx(bucket, _ => _.sample.hits.hits[0]._source);
+  const isSampled = idx(sampleSource, _ => _.transaction.sampled);
+  const sample = {
+    traceId: idx(sampleSource, _ => _.trace.id),
+    transactionId: idx(sampleSource, _ => _.transaction.id)
+  };
 
-    return {
-      key: bucket.key,
-      count: bucket.doc_count,
-      sample: isSampled ? sample : undefined
-    };
-  });
+  return {
+    key: bucket.key,
+    count: bucket.doc_count,
+    sample: isSampled ? sample : undefined
+  };
+}
+
+export function bucketTransformer(response: ESResponse) {
+  const buckets = response.aggregations.distribution.buckets.map(getBucket);
 
   return {
     totalHits: response.hits.total,

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/index.ts
@@ -4,18 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { PromiseReturnType } from '../../../../typings/common';
 import { Setup } from '../../helpers/setup_request';
 import { calculateBucketSize } from './calculate_bucket_size';
 import { getBuckets } from './get_buckets';
-import { IBucket } from './get_buckets/transform';
 
-export interface ITransactionDistributionAPIResponse {
-  totalHits: number;
-  buckets: IBucket[];
-  bucketSize: number;
-  defaultSample?: IBucket['sample'];
-}
-
+export type ITransactionDistributionAPIResponse = PromiseReturnType<
+  typeof getDistribution
+>;
 export async function getDistribution(
   serviceName: string,
   transactionName: string,
@@ -23,7 +19,7 @@ export async function getDistribution(
   transactionId: string,
   traceId: string,
   setup: Setup
-): Promise<ITransactionDistributionAPIResponse> {
+) {
   const bucketSize = await calculateBucketSize(
     serviceName,
     transactionName,

--- a/x-pack/plugins/apm/server/lib/transactions/get_top_transactions/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_top_transactions/index.ts
@@ -10,11 +10,10 @@ import {
   SERVICE_NAME,
   TRANSACTION_TYPE
 } from '../../../../common/elasticsearch_fieldnames';
-import { Setup } from '../../helpers/setup_request';
-
+import { PromiseReturnType } from '../../../../typings/common';
 import { rangeFilter } from '../../helpers/range_filter';
+import { Setup } from '../../helpers/setup_request';
 import { getTransactionGroups } from '../../transaction_groups';
-import { ITransactionGroup } from '../../transaction_groups/transform';
 
 export interface IOptions {
   setup: Setup;
@@ -22,8 +21,9 @@ export interface IOptions {
   serviceName: string;
 }
 
-export type TransactionListAPIResponse = ITransactionGroup[];
-
+export type TransactionListAPIResponse = PromiseReturnType<
+  typeof getTopTransactions
+>;
 export async function getTopTransactions({
   setup,
   transactionType,

--- a/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_transaction/index.ts
@@ -11,22 +11,17 @@ import {
   TRANSACTION_ID
 } from '../../../../common/elasticsearch_fieldnames';
 import { idx } from '../../../../common/idx';
+import { PromiseReturnType } from '../../../../typings/common';
 import { Transaction } from '../../../../typings/es_schemas/ui/Transaction';
 import { rangeFilter } from '../../helpers/range_filter';
 import { Setup } from '../../helpers/setup_request';
 
-export type TransactionAPIResponse = Transaction | undefined;
-
-export interface TransactionWithErrorCountAPIResponse {
-  transaction: TransactionAPIResponse;
-  errorCount: number;
-}
-
+export type TransactionAPIResponse = PromiseReturnType<typeof getTransaction>;
 export async function getTransaction(
   transactionId: string,
   traceId: string,
   setup: Setup
-): Promise<TransactionAPIResponse> {
+) {
   const { start, end, esFilterQuery, client, config } = setup;
 
   const filter: ESFilter[] = [


### PR DESCRIPTION
The `ReturnType` generic is awesome! It can infer the return type of a function. You can read more about it here: https://dev.to/busypeoples/notes-on-typescript-returntype-3m5

Sometimes it's good to have explicit return types but other times it seems we create them because other functions need to specify them as part of their input arguments. In these cases the `ReturnType` generic can be used. 

Advantages:
 - interface will always match and be in sync with the implementation (since it's derived from the implementation)
 - Much easier than hand-writing an interface
 - less code

Disadvantages:
 - Explicit types can work as documentation

What do you think?