### PR TITLE
[7.0] Make time_zone parameter properly volatile (#35536)

### DIFF
--- a/src/legacy/ui/public/agg_types/__tests__/buckets/date_histogram/_params.js
+++ b/src/legacy/ui/public/agg_types/__tests__/buckets/date_histogram/_params.js
@@ -31,7 +31,7 @@ import { timefilter } from 'ui/timefilter';
 
 const config = chrome.getUiSettingsClient();
 
-describe('params', function () {
+describe('date_histogram params', function () {
 
   let paramWriter;
   let writeInterval;
@@ -150,6 +150,12 @@ describe('params', function () {
       config.get.withArgs('dateFormat:tz').returns('Europe/Riga');
       const output = paramWriter.write({});
       expect(output.params).to.have.property('time_zone', 'Europe/Riga');
+    });
+
+    it('should use the fixed time_zone from the index pattern typeMeta', () => {
+      _.set(paramWriter.indexPattern, ['typeMeta', 'aggs', 'date_histogram', timeField, 'time_zone'], 'Europe/Rome');
+      const output = paramWriter.write({ field: timeField });
+      expect(output.params).to.have.property('time_zone', 'Europe/Rome');
     });
 
     afterEach(() => {

--- a/x-pack/plugins/rollup/public/visualize/editor_config.js
+++ b/x-pack/plugins/rollup/public/visualize/editor_config.js
@@ -52,12 +52,8 @@ export function initEditorConfig() {
 
     // Set date histogram time zone based on rollup capabilities
     if (aggTypeName === 'date_histogram') {
-      const timezone = fieldAgg.time_zone || 'UTC';
       const interval = fieldAgg.interval;
       return {
-        time_zone: {
-          fixedValue: timezone,
-        },
         interval: {
           fixedValue: 'custom',
         },


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Make time_zone parameter properly volatile  (#35536)