### PR TITLE
[APM] Central configuration management

### DIFF
--- a/src/legacy/core_plugins/apm_oss/index.js
+++ b/src/legacy/core_plugins/apm_oss/index.js
@@ -32,24 +32,31 @@ export default function apmOss(kibana) {
         indexPattern: Joi.string().default('apm-*'),
 
         // ES Indices
-        sourcemapIndices: Joi.string().default('apm-*'),
+        cmIndex: Joi.string().default('.apm-cm'),
         errorIndices: Joi.string().default('apm-*'),
-        transactionIndices: Joi.string().default('apm-*'),
-        spanIndices: Joi.string().default('apm-*'),
         metricsIndices: Joi.string().default('apm-*'),
         onboardingIndices: Joi.string().default('apm-*'),
+        sourcemapIndices: Joi.string().default('apm-*'),
+        spanIndices: Joi.string().default('apm-*'),
+        transactionIndices: Joi.string().default('apm-*'),
       }).default();
     },
 
     init(server) {
-      server.expose('indexPatterns', _.uniq([
-        'sourcemapIndices',
-        'errorIndices',
-        'transactionIndices',
-        'spanIndices',
-        'metricsIndices',
-        'onboardingIndices'
-      ].map(type => server.config().get(`apm_oss.${type}`))));
-    }
+      server.expose(
+        'indexPatterns',
+        _.uniq(
+          [
+            'cmIndex',
+            'errorIndices',
+            'metricsIndices',
+            'onboardingIndices',
+            'sourcemapIndices',
+            'spanIndices',
+            'transactionIndices',
+          ].map(type => server.config().get(`apm_oss.${type}`))
+        )
+      );
+    },
   });
 }

--- a/x-pack/plugins/apm/public/components/app/Main/routeConfig.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/routeConfig.tsx
@@ -13,6 +13,7 @@ import { ServiceDetails } from '../ServiceDetails';
 import { TransactionDetails } from '../TransactionDetails';
 import { Home } from './Home';
 import { BreadcrumbRoute } from './ProvideBreadcrumbs';
+import { ListSettings } from '../Settings/ListSettings';
 
 interface RouteParams {
   serviceName: string;
@@ -42,6 +43,16 @@ export const routes: BreadcrumbRoute[] = [
     component: Home,
     breadcrumb: i18n.translate('xpack.apm.breadcrumb.servicesTitle', {
       defaultMessage: 'Services'
+    })
+  },
+
+  // Settings: Central configuration management
+  {
+    exact: true,
+    path: '/settings',
+    component: ListSettings,
+    breadcrumb: i18n.translate('xpack.apm.breadcrumb.listSettingsTitle', {
+      defaultMessage: 'Settings'
     })
   },
   {

--- a/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSetting.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSetting.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { toastNotifications } from 'ui/notify';
+import {
+  EuiSelect,
+  EuiForm,
+  EuiFormRow,
+  EuiButton,
+  EuiFlexItem,
+  EuiFieldNumber,
+  EuiTitle
+} from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import { EuiFlexGroup } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  loadCMServices,
+  loadCMEnvironments,
+  saveCMConfiguration
+} from '../../../../services/rest/apm/settings';
+import { useFetcher } from '../../../../hooks/useFetcher';
+import { history } from '../../../../utils/history';
+
+const ENVIRONMENT_NOT_SET = 'ENVIRONMENT_NOT_SET';
+
+export function AddSetting() {
+  const [environment, setEnvironment] = useState<string | undefined>(undefined);
+  const [serviceName, setServiceName] = useState<string | undefined>(undefined);
+  const [sampleRate, setSampleRate] = useState<number | undefined>(undefined);
+  const { data: serviceNames = [] } = useFetcher(loadCMServices, []);
+  const { data: environments = [], status: environmentStatus } = useFetcher(
+    () => {
+      if (serviceName) {
+        return loadCMEnvironments({ serviceName });
+      }
+    },
+    [serviceName]
+  );
+
+  useEffect(
+    () => {
+      if (!isEmpty(environments)) {
+        setEnvironment(undefined);
+      }
+    },
+    [environments]
+  );
+
+  useEffect(
+    () => {
+      if (!isEmpty(serviceNames)) {
+        setServiceName(undefined);
+      }
+    },
+    [serviceNames]
+  );
+
+  const hasAnyAvailableEnvironments = environments.some(env => env.available);
+  const environmentOptions = environments.map(({ name, available }) => ({
+    disabled: !available,
+    text: name === ENVIRONMENT_NOT_SET ? 'Not set' : name,
+    value: name
+  }));
+
+  return (
+    <EuiForm>
+      <EuiTitle>
+        <h2>Agent configuration</h2>
+      </EuiTitle>
+      <form
+        onSubmit={async event => {
+          event.preventDefault();
+
+          try {
+            if (!sampleRate || !serviceName) {
+              throw new Error('Missing arguments');
+            }
+
+            const configuration = {
+              settings: {
+                sample_rate: sampleRate
+              },
+              service: {
+                name: serviceName,
+                environment:
+                  environment === ENVIRONMENT_NOT_SET ? undefined : environment
+              }
+            };
+
+            await saveCMConfiguration(configuration);
+
+            toastNotifications.addSuccess({
+              title: i18n.translate(
+                'xpack.apm.settings.cm.createConfigSucceeded',
+                { defaultMessage: 'Config was created' }
+              )
+            });
+            history.push({
+              ...history.location,
+              pathname: `/settings`
+            });
+          } catch (error) {
+            toastNotifications.addDanger({
+              title: i18n.translate(
+                'xpack.apm.settings.cm.createConfigFailed',
+                { defaultMessage: 'Config could not be created' }
+              )
+            });
+          }
+        }}
+      >
+        <EuiFlexGroup justifyContent="flexStart">
+          <EuiFlexItem grow={false}>
+            <EuiFormRow label="Service name">
+              <EuiSelect
+                hasNoInitialSelection
+                options={serviceNames.map(text => ({ text }))}
+                value={serviceName}
+                onChange={e => {
+                  setServiceName(e.target.value);
+                }}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow
+              label="Service environment"
+              error={
+                'You have created configurations for all environments in this service'
+              }
+              isInvalid={
+                !hasAnyAvailableEnvironments &&
+                (environmentStatus === 'success' ||
+                  environmentStatus === 'failure')
+              }
+            >
+              <EuiSelect
+                hasNoInitialSelection
+                options={environmentOptions}
+                value={environment}
+                onChange={e => {
+                  setEnvironment(e.target.value);
+                }}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow label="Transaction sample rate">
+              <EuiFieldNumber
+                min={0}
+                max={1}
+                step={0.1}
+                placeholder="0.2"
+                value={sampleRate}
+                onChange={e => {
+                  const parsedValue = parseFloat(e.target.value);
+                  setSampleRate(parsedValue);
+                }}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow label="&nbsp;">
+              <EuiButton
+                type="submit"
+                fill
+                disabled={!hasAnyAvailableEnvironments}
+              >
+                Save configuration
+              </EuiButton>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        {/* <p>serviceName: {serviceName}</p>
+        <p>sampleRate: {sampleRate}</p>
+        <p>env: {environment}</p> */}
+      </form>
+    </EuiForm>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -11,17 +11,16 @@ import {
   EuiPortal,
   EuiTitle
 } from '@elastic/eui';
-
 import React from 'react';
-
-import { AddSetting } from './AddSetting';
+import { AddSettingFlyoutBody } from './AddSettingFlyoutBody';
 
 interface Props {
   onClose: () => void;
+  onSubmit: () => void;
   isOpen: boolean;
 }
 
-export function AddSettingsFlyout({ onClose, isOpen }: Props) {
+export function AddSettingsFlyout({ onClose, isOpen, onSubmit }: Props) {
   if (!isOpen) {
     return null;
   }
@@ -34,7 +33,7 @@ export function AddSettingsFlyout({ onClose, isOpen }: Props) {
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
-          <AddSetting />
+          <AddSettingFlyoutBody onSubmit={onSubmit} />
         </EuiFlyoutBody>
       </EuiFlyout>
     </EuiPortal>

--- a/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiPortal
+} from '@elastic/eui';
+
+import React from 'react';
+
+import { AddSetting } from './AddSetting';
+
+interface Props {
+  onClose: () => void;
+  isOpen: boolean;
+}
+
+export function AddSettingsFlyout({ onClose, isOpen }: Props) {
+  if (!isOpen) {
+    return null;
+  }
+  return (
+    <EuiFlyout onClose={onClose} ownFocus={true}>
+      <EuiFlyoutHeader hasBorder>yo</EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <AddSetting />
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -8,7 +8,8 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiPortal
+  EuiPortal,
+  EuiTitle
 } from '@elastic/eui';
 
 import React from 'react';
@@ -25,11 +26,17 @@ export function AddSettingsFlyout({ onClose, isOpen }: Props) {
     return null;
   }
   return (
-    <EuiFlyout onClose={onClose} ownFocus={true}>
-      <EuiFlyoutHeader hasBorder>yo</EuiFlyoutHeader>
-      <EuiFlyoutBody>
-        <AddSetting />
-      </EuiFlyoutBody>
-    </EuiFlyout>
+    <EuiPortal>
+      <EuiFlyout size="s" onClose={onClose} ownFocus={true}>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle>
+            <h2>Agent configuration</h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <AddSetting />
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    </EuiPortal>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/Settings/DeleteModal.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/DeleteModal.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import {
+  EuiConfirmModal,
+  EUI_MODAL_CONFIRM_BUTTON,
+  EuiOverlayMask
+} from '@elastic/eui';
+import { CMListAPIResponse } from '../../../../server/lib/settings/cm/list_configurations';
+
+type Config = CMListAPIResponse[0];
+
+export function DeleteModal({
+  configToBeDeleted,
+  onCancel,
+  onConfirm
+}: {
+  configToBeDeleted: Config | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  if (configToBeDeleted == null) {
+    return null;
+  }
+
+  return (
+    <EuiOverlayMask>
+      <EuiConfirmModal
+        title={`Delete config for '${configToBeDeleted.service.name}' ${
+          configToBeDeleted.service.environment
+            ? `(${configToBeDeleted.service.environment})`
+            : '(no environment)'
+        }`}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        cancelButtonText="Cancel"
+        confirmButtonText="Delete configuration"
+        buttonColor="danger"
+        defaultFocusedButton={EUI_MODAL_CONFIRM_BUTTON}
+      >
+        <p>
+          The sample rate will revert to the specified rate in the settings.yml
+          once the configured agent(s) reach the server
+        </p>
+      </EuiConfirmModal>
+    </EuiOverlayMask>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/Settings/DeleteModal.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/DeleteModal.tsx
@@ -10,7 +10,10 @@ import {
   EUI_MODAL_CONFIRM_BUTTON,
   EuiOverlayMask
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { toastNotifications } from 'ui/notify';
 import { CMListAPIResponse } from '../../../../server/lib/settings/cm/list_configurations';
+import { deleteCMConfiguration } from '../../../services/rest/apm/settings';
 
 type Config = CMListAPIResponse[0];
 
@@ -36,7 +39,26 @@ export function DeleteModal({
             : '(no environment)'
         }`}
         onCancel={onCancel}
-        onConfirm={onConfirm}
+        onConfirm={async () => {
+          onConfirm();
+          try {
+            await deleteCMConfiguration(configToBeDeleted.id);
+
+            toastNotifications.addSuccess({
+              title: i18n.translate(
+                'xpack.apm.settings.cm.deleteConfigSucceeded',
+                { defaultMessage: 'Config was deleted' }
+              )
+            });
+          } catch (error) {
+            toastNotifications.addDanger({
+              title: i18n.translate(
+                'xpack.apm.settings.cm.deleteConfigFailed',
+                { defaultMessage: 'Config could not be deleted' }
+              )
+            });
+          }
+        }}
         cancelButtonText="Cancel"
         confirmButtonText="Delete configuration"
         buttonColor="danger"

--- a/x-pack/plugins/apm/public/components/app/Settings/ListSettings.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/ListSettings.tsx
@@ -17,7 +17,7 @@ import { DeleteModal } from './DeleteModal';
 type Config = CMListAPIResponse[0];
 
 export function ListSettings() {
-  const { data = [] } = useFetcher(loadCMList, []);
+  const { data = [], refresh } = useFetcher(loadCMList, []);
   const [configToBeDeleted, setConfigToBeDeleted] = useState<Config | null>(
     null
   );
@@ -75,11 +75,16 @@ export function ListSettings() {
         }}
         onConfirm={() => {
           setConfigToBeDeleted(null);
+          refresh();
         }}
       />
       <AddSettingsFlyout
         isOpen={isFlyoutOpen}
         onClose={() => setIsFlyoutOpen(false)}
+        onSubmit={() => {
+          setIsFlyoutOpen(false);
+          refresh();
+        }}
       />
       <EuiTitle>
         <h2>Agent configuration</h2>

--- a/x-pack/plugins/apm/public/components/app/Settings/ListSettings.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/ListSettings.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiTitle, EuiIcon } from '@elastic/eui';
+import { loadCMList } from '../../../services/rest/apm/settings';
+import { useFetcher } from '../../../hooks/useFetcher';
+import { ITableColumn, ManagedTable } from '../../shared/ManagedTable';
+import { CMListAPIResponse } from '../../../../server/lib/settings/cm/list_configurations';
+import { AddSettingsFlyout } from './AddSettings/AddSettingFlyout';
+import { DeleteModal } from './DeleteModal';
+
+type Config = CMListAPIResponse[0];
+
+export function ListSettings() {
+  const { data = [] } = useFetcher(loadCMList, []);
+  const [configToBeDeleted, setConfigToBeDeleted] = useState<Config | null>(
+    null
+  );
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+
+  const COLUMNS: Array<ITableColumn<Config>> = [
+    {
+      field: 'service.name',
+      name: i18n.translate('xpack.apm.settingsTable.serviceN  ameColumnLabel', {
+        defaultMessage: 'Service name'
+      }),
+      width: '50%',
+      sortable: true,
+      render: (value: string) => value
+    },
+    {
+      field: 'service.environment',
+      name: i18n.translate('xpack.apm.settingsTable.environmentColumnLabel', {
+        defaultMessage: 'Service environment'
+      }),
+      sortable: true,
+      render: (value: string) => value
+    },
+    {
+      field: 'settings.sample_rate',
+      name: i18n.translate('xpack.apm.settingsTable.sampelRateColumnLabel', {
+        defaultMessage: 'Sample rate'
+      }),
+      sortable: true,
+      render: (value: string) => value
+    },
+    {
+      name: 'Delete',
+      actions: [
+        {
+          name: 'Delete',
+          description: 'Delete this config',
+          icon: 'trash',
+          color: 'danger',
+          type: 'icon',
+          onClick: (config: Config) => {
+            setConfigToBeDeleted(config);
+          }
+        }
+      ]
+    }
+  ];
+
+  return (
+    <>
+      <DeleteModal
+        configToBeDeleted={configToBeDeleted}
+        onCancel={() => {
+          setConfigToBeDeleted(null);
+        }}
+        onConfirm={() => {
+          setConfigToBeDeleted(null);
+        }}
+      />
+      <AddSettingsFlyout
+        isOpen={isFlyoutOpen}
+        onClose={() => setIsFlyoutOpen(false)}
+      />
+      <EuiTitle>
+        <h2>Agent configuration</h2>
+      </EuiTitle>
+      <ManagedTable columns={COLUMNS} items={data} initialPageSize={50} />
+      <a
+        onClick={() => setIsFlyoutOpen(true)}
+        onKeyPress={() => setIsFlyoutOpen(true)}
+      >
+        <EuiIcon type="plusInCircle" /> Add new configuration
+      </a>
+    </>
+  );
+}

--- a/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -8,11 +8,13 @@ import { EuiBasicTable } from '@elastic/eui';
 import { sortByOrder } from 'lodash';
 import React, { Component } from 'react';
 import { idx } from '@kbn/elastic-idx';
+import { StringMap } from '../../../../typings/common';
 
 // TODO: this should really be imported from EUI
 export interface ITableColumn<T> {
-  field: string;
   name: string;
+  actions?: StringMap[];
+  field?: string;
   dataType?: string;
   align?: string;
   width?: string;

--- a/x-pack/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/useFetcher.tsx
@@ -29,16 +29,21 @@ export function useFetcher<Response>(
   useEffect(() => {
     let didCancel = false;
 
-    dispatchStatus({ id, isLoading: true });
-    setResult({
-      data: result.data, // preserve data from previous state while loading next state
-      status: FETCH_STATUS.LOADING,
-      error: undefined
-    });
-
     async function doFetch() {
+      const promise = fn();
+      if (!promise) {
+        return;
+      }
+
+      dispatchStatus({ id, isLoading: true });
+      setResult({
+        data: result.data, // preserve data from previous state while loading next state
+        status: FETCH_STATUS.LOADING,
+        error: undefined
+      });
+
       try {
-        const data = await fn();
+        const data = await promise;
         if (!didCancel) {
           dispatchStatus({ id, isLoading: false });
           setResult({

--- a/x-pack/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/useFetcher.tsx
@@ -16,7 +16,8 @@ export enum FETCH_STATUS {
 
 export function useFetcher<Response>(
   fn: () => Promise<Response> | undefined,
-  useEffectKey: any[]
+  useEffectKey: any[],
+  options = { preservePreviousResponse: true }
 ) {
   const id = useComponentId();
   const { dispatchStatus } = useContext(LoadingIndicatorContext);
@@ -36,8 +37,9 @@ export function useFetcher<Response>(
       }
 
       dispatchStatus({ id, isLoading: true });
+
       setResult({
-        data: result.data, // preserve data from previous state while loading next state
+        data: options.preservePreviousResponse ? result.data : undefined, // preserve data from previous state while loading next state
         status: FETCH_STATUS.LOADING,
         error: undefined
       });

--- a/x-pack/plugins/apm/public/services/rest/apm/settings.ts
+++ b/x-pack/plugins/apm/public/services/rest/apm/settings.ts
@@ -37,6 +37,13 @@ export async function saveCMConfiguration(
   });
 }
 
+export async function deleteCMConfiguration(configId: string) {
+  return callApi({
+    pathname: `/api/apm/settings/cm/${configId}`,
+    method: 'DELETE'
+  });
+}
+
 export async function loadCMList() {
   return callApi<CMListAPIResponse>({
     pathname: `/api/apm/settings/cm`

--- a/x-pack/plugins/apm/public/services/rest/apm/settings.ts
+++ b/x-pack/plugins/apm/public/services/rest/apm/settings.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { callApi } from '../callApi';
+import { CentralConfigurationIntake } from '../../../../server/lib/settings/cm/configuration';
+import { CMServicesAPIResponse } from '../../../../server/lib/settings/cm/get_service_names';
+import { CMSaveConfigurationAPIResponse } from '../../../../server/lib/settings/cm/save_configuration';
+import { CMListAPIResponse } from '../../../../server/lib/settings/cm/list_configurations';
+import { CMEnvironmentsAPIResponse } from '../../../../server/lib/settings/cm/get_environments';
+
+export async function loadCMServices() {
+  return callApi<CMServicesAPIResponse>({
+    pathname: `/api/apm/settings/cm/services`
+  });
+}
+
+export async function loadCMEnvironments({
+  serviceName
+}: {
+  serviceName: string;
+}) {
+  return callApi<CMEnvironmentsAPIResponse>({
+    pathname: `/api/apm/settings/cm/services/${serviceName}/environments`
+  });
+}
+
+export async function saveCMConfiguration(
+  configuration: CentralConfigurationIntake
+) {
+  return callApi<CMSaveConfigurationAPIResponse>({
+    pathname: `/api/apm/settings/cm/new`,
+    method: 'POST',
+    body: JSON.stringify(configuration)
+  });
+}
+
+export async function loadCMList() {
+  return callApi<CMListAPIResponse>({
+    pathname: `/api/apm/settings/cm`
+  });
+}

--- a/x-pack/plugins/apm/server/lib/helpers/input_validation.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/input_validation.ts
@@ -4,12 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import Joi from 'joi';
+import Joi, { Schema } from 'joi';
 export const dateValidation = Joi.alternatives()
   .try(Joi.date().iso(), Joi.number())
   .required();
 
-export const withDefaultValidators = (validators = {}) => {
+export function withDefaultValidators(
+  validators: { [key: string]: Schema } = {}
+) {
   return Joi.object().keys({
     _debug: Joi.bool(),
     start: dateValidation,
@@ -17,4 +19,4 @@ export const withDefaultValidators = (validators = {}) => {
     uiFiltersES: Joi.string(),
     ...validators
   });
-};
+}

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
@@ -24,7 +24,7 @@ export interface APMSearchParams extends SearchParams {
 }
 
 export type ESClient = <T = void, U = void>(
-  type: 'search' | 'index',
+  type: 'search' | 'index' | 'delete',
   params: APMSearchParams
 ) => Promise<AggregationSearchResponse<T, U>>;
 
@@ -90,7 +90,7 @@ function addFilterForLegacyData(
 }
 
 // add additional params for search (aka: read) requests
-async function getParamsForSearchRequest(
+async function getParamsForReadRequest(
   req: Legacy.Request,
   params: APMSearchParams
 ) {
@@ -112,7 +112,7 @@ export function setupRequest(req: Legacy.Request): Setup {
 
   const client: ESClient = async (type, params) => {
     const nextParams =
-      type === 'search' ? await getParamsForSearchRequest(req, params) : params;
+      type === 'search' ? await getParamsForReadRequest(req, params) : params;
 
     if (query._debug) {
       console.log(`--DEBUG ES QUERY--`);

--- a/x-pack/plugins/apm/server/lib/settings/cm/configuration.d.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/configuration.d.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export interface CentralConfigurationIntake {
+  settings: {
+    sample_rate: number;
+  };
+  service: {
+    name: string;
+    environment?: string;
+  };
+}
+
+export interface CentralConfiguration extends CentralConfigurationIntake {
+  '@timestamp': number;
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/delete_configuration.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/delete_configuration.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { Setup } from '../../helpers/setup_request';
+
+export async function deleteConfiguration({
+  configurationId,
+  setup
+}: {
+  configurationId: string;
+  setup: Setup;
+}) {
+  const { client, config } = setup;
+
+  const params = {
+    index: config.get<string>('apm_oss.cmIndex'),
+    id: configurationId
+  };
+
+  return client('delete', params);
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/delete_configuration.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/delete_configuration.ts
@@ -16,6 +16,7 @@ export async function deleteConfiguration({
   const { client, config } = setup;
 
   const params = {
+    refresh: true,
     index: config.get<string>('apm_oss.cmIndex'),
     id: configurationId
   };

--- a/x-pack/plugins/apm/server/lib/settings/cm/get_environments/get_all_environments.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/get_environments/get_all_environments.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { BucketAgg } from 'elasticsearch';
+import { idx } from '@kbn/elastic-idx/target';
+import { Setup } from '../../../helpers/setup_request';
+import {
+  PROCESSOR_EVENT,
+  SERVICE_NAME,
+  SERVICE_ENVIRONMENT
+} from '../../../../../common/elasticsearch_fieldnames';
+
+export async function getAllEnvionments({
+  serviceName,
+  setup
+}: {
+  serviceName: string;
+  setup: Setup;
+}) {
+  const { client, config } = setup;
+
+  const params = {
+    index: [
+      config.get<string>('apm_oss.metricsIndices'),
+      config.get<string>('apm_oss.errorIndices'),
+      config.get<string>('apm_oss.transactionIndices')
+    ],
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            {
+              terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] }
+            },
+            { term: { [SERVICE_NAME]: serviceName } }
+          ]
+        }
+      },
+      aggs: {
+        environments: {
+          terms: {
+            field: SERVICE_ENVIRONMENT,
+            missing: 'ENVIRONMENT_NOT_SET',
+            size: 100
+          }
+        }
+      }
+    }
+  };
+
+  interface Aggs extends BucketAgg {
+    environments: {
+      buckets: BucketAgg[];
+    };
+  }
+
+  const resp = await client<void, Aggs>('search', params);
+  const aggs = resp.aggregations;
+  const buckets = idx(aggs, _ => _.environments.buckets) || [];
+  return buckets.map(bucket => bucket.key);
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/get_environments/get_unavailable_environments.tsx
+++ b/x-pack/plugins/apm/server/lib/settings/cm/get_environments/get_unavailable_environments.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { BucketAgg } from 'elasticsearch';
+import { idx } from '@kbn/elastic-idx/target';
+import { Setup } from '../../../helpers/setup_request';
+import {
+  SERVICE_NAME,
+  SERVICE_ENVIRONMENT
+} from '../../../../../common/elasticsearch_fieldnames';
+
+export async function getUnavailableEnvionments({
+  serviceName,
+  setup
+}: {
+  serviceName: string;
+  setup: Setup;
+}) {
+  const { client, config } = setup;
+
+  const params = {
+    index: config.get<string>('apm_oss.cmIndex'),
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [{ term: { [SERVICE_NAME]: serviceName } }]
+        }
+      },
+      aggs: {
+        environments: {
+          terms: {
+            field: SERVICE_ENVIRONMENT,
+            missing: 'ENVIRONMENT_NOT_SET',
+            size: 100
+          }
+        }
+      }
+    }
+  };
+
+  interface Aggs extends BucketAgg {
+    environments: {
+      buckets: BucketAgg[];
+    };
+  }
+
+  const resp = await client<void, Aggs>('search', params);
+  const aggs = resp.aggregations;
+  const buckets = idx(aggs, _ => _.environments.buckets) || [];
+  return buckets.map(bucket => bucket.key);
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/get_environments/index.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/get_environments/index.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { getAllEnvionments } from './get_all_environments';
+import { Setup } from '../../../helpers/setup_request';
+import { PromiseReturnType } from '../../../../../typings/common';
+import { getUnavailableEnvionments } from './get_unavailable_environments';
+
+export type CMEnvironmentsAPIResponse = PromiseReturnType<
+  typeof getEnvironments
+>;
+
+export async function getEnvironments({
+  serviceName,
+  setup
+}: {
+  serviceName: string;
+  setup: Setup;
+}) {
+  const [allEnvironments, unavailableEnvironments] = await Promise.all([
+    getAllEnvionments({ serviceName, setup }),
+    getUnavailableEnvionments({ serviceName, setup })
+  ]);
+
+  return allEnvironments.map(environment => {
+    return {
+      name: environment,
+      available: !unavailableEnvironments.includes(environment)
+    };
+  });
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/get_service_names.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/get_service_names.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { BucketAgg } from 'elasticsearch';
+import { idx } from '@kbn/elastic-idx/target';
+import { Setup } from '../../helpers/setup_request';
+import { PromiseReturnType } from '../../../../typings/common';
+import {
+  PROCESSOR_EVENT,
+  SERVICE_NAME
+} from '../../../../common/elasticsearch_fieldnames';
+
+export type CMServicesAPIResponse = PromiseReturnType<typeof getServiceNames>;
+export async function getServiceNames({ setup }: { setup: Setup }) {
+  const { client, config } = setup;
+
+  const params = {
+    index: [
+      config.get<string>('apm_oss.metricsIndices'),
+      config.get<string>('apm_oss.errorIndices'),
+      config.get<string>('apm_oss.transactionIndices')
+    ],
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            { terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] } }
+          ]
+        }
+      },
+      aggs: {
+        services: {
+          terms: {
+            field: SERVICE_NAME,
+            size: 100
+          }
+        }
+      }
+    }
+  };
+
+  interface Aggs extends BucketAgg {
+    services: {
+      buckets: BucketAgg[];
+    };
+  }
+
+  const resp = await client<void, Aggs>('search', params);
+  const aggs = resp.aggregations;
+  const buckets = idx(aggs, _ => _.services.buckets) || [];
+  return buckets.map(bucket => bucket.key);
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/list_configurations.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/list_configurations.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { PromiseReturnType } from '../../../../typings/common';
+import { Setup } from '../../helpers/setup_request';
+import { CentralConfiguration } from './configuration';
+
+export type CMListAPIResponse = PromiseReturnType<typeof listConfigurations>;
+export async function listConfigurations({ setup }: { setup: Setup }) {
+  const { client, config } = setup;
+
+  const params = {
+    index: config.get<string>('apm_oss.cmIndex')
+  };
+
+  const resp = await client<CentralConfiguration>('search', params);
+  return resp.hits.hits.map(item => item._source);
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/list_configurations.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/list_configurations.ts
@@ -17,5 +17,8 @@ export async function listConfigurations({ setup }: { setup: Setup }) {
   };
 
   const resp = await client<CentralConfiguration>('search', params);
-  return resp.hits.hits.map(item => item._source);
+  return resp.hits.hits.map(item => ({
+    id: item._id,
+    ...item._source
+  }));
 }

--- a/x-pack/plugins/apm/server/lib/settings/cm/save_configuration.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/save_configuration.ts
@@ -21,6 +21,7 @@ export async function saveConfiguration({
   const { client, config } = setup;
 
   const params = {
+    refresh: true,
     index: config.get<string>('apm_oss.cmIndex'),
     body: {
       timestamp: {

--- a/x-pack/plugins/apm/server/lib/settings/cm/save_configuration.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/save_configuration.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { Setup } from '../../helpers/setup_request';
+import { PromiseReturnType } from '../../../../typings/common';
+import { CentralConfigurationIntake } from './configuration';
+
+export type CMSaveConfigurationAPIResponse = PromiseReturnType<
+  typeof saveConfiguration
+>;
+export async function saveConfiguration({
+  configuration,
+  setup
+}: {
+  configuration: CentralConfigurationIntake;
+  setup: Setup;
+}) {
+  const { client, config } = setup;
+
+  const params = {
+    index: config.get<string>('apm_oss.cmIndex'),
+    body: {
+      timestamp: {
+        us: Date.now() * 1000
+      },
+      ...configuration
+    }
+  };
+
+  return client('index', params);
+}

--- a/x-pack/plugins/apm/server/lib/settings/cm/search.ts
+++ b/x-pack/plugins/apm/server/lib/settings/cm/search.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ESFilter } from 'elasticsearch';
+import { PromiseReturnType } from '../../../../typings/common';
+import {
+  SERVICE_NAME,
+  SERVICE_ENVIRONMENT
+} from '../../../../common/elasticsearch_fieldnames';
+import { Setup } from '../../helpers/setup_request';
+import { CentralConfiguration } from './configuration';
+
+export type CMSearchAPIResponse = PromiseReturnType<
+  typeof searchConfigurations
+>;
+export async function searchConfigurations({
+  serviceName,
+  environment,
+  setup
+}: {
+  serviceName: string;
+  environment?: string;
+  setup: Setup;
+}) {
+  const { client, config } = setup;
+
+  const filters: ESFilter[] = [{ term: { [SERVICE_NAME]: serviceName } }];
+
+  if (environment) {
+    filters.push({ term: { [SERVICE_ENVIRONMENT]: environment } });
+  } else {
+    filters.push({
+      bool: { must_not: { exists: { field: SERVICE_ENVIRONMENT } } }
+    });
+  }
+
+  const params = {
+    index: config.get<string>('apm_oss.cmIndex'),
+    body: {
+      size: 1,
+      query: {
+        bool: { filter: filters }
+      }
+    }
+  };
+
+  const resp = await client<CentralConfiguration>('search', params);
+  return resp.hits.hits[0];
+}

--- a/x-pack/plugins/apm/server/new-platform/plugin.ts
+++ b/x-pack/plugins/apm/server/new-platform/plugin.ts
@@ -14,15 +14,17 @@ import { initServicesApi } from '../routes/services';
 import { initTracesApi } from '../routes/traces';
 import { initTransactionGroupsApi } from '../routes/transaction_groups';
 import { initUIFiltersApi } from '../routes/ui_filters';
+import { initSettingsApi } from '../routes/settings';
 
 export class Plugin {
   public setup(core: InternalCoreSetup) {
-    initUIFiltersApi(core);
-    initTransactionGroupsApi(core);
-    initTracesApi(core);
-    initServicesApi(core);
     initErrorsApi(core);
     initMetricsApi(core);
+    initServicesApi(core);
+    initSettingsApi(core);
+    initTracesApi(core);
+    initTransactionGroupsApi(core);
+    initUIFiltersApi(core);
     makeApmUsageCollector(core as CoreSetupWithUsageCollector);
     ensureIndexPatternExists(core);
   }

--- a/x-pack/plugins/apm/server/routes/settings.ts
+++ b/x-pack/plugins/apm/server/routes/settings.ts
@@ -14,6 +14,7 @@ import { CentralConfigurationIntake } from '../lib/settings/cm/configuration';
 import { searchConfigurations } from '../lib/settings/cm/search';
 import { listConfigurations } from '../lib/settings/cm/list_configurations';
 import { getEnvironments } from '../lib/settings/cm/get_environments';
+import { deleteConfiguration } from '../lib/settings/cm/delete_configuration';
 
 const defaultErrorHandler = (err: Error) => {
   // eslint-disable-next-line
@@ -39,6 +40,28 @@ export function initSettingsApi(core: CoreSetup) {
     handler: async req => {
       const setup = setupRequest(req);
       return await listConfigurations({
+        setup
+      }).catch(defaultErrorHandler);
+    }
+  });
+
+  // delete configuration
+  server.route({
+    method: 'DELETE',
+    path: `/api/apm/settings/cm/{configurationId}`,
+    options: {
+      validate: {
+        query: {
+          _debug: Joi.bool()
+        }
+      },
+      tags: ['access:apm']
+    },
+    handler: async req => {
+      const setup = setupRequest(req);
+      const { configurationId } = req.params;
+      return await deleteConfiguration({
+        configurationId,
         setup
       }).catch(defaultErrorHandler);
     }

--- a/x-pack/plugins/apm/server/routes/settings.ts
+++ b/x-pack/plugins/apm/server/routes/settings.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import Boom from 'boom';
+import { CoreSetup } from 'src/core/server';
+import Joi from 'joi';
+import { setupRequest } from '../lib/helpers/setup_request';
+import { getServiceNames } from '../lib/settings/cm/get_service_names';
+import { saveConfiguration } from '../lib/settings/cm/save_configuration';
+import { CentralConfigurationIntake } from '../lib/settings/cm/configuration';
+import { searchConfigurations } from '../lib/settings/cm/search';
+import { listConfigurations } from '../lib/settings/cm/list_configurations';
+import { getEnvironments } from '../lib/settings/cm/get_environments';
+
+const defaultErrorHandler = (err: Error) => {
+  // eslint-disable-next-line
+  console.error(err.stack);
+  throw Boom.boomify(err, { statusCode: 400 });
+};
+
+export function initSettingsApi(core: CoreSetup) {
+  const { server } = core.http;
+
+  // get list of configurations
+  server.route({
+    method: 'GET',
+    path: `/api/apm/settings/cm`,
+    options: {
+      validate: {
+        query: {
+          _debug: Joi.bool()
+        }
+      },
+      tags: ['access:apm']
+    },
+    handler: async req => {
+      const setup = setupRequest(req);
+      return await listConfigurations({
+        setup
+      }).catch(defaultErrorHandler);
+    }
+  });
+
+  // get list of services
+  server.route({
+    method: 'GET',
+    path: `/api/apm/settings/cm/services`,
+    options: {
+      validate: {
+        query: {
+          _debug: Joi.bool()
+        }
+      },
+      tags: ['access:apm']
+    },
+    handler: async req => {
+      const setup = setupRequest(req);
+      return await getServiceNames({
+        setup
+      }).catch(defaultErrorHandler);
+    }
+  });
+
+  // get environments for service
+  server.route({
+    method: 'GET',
+    path: `/api/apm/settings/cm/services/{serviceName}/environments`,
+    options: {
+      validate: {
+        query: {
+          _debug: Joi.bool()
+        }
+      },
+      tags: ['access:apm']
+    },
+    handler: async req => {
+      const setup = setupRequest(req);
+      const { serviceName } = req.params;
+      return await getEnvironments({
+        serviceName,
+        setup
+      }).catch(defaultErrorHandler);
+    }
+  });
+
+  // store configuration
+  server.route({
+    method: 'POST',
+    path: `/api/apm/settings/cm/new`,
+    options: {
+      validate: {
+        query: {
+          _debug: Joi.bool()
+        }
+      },
+      tags: ['access:apm']
+    },
+    handler: async req => {
+      const setup = setupRequest(req);
+      const configuration = req.payload as CentralConfigurationIntake;
+      return await saveConfiguration({
+        configuration,
+        setup
+      }).catch(defaultErrorHandler);
+    }
+  });
+
+  // Lookup single configuration
+  server.route({
+    method: 'POST',
+    path: `/api/apm/settings/cm/search`,
+    options: {
+      validate: {
+        query: {
+          _debug: Joi.bool()
+        }
+      },
+      tags: ['access:apm']
+    },
+    handler: async (req, h) => {
+      interface Payload {
+        service: {
+          name: string;
+          environment?: string;
+        };
+      }
+
+      const setup = setupRequest(req);
+      const payload = req.payload as Payload;
+      const serviceName = payload.service.name;
+      const environment = payload.service.environment;
+      const config = await searchConfigurations({
+        serviceName,
+        environment,
+        setup
+      });
+
+      if (!config) {
+        return h.response().code(404);
+      }
+
+      return config;
+    }
+  });
+}


### PR DESCRIPTION
TODO: 
 - [ ] Create index template for CM index
 - [ ] Update [documentation](https://www.elastic.co/guide/en/kibana/7.0/apm-settings-kb.html) with `cmIndex` settings 

Questions: 
 - Should the index template for the CM index be created by Kibana or APM Server? (**APM Server**)
 - Should the API return a list of configs or just a single? (**Single config**)
 - If no config is found, should the API return 404 (not found), 204 (empty) or 200 (success)?
 - Should it be possible to create a config, if another config already exists for the exact same combination of `service.name` and `service.environment`? (**No**)
 
Closes #34990 