### PR TITLE
[APM] Waterfall item check before referencing docType

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -254,7 +254,7 @@ function createGetTransactionById(itemsById: IWaterfallIndex) {
     }
 
     const item = itemsById[id];
-    if (item.docType === 'transaction') {
+    if (item && item.docType === 'transaction') {
       return item.transaction;
     }
   };


### PR DESCRIPTION
Fixes #39310 by checking that waterfall items exists before referencing it.

![Trace-waterfall-span-detail-errors-39310](https://user-images.githubusercontent.com/1967266/59802499-fe91ce80-929d-11e9-983f-744123d83401.gif)
