### PR TITLE
[APM] Fix encoding issue with forward slash in path

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/ErrorCountBadge.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/ErrorCountBadge.tsx
@@ -13,7 +13,6 @@ import { idx } from '@kbn/elastic-idx';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import { fontSize } from '../../../../style/variables';
 import { APMLink } from '../../../shared/Links/APMLink';
-import { legacyEncodeURIComponent } from '../../../shared/Links/url_helpers';
 
 const LinkLabel = styled.span`
   font-size: ${fontSize};
@@ -55,7 +54,7 @@ export const ErrorCountBadge: React.SFC<Props> = ({
     <APMLink
       path={`/${idx(transaction, _ => _.service.name)}/errors`}
       query={{
-        kuery: legacyEncodeURIComponent(
+        kuery: encodeURIComponent(
           `trace.id : "${transaction.trace.id}" and transaction.id : "${
             transaction.transaction.id
           }"`

--- a/x-pack/plugins/apm/public/components/shared/KueryBar/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/KueryBar/index.tsx
@@ -13,11 +13,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 import { AutocompleteSuggestion } from 'ui/autocomplete_providers';
 import { StaticIndexPattern } from 'ui/index_patterns';
-import {
-  fromQuery,
-  toQuery,
-  legacyEncodeURIComponent
-} from '../Links/url_helpers';
+import { fromQuery, toQuery } from '../Links/url_helpers';
 import { KibanaLink } from '../Links/KibanaLink';
 // @ts-ignore
 import { Typeahead } from './Typeahead';
@@ -130,7 +126,7 @@ export function KueryBar() {
         ...location,
         search: fromQuery({
           ...toQuery(location.search),
-          kuery: legacyEncodeURIComponent(inputValue.trim())
+          kuery: encodeURIComponent(inputValue.trim())
         })
       });
     } catch (e) {

--- a/x-pack/plugins/apm/public/components/shared/Links/TransactionLink.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/TransactionLink.tsx
@@ -22,7 +22,9 @@ export const TransactionLink: React.SFC<TransactionLinkProps> = ({
   }
 
   const serviceName = transaction.service.name;
-  const transactionType = transaction.transaction.type;
+  const transactionType = legacyEncodeURIComponent(
+    transaction.transaction.type
+  );
   const traceId = transaction.trace.id;
   const transactionId = transaction.transaction.id;
   const name = transaction.transaction.name;

--- a/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -44,7 +44,7 @@ type APMQueryParamsRaw = StringifyAll<APMQueryParams>;
 // This is downright horrible 😭 💔
 // Angular decodes encoded url tokens like "%2F" to "/" which causes problems when path params contains forward slashes
 // This was originally fixed in Angular, but roled back to avoid breaking backwards compatability: https://github.com/angular/angular.js/commit/2bdf7126878c87474bb7588ce093d0a3c57b0026
-export function legacyEncodeURIComponent(rawUrl?: string) {
+export function legacyEncodeURIComponent(rawUrl: string | undefined) {
   return (
     rawUrl &&
     encodeURIComponent(rawUrl)
@@ -53,6 +53,6 @@ export function legacyEncodeURIComponent(rawUrl?: string) {
   );
 }
 
-export function legacyDecodeURIComponent(encodedUrl?: string) {
+export function legacyDecodeURIComponent(encodedUrl: string | undefined) {
   return encodedUrl && decodeURIComponent(encodedUrl.replace(/~/g, '%'));
 }

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts
@@ -67,7 +67,7 @@ export function resolveUrlParams(location: Location, state: IUrlParams) {
     detailTab: toString(detailTab),
     flyoutDetailTab: toString(flyoutDetailTab),
     spanId: toNumber(spanId),
-    kuery: legacyDecodeURIComponent(kuery),
+    kuery: kuery && decodeURIComponent(kuery),
     // path params
     processorEvent,
     serviceName,

--- a/x-pack/plugins/apm/public/hooks/useTransactionDetailsCharts.ts
+++ b/x-pack/plugins/apm/public/hooks/useTransactionDetailsCharts.ts
@@ -5,7 +5,7 @@
  */
 
 import { useMemo } from 'react';
-import { loadTransactionDetailsCharts } from '../services/rest/apm/transaction_groups';
+import { loadTransactionCharts } from '../services/rest/apm/transaction_groups';
 import { getTransactionCharts } from '../selectors/chartSelectors';
 import { IUrlParams } from '../context/UrlParamsContext/types';
 import { useUiFilters } from '../context/UrlParamsContext';
@@ -24,7 +24,7 @@ export function useTransactionDetailsCharts(urlParams: IUrlParams) {
   const { data, error, status } = useFetcher(
     () => {
       if (serviceName && start && end && transactionName && transactionType) {
-        return loadTransactionDetailsCharts({
+        return loadTransactionCharts({
           serviceName,
           start,
           end,

--- a/x-pack/plugins/apm/public/hooks/useTransactionOverviewCharts.ts
+++ b/x-pack/plugins/apm/public/hooks/useTransactionOverviewCharts.ts
@@ -5,7 +5,7 @@
  */
 
 import { useMemo } from 'react';
-import { loadTransactionOverviewCharts } from '../services/rest/apm/transaction_groups';
+import { loadTransactionCharts } from '../services/rest/apm/transaction_groups';
 import { getTransactionCharts } from '../selectors/chartSelectors';
 import { IUrlParams } from '../context/UrlParamsContext/types';
 import { useUiFilters } from '../context/UrlParamsContext';
@@ -18,7 +18,7 @@ export function useTransactionOverviewCharts(urlParams: IUrlParams) {
   const { data, error, status } = useFetcher(
     () => {
       if (serviceName && start && end) {
-        return loadTransactionOverviewCharts({
+        return loadTransactionCharts({
           serviceName,
           start,
           end,

--- a/x-pack/plugins/apm/public/services/rest/apm/error_groups.ts
+++ b/x-pack/plugins/apm/public/services/rest/apm/error_groups.ts
@@ -74,15 +74,12 @@ export async function loadErrorDistribution({
   uiFilters: UIFilters;
   errorGroupId?: string;
 }) {
-  const pathname = errorGroupId
-    ? `/api/apm/services/${serviceName}/errors/${errorGroupId}/distribution`
-    : `/api/apm/services/${serviceName}/errors/distribution`;
-
   return callApi<ErrorDistributionAPIResponse>({
-    pathname,
+    pathname: `/api/apm/services/${serviceName}/errors/distribution`,
     query: {
       start,
       end,
+      groupId: errorGroupId,
       uiFiltersES: await getUiFiltersES(uiFilters)
     }
   });

--- a/x-pack/plugins/apm/public/services/rest/apm/transaction_groups.ts
+++ b/x-pack/plugins/apm/public/services/rest/apm/transaction_groups.ts
@@ -25,10 +25,11 @@ export async function loadTransactionList({
   uiFilters: UIFilters;
 }) {
   return await callApi<TransactionListAPIResponse>({
-    pathname: `/api/apm/services/${serviceName}/transaction_groups/${transactionType}`,
+    pathname: `/api/apm/services/${serviceName}/transaction_groups`,
     query: {
       start,
       end,
+      transactionType,
       uiFiltersES: await getUiFiltersES(uiFilters)
     }
   });
@@ -54,12 +55,12 @@ export async function loadTransactionDistribution({
   uiFilters: UIFilters;
 }) {
   return callApi<ITransactionDistributionAPIResponse>({
-    pathname: `/api/apm/services/${serviceName}/transaction_groups/${transactionType}/${encodeURIComponent(
-      transactionName
-    )}/distribution`,
+    pathname: `/api/apm/services/${serviceName}/transaction_groups/distribution`,
     query: {
       start,
       end,
+      transactionType,
+      transactionName,
       transactionId,
       traceId,
       uiFiltersES: await getUiFiltersES(uiFilters)
@@ -67,7 +68,7 @@ export async function loadTransactionDistribution({
   });
 }
 
-export async function loadTransactionDetailsCharts({
+export async function loadTransactionCharts({
   serviceName,
   start,
   end,
@@ -78,44 +79,17 @@ export async function loadTransactionDetailsCharts({
   serviceName: string;
   start: string;
   end: string;
-  transactionType: string;
-  transactionName: string;
-  uiFilters: UIFilters;
-}) {
-  return callApi<TimeSeriesAPIResponse>({
-    pathname: `/api/apm/services/${serviceName}/transaction_groups/${transactionType}/${encodeURIComponent(
-      transactionName
-    )}/charts`,
-    query: {
-      start,
-      end,
-      uiFiltersES: await getUiFiltersES(uiFilters)
-    }
-  });
-}
-
-export async function loadTransactionOverviewCharts({
-  serviceName,
-  start,
-  end,
-  uiFilters,
-  transactionType
-}: {
-  serviceName: string;
-  start: string;
-  end: string;
   transactionType?: string;
+  transactionName?: string;
   uiFilters: UIFilters;
 }) {
-  const pathname = transactionType
-    ? `/api/apm/services/${serviceName}/transaction_groups/${transactionType}/charts`
-    : `/api/apm/services/${serviceName}/transaction_groups/charts`;
-
   return callApi<TimeSeriesAPIResponse>({
-    pathname,
+    pathname: `/api/apm/services/${serviceName}/transaction_groups/charts`,
     query: {
       start,
       end,
+      transactionType,
+      transactionName,
       uiFiltersES: await getUiFiltersES(uiFilters)
     }
   });

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
@@ -14,10 +14,10 @@ function getBucketSize({ start, end, config }: Setup) {
 }
 
 export type ErrorDistributionAPIResponse = PromiseReturnType<
-  typeof getDistribution
+  typeof getErrorDistribution
 >;
 
-export async function getDistribution({
+export async function getErrorDistribution({
   serviceName,
   groupId,
   setup

--- a/x-pack/plugins/apm/server/lib/transactions/charts/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/index.ts
@@ -14,8 +14,10 @@ function getDates(apmTimeseries: ApmTimeSeriesResponse) {
   return apmTimeseries.responseTimes.avg.map(p => p.x);
 }
 
-export type TimeSeriesAPIResponse = PromiseReturnType<typeof getChartsData>;
-export async function getChartsData(options: {
+export type TimeSeriesAPIResponse = PromiseReturnType<
+  typeof getTransactionCharts
+>;
+export async function getTransactionCharts(options: {
   serviceName: string;
   transactionType?: string;
   transactionName?: string;

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/index.ts
@@ -10,16 +10,23 @@ import { calculateBucketSize } from './calculate_bucket_size';
 import { getBuckets } from './get_buckets';
 
 export type ITransactionDistributionAPIResponse = PromiseReturnType<
-  typeof getDistribution
+  typeof getTransactionDistribution
 >;
-export async function getDistribution(
-  serviceName: string,
-  transactionName: string,
-  transactionType: string,
-  transactionId: string,
-  traceId: string,
-  setup: Setup
-) {
+export async function getTransactionDistribution({
+  serviceName,
+  transactionName,
+  transactionType,
+  transactionId,
+  traceId,
+  setup
+}: {
+  serviceName: string;
+  transactionName: string;
+  transactionType: string;
+  transactionId: string;
+  traceId: string;
+  setup: Setup;
+}) {
   const bucketSize = await calculateBucketSize(
     serviceName,
     transactionName,

--- a/x-pack/plugins/apm/server/routes/transaction_groups.ts
+++ b/x-pack/plugins/apm/server/routes/transaction_groups.ts
@@ -9,8 +9,8 @@ import Joi from 'joi';
 import { InternalCoreSetup } from 'src/core/server';
 import { withDefaultValidators } from '../lib/helpers/input_validation';
 import { setupRequest } from '../lib/helpers/setup_request';
-import { getChartsData } from '../lib/transactions/charts';
-import { getDistribution } from '../lib/transactions/distribution';
+import { getTransactionCharts } from '../lib/transactions/charts';
+import { getTransactionDistribution } from '../lib/transactions/distribution';
 import { getTopTransactions } from '../lib/transactions/get_top_transactions';
 
 const defaultErrorHandler = (err: Error) => {
@@ -24,18 +24,18 @@ export function initTransactionGroupsApi(core: InternalCoreSetup) {
 
   server.route({
     method: 'GET',
-    path:
-      '/api/apm/services/{serviceName}/transaction_groups/{transactionType}',
+    path: '/api/apm/services/{serviceName}/transaction_groups',
     options: {
       validate: {
         query: withDefaultValidators({
-          query: Joi.string()
+          transactionType: Joi.string()
         })
       },
       tags: ['access:apm']
     },
     handler: req => {
-      const { serviceName, transactionType } = req.params;
+      const { serviceName } = req.params;
+      const { transactionType } = req.query as { transactionType?: string };
       const setup = setupRequest(req);
 
       return getTopTransactions({
@@ -48,59 +48,25 @@ export function initTransactionGroupsApi(core: InternalCoreSetup) {
 
   server.route({
     method: 'GET',
-    path: `/api/apm/services/{serviceName}/transaction_groups/{transactionType}/charts`,
-    options: {
-      validate: {
-        query: withDefaultValidators()
-      },
-      tags: ['access:apm']
-    },
-    handler: req => {
-      const setup = setupRequest(req);
-      const { serviceName, transactionType } = req.params;
-
-      return getChartsData({
-        serviceName,
-        transactionType,
-        setup
-      }).catch(defaultErrorHandler);
-    }
-  });
-
-  server.route({
-    method: 'GET',
     path: `/api/apm/services/{serviceName}/transaction_groups/charts`,
     options: {
       validate: {
-        query: withDefaultValidators()
+        query: withDefaultValidators({
+          transactionType: Joi.string(),
+          transactionName: Joi.string()
+        })
       },
       tags: ['access:apm']
     },
     handler: req => {
       const setup = setupRequest(req);
       const { serviceName } = req.params;
+      const { transactionType, transactionName } = req.query as {
+        transactionType?: string;
+        transactionName?: string;
+      };
 
-      return getChartsData({
-        serviceName,
-        setup
-      }).catch(defaultErrorHandler);
-    }
-  });
-
-  server.route({
-    method: 'GET',
-    path: `/api/apm/services/{serviceName}/transaction_groups/{transactionType}/{transactionName}/charts`,
-    options: {
-      validate: {
-        query: withDefaultValidators()
-      },
-      tags: ['access:apm']
-    },
-    handler: req => {
-      const setup = setupRequest(req);
-      const { serviceName, transactionType, transactionName } = req.params;
-
-      return getChartsData({
+      return getTransactionCharts({
         serviceName,
         transactionType,
         transactionName,
@@ -111,10 +77,12 @@ export function initTransactionGroupsApi(core: InternalCoreSetup) {
 
   server.route({
     method: 'GET',
-    path: `/api/apm/services/{serviceName}/transaction_groups/{transactionType}/{transactionName}/distribution`,
+    path: `/api/apm/services/{serviceName}/transaction_groups/distribution`,
     options: {
       validate: {
         query: withDefaultValidators({
+          transactionType: Joi.string(),
+          transactionName: Joi.string(),
           transactionId: Joi.string().default(''),
           traceId: Joi.string().default('')
         })
@@ -123,19 +91,27 @@ export function initTransactionGroupsApi(core: InternalCoreSetup) {
     },
     handler: req => {
       const setup = setupRequest(req);
-      const { serviceName, transactionType, transactionName } = req.params;
-      const { transactionId, traceId } = req.query as {
+      const { serviceName } = req.params;
+      const {
+        transactionType,
+        transactionName,
+        transactionId,
+        traceId
+      } = req.query as {
+        transactionType: string;
+        transactionName: string;
         transactionId: string;
         traceId: string;
       };
-      return getDistribution(
+
+      return getTransactionDistribution({
         serviceName,
-        transactionName,
         transactionType,
+        transactionName,
         transactionId,
         traceId,
         setup
-      ).catch(defaultErrorHandler);
+      }).catch(defaultErrorHandler);
     }
   });
 }

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -42,7 +42,7 @@ export default function featureControlsTests({ getService }: KibanaFunctionalTes
       expectResponse: expect200,
     },
     {
-      url: `/api/apm/services/foo/errors/bar/distribution?start=${start}&end=${end}`,
+      url: `/api/apm/services/foo/errors/distribution?start=${start}&end=${end}&groupId=bar`,
       expectForbidden: expect404,
       expectResponse: (result: any) => {
         expect(result.response).to.have.property('statusCode', 400);
@@ -101,12 +101,12 @@ export default function featureControlsTests({ getService }: KibanaFunctionalTes
       },
     },
     {
-      url: `/api/apm/services/foo/transaction_groups/bar?start=${start}&end=${end}`,
+      url: `/api/apm/services/foo/transaction_groups?start=${start}&end=${end}&transactionType=bar`,
       expectForbidden: expect404,
       expectResponse: expect200,
     },
     {
-      url: `/api/apm/services/foo/transaction_groups/bar/charts?start=${start}&end=${end}`,
+      url: `/api/apm/services/foo/transaction_groups/charts?start=${start}&end=${end}&transactionType=bar`,
       expectForbidden: expect404,
       expectResponse: expect200,
     },
@@ -116,12 +116,12 @@ export default function featureControlsTests({ getService }: KibanaFunctionalTes
       expectResponse: expect200,
     },
     {
-      url: `/api/apm/services/foo/transaction_groups/bar/baz/charts?start=${start}&end=${end}`,
+      url: `/api/apm/services/foo/transaction_groups/charts?start=${start}&end=${end}&transactionType=bar&transactionName=baz`,
       expectForbidden: expect404,
       expectResponse: expect200,
     },
     {
-      url: `/api/apm/services/foo/transaction_groups/bar/baz/distribution?start=${start}&end=${end}`,
+      url: `/api/apm/services/foo/transaction_groups/distribution?start=${start}&end=${end}&transactionType=bar&transactionName=baz`,
       expectForbidden: expect404,
       expectResponse: (result: any) => {
         expect(result.response).to.have.property('statusCode', 400);


### PR DESCRIPTION
Closes #34866

- Client: Only use `legacyEncodeURIComponent` for path params that may contain forward slashes (`transactionType` and `transactionName`)
- Server: Move `transactionType` and `transactionName` from path params to query params (and thus avoid `legacyEncodeURIComponent`)
- Group duplicate endpoints together 
    - `loadTransactionDetailsCharts` + `loadTransactionOverviewCharts` = `loadTransactionCharts`

