### PR TITLE
[Code] more history test cases

### DIFF
--- a/x-pack/plugins/code/public/components/main/side_tabs.tsx
+++ b/x-pack/plugins/code/public/components/main/side_tabs.tsx
@@ -66,14 +66,12 @@ class CodeSideTabs extends React.PureComponent<Props> {
         id: Tabs.file,
         name: 'File',
         content: fileTabContent,
-        isSelected: Tabs.file === this.sideTab,
         'data-test-subj': 'codeFileTreeTab',
       },
       {
         id: Tabs.structure,
         name: 'Structure',
         content: structureTabContent,
-        isSelected: Tabs.structure === this.sideTab,
         disabled: this.props.match.params.pathType === PathTypes.tree || !this.props.hasStructure,
         'data-test-subj': 'codeStructureTreeTab',
       },
@@ -88,15 +86,16 @@ class CodeSideTabs extends React.PureComponent<Props> {
   };
 
   public render() {
+    const tabs = this.tabs;
+    const selectedTab = tabs.find(t => t.id === this.sideTab);
     return (
       <div>
         <EuiTabbedContent
           className="code-navigation__sidebar"
-          tabs={this.tabs}
-          initialSelectedTab={this.tabs.find(t => t.id === this.sideTab)}
+          tabs={tabs}
           onTabClick={tab => this.switchTab(tab.id as Tabs)}
           expand={true}
-          selectedTab={this.tabs.find(t => t.id === this.sideTab)}
+          selectedTab={selectedTab}
         />
         <Shortcut
           keyCode="t"

--- a/x-pack/test/functional/apps/code/code_intelligence.ts
+++ b/x-pack/test/functional/apps/code/code_intelligence.ts
@@ -25,6 +25,59 @@ export default function codeIntelligenceFunctionalTests({
   describe('Code', () => {
     describe('Code intelligence in source view page', () => {
       const repositoryListSelector = 'codeRepositoryList codeRepositoryItem';
+      const testGoToDefinition = async () => {
+        await retry.try(async () => {
+          expect(await testSubjects.exists('codeSourceViewer')).to.be(true);
+        });
+
+        // Hover on the 'UserModel' reference on line 5.
+        await retry.tryForTime(300000, async () => {
+          const spans = await find.allByCssSelector('.mtk31', FIND_TIME);
+          expect(spans.length).to.greaterThan(1);
+          const userModelSpan = spans[1];
+          expect(await userModelSpan.getVisibleText()).to.equal('UserModel');
+          await browser.moveMouseTo(userModelSpan);
+          // Expect the go to definition button show up eventually.
+          expect(await testSubjects.exists('codeGoToDefinitionButton')).to.be(true);
+
+          await testSubjects.click('codeGoToDefinitionButton');
+          await retry.tryForTime(5000, async () => {
+            const currentUrl: string = await browser.getCurrentUrl();
+            log.info(`Jump to url: ${currentUrl}`);
+            // Expect to jump to src/models/User.ts file on line 5.
+            expect(currentUrl.indexOf('src/models/User.ts!L5:13')).to.greaterThan(0);
+          });
+        });
+      };
+      const testGoToDefinitionFromRoot = async () => {
+        log.debug('Hover on a reference and jump to definition across file');
+
+        // Visit the /src/controllers/user.ts file
+        // Wait the file tree to be rendered and click the 'src' folder on the file tree.
+        await retry.try(async () => {
+          expect(await testSubjects.exists('codeFileTreeNode-Directory-src')).to.be(true);
+        });
+
+        await testSubjects.click('codeFileTreeNode-Directory-src');
+
+        await retry.try(async () => {
+          expect(await testSubjects.exists('codeFileTreeNode-Directory-src/controllers')).to.be(
+            true
+          );
+        });
+
+        await testSubjects.click('codeFileTreeNode-Directory-src/controllers');
+        // Then the 'controllers' folder on the file tree.
+        await retry.try(async () => {
+          expect(await testSubjects.exists('codeFileTreeNode-File-src/controllers/user.ts')).to.be(
+            true
+          );
+        });
+
+        await testSubjects.click('codeFileTreeNode-File-src/controllers/user.ts');
+        // Then the 'user.ts' file on the file tree.
+        await testGoToDefinition();
+      };
 
       before(async () => {
         // Navigate to the code app.
@@ -81,63 +134,11 @@ export default function codeIntelligenceFunctionalTests({
       });
 
       it('Hover on a reference and jump to definition across file', async () => {
-        log.debug('Hover on a reference and jump to definition across file');
+        await testGoToDefinitionFromRoot();
 
-        // Visit the /src/controllers/user.ts file
-        // Wait the file tree to be rendered and click the 'src' folder on the file tree.
-        await retry.try(async () => {
-          expect(await testSubjects.exists('codeFileTreeNode-Directory-src')).to.be(true);
-        });
-
-        await testSubjects.click('codeFileTreeNode-Directory-src');
-        await retry.try(async () => {
-          expect(await testSubjects.exists('codeFileTreeNode-Directory-src/controllers')).to.be(
-            true
-          );
-        });
-
-        await testSubjects.click('codeFileTreeNode-Directory-src/controllers');
-        // Then the 'controllers' folder on the file tree.
-        await retry.try(async () => {
-          expect(await testSubjects.exists('codeFileTreeNode-File-src/controllers/user.ts')).to.be(
-            true
-          );
-        });
-
-        await testSubjects.click('codeFileTreeNode-File-src/controllers/user.ts');
-        // Then the 'user.ts' file on the file tree.
-        await retry.try(async () => {
-          expect(await testSubjects.exists('codeSourceViewer')).to.be(true);
-        });
-
-        // Hover on the 'UserModel' reference on line 5.
-        await retry.tryForTime(300000, async () => {
-          const spans = await find.allByCssSelector('.mtk31', FIND_TIME);
-          expect(spans.length).to.greaterThan(1);
-          const userModelSpan = spans[1];
-          expect(await userModelSpan.getVisibleText()).to.equal('UserModel');
-          await browser.moveMouseTo(userModelSpan);
-          // Expect the go to definition button show up eventually.
-          expect(await testSubjects.exists('codeGoToDefinitionButton')).to.be(true);
-
-          await testSubjects.click('codeGoToDefinitionButton');
-          await retry.tryForTime(5000, async () => {
-            const currentUrl: string = await browser.getCurrentUrl();
-            log.info(`Jump to url: ${currentUrl}`);
-            // Expect to jump to src/models/User.ts file on line 5.
-            expect(currentUrl.indexOf('src/models/User.ts!L5:13')).to.greaterThan(0);
-          });
-
-          // it should goes back to controllers/user.ts
-          await browser.goBack();
-
-          await retry.try(async () => {
-            const $spans = await find.allByCssSelector('.mtk31', FIND_TIME);
-            expect($spans.length).to.greaterThan(1);
-            const $userModelSpan = $spans[1];
-            expect(await $userModelSpan.getVisibleText()).to.equal('UserModel');
-          });
-        });
+        // can go back and go to definition again
+        await browser.goBack();
+        await testGoToDefinition();
       });
 
       it('Find references and jump to reference', async () => {

--- a/x-pack/test/functional/apps/code/history.ts
+++ b/x-pack/test/functional/apps/code/history.ts
@@ -112,6 +112,43 @@ export default function manageRepositoriesFunctionalTests({
         });
       });
 
+      it('in search page, change language filters can go back and forward', async () => {
+        log.debug('it select typescript language filter');
+        const url = `${PageObjects.common.getHostPort()}/app/code#/search?q=string&p=&langs=typescript`;
+        await browser.get(url);
+
+        const language = await (await find.byCssSelector(
+          '.euiFacetButton--isSelected'
+        )).getVisibleText();
+
+        expect(language.indexOf('typescript')).to.equal(0);
+
+        const unselectedFilter = (await find.allByCssSelector('.euiFacetButton--unSelected'))[1];
+        await unselectedFilter.click();
+
+        const l = await (await find.allByCssSelector(
+          '.euiFacetButton--isSelected'
+        ))[1].getVisibleText();
+
+        expect(l.indexOf('javascript')).to.equal(0);
+
+        await browser.goBack();
+
+        const lang = await (await find.byCssSelector(
+          '.euiFacetButton--isSelected'
+        )).getVisibleText();
+
+        expect(lang.indexOf('typescript')).to.equal(0);
+
+        await driver.navigate().forward();
+
+        const filter = await (await find.allByCssSelector(
+          '.euiFacetButton--isSelected'
+        ))[1].getVisibleText();
+
+        expect(filter.indexOf('javascript')).to.equal(0);
+      });
+
       it('in source view page file line number changed can go back and forward', async () => {
         log.debug('it goes back after line number changed');
         const url = `${PageObjects.common.getHostPort()}/app/code#/github.com/Microsoft/TypeScript-Node-Starter`;
@@ -138,6 +175,35 @@ export default function manageRepositoriesFunctionalTests({
         await retry.try(async () => {
           const existence = await find.existsByCssSelector('.code-line-number-21', FIND_TIME);
           expect(existence).to.be(true);
+        });
+      });
+
+      it('in source view page, switch side tab can go back and forward', async () => {
+        log.debug('it goes back after line number changed');
+        const url = `${PageObjects.common.getHostPort()}/app/code#/github.com/Microsoft/TypeScript-Node-Starter/blob/master/src/controllers/api.ts`;
+        await browser.get(url);
+        // refresh so language server will be initialized.
+        await browser.refresh();
+        // wait for tab is not disabled
+        await PageObjects.common.sleep(5000);
+        await testSubjects.click('codeStructureTreeTab');
+        await retry.try(async () => {
+          const tabText = await (await find.byCssSelector('.euiTab-isSelected')).getVisibleText();
+          expect(tabText).to.equal('Structure');
+        });
+
+        await browser.goBack();
+
+        await retry.try(async () => {
+          const tabText = await (await find.byCssSelector('.euiTab-isSelected')).getVisibleText();
+          expect(tabText).to.equal('File');
+        });
+
+        await driver.navigate().forward();
+
+        await retry.try(async () => {
+          const tabText = await (await find.byCssSelector('.euiTab-isSelected')).getVisibleText();
+          expect(tabText).to.equal('Structure');
         });
       });
     });


### PR DESCRIPTION
## Summary

- [x] in source view page, switch tab can go back and forward

- [x] in search page, apply search filter can go back and forward

- [x] go to definition can go back and go to definition again, cover [this issue](https://github.com/elastic/kibana/pull/32968)