### PR TITLE
[7.x] Fixes #34606 - Adjust CSS to fix scrolling bug in Waffle Map (#34881)

### DIFF
--- a/x-pack/plugins/infra/public/components/nodes_overview/index.tsx
+++ b/x-pack/plugins/infra/public/components/nodes_overview/index.tsx
@@ -222,7 +222,7 @@ const ViewSwitcherContainer = euiStyled.div`
 const MapContainer = euiStyled.div`
   position: absolute;
   display: flex;
-  top: 0;
+  top: 70px;
   right: 0;
   bottom: 0;
   left: 0;

--- a/x-pack/plugins/infra/public/components/waffle/map.tsx
+++ b/x-pack/plugins/infra/public/components/waffle/map.tsx
@@ -99,7 +99,7 @@ export const Map: React.SFC<Props> = ({
 const WaffleMapOuterContainer = euiStyled.div`
   flex: 1 0 0%;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixes #34606 - Adjust CSS to fix scrolling bug in Waffle Map  (#34881)