### PR TITLE
Disable CCR and Remote Clusters API integration tests on Cloud.

### DIFF
--- a/x-pack/test/api_integration/apis/management/cross_cluster_replication/auto_follow_pattern.js
+++ b/x-pack/test/api_integration/apis/management/cross_cluster_replication/auto_follow_pattern.js
@@ -22,7 +22,9 @@ export default function ({ getService }) {
     deleteAllAutoFollowPatterns
   } = registerAutoFollowPatternHelpers(supertest);
 
-  describe('auto follow patterns', () => {
+  describe('auto follow patterns', function () {
+    this.tags(['skipCloud']);
+
     after(() => deleteAllAutoFollowPatterns().then(deleteAllClusters));
 
     describe('list()', () => {

--- a/x-pack/test/api_integration/apis/management/cross_cluster_replication/follower_indices.js
+++ b/x-pack/test/api_integration/apis/management/cross_cluster_replication/follower_indices.js
@@ -26,7 +26,9 @@ export default function ({ getService }) {
 
   const { createIndex, deleteAllIndices } = registerElasticSearchHelpers(es);
 
-  describe('follower indices', () => {
+  describe('follower indices', function () {
+    this.tags(['skipCloud']);
+
     before(() => addCluster());
 
     after(() => Promise.all([

--- a/x-pack/test/api_integration/apis/management/remote_clusters/remote_clusters.js
+++ b/x-pack/test/api_integration/apis/management/remote_clusters/remote_clusters.js
@@ -10,7 +10,9 @@ import { API_BASE_PATH, NODE_SEED } from './constants';
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
-  describe('Remote Clusters', () => {
+  describe('Remote Clusters', function () {
+    this.tags(['skipCloud']);
+
     describe('Empty List', () => {
       it('should return an empty array when there are no remote clusters', async () => {
         const uri = `${API_BASE_PATH}`;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/37389

These features are disabled on Cloud.

Forward-port of https://github.com/elastic/kibana/pull/38612.