### PR TITLE
Skip Index Management API integration tests that are inapplicable to Cloud, when they are run on Cloud.

### DIFF
--- a/x-pack/test/api_integration/apis/management/index_management/indices.js
+++ b/x-pack/test/api_integration/apis/management/index_management/indices.js
@@ -48,7 +48,10 @@ export default function ({ getService }) {
       });
     });
 
-    describe('close', () => {
+    describe('close', function () {
+      // The Cloud backend disallows users from closing indices.
+      this.tags(['skipCloud']);
+
       it('should close an index', async () => {
         const index = await createIndex();
 
@@ -64,7 +67,11 @@ export default function ({ getService }) {
       });
     });
 
-    describe('open', () => {
+    describe('open', function () {
+      // The Cloud backend disallows users from closing indices, so there's no point testing
+      // the open behavior.
+      this.tags(['skipCloud']);
+
       it('should open an index', async () => {
         const index = await createIndex();
 
@@ -170,8 +177,10 @@ export default function ({ getService }) {
       });
     });
 
-    describe('list', () => {
-      it('should list all the indices with the expected properties and data enrichers', async () => {
+    describe('list', function () {
+      this.tags(['skipCloud']);
+
+      it('should list all the indices with the expected properties and data enrichers', async function () {
         const { body } = await list().expect(200);
         const expectedKeys = [
           'health',
@@ -186,32 +195,38 @@ export default function ({ getService }) {
           'aliases',
           'ilm', // data enricher
           'isRollupIndex', // data enricher
+          // Cloud disables CCR, so wouldn't expect follower indices.
           'isFollowerIndex' // data enricher
         ];
         expect(Object.keys(body[0])).to.eql(expectedKeys);
       });
     });
 
-    describe('reload', () => {
-      it('should list all the indices with the expected properties and data enrichers', async () => {
-        const { body } = await reload().expect(200);
-        const expectedKeys = [
-          'health',
-          'status',
-          'name',
-          'uuid',
-          'primary',
-          'replica',
-          'documents',
-          'size',
-          'isFrozen',
-          'aliases',
-          'ilm', // data enricher
-          'isRollupIndex', // data enricher
-          'isFollowerIndex' // data enricher
-        ];
-        expect(Object.keys(body[0])).to.eql(expectedKeys);
-        expect(body.length > 1).to.be(true); // to contrast it with the next test
+    describe('reload', function () {
+      describe('(not on Cloud)', function () {
+        this.tags(['skipCloud']);
+
+        it('should list all the indices with the expected properties and data enrichers', async function () {
+          const { body } = await reload().expect(200);
+          const expectedKeys = [
+            'health',
+            'status',
+            'name',
+            'uuid',
+            'primary',
+            'replica',
+            'documents',
+            'size',
+            'isFrozen',
+            'aliases',
+            'ilm', // data enricher
+            'isRollupIndex', // data enricher
+            // Cloud disables CCR, so wouldn't expect follower indices.
+            'isFollowerIndex' // data enricher
+          ];
+          expect(Object.keys(body[0])).to.eql(expectedKeys);
+          expect(body.length > 1).to.be(true); // to contrast it with the next test
+        });
       });
 
       it('should allow reloading only certain indices', async () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/37393