### PR TITLE
Fixes URL param bugs

### DIFF
--- a/x-pack/plugins/apm/public/context/UrlParamsContext/__tests__/UrlParamsContext.test.tsx
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/__tests__/UrlParamsContext.test.tsx
@@ -48,8 +48,10 @@ describe('UrlParamsContext', () => {
 
     expect(params).toEqual({
       start: '2000-06-14T12:00:00.000Z',
+      serviceName: 'test',
       end: '2000-06-15T12:00:00.000Z',
       page: 0,
+      processorEvent: 'transaction',
       rangeFrom: 'now-24h',
       rangeTo: 'now',
       refreshInterval: 0,

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/helpers.ts
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/helpers.ts
@@ -60,6 +60,7 @@ export function getPathParams(pathname: string = '') {
   const paths = getPathAsArray(pathname);
   const pageName = paths[1];
 
+  // TODO: use react router's real match params instead of guessing the path order
   switch (pageName) {
     case 'transactions':
       return {
@@ -80,6 +81,9 @@ export function getPathParams(pathname: string = '') {
         serviceName: paths[0]
       };
     default:
-      return {};
+      return {
+        processorEvent: 'transaction',
+        serviceName: paths[0]
+      };
   }
 }

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/index.tsx
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/index.tsx
@@ -35,7 +35,7 @@ export function urlParamsReducer(
 ): IUrlParams {
   switch (action.type) {
     case LOCATION_UPDATE: {
-      return resolveUrlParams(action.location);
+      return resolveUrlParams(action.location, state);
     }
 
     case TIME_RANGE_REFRESH:
@@ -59,7 +59,7 @@ const UrlParamsProvider: React.FC<{}> = ({ children }) => {
   const location = useLocation();
   const [urlParams, dispatch] = useReducer(
     urlParamsReducer,
-    resolveUrlParams(location)
+    resolveUrlParams(location, {})
   );
 
   function refreshTimeRange(time: TimeRange) {

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts
@@ -21,7 +21,7 @@ import {
 } from '../../components/shared/Links/url_helpers';
 import { TIMEPICKER_DEFAULTS } from './constants';
 
-export function resolveUrlParams(location: Location, state: IUrlParams = {}) {
+export function resolveUrlParams(location: Location, state: IUrlParams) {
   const {
     processorEvent,
     serviceName,


### PR DESCRIPTION
## Summary

Fixes some bugs with flashing UI and a broken service-level breadcrumb link by properly passing previous state into our resolveUrlParams function and by handling url paths that are just a service name, like "/opbeans-go