### PR TITLE
[SR] Prevent snapshots in Cloud-managed repository from being deleted in the UI

### DIFF
--- a/x-pack/legacy/plugins/snapshot_restore/common/types/snapshot.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/common/types/snapshot.ts
@@ -22,6 +22,7 @@ export interface SnapshotDetails {
   durationInMillis: number;
   indexFailures: any[];
   shards: SnapshotDetailsShardsStatus;
+  isManagedRepository?: boolean;
 }
 
 interface SnapshotDetailsShardsStatus {

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/restore_list/restore_list.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/restore_list/restore_list.tsx
@@ -15,9 +15,10 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiLoadingSpinner,
+  EuiLink,
 } from '@elastic/eui';
 import { SectionError, SectionLoading } from '../../../components';
-import { UIM_RESTORE_LIST_LOAD } from '../../../constants';
+import { UIM_RESTORE_LIST_LOAD, BASE_PATH } from '../../../constants';
 import { useAppDependencies } from '../../../index';
 import { useLoadRestores } from '../../../services/http';
 import { useAppState } from '../../../services/state';
@@ -123,7 +124,7 @@ export const RestoreList: React.FunctionComponent = () => {
           <h1>
             <FormattedMessage
               id="xpack.snapshotRestore.restoreList.emptyPromptTitle"
-              defaultMessage="You don't have any snapshot restores"
+              defaultMessage="You don't have any restored snapshots"
             />
           </h1>
         }
@@ -132,7 +133,17 @@ export const RestoreList: React.FunctionComponent = () => {
             <p>
               <FormattedMessage
                 id="xpack.snapshotRestore.restoreList.emptyPromptDescription"
-                defaultMessage="Track progress of indices that are restored from snapshots."
+                defaultMessage="Go to {snapshotsLink} to start a restore."
+                values={{
+                  snapshotsLink: (
+                    <EuiLink href={`#${BASE_PATH}/snapshots`}>
+                      <FormattedMessage
+                        id="xpack.snapshotRestore.restoreList.emptyPromptDescriptionLink"
+                        defaultMessage="Snapshots"
+                      />
+                    </EuiLink>
+                  ),
+                }}
               />
             </p>
           </Fragment>

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/restore_list/restore_table/shards_table.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/restore_list/restore_table/shards_table.tsx
@@ -81,6 +81,7 @@ export const ShardsTable: React.FunctionComponent<Props> = ({ shards }) => {
                   <FormattedMessage
                     id="xpack.snapshotRestore.restoreList.shardTable.primaryAbbreviationText"
                     defaultMessage="P"
+                    description="Used as an abbreviation for 'Primary', as in 'Primary shard'"
                   />
                 </strong>
               </EuiToolTip>

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_details/snapshot_details.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_details/snapshot_details.tsx
@@ -199,6 +199,18 @@ export const SnapshotDetails: React.FunctionComponent<Props> = ({
                             onSnapshotDeleted
                           )
                         }
+                        isDisabled={snapshotDetails.isManagedRepository}
+                        title={
+                          snapshotDetails.isManagedRepository
+                            ? i18n.translate(
+                                'xpack.snapshotRestore.snapshotDetails.deleteManagedRepositorySnapshotButtonTitle',
+                                {
+                                  defaultMessage:
+                                    'You cannot delete a managed repository snapshot.',
+                                }
+                              )
+                            : null
+                        }
                       >
                         <FormattedMessage
                           id="xpack.snapshotRestore.snapshotDetails.deleteButtonLabel"

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_details/snapshot_details.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_details/snapshot_details.tsx
@@ -206,7 +206,7 @@ export const SnapshotDetails: React.FunctionComponent<Props> = ({
                                 'xpack.snapshotRestore.snapshotDetails.deleteManagedRepositorySnapshotButtonTitle',
                                 {
                                   defaultMessage:
-                                    'You cannot delete a managed repository snapshot.',
+                                    'You cannot delete a snapshot stored in a managed repository.',
                                 }
                               )
                             : null

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_list.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_list.tsx
@@ -42,7 +42,7 @@ export const SnapshotList: React.FunctionComponent<RouteComponentProps<MatchPara
   const {
     error,
     loading,
-    data: { snapshots = [], repositories = [], errors = {} },
+    data: { snapshots = [], repositories = [], managedRepository = undefined, errors = {} },
     request: reload,
   } = useLoadSnapshots();
 
@@ -283,6 +283,7 @@ export const SnapshotList: React.FunctionComponent<RouteComponentProps<MatchPara
         <SnapshotTable
           snapshots={snapshots}
           repositories={repositories}
+          managedRepository={managedRepository}
           reload={reload}
           openSnapshotDetailsUrl={openSnapshotDetailsUrl}
           onSnapshotDeleted={onSnapshotDeleted}

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_list.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_list.tsx
@@ -42,7 +42,7 @@ export const SnapshotList: React.FunctionComponent<RouteComponentProps<MatchPara
   const {
     error,
     loading,
-    data: { snapshots = [], repositories = [], managedRepository = undefined, errors = {} },
+    data: { snapshots = [], repositories = [], errors = {} },
     request: reload,
   } = useLoadSnapshots();
 
@@ -283,7 +283,6 @@ export const SnapshotList: React.FunctionComponent<RouteComponentProps<MatchPara
         <SnapshotTable
           snapshots={snapshots}
           repositories={repositories}
-          managedRepository={managedRepository}
           reload={reload}
           openSnapshotDetailsUrl={openSnapshotDetailsUrl}
           onSnapshotDeleted={onSnapshotDeleted}

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_table/snapshot_table.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_table/snapshot_table.tsx
@@ -200,7 +200,8 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
                     : i18n.translate(
                         'xpack.snapshotRestore.snapshotList.table.deleteManagedRepositorySnapshotTooltip',
                         {
-                          defaultMessage: 'You cannot delete a managed repository snapshot.',
+                          defaultMessage:
+                            'You cannot delete a snapshot stored in a managed repository.',
                         }
                       );
                   return (
@@ -262,7 +263,7 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
         return i18n.translate(
           'xpack.snapshotRestore.snapshotList.table.deleteManagedRepositorySnapshotTooltip',
           {
-            defaultMessage: 'You cannot delete a managed repository snapshot.',
+            defaultMessage: 'You cannot delete a snapshot stored in a managed repository.',
           }
         );
       }

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_table/snapshot_table.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_table/snapshot_table.tsx
@@ -26,7 +26,6 @@ import { DataPlaceholder, SnapshotDeleteProvider } from '../../../../components'
 interface Props {
   snapshots: SnapshotDetails[];
   repositories: string[];
-  managedRepository?: string;
   reload: () => Promise<void>;
   openSnapshotDetailsUrl: (repositoryName: string, snapshotId: string) => string;
   repositoryFilter?: string;
@@ -36,7 +35,6 @@ interface Props {
 export const SnapshotTable: React.FunctionComponent<Props> = ({
   snapshots,
   repositories,
-  managedRepository,
   reload,
   openSnapshotDetailsUrl,
   onSnapshotDeleted,
@@ -190,22 +188,21 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
           },
         },
         {
-          render: ({ snapshot, repository }: SnapshotDetails) => {
+          render: ({ snapshot, repository, isManagedRepository }: SnapshotDetails) => {
             return (
               <SnapshotDeleteProvider>
                 {deleteSnapshotPrompt => {
-                  const label =
-                    repository !== managedRepository
-                      ? i18n.translate(
-                          'xpack.snapshotRestore.snapshotList.table.actionDeleteTooltip',
-                          { defaultMessage: 'Delete' }
-                        )
-                      : i18n.translate(
-                          'xpack.snapshotRestore.snapshotList.table.deleteManagedRepositorySnapshotTooltip',
-                          {
-                            defaultMessage: 'You cannot delete a managed repository snapshot.',
-                          }
-                        );
+                  const label = !isManagedRepository
+                    ? i18n.translate(
+                        'xpack.snapshotRestore.snapshotList.table.actionDeleteTooltip',
+                        { defaultMessage: 'Delete' }
+                      )
+                    : i18n.translate(
+                        'xpack.snapshotRestore.snapshotList.table.deleteManagedRepositorySnapshotTooltip',
+                        {
+                          defaultMessage: 'You cannot delete a managed repository snapshot.',
+                        }
+                      );
                   return (
                     <EuiToolTip content={label}>
                       <EuiButtonIcon
@@ -222,7 +219,7 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
                         onClick={() =>
                           deleteSnapshotPrompt([{ snapshot, repository }], onSnapshotDeleted)
                         }
-                        isDisabled={Boolean(repository === managedRepository)}
+                        isDisabled={isManagedRepository}
                       />
                     </EuiToolTip>
                   );
@@ -259,7 +256,7 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
 
   const selection = {
     onSelectionChange: (newSelectedItems: SnapshotDetails[]) => setSelectedItems(newSelectedItems),
-    selectable: ({ repository }: SnapshotDetails) => Boolean(repository !== managedRepository),
+    selectable: ({ isManagedRepository }: SnapshotDetails) => !isManagedRepository,
     selectableMessage: (selectable: boolean) => {
       if (!selectable) {
         return i18n.translate(

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_table/snapshot_table.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/snapshot_list/snapshot_table/snapshot_table.tsx
@@ -26,6 +26,7 @@ import { DataPlaceholder, SnapshotDeleteProvider } from '../../../../components'
 interface Props {
   snapshots: SnapshotDetails[];
   repositories: string[];
+  managedRepository?: string;
   reload: () => Promise<void>;
   openSnapshotDetailsUrl: (repositoryName: string, snapshotId: string) => string;
   repositoryFilter?: string;
@@ -35,6 +36,7 @@ interface Props {
 export const SnapshotTable: React.FunctionComponent<Props> = ({
   snapshots,
   repositories,
+  managedRepository,
   reload,
   openSnapshotDetailsUrl,
   onSnapshotDeleted,
@@ -192,10 +194,18 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
             return (
               <SnapshotDeleteProvider>
                 {deleteSnapshotPrompt => {
-                  const label = i18n.translate(
-                    'xpack.snapshotRestore.snapshotList.table.actionDeleteTooltip',
-                    { defaultMessage: 'Delete' }
-                  );
+                  const label =
+                    repository !== managedRepository
+                      ? i18n.translate(
+                          'xpack.snapshotRestore.snapshotList.table.actionDeleteTooltip',
+                          { defaultMessage: 'Delete' }
+                        )
+                      : i18n.translate(
+                          'xpack.snapshotRestore.snapshotList.table.deleteManagedRepositorySnapshotTooltip',
+                          {
+                            defaultMessage: 'You cannot delete a managed repository snapshot.',
+                          }
+                        );
                   return (
                     <EuiToolTip content={label}>
                       <EuiButtonIcon
@@ -212,6 +222,7 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
                         onClick={() =>
                           deleteSnapshotPrompt([{ snapshot, repository }], onSnapshotDeleted)
                         }
+                        isDisabled={Boolean(repository === managedRepository)}
                       />
                     </EuiToolTip>
                   );
@@ -248,6 +259,17 @@ export const SnapshotTable: React.FunctionComponent<Props> = ({
 
   const selection = {
     onSelectionChange: (newSelectedItems: SnapshotDetails[]) => setSelectedItems(newSelectedItems),
+    selectable: ({ repository }: SnapshotDetails) => Boolean(repository !== managedRepository),
+    selectableMessage: (selectable: boolean) => {
+      if (!selectable) {
+        return i18n.translate(
+          'xpack.snapshotRestore.snapshotList.table.deleteManagedRepositorySnapshotTooltip',
+          {
+            defaultMessage: 'You cannot delete a managed repository snapshot.',
+          }
+        );
+      }
+    },
   };
 
   const search = {

--- a/x-pack/legacy/plugins/snapshot_restore/server/lib/get_managed_repository_name.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/lib/get_managed_repository_name.ts
@@ -4,6 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+// Cloud has its own system for managing snapshots and we want to make
+// this clear when Snapshot and Restore is used in a Cloud deployment.
+// Retrieve the Cloud-managed repository name so that UI can switch
+// logical paths based on this information.
 export const getManagedRepositoryName = async (
   callWithInternalUser: any
 ): Promise<string | undefined> => {
@@ -20,7 +24,9 @@ export const getManagedRepositoryName = async (
     };
     return managedRepositoryName;
   } catch (e) {
-    // Silently swallow error and return undefined
+    // Silently swallow error and return undefined for managed repository name
+    // so that downstream calls are not blocked. In a healthy environment we do
+    // not expect to reach here.
     return;
   }
 };

--- a/x-pack/legacy/plugins/snapshot_restore/server/lib/get_managed_repository_name.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/lib/get_managed_repository_name.ts
@@ -4,16 +4,23 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export const getManagedRepositoryName = async (callWithInternalUser: any): Promise<string> => {
-  const { persistent, transient, defaults } = await callWithInternalUser('cluster.getSettings', {
-    filterPath: '*.*managed_repository',
-    flatSettings: true,
-    includeDefaults: true,
-  });
-  const { 'cluster.metadata.managed_repository': managedRepositoryName = undefined } = {
-    ...defaults,
-    ...persistent,
-    ...transient,
-  };
-  return managedRepositoryName;
+export const getManagedRepositoryName = async (
+  callWithInternalUser: any
+): Promise<string | undefined> => {
+  try {
+    const { persistent, transient, defaults } = await callWithInternalUser('cluster.getSettings', {
+      filterPath: '*.*managed_repository',
+      flatSettings: true,
+      includeDefaults: true,
+    });
+    const { 'cluster.metadata.managed_repository': managedRepositoryName = undefined } = {
+      ...defaults,
+      ...persistent,
+      ...transient,
+    };
+    return managedRepositoryName;
+  } catch (e) {
+    // Silently swallow error and return undefined
+    return;
+  }
 };

--- a/x-pack/legacy/plugins/snapshot_restore/server/lib/get_managed_repository_name.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/lib/get_managed_repository_name.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const getManagedRepositoryName = async (callWithInternalUser: any): Promise<string> => {
+  const { persistent, transient, defaults } = await callWithInternalUser('cluster.getSettings', {
+    filterPath: '*.*managed_repository',
+    flatSettings: true,
+    includeDefaults: true,
+  });
+  const { 'cluster.metadata.managed_repository': managedRepositoryName = undefined } = {
+    ...defaults,
+    ...persistent,
+    ...transient,
+  };
+  return managedRepositoryName;
+};

--- a/x-pack/legacy/plugins/snapshot_restore/server/lib/index.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/lib/index.ts
@@ -11,3 +11,4 @@ export {
 export { cleanSettings } from './clean_settings';
 export { deserializeSnapshotDetails } from './snapshot_serialization';
 export { deserializeRestoreShard } from './restore_serialization';
+export { getManagedRepositoryName } from './get_managed_repository_name';

--- a/x-pack/legacy/plugins/snapshot_restore/server/lib/snapshot_serialization.test.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/lib/snapshot_serialization.test.ts
@@ -91,6 +91,7 @@ describe('deserializeSnapshotDetails', () => {
         failed: 1,
         successful: 2,
       },
+      isManagedRepository: false,
     });
   });
 });

--- a/x-pack/legacy/plugins/snapshot_restore/server/lib/snapshot_serialization.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/lib/snapshot_serialization.ts
@@ -11,7 +11,8 @@ import { SnapshotDetailsEs } from '../types';
 
 export function deserializeSnapshotDetails(
   repository: string,
-  snapshotDetailsEs: SnapshotDetailsEs
+  snapshotDetailsEs: SnapshotDetailsEs,
+  managedRepository?: string
 ): SnapshotDetails {
   if (!snapshotDetailsEs || typeof snapshotDetailsEs !== 'object') {
     throw new Error('Unable to deserialize snapshot details');
@@ -75,5 +76,6 @@ export function deserializeSnapshotDetails(
     durationInMillis,
     indexFailures,
     shards,
+    isManagedRepository: repository === managedRepository,
   };
 }

--- a/x-pack/legacy/plugins/snapshot_restore/server/routes/api/register_routes.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/routes/api/register_routes.ts
@@ -13,6 +13,6 @@ import { registerRestoreRoutes } from './restore';
 export const registerRoutes = (router: Router, plugins: Plugins): void => {
   registerAppRoutes(router, plugins);
   registerRepositoriesRoutes(router, plugins);
-  registerSnapshotsRoutes(router);
+  registerSnapshotsRoutes(router, plugins);
   registerRestoreRoutes(router);
 };

--- a/x-pack/legacy/plugins/snapshot_restore/server/routes/api/snapshots.test.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/routes/api/snapshots.test.ts
@@ -87,10 +87,19 @@ describe('[Snapshot and Restore API Routes] Snapshots', () => {
       const expectedResponse = {
         errors: {},
         repositories: ['fooRepository', 'barRepository'],
-        managedRepository: 'found-snapshots',
         snapshots: [
-          { ...defaultSnapshot, repository: 'fooRepository', snapshot: 'snapshot1' },
-          { ...defaultSnapshot, repository: 'barRepository', snapshot: 'snapshot2' },
+          {
+            ...defaultSnapshot,
+            repository: 'fooRepository',
+            snapshot: 'snapshot1',
+            isManagedRepository: false,
+          },
+          {
+            ...defaultSnapshot,
+            repository: 'barRepository',
+            snapshot: 'snapshot2',
+            isManagedRepository: false,
+          },
         ],
       };
 
@@ -105,7 +114,6 @@ describe('[Snapshot and Restore API Routes] Snapshots', () => {
         errors: [],
         snapshots: [],
         repositories: [],
-        managedRepository: 'found-snapshots',
       };
 
       const response = await getAllHandler(mockRequest, callWithRequest, mockResponseToolkit);
@@ -148,6 +156,7 @@ describe('[Snapshot and Restore API Routes] Snapshots', () => {
         ...defaultSnapshot,
         snapshot,
         repository,
+        isManagedRepository: false,
       };
 
       const response = await getOneHandler(mockOneRequest, callWithRequest, mockResponseToolkit);

--- a/x-pack/legacy/plugins/snapshot_restore/server/routes/api/snapshots.ts
+++ b/x-pack/legacy/plugins/snapshot_restore/server/routes/api/snapshots.ts
@@ -45,7 +45,7 @@ export const getAllHandler: RouterRouteHandler = async (
   const repositoryNames = Object.keys(repositoriesByName);
 
   if (repositoryNames.length === 0) {
-    return { snapshots: [], errors: [], repositories: [], managedRepository };
+    return { snapshots: [], errors: [], repositories: [] };
   }
 
   const snapshots: SnapshotDetails[] = [];
@@ -71,7 +71,7 @@ export const getAllHandler: RouterRouteHandler = async (
       // Decorate each snapshot with the repository with which it's associated.
       fetchedResponses.forEach(({ snapshots: fetchedSnapshots }) => {
         fetchedSnapshots.forEach(snapshot => {
-          snapshots.push(deserializeSnapshotDetails(repository, snapshot));
+          snapshots.push(deserializeSnapshotDetails(repository, snapshot, managedRepository));
         });
       });
 
@@ -88,7 +88,6 @@ export const getAllHandler: RouterRouteHandler = async (
   return {
     snapshots,
     repositories,
-    managedRepository,
     errors,
   };
 };
@@ -98,6 +97,7 @@ export const getOneHandler: RouterRouteHandler = async (
   callWithRequest
 ): Promise<SnapshotDetails> => {
   const { repository, snapshot } = req.params;
+  const managedRepository = await getManagedRepositoryName(callWithInternalUser);
   const {
     responses: snapshotResponses,
   }: {
@@ -112,7 +112,11 @@ export const getOneHandler: RouterRouteHandler = async (
   });
 
   if (snapshotResponses && snapshotResponses[0] && snapshotResponses[0].snapshots) {
-    return deserializeSnapshotDetails(repository, snapshotResponses[0].snapshots[0]);
+    return deserializeSnapshotDetails(
+      repository,
+      snapshotResponses[0].snapshots[0],
+      managedRepository
+    );
   }
 
   // If snapshot doesn't exist, ES will return 200 with an error object, so manually throw 404 here


### PR DESCRIPTION
Relates to https://github.com/elastic/cloud/issues/34704

## Summary

This PR prevents snapshots stored in the ECE/ESS-managed repository from being deleted via the UI. The reason for this is because ECE and ESS have their own [snapshot retention policies](https://github.com/elastic/cloud/issues/34704#issuecomment-503103690). Until we have a stack SLM UI that can fully replace Cloud's current SLM UI, let's prevent users from deleting these snapshots as to not conflict with Cloud's retention policy.

This is similar to the behavior we did to prevent users from deleting the managed repository from the UI: https://github.com/elastic/kibana/pull/36947

**Note that we do allow users to _restore_ managed repository snapshots from the UI. This disabling behavior only applies to _deletion_.**

cc @elastic/cloud-stack-n-soln

## Testing instructions
1. Add `cluster.metadata.managed_repository` setting via Console:
```
PUT /_cluster/settings
{
  "persistent": {
    "cluster.metadata.managed_repository": "found-snapshots"
  }
}
```
2. Create a repository with the same name as your setting value (`found-snapshots`)

Note: Neither step is necessary when this goes live on Cloud, as both the repository and the setting will already exist, we are just mocking the environment locally here 🙂

## Screenshots

In snapshots table, deletion is disabled (user is not able to select the row and trash can icon is disabled):

![image](https://user-images.githubusercontent.com/1965714/60471085-f16acd00-9c17-11e9-9160-b8e22857aa3f.png)

In snapshot details, Delete button is disabled:

![image](https://user-images.githubusercontent.com/1965714/60471102-0ba4ab00-9c18-11e9-9d25-ea774b435141.png)
