### PR TITLE
[ftr] replace getProperty with getAttribute

### DIFF
--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -48,11 +48,11 @@ export default function ({ getService, getPageObjects }) {
       });
       await retry.try(async function () {
         const predecessorCountPicker = await PageObjects.context.getPredecessorCountPicker();
-        expect(await predecessorCountPicker.getProperty('value')).to.equal(`${TEST_DEFAULT_CONTEXT_SIZE}`);
+        expect(await predecessorCountPicker.getAttribute('value')).to.equal(`${TEST_DEFAULT_CONTEXT_SIZE}`);
       });
       await retry.try(async function () {
         const successorCountPicker = await PageObjects.context.getSuccessorCountPicker();
-        expect(await successorCountPicker.getProperty('value')).to.equal(`${TEST_DEFAULT_CONTEXT_SIZE}`);
+        expect(await successorCountPicker.getAttribute('value')).to.equal(`${TEST_DEFAULT_CONTEXT_SIZE}`);
       });
     });
 

--- a/test/functional/apps/management/_kibana_settings.js
+++ b/test/functional/apps/management/_kibana_settings.js
@@ -50,7 +50,7 @@ export default function ({ getService, getPageObjects }) {
       it ('defaults to false', async () => {
         await PageObjects.settings.clickKibanaSettings();
         const storeInSessionStorage = await PageObjects.settings.getAdvancedSettingCheckbox('state:storeInSessionStorage');
-        expect(storeInSessionStorage).to.be(false);
+        expect(storeInSessionStorage).to.be('false');
       });
 
       it('when false, dashboard state is unhashed', async function () {
@@ -73,7 +73,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.settings.clickKibanaSettings();
         await PageObjects.settings.toggleAdvancedSettingCheckbox('state:storeInSessionStorage');
         const storeInSessionStorage = await PageObjects.settings.getAdvancedSettingCheckbox('state:storeInSessionStorage');
-        expect(storeInSessionStorage).to.be(true);
+        expect(storeInSessionStorage).to.be('true');
       });
 
       it('when true, dashboard state is hashed', async function () {

--- a/test/functional/apps/management/_kibana_settings.js
+++ b/test/functional/apps/management/_kibana_settings.js
@@ -47,10 +47,10 @@ export default function ({ getService, getPageObjects }) {
     });
 
     describe('state:storeInSessionStorage', () => {
-      it ('defaults to false', async () => {
+      it ('defaults to null', async () => {
         await PageObjects.settings.clickKibanaSettings();
         const storeInSessionStorage = await PageObjects.settings.getAdvancedSettingCheckbox('state:storeInSessionStorage');
-        expect(storeInSessionStorage).to.be('false');
+        expect(storeInSessionStorage).to.be(null);
       });
 
       it('when false, dashboard state is unhashed', async function () {

--- a/test/functional/apps/visualize/input_control_vis/chained_controls.js
+++ b/test/functional/apps/visualize/input_control_vis/chained_controls.js
@@ -38,8 +38,8 @@ export default function ({ getService, getPageObjects }) {
       expect(parentControlMenu.trim().split('\n').join()).to.equal('BD,BR,CN,ID,IN,JP,NG,PK,RU,US');
 
       const childControlInput = await find.byCssSelector('[data-test-subj="inputControl1"] input');
-      const isDisabled = await childControlInput.getProperty('disabled');
-      expect(isDisabled).to.equal(true);
+      const isDisabled = await childControlInput.getAttribute('disabled');
+      expect(isDisabled).to.equal('true');
     });
 
     it('should filter child control options by parent control value', async () => {
@@ -66,8 +66,8 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.common.sleep(500); // give time for filter to be removed and event handlers to fire
 
       const childControlInput = await find.byCssSelector('[data-test-subj="inputControl1"] input');
-      const isDisabled = await childControlInput.getProperty('disabled');
-      expect(isDisabled).to.equal(true);
+      const isDisabled = await childControlInput.getAttribute('disabled');
+      expect(isDisabled).to.equal('true');
 
       await testSubjects.click('inputControlCancelBtn');
     });

--- a/test/functional/apps/visualize/input_control_vis/input_control_options.js
+++ b/test/functional/apps/visualize/input_control_vis/input_control_options.js
@@ -171,8 +171,8 @@ export default function ({ getService, getPageObjects }) {
 
         // Expect control to be disabled because no terms could be gathered with time filter applied
         const input = await find.byCssSelector('[data-test-subj="inputControl0"] input');
-        const isDisabled = await input.getProperty('disabled');
-        expect(isDisabled).to.equal(true);
+        const isDisabled = await input.getAttribute('disabled');
+        expect(isDisabled).to.equal('true');
       });
 
       it('should re-create control when global time filter is updated', async () => {

--- a/test/functional/page_objects/dashboard_page.js
+++ b/test/functional/page_objects/dashboard_page.js
@@ -151,7 +151,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
     }
 
     async getCloneTitle() {
-      return await testSubjects.getProperty('clonedDashboardTitle', 'value');
+      return await testSubjects.getAttribute('clonedDashboardTitle', 'value');
     }
 
     async confirmClone() {
@@ -277,8 +277,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
     async isMarginsOn() {
       log.debug('isMarginsOn');
       await this.openOptions();
-      const marginsCheckbox = await testSubjects.find('dashboardMarginsCheckbox');
-      return await marginsCheckbox.getProperty('checked');
+      return await testSubjects.getAttribute('dashboardMarginsCheckbox', 'checked');
     }
 
     async useMargins(on = true) {
@@ -410,7 +409,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
 
     async getSearchFilterValue() {
       const searchFilter = await this.getSearchFilter();
-      return await searchFilter.getProperty('value');
+      return await searchFilter.getAttribute('value');
     }
 
     async getSearchFilter() {
@@ -536,7 +535,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
     async setSaveAsNewCheckBox(checked) {
       log.debug('saveAsNewCheckbox: ' + checked);
       const saveAsNewCheckbox = await testSubjects.find('saveAsNewCheckbox');
-      const isAlreadyChecked = await saveAsNewCheckbox.getProperty('checked');
+      const isAlreadyChecked = (await saveAsNewCheckbox.getAttribute('checked') === 'true');
       if (isAlreadyChecked !== checked) {
         log.debug('Flipping save as new checkbox');
         await retry.try(() => saveAsNewCheckbox.click());

--- a/test/functional/page_objects/dashboard_page.js
+++ b/test/functional/page_objects/dashboard_page.js
@@ -545,7 +545,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
     async setStoreTimeWithDashboard(checked) {
       log.debug('Storing time with dashboard: ' + checked);
       const storeTimeCheckbox = await testSubjects.find('storeTimeWithDashboard');
-      const isAlreadyChecked = await storeTimeCheckbox.getProperty('checked');
+      const isAlreadyChecked = (await storeTimeCheckbox.getAttribute('checked') === 'true');
       if (isAlreadyChecked !== checked) {
         log.debug('Flipping store time checkbox');
         await retry.try(() => storeTimeCheckbox.click());

--- a/test/functional/page_objects/discover_page.js
+++ b/test/functional/page_objects/discover_page.js
@@ -161,7 +161,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
     }
 
     async getChartInterval() {
-      const selectedValue = await testSubjects.getProperty('discoverIntervalSelect', 'value');
+      const selectedValue = await testSubjects.getAttribute('discoverIntervalSelect', 'value');
       const selectedOption = await find.byCssSelector('option[value="' + selectedValue + '"]');
       return selectedOption.getVisibleText();
     }
@@ -217,7 +217,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
 
     async getSidebarWidth() {
       const sidebar = await find.byCssSelector('.sidebar-list');
-      return await sidebar.getProperty('clientWidth');
+      return await sidebar.getAttribute('clientWidth');
     }
 
     async hasNoResults() {

--- a/test/functional/page_objects/settings_page.js
+++ b/test/functional/page_objects/settings_page.js
@@ -63,7 +63,7 @@ export function SettingsPageProvider({ getService, getPageObjects }) {
     async getAdvancedSettings(propertyName) {
       log.debug('in getAdvancedSettings');
       const setting = await testSubjects.find(`advancedSetting-editField-${propertyName}`);
-      return await setting.getProperty('value');
+      return await setting.getAttribute('value');
     }
 
     async expectDisabledAdvancedSetting(propertyName) {
@@ -73,7 +73,7 @@ export function SettingsPageProvider({ getService, getPageObjects }) {
 
     async getAdvancedSettingCheckbox(propertyName) {
       log.debug('in getAdvancedSettingCheckbox');
-      return await testSubjects.getProperty(`advancedSetting-editField-${propertyName}`, 'checked');
+      return await testSubjects.getAttribute(`advancedSetting-editField-${propertyName}`, 'checked');
     }
 
     async clearAdvancedSettings(propertyName) {
@@ -267,7 +267,7 @@ export function SettingsPageProvider({ getService, getPageObjects }) {
     }
 
     async getPopularity() {
-      return await testSubjects.getProperty('editorFieldCount', 'value');
+      return await testSubjects.getAttribute('editorFieldCount', 'value');
     }
 
     async controlChangeCancel() {

--- a/test/functional/page_objects/visualize_page.js
+++ b/test/functional/page_objects/visualize_page.js
@@ -571,8 +571,7 @@ export function VisualizePageProvider({ getService, getPageObjects, updateBaseli
     }
 
     async getNumericInterval(agg = 2) {
-      const intervalElement = await testSubjects.find(`visEditorInterval${agg}`);
-      return await intervalElement.getProperty('value');
+      return await testSubjects.getAttribute(`visEditorInterval${agg}`, 'value');
     }
 
     async setNumericInterval(newValue, { append } = {}, agg = 2) {
@@ -1214,7 +1213,7 @@ export function VisualizePageProvider({ getService, getPageObjects, updateBaseli
 
     async getBucketErrorMessage() {
       const error = await find.byCssSelector('[group-name="buckets"] [data-test-subj="defaultEditorAggSelect"] + .euiFormErrorText');
-      const errorMessage = await error.getProperty('innerText');
+      const errorMessage = await error.getAttribute('innerText');
       log.debug(errorMessage);
       return errorMessage;
     }

--- a/test/functional/services/global_nav.js
+++ b/test/functional/services/global_nav.js
@@ -45,8 +45,7 @@ export function GlobalNavProvider({ getService }) {
 
     async badgeExistsOrFail(expectedLabel) {
       await testSubjects.existOrFail('headerBadge');
-      const element = await testSubjects.find('headerBadge');
-      const actualLabel = await element.getAttribute('data-test-badge-label');
+      const actualLabel = await testSubjects.getAttribute('headerBadge', 'data-test-badge-label');
       expect(actualLabel.toUpperCase()).to.equal(expectedLabel.toUpperCase());
     }
 

--- a/test/functional/services/inspector.js
+++ b/test/functional/services/inspector.js
@@ -30,8 +30,7 @@ export function InspectorProvider({ getService }) {
 
   return new class Inspector {
     async getIsEnabled() {
-      const button = await testSubjects.find('openInspectorButton');
-      const ariaDisabled = await button.getAttribute('aria-disabled');
+      const ariaDisabled = await testSubjects.getAttribute('openInspectorButton', 'aria-disabled');
       return ariaDisabled !== 'true';
     }
 

--- a/test/functional/services/lib/web_element_wrapper/web_element_wrapper.ts
+++ b/test/functional/services/lib/web_element_wrapper/web_element_wrapper.ts
@@ -242,32 +242,6 @@ export class WebElementWrapper {
   }
 
   /**
-   * Retrieves the current value of the given attribute of this element. Will return the current
-   * value, even if it has been modified after the page has been loaded. More exactly, this method
-   * will return the value of the given attribute, unless that attribute is not present, in which
-   * case the value of the property with the same name is returned. If neither value is set, null
-   * is returned (for example, the "value" property of a textarea element). The "style" attribute
-   * is converted as best can be to a text representation with a trailing semi-colon.
-   * https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_WebElement.html#getAttribute
-   *
-   * @param {string} name
-   * @return {Promise<any>}
-   */
-  public async getProperty(name: string): Promise<string | boolean> {
-    const property = await this._webElement.getAttribute(name);
-
-    // leadfoot compatibility convertion
-    if (property == null) {
-      return false;
-    }
-    if (['true', 'false'].includes(property)) {
-      return property === 'true';
-    } else {
-      return property;
-    }
-  }
-
-  /**
    * Retrieves the value of a computed style property for this instance. If the element inherits
    * the named style from its parent, the parent will be queried for its value. Where possible,
    * color values will be converted to their hex representation (e.g. #00ff00 instead of rgb(0, 255, 0)).
@@ -542,7 +516,7 @@ export class WebElementWrapper {
    * @return {Promise<void>}
    */
   public async parseDomContent(): Promise<any> {
-    const htmlContent: any = await this.getProperty('innerHTML');
+    const htmlContent: any = await this.getAttribute('innerHTML');
     const $: any = cheerio.load(htmlContent, {
       normalizeWhitespace: true,
       xmlMode: true,

--- a/test/functional/services/query_bar.js
+++ b/test/functional/services/query_bar.js
@@ -27,7 +27,7 @@ export function QueryBarProvider({ getService, getPageObjects }) {
   class QueryBar {
 
     async getQueryString() {
-      return await testSubjects.getProperty('queryInput', 'value');
+      return await testSubjects.getAttribute('queryInput', 'value');
     }
 
     async setQuery(query) {

--- a/test/functional/services/test_subjects.ts
+++ b/test/functional/services/test_subjects.ts
@@ -134,21 +134,6 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
       });
     }
 
-    public async getPropertyAll(selector: string, property: string): Promise<string[]> {
-      log.debug(`TestSubjects.getPropertyAll(${selector}, ${property})`);
-      return await this._mapAll(selector, async (element: WebElementWrapper) => {
-        return (await element.getProperty(property)) as string;
-      });
-    }
-
-    public async getProperty(selector: string, property: string): Promise<string> {
-      log.debug(`TestSubjects.getProperty(${selector}, ${property})`);
-      return await retry.try(async () => {
-        const element = await this.find(selector);
-        return (await element.getProperty(property)) as string;
-      });
-    }
-
     public async getAttributeAll(selector: string, attribute: string): Promise<string[]> {
       log.debug(`TestSubjects.getAttributeAll(${selector}, ${attribute})`);
       return await this._mapAll(selector, async (element: WebElementWrapper) => {

--- a/test/functional/services/visualize_listing_table.js
+++ b/test/functional/services/visualize_listing_table.js
@@ -40,8 +40,7 @@ export function VisualizeListingTableProvider({ getService, getPageObjects }) {
       let visualizationNames = [];
       while (morePages) {
         visualizationNames = visualizationNames.concat(await this.getAllVisualizationNamesOnCurrentPage());
-        const pagerNextButton = await testSubjects.find('pagerNextButton');
-        morePages = !(await pagerNextButton.getProperty('disabled'));
+        morePages = !(await testSubjects.getAttribute('pagerNextButton', 'disabled') === 'true');
         if (morePages) {
           await testSubjects.click('pagerNextButton');
           await PageObjects.header.waitUntilLoadingHasFinished();

--- a/test/plugin_functional/test_suites/custom_visualizations/self_changing_vis.js
+++ b/test/plugin_functional/test_suites/custom_visualizations/self_changing_vis.js
@@ -29,8 +29,7 @@ export default function ({ getService, getPageObjects }) {
   }
 
   async function getEditorValue() {
-    const editor = await testSubjects.find('counterEditor');
-    return await editor.getProperty('value');
+    return await testSubjects.getAttribute('counterEditor', 'value');
   }
 
   describe('self changing vis', function describeIndexTests() {

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -34,7 +34,7 @@ export default function ({ getService, getPageObjects }) {
       const actionElement = await testSubjects.find('dashboardPanelAction-samplePanelLink');
       const actionElementTag = await actionElement.getTagName();
       expect(actionElementTag).to.be('a');
-      const actionElementLink = await actionElement.getProperty('href');
+      const actionElementLink = await actionElement.getAttribute('href');
       expect(actionElementLink).to.be('https://example.com/kibana/test');
     });
 

--- a/x-pack/test/functional/apps/security/management.js
+++ b/x-pack/test/functional/apps/security/management.js
@@ -77,10 +77,9 @@ export default function ({ getService, getPageObjects }) {
           await PageObjects.settings.clickLinkText('new-user');
           const currentUrl = await browser.getCurrentUrl();
           expect(currentUrl).to.contain(EDIT_USERS_PATH);
-          const userNameInput = await testSubjects.find('userFormUserNameInput');
           // allow time for user to load
           await PageObjects.common.sleep(500);
-          const userName = await userNameInput.getProperty('value');
+          const userName = await testSubjects.getAttribute('userFormUserNameInput', 'value');
           expect(userName).to.equal('new-user');
         });
 
@@ -120,8 +119,7 @@ export default function ({ getService, getPageObjects }) {
           const currentUrl = await browser.getCurrentUrl();
           expect(currentUrl).to.contain(EDIT_ROLES_PATH);
 
-          const userNameInput = await testSubjects.find('roleFormNameInput');
-          const userName = await userNameInput.getProperty('value');
+          const userName = await testSubjects.getAttribute('roleFormNameInput', 'value');
           expect(userName).to.equal('a-my-new-role');
         });
 

--- a/x-pack/test/functional/page_objects/security_page.js
+++ b/x-pack/test/functional/page_objects/security_page.js
@@ -226,7 +226,7 @@ export function SecurityPageProvider({ getService, getPageObjects }) {
           fullname: await fullnameElement.getVisibleText(),
           email: await emailElement.getVisibleText(),
           roles: (await rolesElement.getVisibleText()).split(',').map(role => role.trim()),
-          reserved: (await isReservedElementVisible.getProperty('innerHTML')).includes('reservedUser')
+          reserved: (await isReservedElementVisible.getAttribute('innerHTML')).includes('reservedUser')
         };
       });
     }

--- a/x-pack/test/functional/page_objects/watcher_page.js
+++ b/x-pack/test/functional/page_objects/watcher_page.js
@@ -56,7 +56,7 @@ export function WatcherPageProvider({ getPageObjects, getService }) {
         const name = await watch.findByCssSelector('td:nth-child(3)');
 
         return {
-          checkBox: (await checkBox.getProperty('innerHTML')).includes('input'),
+          checkBox: (await checkBox.getAttribute('innerHTML')).includes('input'),
           id: await id.getVisibleText(),
           name: (await name.getVisibleText()).split(',').map(role => role.trim()),
         };

--- a/x-pack/test/functional/services/monitoring/elasticsearch_index_detail.js
+++ b/x-pack/test/functional/services/monitoring/elasticsearch_index_detail.js
@@ -24,7 +24,7 @@ export function MonitoringElasticsearchIndexDetailProvider({ getService }) {
         documentCount: await testSubjects.getVisibleText(SUBJ_SUMMARY_DOCUMENT_COUNT),
         totalShards: await testSubjects.getVisibleText(SUBJ_SUMMARY_TOTAL_SHARDS),
         unassignedShards: await testSubjects.getVisibleText(SUBJ_SUMMARY_UNASSIGNED_SHARDS),
-        health: await testSubjects.getProperty(SUBJ_SUMMARY_HEALTH, 'alt'),
+        health: await testSubjects.getAttribute(SUBJ_SUMMARY_HEALTH, 'alt'),
       };
     }
 

--- a/x-pack/test/functional/services/monitoring/elasticsearch_indices.js
+++ b/x-pack/test/functional/services/monitoring/elasticsearch_indices.js
@@ -59,7 +59,7 @@ export function MonitoringElasticsearchIndicesProvider({ getService, getPageObje
 
     async getIndicesAll() {
       const names = await testSubjects.getVisibleTextAll(SUBJ_INDICES_NAMES);
-      const statuses = await testSubjects.getPropertyAll(SUBJ_INDICES_STATUSES, 'alt');
+      const statuses = await testSubjects.getAttributeAll(SUBJ_INDICES_STATUSES, 'alt');
       const documentCounts = await testSubjects.getVisibleTextAll(SUBJ_INDICES_DOCUMENT_COUNTS);
       const dataSizes = await testSubjects.getVisibleTextAll(SUBJ_INDICES_DATA_SIZES);
       const indexRates = await testSubjects.getVisibleTextAll(SUBJ_INDICES_INDEX_RATES);

--- a/x-pack/test/functional/services/monitoring/elasticsearch_node_detail.js
+++ b/x-pack/test/functional/services/monitoring/elasticsearch_node_detail.js
@@ -30,7 +30,7 @@ export function MonitoringElasticsearchNodeDetailProvider({ getService }) {
         indicesCount: await testSubjects.getVisibleText(SUBJ_SUMMARY_INDICES_COUNT),
         shardsCount: await testSubjects.getVisibleText(SUBJ_SUMMARY_SHARDS_COUNT),
         nodeType: await testSubjects.getVisibleText(SUBJ_SUMMARY_NODE_TYPE),
-        status: await testSubjects.getProperty(SUBJ_SUMMARY_STATUS, 'alt'),
+        status: await testSubjects.getAttribute(SUBJ_SUMMARY_STATUS, 'alt'),
       };
     }
 

--- a/x-pack/test/functional/services/monitoring/elasticsearch_nodes.js
+++ b/x-pack/test/functional/services/monitoring/elasticsearch_nodes.js
@@ -106,7 +106,7 @@ export function MonitoringElasticsearchNodesProvider({ getService, getPageObject
 
     async getNodesAll() {
       const names = await testSubjects.getVisibleTextAll(SUBJ_NODES_NAMES);
-      const statuses = await testSubjects.getPropertyAll(SUBJ_NODES_STATUSES, 'alt');
+      const statuses = await testSubjects.getAttributeAll(SUBJ_NODES_STATUSES, 'alt');
       const cpus = await testSubjects.getVisibleTextAll(SUBJ_NODES_CPUS);
       const loads = await testSubjects.getVisibleTextAll(SUBJ_NODES_LOADS);
       const memories = await testSubjects.getVisibleTextAll(SUBJ_NODES_MEMS);

--- a/x-pack/test/functional/services/monitoring/elasticsearch_summary_status.js
+++ b/x-pack/test/functional/services/monitoring/elasticsearch_summary_status.js
@@ -28,7 +28,7 @@ export function MonitoringElasticsearchSummaryStatusProvider({ getService }) {
         unassignedShards: await testSubjects.getVisibleText(SUBJ_SUMMARY_UNASSIGNED_SHARDS),
         documentCount: await testSubjects.getVisibleText(SUBJ_SUMMARY_DOCUMENT_COUNT),
         dataSize: await testSubjects.getVisibleText(SUBJ_SUMMARY_DATA_SIZE),
-        health: await testSubjects.getProperty(SUBJ_SUMMARY_HEALTH, 'alt'),
+        health: await testSubjects.getAttribute(SUBJ_SUMMARY_HEALTH, 'alt'),
       };
     }
 

--- a/x-pack/test/functional/services/monitoring/kibana_instance.js
+++ b/x-pack/test/functional/services/monitoring/kibana_instance.js
@@ -30,7 +30,7 @@ export function MonitoringKibanaInstanceProvider({ getService }) {
         osFreeMemory: await testSubjects.getVisibleText(SUBJ_SUMMARY_OS_FREE_MEMORY),
         version: await testSubjects.getVisibleText(SUBJ_SUMMARY_VERSION),
         uptime: await testSubjects.getVisibleText(SUBJ_SUMMARY_UPTIME),
-        health: await testSubjects.getProperty(SUBJ_SUMMARY_HEALTH, 'alt'),
+        health: await testSubjects.getAttribute(SUBJ_SUMMARY_HEALTH, 'alt'),
       };
     }
 

--- a/x-pack/test/functional/services/monitoring/kibana_summary_status.js
+++ b/x-pack/test/functional/services/monitoring/kibana_summary_status.js
@@ -24,7 +24,7 @@ export function MonitoringKibanaSummaryStatusProvider({ getService }) {
         requests: await testSubjects.getVisibleText(SUBJ_SUMMARY_REQUESTS),
         connections: await testSubjects.getVisibleText(SUBJ_SUMMARY_CONNECTIONS),
         maxResponseTime: await testSubjects.getVisibleText(SUBJ_SUMMARY_MAX_RESPONSE_TIME),
-        health: await testSubjects.getProperty(SUBJ_SUMMARY_HEALTH, 'alt'),
+        health: await testSubjects.getAttribute(SUBJ_SUMMARY_HEALTH, 'alt'),
       };
     }
 

--- a/x-pack/test/functional/services/pipeline_editor.js
+++ b/x-pack/test/functional/services/pipeline_editor.js
@@ -123,15 +123,15 @@ export function PipelineEditorProvider({ getService }) {
      */
     async assertInputs(expectedValues) {
       const values = await propsAsync({
-        id: testSubjects.getProperty(SUBJ_INPUT_ID, 'value'),
-        description: testSubjects.getProperty(SUBJ_INPUT_DESCRIPTION, 'value'),
-        pipeline: aceEditor.getValue(SUBJ_UI_ACE_PIPELINE),
-        workers: testSubjects.getProperty(SUBJ_INPUT_WORKERS, 'value'),
-        batchSize: testSubjects.getProperty(SUBJ_INPUT_BATCH_SIZE, 'value'),
-        queueType: testSubjects.getProperty(SUBJ_SELECT_QUEUE_TYPE, 'value'),
-        queueMaxBytesNumber: testSubjects.getProperty(SUBJ_INPUT_QUEUE_MAX_BYTES_NUMBER, 'value'),
-        queueMaxBytesUnits: testSubjects.getProperty(SUBJ_SELECT_QUEUE_MAX_BYTES_UNITS, 'value'),
-        queueCheckpointWrites: testSubjects.getProperty(
+        id: testSubjects.getAttribute(SUBJ_INPUT_ID, 'value'),
+        description: testSubjects.getAttribute(SUBJ_INPUT_DESCRIPTION, 'value'),
+        pipeline: aceEditor.getAttribute(SUBJ_UI_ACE_PIPELINE),
+        workers: testSubjects.getAttribute(SUBJ_INPUT_WORKERS, 'value'),
+        batchSize: testSubjects.getAttribute(SUBJ_INPUT_BATCH_SIZE, 'value'),
+        queueType: testSubjects.getAttribute(SUBJ_SELECT_QUEUE_TYPE, 'value'),
+        queueMaxBytesNumber: testSubjects.getAttribute(SUBJ_INPUT_QUEUE_MAX_BYTES_NUMBER, 'value'),
+        queueMaxBytesUnits: testSubjects.getAttribute(SUBJ_SELECT_QUEUE_MAX_BYTES_UNITS, 'value'),
+        queueCheckpointWrites: testSubjects.getAttribute(
           SUBJ_INPUT_QUEUE_CHECKPOINT_WRITES,
           'value'
         ),

--- a/x-pack/test/functional/services/pipeline_editor.js
+++ b/x-pack/test/functional/services/pipeline_editor.js
@@ -125,7 +125,7 @@ export function PipelineEditorProvider({ getService }) {
       const values = await propsAsync({
         id: testSubjects.getAttribute(SUBJ_INPUT_ID, 'value'),
         description: testSubjects.getAttribute(SUBJ_INPUT_DESCRIPTION, 'value'),
-        pipeline: aceEditor.getAttribute(SUBJ_UI_ACE_PIPELINE),
+        pipeline: aceEditor.getValue(SUBJ_UI_ACE_PIPELINE),
         workers: testSubjects.getAttribute(SUBJ_INPUT_WORKERS, 'value'),
         batchSize: testSubjects.getAttribute(SUBJ_INPUT_BATCH_SIZE, 'value'),
         queueType: testSubjects.getAttribute(SUBJ_SELECT_QUEUE_TYPE, 'value'),

--- a/x-pack/test/reporting/functional/reporting.js
+++ b/x-pack/test/reporting/functional/reporting.js
@@ -30,16 +30,16 @@ export default function ({ getService, getPageObjects }) {
     const expectDisabledGenerateReportButton = async () => {
       const generateReportButton = await PageObjects.reporting.getGenerateReportButton();
       await retry.try(async () => {
-        const isDisabled = await generateReportButton.getProperty('disabled');
-        expect(isDisabled).to.be(true);
+        const isDisabled = await generateReportButton.getAttribute('disabled');
+        expect(isDisabled).to.be('true');
       });
     };
 
     const expectEnabledGenerateReportButton = async () => {
       const generateReportButton = await PageObjects.reporting.getGenerateReportButton();
       await retry.try(async () => {
-        const isDisabled = await generateReportButton.getProperty('disabled');
-        expect(isDisabled).to.be(false);
+        const isDisabled = await generateReportButton.getAttribute('disabled');
+        expect(isDisabled).to.be('false');
       });
     };
 

--- a/x-pack/test/reporting/functional/reporting.js
+++ b/x-pack/test/reporting/functional/reporting.js
@@ -39,7 +39,7 @@ export default function ({ getService, getPageObjects }) {
       const generateReportButton = await PageObjects.reporting.getGenerateReportButton();
       await retry.try(async () => {
         const isDisabled = await generateReportButton.getAttribute('disabled');
-        expect(isDisabled).to.be('false');
+        expect(isDisabled).to.be(null);
       });
     };
 


### PR DESCRIPTION
## Summary

Since FTR migration to Webdriver we kept 2 Leadfoot functions: `getProperty` & `getAttribute`.
It is a bit confusing to see both of them in tests as WebDriver API provides `getAttribute` only and currently `getProperty` wraps up the same call.

This PR gets rid of all `getProperty` usages in favour of `getAttribute`.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

