### PR TITLE
[APM] Fix issues with metric charts when `noHits=true`

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/MetricsChart.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/MetricsChart.tsx
@@ -16,7 +16,7 @@ import {
   asDecimal
 } from '../../../utils/formatters';
 import { Coordinate } from '../../../../typings/timeseries';
-import { getEmptySerie } from '../../shared/charts/CustomPlot/getEmptySeries';
+import { getEmptySeries } from '../../shared/charts/CustomPlot/getEmptySeries';
 
 interface Props {
   start: number | string | undefined;
@@ -44,7 +44,7 @@ export function MetricsChart({ start, end, chart, hoverXHandlers }: Props) {
       <CustomPlot
         {...hoverXHandlers}
         noHits={noHits}
-        series={noHits ? getEmptySerie(start, end) : transformedSeries}
+        series={noHits ? getEmptySeries(start, end) : transformedSeries}
         tickFormatY={formatYValue}
         formatTooltipValue={formatTooltip}
         yMax={chart.yUnit === 'percent' ? 1 : 'max'}

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/MetricsChart.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/MetricsChart.tsx
@@ -16,13 +16,16 @@ import {
   asDecimal
 } from '../../../utils/formatters';
 import { Coordinate } from '../../../../typings/timeseries';
+import { getEmptySerie } from '../../shared/charts/CustomPlot/getEmptySeries';
 
 interface Props {
+  start: number | string | undefined;
+  end: number | string | undefined;
   chart: GenericMetricsChart;
   hoverXHandlers: HoverXHandlers;
 }
 
-export function MetricsChart({ chart, hoverXHandlers }: Props) {
+export function MetricsChart({ start, end, chart, hoverXHandlers }: Props) {
   const formatYValue = getYTickFormatter(chart);
   const formatTooltip = getTooltipFormatter(chart);
 
@@ -31,6 +34,8 @@ export function MetricsChart({ chart, hoverXHandlers }: Props) {
     legendValue: formatYValue(series.overallValue)
   }));
 
+  const noHits = chart.totalHits === 0;
+
   return (
     <React.Fragment>
       <EuiTitle size="xs">
@@ -38,8 +43,8 @@ export function MetricsChart({ chart, hoverXHandlers }: Props) {
       </EuiTitle>
       <CustomPlot
         {...hoverXHandlers}
-        noHits={chart.totalHits === 0}
-        series={transformedSeries}
+        noHits={noHits}
+        series={noHits ? getEmptySerie(start, end) : transformedSeries}
         tickFormatY={formatYValue}
         formatTooltipValue={formatTooltip}
         yMax={chart.yUnit === 'percent' ? 1 : 'max'}

--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceMetrics.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceMetrics.tsx
@@ -18,6 +18,7 @@ interface ServiceMetricsProps {
 
 export function ServiceMetrics({ urlParams, agentName }: ServiceMetricsProps) {
   const { data } = useServiceMetricCharts(urlParams, agentName);
+  const { start, end } = urlParams;
   return (
     <React.Fragment>
       <SyncChartGroup
@@ -26,7 +27,12 @@ export function ServiceMetrics({ urlParams, agentName }: ServiceMetricsProps) {
             {data.charts.map(chart => (
               <EuiFlexItem key={chart.key}>
                 <EuiPanel>
-                  <MetricsChart chart={chart} hoverXHandlers={hoverXHandlers} />
+                  <MetricsChart
+                    start={start}
+                    end={end}
+                    chart={chart}
+                    hoverXHandlers={hoverXHandlers}
+                  />
                 </EuiPanel>
               </EuiFlexItem>
             ))}

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/getEmptySeries.ts
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/getEmptySeries.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { memoize } from 'lodash';
+import d3 from 'd3';
+
+export const getEmptySerie = memoize(
+  (
+    start: number | string = Date.now() - 3600000,
+    end: number | string = Date.now()
+  ) => {
+    const dates = d3.time
+      .scale()
+      .domain([new Date(start), new Date(end)])
+      .ticks();
+
+    return [
+      {
+        data: dates.map(x => ({
+          x: x.getTime(),
+          y: 1
+        }))
+      }
+    ];
+  },
+  (start: string, end: string) => [start, end].join('_')
+);

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/getEmptySeries.ts
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/getEmptySeries.ts
@@ -7,7 +7,7 @@
 import { memoize } from 'lodash';
 import d3 from 'd3';
 
-export const getEmptySerie = memoize(
+export const getEmptySeries = memoize(
   (
     start: number | string = Date.now() - 3600000,
     end: number | string = Date.now()

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
@@ -13,10 +13,8 @@ import { InnerCustomPlot } from '../index';
 import responseWithData from './responseWithData.json';
 import VoronoiPlot from '../VoronoiPlot';
 import InteractivePlot from '../InteractivePlot';
-import {
-  getResponseTimeSeries,
-  getEmptySerie
-} from '../../../../../selectors/chartSelectors';
+import { getResponseTimeSeries } from '../../../../../selectors/chartSelectors';
+import { getEmptySerie } from '../getEmptySeries';
 
 function getXValueByIndex(index) {
   return responseWithData.responseTimes.avg[index].x;

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
@@ -14,7 +14,7 @@ import responseWithData from './responseWithData.json';
 import VoronoiPlot from '../VoronoiPlot';
 import InteractivePlot from '../InteractivePlot';
 import { getResponseTimeSeries } from '../../../../../selectors/chartSelectors';
-import { getEmptySerie } from '../getEmptySeries';
+import { getEmptySeries } from '../getEmptySeries';
 
 function getXValueByIndex(index) {
   return responseWithData.responseTimes.avg[index].x;
@@ -287,7 +287,7 @@ describe('when response has no data', () => {
   const onSelectionEnd = jest.fn();
   let wrapper;
   beforeEach(() => {
-    const series = getEmptySerie(1451606400000, 1451610000000);
+    const series = getEmptySeries(1451606400000, 1451610000000);
 
     wrapper = mount(
       <InnerCustomPlot

--- a/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
@@ -27,7 +27,7 @@ import { MLJobLink } from '../../Links/MachineLearningLinks/MLJobLink';
 import CustomPlot from '../CustomPlot';
 import { SyncChartGroup } from '../SyncChartGroup';
 import { LicenseContext } from '../../../../context/LicenseContext';
-import { getEmptySerie } from '../CustomPlot/getEmptySeries';
+import { getEmptySeries } from '../CustomPlot/getEmptySeries';
 
 interface TransactionChartProps {
   hasMLJob: boolean;
@@ -159,7 +159,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
                   <CustomPlot
                     noHits={noHits}
                     series={
-                      noHits ? getEmptySerie(start, end) : responseTimeSeries
+                      noHits ? getEmptySeries(start, end) : responseTimeSeries
                     }
                     {...hoverXHandlers}
                     tickFormatY={this.getResponseTimeTickFormatter}
@@ -177,7 +177,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
                   </EuiTitle>
                   <CustomPlot
                     noHits={noHits}
-                    series={noHits ? getEmptySerie(start, end) : tpmSeries}
+                    series={noHits ? getEmptySeries(start, end) : tpmSeries}
                     {...hoverXHandlers}
                     tickFormatY={this.getTPMFormatter}
                     formatTooltipValue={this.getTPMTooltipFormatter}

--- a/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
@@ -27,6 +27,7 @@ import { MLJobLink } from '../../Links/MachineLearningLinks/MLJobLink';
 import CustomPlot from '../CustomPlot';
 import { SyncChartGroup } from '../SyncChartGroup';
 import { LicenseContext } from '../../../../context/LicenseContext';
+import { getEmptySerie } from '../CustomPlot/getEmptySeries';
 
 interface TransactionChartProps {
   hasMLJob: boolean;
@@ -134,7 +135,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
   public render() {
     const { charts, urlParams } = this.props;
     const { noHits, responseTimeSeries, tpmSeries } = charts;
-    const { transactionType } = urlParams;
+    const { transactionType, start, end } = urlParams;
 
     return (
       <SyncChartGroup
@@ -157,7 +158,9 @@ export class TransactionCharts extends Component<TransactionChartProps> {
                   </EuiFlexGroup>
                   <CustomPlot
                     noHits={noHits}
-                    series={responseTimeSeries}
+                    series={
+                      noHits ? getEmptySerie(start, end) : responseTimeSeries
+                    }
                     {...hoverXHandlers}
                     tickFormatY={this.getResponseTimeTickFormatter}
                     formatTooltipValue={this.getResponseTimeTooltipFormatter}
@@ -174,7 +177,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
                   </EuiTitle>
                   <CustomPlot
                     noHits={noHits}
-                    series={tpmSeries}
+                    series={noHits ? getEmptySerie(start, end) : tpmSeries}
                     {...hoverXHandlers}
                     tickFormatY={this.getTPMFormatter}
                     formatTooltipValue={this.getTPMTooltipFormatter}


### PR DESCRIPTION
Closes #37208

This is a follow-up to https://github.com/elastic/kibana/pull/37210 which also attempted to fix #37208.
While that PR _did_ fix an issue, there was an additional issue with the metric chart causing it to fail.

If there are no results for an elasticsearch query it will still return a bucket aggregation result set. This will contain `null` values for all buckets which causes the `CustomPlot` series to throw. 

In the past to fix this we added the `noHits` property to ensure that we replaced the "null" series from the backend with a static "empty series" data set. However, during the refactor of metrics in https://github.com/elastic/kibana/pull/35651 this was changed for metric charts which no longer replaces the series with the static "empty serie".

We might have to re-think how we do this - I'm definitely open to better suggestions but since this is a blocker for 7.2 I'd like to go with a simpler fix, and then we can re-think how this is done for 7.3.