### PR TITLE
[7.0] Fixes bug where tooltip doesn't line up with data (#34749)

### DIFF
--- a/x-pack/plugins/infra/public/components/metrics/sections/chart_section.tsx
+++ b/x-pack/plugins/infra/public/components/metrics/sections/chart_section.tsx
@@ -176,6 +176,7 @@ export const ChartSection = injectI18n(
               <EuiXAxis marginLeft={MARGIN_LEFT} />
               <EuiYAxis tickFormat={formatterFunction} marginLeft={MARGIN_LEFT} />
               <EuiCrosshairX
+                marginLeft={MARGIN_LEFT}
                 seriesNames={seriesLabels}
                 itemsFormat={itemsFormatter}
                 titleFormat={titleFormatter}

--- a/x-pack/plugins/infra/types/eui_experimental.d.ts
+++ b/x-pack/plugins/infra/types/eui_experimental.d.ts
@@ -59,6 +59,7 @@ declare module '@elastic/eui/lib/experimental' {
     value: any;
   }
   type EuiCrosshairXProps = CommonProps & {
+    marginLeft?: number;
     seriesNames: string[];
     titleFormat?: (dataPoints: EuiDataPoint[]) => EuiFormattedValue | undefined;
     itemsFormat?: (dataPoints: EuiDataPoint[]) => EuiFormattedValue[];


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Fixes bug where tooltip doesn't line up with data  (#34749)