### PR TITLE
[APM] Hide CPU, Memory metrics charts for RUM services

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceDetailTabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceDetailTabs.tsx
@@ -17,50 +17,48 @@ interface TabsProps {
   transactionTypes: string[];
   urlParams: IUrlParams;
   location: Location;
+  isRumAgent?: boolean;
 }
 
 export class ServiceDetailTabs extends React.Component<TabsProps> {
   public render() {
-    const { transactionTypes, urlParams, location } = this.props;
+    const { transactionTypes, urlParams, location, isRumAgent } = this.props;
     const { serviceName } = urlParams;
     const headTransactionType = transactionTypes[0];
-    const tabs = [
-      {
-        name: i18n.translate('xpack.apm.serviceDetails.transactionsTabLabel', {
-          defaultMessage: 'Transactions'
-        }),
-        path: headTransactionType
-          ? `/${serviceName}/transactions/${headTransactionType}`
-          : `/${serviceName}/transactions`,
-        routePath: `/${serviceName}/transactions/:transactionType?`,
-        render: () => (
-          <TransactionOverview
-            urlParams={urlParams}
-            serviceTransactionTypes={transactionTypes}
-          />
-        )
-      },
-      {
-        name: i18n.translate('xpack.apm.serviceDetails.errorsTabLabel', {
-          defaultMessage: 'Errors'
-        }),
-        path: `/${serviceName}/errors`,
-        render: () => {
-          return (
-            <ErrorGroupOverview urlParams={urlParams} location={location} />
-          );
-        }
-      },
-      {
-        name: i18n.translate('xpack.apm.serviceDetails.metricsTabLabel', {
-          defaultMessage: 'Metrics'
-        }),
-        path: `/${serviceName}/metrics`,
-        render: () => (
-          <ServiceMetrics urlParams={urlParams} location={location} />
-        )
+    const transactionsTab = {
+      name: i18n.translate('xpack.apm.serviceDetails.transactionsTabLabel', {
+        defaultMessage: 'Transactions'
+      }),
+      path: headTransactionType
+        ? `/${serviceName}/transactions/${headTransactionType}`
+        : `/${serviceName}/transactions`,
+      routePath: `/${serviceName}/transactions/:transactionType?`,
+      render: () => (
+        <TransactionOverview
+          urlParams={urlParams}
+          serviceTransactionTypes={transactionTypes}
+        />
+      )
+    };
+    const errorsTab = {
+      name: i18n.translate('xpack.apm.serviceDetails.errorsTabLabel', {
+        defaultMessage: 'Errors'
+      }),
+      path: `/${serviceName}/errors`,
+      render: () => {
+        return <ErrorGroupOverview urlParams={urlParams} location={location} />;
       }
-    ];
+    };
+    const metricsTab = {
+      name: i18n.translate('xpack.apm.serviceDetails.metricsTabLabel', {
+        defaultMessage: 'Metrics'
+      }),
+      path: `/${serviceName}/metrics`,
+      render: () => <ServiceMetrics urlParams={urlParams} location={location} />
+    };
+    const tabs = isRumAgent
+      ? [transactionsTab, errorsTab]
+      : [transactionsTab, errorsTab, metricsTab];
 
     return <HistoryTabs tabs={tabs} />;
   }

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/view.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/view.tsx
@@ -14,6 +14,7 @@ import { IUrlParams } from '../../../store/urlParams';
 import { FilterBar } from '../../shared/FilterBar';
 import { ServiceDetailTabs } from './ServiceDetailTabs';
 import { ServiceIntegrations } from './ServiceIntegrations';
+import { isRumAgentName } from '../../../../common/agent_name';
 
 interface Props {
   urlParams: IUrlParams;
@@ -30,6 +31,8 @@ export function ServiceDetailsView({ urlParams, location }: Props) {
   if (!serviceDetailsData) {
     return null;
   }
+
+  const isRumAgent = isRumAgentName(serviceDetailsData.agentName || '');
 
   return (
     <React.Fragment>
@@ -55,6 +58,7 @@ export function ServiceDetailsView({ urlParams, location }: Props) {
         location={location}
         urlParams={urlParams}
         transactionTypes={serviceDetailsData.types}
+        isRumAgent={isRumAgent}
       />
     </React.Fragment>
   );


### PR DESCRIPTION
Closes #34781
Renders a different set of service navigation tabs when a rum agent is detected:
- RUM agent service tabs: [Transaction, Errors]
- Service tabs otherwise: [Transaction, Errors, Metrics]