### PR TITLE
[APM] Remove open-ended index signatures from interfaces

### DIFF
--- a/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
+++ b/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
@@ -5,13 +5,14 @@
  */
 
 import { get } from 'lodash';
+import { AllowUnknownProperties } from '../typings/common';
 import { APMError } from '../typings/es_schemas/ui/APMError';
 import { Span } from '../typings/es_schemas/ui/Span';
 import { Transaction } from '../typings/es_schemas/ui/Transaction';
 import * as fieldnames from './elasticsearch_fieldnames';
 
 describe('Transaction', () => {
-  const transaction: Transaction = {
+  const transaction: AllowUnknownProperties<Transaction> = {
     '@timestamp': new Date().toString(),
     '@metadata': 'whatever',
     observer: 'whatever',
@@ -58,7 +59,7 @@ describe('Transaction', () => {
 });
 
 describe('Span', () => {
-  const span: Span = {
+  const span: AllowUnknownProperties<Span> = {
     '@timestamp': new Date().toString(),
     '@metadata': 'whatever',
     observer: 'whatever',
@@ -103,7 +104,7 @@ describe('Span', () => {
 });
 
 describe('Error', () => {
-  const errorDoc: APMError = {
+  const errorDoc: AllowUnknownProperties<APMError> = {
     '@metadata': 'whatever',
     observer: 'whatever',
     agent: {
@@ -156,7 +157,9 @@ describe('Error', () => {
   matchSnapshot(errorDoc);
 });
 
-function matchSnapshot(obj: Span | Transaction | APMError) {
+function matchSnapshot(
+  obj: AllowUnknownProperties<Span | Transaction | APMError>
+) {
   Object.entries(fieldnames).forEach(([key, longKey]) => {
     const value = get(obj, longKey);
     it(key, () => {

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/__test__/mockData.ts
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/__test__/mockData.ts
@@ -7,7 +7,7 @@
 import { Location } from 'history';
 import { Transaction } from 'x-pack/plugins/apm/typings/es_schemas/ui/Transaction';
 
-export const transaction: Transaction = {
+export const transaction = {
   '@metadata': 'whatever',
   observer: 'whatever',
   agent: {
@@ -77,7 +77,7 @@ export const transaction: Transaction = {
   timestamp: {
     us: 1545092070952472
   }
-};
+} as Transaction;
 
 export const location: Location = {
   state: '',

--- a/x-pack/plugins/apm/typings/common.ts
+++ b/x-pack/plugins/apm/typings/common.ts
@@ -7,3 +7,10 @@
 export interface StringMap<T = unknown> {
   [key: string]: T;
 }
+
+// Allow unknown properties in an object
+export type AllowUnknownProperties<T> = T extends object
+  ? { [P in keyof T]: AllowUnknownProperties<T[P]> } & {
+      [key: string]: unknown;
+    }
+  : T;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/APMBaseDoc.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/APMBaseDoc.ts
@@ -17,5 +17,4 @@ export interface APMBaseDoc {
   labels?: {
     [key: string]: string | number | boolean;
   };
-  [key: string]: unknown;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/ErrorRaw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/ErrorRaw.ts
@@ -27,13 +27,11 @@ interface Exception {
   module?: string;
   handled?: boolean;
   stacktrace?: IStackframe[];
-  [key: string]: unknown;
 }
 
 interface Log {
   message: string;
   stacktrace?: IStackframe[];
-  [key: string]: unknown;
 }
 
 export interface ErrorRaw extends APMBaseDoc {
@@ -50,9 +48,7 @@ export interface ErrorRaw extends APMBaseDoc {
     // either exception or log are given
     exception?: Exception[];
     log?: Log;
-    [key: string]: unknown;
   };
-  [key: string]: unknown;
 
   // Shared by errors and transactions
   container?: Container;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/SpanRaw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/SpanRaw.ts
@@ -31,14 +31,11 @@ export interface SpanRaw extends APMBaseDoc {
       url?: {
         original?: string;
       };
-      [key: string]: unknown;
     };
     db?: {
       statement?: string;
       type?: string;
-      [key: string]: unknown;
     };
-    [key: string]: unknown;
   };
   transaction?: {
     id: string;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/TransactionRaw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/TransactionRaw.ts
@@ -31,7 +31,6 @@ export interface TransactionRaw extends APMBaseDoc {
       agent?: {
         [name: string]: number;
       };
-      [key: string]: unknown;
     };
     name?: string;
     result?: string;
@@ -41,9 +40,7 @@ export interface TransactionRaw extends APMBaseDoc {
       dropped?: number;
     };
     type: string;
-    [key: string]: unknown;
   };
-  [key: string]: unknown;
 
   // Shared by errors and transactions
   container?: Container;

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/Host.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/Host.ts
@@ -6,5 +6,4 @@
 
 export interface Host {
   hostname?: string;
-  [key: string]: unknown;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/Kubernetes.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/Kubernetes.ts
@@ -6,5 +6,4 @@
 
 export interface Kubernetes {
   pod: { uid: string; [key: string]: unknown };
-  [key: string]: unknown;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/Service.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/Service.ts
@@ -18,5 +18,4 @@ export interface Service {
     name: string;
     version?: string;
   };
-  [key: string]: unknown;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/Stackframe.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/Stackframe.ts
@@ -19,7 +19,6 @@ interface IStackframeBase {
   line: {
     number: number;
   };
-  [key: string]: unknown;
 }
 
 export interface IStackframeWithLineContext extends IStackframeBase {

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/Url.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/Url.ts
@@ -6,5 +6,4 @@
 
 export interface Url {
   full: string;
-  [key: string]: unknown;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/User.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/User.ts
@@ -6,5 +6,4 @@
 
 export interface User {
   id: string;
-  [key: string]: unknown;
 }


### PR DESCRIPTION
Closes #34061

To avoid [this bug](https://github.com/elastic/kibana/issues/34044) from occurring again, we should narrow the interface definitions, and not allow the open-ended `[key: string]: unknown;` which allows any property to be accessed regardless whether it exists or not.

This will also require an update of the integration test: https://github.com/elastic/apm-integration-testing/pull/414