### PR TITLE
[APM] Replaced the icon for the LibraryFrames toggle

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Icons.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Icons.tsx
@@ -6,17 +6,15 @@
 
 import { EuiIcon } from '@elastic/eui';
 import React from 'react';
-import { units } from '../../style/variables';
 
 export function Ellipsis({ horizontal }: { horizontal: boolean }) {
   return (
     <EuiIcon
       style={{
         transition: 'transform 0.1s',
-        transform: `rotate(${horizontal ? 90 : 0}deg)`,
-        marginRight: units.half
+        transform: `rotate(${horizontal ? 90 : 0}deg)`
       }}
-      type="boxesVertical"
+      type="arrowRight"
     />
   );
 }


### PR DESCRIPTION
## Summary

Replacing the `boxesVertical` icon for the `arrowRight` since it's more consistent with the general accordion style component.

_Existing toggle icon_

<img width="395" alt="Screenshot 2019-05-10 at 12 12 54" src="https://user-images.githubusercontent.com/4104278/57520121-30b62500-731d-11e9-85ce-7637b2a4ec50.png">

_New toggle icon_

![Kapture 2019-05-10 at 12 12 17](https://user-images.githubusercontent.com/4104278/57520132-36ac0600-731d-11e9-8d09-1043b414f601.gif) 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

