### PR TITLE
[APM] Java metrics follow-up fixes

### DIFF
--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/heap_memory/index.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/heap_memory/index.ts
@@ -25,7 +25,7 @@ const chartBase: ChartBase<HeapMemoryMetrics> = {
       title: i18n.translate(
         'xpack.apm.agentMetrics.java.heapMemorySeriesUsed',
         {
-          defaultMessage: 'Used'
+          defaultMessage: 'Avg. used'
         }
       ),
       color: theme.euiColorVis0
@@ -34,18 +34,15 @@ const chartBase: ChartBase<HeapMemoryMetrics> = {
       title: i18n.translate(
         'xpack.apm.agentMetrics.java.heapMemorySeriesCommitted',
         {
-          defaultMessage: 'Committed'
+          defaultMessage: 'Avg. committed'
         }
       ),
       color: theme.euiColorVis1
     },
     heapMemoryMax: {
-      title: i18n.translate(
-        'xpack.apm.agentMetrics.java.nonHeapMemorySeriesMax',
-        {
-          defaultMessage: 'Max'
-        }
-      ),
+      title: i18n.translate('xpack.apm.agentMetrics.java.heapMemorySeriesMax', {
+        defaultMessage: 'Avg. limit'
+      }),
       color: theme.euiColorVis2
     }
   }

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/index.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/index.ts
@@ -8,9 +8,13 @@ import { getHeapMemoryChart } from './heap_memory';
 import { Setup } from '../../../helpers/setup_request';
 import { getNonHeapMemoryChart } from './non_heap_memory';
 import { getThreadCountChart } from './thread_count';
+import { getCPUChartData } from '../shared/cpu';
+import { getMemoryChartData } from '../shared/memory';
 
 export async function getJavaMetricsCharts(setup: Setup, serviceName: string) {
   const charts = await Promise.all([
+    getCPUChartData(setup, serviceName),
+    getMemoryChartData(setup, serviceName),
     getHeapMemoryChart(setup, serviceName),
     getNonHeapMemoryChart(setup, serviceName),
     getThreadCountChart(setup, serviceName)

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/non_heap_memory/index.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/non_heap_memory/index.ts
@@ -23,7 +23,7 @@ const chartBase: ChartBase<NonHeapMemoryMetrics> = {
       title: i18n.translate(
         'xpack.apm.agentMetrics.java.nonHeapMemorySeriesUsed',
         {
-          defaultMessage: 'Used'
+          defaultMessage: 'Avg. used'
         }
       ),
       color: theme.euiColorVis0
@@ -32,7 +32,7 @@ const chartBase: ChartBase<NonHeapMemoryMetrics> = {
       title: i18n.translate(
         'xpack.apm.agentMetrics.java.nonHeapMemorySeriesCommitted',
         {
-          defaultMessage: 'Committed'
+          defaultMessage: 'Avg. committed'
         }
       ),
       color: theme.euiColorVis1

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/thread_count/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/thread_count/fetcher.ts
@@ -23,7 +23,7 @@ export async function fetch(setup: Setup, serviceName: string) {
 
   const aggs = {
     threadCount: { avg: { field: METRIC_JAVA_THREAD_COUNT } },
-    threadCountMax: { max: { field: METRIC_JAVA_THREAD_COUNT } } // TODO is there a max field?
+    threadCountMax: { max: { field: METRIC_JAVA_THREAD_COUNT } }
   };
 
   const params = {

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/thread_count/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/thread_count/fetcher.ts
@@ -22,7 +22,8 @@ export async function fetch(setup: Setup, serviceName: string) {
   const { start, end, uiFiltersES, client, config } = setup;
 
   const aggs = {
-    threadCount: { avg: { field: METRIC_JAVA_THREAD_COUNT } }
+    threadCount: { avg: { field: METRIC_JAVA_THREAD_COUNT } },
+    threadCountMax: { max: { field: METRIC_JAVA_THREAD_COUNT } } // TODO is there a max field?
   };
 
   const params = {
@@ -35,9 +36,7 @@ export async function fetch(setup: Setup, serviceName: string) {
             { term: { [SERVICE_NAME]: serviceName } },
             { term: { [PROCESSOR_EVENT]: 'metric' } },
             { term: { [SERVICE_AGENT_NAME]: 'java' } },
-            {
-              range: rangeFilter(start, end)
-            },
+            { range: rangeFilter(start, end) },
             ...uiFiltersES
           ]
         }

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/java/thread_count/index.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/java/thread_count/index.ts
@@ -21,9 +21,15 @@ const chartBase: ChartBase<ThreadCountMetrics> = {
   series: {
     threadCount: {
       title: i18n.translate('xpack.apm.agentMetrics.java.threadCount', {
-        defaultMessage: 'Count'
+        defaultMessage: 'Avg. count'
       }),
       color: theme.euiColorVis0
+    },
+    threadCountMax: {
+      title: i18n.translate('xpack.apm.agentMetrics.java.threadCountMax', {
+        defaultMessage: 'Max count'
+      }),
+      color: theme.euiColorVis1
     }
   }
 };

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/fetcher.ts
@@ -45,6 +45,16 @@ export async function fetch(setup: Setup, serviceName: string) {
             {
               range: rangeFilter(start, end)
             },
+            {
+              exists: {
+                field: METRIC_SYSTEM_FREE_MEMORY
+              }
+            },
+            {
+              exists: {
+                field: METRIC_SYSTEM_TOTAL_MEMORY
+              }
+            },
             ...uiFiltersES
           ]
         }

--- a/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/index.ts
+++ b/x-pack/plugins/apm/server/lib/metrics/by_agent/shared/memory/index.ts
@@ -14,7 +14,7 @@ const chartBase: ChartBase<MemoryMetrics> = {
   title: i18n.translate(
     'xpack.apm.serviceDetails.metrics.memoryUsageChartTitle',
     {
-      defaultMessage: 'Memory usage'
+      defaultMessage: 'System memory usage'
     }
   ),
   key: 'memory_usage_chart',
@@ -23,12 +23,12 @@ const chartBase: ChartBase<MemoryMetrics> = {
   series: {
     memoryUsedMax: {
       title: i18n.translate('xpack.apm.chart.memorySeries.systemMaxLabel', {
-        defaultMessage: 'System max'
+        defaultMessage: 'Max'
       })
     },
     memoryUsedAvg: {
       title: i18n.translate('xpack.apm.chart.memorySeries.systemAverageLabel', {
-        defaultMessage: 'System average'
+        defaultMessage: 'Average'
       })
     }
   }

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -3626,7 +3626,6 @@
     "xpack.apm.agentMetrics.java.heapMemorySeriesUsed": "使用中",
     "xpack.apm.agentMetrics.java.nonHeapMemoryChartTitle": "ヒープ領域以外",
     "xpack.apm.agentMetrics.java.nonHeapMemorySeriesCommitted": "割当",
-    "xpack.apm.agentMetrics.java.nonHeapMemorySeriesMax": "最高",
     "xpack.apm.agentMetrics.java.nonHeapMemorySeriesUsed": "使用中",
     "xpack.apm.agentMetrics.java.threadCount": "カウント",
     "xpack.apm.agentMetrics.java.threadCountChartTitle": "スレッド数",


### PR DESCRIPTION
[APM] Closes #69301 by adding CPU/Memory graphs back to java-specific metrics, modifying java metrics chart labels, and adding thread count max line to chart.

<img width="1204" alt="Screen Shot 2019-05-29 at 10 15 24 PM" src="https://user-images.githubusercontent.com/1967266/58610179-633da880-825f-11e9-94aa-0c549c23ec77.png">
<img width="1203" alt="Screen Shot 2019-05-29 at 10 15 42 PM" src="https://user-images.githubusercontent.com/1967266/58610180-633da880-825f-11e9-8d1a-98dcd7789ff6.png">
