### PR TITLE
Remove RefreshConfig type from embeddable packages

### DIFF
--- a/src/legacy/core_plugins/embeddable_api/public/index.ts
+++ b/src/legacy/core_plugins/embeddable_api/public/index.ts
@@ -29,15 +29,7 @@ export {
   isErrorEmbeddable,
 } from './embeddables';
 
-export {
-  Query,
-  TimeRange,
-  RefreshConfig,
-  ViewMode,
-  QueryLanguageType,
-  Trigger,
-  IRegistry,
-} from './types';
+export { Query, TimeRange, ViewMode, QueryLanguageType, Trigger, IRegistry } from './types';
 
 export { actionRegistry, Action, ActionContext, IncompatibleActionError } from './actions';
 

--- a/src/legacy/core_plugins/embeddable_api/public/types.ts
+++ b/src/legacy/core_plugins/embeddable_api/public/types.ts
@@ -54,11 +54,6 @@ export interface TimeRange {
   from: string;
 }
 
-export interface RefreshConfig {
-  pause: boolean;
-  value: number;
-}
-
 export enum QueryLanguageType {
   KUERY = 'kuery',
   LUCENE = 'lucene',

--- a/src/legacy/core_plugins/kibana/public/dashboard/actions/view.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/actions/view.ts
@@ -20,7 +20,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { createAction } from 'redux-actions';
-import { Filters, Query, RefreshConfig, TimeRange } from 'ui/embeddable';
+import { Filters, Query, TimeRange } from 'ui/embeddable';
+import { RefreshInterval } from 'ui/timefilter/timefilter';
 import { KibanaAction } from '../../selectors/types';
 import { DashboardViewMode } from '../dashboard_view_mode';
 import { PanelId } from '../selectors';
@@ -68,7 +69,7 @@ export interface UpdateTimeRangeAction
   extends KibanaAction<ViewActionTypeKeys.UPDATE_TIME_RANGE, TimeRange> {}
 
 export interface UpdateRefreshConfigAction
-  extends KibanaAction<ViewActionTypeKeys.UPDATE_REFRESH_CONFIG, RefreshConfig> {}
+  extends KibanaAction<ViewActionTypeKeys.UPDATE_REFRESH_CONFIG, RefreshInterval> {}
 
 export interface UpdateFiltersAction
   extends KibanaAction<ViewActionTypeKeys.UPDATE_FILTERS, Filters> {}
@@ -104,7 +105,7 @@ export const updateHidePanelTitles = createAction<boolean>(
   ViewActionTypeKeys.UPDATE_HIDE_PANEL_TITLES
 );
 export const updateTimeRange = createAction<TimeRange>(ViewActionTypeKeys.UPDATE_TIME_RANGE);
-export const updateRefreshConfig = createAction<RefreshConfig>(
+export const updateRefreshConfig = createAction<RefreshInterval>(
   ViewActionTypeKeys.UPDATE_REFRESH_CONFIG
 );
 export const updateFilters = createAction<Filters>(ViewActionTypeKeys.UPDATE_FILTERS);

--- a/src/legacy/core_plugins/kibana/public/dashboard/dashboard_state_manager.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/dashboard_state_manager.ts
@@ -27,6 +27,7 @@ import { TimeRange, Query } from 'ui/embeddable';
 import { Timefilter } from 'ui/timefilter';
 import { Filter } from '@kbn/es-query';
 import moment from 'moment';
+import { RefreshInterval } from 'ui/timefilter/timefilter';
 import { DashboardViewMode } from './dashboard_view_mode';
 import { FilterUtils } from './lib/filter_utils';
 import { PanelUtils } from './panel/panel_utils';
@@ -212,13 +213,8 @@ export class DashboardStateManager {
     );
   }
 
-  public handleRefreshConfigChange({ pause, value }: { pause: boolean; value: number }) {
-    store.dispatch(
-      updateRefreshConfig({
-        isPaused: pause,
-        interval: value,
-      })
-    );
+  public handleRefreshConfigChange(refreshInterval: RefreshInterval) {
+    store.dispatch(updateRefreshConfig(refreshInterval));
   }
 
   /**

--- a/src/legacy/core_plugins/kibana/public/dashboard/reducers/view.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/reducers/view.ts
@@ -20,8 +20,9 @@
 import { cloneDeep } from 'lodash';
 import { Reducer } from 'redux';
 
-import { Filters, Query, RefreshConfig, TimeRange } from 'ui/embeddable';
+import { Filters, Query, TimeRange } from 'ui/embeddable';
 import { QueryLanguageType } from 'ui/embeddable/types';
+import { RefreshInterval } from 'ui/timefilter/timefilter';
 import { ViewActions, ViewActionTypeKeys } from '../actions';
 import { DashboardViewMode } from '../dashboard_view_mode';
 import { PanelId, ViewState } from '../selectors';
@@ -61,7 +62,7 @@ const updateTimeRange = (view: ViewState, timeRange: TimeRange) => ({
   timeRange,
 });
 
-const updateRefreshConfig = (view: ViewState, refreshConfig: RefreshConfig) => ({
+const updateRefreshConfig = (view: ViewState, refreshConfig: RefreshInterval) => ({
   ...view,
   refreshConfig,
 });
@@ -93,7 +94,7 @@ export const viewReducer: Reducer<ViewState> = (
     isFullScreenMode: false,
     query: { language: QueryLanguageType.LUCENE, query: '' },
     timeRange: { to: 'now', from: 'now-15m' },
-    refreshConfig: { isPaused: true, interval: 0 },
+    refreshConfig: { pause: true, value: 0 },
     useMargins: true,
     viewMode: DashboardViewMode.VIEW,
   },

--- a/src/legacy/core_plugins/kibana/public/dashboard/selectors/dashboard.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/selectors/dashboard.ts
@@ -18,9 +18,10 @@
  */
 
 import _ from 'lodash';
-import { ContainerState, EmbeddableMetadata, Query, RefreshConfig, TimeRange } from 'ui/embeddable';
+import { ContainerState, EmbeddableMetadata, Query, TimeRange } from 'ui/embeddable';
 import { EmbeddableCustomization } from 'ui/embeddable/types';
 import { Filter } from '@kbn/es-query';
+import { RefreshInterval } from 'ui/timefilter/timefilter';
 import { DashboardViewMode } from '../dashboard_view_mode';
 import {
   DashboardMetadata,
@@ -109,7 +110,7 @@ export const getMaximizedPanelId = (dashboard: DashboardState): PanelId | undefi
 
 export const getTimeRange = (dashboard: DashboardState): TimeRange => dashboard.view.timeRange;
 
-export const getRefreshConfig = (dashboard: DashboardState): RefreshConfig =>
+export const getRefreshConfig = (dashboard: DashboardState): RefreshInterval =>
   dashboard.view.refreshConfig;
 
 export const getFilters = (dashboard: DashboardState): Filter[] => dashboard.view.filters;

--- a/src/legacy/core_plugins/kibana/public/dashboard/selectors/types.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/selectors/types.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import { EmbeddableMetadata, Query, RefreshConfig, TimeRange } from 'ui/embeddable';
+import { EmbeddableMetadata, Query, TimeRange } from 'ui/embeddable';
 import { Filter } from '@kbn/es-query';
+import { RefreshInterval } from 'ui/timefilter/timefilter';
 import { DashboardViewMode } from '../dashboard_view_mode';
 import { SavedDashboardPanelMap } from '../types';
 
@@ -29,7 +30,7 @@ export interface ViewState {
   readonly maximizedPanelId?: string;
   readonly visibleContextMenuPanelId?: string;
   readonly timeRange: TimeRange;
-  readonly refreshConfig: RefreshConfig;
+  readonly refreshConfig: RefreshInterval;
   readonly hidePanelTitles: boolean;
   readonly useMargins: boolean;
   readonly query: Query;

--- a/src/legacy/ui/public/embeddable/index.ts
+++ b/src/legacy/ui/public/embeddable/index.ts
@@ -21,12 +21,4 @@ export { EmbeddableFactory, OnEmbeddableStateChanged } from './embeddable_factor
 export * from './embeddable';
 export * from './context_menu_actions';
 export { EmbeddableFactoriesRegistryProvider } from './embeddable_factories_registry';
-export {
-  ContainerState,
-  EmbeddableState,
-  Query,
-  Filters,
-  Filter,
-  TimeRange,
-  RefreshConfig,
-} from './types';
+export { ContainerState, EmbeddableState, Query, Filters, Filter, TimeRange } from './types';

--- a/src/legacy/ui/public/embeddable/types.ts
+++ b/src/legacy/ui/public/embeddable/types.ts
@@ -18,6 +18,7 @@
  */
 
 import { Filter } from '@kbn/es-query';
+import { RefreshInterval } from 'ui/timefilter/timefilter';
 
 // Should go away soon once everyone imports from kbn/es-query
 export { Filter } from '@kbn/es-query';
@@ -25,11 +26,6 @@ export { Filter } from '@kbn/es-query';
 export interface TimeRange {
   to: string;
   from: string;
-}
-
-export interface RefreshConfig {
-  isPaused: boolean;
-  interval: number;
 }
 
 export interface FilterMeta {
@@ -62,7 +58,7 @@ export interface ContainerState {
 
   filters: Filter[];
 
-  refreshConfig: RefreshConfig;
+  refreshConfig: RefreshInterval;
 
   query: Query;
 

--- a/src/legacy/ui/public/filter_manager/lib/__tests__/change_time_filter.test.js
+++ b/src/legacy/ui/public/filter_manager/lib/__tests__/change_time_filter.test.js
@@ -27,7 +27,7 @@ jest.mock('ui/chrome',
             case 'timepicker:timeDefaults':
               return { from: 'now-15m', to: 'now' };
             case 'timepicker:refreshIntervalDefaults':
-              return { display: 'Off', pause: false, value: 0 };
+              return { pause: false, value: 0 };
             default:
               throw new Error(`Unexpected config key: ${key}`);
           }

--- a/src/legacy/ui/public/timefilter/timefilter.d.ts
+++ b/src/legacy/ui/public/timefilter/timefilter.d.ts
@@ -24,9 +24,7 @@ import moment = require('moment');
 // NOTE: These types are somewhat guessed, they may be incorrect.
 
 export interface RefreshInterval {
-  display?: string;
   pause: boolean;
-  section?: string;
   value: number;
 }
 

--- a/src/legacy/ui/public/vis/vis_filters/brush_event.test.js
+++ b/src/legacy/ui/public/vis/vis_filters/brush_event.test.js
@@ -27,7 +27,7 @@ jest.mock('ui/chrome',
             case 'timepicker:timeDefaults':
               return { from: 'now-15m', to: 'now' };
             case 'timepicker:refreshIntervalDefaults':
-              return { display: 'Off', pause: false, value: 0 };
+              return { pause: false, value: 0 };
             default:
               throw new Error(`Unexpected config key: ${key}`);
           }

--- a/x-pack/plugins/__mocks__/ui/chrome.js
+++ b/x-pack/plugins/__mocks__/ui/chrome.js
@@ -13,7 +13,7 @@ function getUiSettingsClient() {
         case 'timepicker:timeDefaults':
           return { from: 'now-15m', to: 'now', mode: 'quick' };
         case 'timepicker:refreshIntervalDefaults':
-          return { display: 'Off', pause: false, value: 0 };
+          return { pause: false, value: 0 };
         case 'siem:defaultIndex':
           return ['auditbeat-*', 'filebeat-*', 'packetbeat-*', 'winlogbeat-*'];
         default:

--- a/x-pack/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
+++ b/x-pack/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
@@ -24,7 +24,7 @@ jest.mock(
             case 'timepicker:timeDefaults':
               return { from: 'now-15m', to: 'now', mode: 'quick' };
             case 'timepicker:refreshIntervalDefaults':
-              return { display: 'Off', pause: false, value: 0 };
+              return { pause: false, value: 0 };
             default:
               throw new Error(`Unexpected config key: ${key}`);
           }

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.js
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.js
@@ -72,7 +72,11 @@ export class MapEmbeddable extends Embeddable {
       this._dispatchSetQuery(containerState);
     }
 
-    if (!_.isEqual(containerState.refreshConfig, this._prevRefreshConfig)) {
+    const refreshConfig = {
+      isPaused: containerState.refreshConfig.pause,
+      interval: containerState.refreshConfig.value
+    };
+    if (!_.isEqual(refreshConfig, this._prevRefreshConfig)) {
       this._dispatchSetRefreshConfig(containerState);
     }
   }
@@ -89,8 +93,12 @@ export class MapEmbeddable extends Embeddable {
   }
 
   _dispatchSetRefreshConfig({ refreshConfig }) {
-    this._prevRefreshConfig = refreshConfig;
-    this._store.dispatch(setRefreshConfig(refreshConfig));
+    const internalRefreshConfig = {
+      isPaused: refreshConfig.pause,
+      interval: refreshConfig.value
+    };
+    this._prevRefreshConfig = internalRefreshConfig;
+    this._store.dispatch(setRefreshConfig(internalRefreshConfig));
   }
 
   /**

--- a/x-pack/plugins/monitoring/public/monitoring.js
+++ b/x-pack/plugins/monitoring/public/monitoring.js
@@ -29,7 +29,6 @@ uiSettings.overrideLocalDefault('timepicker:timeDefaults', JSON.stringify({
 
 // default autorefresh to active and refreshing every 10 seconds
 uiSettings.overrideLocalDefault('timepicker:refreshIntervalDefaults', JSON.stringify({
-  display: '10 seconds',
   pause: false,
   value: 10000
 }));


### PR DESCRIPTION
Instead use the RefreshInterval type in the timefilter plugin.

With new Embeddable API, this type won't even be in that package, only used in the dashboard package.