### PR TITLE
[visualize/_shared_item] skip test due to the bug

### DIFF
--- a/test/functional/apps/visualize/_shared_item.js
+++ b/test/functional/apps/visualize/_shared_item.js
@@ -24,7 +24,8 @@ export default function ({ getService, getPageObjects }) {
   const retry = getService('retry');
   const PageObjects = getPageObjects(['common', 'visualize']);
 
-  describe('data-shared-item', function indexPatternCreation() {
+  // https://github.com/elastic/kibana/issues/37130
+  describe.skip('data-shared-item', function indexPatternCreation() {
     before(async function () {
       log.debug('navigateToApp visualize');
       await PageObjects.common.navigateToApp('visualize');


### PR DESCRIPTION
Skipping one of the functional vizualize tests due to bug #37130 
It fails pretty often on CI for Firefox and can be reproduced in both Firefox/Chrome locally.