### PR TITLE
[APM] Add Uptime link to Transaction action menu

### DIFF
--- a/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
+++ b/x-pack/plugins/apm/common/elasticsearch_fieldnames.test.ts
@@ -24,7 +24,7 @@ describe('Transaction', () => {
       request: { method: 'GET' },
       response: { status_code: 200 }
     },
-    url: { full: 'http://www.elastic.co' },
+    url: { full: 'http://www.elastic.co', domain: 'www.elastic.co' },
     service: {
       name: 'service name',
       language: { name: 'nodejs', version: 'v1337' }

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -152,22 +152,19 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
     condition
   }));
 
-  const uptimeLink =
-    transaction && transaction.url
-      ? url.format({
-          pathname: chrome.addBasePath('/app/uptime'),
-          hash: `/?${fromQuery(
-            pick(
-              {
-                dateRangeStart: urlParams.rangeFrom,
-                dateRangeEnd: urlParams.rangeTo,
-                search: `url.domain:${transaction.url.domain}`
-              },
-              (val: string) => !!val
-            )
-          )}`
-        })
-      : null;
+  const uptimeLink = url.format({
+    pathname: chrome.addBasePath('/app/uptime'),
+    hash: `/?${fromQuery(
+      pick(
+        {
+          dateRangeStart: urlParams.rangeFrom,
+          dateRangeEnd: urlParams.rangeTo,
+          search: `url.domain:${idx(transaction, t => t.url.domain)}`
+        },
+        (val: string) => !!val
+      )
+    )}`
+  });
 
   const menuItems = [
     ...infraItems,
@@ -195,7 +192,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
           })}
         </EuiLink>
       ),
-      condition: uptimeLink
+      condition: transaction && transaction.url
     }
   ]
     .filter(({ condition }) => condition)

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -160,19 +160,22 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       : null
   );
 
-  const uptimeLink = url.format({
-    pathname: chrome.addBasePath('/app/uptime'),
-    hash: `/?${fromQuery(
-      pick(
-        {
-          dateRangeStart: urlParams.rangeFrom,
-          dateRangeEnd: urlParams.rangeTo,
-          search: urlParams.kuery
-        },
-        (val: string) => !!val
-      )
-    )}`
-  });
+  const uptimeLink =
+    transaction && transaction.url
+      ? url.format({
+          pathname: chrome.addBasePath('/app/uptime'),
+          hash: `/?${fromQuery(
+            pick(
+              {
+                dateRangeStart: urlParams.rangeFrom,
+                dateRangeEnd: urlParams.rangeTo,
+                search: `url.domain:${transaction.url.domain}`
+              },
+              (val: string) => !!val
+            )
+          )}`
+        })
+      : null;
 
   const menuItems = removeEmptyItems([
     ...infraItems,
@@ -190,17 +193,19 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
         </DiscoverTransactionLink>
       )
     },
-    {
-      icon: 'uptimeApp',
-      key: 'uptime',
-      child: (
-        <EuiLink href={uptimeLink}>
-          {i18n.translate('xpack.apm.transactionActionMenu.viewInUptime', {
-            defaultMessage: 'View in Uptime'
-          })}
-        </EuiLink>
-      )
-    }
+    uptimeLink
+      ? {
+          icon: 'uptimeApp',
+          key: 'uptime',
+          child: (
+            <EuiLink href={uptimeLink}>
+              {i18n.translate('xpack.apm.transactionActionMenu.viewInUptime', {
+                defaultMessage: 'View monitor status'
+              })}
+            </EuiLink>
+          )
+        }
+      : null
   ]).map(({ icon, key, child }) => (
     <EuiContextMenuItem icon={icon} key={key}>
       <EuiFlexGroup gutterSize="s">

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -11,14 +11,20 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiPopover
+  EuiPopover,
+  EuiLink
 } from '@elastic/eui';
+import chrome from 'ui/chrome';
+import url from 'url';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { useState, FunctionComponent } from 'react';
 import { idx } from '@kbn/elastic-idx';
+import { pick } from 'lodash';
 import { Transaction } from '../../../../typings/es_schemas/ui/Transaction';
 import { DiscoverTransactionLink } from '../Links/DiscoverLinks/DiscoverTransactionLink';
 import { InfraLink } from '../Links/InfraLink';
+import { useUrlParams } from '../../../hooks/useUrlParams';
+import { fromQuery } from '../Links/url_helpers';
 
 function getInfraMetricsQuery(transaction: Transaction) {
   const plus5 = new Date(transaction['@timestamp']);
@@ -43,168 +49,184 @@ function ActionMenuButton({ onClick }: { onClick: () => void }) {
   );
 }
 
+function removeEmptyItems<T extends {}>(
+  items: Array<T | null | undefined>
+): T[] {
+  return items.filter(item => !!item) as T[];
+}
+
 interface Props {
   readonly transaction: Transaction;
 }
 
-interface State {
-  readonly isOpen: boolean;
-}
+export const TransactionActionMenu: FunctionComponent<Props> = (
+  props: Props
+) => {
+  const { transaction } = props;
 
-export class TransactionActionMenu extends React.Component<Props, State> {
-  public state: State = {
-    isOpen: false
-  };
+  const [isOpen, setIsOpen] = useState(false);
 
-  public toggle = () => {
-    this.setState(state => ({ isOpen: !state.isOpen }));
-  };
+  const { urlParams } = useUrlParams();
 
-  public close = () => {
-    this.setState({ isOpen: false });
-  };
+  const hostName = idx(transaction, _ => _.host.hostname);
+  const podId = idx(transaction, _ => _.kubernetes.pod.uid);
+  const containerId = idx(transaction, _ => _.container.id);
+  const traceId = idx(transaction, _ => _.trace.id);
+  const time = new Date(transaction['@timestamp']).getTime();
+  const infraMetricsQuery = getInfraMetricsQuery(transaction);
 
-  public getInfraActions() {
-    const { transaction } = this.props;
-    const hostName = idx(transaction, _ => _.host.hostname);
-    const podId = idx(transaction, _ => _.kubernetes.pod.uid);
-    const containerId = idx(transaction, _ => _.container.id);
-    const traceId = idx(transaction, _ => _.trace.id);
-    const time = new Date(transaction['@timestamp']).getTime();
-    const infraMetricsQuery = getInfraMetricsQuery(transaction);
+  const infraItems = [
+    {
+      icon: 'loggingApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showPodLogsLinkLabel',
+        { defaultMessage: 'Show pod logs' }
+      ),
+      condition: podId,
+      path: `/link-to/pod-logs/${podId}`,
+      query: { time }
+    },
+    {
+      icon: 'loggingApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showContainerLogsLinkLabel',
+        { defaultMessage: 'Show container logs' }
+      ),
+      condition: containerId,
+      path: `/link-to/container-logs/${containerId}`,
+      query: { time }
+    },
+    {
+      icon: 'loggingApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showHostLogsLinkLabel',
+        { defaultMessage: 'Show host logs' }
+      ),
+      condition: hostName,
+      path: `/link-to/host-logs/${hostName}`,
+      query: { time }
+    },
+    {
+      icon: 'loggingApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showTraceLogsLinkLabel',
+        { defaultMessage: 'Show trace logs' }
+      ),
+      target: traceId,
+      hash: `/link-to/logs`,
+      query: { time, filter: `trace.id:${traceId}` }
+    },
+    {
+      icon: 'infraApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showPodMetricsLinkLabel',
+        { defaultMessage: 'Show pod metrics' }
+      ),
+      condition: podId,
+      path: `/link-to/pod-detail/${podId}`,
+      query: infraMetricsQuery
+    },
+    {
+      icon: 'infraApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showContainerMetricsLinkLabel',
+        { defaultMessage: 'Show container metrics' }
+      ),
+      condition: containerId,
+      path: `/link-to/container-detail/${containerId}`,
+      query: infraMetricsQuery
+    },
+    {
+      icon: 'infraApp',
+      label: i18n.translate(
+        'xpack.apm.transactionActionMenu.showHostMetricsLinkLabel',
+        { defaultMessage: 'Show host metrics' }
+      ),
+      condition: hostName,
+      path: `/link-to/host-detail/${hostName}`,
+      query: infraMetricsQuery
+    }
+  ].map(({ icon, label, condition, path, query }, index) =>
+    !!condition
+      ? {
+          icon,
+          key: `infra-link-${index}`,
+          child: (
+            <InfraLink path={path} query={query}>
+              {label}
+            </InfraLink>
+          )
+        }
+      : null
+  );
 
-    return [
-      {
-        icon: 'loggingApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showPodLogsLinkLabel',
-          { defaultMessage: 'Show pod logs' }
-        ),
-        condition: podId,
-        path: `/link-to/pod-logs/${podId}`,
-        query: { time }
-      },
-      {
-        icon: 'loggingApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showContainerLogsLinkLabel',
-          { defaultMessage: 'Show container logs' }
-        ),
-        condition: containerId,
-        path: `/link-to/container-logs/${containerId}`,
-        query: { time }
-      },
-      {
-        icon: 'loggingApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showHostLogsLinkLabel',
-          { defaultMessage: 'Show host logs' }
-        ),
-        condition: hostName,
-        path: `/link-to/host-logs/${hostName}`,
-        query: { time }
-      },
-      {
-        icon: 'loggingApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showTraceLogsLinkLabel',
-          { defaultMessage: 'Show trace logs' }
-        ),
-        target: traceId,
-        hash: `/link-to/logs`,
-        query: { time, filter: `trace.id:${traceId}` }
-      },
-      {
-        icon: 'infraApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showPodMetricsLinkLabel',
-          { defaultMessage: 'Show pod metrics' }
-        ),
-        condition: podId,
-        path: `/link-to/pod-detail/${podId}`,
-        query: infraMetricsQuery
-      },
-      {
-        icon: 'infraApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showContainerMetricsLinkLabel',
-          { defaultMessage: 'Show container metrics' }
-        ),
-        condition: containerId,
-        path: `/link-to/container-detail/${containerId}`,
-        query: infraMetricsQuery
-      },
-      {
-        icon: 'infraApp',
-        label: i18n.translate(
-          'xpack.apm.transactionActionMenu.showHostMetricsLinkLabel',
-          { defaultMessage: 'Show host metrics' }
-        ),
-        condition: hostName,
-        path: `/link-to/host-detail/${hostName}`,
-        query: infraMetricsQuery
-      }
-    ]
-      .filter(({ condition }) => Boolean(condition))
-      .map(({ icon, label, path, query }, index) => {
-        return (
-          <EuiContextMenuItem icon={icon} key={index}>
-            <EuiFlexGroup gutterSize="s">
-              <EuiFlexItem>
-                <InfraLink path={path} query={query}>
-                  {label}
-                </InfraLink>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="popout" />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiContextMenuItem>
-        );
-      });
-  }
+  const uptimeLink = url.format({
+    pathname: chrome.addBasePath('/app/uptime'),
+    hash: `/?${fromQuery(
+      pick(
+        {
+          dateRangeStart: urlParams.rangeFrom,
+          dateRangeEnd: urlParams.rangeTo,
+          search: urlParams.kuery
+        },
+        (val: string) => !!val
+      )
+    )}`
+  });
 
-  public render() {
-    const { transaction } = this.props;
-
-    const items = [
-      ...this.getInfraActions(),
-      <EuiContextMenuItem icon="discoverApp" key="discover-transaction">
-        <EuiFlexGroup gutterSize="s">
-          <EuiFlexItem>
-            <DiscoverTransactionLink transaction={transaction}>
-              {i18n.translate(
-                'xpack.apm.transactionActionMenu.viewSampleDocumentLinkLabel',
-                {
-                  defaultMessage: 'View sample document'
-                }
-              )}
-            </DiscoverTransactionLink>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiIcon type="popout" />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiContextMenuItem>
-    ];
-
-    return (
-      <EuiPopover
-        id="transactionActionMenu"
-        button={<ActionMenuButton onClick={this.toggle} />}
-        isOpen={this.state.isOpen}
-        closePopover={this.close}
-        anchorPosition="downRight"
-        panelPaddingSize="none"
-      >
-        <EuiContextMenuPanel
-          items={items}
-          title={i18n.translate(
-            'xpack.apm.transactionActionMenu.actionsLabel',
-            { defaultMessage: 'Actions' }
+  const menuItems = removeEmptyItems([
+    ...infraItems,
+    {
+      icon: 'discoverApp',
+      key: 'discover-transaction',
+      child: (
+        <DiscoverTransactionLink transaction={transaction}>
+          {i18n.translate(
+            'xpack.apm.transactionActionMenu.viewSampleDocumentLinkLabel',
+            {
+              defaultMessage: 'View sample document'
+            }
           )}
-        />
-      </EuiPopover>
-    );
-  }
-}
+        </DiscoverTransactionLink>
+      )
+    },
+    {
+      icon: 'uptimeApp',
+      key: 'uptime',
+      child: (
+        <EuiLink href={uptimeLink}>
+          {i18n.translate('xpack.apm.transactionActionMenu.viewInUptime', {
+            defaultMessage: 'View in Uptime'
+          })}
+        </EuiLink>
+      )
+    }
+  ]).map(({ icon, key, child }) => (
+    <EuiContextMenuItem icon={icon} key={key}>
+      <EuiFlexGroup gutterSize="s">
+        <EuiFlexItem>{child}</EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="popout" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiContextMenuItem>
+  ));
+
+  return (
+    <EuiPopover
+      id="transactionActionMenu"
+      button={<ActionMenuButton onClick={() => setIsOpen(!isOpen)} />}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="downRight"
+      panelPaddingSize="none"
+    >
+      <EuiContextMenuPanel
+        items={menuItems}
+        title={i18n.translate('xpack.apm.transactionActionMenu.actionsLabel', {
+          defaultMessage: 'Actions'
+        })}
+      />
+    </EuiPopover>
+  );
+};

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/Url.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/Url.ts
@@ -5,5 +5,6 @@
  */
 
 export interface Url {
+  domain: string;
   full: string;
 }


### PR DESCRIPTION
Closes #35144

Adds a link to the transaction menu to view a transaction (sample) in Uptime.

## Summary

~~Label is still WIP, have to consult w/ Uptime about what the right label is (and if the URL is correct).~~

Moves TransactionActionMenu to hooks, and makes sure there's only one branch where the element for a link gets created (instead of two like before). Small change, but will help if there are any changes to the layout.

From

![image](https://user-images.githubusercontent.com/352732/57468659-33fdd200-7285-11e9-9470-aafc52ef1a2c.png)


To 

![image](https://user-images.githubusercontent.com/352732/57468619-1d577b00-7285-11e9-9b9c-92e55e2c065b.png)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- ~~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

