### PR TITLE
[APM] Display parsed user agent in Transaction Details

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -7,7 +7,6 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { idx } from '@kbn/elastic-idx';
-import { identity } from 'lodash';
 import {
   TRANSACTION_DURATION,
   TRANSACTION_RESULT,
@@ -129,7 +128,7 @@ export function StickyTransactionProperties({
       label: i18n.translate('xpack.apm.transactionDetails.browserLabel', {
         defaultMessage: 'Browser'
       }),
-      val: [userAgent.name, userAgent.version].filter(identity).join(' '),
+      val: [userAgent.name, userAgent.version].filter(Boolean).join(' '),
       truncated: true,
       width
     });

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -7,6 +7,7 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { idx } from '@kbn/elastic-idx';
+import { identity } from 'lodash';
 import {
   TRANSACTION_DURATION,
   TRANSACTION_RESULT,
@@ -118,6 +119,40 @@ export function StickyTransactionProperties({
       width: '18%'
     }
   ];
+
+  const { user_agent: userAgent } = transaction;
+
+  if (userAgent) {
+    const { os, device } = userAgent;
+    const width = '25%';
+    stickyProperties.push({
+      label: i18n.translate('xpack.apm.transactionDetails.browserLabel', {
+        defaultMessage: 'Browser'
+      }),
+      val: [userAgent.name, userAgent.version].filter(identity).join(' '),
+      truncated: true,
+      width
+    });
+
+    if (os) {
+      stickyProperties.push({
+        label: i18n.translate('xpack.apm.transactionDetails.osLabel', {
+          defaultMessage: 'OS'
+        }),
+        val: os.full,
+        truncated: true,
+        width
+      });
+    }
+
+    stickyProperties.push({
+      label: i18n.translate('xpack.apm.transactionDetails.deviceLabel', {
+        defaultMessage: 'OS'
+      }),
+      val: device.name,
+      width
+    });
+  }
 
   return <StickyProperties stickyProperties={stickyProperties} />;
 }

--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/__snapshots__/StickyProperties.test.js.snap
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/__snapshots__/StickyProperties.test.js.snap
@@ -12,6 +12,7 @@ exports[`StickyProperties should render entire component 1`] = `
   wrap={true}
 >
   <EuiFlexItem
+    grow={false}
     key="0"
     style={
       Object {
@@ -40,6 +41,7 @@ exports[`StickyProperties should render entire component 1`] = `
     />
   </EuiFlexItem>
   <EuiFlexItem
+    grow={false}
     key="1"
     style={
       Object {
@@ -74,6 +76,7 @@ exports[`StickyProperties should render entire component 1`] = `
     </EuiToolTip>
   </EuiFlexItem>
   <EuiFlexItem
+    grow={false}
     key="2"
     style={
       Object {
@@ -102,6 +105,7 @@ exports[`StickyProperties should render entire component 1`] = `
     </PropertyValue>
   </EuiFlexItem>
   <EuiFlexItem
+    grow={false}
     key="3"
     style={
       Object {
@@ -130,6 +134,7 @@ exports[`StickyProperties should render entire component 1`] = `
     </PropertyValue>
   </EuiFlexItem>
   <EuiFlexItem
+    grow={false}
     key="4"
     style={
       Object {

--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
@@ -142,6 +142,7 @@ export function StickyProperties({
                 minWidth: width,
                 ...itemStyles
               }}
+              grow={false}
             >
               {getPropertyLabel(prop)}
               {getPropertyValue(prop)}

--- a/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -37,5 +37,6 @@ export async function getTraceItems(traceId: string, setup: Setup) {
   };
 
   const resp = await client.search<Transaction | Span>(params);
+
   return resp.hits.hits.map(hit => hit._source);
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/TransactionRaw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/TransactionRaw.ts
@@ -14,6 +14,7 @@ import { Process } from './fields/Process';
 import { Service } from './fields/Service';
 import { Url } from './fields/Url';
 import { User } from './fields/User';
+import { UserAgent } from './fields/UserAgent';
 
 interface Processor {
   name: 'transaction';
@@ -52,4 +53,5 @@ export interface TransactionRaw extends APMBaseDoc {
   service: Service;
   url?: Url;
   user?: User;
+  user_agent?: UserAgent;
 }

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/UserAgent.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/UserAgent.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export interface UserAgent {
+  device: {
+    name: string;
+  };
+  name: string;
+  original: string;
+  os?: {
+    name: string;
+    version: string;
+    full: string;
+  };
+  version?: string;
+}


### PR DESCRIPTION
Closes #37865.

- Update Transaction typings to include user_agent
- Display user agent fields in Transaction Details if available

Before:
![image](https://user-images.githubusercontent.com/352732/59596962-ff3d3000-90f8-11e9-86b3-af75e42987b6.png)


After:
![image](https://user-images.githubusercontent.com/352732/59596830-bd13ee80-90f8-11e9-9692-e3a3579e7446.png)


## Definition of Done for APM UI

- [ ] Flag and create issues of things that are left out
- [x] Before/after images or gif of UI changes
- [x] Release labels
- [ ] Designer sign-off for UI related changes
- [ ] ~~PM approval for bigger, user-facing features~~
- [ ] Add to Observability Weekly Updates