### PR TITLE
[APM] Fixed positioning of WatcherFlyout CTA button

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
@@ -599,18 +599,24 @@ export class WatcherFlyout extends Component<
         </EuiFlyoutHeader>
         <EuiFlyoutBody>{flyoutBody}</EuiFlyoutBody>
         <EuiFlyoutFooter>
-          <EuiButton
-            onClick={this.createWatch}
-            fill
-            disabled={!this.state.actions.email && !this.state.actions.slack}
-          >
-            {i18n.translate(
-              'xpack.apm.serviceDetails.enableErrorReportsPanel.createWatchButtonLabel',
-              {
-                defaultMessage: 'Create watch'
-              }
-            )}
-          </EuiButton>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                onClick={this.createWatch}
+                fill
+                disabled={
+                  !this.state.actions.email && !this.state.actions.slack
+                }
+              >
+                {i18n.translate(
+                  'xpack.apm.serviceDetails.enableErrorReportsPanel.createWatchButtonLabel',
+                  {
+                    defaultMessage: 'Create watch'
+                  }
+                )}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlyoutFooter>
       </EuiFlyout>
     );


### PR DESCRIPTION
Closes #38876 

## Summary

Repositions the "Create watch" primary CTA button in the Flyout to the right as per the EUI guidelines and keeps it consistent with the Machine Learning flyout.

**Before**

![screencapture-apm-elstc-co-epx-app-apm-2019-06-20-11_04_49](https://user-images.githubusercontent.com/4104278/59836324-9a2d4880-934b-11e9-885f-834decdb4663.png)

**After**

![screencapture-localhost-5601-btq-app-apm-2019-06-20-11_02_16](https://user-images.githubusercontent.com/4104278/59836341-a0bbc000-934b-11e9-8477-dc6c0fa8a90f.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

