### PR TITLE
Clarifying report date-math syntax expressions in watch

### DIFF
--- a/docs/reporting/automating-report-generation.asciidoc
+++ b/docs/reporting/automating-report-generation.asciidoc
@@ -29,6 +29,8 @@ in an `email` action. For more information, see
 
 include::watch-example.asciidoc[]
 
+NOTE: The report Generation URL may contain date-math expressions that cause the watch to fail with a `parse_exception`. Remove curly braces `{`  `}` from date-math expressions and URL-encode characters to avoid this. For example: `...(range:(%27@timestamp%27:(gte:now-15m%2Fd,lte:now%2Fd))))...`
+
 For more information about configuring watches, see
 {stack-ov}/how-watcher-works.html[How Watcher Works].
 


### PR DESCRIPTION
I added an example of using a csv report Generation URL that contains date-math in the URL, which can cause the watch to fail if not properly formatted.  This can arise when copying the csv URL from Kibana but not removing the curly brackets or properly URL-encoding the required characters, and the resulting watch `parse_exception` can be hard to track down.  Users should be aware that the working report URL they copy from Kibana may not work in the watch without adjusting things like this.

I wasn't sure if the example expression was too much or too specific to include in a Note format, and am open to re-working if the presentation could be improved.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [+ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

