### PR TITLE
[7.2] [Tagcloud] Allow to send showLabel parameter with false value (#36563)

### DIFF
--- a/src/legacy/ui/public/visualize/loader/pipeline_helpers/__snapshots__/build_pipeline.test.js.snap
+++ b/src/legacy/ui/public/visualize/loader/pipeline_helpers/__snapshots__/build_pipeline.test.js.snap
@@ -28,6 +28,8 @@ exports[`visualize loader pipeline helpers: build pipeline buildPipelineVisFunct
 
 exports[`visualize loader pipeline helpers: build pipeline buildPipelineVisFunction handles table function without splits or buckets 1`] = `"kibana_table visConfig='{\\"foo\\":\\"bar\\",\\"dimensions\\":{\\"metrics\\":[0,1],\\"buckets\\":[]}}' "`;
 
+exports[`visualize loader pipeline helpers: build pipeline buildPipelineVisFunction handles tagcloud function with boolean param showLabel 1`] = `"tagcloud metric={visdimension 0} showLabel=false "`;
+
 exports[`visualize loader pipeline helpers: build pipeline buildPipelineVisFunction handles tagcloud function with buckets 1`] = `"tagcloud metric={visdimension 0}  bucket={visdimension 1 } "`;
 
 exports[`visualize loader pipeline helpers: build pipeline buildPipelineVisFunction handles tagcloud function without buckets 1`] = `"tagcloud metric={visdimension 0} "`;

--- a/src/legacy/ui/public/visualize/loader/pipeline_helpers/build_pipeline.test.js
+++ b/src/legacy/ui/public/visualize/loader/pipeline_helpers/build_pipeline.test.js
@@ -183,6 +183,14 @@ describe('visualize loader pipeline helpers: build pipeline', () => {
         const actual = buildPipelineVisFunction.tagcloud({ params }, schemas);
         expect(actual).toMatchSnapshot();
       });
+
+      it('with boolean param showLabel', () => {
+        const schemas = { metric: [{ accessor: 0 }] };
+        const params = { showLabel: false };
+        const actual = buildPipelineVisFunction.tagcloud({ params }, schemas);
+        expect(actual).toMatchSnapshot();
+      });
+
     });
 
     describe('handles region_map function', () => {

--- a/src/legacy/ui/public/visualize/loader/pipeline_helpers/build_pipeline.ts
+++ b/src/legacy/ui/public/visualize/loader/pipeline_helpers/build_pipeline.ts
@@ -267,7 +267,7 @@ export const buildPipelineVisFunction: BuildPipelineVisFunction = {
     if (maxFontSize) {
       expr += `maxFontSize=${maxFontSize} `;
     }
-    if (showLabel) {
+    if (showLabel !== undefined) {
       expr += `showLabel=${showLabel} `;
     }
 


### PR DESCRIPTION
Backports the following commits to 7.2:
 - [Tagcloud] Allow to send showLabel parameter with false value (#36563) (#36960)