### PR TITLE
[APM] Updated placeholder copy in Kuery bar

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/KueryBar/Typeahead/index.js
+++ b/x-pack/plugins/apm/public/components/shared/KueryBar/Typeahead/index.js
@@ -174,7 +174,7 @@ export class Typeahead extends Component {
                   'Search transactions and errors… (E.g. {queryExample})',
                 values: {
                   queryExample:
-                    'transaction.duration.us > 300000 AND context.response.status_code >= 400'
+                    'transaction.duration.us > 300000 AND http.response.status_code >= 400'
                 }
               }
             )}


### PR DESCRIPTION
## Summary

Updates the placeholder copy in the Kuery bar. Since we switched to ECS, the status code field has switched from `context.http.response.status_code` to `http.response.status_code`.

<img width="1018" alt="Screenshot 2019-05-08 at 09 27 38" src="https://user-images.githubusercontent.com/4104278/57357865-42a89400-7174-11e9-8c19-081ff2a611d0.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

