### PR TITLE
[APM] Navigate to default transaction sample

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -116,23 +116,16 @@ export const TransactionDistribution: FunctionComponent<Props> = (
       const defaultSample =
         distribution && distribution.defaultSample
           ? distribution.defaultSample
-          : null;
+          : {};
 
       const parsedQueryParams = toQuery(search);
-
-      const nextTransaction = defaultSample
-        ? {
-            traceId: defaultSample.traceId,
-            transactionId: defaultSample.transactionId
-          }
-        : {};
 
       history.replace({
         pathname,
         hash,
         search: fromQuery({
           ...omit(parsedQueryParams, 'transactionId', 'traceId'),
-          ...nextTransaction
+          ...defaultSample
         })
       });
     },

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -7,7 +7,6 @@
 import { EuiIconTip, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import d3 from 'd3';
-import { Location } from 'history';
 import React, { FunctionComponent, useEffect, useCallback } from 'react';
 import { omit } from 'lodash';
 import { ITransactionDistributionAPIResponse } from '../../../../../server/lib/transactions/distribution';
@@ -89,7 +88,6 @@ const getFormatYLong = (transactionType: string | undefined) => (t: number) => {
 };
 
 interface Props {
-  location: Location;
   distribution?: ITransactionDistributionAPIResponse;
   urlParams: IUrlParams;
 }
@@ -98,7 +96,6 @@ export const TransactionDistribution: FunctionComponent<Props> = (
   props: Props
 ) => {
   const {
-    location: { pathname, search, hash },
     distribution,
     urlParams: { transactionId, traceId, transactionType }
   } = props;
@@ -118,18 +115,17 @@ export const TransactionDistribution: FunctionComponent<Props> = (
           ? distribution.defaultSample
           : {};
 
-      const parsedQueryParams = toQuery(search);
+      const parsedQueryParams = toQuery(history.location.search);
 
       history.replace({
-        pathname,
-        hash,
+        ...history.location,
         search: fromQuery({
           ...omit(parsedQueryParams, 'transactionId', 'traceId'),
           ...defaultSample
         })
       });
     },
-    [distribution, pathname, hash, search]
+    [distribution]
   );
 
   useEffect(
@@ -214,10 +210,9 @@ export const TransactionDistribution: FunctionComponent<Props> = (
         onClick={(bucket: IChartPoint) => {
           if (bucket.sample && bucket.y > 0) {
             history.push({
-              pathname,
-              hash,
+              ...history.location,
               search: fromQuery({
-                ...toQuery(search),
+                ...toQuery(history.location.search),
                 transactionId: bucket.sample.transactionId,
                 traceId: bucket.sample.traceId
               })

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -8,7 +8,8 @@ import { EuiIconTip, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import d3 from 'd3';
 import { Location } from 'history';
-import React, { Component } from 'react';
+import React, { FunctionComponent, useEffect, useCallback } from 'react';
+import { omit } from 'lodash';
 import { ITransactionDistributionAPIResponse } from '../../../../../server/lib/transactions/distribution';
 import { IBucket } from '../../../../../server/lib/transactions/distribution/get_buckets/transform';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
@@ -47,191 +48,212 @@ export function getFormattedBuckets(buckets: IBucket[], bucketSize: number) {
   );
 }
 
+const getFormatYShort = (transactionType: string | undefined) => (
+  t: number
+) => {
+  return i18n.translate(
+    'xpack.apm.transactionDetails.transactionsDurationDistributionChart.unitShortLabel',
+    {
+      defaultMessage:
+        '{transCount} {transType, select, request {req.} other {trans.}}',
+      values: {
+        transCount: t,
+        transType: transactionType
+      }
+    }
+  );
+};
+
+const getFormatYLong = (transactionType: string | undefined) => (t: number) => {
+  return transactionType === 'request'
+    ? i18n.translate(
+        'xpack.apm.transactionDetails.transactionsDurationDistributionChart.requestTypeUnitLongLabel',
+        {
+          defaultMessage:
+            '{transCount, plural, =0 {# request} one {# request} other {# requests}}',
+          values: {
+            transCount: t
+          }
+        }
+      )
+    : i18n.translate(
+        'xpack.apm.transactionDetails.transactionsDurationDistributionChart.transactionTypeUnitLongLabel',
+        {
+          defaultMessage:
+            '{transCount, plural, =0 {# transaction} one {# transaction} other {# transactions}}',
+          values: {
+            transCount: t
+          }
+        }
+      );
+};
+
 interface Props {
   location: Location;
   distribution?: ITransactionDistributionAPIResponse;
   urlParams: IUrlParams;
 }
 
-export class TransactionDistribution extends Component<Props> {
-  public formatYShort = (t: number) => {
-    return i18n.translate(
-      'xpack.apm.transactionDetails.transactionsDurationDistributionChart.unitShortLabel',
-      {
-        defaultMessage:
-          '{transCount} {transType, select, request {req.} other {trans.}}',
-        values: {
-          transCount: t,
-          transType: this.props.urlParams.transactionType
-        }
+export const TransactionDistribution: FunctionComponent<Props> = (
+  props: Props
+) => {
+  const {
+    location: { pathname, search, hash },
+    distribution,
+    urlParams: { transactionId, traceId, transactionType }
+  } = props;
+
+  const formatYShort = useCallback(getFormatYShort(transactionType), [
+    transactionType
+  ]);
+
+  const formatYLong = useCallback(getFormatYLong(transactionType), [
+    transactionType
+  ]);
+
+  const redirectToDefaultSample = useCallback(
+    () => {
+      const defaultSample =
+        distribution && distribution.defaultSample
+          ? distribution.defaultSample
+          : null;
+
+      const parsedQueryParams = toQuery(search);
+
+      const nextTransaction = defaultSample
+        ? {
+            traceId: defaultSample.traceId,
+            transactionId: defaultSample.transactionId
+          }
+        : {};
+
+      history.replace({
+        pathname,
+        hash,
+        search: fromQuery({
+          ...omit(parsedQueryParams, 'transactionId', 'traceId'),
+          ...nextTransaction
+        })
+      });
+    },
+    [distribution, pathname, hash, search]
+  );
+
+  useEffect(
+    () => {
+      const selectedSampleIsAvailable = distribution
+        ? !!distribution.buckets.find(
+            bucket =>
+              !!(
+                bucket.sample &&
+                bucket.sample.transactionId === transactionId &&
+                bucket.sample.traceId === traceId
+              )
+          )
+        : false;
+
+      if (!selectedSampleIsAvailable && !!distribution) {
+        redirectToDefaultSample();
       }
-    );
-  };
+    },
+    [distribution, transactionId, traceId, redirectToDefaultSample]
+  );
 
-  public formatYLong = (t: number) => {
-    return this.props.urlParams.transactionType === 'request'
-      ? i18n.translate(
-          'xpack.apm.transactionDetails.transactionsDurationDistributionChart.requestTypeUnitLongLabel',
-          {
-            defaultMessage:
-              '{transCount, plural, =0 {# request} one {# request} other {# requests}}',
-            values: {
-              transCount: t
-            }
-          }
-        )
-      : i18n.translate(
-          'xpack.apm.transactionDetails.transactionsDurationDistributionChart.transactionTypeUnitLongLabel',
-          {
-            defaultMessage:
-              '{transCount, plural, =0 {# transaction} one {# transaction} other {# transactions}}',
-            values: {
-              transCount: t
-            }
-          }
-        );
-  };
-
-  public redirectToTransactionType() {
-    const { urlParams, location, distribution } = this.props;
-
-    if (
-      !distribution ||
-      !distribution.defaultSample ||
-      urlParams.traceId ||
-      urlParams.transactionId
-    ) {
-      return;
-    }
-
-    const { traceId, transactionId } = distribution.defaultSample;
-
-    history.replace({
-      ...location,
-      search: fromQuery({
-        ...toQuery(location.search),
-        traceId,
-        transactionId
-      })
-    });
-  }
-
-  public componentDidMount() {
-    this.redirectToTransactionType();
-  }
-
-  public componentDidUpdate() {
-    this.redirectToTransactionType();
-  }
-
-  public render() {
-    const { location, distribution, urlParams } = this.props;
-
-    if (!distribution || !urlParams.traceId || !urlParams.transactionId) {
-      return null;
-    }
-
-    const buckets = getFormattedBuckets(
-      distribution.buckets,
-      distribution.bucketSize
-    );
-
-    const isEmpty = distribution.totalHits === 0;
-    const xMax = d3.max(buckets, d => d.x) || 0;
-    const timeFormatter = getTimeFormatter(xMax);
-    const unit = timeUnit(xMax);
-
-    if (isEmpty) {
-      return (
-        <EmptyMessage
-          heading={i18n.translate(
-            'xpack.apm.transactionDetails.notFoundLabel',
-            {
-              defaultMessage: 'No transactions were found.'
-            }
-          )}
-        />
-      );
-    }
-
-    const bucketIndex = buckets.findIndex(
-      bucket =>
-        bucket.sample != null &&
-        bucket.sample.transactionId === urlParams.transactionId &&
-        bucket.sample.traceId === urlParams.traceId
-    );
-
+  if (!distribution || !distribution.totalHits || !traceId || !transactionId) {
     return (
-      <div>
-        <EuiTitle size="xs">
-          <h5>
-            {i18n.translate(
-              'xpack.apm.transactionDetails.transactionsDurationDistributionChartTitle',
-              {
-                defaultMessage: 'Transactions duration distribution'
-              }
-            )}{' '}
-            <EuiIconTip
-              title={i18n.translate(
-                'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingLabel',
-                {
-                  defaultMessage: 'Sampling'
-                }
-              )}
-              content={i18n.translate(
-                'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingDescription',
-                {
-                  defaultMessage:
-                    "Each bucket will show a sample transaction. If there's no sample available, it's most likely because of the sampling limit set in the agent configuration."
-                }
-              )}
-              position="top"
-            />
-          </h5>
-        </EuiTitle>
-
-        <Histogram
-          buckets={buckets}
-          bucketSize={distribution.bucketSize}
-          bucketIndex={bucketIndex}
-          onClick={(bucket: IChartPoint) => {
-            if (bucket.sample && bucket.y > 0) {
-              history.push({
-                ...location,
-                search: fromQuery({
-                  ...toQuery(location.search),
-                  transactionId: bucket.sample.transactionId,
-                  traceId: bucket.sample.traceId
-                })
-              });
-            }
-          }}
-          formatX={timeFormatter}
-          formatYShort={this.formatYShort}
-          formatYLong={this.formatYLong}
-          verticalLineHover={(bucket: IChartPoint) =>
-            bucket.y > 0 && !bucket.sample
-          }
-          backgroundHover={(bucket: IChartPoint) =>
-            bucket.y > 0 && bucket.sample
-          }
-          tooltipHeader={(bucket: IChartPoint) =>
-            `${timeFormatter(bucket.x0, { withUnit: false })} - ${timeFormatter(
-              bucket.x,
-              { withUnit: false }
-            )} ${unit}`
-          }
-          tooltipFooter={(bucket: IChartPoint) =>
-            !bucket.sample &&
-            i18n.translate(
-              'xpack.apm.transactionDetails.transactionsDurationDistributionChart.noSampleTooltip',
-              {
-                defaultMessage: 'No sample available for this bucket'
-              }
-            )
-          }
-        />
-      </div>
+      <EmptyMessage
+        heading={i18n.translate('xpack.apm.transactionDetails.notFoundLabel', {
+          defaultMessage: 'No transactions were found.'
+        })}
+      />
     );
   }
-}
+
+  const buckets = getFormattedBuckets(
+    distribution.buckets,
+    distribution.bucketSize
+  );
+
+  const xMax = d3.max(buckets, d => d.x) || 0;
+  const timeFormatter = getTimeFormatter(xMax);
+  const unit = timeUnit(xMax);
+
+  const bucketIndex = buckets.findIndex(
+    bucket =>
+      bucket.sample != null &&
+      bucket.sample.transactionId === transactionId &&
+      bucket.sample.traceId === traceId
+  );
+
+  return (
+    <div>
+      <EuiTitle size="xs">
+        <h5>
+          {i18n.translate(
+            'xpack.apm.transactionDetails.transactionsDurationDistributionChartTitle',
+            {
+              defaultMessage: 'Transactions duration distribution'
+            }
+          )}{' '}
+          <EuiIconTip
+            title={i18n.translate(
+              'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingLabel',
+              {
+                defaultMessage: 'Sampling'
+              }
+            )}
+            content={i18n.translate(
+              'xpack.apm.transactionDetails.transactionsDurationDistributionChartTooltip.samplingDescription',
+              {
+                defaultMessage:
+                  "Each bucket will show a sample transaction. If there's no sample available, it's most likely because of the sampling limit set in the agent configuration."
+              }
+            )}
+            position="top"
+          />
+        </h5>
+      </EuiTitle>
+
+      <Histogram
+        buckets={buckets}
+        bucketSize={distribution.bucketSize}
+        bucketIndex={bucketIndex}
+        onClick={(bucket: IChartPoint) => {
+          if (bucket.sample && bucket.y > 0) {
+            history.push({
+              pathname,
+              hash,
+              search: fromQuery({
+                ...toQuery(search),
+                transactionId: bucket.sample.transactionId,
+                traceId: bucket.sample.traceId
+              })
+            });
+          }
+        }}
+        formatX={timeFormatter}
+        formatYShort={formatYShort}
+        formatYLong={formatYLong}
+        verticalLineHover={(bucket: IChartPoint) =>
+          bucket.y > 0 && !bucket.sample
+        }
+        backgroundHover={(bucket: IChartPoint) => bucket.y > 0 && bucket.sample}
+        tooltipHeader={(bucket: IChartPoint) =>
+          `${timeFormatter(bucket.x0, { withUnit: false })} - ${timeFormatter(
+            bucket.x,
+            { withUnit: false }
+          )} ${unit}`
+        }
+        tooltipFooter={(bucket: IChartPoint) =>
+          !bucket.sample &&
+          i18n.translate(
+            'xpack.apm.transactionDetails.transactionsDurationDistributionChart.noSampleTooltip',
+            {
+              defaultMessage: 'No sample available for this bucket'
+            }
+          )
+        }
+      />
+    </div>
+  );
+};

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
@@ -50,7 +50,6 @@ export function TransactionDetails() {
         <TransactionDistribution
           distribution={distributionData}
           urlParams={urlParams}
-          location={location}
         />
       </EuiPanel>
 

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
@@ -5,14 +5,12 @@
  */
 
 import { EuiPanel, EuiSpacer, EuiTitle, EuiHorizontalRule } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
 import _ from 'lodash';
 import React from 'react';
 import { useTransactionDetailsCharts } from '../../../hooks/useTransactionDetailsCharts';
 import { useTransactionDistribution } from '../../../hooks/useTransactionDistribution';
 import { useWaterfall } from '../../../hooks/useWaterfall';
 import { TransactionCharts } from '../../shared/charts/TransactionCharts';
-import { EmptyMessage } from '../../shared/EmptyMessage';
 import { ApmHeader } from '../../shared/ApmHeader';
 import { TransactionDistribution } from './Distribution';
 import { Transaction } from './Transaction';
@@ -58,23 +56,7 @@ export function TransactionDetails() {
 
       <EuiSpacer size="s" />
 
-      {!transaction ? (
-        <EmptyMessage
-          heading={i18n.translate(
-            'xpack.apm.transactionDetails.noTransactionTitle',
-            {
-              defaultMessage: 'No transaction sample available.'
-            }
-          )}
-          subheading={i18n.translate(
-            'xpack.apm.transactionDetails.noTransactionDescription',
-            {
-              defaultMessage:
-                'Try another time range, reset the search filter or select another bucket from the distribution histogram.'
-            }
-          )}
-        />
-      ) : (
+      {transaction && (
         <Transaction
           location={location}
           transaction={transaction}

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -3837,8 +3837,6 @@
     "xpack.apm.transactionDetails.errorsOverviewLinkTooltip": "{errorCount, plural, one {1 件の関連エラーを表示} other {# 件の関連エラーを表示}}",
     "xpack.apm.transactionDetails.notFoundLabel": "トランザクションが見つかりませんでした。",
     "xpack.apm.transactionDetails.noTraceParentButtonTooltip": "トレースの親が見つかりませんでした",
-    "xpack.apm.transactionDetails.noTransactionDescription": "別の時間範囲を試すか、検索フィルターをリセットするか、分布ヒストグラムから別のバケットを選択してみてください。",
-    "xpack.apm.transactionDetails.noTransactionTitle": "利用可能なトランザクションサンプルがありません。",
     "xpack.apm.transactionDetails.percentOfTraceLabel": "トレースの %",
     "xpack.apm.transactionDetails.resultLabel": "結果",
     "xpack.apm.transactionDetails.serviceLabel": "サービス",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3332,8 +3332,6 @@
     "xpack.apm.transactionDetails.durationLabel": "持续时间",
     "xpack.apm.transactionDetails.notFoundLabel": "未找到任何事务。",
     "xpack.apm.transactionDetails.noTraceParentButtonTooltip": "找不到上级追溯",
-    "xpack.apm.transactionDetails.noTransactionDescription": "尝试其他时间范围，重置搜索筛选或从分布直方图中选择其他存储桶。",
-    "xpack.apm.transactionDetails.noTransactionTitle": "没有可用的事务样例。",
     "xpack.apm.transactionDetails.percentOfTraceLabel": "追溯的 %",
     "xpack.apm.transactionDetails.resultLabel": "结果",
     "xpack.apm.transactionDetails.serviceLabel": "服务",


### PR DESCRIPTION
Closes #33695, #33545.

If the distribution data changes, and the currently selected transaction sample is no longer available, we navigate to the default sample of the latest distribution data.

Previously, a displayed sample would "stick" if the new distribution data did not have a default sample.

## Summary

- Moves TransactionDetails/Distribution from a class component w/ lifecycle methods to a functional component w/ hooks. The assumption is that hooks are better at describing when things should change than lifecycle methods (my 2$: code is a little more complicated, but more robust as well).
- Basic idea here: on any distribution data change, check if the selected transaction sample is available in the data, if not, either: A) clear the sample when the new data has no default sample, B) select the default sample from the new data.
- In TransactionDetails, we're now stuck with two empty messages if for the given filters, there is no data. This PR removes the empty message from the Transaction sample component if there is no transaction, so only one message is displayed.

I'm looking for feedback on:

- Is this usage of hooks correct and in line with how we like to move forward? Especially the stuff around memoizing callbacks to be able to pass them as dependencies, and using ref for location (without it, we run into an infinite loop), seems complicated. Can we make it more straightforward without losing the robustness?
- Perhaps it's better to lift the redirect logic into TransactionDetails? I'm not sure why it's in Distribution, feels too deep, and perhaps things (like the stacked empty messages) are handled in a better way if that logic (and deciding what "empty" means) is in TransactionDetails.
- Any suggestions on what tests would need to be added?

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

