### PR TITLE
[6.7 Patch] Persists current kuery value from URL if present

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -68,11 +68,17 @@ function getQueryWithRisonParams(location: Location, query: RisonDecoded = {}) {
   const encodedG = rison.encode(combinedG);
   const encodedA = query._a ? rison.encode(query._a) : '';
 
-  return {
+  const queryWithRisonParams: QueryParams = {
     ...query,
     _g: encodedG,
     _a: encodedA
   };
+
+  if (currentQuery.kuery) {
+    queryWithRisonParams.kuery = currentQuery.kuery;
+  }
+
+  return queryWithRisonParams;
 }
 
 export interface KibanaHrefArgs {


### PR DESCRIPTION
## Summary

Fixes problem where the kuery bar value is not persisted as you click around inside the APM UI because we don't add the current value into the links that users use to navigate the UI.

This PR adds the `kuery` value, if present in the current URL, to the href of new URLs that we create.

![6 7-persist-kuery](https://user-images.githubusercontent.com/159370/56963324-a30d5500-6b26-11e9-89f7-f01f04a6d9ee.gif)
