### PR TITLE
[Maps] use coalesce to ensure number always passed to interpolate for data driven size styling

### DIFF
--- a/docs/maps/vector-style.asciidoc
+++ b/docs/maps/vector-style.asciidoc
@@ -44,6 +44,11 @@ To enable data driven styling, click image:maps/images/gs_link_icon.png[] next t
 
 NOTE: The image:maps/images/gs_link_icon.png[] button is only available for vector features that contain numeric properties.
 
+NOTE: *Fill color* and *Border color* style properties are set to transparent and are not visible
+when the property value is undefined for a feature.
+*Border width* and *Symbol size* style properties are set to the minimum size
+when the property value is undefined for a feature.
+
 The image below shows an example of data driven styling using the <<add-sample-data, Kibana sample web logs>> data set.
 The *kibana_sample_data_logs* layer uses data driven styling for fill color and symbol size style properties.
 

--- a/docs/maps/vector-style.asciidoc
+++ b/docs/maps/vector-style.asciidoc
@@ -44,7 +44,7 @@ To enable data driven styling, click image:maps/images/gs_link_icon.png[] next t
 
 NOTE: The image:maps/images/gs_link_icon.png[] button is only available for vector features that contain numeric properties.
 
-NOTE: *Fill color* and *Border color* style properties are set to transparent and are not visible
+NOTE: *The Fill color* and *Border color* style properties are set to transparent and are not visible
 when the property value is undefined for a feature.
 *Border width* and *Symbol size* style properties are set to the minimum size
 when the property value is undefined for a feature.

--- a/docs/maps/vector-style.asciidoc
+++ b/docs/maps/vector-style.asciidoc
@@ -41,8 +41,7 @@ image::maps/images/vector_style_static.png[]
 
 Use data driven styling to symbolize features from a range of numeric property values.
 To enable data driven styling, click image:maps/images/gs_link_icon.png[] next to the property.
-
-NOTE: The image:maps/images/gs_link_icon.png[] button is only available for vector features that contain numeric properties.
+This button is only available when vector features contain numeric properties.
 
 NOTE: *The Fill color* and *Border color* style properties are set to transparent and are not visible
 when the property value is undefined for a feature.

--- a/docs/maps/vector-style.asciidoc
+++ b/docs/maps/vector-style.asciidoc
@@ -46,7 +46,7 @@ NOTE: The image:maps/images/gs_link_icon.png[] button is only available for vect
 
 NOTE: *The Fill color* and *Border color* style properties are set to transparent and are not visible
 when the property value is undefined for a feature.
-*Border width* and *Symbol size* style properties are set to the minimum size
+*The Border width* and *Symbol size* style properties are set to the minimum size
 when the property value is undefined for a feature.
 
 The image below shows an example of data driven styling using the <<add-sample-data, Kibana sample web logs>> data set.

--- a/x-pack/plugins/maps/public/shared/layers/styles/vector_style.js
+++ b/x-pack/plugins/maps/public/shared/layers/styles/vector_style.js
@@ -554,7 +554,7 @@ export class VectorStyle extends AbstractStyle {
       mbMap.setLayoutProperty(symbolLayerId, 'icon-size', [
         'interpolate',
         ['linear'],
-        ['get', targetName],
+        ['coalesce', ['get', targetName], 0],
         0, iconSize.options.minSize / halfIconPixels,
         1, iconSize.options.maxSize / halfIconPixels
       ]);

--- a/x-pack/plugins/maps/public/shared/layers/styles/vector_style.js
+++ b/x-pack/plugins/maps/public/shared/layers/styles/vector_style.js
@@ -415,7 +415,7 @@ export class VectorStyle extends AbstractStyle {
     return   [
       'interpolate',
       ['linear'],
-      ['feature-state', targetName],
+      ['coalesce', ['feature-state', targetName], 0],
       0, minSize,
       1, maxSize
     ];


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/38021

PR also updates docs with behavior for styling when property feature is undefined

<img width="400" alt="Screen Shot 2019-06-12 at 3 57 40 PM" src="https://user-images.githubusercontent.com/373691/59389170-e87a9000-8d2a-11e9-8e03-f8746d446b5f.png">
