### PR TITLE
[APM] Layout – Condense panel gutters and spacers

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
@@ -186,7 +186,7 @@ export function ErrorGroupDetails() {
           )}
         />
       </EuiPanel>
-      <EuiSpacer />
+      <EuiSpacer size="s" />
       {showDetails && (
         <DetailView
           errorGroup={errorGroupData}

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/index.tsx
@@ -92,7 +92,7 @@ const ErrorGroupOverview: React.SFC<ErrorGroupOverviewProps> = ({
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="s" />
 
       <EuiPanel>
         <EuiTitle size="xs">

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceMetrics.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceMetrics.tsx
@@ -22,7 +22,7 @@ export function ServiceMetrics({ urlParams, agentName }: ServiceMetricsProps) {
     <React.Fragment>
       <SyncChartGroup
         render={hoverXHandlers => (
-          <EuiFlexGrid columns={2}>
+          <EuiFlexGrid columns={2} gutterSize="s">
             {data.charts.map(chart => (
               <EuiFlexItem key={chart.key}>
                 <EuiPanel>

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
@@ -109,7 +109,7 @@ export const Transaction: React.SFC<Props> = ({
     <EuiPanel paddingSize="m">
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem>
-          <EuiTitle size="s">
+          <EuiTitle size="xs">
             <h5>
               {i18n.translate(
                 'xpack.apm.transactionDetails.transactionSampleTitle',
@@ -133,8 +133,6 @@ export const Transaction: React.SFC<Props> = ({
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
-
-      <EuiSpacer />
 
       <StickyTransactionProperties
         errorCount={

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiPanel, EuiSpacer, EuiTitle, EuiHorizontalRule } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import _ from 'lodash';
 import React from 'react';
@@ -46,7 +46,7 @@ export function TransactionDetails() {
         location={location}
       />
 
-      <EuiSpacer />
+      <EuiHorizontalRule size="full" margin="l" />
 
       <EuiPanel>
         <TransactionDistribution
@@ -56,7 +56,7 @@ export function TransactionDetails() {
         />
       </EuiPanel>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="s" />
 
       {!transaction ? (
         <EmptyMessage

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -120,7 +120,7 @@ export function TransactionOverview({
         urlParams={urlParams}
       />
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size="s" />
 
       <EuiPanel>
         <EuiTitle size="xs">

--- a/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
@@ -139,7 +139,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
     return (
       <SyncChartGroup
         render={hoverXHandlers => (
-          <EuiFlexGrid columns={2}>
+          <EuiFlexGrid columns={2} gutterSize="s">
             <EuiFlexItem>
               <EuiPanel>
                 <React.Fragment>


### PR DESCRIPTION
## Summary

We're adding more and more elements to each layout views, and this PR is decreasing the gutter size of panels and spacers between components. The outcome is a slightly more condensed layout for all views  (except Services and Traces views that only consists of a single panel). This helps having more space for the charts and content when we implement the left sidebar for filters (https://github.com/elastic/kibana/issues/34922).

### Examples

What's changing? This is just redlining the changed areas of each layout.

<img width="1818" alt="Screenshot 2019-05-09 at 10 42 34" src="https://user-images.githubusercontent.com/4104278/57440285-06defe80-7248-11e9-94f3-af9edfb3ed45.png">

#### Transaction overview

<img width="1818" alt="Screenshot 2019-05-09 at 10 42 34" src="https://user-images.githubusercontent.com/4104278/57440140-be274580-7247-11e9-86d5-883ab167d707.png">

#### Transaction detail

For the Transaction detail page, we're adding a horizontal rule to split the group charts and the transaction distribution and sample view. This is intended to show separation between the two, that one is an overview (charts) and the other an interactive element.

<img width="1818" alt="Screenshot 2019-05-09 at 10 42 45" src="https://user-images.githubusercontent.com/4104278/57440152-c41d2680-7247-11e9-8ad0-75dcc186b1a0.png">

#### Errors overview

<img width="1818" alt="Screenshot 2019-05-09 at 10 42 58" src="https://user-images.githubusercontent.com/4104278/57440162-c7b0ad80-7247-11e9-85bb-7496eac193d6.png">

#### Errors detail

<img width="1818" alt="Screenshot 2019-05-09 at 10 43 02" src="https://user-images.githubusercontent.com/4104278/57440169-caab9e00-7247-11e9-911a-5f0cfef74530.png">

#### Metrics

<img width="1818" alt="Screenshot 2019-05-09 at 10 43 17" src="https://user-images.githubusercontent.com/4104278/57440197-d72ff680-7247-11e9-876b-18bf6b59b98a.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

