### PR TITLE
[7.x] Make time_zone parameter properly volatile (#35536)

### DIFF
--- a/src/legacy/ui/public/agg_types/__tests__/buckets/date_histogram/_params.js
+++ b/src/legacy/ui/public/agg_types/__tests__/buckets/date_histogram/_params.js
@@ -31,7 +31,7 @@ import { timefilter } from 'ui/timefilter';
 
 const config = chrome.getUiSettingsClient();
 
-describe('params', function () {
+describe('date_histogram params', function () {
 
   let paramWriter;
   let writeInterval;
@@ -150,6 +150,12 @@ describe('params', function () {
       config.get.withArgs('dateFormat:tz').returns('Europe/Riga');
       const output = paramWriter.write({});
       expect(output.params).to.have.property('time_zone', 'Europe/Riga');
+    });
+
+    it('should use the fixed time_zone from the index pattern typeMeta', () => {
+      _.set(paramWriter.indexPattern, ['typeMeta', 'aggs', 'date_histogram', timeField, 'time_zone'], 'Europe/Rome');
+      const output = paramWriter.write({ field: timeField });
+      expect(output.params).to.have.property('time_zone', 'Europe/Rome');
     });
 
     afterEach(() => {

--- a/src/legacy/ui/public/agg_types/buckets/date_histogram.js
+++ b/src/legacy/ui/public/agg_types/buckets/date_histogram.js
@@ -155,16 +155,25 @@ export const dateHistogramBucketAgg = new BucketAggType({
     },
     {
       name: 'time_zone',
-      default: () => {
-        const isDefaultTimezone = config.isDefault('dateFormat:tz');
-        return isDefaultTimezone ? detectedTimezone || tzOffset : config.get('dateFormat:tz');
-      },
-      serialize() {
-        // We don't want to store the `time_zone` parameter ever in the saved object for the visualization.
-        // If we would store this changing the time zone in Kibana would not affect any already saved visualizations
-        // anymore, which is not the desired behavior. So always returning undefined here, makes sure we're never
-        // saving that parameter and just keep it "transient".
-        return undefined;
+      default: undefined,
+      // We don't ever want this parameter to be serialized out (when saving or to URLs)
+      // since we do all the logic handling it "on the fly" in the `write` method, to prevent
+      // time_zones being persisted into saved_objects
+      serialize: () => undefined,
+      write: (agg, output) => {
+        // If a time_zone has been set explicitly always prefer this.
+        let tz = agg.params.time_zone;
+        if (!tz && agg.params.field) {
+          // If a field has been configured check the index pattern's typeMeta if a date_histogram on that
+          // field requires a specific time_zone
+          tz = _.get(agg.getIndexPattern(), ['typeMeta', 'aggs', 'date_histogram', agg.params.field.name, 'time_zone']);
+        }
+        if (!tz) {
+          // If the index pattern typeMeta data, didn't had a time zone assigned for the selected field use the configured tz
+          const isDefaultTimezone = config.isDefault('dateFormat:tz');
+          tz = isDefaultTimezone ? detectedTimezone || tzOffset : config.get('dateFormat:tz');
+        }
+        output.params.time_zone = tz;
       },
     },
     {

--- a/x-pack/plugins/rollup/public/visualize/editor_config.js
+++ b/x-pack/plugins/rollup/public/visualize/editor_config.js
@@ -52,12 +52,8 @@ export function initEditorConfig() {
 
     // Set date histogram time zone based on rollup capabilities
     if (aggTypeName === 'date_histogram') {
-      const timezone = fieldAgg.time_zone || 'UTC';
       const interval = fieldAgg.interval;
       return {
-        time_zone: {
-          fixedValue: timezone,
-        },
         interval: {
           fixedValue: 'custom',
         },


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make time_zone parameter properly volatile  (#35536)