### PR TITLE
[APM] Increase default page size of the Services list

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/__test__/__snapshots__/List.test.js.snap
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/__test__/__snapshots__/List.test.js.snap
@@ -55,6 +55,7 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
       },
     ]
   }
+  initialPageSize={50}
   initialSort={
     Object {
       "direction": "asc",
@@ -105,6 +106,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
       },
     ]
   }
+  initialPageSize={50}
   initialSort={
     Object {
       "direction": "asc",

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
@@ -116,6 +116,7 @@ export function ServiceList({ items = [], noItemsMessage }: Props) {
       items={items}
       noItemsMessage={noItemsMessage}
       initialSort={{ field: 'serviceName', direction: 'asc' }}
+      initialPageSize={50}
     />
   );
 }


### PR DESCRIPTION
Closes #34441 by increasing the default page size of the services list

![service-list-page-size-increase](https://user-images.githubusercontent.com/1967266/56540866-cc265800-651e-11e9-94dc-902d84e0e24a.gif)
