### PR TITLE
[APM] Hide ml data when kuery is active

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceMetrics.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceMetrics.tsx
@@ -51,6 +51,7 @@ export function ServiceMetrics({ urlParams, location }: ServiceMetricsProps) {
   return (
     <React.Fragment>
       <TransactionCharts
+        hasMLJob={false}
         charts={transactionOverviewChartsData}
         urlParams={urlParams}
         location={location}

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/view.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/view.tsx
@@ -43,6 +43,7 @@ export function TransactionDetailsView({ urlParams, location }: Props) {
       <EuiSpacer size="s" />
 
       <TransactionCharts
+        hasMLJob={false}
         charts={transactionDetailsChartsData}
         urlParams={urlParams}
         location={location}

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/__jest__/TransactionOverview.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/__jest__/TransactionOverview.test.tsx
@@ -14,6 +14,16 @@ import { TransactionOverview } from '..';
 import configureStore from '../../../../store/config/configureStore';
 import { IUrlParams } from '../../../../store/urlParams';
 
+// Suppress warnings about "act" until async/await syntax is supported: https://github.com/facebook/react/issues/14769
+/* eslint-disable no-console */
+const originalError = console.error;
+beforeAll(() => {
+  console.error = jest.fn();
+});
+afterAll(() => {
+  console.error = originalError;
+});
+
 function setup(props: {
   urlParams: IUrlParams;
   serviceTransactionTypes: string[];

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -58,12 +58,6 @@ export function TransactionOverviewView({
 }: TransactionOverviewProps) {
   const { serviceName, transactionType } = urlParams;
 
-  // TODO: improve urlParams typings.
-  // `serviceName` will never be undefined here, and this check should not be needed
-  if (!serviceName || !transactionType) {
-    return null;
-  }
-
   // redirect to first transaction type
   useRedirect(
     history,
@@ -77,6 +71,12 @@ export function TransactionOverviewView({
   const { data: transactionOverviewCharts } = useTransactionOverviewCharts(
     urlParams
   );
+
+  // TODO: improve urlParams typings.
+  // `serviceName` or `transactionType` will never be undefined here, and this check should not be needed
+  if (!serviceName || !transactionType) {
+    return null;
+  }
 
   const { data: transactionListData } = useTransactionList(urlParams);
   const { data: hasMLJob = false } = useFetcher(

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -23,6 +23,8 @@ import { TransactionCharts } from '../../shared/charts/TransactionCharts';
 import { legacyEncodeURIComponent } from '../../shared/Links/url_helpers';
 import { TransactionList } from './List';
 import { useRedirect } from './useRedirect';
+import { useFetcher } from '../../../hooks/useFetcher';
+import { getHasMLJob } from '../../../services/rest/ml';
 
 interface TransactionOverviewProps extends RouteComponentProps {
   urlParams: IUrlParams;
@@ -56,6 +58,12 @@ export function TransactionOverviewView({
 }: TransactionOverviewProps) {
   const { serviceName, transactionType } = urlParams;
 
+  // TODO: improve urlParams typings.
+  // `serviceName` will never be undefined here, and this check should not be needed
+  if (!serviceName) {
+    return null;
+  }
+
   // redirect to first transaction type
   useRedirect(
     history,
@@ -71,6 +79,10 @@ export function TransactionOverviewView({
   );
 
   const { data: transactionListData } = useTransactionList(urlParams);
+  const { data: hasMLJob = false } = useFetcher(
+    () => getHasMLJob({ serviceName, transactionType }),
+    [serviceName, transactionType]
+  );
 
   // filtering by type is currently required
   if (!serviceName || !transactionType) {
@@ -107,6 +119,7 @@ export function TransactionOverviewView({
       ) : null}
 
       <TransactionCharts
+        hasMLJob={hasMLJob}
         charts={transactionOverviewCharts}
         location={location}
         urlParams={urlParams}

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -60,7 +60,7 @@ export function TransactionOverviewView({
 
   // TODO: improve urlParams typings.
   // `serviceName` will never be undefined here, and this check should not be needed
-  if (!serviceName) {
+  if (!serviceName || !transactionType) {
     return null;
   }
 
@@ -83,11 +83,6 @@ export function TransactionOverviewView({
     () => getHasMLJob({ serviceName, transactionType }),
     [serviceName, transactionType]
   );
-
-  // filtering by type is currently required
-  if (!serviceName || !transactionType) {
-    return null;
-  }
 
   return (
     <React.Fragment>

--- a/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
@@ -16,6 +16,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { Location } from 'history';
 import React, { Component } from 'react';
+import { isEmpty } from 'lodash';
 import styled from 'styled-components';
 import { Coordinate } from '../../../../../typings/timeseries';
 import { ITransactionChartData } from '../../../../store/selectors/chartSelectors';
@@ -28,6 +29,7 @@ import CustomPlot from '../CustomPlot';
 import { SyncChartGroup } from '../SyncChartGroup';
 
 interface TransactionChartProps {
+  hasMLJob: boolean;
   charts: ITransactionChartData;
   location: Location;
   urlParams: IUrlParams;
@@ -75,32 +77,41 @@ export class TransactionCharts extends Component<TransactionChartProps> {
     return this.getTPMFormatter(p.y);
   };
 
-  public renderMLHeader(mlAvailable: boolean) {
-    const hasMLJob = this.props.charts.hasMLJob;
-    if (!mlAvailable || !hasMLJob) {
+  public renderMLHeader(hasValidMlLicense: boolean) {
+    const { hasMLJob } = this.props;
+    if (!hasValidMlLicense || !hasMLJob) {
       return null;
     }
 
-    const { serviceName, transactionType } = this.props.urlParams;
-
+    const { serviceName, transactionType, kuery } = this.props.urlParams;
     if (!serviceName) {
       return null;
     }
 
+    const hasKuery = !isEmpty(kuery);
+    const icon = hasKuery ? (
+      <EuiIconTip
+        aria-label="Warning"
+        type="alert"
+        color="warning"
+        content="The Machine learning results are hidden when the search bar is used for filtering"
+      />
+    ) : (
+      <EuiIconTip
+        content={i18n.translate(
+          'xpack.apm.metrics.transactionChart.machineLearningTooltip',
+          {
+            defaultMessage:
+              'The stream around the average duration shows the expected bounds. An annotation is shown for anomaly scores >= 75.'
+          }
+        )}
+      />
+    );
+
     return (
       <EuiFlexItem grow={false}>
         <ShiftedEuiText size="xs">
-          <ShiftedIconWrapper>
-            <EuiIconTip
-              content={i18n.translate(
-                'xpack.apm.metrics.transactionChart.machineLearningTooltip',
-                {
-                  defaultMessage:
-                    'The stream around the average duration shows the expected bounds. An annotation is shown for anomaly scores >= 75.'
-                }
-              )}
-            />
-          </ShiftedIconWrapper>
+          <ShiftedIconWrapper>{icon}</ShiftedIconWrapper>
           <span>
             {i18n.translate(
               'xpack.apm.metrics.transactionChart.machineLearningLabel',

--- a/x-pack/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/plugins/apm/public/services/rest/ml.ts
@@ -76,8 +76,7 @@ export async function getHasMLJob({
   transactionType
 }: {
   serviceName: string;
-  transactionType?: string;
-  anomalyName?: string;
+  transactionType: string;
 }) {
   try {
     await callApi<MLJobApiResponse>({

--- a/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
+++ b/x-pack/plugins/apm/public/store/selectors/chartSelectors.ts
@@ -61,7 +61,6 @@ export interface ITransactionChartData {
   noHits: boolean;
   tpmSeries: ITpmBucket[] | IEmptySeries[];
   responseTimeSeries: TimeSerie[] | IEmptySeries[];
-  hasMLJob: boolean;
 }
 
 const INITIAL_DATA = {
@@ -94,8 +93,7 @@ export function getTransactionCharts(
   return {
     noHits,
     tpmSeries,
-    responseTimeSeries,
-    hasMLJob: anomalyTimeseries !== undefined
+    responseTimeSeries
   };
 }
 

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/index.test.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/index.test.ts
@@ -7,10 +7,10 @@
 import { getAnomalySeries } from '.';
 import { mlAnomalyResponse } from './mock-responses/mlAnomalyResponse';
 import { mlBucketSpanResponse } from './mock-responses/mlBucketSpanResponse';
-import { AnomalyTimeSeriesResponse } from './transform';
+import { PromiseReturnType } from '../../../../../typings/common';
 
 describe('getAnomalySeries', () => {
-  let avgAnomalies: Required<AnomalyTimeSeriesResponse>;
+  let avgAnomalies: PromiseReturnType<typeof getAnomalySeries>;
   beforeEach(async () => {
     const clientSpy = jest
       .fn()
@@ -42,7 +42,7 @@ describe('getAnomalySeries', () => {
 
   it('should remove buckets outside date range from anomalyBoundaries', () => {
     expect(
-      avgAnomalies!.anomalyBoundaries.filter(
+      avgAnomalies!.anomalyBoundaries!.filter(
         bucket => bucket.x < 100 || bucket.x > 100000
       ).length
     ).toBe(0);
@@ -50,7 +50,7 @@ describe('getAnomalySeries', () => {
 
   it('should remove buckets with null from anomalyBoundaries', () => {
     expect(
-      avgAnomalies!.anomalyBoundaries.filter(p => p.y === null).length
+      avgAnomalies!.anomalyBoundaries!.filter(p => p.y === null).length
     ).toBe(0);
   });
 

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_anomaly_data/index.ts
@@ -33,6 +33,11 @@ export async function getAnomalySeries({
     return;
   }
 
+  // don't fetch anomalies if kuery filter is applied
+  if (setup.esFilterQuery) {
+    return;
+  }
+
   const mlBucketSize = await getMlBucketSize({
     serviceName,
     transactionType,


### PR DESCRIPTION
Closes #26339

**With ML baseline**
![Screenshot 2019-04-12 at 13 24 08](https://user-images.githubusercontent.com/209966/56034050-6ec42700-5d26-11e9-8429-00f03ceb9494.png)

**Kuery filter is applied and ML baseline is hidden, and warning is displayed**
![Screenshot 2019-04-12 at 13 23 06](https://user-images.githubusercontent.com/209966/56033952-23117d80-5d26-11e9-9ce6-9d1301e7e290.png)