### PR TITLE
[APM] Add support for new agent 'dotnet' in apm

### DIFF
--- a/x-pack/plugins/apm/common/agent_name.ts
+++ b/x-pack/plugins/apm/common/agent_name.ts
@@ -19,6 +19,7 @@ const agentNames: { [agentName in AgentName]: agentName } = {
   nodejs: 'nodejs',
   'js-base': 'js-base',
   'rum-js': 'rum-js',
+  dotnet: 'dotnet',
   ruby: 'ruby',
   go: 'go'
 };

--- a/x-pack/plugins/apm/mappings.json
+++ b/x-pack/plugins/apm/mappings.json
@@ -26,6 +26,10 @@
             "type": "long",
             "null_value": 0
           },
+          "dotnet": {
+            "type": "long",
+            "null_value": 0
+          },
           "ruby": {
             "type": "long",
             "null_value": 0

--- a/x-pack/plugins/apm/public/utils/documentation/agents.ts
+++ b/x-pack/plugins/apm/public/utils/documentation/agents.ts
@@ -19,6 +19,7 @@ const customUrls = {
   java: undefined,
   nodejs: `${AGENT_URL_ROOT}/nodejs/2.x/agent-api.html#apm-set-custom-context`,
   python: `${AGENT_URL_ROOT}/python/4.x/api.html#api-set-custom-context`,
+  dotnet: undefined,
   ruby: `${AGENT_URL_ROOT}/ruby/2.x/context.html#_adding_custom_context`,
   go: undefined
 };
@@ -30,6 +31,7 @@ const AGENT_DOC_URLS: DocUrls = {
     java: `${AGENT_URL_ROOT}/java/1.x/public-api.html#api-transaction-set-user`,
     nodejs: `${AGENT_URL_ROOT}/nodejs/2.x/agent-api.html#apm-set-user-context`,
     python: `${AGENT_URL_ROOT}/python/4.x/api.html#api-set-user-context`,
+    dotnet: undefined,
     ruby: `${AGENT_URL_ROOT}/ruby/2.x/context.html#_providing_info_about_the_user`,
     go: undefined
   },
@@ -39,6 +41,7 @@ const AGENT_DOC_URLS: DocUrls = {
     java: `${AGENT_URL_ROOT}/java/1.x/public-api.html#api-transaction-add-tag`,
     nodejs: `${AGENT_URL_ROOT}/nodejs/2.x/agent-api.html#apm-set-tag`,
     python: `${AGENT_URL_ROOT}/python/4.x/api.html#api-tag`,
+    dotnet: `${AGENT_URL_ROOT}/dotnet/current/public-api.html#api-transaction-tags`,
     ruby: `${AGENT_URL_ROOT}/ruby/2.x/context.html#_adding_tags`,
     go: undefined
   },

--- a/x-pack/plugins/apm/typings/es_schemas/ui/fields/Agent.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/ui/fields/Agent.ts
@@ -15,6 +15,7 @@ export type AgentName =
   | 'rum-js'
   | 'nodejs'
   | 'python'
+  | 'dotnet'
   | 'ruby';
 
 export interface Agent {


### PR DESCRIPTION
Addresses #33572 by adding support for new agent 'dotnet' in apm telemetry & documentation links.