### PR TITLE
[APM] Change labels of user agent

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -138,7 +138,7 @@ export function StickyTransactionProperties({
         label: i18n.translate('xpack.apm.transactionDetails.userAgentOsLabel', {
           defaultMessage: 'User agent OS'
         }),
-        val: os.full,
+        val: os.full || os.name,
         truncated: true,
         width
       });

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -144,16 +144,18 @@ export function StickyTransactionProperties({
       });
     }
 
-    stickyProperties.push({
-      label: i18n.translate(
-        'xpack.apm.transactionDetails.userAgentDeviceLabel',
-        {
-          defaultMessage: 'User agent device'
-        }
-      ),
-      val: device.name,
-      width
-    });
+    if (device) {
+      stickyProperties.push({
+        label: i18n.translate(
+          'xpack.apm.transactionDetails.userAgentDeviceLabel',
+          {
+            defaultMessage: 'User agent device'
+          }
+        ),
+        val: device.name,
+        width
+      });
+    }
   }
 
   return <StickyProperties stickyProperties={stickyProperties} />;

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -125,8 +125,8 @@ export function StickyTransactionProperties({
     const { os, device } = userAgent;
     const width = '25%';
     stickyProperties.push({
-      label: i18n.translate('xpack.apm.transactionDetails.browserLabel', {
-        defaultMessage: 'Browser'
+      label: i18n.translate('xpack.apm.transactionDetails.userAgentLabel', {
+        defaultMessage: 'User agent'
       }),
       val: [userAgent.name, userAgent.version].filter(Boolean).join(' '),
       truncated: true,
@@ -135,8 +135,8 @@ export function StickyTransactionProperties({
 
     if (os) {
       stickyProperties.push({
-        label: i18n.translate('xpack.apm.transactionDetails.osLabel', {
-          defaultMessage: 'OS'
+        label: i18n.translate('xpack.apm.transactionDetails.userAgentOsLabel', {
+          defaultMessage: 'User agent OS'
         }),
         val: os.full,
         truncated: true,
@@ -145,9 +145,12 @@ export function StickyTransactionProperties({
     }
 
     stickyProperties.push({
-      label: i18n.translate('xpack.apm.transactionDetails.deviceLabel', {
-        defaultMessage: 'OS'
-      }),
+      label: i18n.translate(
+        'xpack.apm.transactionDetails.userAgentDeviceLabel',
+        {
+          defaultMessage: 'User agent device'
+        }
+      ),
       val: device.name,
       width
     });

--- a/x-pack/legacy/plugins/apm/typings/es_schemas/raw/fields/UserAgent.ts
+++ b/x-pack/legacy/plugins/apm/typings/es_schemas/raw/fields/UserAgent.ts
@@ -5,10 +5,10 @@
  */
 
 export interface UserAgent {
-  device: {
+  device?: {
     name: string;
   };
-  name: string;
+  name?: string;
   original: string;
   os?: {
     name: string;

--- a/x-pack/legacy/plugins/apm/typings/es_schemas/raw/fields/UserAgent.ts
+++ b/x-pack/legacy/plugins/apm/typings/es_schemas/raw/fields/UserAgent.ts
@@ -12,8 +12,8 @@ export interface UserAgent {
   original: string;
   os?: {
     name: string;
-    version: string;
-    full: string;
+    version?: string;
+    full?: string;
   };
   version?: string;
 }


### PR DESCRIPTION
As discussed in APM UI Weekly, this changes the "Browser" and "OS" labels to "User agent" and "User agent OS", as this is more reflective of the `user_agent` field.

![image](https://user-images.githubusercontent.com/352732/60085496-b826ee80-9739-11e9-8ce6-d9282845f8b5.png)
