### PR TITLE
[APM] Fix bug in ML transaction type selector and minor cleanup

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/TransactionSelect.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/TransactionSelect.tsx
@@ -16,23 +16,21 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { getMlJobId } from '../../../../../../common/ml_job_constants';
-import { MLJobApiResponse } from '../../../../../services/rest/ml';
 
 interface TransactionSelectProps {
   serviceName: string;
-  existingJobs: MLJobApiResponse['jobs'];
   transactionTypes: string[];
-  selected?: string;
   onChange: (value: string) => void;
+  hasMLJob: boolean;
+  selectedTransactionType: string;
 }
 
 export function TransactionSelect({
   serviceName,
-  existingJobs,
   transactionTypes,
-  selected,
-  onChange
+  onChange,
+  hasMLJob,
+  selectedTransactionType
 }: TransactionSelectProps) {
   return (
     <EuiFormRow
@@ -44,12 +42,9 @@ export function TransactionSelect({
       )}
     >
       <EuiSuperSelect
-        valueOfSelected={selected}
+        valueOfSelected={selectedTransactionType}
         onChange={onChange}
         options={transactionTypes.map(transactionType => {
-          const hasMlJobs = existingJobs.some(
-            job => job.job_id === getMlJobId(serviceName, transactionType)
-          );
           return {
             value: transactionType,
             inputDisplay: transactionType,
@@ -59,7 +54,7 @@ export function TransactionSelect({
                   <EuiText>{transactionType}</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  {hasMlJobs ? (
+                  {hasMLJob ? (
                     <EuiToolTip
                       content={i18n.translate(
                         'xpack.apm.serviceDetails.enableAnomalyDetectionPanel.existedJobTooltip',

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/TransactionSelect.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/TransactionSelect.tsx
@@ -8,28 +8,22 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
-  EuiIcon,
   // @ts-ignore
   EuiSuperSelect,
-  EuiText,
-  EuiToolTip
+  EuiText
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 
 interface TransactionSelectProps {
-  serviceName: string;
   transactionTypes: string[];
   onChange: (value: string) => void;
-  hasMLJob: boolean;
   selectedTransactionType: string;
 }
 
 export function TransactionSelect({
-  serviceName,
   transactionTypes,
   onChange,
-  hasMLJob,
   selectedTransactionType
 }: TransactionSelectProps) {
   return (
@@ -52,22 +46,6 @@ export function TransactionSelect({
               <EuiFlexGroup justifyContent="spaceBetween">
                 <EuiFlexItem>
                   <EuiText>{transactionType}</EuiText>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  {hasMLJob ? (
-                    <EuiToolTip
-                      content={i18n.translate(
-                        'xpack.apm.serviceDetails.enableAnomalyDetectionPanel.existedJobTooltip',
-                        {
-                          defaultMessage: 'ML job exists for this type'
-                        }
-                      )}
-                    >
-                      <EuiIcon type="machineLearningApp" />
-                    </EuiToolTip>
-                  ) : (
-                    <EuiIcon type="empty" />
-                  )}
                 </EuiFlexItem>
               </EuiFlexGroup>
             )

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/index.tsx
@@ -22,17 +22,13 @@ interface Props {
 
 interface State {
   isCreatingJob: boolean;
-  hasMLJob: boolean;
   hasIndexPattern: boolean;
-  selectedTransactionType?: string;
 }
 
 export class MachineLearningFlyout extends Component<Props, State> {
   public state: State = {
     isCreatingJob: false,
-    hasIndexPattern: false,
-    hasMLJob: false,
-    selectedTransactionType: this.props.urlParams.transactionType
+    hasIndexPattern: false
   };
   public willUnmount = false;
 
@@ -46,18 +42,6 @@ export class MachineLearningFlyout extends Component<Props, State> {
       // TODO: this is causing warning from react because setState happens after
       // the component has been unmounted - dispite of the checks
       this.setState({ hasIndexPattern: !!indexPattern });
-    }
-  }
-
-  // TODO: This should use `getDerivedStateFromProps`
-  public componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.urlParams.transactionType !==
-      this.props.urlParams.transactionType
-    ) {
-      this.setState({
-        selectedTransactionType: this.props.urlParams.transactionType
-      });
     }
   }
 
@@ -157,20 +141,10 @@ export class MachineLearningFlyout extends Component<Props, State> {
     });
   };
 
-  public onChangeTransaction(value: string) {
-    this.setState({
-      selectedTransactionType: value
-    });
-  }
-
   public render() {
     const { isOpen, onClose, urlParams, serviceTransactionTypes } = this.props;
-    const { serviceName, transactionType } = urlParams;
-    const {
-      isCreatingJob,
-      hasIndexPattern,
-      selectedTransactionType
-    } = this.state;
+    const { serviceName } = urlParams;
+    const { isCreatingJob, hasIndexPattern } = this.state;
 
     if (!isOpen || !serviceName) {
       return null;
@@ -180,13 +154,10 @@ export class MachineLearningFlyout extends Component<Props, State> {
       <MachineLearningFlyoutView
         hasIndexPattern={hasIndexPattern}
         isCreatingJob={isCreatingJob}
-        onChangeTransaction={this.onChangeTransaction}
         onClickCreate={this.onClickCreate}
         onClose={onClose}
-        selectedTransactionType={selectedTransactionType}
         serviceName={serviceName}
         serviceTransactionTypes={serviceTransactionTypes}
-        transactionType={transactionType}
       />
     );
   }

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/view.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/view.tsx
@@ -201,8 +201,6 @@ export function MachineLearningFlyoutView({
           <EuiFlexItem>
             {serviceTransactionTypes.length > 1 ? (
               <TransactionSelect
-                hasMLJob={hasMLJob}
-                serviceName={serviceName}
                 selectedTransactionType={transactionType}
                 transactionTypes={serviceTransactionTypes}
                 onChange={(value: string) => {

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/view.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/MachineLearningFlyout/view.tsx
@@ -20,10 +20,9 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import React from 'react';
-import { getMlJobId } from '../../../../../../common/ml_job_constants';
+import React, { useState } from 'react';
 import { FETCH_STATUS, useFetcher } from '../../../../../hooks/useFetcher';
-import { getMLJob } from '../../../../../services/rest/ml';
+import { getHasMLJob } from '../../../../../services/rest/ml';
 import { KibanaLink } from '../../../../shared/Links/KibanaLink';
 import { MLJobLink } from '../../../../shared/Links/MachineLearningLinks/MLJobLink';
 import { MLLink } from '../../../../shared/Links/MachineLearningLinks/MLLink';
@@ -32,39 +31,29 @@ import { TransactionSelect } from './TransactionSelect';
 interface Props {
   hasIndexPattern: boolean;
   isCreatingJob: boolean;
-  onChangeTransaction: (value: string) => void;
   onClickCreate: () => void;
   onClose: () => void;
-  selectedTransactionType?: string;
   serviceName: string;
   serviceTransactionTypes: string[];
-  transactionType?: string;
 }
 
-const INITIAL_DATA = { count: 0, jobs: [] };
 export function MachineLearningFlyoutView({
   hasIndexPattern,
   isCreatingJob,
-  onChangeTransaction,
   onClickCreate,
   onClose,
-  selectedTransactionType,
   serviceName,
-  serviceTransactionTypes,
-  transactionType
+  serviceTransactionTypes
 }: Props) {
-  const { data = INITIAL_DATA, status } = useFetcher(
-    () => getMLJob({ serviceName, transactionType }),
+  const [transactionType, setTransactionType] = useState(
+    serviceTransactionTypes[0]
+  );
+  const { data: hasMLJob = false, status } = useFetcher(
+    () => getHasMLJob({ serviceName, transactionType }),
     [serviceName, transactionType]
   );
 
-  if (status === FETCH_STATUS.LOADING) {
-    return null;
-  }
-
-  const hasMLJob = data.jobs.some(
-    job => job.job_id === getMlJobId(serviceName, selectedTransactionType)
-  );
+  const isLoadingMLJob = status === FETCH_STATUS.LOADING;
 
   return (
     <EuiFlyout onClose={onClose} size="s">
@@ -212,11 +201,13 @@ export function MachineLearningFlyoutView({
           <EuiFlexItem>
             {serviceTransactionTypes.length > 1 ? (
               <TransactionSelect
+                hasMLJob={hasMLJob}
                 serviceName={serviceName}
+                selectedTransactionType={transactionType}
                 transactionTypes={serviceTransactionTypes}
-                selected={selectedTransactionType}
-                existingJobs={data.jobs}
-                onChange={onChangeTransaction}
+                onChange={(value: string) => {
+                  setTransactionType(value);
+                }}
               />
             ) : null}
           </EuiFlexItem>
@@ -225,7 +216,12 @@ export function MachineLearningFlyoutView({
               <EuiButton
                 onClick={onClickCreate}
                 fill
-                disabled={isCreatingJob || hasMLJob || !hasIndexPattern}
+                disabled={
+                  isCreatingJob ||
+                  hasMLJob ||
+                  !hasIndexPattern ||
+                  isLoadingMLJob
+                }
               >
                 {i18n.translate(
                   'xpack.apm.serviceDetails.enableAnomalyDetectionPanel.createNewJobButtonLabel',

--- a/x-pack/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/plugins/apm/public/services/rest/ml.ts
@@ -71,7 +71,7 @@ export interface MLJobApiResponse {
   }>;
 }
 
-export async function getMLJob({
+export async function getHasMLJob({
   serviceName,
   transactionType
 }: {
@@ -79,11 +79,16 @@ export async function getMLJob({
   transactionType?: string;
   anomalyName?: string;
 }) {
-  return callApi<MLJobApiResponse>({
-    method: 'GET',
-    pathname: `/api/ml/anomaly_detectors/${getMlJobId(
-      serviceName,
-      transactionType
-    )}`
-  });
+  try {
+    await callApi<MLJobApiResponse>({
+      method: 'HEAD',
+      pathname: `/api/ml/anomaly_detectors/${getMlJobId(
+        serviceName,
+        transactionType
+      )}`
+    });
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3300,7 +3300,6 @@
     "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.createMLJobDescription.transactionDurationGraphText": "事务持续时间图表",
     "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.createNewJobButtonLabel": "创建新作业",
     "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.enableAnomalyDetectionTitle": "启用异常检测",
-    "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.existedJobTooltip": "此类型的 ML 作业已存在",
     "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.jobCreatedNotificationText": "现在正在运行对 {serviceName}（{transactionType}）的分析。可能要花费点时间，才会将结果添加响应时间图表。",
     "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.jobCreatedNotificationText.viewJobLinkText": "查看作业",
     "xpack.apm.serviceDetails.enableAnomalyDetectionPanel.jobCreatedNotificationTitle": "作业已成功创建",


### PR DESCRIPTION
Closes #34928

This removes a lot of logic around fetching and determining whether the selected transaction type has an ML job associated.
It also removes the coupling between the transaction type chosen on the main page, and the transaction type chosen in the ML flyout.