### PR TITLE
[APM] Remove ML "Viewing existing jobs" from Integrations context menu

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
@@ -60,18 +60,6 @@ export class ServiceIntegrations extends React.Component<Props, State> {
           this.closePopover();
           this.openFlyout('ML');
         }
-      },
-      {
-        name: i18n.translate(
-          'xpack.apm.serviceDetails.integrationsMenu.viewMLJobsButtonLabel',
-          {
-            defaultMessage: 'View existing ML jobs'
-          }
-        ),
-        icon: 'machineLearningApp',
-        href: chrome.addBasePath('/app/ml'),
-        target: '_blank',
-        onClick: () => this.closePopover()
       }
     ];
   };

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3313,7 +3313,6 @@
     "xpack.apm.serviceDetails.integrationsMenu.enableMLAnomalyDetectionButtonTooltip": "为此服务设置 Machine Learning 作业",
     "xpack.apm.serviceDetails.integrationsMenu.enableWatcherErrorReportsButtonLabel": "启用 Watcher 错误报告",
     "xpack.apm.serviceDetails.integrationsMenu.integrationsButtonLabel": "集成",
-    "xpack.apm.serviceDetails.integrationsMenu.viewMLJobsButtonLabel": "查看现有 ML 作业",
     "xpack.apm.serviceDetails.integrationsMenu.viewWatchesButtonLabel": "查看现有监视",
     "xpack.apm.serviceDetails.metrics.cpuUsageChartTitle": "CPU 使用",
     "xpack.apm.serviceDetails.metrics.errorOccurrencesChartTitle": "错误发生次数",


### PR DESCRIPTION
Closes #28447.

Removes "View existing ML jobs" from Integrations context menu in ServiceDetails view, and removes the (only/zn-CH) translation associated with it.

It's the assumption that the link is not all that useful/used because you have a direct link to the active job by the graph on the selected service, and the link is unusable by users with basic license as they don't have access the jobs management page in ML.

## Summary

Removes "View existing ML jobs" from Integrations context menu in ServiceDetails view, and removes the (only/zn-CH) translation associated with it.

Before:

![image](https://user-images.githubusercontent.com/352732/57240877-f3f1e180-702f-11e9-96ff-d3cb1d35fc63.png)

After:
![image](https://user-images.githubusercontent.com/352732/57240834-d15fc880-702f-11e9-8aec-53cbca271a45.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

