### PR TITLE
[Infra UI] Reset error when IP address changes to valid entry

### DIFF
--- a/x-pack/plugins/infra/public/pages/link_to/use_host_ip_to_name.test.ts
+++ b/x-pack/plugins/infra/public/pages/link_to/use_host_ip_to_name.test.ts
@@ -27,6 +27,7 @@ describe('useHostIpToName Hook', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(null);
   });
+
   it('should handle errors', async () => {
     const error = new Error('Host not found');
     mockedFetch.post.mockRejectedValue(error);
@@ -37,5 +38,23 @@ describe('useHostIpToName Hook', () => {
     expect(result.current.name).toBe(null);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(error);
+  });
+
+  it('should reset errors', async () => {
+    const error = new Error('Host not found');
+    mockedFetch.post.mockRejectedValue(error);
+    const { result, waitForNextUpdate, rerender } = renderUseHostIpToNameHook();
+    expect(result.current.name).toBe(null);
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.name).toBe(null);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(error);
+    mockedFetch.post.mockResolvedValue({ data: { host: 'example-01' } } as any);
+    rerender({ ipAddress: '192.168.1.2', indexPattern: 'metricbeat-*' });
+    await waitForNextUpdate();
+    expect(result.current.name).toBe('example-01');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(null);
   });
 });

--- a/x-pack/plugins/infra/public/pages/link_to/use_host_ip_to_name.ts
+++ b/x-pack/plugins/infra/public/pages/link_to/use_host_ip_to_name.ts
@@ -17,6 +17,7 @@ export const useHostIpToName = (ipAddress: string | null, indexPattern: string |
     () => {
       (async () => {
         setLoadingState(true);
+        setError(null);
         try {
           if (ipAddress && indexPattern) {
             const response = await fetch.post<IpToHostResponse>('../api/infra/ip_to_host', {
@@ -25,7 +26,6 @@ export const useHostIpToName = (ipAddress: string | null, indexPattern: string |
             });
             setLoadingState(false);
             setData(response.data);
-            setError(null);
           }
         } catch (err) {
           setLoadingState(false);

--- a/x-pack/plugins/infra/public/pages/link_to/use_host_ip_to_name.ts
+++ b/x-pack/plugins/infra/public/pages/link_to/use_host_ip_to_name.ts
@@ -25,6 +25,7 @@ export const useHostIpToName = (ipAddress: string | null, indexPattern: string |
             });
             setLoadingState(false);
             setData(response.data);
+            setError(null);
           }
         } catch (err) {
           setLoadingState(false);


### PR DESCRIPTION
## Summary

This PR fixes elastic/kibana#37999 by resetting the error upon a successful request. Before this change, if the . user changed the IP address in the URL to a valid one, it would continue to display the error message and fail to redirect.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~