### PR TITLE
[Logstash Management] Default pipeline workers input to empty

### DIFF
--- a/x-pack/plugins/logstash/public/components/pipeline_editor/pipeline_editor.js
+++ b/x-pack/plugins/logstash/public/components/pipeline_editor/pipeline_editor.js
@@ -43,7 +43,7 @@ class PipelineEditorUi extends React.Component {
     } = this.props;
 
     const pipelineWorkersSet = typeof settings['pipeline.workers'] === 'number';
-    const pipelineWorkers = pipelineWorkersSet ? settings['pipeline.workers'] : 1;
+    const pipelineWorkers = pipelineWorkersSet ? settings['pipeline.workers'] : null;
     this.state = {
       maxBytesNumber: settings['queue.max_bytes.number'],
       maxBytesUnit: settings['queue.max_bytes.units'],
@@ -337,6 +337,7 @@ class PipelineEditorUi extends React.Component {
             >
               <EuiFieldNumber
                 data-test-subj="inputWorkers"
+                min={0}
                 onChange={e => this.handleNumberChange('pipeline.workers', e.target.value)}
                 value={this.state.pipeline.settings['pipeline.workers']}
               />

--- a/x-pack/plugins/logstash/public/components/pipeline_editor/pipeline_editor.js
+++ b/x-pack/plugins/logstash/public/components/pipeline_editor/pipeline_editor.js
@@ -352,6 +352,7 @@ class PipelineEditorUi extends React.Component {
               >
                 <EuiFieldNumber
                   data-test-subj="inputBatchSize"
+                  min={0}
                   onChange={e => this.handleNumberChange('pipeline.batch.size', e.target.value)}
                   value={this.state.pipeline.settings['pipeline.batch.size']}
                 />
@@ -365,6 +366,7 @@ class PipelineEditorUi extends React.Component {
               >
                 <EuiFieldNumber
                   data-test-subj="inputBatchDelay"
+                  min={0}
                   onChange={e => this.handleNumberChange('pipeline.batch.delay', e.target.value)}
                   value={this.state.pipeline.settings['pipeline.batch.delay']}
                 />
@@ -394,6 +396,7 @@ class PipelineEditorUi extends React.Component {
               >
                 <EuiFieldNumber
                   data-test-subj="inputQueueMaxBytesNumber"
+                  min={0}
                   onChange={e => this.handleMaxByteNumberChange(e.target.value)}
                   value={this.state.maxBytesNumber}
                 />
@@ -415,6 +418,7 @@ class PipelineEditorUi extends React.Component {
               >
                 <EuiFieldNumber
                   data-test-subj="inputQueueCheckpointWrites"
+                  min={0}
                   onChange={e => this.handleNumberChange('queue.checkpoint.writes', e.target.value)}
                   value={this.state.pipeline.settings['queue.checkpoint.writes']}
                 />


### PR DESCRIPTION
Currently the # of pipeline workers field in the _Create/Edit Pipeline_ UI defaults to 1, which is incorrect. By default the # of pipeline workers used by a Logstash node equals the number of cores on the system. A better default for the field in the UI would be to leave the field blank. This PR makes this change.

Finally, since none of the number fields on this form can accept values less than 0, including the # of pipeline workers, this PR sets their `min` prop to `0`. This will prevent a user from using the down arrow button on the field to make the value below 0.