### PR TITLE
[7.x] [Infra UI] Allow Metrics Explorer to set KQL filters in TSVB (#38280)

### DIFF
--- a/x-pack/plugins/infra/public/components/metrics_explorer/helpers/create_tsvb_link.test.ts
+++ b/x-pack/plugins/infra/public/components/metrics_explorer/helpers/create_tsvb_link.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { createTSVBLink } from './create_tsvb_link';
+import { createTSVBLink, createFilterFromOptions } from './create_tsvb_link';
 import { source, options, timeRange } from '../../../utils/fixtures/metrics_explorer';
 import uuid from 'uuid';
 import { OutputBuffer } from 'uuid/interfaces';
@@ -19,7 +19,7 @@ describe('createTSVBLink()', () => {
   it('should just work', () => {
     const link = createTSVBLink(source, options, series, timeRange);
     expect(link).toBe(
-      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'metricbeat-*',filter:'host.name: example-01',id:test-id,index_pattern:'metricbeat-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))"
+      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'metricbeat-*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'metricbeat-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))"
     );
   });
   it('should work with rates', () => {
@@ -31,14 +31,14 @@ describe('createTSVBLink()', () => {
     };
     const link = createTSVBLink(source, customOptions, series, timeRange);
     expect(link).toBe(
-      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'metricbeat-*',filter:'host.name: example-01',id:test-id,index_pattern:'metricbeat-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:bytes,id:test-id,label:'rate(system.network.out.bytes)',line_width:2,metrics:!((field:system.network.out.bytes,id:test-id,type:max),(field:test-id,id:test-id,type:derivative,unit:'1s'),(field:test-id,id:test-id,type:positive_only)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}}/s)),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))"
+      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'metricbeat-*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'metricbeat-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:bytes,id:test-id,label:'rate(system.network.out.bytes)',line_width:2,metrics:!((field:system.network.out.bytes,id:test-id,type:max),(field:test-id,id:test-id,type:derivative,unit:'1s'),(field:test-id,id:test-id,type:positive_only)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}}/s)),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))"
     );
   });
   it('should work with time range', () => {
     const customTimeRange = { ...timeRange, from: 'now-10m', to: 'now' };
     const link = createTSVBLink(source, options, series, customTimeRange);
     expect(link).toBe(
-      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-10m,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'metricbeat-*',filter:'host.name: example-01',id:test-id,index_pattern:'metricbeat-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))"
+      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-10m,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'metricbeat-*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'metricbeat-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:'@timestamp',type:timeseries),title:example-01,type:metrics))"
     );
   });
   it('should work with source', () => {
@@ -49,7 +49,7 @@ describe('createTSVBLink()', () => {
     };
     const link = createTSVBLink(customSource, options, series, timeRange);
     expect(link).toBe(
-      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:'host.name: example-01',id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))"
+      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))"
     );
   });
   it('should work with filterQuery', () => {
@@ -61,7 +61,16 @@ describe('createTSVBLink()', () => {
     const customOptions = { ...options, filterQuery: 'system.network.name:lo*' };
     const link = createTSVBLink(customSource, customOptions, series, timeRange);
     expect(link).toBe(
-      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:'system.network.name:lo* AND host.name: example-01',id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))"
+      "../app/kibana#/visualize/create?type=metrics&_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_position:left,axis_scale:normal,default_index_pattern:'my-beats-*',filter:(language:kuery,query:'system.network.name:lo* and host.name : \"example-01\"'),id:test-id,index_pattern:'my-beats-*',interval:auto,series:!((axis_position:right,chart_type:line,color:%233185FC,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))"
     );
+  });
+
+  test('createFilterFromOptions()', () => {
+    const customOptions = { ...options, groupBy: 'host.name' };
+    const customSeries = { ...series, id: 'test"foo' };
+    expect(createFilterFromOptions(customOptions, customSeries)).toEqual({
+      language: 'kuery',
+      query: 'host.name : "test\\"foo"',
+    });
   });
 });

--- a/x-pack/plugins/infra/public/components/metrics_explorer/helpers/create_tsvb_link.ts
+++ b/x-pack/plugins/infra/public/components/metrics_explorer/helpers/create_tsvb_link.ts
@@ -79,7 +79,7 @@ const mapMetricToSeries = (metric: MetricsExplorerOptionsMetric) => {
   };
 };
 
-const createFilterFromOptions = (
+export const createFilterFromOptions = (
   options: MetricsExplorerOptions,
   series: MetricsExplorerSeries
 ) => {
@@ -88,9 +88,10 @@ const createFilterFromOptions = (
     filters.push(options.filterQuery);
   }
   if (options.groupBy) {
-    filters.push(`${options.groupBy}: ${series.id}`);
+    const id = series.id.replace('"', '\\"');
+    filters.push(`${options.groupBy} : "${id}"`);
   }
-  return filters.join(' AND ');
+  return { language: 'kuery', query: filters.join(' and ') };
 };
 
 export const createTSVBLink = (

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/populate_series_with_tsvb_data.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/populate_series_with_tsvb_data.ts
@@ -17,6 +17,7 @@ import {
   MetricsExplorerWrappedRequest,
 } from '../types';
 import { createMetricModel } from './create_metrics_model';
+import { JsonObject } from '../../../../common/typed_json';
 
 export const populateSeriesWithTSVBData = (
   req: InfraFrameworkRequest<MetricsExplorerWrappedRequest>,
@@ -33,7 +34,22 @@ export const populateSeriesWithTSVBData = (
   }
 
   // Set the filter for the group by or match everything
-  const filters = options.groupBy ? [{ match: { [options.groupBy]: series.id } }] : [];
+  const filters: JsonObject[] = options.groupBy
+    ? [{ match: { [options.groupBy]: series.id } }]
+    : [];
+  if (options.filterQuery) {
+    try {
+      const filterQuery = JSON.parse(options.filterQuery);
+      filters.push(filterQuery);
+    } catch (error) {
+      filters.push({
+        query_string: {
+          query: options.filterQuery,
+          analyze_wildcard: true,
+        },
+      });
+    }
+  }
   const timerange = { min: options.timerange.from, max: options.timerange.to };
 
   // Create the TSVB model based on the request options

--- a/x-pack/test/api_integration/apis/infra/metrics_explorer.ts
+++ b/x-pack/test/api_integration/apis/infra/metrics_explorer.ts
@@ -66,6 +66,48 @@ const metricsExplorerTest: KbnTestProvider = ({ getService }) => {
       });
     });
 
+    it('should apply filterQuery to data', async () => {
+      const postBody = {
+        timerange: {
+          field: '@timestamp',
+          to: max,
+          from: min,
+          interval: '>=1m',
+        },
+        indexPattern: 'metricbeat-*',
+        filterQuery:
+          '{"bool":{"should":[{"range":{"system.cpu.user.pct":{"gt":0.01}}}],"minimum_should_match":1}}',
+        metrics: [
+          {
+            aggregation: 'avg',
+            field: 'system.cpu.user.pct',
+            rate: false,
+          },
+        ],
+      };
+      const response = await supertest
+        .post('/api/infra/metrics_explorer')
+        .set('kbn-xsrf', 'xxx')
+        .send(postBody)
+        .expect(200);
+      const body: MetricsExplorerResponse = response.body;
+      expect(body).to.have.property('series');
+      expect(body.series).length(1);
+      const firstSeries = first(body.series);
+      expect(firstSeries).to.have.property('id', 'ALL');
+      expect(firstSeries).to.have.property('columns');
+      expect(firstSeries).to.have.property('rows');
+      expect(firstSeries!.columns).to.eql([
+        { name: 'timestamp', type: 'date' },
+        { name: 'metric_0', type: 'number' },
+      ]);
+      expect(firstSeries!.rows).to.have.length(9);
+      expect(firstSeries!.rows![1]).to.eql({
+        metric_0: 0.024,
+        timestamp: 1547571300000,
+      });
+    });
+
     it('should work for empty metrics', async () => {
       const postBody = {
         timerange: {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Infra UI] Fixes 38141 - Allow Metrics Explorer to set KQL filters in TSVB  (#38280)