### PR TITLE
[APM] Apply `useMemo` to context providers and avoid passing unrelated props to heavy components

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionTabs.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/TransactionTabs.tsx
@@ -6,10 +6,8 @@
 
 import { EuiSpacer, EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Location } from 'history';
 import React from 'react';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
-import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { fromQuery, toQuery } from '../../../shared/Links/url_helpers';
 import { history } from '../../../../utils/history';
 import { TransactionMetadata } from '../../../shared/MetadataTable/TransactionMetadata';
@@ -31,21 +29,14 @@ const metadataTab = {
 };
 
 interface Props {
-  location: Location;
   transaction: Transaction;
-  urlParams: IUrlParams;
+  detailTab: string | undefined;
   waterfall: IWaterfall;
 }
 
-export function TransactionTabs({
-  location,
-  transaction,
-  urlParams,
-  waterfall
-}: Props) {
+export function TransactionTabs({ transaction, detailTab, waterfall }: Props) {
   const tabs = [timelineTab, metadataTab];
-  const currentTab =
-    urlParams.detailTab === metadataTab.key ? metadataTab : timelineTab;
+  const currentTab = detailTab === metadataTab.key ? metadataTab : timelineTab;
 
   return (
     <React.Fragment>
@@ -55,9 +46,9 @@ export function TransactionTabs({
             <EuiTab
               onClick={() => {
                 history.replace({
-                  ...location,
+                  ...history.location,
                   search: fromQuery({
-                    ...toQuery(location.search),
+                    ...toQuery(history.location.search),
                     detailTab: key
                   })
                 });
@@ -74,12 +65,7 @@ export function TransactionTabs({
       <EuiSpacer />
 
       {currentTab.key === timelineTab.key ? (
-        <WaterfallContainer
-          transaction={transaction}
-          location={location}
-          urlParams={urlParams}
-          waterfall={waterfall}
-        />
+        <WaterfallContainer transaction={transaction} waterfall={waterfall} />
       ) : (
         <TransactionMetadata transaction={transaction} />
       )}

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/Flyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/Flyout.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { SpanFlyout } from './SpanFlyout';
+import { TransactionFlyout } from './TransactionFlyout';
+import { IWaterfall } from './waterfall_helpers/waterfall_helpers';
+import { useUrlParams } from '../../../../../../hooks/useUrlParams';
+
+interface Props {
+  waterfall: IWaterfall;
+  onClose: () => void;
+}
+
+export function Flyout({ waterfall, onClose }: Props) {
+  const { urlParams } = useUrlParams();
+  const currentItem =
+    urlParams.waterfallItemId && waterfall.itemsById[urlParams.waterfallItemId];
+
+  if (!currentItem) {
+    return null;
+  }
+
+  switch (currentItem.docType) {
+    case 'span':
+      const parentTransaction = waterfall.getTransactionById(
+        currentItem.parentId
+      );
+
+      return (
+        <SpanFlyout
+          totalDuration={waterfall.duration}
+          span={currentItem.span}
+          parentTransaction={parentTransaction}
+          onClose={onClose}
+        />
+      );
+    case 'transaction':
+      return (
+        <TransactionFlyout
+          transaction={currentItem.transaction}
+          onClose={onClose}
+          traceRootDuration={waterfall.traceRootDuration}
+          errorCount={currentItem.errorCount}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/WaterfallItem.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/WaterfallItem.tsx
@@ -20,7 +20,6 @@ type ItemType = 'transaction' | 'span';
 interface IContainerStyleProps {
   type: ItemType;
   timelineMargins: ITimelineMargins;
-  isSelected: boolean;
 }
 
 interface IBarStyleProps {
@@ -39,8 +38,6 @@ const Container = styled<IContainerStyleProps, 'div'>('div')`
   margin-right: ${props => px(props.timelineMargins.right)};
   margin-left: ${props => px(props.timelineMargins.left)};
   border-top: 1px solid ${theme.euiColorLightShade};
-  background-color: ${props =>
-    props.isSelected ? theme.euiColorLightestShade : 'initial'};
   cursor: pointer;
 
   &:hover {
@@ -82,7 +79,6 @@ interface IWaterfallItemProps {
   totalDuration?: number;
   item: IWaterfallItem;
   color: string;
-  isSelected: boolean;
   errorCount: number;
   onClick: () => unknown;
 }
@@ -167,7 +163,6 @@ export function WaterfallItem({
   totalDuration,
   item,
   color,
-  isSelected,
   errorCount,
   onClick
 }: IWaterfallItemProps) {
@@ -182,7 +177,6 @@ export function WaterfallItem({
     <Container
       type={item.docType}
       timelineMargins={timelineMargins}
-      isSelected={isSelected}
       onClick={onClick}
     >
       <ItemBar // using inline styles instead of props to avoid generating a css class for each item

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/index.tsx
@@ -4,29 +4,21 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Location } from 'history';
-import React, { Component } from 'react';
+import React from 'react';
 // @ts-ignore
 import { StickyContainer } from 'react-sticky';
 import styled from 'styled-components';
-import { IUrlParams } from '../../../../../../context/UrlParamsContext/types';
 // @ts-ignore
 import Timeline from '../../../../../shared/charts/Timeline';
-import {
-  APMQueryParams,
-  fromQuery,
-  toQuery
-} from '../../../../../shared/Links/url_helpers';
+import { fromQuery, toQuery } from '../../../../../shared/Links/url_helpers';
 import { history } from '../../../../../../utils/history';
 import { AgentMark } from '../get_agent_marks';
-import { SpanFlyout } from './SpanFlyout';
-import { TransactionFlyout } from './TransactionFlyout';
 import {
   IServiceColors,
-  IWaterfall,
-  IWaterfallItem
+  IWaterfall
 } from './waterfall_helpers/waterfall_helpers';
 import { WaterfallItem } from './WaterfallItem';
+import { Flyout } from './Flyout';
 
 const Container = styled.div`
   transition: 0.1s padding ease;
@@ -43,125 +35,74 @@ const TIMELINE_MARGINS = {
 
 interface Props {
   agentMarks: AgentMark[];
-  urlParams: IUrlParams;
   waterfall: IWaterfall;
-  location: Location;
   serviceColors: IServiceColors;
 }
 
-export class Waterfall extends Component<Props> {
-  public onOpenFlyout = (item: IWaterfallItem) => {
-    this.setQueryParams({
-      flyoutDetailTab: undefined,
-      waterfallItemId: String(item.id)
-    });
-  };
+export function Waterfall({ agentMarks, waterfall, serviceColors }: Props) {
+  const itemContainerHeight = 58; // TODO: This is a nasty way to calculate the height of the svg element. A better approach should be found
+  const waterfallHeight = itemContainerHeight * waterfall.orderedItems.length;
 
-  public onCloseFlyout = () => {
-    this.setQueryParams({
-      flyoutDetailTab: undefined,
-      waterfallItemId: undefined
-    });
-  };
+  return (
+    <Container>
+      <StickyContainer>
+        <Timeline
+          agentMarks={agentMarks}
+          duration={waterfall.duration}
+          traceRootDuration={waterfall.traceRootDuration}
+          height={waterfallHeight}
+          margins={TIMELINE_MARGINS}
+        />
+        <div
+          style={{
+            paddingTop: TIMELINE_MARGINS.top
+          }}
+        >
+          {waterfall.orderedItems.map(item => {
+            const errorCount =
+              item.docType === 'transaction'
+                ? waterfall.errorCountByTransactionId[
+                    item.transaction.transaction.id
+                  ]
+                : 0;
 
-  public renderWaterfallItem = (item: IWaterfallItem) => {
-    const { serviceColors, waterfall, urlParams }: Props = this.props;
+            return (
+              <WaterfallItem
+                key={item.id}
+                timelineMargins={TIMELINE_MARGINS}
+                color={serviceColors[item.serviceName]}
+                item={item}
+                totalDuration={waterfall.duration}
+                errorCount={errorCount}
+                onClick={() => {
+                  history.replace({
+                    ...history.location,
+                    search: fromQuery({
+                      ...toQuery(history.location.search),
+                      flyoutDetailTab: undefined,
+                      waterfallItemId: String(item.id)
+                    })
+                  });
+                }}
+              />
+            );
+          })}
+        </div>
+      </StickyContainer>
 
-    const errorCount =
-      item.docType === 'transaction'
-        ? waterfall.errorCountByTransactionId[item.transaction.transaction.id]
-        : 0;
-
-    return (
-      <WaterfallItem
-        key={item.id}
-        timelineMargins={TIMELINE_MARGINS}
-        color={serviceColors[item.serviceName]}
-        item={item}
-        totalDuration={waterfall.duration}
-        isSelected={item.id === urlParams.waterfallItemId}
-        errorCount={errorCount}
-        onClick={() => this.onOpenFlyout(item)}
+      <Flyout
+        waterfall={waterfall}
+        onClose={() => {
+          history.replace({
+            ...history.location,
+            search: fromQuery({
+              ...toQuery(history.location.search),
+              flyoutDetailTab: undefined,
+              waterfallItemId: undefined
+            })
+          });
+        }}
       />
-    );
-  };
-
-  public getFlyOut = () => {
-    const { waterfall, urlParams } = this.props;
-
-    const currentItem =
-      urlParams.waterfallItemId &&
-      waterfall.itemsById[urlParams.waterfallItemId];
-
-    if (!currentItem) {
-      return null;
-    }
-
-    switch (currentItem.docType) {
-      case 'span':
-        const parentTransaction = waterfall.getTransactionById(
-          currentItem.parentId
-        );
-
-        return (
-          <SpanFlyout
-            totalDuration={waterfall.duration}
-            span={currentItem.span}
-            parentTransaction={parentTransaction}
-            onClose={this.onCloseFlyout}
-          />
-        );
-      case 'transaction':
-        return (
-          <TransactionFlyout
-            transaction={currentItem.transaction}
-            onClose={this.onCloseFlyout}
-            traceRootDuration={waterfall.traceRootDuration}
-            errorCount={currentItem.errorCount}
-          />
-        );
-      default:
-        return null;
-    }
-  };
-
-  public render() {
-    const { waterfall } = this.props;
-    const itemContainerHeight = 58; // TODO: This is a nasty way to calculate the height of the svg element. A better approach should be found
-    const waterfallHeight = itemContainerHeight * waterfall.orderedItems.length;
-
-    return (
-      <Container>
-        <StickyContainer>
-          <Timeline
-            agentMarks={this.props.agentMarks}
-            duration={waterfall.duration}
-            traceRootDuration={waterfall.traceRootDuration}
-            height={waterfallHeight}
-            margins={TIMELINE_MARGINS}
-          />
-          <div
-            style={{
-              paddingTop: TIMELINE_MARGINS.top
-            }}
-          >
-            {waterfall.orderedItems.map(this.renderWaterfallItem)}
-          </div>
-        </StickyContainer>
-
-        {this.getFlyOut()}
-      </Container>
-    );
-  }
-
-  private setQueryParams(params: APMQueryParams) {
-    const { location } = this.props;
-    history.replace({
-      ...location,
-      search: fromQuery({
-        ...toQuery(location.search),
-        ...params
-      })
-    });
-  }
+    </Container>
+  );
 }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/index.tsx
@@ -4,28 +4,19 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Location } from 'history';
 import React from 'react';
 import { Transaction } from '../../../../../../typings/es_schemas/ui/Transaction';
-import { IUrlParams } from '../../../../../context/UrlParamsContext/types';
 import { getAgentMarks } from './get_agent_marks';
 import { ServiceLegends } from './ServiceLegends';
 import { Waterfall } from './Waterfall';
 import { IWaterfall } from './Waterfall/waterfall_helpers/waterfall_helpers';
 
 interface Props {
-  urlParams: IUrlParams;
   transaction: Transaction;
-  location: Location;
   waterfall: IWaterfall;
 }
 
-export function WaterfallContainer({
-  location,
-  urlParams,
-  transaction,
-  waterfall
-}: Props) {
+export function WaterfallContainer({ transaction, waterfall }: Props) {
   const agentMarks = getAgentMarks(transaction);
   if (!waterfall) {
     return null;
@@ -36,9 +27,7 @@ export function WaterfallContainer({
       <ServiceLegends serviceColors={waterfall.serviceColors} />
       <Waterfall
         agentMarks={agentMarks}
-        location={location}
         serviceColors={waterfall.serviceColors}
-        urlParams={urlParams}
         waterfall={waterfall}
       />
     </div>

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
@@ -14,10 +14,8 @@ import {
   EuiToolTip
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Location } from 'history';
 import React from 'react';
 import { Transaction as ITransaction } from '../../../../../typings/es_schemas/ui/Transaction';
-import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { TransactionLink } from '../../../shared/Links/TransactionLink';
 import { TransactionActionMenu } from '../../../shared/TransactionActionMenu/TransactionActionMenu';
 import { StickyTransactionProperties } from './StickyTransactionProperties';
@@ -94,64 +92,59 @@ function MaybeViewTraceLink({
 
 interface Props {
   transaction: ITransaction;
-  urlParams: IUrlParams;
-  location: Location;
   waterfall: IWaterfall;
+  detailTab: string | undefined;
 }
 
-export const Transaction: React.SFC<Props> = ({
-  transaction,
-  urlParams,
-  location,
-  waterfall
-}) => {
-  return (
-    <EuiPanel paddingSize="m">
-      <EuiFlexGroup justifyContent="spaceBetween">
-        <EuiFlexItem>
-          <EuiTitle size="s">
-            <h5>
-              {i18n.translate(
-                'xpack.apm.transactionDetails.transactionSampleTitle',
-                {
-                  defaultMessage: 'Transaction sample'
-                }
-              )}
-            </h5>
-          </EuiTitle>
-        </EuiFlexItem>
+export const Transaction: React.SFC<Props> = React.memo(
+  ({ transaction, detailTab, waterfall }) => {
+    return (
+      <EuiPanel paddingSize="m">
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h5>
+                {i18n.translate(
+                  'xpack.apm.transactionDetails.transactionSampleTitle',
+                  {
+                    defaultMessage: 'Transaction sample'
+                  }
+                )}
+              </h5>
+            </EuiTitle>
+          </EuiFlexItem>
 
-        <EuiFlexItem>
-          <EuiFlexGroup justifyContent="flexEnd">
-            <EuiFlexItem grow={false}>
-              <TransactionActionMenu transaction={transaction} />
-            </EuiFlexItem>
-            <MaybeViewTraceLink
-              transaction={transaction}
-              waterfall={waterfall}
-            />
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiFlexGroup justifyContent="flexEnd">
+              <EuiFlexItem grow={false}>
+                <TransactionActionMenu transaction={transaction} />
+              </EuiFlexItem>
+              <MaybeViewTraceLink
+                transaction={transaction}
+                waterfall={waterfall}
+              />
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
 
-      <EuiSpacer />
+        <EuiSpacer />
 
-      <StickyTransactionProperties
-        errorCount={
-          waterfall.errorCountByTransactionId[transaction.transaction.id]
-        }
-        transaction={transaction}
-        totalDuration={waterfall.traceRootDuration}
-      />
+        <StickyTransactionProperties
+          errorCount={
+            waterfall.errorCountByTransactionId[transaction.transaction.id]
+          }
+          transaction={transaction}
+          totalDuration={waterfall.traceRootDuration}
+        />
 
-      <EuiSpacer />
+        <EuiSpacer />
 
-      <TransactionTabs
-        transaction={transaction}
-        location={location}
-        urlParams={urlParams}
-        waterfall={waterfall}
-      />
-    </EuiPanel>
-  );
-};
+        <TransactionTabs
+          transaction={transaction}
+          detailTab={detailTab}
+          waterfall={waterfall}
+        />
+      </EuiPanel>
+    );
+  }
+);

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
@@ -22,6 +22,7 @@ import { useUrlParams } from '../../../hooks/useUrlParams';
 export function TransactionDetails() {
   const location = useLocation();
   const { urlParams } = useUrlParams();
+  const { detailTab } = urlParams;
   const { data: distributionData } = useTransactionDistribution(urlParams);
   const { data: transactionDetailsChartsData } = useTransactionDetailsCharts(
     urlParams
@@ -50,9 +51,10 @@ export function TransactionDetails() {
 
       <EuiPanel>
         <TransactionDistribution
+          traceId={urlParams.traceId}
+          transactionId={urlParams.transactionId}
+          transactionType={urlParams.transactionType}
           distribution={distributionData}
-          urlParams={urlParams}
-          location={location}
         />
       </EuiPanel>
 
@@ -76,9 +78,8 @@ export function TransactionDetails() {
         />
       ) : (
         <Transaction
-          location={location}
           transaction={transaction}
-          urlParams={urlParams}
+          detailTab={detailTab}
           waterfall={waterfall}
         />
       )}

--- a/x-pack/plugins/apm/public/context/LoadingIndicatorContext.tsx
+++ b/x-pack/plugins/apm/public/context/LoadingIndicatorContext.tsx
@@ -45,6 +45,10 @@ export function LoadingIndicatorProvider({
   const isLoading = useMemo(() => getIsAnyLoading(statuses), [statuses]);
   const shouldShowLoadingIndicator = useDelayedVisibility(isLoading);
 
+  const contextValue = React.useMemo(() => ({ statuses, dispatchStatus }), [
+    statuses
+  ]);
+
   return (
     <Fragment>
       {shouldShowLoadingIndicator && (
@@ -54,7 +58,7 @@ export function LoadingIndicatorProvider({
       )}
 
       <LoadingIndicatorContext.Provider
-        value={{ statuses, dispatchStatus }}
+        value={contextValue}
         children={children}
       />
     </Fragment>

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/index.tsx
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/index.tsx
@@ -73,12 +73,11 @@ const UrlParamsProvider: React.FC<{}> = ({ children }) => {
     [location]
   );
 
-  return (
-    <UrlParamsContext.Provider
-      children={children}
-      value={{ urlParams, refreshTimeRange }}
-    />
-  );
+  const contextValue = React.useMemo(() => ({ urlParams, refreshTimeRange }), [
+    urlParams
+  ]);
+
+  return <UrlParamsContext.Provider children={children} value={contextValue} />;
 };
 
 export { UrlParamsContext, UrlParamsProvider };

--- a/x-pack/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/useFetcher.tsx
@@ -24,7 +24,11 @@ export function useFetcher<Response>(
     data?: Response;
     status?: FETCH_STATUS;
     error?: Error;
-  }>({});
+  }>({
+    data: undefined,
+    status: FETCH_STATUS.LOADING,
+    error: undefined
+  });
 
   useEffect(() => {
     let didCancel = false;


### PR DESCRIPTION
 - Apply `useMemo` to context providers the have non-primitive types as values (objects, arrays etc) to avoid re-rendering of context provider to cause re-render of consumers
- Whenever a property in `urlParams` change, all consumers of `useUrlParams` re-renders. This can be quite expensive if a lot of unrelated urlParams prop changes causes CPU heavy components to re-render. To avoid this I'm cherry-picking the urlParams and only passing those to the component. I only did this for the TransactionDistribution component and Waterfall related components.

