### PR TITLE
[APM] Fix path params bug for incorrect serviceName

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -84,12 +84,6 @@ export const EnvironmentFilter: React.FC = () => {
   const { urlParams, uiFilters } = useUrlParams();
   const { start, end, serviceName } = urlParams;
 
-  // TODO fix the bug in urlParams that this code defensively overcomes
-  let realServiceName = serviceName;
-  if (serviceName === 'services') {
-    realServiceName = undefined;
-  }
-
   const { environment } = uiFilters;
   const { data: environments = [], status = 'loading' } = useFetcher(
     () => {
@@ -97,11 +91,11 @@ export const EnvironmentFilter: React.FC = () => {
         return loadServiceEnvironments({
           start,
           end,
-          serviceName: realServiceName
+          serviceName
         });
       }
     },
-    [start, end, realServiceName]
+    [start, end, serviceName]
   );
 
   return (

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/helpers.ts
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/helpers.ts
@@ -58,7 +58,7 @@ export function removeUndefinedProps<T>(obj: T): Partial<T> {
 
 export function getPathParams(pathname: string = '') {
   const paths = getPathAsArray(pathname);
-  const pageName = paths[1];
+  const pageName = paths.length > 1 ? paths[1] : paths[0];
 
   // TODO: use react router's real match params instead of guessing the path order
   switch (pageName) {
@@ -79,6 +79,12 @@ export function getPathParams(pathname: string = '') {
       return {
         processorEvent: 'metric',
         serviceName: paths[0]
+      };
+    case 'services': // fall thru since services and traces share path params
+    case 'traces':
+      return {
+        processorEvent: 'transaction',
+        serviceName: undefined
       };
     default:
       return {


### PR DESCRIPTION
Closes #36992 by fixing path params bug by checking if serviceName even exists in the current pathname
