### PR TITLE
[APM] Reduce loading indicator flickering

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/Delayed/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/Delayed/index.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { Delayed } from '.';
+
+// Advanced time like setTimeout and mocks Date.now() to stay in sync
+class AdvanceTimer {
+  public nowTime = 0;
+  public advance(ms: number) {
+    this.nowTime += ms;
+    jest.spyOn(Date, 'now').mockReturnValue(this.nowTime);
+    jest.advanceTimersByTime(ms);
+  }
+}
+
+describe('Delayed', () => {
+  it('should not flicker between show/hide when the hide interval is very short', async () => {
+    jest.useFakeTimers();
+    const visibilityChanges: boolean[] = [];
+    const advanceTimer = new AdvanceTimer();
+    const delayed = new Delayed();
+
+    delayed.onChange(isVisible => visibilityChanges.push(isVisible));
+
+    for (let i = 1; i < 100; i += 2) {
+      delayed.show();
+      advanceTimer.advance(1000);
+      delayed.hide();
+      advanceTimer.advance(20);
+    }
+    advanceTimer.advance(100);
+
+    expect(visibilityChanges).toEqual([true, false]);
+  });
+
+  it('should not be shown at all when the duration is very short', async () => {
+    jest.useFakeTimers();
+    const advanceTimer = new AdvanceTimer();
+    const visibilityChanges: boolean[] = [];
+    const delayed = new Delayed();
+
+    delayed.onChange(isVisible => visibilityChanges.push(isVisible));
+
+    delayed.show();
+    advanceTimer.advance(30);
+    delayed.hide();
+    advanceTimer.advance(1000);
+
+    expect(visibilityChanges).toEqual([]);
+  });
+
+  it('should be displayed for minimum 1000ms', async () => {
+    jest.useFakeTimers();
+    const visibilityChanges: boolean[] = [];
+    const advanceTimer = new AdvanceTimer();
+    const delayed = new Delayed();
+
+    delayed.onChange(isVisible => visibilityChanges.push(isVisible));
+
+    delayed.show();
+    advanceTimer.advance(200);
+    delayed.hide();
+    advanceTimer.advance(950);
+    expect(visibilityChanges).toEqual([true]);
+    advanceTimer.advance(100);
+    expect(visibilityChanges).toEqual([true, false]);
+    delayed.show();
+    advanceTimer.advance(50);
+    expect(visibilityChanges).toEqual([true, false, true]);
+    delayed.hide();
+    advanceTimer.advance(950);
+    expect(visibilityChanges).toEqual([true, false, true]);
+    advanceTimer.advance(100);
+    expect(visibilityChanges).toEqual([true, false, true, false]);
+  });
+
+  it('should be displayed for minimum 2000ms', async () => {
+    jest.useFakeTimers();
+    const visibilityChanges: boolean[] = [];
+    const advanceTimer = new AdvanceTimer();
+    const delayed = new Delayed({ minimumVisibleDuration: 2000 });
+
+    delayed.onChange(isVisible => visibilityChanges.push(isVisible));
+
+    delayed.show();
+    advanceTimer.advance(200);
+    delayed.hide();
+    advanceTimer.advance(1950);
+    expect(visibilityChanges).toEqual([true]);
+    advanceTimer.advance(100);
+    expect(visibilityChanges).toEqual([true, false]);
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/Delayed/index.ts
+++ b/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/Delayed/index.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+type Callback = (isVisible: boolean) => void;
+
+export class Delayed {
+  public isVisible = false;
+  public timeoutId?: number;
+  public displayedAt = 0;
+  public enqueuedAt = 0;
+  public minimumVisibleDuration: number;
+  public hideDelayMs: number;
+  public showDelayMs: number;
+
+  constructor({
+    minimumVisibleDuration = 1000,
+    showDelayMs = 50,
+    hideDelayMs = 50
+  } = {}) {
+    this.minimumVisibleDuration = minimumVisibleDuration;
+    this.hideDelayMs = hideDelayMs;
+    this.showDelayMs = showDelayMs;
+  }
+
+  public onChangeCallback: Callback = () => null;
+
+  public show() {
+    this.updateState(true);
+  }
+
+  public updateState(isVisible: boolean) {
+    window.clearTimeout(this.timeoutId);
+    const ms = !isVisible
+      ? Math.max(
+          this.displayedAt + this.minimumVisibleDuration - Date.now(),
+          this.hideDelayMs
+        )
+      : this.showDelayMs;
+
+    this.timeoutId = window.setTimeout(() => {
+      if (this.isVisible !== isVisible) {
+        this.isVisible = isVisible;
+        this.onChangeCallback(isVisible);
+        if (isVisible) {
+          this.displayedAt = Date.now();
+        }
+      }
+    }, ms);
+  }
+
+  public hide() {
+    this.updateState(false);
+  }
+
+  public onChange(onChangeCallback: Callback) {
+    this.onChangeCallback = onChangeCallback;
+  }
+}

--- a/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/Delayed/index.ts
+++ b/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/Delayed/index.ts
@@ -7,13 +7,12 @@
 type Callback = (isVisible: boolean) => void;
 
 export class Delayed {
-  public isVisible = false;
-  public timeoutId?: number;
-  public displayedAt = 0;
-  public enqueuedAt = 0;
-  public minimumVisibleDuration: number;
-  public hideDelayMs: number;
-  public showDelayMs: number;
+  private displayedAt = 0;
+  private hideDelayMs: number;
+  private isVisible = false;
+  private minimumVisibleDuration: number;
+  private showDelayMs: number;
+  private timeoutId?: number;
 
   constructor({
     minimumVisibleDuration = 1000,
@@ -25,13 +24,9 @@ export class Delayed {
     this.showDelayMs = showDelayMs;
   }
 
-  public onChangeCallback: Callback = () => null;
+  private onChangeCallback: Callback = () => null;
 
-  public show() {
-    this.updateState(true);
-  }
-
-  public updateState(isVisible: boolean) {
+  private updateState(isVisible: boolean) {
     window.clearTimeout(this.timeoutId);
     const ms = !isVisible
       ? Math.max(
@@ -49,6 +44,10 @@ export class Delayed {
         }
       }
     }, ms);
+  }
+
+  public show() {
+    this.updateState(true);
   }
 
   public hide() {

--- a/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/index.test.tsx
@@ -10,7 +10,7 @@ import { useDelayedVisibility } from '.';
 afterEach(cleanup);
 
 // Suppress warnings about "act" until async/await syntax is supported: https://github.com/facebook/react/issues/14769
-/* tslint:disable:no-console */
+/* eslint-disable no-console */
 const originalError = console.error;
 beforeAll(() => {
   console.error = jest.fn();

--- a/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/index.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { cleanup, renderHook } from 'react-hooks-testing-library';
+import { useDelayedVisibility } from '.';
+
+afterEach(cleanup);
+
+// Suppress warnings about "act" until async/await syntax is supported: https://github.com/facebook/react/issues/14769
+/* tslint:disable:no-console */
+const originalError = console.error;
+beforeAll(() => {
+  console.error = jest.fn();
+});
+afterAll(() => {
+  console.error = originalError;
+});
+
+describe('useFetcher', () => {
+  let hook;
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  it('is initially false', () => {
+    hook = renderHook(isLoading => useDelayedVisibility(isLoading), {
+      initialProps: false
+    });
+    expect(hook.result.current).toEqual(false);
+  });
+
+  it('does not change to true immediately', () => {
+    hook = renderHook(isLoading => useDelayedVisibility(isLoading), {
+      initialProps: false
+    });
+
+    hook.rerender(true);
+    jest.advanceTimersByTime(10);
+    expect(hook.result.current).toEqual(false);
+    jest.advanceTimersByTime(50);
+    expect(hook.result.current).toEqual(true);
+  });
+
+  it('does not change to false immediately', () => {
+    hook = renderHook(isLoading => useDelayedVisibility(isLoading), {
+      initialProps: false
+    });
+
+    hook.rerender(true);
+    jest.advanceTimersByTime(100);
+    hook.rerender(false);
+    expect(hook.result.current).toEqual(true);
+  });
+
+  it('is true for minimum 1000ms', () => {
+    hook = renderHook(isLoading => useDelayedVisibility(isLoading), {
+      initialProps: false
+    });
+
+    hook.rerender(true);
+    jest.advanceTimersByTime(100);
+    hook.rerender(false);
+    jest.advanceTimersByTime(900);
+    expect(hook.result.current).toEqual(true);
+    jest.advanceTimersByTime(100);
+    expect(hook.result.current).toEqual(false);
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/index.ts
+++ b/x-pack/plugins/apm/public/components/app/Main/useDelayedVisibility/index.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Delayed } from './Delayed';
+
+export function useDelayedVisibility(
+  visible: boolean,
+  hideDelayMs?: number,
+  showDelayMs?: number,
+  minimumVisibleDuration?: number
+) {
+  const [isVisible, setIsVisible] = useState(false);
+  const delayedRef = useRef<Delayed | null>(null);
+
+  useEffect(
+    () => {
+      const delayed = new Delayed({
+        hideDelayMs,
+        showDelayMs,
+        minimumVisibleDuration
+      });
+      delayed.onChange(visibility => {
+        setIsVisible(visibility);
+      });
+      delayedRef.current = delayed;
+    },
+    [hideDelayMs, showDelayMs, minimumVisibleDuration]
+  );
+
+  useEffect(
+    () => {
+      if (!delayedRef.current) {
+        return;
+      }
+
+      if (visible) {
+        delayedRef.current.show();
+      } else {
+        delayedRef.current.hide();
+      }
+    },
+    [visible]
+  );
+
+  return isVisible;
+}

--- a/x-pack/plugins/apm/public/hooks/useComponentId.tsx
+++ b/x-pack/plugins/apm/public/hooks/useComponentId.tsx
@@ -4,8 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export const STATUS = {
-  FAILURE: 'FAILURE',
-  SUCCESS: 'SUCCESS',
-  LOADING: 'LOADING'
-};
+import { useRef } from 'react';
+
+let uniqueId = 0;
+const getUniqueId = () => uniqueId++;
+
+export function useComponentId() {
+  const idRef = useRef(getUniqueId());
+  return idRef.current;
+}

--- a/x-pack/plugins/apm/public/hooks/useFetcher.integration.test.tsx
+++ b/x-pack/plugins/apm/public/hooks/useFetcher.integration.test.tsx
@@ -30,9 +30,6 @@ describe('when simulating race condition', () => {
 
   beforeEach(async () => {
     jest.useFakeTimers();
-    jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation(cb => cb(0) as any);
 
     renderSpy = jest.fn();
     requestCallOrder = [];

--- a/x-pack/plugins/apm/public/hooks/useFetcher.test.tsx
+++ b/x-pack/plugins/apm/public/hooks/useFetcher.test.tsx
@@ -32,17 +32,16 @@ describe('useFetcher', () => {
       hook = renderHook(() => useFetcher(() => fn(), []));
     });
 
-    it('should initially be empty', async () => {
+    it('should have loading spinner initally', async () => {
       expect(hook.result.current).toEqual({
         data: undefined,
         error: undefined,
-        status: undefined
+        status: 'loading'
       });
     });
 
-    it('should show loading spinner after 100ms', async () => {
+    it('should still show loading spinner after 100ms', async () => {
       jest.advanceTimersByTime(100);
-      await hook.waitForNextUpdate();
 
       expect(hook.result.current).toEqual({
         data: undefined,
@@ -74,17 +73,16 @@ describe('useFetcher', () => {
       hook = renderHook(() => useFetcher(() => fn(), []));
     });
 
-    it('should initially be empty', async () => {
+    it('should have loading spinner initally', async () => {
       expect(hook.result.current).toEqual({
         data: undefined,
         error: undefined,
-        status: undefined
+        status: 'loading'
       });
     });
 
-    it('should show loading spinner after 100ms', async () => {
+    it('should still show loading spinner after 100ms', async () => {
       jest.advanceTimersByTime(100);
-      await hook.waitForNextUpdate();
 
       expect(hook.result.current).toEqual({
         data: undefined,
@@ -117,6 +115,12 @@ describe('useFetcher', () => {
           }
         }
       );
+      expect(hook.result.current).toEqual({
+        data: undefined,
+        error: undefined,
+        status: 'loading'
+      });
+
       await hook.waitForNextUpdate();
 
       // assert: first response has loaded and should be rendered
@@ -136,7 +140,6 @@ describe('useFetcher', () => {
       });
 
       jest.advanceTimersByTime(100);
-      await hook.waitForNextUpdate();
 
       // assert: while loading new data the previous data should still be rendered
       expect(hook.result.current).toEqual({


### PR DESCRIPTION
Since we only have a single global loading indicator, we have to do some tricks to make sure it isn't displayed/hidden too rapidly whenever multiple components fetches data.

**Don't show for quick fetches**
For instance, if a component loads within 50ms it doesn't make sense to show the loading indicator, since it will just flash too quick for the user to understand what's happening. 
If the load happens that quickly it feels instantly anyway, and there is no reason to make the user aware of potential lag.

**Show indicator for a minimum amount of time**
If something takes more than 50ms to load the loading indicator should be displayed. If the fetch action only takes 100ms the loading indicator is only displayed for 50ms which (again) will just annoy the user. To avoid this the indicator should be displayed for a minimum duration that is perceivable to the user. In our case the loading indicator has a natural duration of 1000ms, so I used this as the minimum duration.

**Optimize for multiple fetches**
Often we make several sequential requests. In this case the second request will start shortly after the first has ended. To avoid hiding the indicator immediately after the first request finishes, only to display the indicator when the second request starts, we should add a delay before hiding the indicator. This way several sequential requests feels like a single action (judging from the loading indicator)

I have previously wrapped some of this in `EuiDelayHide`. It doesn't do all of the above, and it doesn't make a lot of sense for this to be in EUI. If we are the only consumers I'll try to remove it from EUI.