### PR TITLE
[APM] Don't redirect to default sample before data has been loaded

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -90,6 +90,7 @@ const getFormatYLong = (transactionType: string | undefined) => (t: number) => {
 interface Props {
   distribution?: ITransactionDistributionAPIResponse;
   urlParams: IUrlParams;
+  loading: boolean;
 }
 
 export const TransactionDistribution: FunctionComponent<Props> = (
@@ -97,7 +98,8 @@ export const TransactionDistribution: FunctionComponent<Props> = (
 ) => {
   const {
     distribution,
-    urlParams: { transactionId, traceId, transactionType }
+    urlParams: { transactionId, traceId, transactionType },
+    loading
   } = props;
 
   const formatYShort = useCallback(getFormatYShort(transactionType), [
@@ -125,11 +127,14 @@ export const TransactionDistribution: FunctionComponent<Props> = (
         })
       });
     },
-    [distribution]
+    [distribution, loading]
   );
 
   useEffect(
     () => {
+      if (loading) {
+        return;
+      }
       const selectedSampleIsAvailable = distribution
         ? !!distribution.buckets.find(
             bucket =>
@@ -145,7 +150,7 @@ export const TransactionDistribution: FunctionComponent<Props> = (
         redirectToDefaultSample();
       }
     },
-    [distribution, transactionId, traceId, redirectToDefaultSample]
+    [distribution, transactionId, traceId, redirectToDefaultSample, loading]
   );
 
   if (!distribution || !distribution.totalHits || !traceId || !transactionId) {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
@@ -16,11 +16,15 @@ import { TransactionDistribution } from './Distribution';
 import { Transaction } from './Transaction';
 import { useLocation } from '../../../hooks/useLocation';
 import { useUrlParams } from '../../../hooks/useUrlParams';
+import { FETCH_STATUS } from '../../../hooks/useFetcher';
 
 export function TransactionDetails() {
   const location = useLocation();
   const { urlParams } = useUrlParams();
-  const { data: distributionData } = useTransactionDistribution(urlParams);
+  const {
+    data: distributionData,
+    status: distributionStatus
+  } = useTransactionDistribution(urlParams);
   const { data: transactionDetailsChartsData } = useTransactionDetailsCharts(
     urlParams
   );
@@ -49,6 +53,10 @@ export function TransactionDetails() {
       <EuiPanel>
         <TransactionDistribution
           distribution={distributionData}
+          loading={
+            distributionStatus === FETCH_STATUS.LOADING ||
+            distributionStatus === undefined
+          }
           urlParams={urlParams}
         />
       </EuiPanel>


### PR DESCRIPTION
Fixes an issue w/ the transaction sample redirect being too aggressive & redirecting to the default sample before the data has been fully loaded. This makes deeplinking to samples unreliable.

## Definition of Done for APM UI

- [ ] ~~Flag and create issues of things that are left out~~
- [ ] ~~Before/after images or gif of UI changes~~
- [x] Release labels
- [ ] ~~Designer sign-off for UI related changes~~
- [ ] ~~PM approval for bigger, user-facing features~~
- [ ] Add to Observability Weekly Updates