### PR TITLE
Skip ILM node API integration tests on Cloud

### DIFF
--- a/x-pack/test/api_integration/apis/management/index_lifecycle_management/nodes.js
+++ b/x-pack/test/api_integration/apis/management/index_lifecycle_management/nodes.js
@@ -18,7 +18,11 @@ export default function ({ getService }) {
   const { getNodesStats } = initElasticsearchHelpers(es);
   const { loadNodes, getNodeDetails } = registerHelpers({ supertest });
 
-  describe('nodes', () => {
+  describe('nodes', function () {
+    // Cloud disallows setting custom node attributes, so we can't use `NODE_CUSTOM_ATTRIBUTE`
+    // to retrieve the IDs we expect.
+    this.tags(['skipCloud']);
+
     describe('list', () => {
       it('should return the list of ES node for each custom attributes', async () => {
         const nodeStats = await getNodesStats();


### PR DESCRIPTION
These tests depend on setting custom node attributes and Cloud disallows that.

Fixes https://github.com/elastic/kibana/issues/37394
