### PR TITLE
[Infra UI] Fixes #34606 - Adjust CSS to fix scrolling bug in Waffle Map

### DIFF
--- a/x-pack/plugins/infra/public/components/nodes_overview/index.tsx
+++ b/x-pack/plugins/infra/public/components/nodes_overview/index.tsx
@@ -222,7 +222,7 @@ const ViewSwitcherContainer = euiStyled.div`
 const MapContainer = euiStyled.div`
   position: absolute;
   display: flex;
-  top: 0;
+  top: 70px;
   right: 0;
   bottom: 0;
   left: 0;

--- a/x-pack/plugins/infra/public/components/waffle/map.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/map.tsx
@@ -99,7 +99,7 @@ export const Map: React.SFC<Props> = ({
 const WaffleMapOuterContainer = euiStyled.div`
   flex: 1 0 0%;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

This PR fixes elastic/kibana#34606 by adjusting the CSS on the custom flex components for the waffle map. This also lowers the scrolling section so we the controls are not lost.

#### Before

![image](https://user-images.githubusercontent.com/41702/55904689-54067c80-5b85-11e9-823f-d4e6a0e6a4cc.png)


#### After

![image](https://user-images.githubusercontent.com/41702/55903311-3be12e00-5b82-11e9-9438-8d8f58a6cba9.png)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

