### PR TITLE
[APM] Moves the APM index creation from server startup

### DIFF
--- a/x-pack/plugins/apm/public/services/rest/savedObjects.ts
+++ b/x-pack/plugins/apm/public/services/rest/savedObjects.ts
@@ -5,7 +5,6 @@
  */
 
 import { memoize } from 'lodash';
-import chrome from 'ui/chrome';
 import { callApi } from './callApi';
 
 export interface ISavedObject {
@@ -16,25 +15,13 @@ export interface ISavedObject {
   type: string;
 }
 
-interface ISavedObjectAPIResponse {
-  saved_objects: ISavedObject[];
-}
-
 export const getAPMIndexPattern = memoize(async () => {
-  const apmIndexPatternTitle: string = chrome.getInjected(
-    'apmIndexPatternTitle'
-  );
-  const res = await callApi<ISavedObjectAPIResponse>({
-    pathname: `/api/saved_objects/_find`,
-    query: {
-      type: 'index-pattern',
-      search: `"${apmIndexPatternTitle}"`,
-      search_fields: 'title',
-      per_page: 200
-    }
-  });
-
-  return res.saved_objects.find(
-    savedObject => savedObject.attributes.title === apmIndexPatternTitle
-  );
+  try {
+    return await callApi<ISavedObject>({
+      method: 'GET',
+      pathname: `/api/apm/index_pattern`
+    });
+  } catch (error) {
+    return;
+  }
 });

--- a/x-pack/plugins/apm/server/lib/index_pattern/index.ts
+++ b/x-pack/plugins/apm/server/lib/index_pattern/index.ts
@@ -5,21 +5,24 @@
  */
 import { InternalCoreSetup } from 'src/core/server';
 import { getSavedObjectsClient } from '../helpers/saved_objects_client';
-import indexPattern from '../../../../../../src/legacy/core_plugins/kibana/server/tutorials/apm/index_pattern.json';
+import apmIndexPattern from '../../../../../../src/legacy/core_plugins/kibana/server/tutorials/apm/index_pattern.json';
 
-export async function ensureIndexPatternExists(core: InternalCoreSetup) {
+export async function getIndexPattern(core: InternalCoreSetup) {
   const { server } = core.http;
   const config = server.config();
   const apmIndexPatternTitle = config.get('apm_oss.indexPattern');
   const savedObjectsClient = getSavedObjectsClient(server);
-  const savedObjects = [
-    {
-      ...indexPattern,
-      attributes: {
-        ...indexPattern.attributes,
+  try {
+    return await savedObjectsClient.get('index-pattern', apmIndexPattern.id);
+  } catch (error) {
+    // if GET fails, then create a new index pattern saved object
+    return await savedObjectsClient.create(
+      'index-pattern',
+      {
+        ...apmIndexPattern.attributes,
         title: apmIndexPatternTitle
-      }
-    }
-  ];
-  await savedObjectsClient.bulkCreate(savedObjects, { overwrite: false });
+      },
+      { id: apmIndexPattern.id, overwrite: false }
+    );
+  }
 }

--- a/x-pack/plugins/apm/server/new-platform/plugin.ts
+++ b/x-pack/plugins/apm/server/new-platform/plugin.ts
@@ -6,7 +6,6 @@
 
 import { InternalCoreSetup } from 'src/core/server';
 import { makeApmUsageCollector } from '../lib/apm_telemetry';
-import { ensureIndexPatternExists } from '../lib/index_pattern';
 import { CoreSetupWithUsageCollector } from '../lib/apm_telemetry/make_apm_usage_collector';
 import { initErrorsApi } from '../routes/errors';
 import { initMetricsApi } from '../routes/metrics';
@@ -14,6 +13,7 @@ import { initServicesApi } from '../routes/services';
 import { initTracesApi } from '../routes/traces';
 import { initTransactionGroupsApi } from '../routes/transaction_groups';
 import { initUIFiltersApi } from '../routes/ui_filters';
+import { initIndexPatternApi } from '../routes/index_pattern';
 
 export class Plugin {
   public setup(core: InternalCoreSetup) {
@@ -23,7 +23,7 @@ export class Plugin {
     initServicesApi(core);
     initErrorsApi(core);
     initMetricsApi(core);
+    initIndexPatternApi(core);
     makeApmUsageCollector(core as CoreSetupWithUsageCollector);
-    ensureIndexPatternExists(core);
   }
 }

--- a/x-pack/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/index_pattern.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import Boom from 'boom';
+import { InternalCoreSetup } from 'src/core/server';
+import { getIndexPattern } from '../lib/index_pattern';
+
+const ROOT = '/api/apm/index_pattern';
+const defaultErrorHandler = (err: Error) => {
+  // eslint-disable-next-line
+  console.error(err.stack);
+  throw Boom.boomify(err, { statusCode: 400 });
+};
+
+export function initIndexPatternApi(core: InternalCoreSetup) {
+  const { server } = core.http;
+  server.route({
+    method: 'GET',
+    path: ROOT,
+    options: {
+      tags: ['access:apm']
+    },
+    handler: async req => {
+      return await getIndexPattern(core).catch(defaultErrorHandler);
+    }
+  });
+}

--- a/x-pack/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/index_pattern.ts
@@ -9,10 +9,10 @@ import { InternalCoreSetup } from 'src/core/server';
 import { getIndexPattern } from '../lib/index_pattern';
 
 const ROOT = '/api/apm/index_pattern';
-const defaultErrorHandler = (err: Error) => {
+const defaultErrorHandler = (err: Error & { status?: number }) => {
   // eslint-disable-next-line
   console.error(err.stack);
-  throw Boom.boomify(err, { statusCode: 400 });
+  throw Boom.boomify(err, { statusCode: err.status || 500 });
 };
 
 export function initIndexPatternApi(core: InternalCoreSetup) {


### PR DESCRIPTION
Closes #37499 by moving the APM index creation from server startup to savedObject request for the index pattern. It first checks if the index pattern is saved, if not it creates it.