### PR TITLE
Run more tests in firefox

### DIFF
--- a/.ci/jobs.yml
+++ b/.ci/jobs.yml
@@ -1,33 +1,37 @@
 JOB:
   - kibana-intake
   - x-pack-intake
-  - kibana-firefoxSmoke
-  - kibana-ciGroup1
-  - kibana-ciGroup2
-  - kibana-ciGroup3
-  - kibana-ciGroup4
-  - kibana-ciGroup5
-  - kibana-ciGroup6
-  - kibana-ciGroup7
-  - kibana-ciGroup8
-  - kibana-ciGroup9
-  - kibana-ciGroup10
-  - kibana-ciGroup11
-  - kibana-ciGroup12
+  # - kibana-firefoxSmoke
+  # - kibana-ciGroup1
+  # - kibana-ciGroup2
+  # - kibana-ciGroup3
+  # - kibana-ciGroup4
+  # - kibana-ciGroup5
+  # - kibana-ciGroup6
+  # - kibana-ciGroup7
+  # - kibana-ciGroup8
+  # - kibana-ciGroup9
+  # - kibana-ciGroup10
+  # - kibana-ciGroup11
+  # - kibana-ciGroup12
   # - kibana-visualRegression
 
   # make sure all x-pack-ciGroups are listed in test/scripts/jenkins_xpack_ci_group.sh
-  - x-pack-firefoxSmoke
-  - x-pack-ciGroup1
-  - x-pack-ciGroup2
-  - x-pack-ciGroup3
-  - x-pack-ciGroup4
-  - x-pack-ciGroup5
-  - x-pack-ciGroup6
-  - x-pack-ciGroup7
-  - x-pack-ciGroup8
-  - x-pack-ciGroup9
-  - x-pack-ciGroup10
+  - x-pack-firefoxSmoke-1
+  - x-pack-firefoxSmoke-2
+  - x-pack-firefoxSmoke-3
+  - x-pack-firefoxSmoke-4
+  - x-pack-firefoxSmoke-5
+  # - x-pack-ciGroup1
+  # - x-pack-ciGroup2
+  # - x-pack-ciGroup3
+  # - x-pack-ciGroup4
+  # - x-pack-ciGroup5
+  # - x-pack-ciGroup6
+  # - x-pack-ciGroup7
+  # - x-pack-ciGroup8
+  # - x-pack-ciGroup9
+  # - x-pack-ciGroup10
   # - x-pack-visualRegression
 
 # `~` is yaml for `null`

--- a/.ci/jobs.yml
+++ b/.ci/jobs.yml
@@ -1,37 +1,33 @@
 JOB:
   - kibana-intake
   - x-pack-intake
-  # - kibana-firefoxSmoke
-  # - kibana-ciGroup1
-  # - kibana-ciGroup2
-  # - kibana-ciGroup3
-  # - kibana-ciGroup4
-  # - kibana-ciGroup5
-  # - kibana-ciGroup6
-  # - kibana-ciGroup7
-  # - kibana-ciGroup8
-  # - kibana-ciGroup9
-  # - kibana-ciGroup10
-  # - kibana-ciGroup11
-  # - kibana-ciGroup12
+  - kibana-firefoxSmoke
+  - kibana-ciGroup1
+  - kibana-ciGroup2
+  - kibana-ciGroup3
+  - kibana-ciGroup4
+  - kibana-ciGroup5
+  - kibana-ciGroup6
+  - kibana-ciGroup7
+  - kibana-ciGroup8
+  - kibana-ciGroup9
+  - kibana-ciGroup10
+  - kibana-ciGroup11
+  - kibana-ciGroup12
   # - kibana-visualRegression
 
   # make sure all x-pack-ciGroups are listed in test/scripts/jenkins_xpack_ci_group.sh
-  - x-pack-firefoxSmoke-1
-  - x-pack-firefoxSmoke-2
-  - x-pack-firefoxSmoke-3
-  - x-pack-firefoxSmoke-4
-  - x-pack-firefoxSmoke-5
-  # - x-pack-ciGroup1
-  # - x-pack-ciGroup2
-  # - x-pack-ciGroup3
-  # - x-pack-ciGroup4
-  # - x-pack-ciGroup5
-  # - x-pack-ciGroup6
-  # - x-pack-ciGroup7
-  # - x-pack-ciGroup8
-  # - x-pack-ciGroup9
-  # - x-pack-ciGroup10
+  - x-pack-firefoxSmoke
+  - x-pack-ciGroup1
+  - x-pack-ciGroup2
+  - x-pack-ciGroup3
+  - x-pack-ciGroup4
+  - x-pack-ciGroup5
+  - x-pack-ciGroup6
+  - x-pack-ciGroup7
+  - x-pack-ciGroup8
+  - x-pack-ciGroup9
+  - x-pack-ciGroup10
   # - x-pack-visualRegression
 
 # `~` is yaml for `null`

--- a/src/functional_test_runner/lib/mocha/setup_mocha.js
+++ b/src/functional_test_runner/lib/mocha/setup_mocha.js
@@ -60,10 +60,8 @@ export async function setupMocha(lifecycle, log, config, providers) {
   filterSuitesByTags({
     log,
     mocha,
-    include: config.get('suiteTags.include')
-      .map(tag => tag.replace(/-\d+$/, '')),
-    exclude: config.get('suiteTags.exclude')
-      .map(tag => tag.replace(/-\d+$/, ''))
+    include: config.get('suiteTags.include'),
+    exclude: config.get('suiteTags.exclude'),
   });
 
   return mocha;

--- a/src/functional_test_runner/lib/mocha/setup_mocha.js
+++ b/src/functional_test_runner/lib/mocha/setup_mocha.js
@@ -60,8 +60,10 @@ export async function setupMocha(lifecycle, log, config, providers) {
   filterSuitesByTags({
     log,
     mocha,
-    include: config.get('suiteTags.include'),
-    exclude: config.get('suiteTags.exclude'),
+    include: config.get('suiteTags.include')
+      .map(tag => tag.replace(/-\d+$/, '')),
+    exclude: config.get('suiteTags.exclude')
+      .map(tag => tag.replace(/-\d+$/, ''))
   });
 
   return mocha;

--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -3,7 +3,7 @@
 set -e
 trap 'node "$KIBANA_DIR/src/dev/failed_tests/cli"' EXIT
 
-#yarn run grunt functionalTests:ensureAllTestsInCiGroup;
+yarn run grunt functionalTests:ensureAllTestsInCiGroup;
 
 node scripts/build --debug --oss;
 

--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -3,7 +3,7 @@
 set -e
 trap 'node "$KIBANA_DIR/src/dev/failed_tests/cli"' EXIT
 
-yarn run grunt functionalTests:ensureAllTestsInCiGroup;
+#yarn run grunt functionalTests:ensureAllTestsInCiGroup;
 
 node scripts/build --debug --oss;
 

--- a/x-pack/test/functional/apps/code/explore_repository.ts
+++ b/x-pack/test/functional/apps/code/explore_repository.ts
@@ -23,7 +23,8 @@ export default function exploreRepositoryFunctionalTests({
 
   const FIND_TIME = config.get('timeouts.find');
 
-  describe('Explore Repository', () => {
+  describe('Explore Repository', function() {
+    this.tags('smoke');
     describe('Explore a repository', () => {
       const repositoryListSelector = 'codeRepositoryList codeRepositoryItem';
 

--- a/x-pack/test/functional/apps/code/search.ts
+++ b/x-pack/test/functional/apps/code/search.ts
@@ -16,6 +16,7 @@ export default function searchFunctonalTests({ getService, getPageObjects }: Tes
   const PageObjects = getPageObjects(['common', 'header', 'security', 'code', 'home']);
 
   describe('Search', function() {
+    this.tags('smoke');
     const symbolTypeaheadListSelector = 'codeTypeaheadList-symbol codeTypeaheadItem';
     const fileTypeaheadListSelector = 'codeTypeaheadList-file codeTypeaheadItem';
     const searchResultListSelector = 'codeSearchResultList codeSearchResultFileItem';

--- a/x-pack/test/functional/apps/code/search.ts
+++ b/x-pack/test/functional/apps/code/search.ts
@@ -15,7 +15,7 @@ export default function searchFunctonalTests({ getService, getPageObjects }: Tes
   const log = getService('log');
   const PageObjects = getPageObjects(['common', 'header', 'security', 'code', 'home']);
 
-  describe('Search', () => {
+  describe('Search', function() {
     const symbolTypeaheadListSelector = 'codeTypeaheadList-symbol codeTypeaheadItem';
     const fileTypeaheadListSelector = 'codeTypeaheadList-file codeTypeaheadItem';
     const searchResultListSelector = 'codeSearchResultList codeSearchResultFileItem';

--- a/x-pack/test/functional/apps/infra/logs_source_configuration.ts
+++ b/x-pack/test/functional/apps/infra/logs_source_configuration.ts
@@ -15,7 +15,8 @@ export default ({ getPageObjects, getService }: KibanaFunctionalTestDefaultProvi
   const infraSourceConfigurationFlyout = getService('infraSourceConfigurationFlyout');
   const pageObjects = getPageObjects(['infraLogs']);
 
-  describe('Logs Page', () => {
+  describe('Logs Page', function() {
+    this.tags('smoke');
     before(async () => {
       await esArchiver.load('empty_kibana');
     });

--- a/x-pack/test/functional/apps/infra/metrics_source_configuration.ts
+++ b/x-pack/test/functional/apps/infra/metrics_source_configuration.ts
@@ -15,7 +15,8 @@ export default ({ getPageObjects, getService }: KibanaFunctionalTestDefaultProvi
   const infraSourceConfigurationFlyout = getService('infraSourceConfigurationFlyout');
   const pageObjects = getPageObjects(['common', 'infraHome']);
 
-  describe('Infrastructure Snapshot Page', () => {
+  describe('Infrastructure Snapshot Page', function() {
+    this.tags('smoke');
     before(async () => {
       await esArchiver.load('empty_kibana');
     });

--- a/x-pack/test/functional/apps/logstash/index.js
+++ b/x-pack/test/functional/apps/logstash/index.js
@@ -6,7 +6,7 @@
 
 export default function ({ loadTestFile }) {
   describe('logstash', function () {
-    this.tags('ciGroup2');
+    this.tags(['ciGroup2', 'smoke']);
 
     loadTestFile(require.resolve('./pipeline_list'));
     loadTestFile(require.resolve('./pipeline_create'));

--- a/x-pack/test/functional/apps/machine_learning/pages.ts
+++ b/x-pack/test/functional/apps/machine_learning/pages.ts
@@ -11,7 +11,8 @@ export default function({ getService }: KibanaFunctionalTestDefaultProviders) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  describe('page navigation', () => {
+  describe('page navigation', function() {
+    this.tags('smoke');
     before(async () => {
       await esArchiver.load('empty_kibana');
     });

--- a/x-pack/test/functional/apps/security/security.js
+++ b/x-pack/test/functional/apps/security/security.js
@@ -11,7 +11,8 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['security']);
   const testSubjects = getService('testSubjects');
 
-  describe('Security', () => {
+  describe('Security', function () {
+    this.tags('smoke');
     describe('Login Page', () => {
       before(async () => {
         await esArchiver.load('empty_kibana');

--- a/x-pack/test/functional/apps/spaces/spaces_selection.ts
+++ b/x-pack/test/functional/apps/spaces/spaces_selection.ts
@@ -20,7 +20,8 @@ export default function spaceSelectorFunctonalTests({
     'spaceSelector',
   ]);
 
-  describe('Spaces', () => {
+  describe('Spaces', function() {
+    this.tags('smoke');
     describe('Space Selector', () => {
       before(async () => await esArchiver.load('spaces/selector'));
       after(async () => await esArchiver.unload('spaces/selector'));


### PR DESCRIPTION
## Summary

Add more functional tests to run in Firefox browser.

Since there were no Firefox-specific test failures with dedicated jobs, I want to increase `smoke` suite on X-Pack from 28 to 83 tests:

<img width="1340" alt="elastic+kibana+pull-request:JOB=x-pack-firefoxSmok" src="https://user-images.githubusercontent.com/10977896/60598043-51927800-9dac-11e9-979c-495d3bd6ee8b.png">

Average `JOB=x-pack-firefoxSmoke` run time: 51-55 min


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

~~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
~~- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

