### PR TITLE
Plugin typings

### DIFF
--- a/src/legacy/plugin_discovery/types.ts
+++ b/src/legacy/plugin_discovery/types.ts
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Server } from '../server/kbn_server';
+import { Capabilities } from '../../core/public';
+
+/**
+ * Usage
+ *
+ * ```
+ * const apmOss: LegacyPlugin = (kibana) => {
+ *   return new kibana.Plugin({
+ *     id: 'apm_oss',
+ *     // ...
+ *   });
+ * };
+ * ```
+ */
+export type LegacyPlugin = (kibana: LegacyPluginApi) => ArrayOrItem<LegacyPluginSpec[]>;
+
+export type ArrayOrItem<T> = T | T[];
+
+export interface LegacyPluginApi {
+  Plugin: new (options: Partial<LegacyPluginOptions>) => LegacyPluginSpec;
+}
+
+export interface LegacyPluginOptions {
+  id: string;
+  require: string[];
+  version: string;
+  kibanaVersion: 'kibana';
+  uiExports: any;
+  uiCapabilities?: Capabilities;
+  publicDir: any;
+  configPrefix: any;
+  config: any;
+  deprecations: any;
+  preInit: any;
+  init: InitPluginFunction;
+  postInit: any;
+  isEnabled: boolean;
+}
+
+export interface UiExports {
+  injectDefaultVars: (server: Server) => { [key: string]: any };
+  styleSheetPaths?: string;
+}
+
+export type InitPluginFunction = (server: Server) => void;
+
+export interface LegacyPluginSpec {
+  getPack(): any;
+  getPkg(): any;
+  getPath(): string;
+  getId(): string;
+  getVersion(): string;
+  isEnabled(config: any): boolean;
+  getExpectedKibanaVersion(): string;
+  isVersionCompatible(actualKibanaVersion: any): boolean;
+  getRequiredPluginIds(): string[];
+  getPublicDir(): string | null;
+  getExportSpecs(): any;
+  getUiCapabilitiesProvider(): any;
+  getPreInitHandler(): any;
+  getInitHandler(): any;
+  getPostInitHandler(): any;
+  getConfigPrefix(): string;
+  getConfigSchemaProvider(): any;
+  readConfigValue(config: any, key: string): any;
+  getDeprecationsProvider(): any;
+}

--- a/src/legacy/plugin_discovery/types.ts
+++ b/src/legacy/plugin_discovery/types.ts
@@ -19,6 +19,7 @@
 
 import { Server } from '../server/kbn_server';
 import { Capabilities } from '../../core/public';
+import { SavedObjectsSchemaDefinition } from '../server/saved_objects/schema';
 
 /**
  * Usage
@@ -32,7 +33,7 @@ import { Capabilities } from '../../core/public';
  * };
  * ```
  */
-export type LegacyPlugin = (kibana: LegacyPluginApi) => ArrayOrItem<LegacyPluginSpec>;
+export type LegacyPluginInitializer = (kibana: LegacyPluginApi) => ArrayOrItem<LegacyPluginSpec>;
 
 export type ArrayOrItem<T> = T | T[];
 
@@ -45,7 +46,25 @@ export interface LegacyPluginOptions {
   require: string[];
   version: string;
   kibanaVersion: 'kibana';
-  uiExports: any;
+  uiExports: Partial<{
+    app: Partial<{
+      title: string;
+      description: string;
+      main: string;
+      icon: string;
+      euiIconType: string;
+      order: number;
+    }>;
+    apps: any;
+    hacks: string[];
+    devTools: string[];
+    styleSheetPaths: string;
+    injectDefaultVars: (server: Server) => Record<string, any>;
+    noParse: string[];
+    home: string[];
+    mappings: any;
+    savedObjectSchemas: SavedObjectsSchemaDefinition;
+  }>;
   uiCapabilities?: Capabilities;
   publicDir: any;
   configPrefix: any;
@@ -55,11 +74,6 @@ export interface LegacyPluginOptions {
   init: InitPluginFunction;
   postInit: any;
   isEnabled: boolean;
-}
-
-export interface UiExports {
-  injectDefaultVars: (server: Server) => { [key: string]: any };
-  styleSheetPaths?: string;
 }
 
 export type InitPluginFunction = (server: Server) => void;

--- a/src/legacy/plugin_discovery/types.ts
+++ b/src/legacy/plugin_discovery/types.ts
@@ -32,7 +32,7 @@ import { Capabilities } from '../../core/public';
  * };
  * ```
  */
-export type LegacyPlugin = (kibana: LegacyPluginApi) => ArrayOrItem<LegacyPluginSpec[]>;
+export type LegacyPlugin = (kibana: LegacyPluginApi) => ArrayOrItem<LegacyPluginSpec>;
 
 export type ArrayOrItem<T> = T | T[];
 

--- a/src/legacy/types.ts
+++ b/src/legacy/types.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from './plugin_discovery/types';

--- a/x-pack/plugins/apm/index.ts
+++ b/x-pack/plugins/apm/index.ts
@@ -8,11 +8,11 @@ import { i18n } from '@kbn/i18n';
 import { Server } from 'hapi';
 import { resolve } from 'path';
 import { CoreSetup, PluginInitializerContext } from 'src/core/server/index.js';
-import { LegacyPlugin } from 'src/legacy/types';
+import { LegacyPluginInitializer } from 'src/legacy/types';
 import mappings from './mappings.json';
 import { plugin } from './server/new-platform/index';
 
-export const apm: LegacyPlugin = kibana => {
+export const apm: LegacyPluginInitializer = kibana => {
   return new kibana.Plugin({
     require: ['kibana', 'elasticsearch', 'xpack_main', 'apm_oss'],
     id: 'apm',

--- a/x-pack/plugins/apm/index.ts
+++ b/x-pack/plugins/apm/index.ts
@@ -8,11 +8,11 @@ import { i18n } from '@kbn/i18n';
 import { Server } from 'hapi';
 import { resolve } from 'path';
 import { CoreSetup, PluginInitializerContext } from 'src/core/server/index.js';
+import { LegacyPlugin } from 'src/legacy/types';
 import mappings from './mappings.json';
 import { plugin } from './server/new-platform/index';
 
-// TODO: get proper types
-export function apm(kibana: any) {
+export const apm: LegacyPlugin = kibana => {
   return new kibana.Plugin({
     require: ['kibana', 'elasticsearch', 'xpack_main', 'apm_oss'],
     id: 'apm',
@@ -110,4 +110,4 @@ export function apm(kibana: any) {
       plugin(initializerContext).setup(core);
     }
   });
-}
+};


### PR DESCRIPTION
## Summary

Adds TypeScript typings to legacy plugin functions. So they can be annotated like this:

```
const apmOss: LegacyPlugin = kibana => {
  // ...
};
```

Autocompletion:

![image](https://user-images.githubusercontent.com/9773803/57524454-1d5c8700-7328-11e9-8a99-afa3ca345d24.png)


In this PR I did not want to type annotate the whole legacy plugin system, but at least the most necessary part to get the ball rolling. (Added type annotation to APM plugin just because it is the first plugin in `x-pack`.)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

