### PR TITLE
[7.2] functional tests/firefox wait for loading after page refresh (#38082)

### DIFF
--- a/test/functional/apps/dashboard/panel_controls.js
+++ b/test/functional/apps/dashboard/panel_controls.js
@@ -38,6 +38,7 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.dashboard.initTests();
       await kibanaServer.uiSettings.disableToastAutohide();
       await browser.refresh();
+      await PageObjects.header.awaitKibanaChrome();
 
       // This flip between apps fixes the url so state is preserved when switching apps in test mode.
       // Without this flip the url in test mode looks something like

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -438,6 +438,7 @@ export default function ({ getService, getPageObjects }) {
       it('should show bars in the correct time zone after switching', async function () {
         await kibanaServer.uiSettings.replace({ 'dateFormat:tz': 'America/Phoenix' });
         await browser.refresh();
+        await PageObjects.header.awaitKibanaChrome();
         await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
 
         const maxTicks = [

--- a/test/functional/apps/home/_navigation.js
+++ b/test/functional/apps/home/_navigation.js
@@ -22,7 +22,7 @@ import expect from '@kbn/expect';
 
 export default function ({ getService, getPageObjects }) {
   const browser = getService('browser');
-  const PageObjects = getPageObjects(['common', 'home', 'timePicker']);
+  const PageObjects = getPageObjects(['common', 'header', 'home', 'timePicker']);
   const appsMenu = getService('appsMenu');
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
@@ -36,6 +36,7 @@ export default function ({ getService, getPageObjects }) {
       await esArchiver.loadIfNeeded('makelogs');
       await kibanaServer.uiSettings.disableToastAutohide();
       await browser.refresh();
+      await PageObjects.header.awaitKibanaChrome();
     });
 
     // FLAKY: https://github.com/elastic/kibana/issues/33468

--- a/test/functional/apps/visualize/_point_series_options.js
+++ b/test/functional/apps/visualize/_point_series_options.js
@@ -201,6 +201,7 @@ export default function ({ getService, getPageObjects }) {
       it('should show round labels in different timezone', async function () {
         await kibanaServer.uiSettings.replace({ 'dateFormat:tz': 'America/Phoenix' });
         await browser.refresh();
+        await PageObjects.header.awaitKibanaChrome();
         await initChart();
 
         const labels = await PageObjects.visualize.getXAxisLabels();


### PR DESCRIPTION
Backports the following commits to 7.2:
 - functional tests/firefox wait for loading after page refresh  (#38082)