### PR TITLE
Break out beats modules by type in telemetry

### DIFF
--- a/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/__tests__/fixtures/beats_stats_results.json
+++ b/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/__tests__/fixtures/beats_stats_results.json
@@ -59,10 +59,10 @@
             "type": "beats_state",
             "cluster_uuid": "W7hppdX7R229Oy3KQbZrTw",
             "beats_state": {
+              "beat": {
+                 "type": "car"
+              },
               "state": {
-                "beat": {
-                  "type": "car"
-                },
                 "module": {
                   "count": 1,
                   "names": [

--- a/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/__tests__/fixtures/beats_stats_results.json
+++ b/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/__tests__/fixtures/beats_stats_results.json
@@ -60,6 +60,9 @@
             "cluster_uuid": "W7hppdX7R229Oy3KQbZrTw",
             "beats_state": {
               "state": {
+                "beat": {
+                  "type": "car"
+                },
                 "module": {
                   "count": 1,
                   "names": [
@@ -11603,6 +11606,6 @@
       ]
     }
   },
-  
+
   {}
 ]

--- a/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/__tests__/get_beats_stats.js
+++ b/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/__tests__/get_beats_stats.js
@@ -139,7 +139,7 @@ describe('Get Beats Stats', () => {
           hosts: 1,
           module: {
             count: 1,
-            names: [ 'ferrari' ],
+            names: [ 'car.ferrari' ],
           },
           input: {
             count: 1,

--- a/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/get_beats_stats.js
+++ b/x-pack/legacy/plugins/telemetry/server/collectors/monitoring/get_beats_stats.js
@@ -97,9 +97,10 @@ export function processResults(results = [], { clusters, clusterHostSets, cluste
       }
 
       const stateModule = get(hit, '_source.beats_state.state.module');
+      const statsType = get(hit, '_source.beats_state.beat.type');
       if (stateModule !== undefined) {
         const moduleSet = clusterModuleSets[clusterUuid];
-        stateModule.names.forEach(name => moduleSet.add(name));
+        stateModule.names.forEach(name => moduleSet.add(statsType + '.' + name));
         clusters[clusterUuid].module.names = Array.from(moduleSet);
         clusters[clusterUuid].module.count += stateModule.count;
       }
@@ -189,6 +190,7 @@ async function fetchBeatsByType(server, callCluster, clusterUuids, start, end, {
       'hits.hits._source.beats_state.state.module',
       'hits.hits._source.beats_state.state.host',
       'hits.hits._source.beats_state.state.heartbeat',
+      'hits.hits._source.beats_state.beat.type',
     ],
     body: {
       query: createQuery({


### PR DESCRIPTION
## Summary

This change attempts to provide a path forward for the problem outlined here:

https://github.com/elastic/telemetry/issues/63

What it does is to simply to concatenate the type of beat with the name of the beat itself. Prior to this PR, a user who might be using a module which is named `foo` which is present and enabled across multiple imaginary beats `a` and `b` would simply be recorded by telemetry as having two instances of `foo` in use with no way to distinguish what beat they were used by.

This changes behavior so that in that circumstance , we now we record this module usage as `a.foo` and `b.foo`.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

