### PR TITLE
[APM] Replace `omitLegacyData` with `includeLegacyData`

### DIFF
--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
@@ -20,7 +20,7 @@ function decodeEsQuery(esQuery?: string) {
 }
 
 export interface APMSearchParams extends SearchParams {
-  omitLegacyData?: boolean;
+  includeLegacyData?: boolean;
 }
 
 export type ESClient = <T = void, U = void>(
@@ -69,10 +69,10 @@ export function isApmIndex(
 
 function addFilterForLegacyData(
   apmIndices: string[],
-  { omitLegacyData = true, ...params }: APMSearchParams
+  { includeLegacyData = false, ...params }: APMSearchParams
 ): SearchParams {
   // search across all data (including data)
-  if (!omitLegacyData || !isApmIndex(apmIndices, params.index)) {
+  if (includeLegacyData || !isApmIndex(apmIndices, params.index)) {
     return params;
   }
 

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_legacy_data_status.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_legacy_data_status.ts
@@ -15,7 +15,7 @@ export async function getLegacyDataStatus(setup: Setup) {
   const { client, config } = setup;
 
   const params: APMSearchParams = {
-    omitLegacyData: false,
+    includeLegacyData: true,
     terminateAfter: 1,
     index: [config.get('apm_oss.transactionIndices')],
     body: {


### PR DESCRIPTION
When backporting https://github.com/elastic/kibana/pull/34356 I noticed some inconsistencies in the unit test for setup_request, that I fixed while backporting. To keep master consistent I also chose to make there changes here. On top of that I also flipped `omitLegacyData` to `includeLegacyData` - the double negation felt awkward.