### PR TITLE
[Infra UI] Convert bytes to bits before formatting for bits

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/helpers/create_formatter_for_metrics.test.ts
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/helpers/create_formatter_for_metrics.test.ts
@@ -28,7 +28,7 @@ describe('createFormatterForMetric()', () => {
       field: 'system.network.out.bytes',
     };
     const format = createFormatterForMetric(metric);
-    expect(format(103929292)).toBe('103.9Mbit/s');
+    expect(format(103929292)).toBe('831.4Mbit/s');
   });
   it('should just work for bytes', () => {
     const metric = {

--- a/x-pack/legacy/plugins/infra/public/lib/lib.ts
+++ b/x-pack/legacy/plugins/infra/public/lib/lib.ts
@@ -194,11 +194,7 @@ export enum InfraFormatterType {
 
 export enum InfraWaffleMapDataFormat {
   bytesDecimal = 'bytesDecimal',
-  bytesBinaryIEC = 'bytesBinaryIEC',
-  bytesBinaryJEDEC = 'bytesBinaryJEDEC',
   bitsDecimal = 'bitsDecimal',
-  bitsBinaryIEC = 'bitsBinaryIEC',
-  bitsBinaryJEDEC = 'bitsBinaryJEDEC',
   abbreviatedNumber = 'abbreviatedNumber',
 }
 

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.test.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.test.ts
@@ -5,34 +5,34 @@
  */
 
 import { InfraWaffleMapDataFormat } from '../../lib/lib';
-import { createDataFormatter } from './data';
+import { createBytesFormatter } from './bytes';
 describe('createDataFormatter', () => {
   it('should format bytes as bytesDecimal', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bytesDecimal);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesDecimal);
     expect(formatter(1000000)).toBe('1MB');
   });
   it('should format bytes as bytesBinaryIEC', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bytesBinaryIEC);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesBinaryIEC);
     expect(formatter(1000000)).toBe('976.6Kib');
   });
   it('should format bytes as bytesBinaryJEDEC', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bytesBinaryJEDEC);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesBinaryJEDEC);
     expect(formatter(1000000)).toBe('976.6KB');
   });
   it('should format bytes as bitsDecimal', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bitsDecimal);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsDecimal);
     expect(formatter(1000000)).toBe('8Mbit');
   });
   it('should format bytes as bitsBinaryIEC', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bitsBinaryIEC);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsBinaryIEC);
     expect(formatter(1000000)).toBe('7.6Mibit');
   });
   it('should format bytes as bitsBinaryJEDEC', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bitsBinaryJEDEC);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsBinaryJEDEC);
     expect(formatter(1000000)).toBe('7.6Mbit');
   });
   it('should format bytes as abbreviatedNumber', () => {
-    const formatter = createDataFormatter(InfraWaffleMapDataFormat.abbreviatedNumber);
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.abbreviatedNumber);
     expect(formatter(1000000)).toBe('1M');
   });
 });

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.test.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.test.ts
@@ -11,25 +11,9 @@ describe('createDataFormatter', () => {
     const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesDecimal);
     expect(formatter(1000000)).toBe('1MB');
   });
-  it('should format bytes as bytesBinaryIEC', () => {
-    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesBinaryIEC);
-    expect(formatter(1000000)).toBe('976.6Kib');
-  });
-  it('should format bytes as bytesBinaryJEDEC', () => {
-    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesBinaryJEDEC);
-    expect(formatter(1000000)).toBe('976.6KB');
-  });
   it('should format bytes as bitsDecimal', () => {
     const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsDecimal);
     expect(formatter(1000000)).toBe('8Mbit');
-  });
-  it('should format bytes as bitsBinaryIEC', () => {
-    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsBinaryIEC);
-    expect(formatter(1000000)).toBe('7.6Mibit');
-  });
-  it('should format bytes as bitsBinaryJEDEC', () => {
-    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsBinaryJEDEC);
-    expect(formatter(1000000)).toBe('7.6Mbit');
   });
   it('should format bytes as abbreviatedNumber', () => {
     const formatter = createBytesFormatter(InfraWaffleMapDataFormat.abbreviatedNumber);

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
@@ -68,7 +68,7 @@ const BIT_BASES = [
   InfraWaffleMapDataFormat.bitsDecimal,
 ];
 
-export const createDataFormatter = (format: InfraWaffleMapDataFormat) => (bytes: number) => {
+export const createBytesFormatter = (format: InfraWaffleMapDataFormat) => (bytes: number) => {
   const labels = LABELS[format];
   const base = BASES[format];
   const value = BIT_BASES.includes(format) ? bytes * 8 : bytes;

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
@@ -41,7 +41,7 @@ const BASES = {
 export const createBytesFormatter = (format: InfraWaffleMapDataFormat) => (bytes: number) => {
   const labels = LABELS[format];
   const base = BASES[format];
-  const value = InfraWaffleMapDataFormat.bitsDecimal ? bytes * 8 : bytes;
+  const value = format === InfraWaffleMapDataFormat.bitsDecimal ? bytes * 8 : bytes;
   // Use an exponetial equation to get the power to determine which label to use. If the power
   // is greater then the max label then use the max label.
   const power = Math.min(Math.floor(Math.log(Math.abs(value)) / Math.log(base)), labels.length - 1);

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
@@ -14,18 +14,6 @@ import { formatNumber } from './number';
  */
 const LABELS = {
   [InfraWaffleMapDataFormat.bytesDecimal]: ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-  [InfraWaffleMapDataFormat.bytesBinaryIEC]: [
-    'b',
-    'Kib',
-    'Mib',
-    'Gib',
-    'Tib',
-    'Pib',
-    'Eib',
-    'Zib',
-    'Yib',
-  ],
-  [InfraWaffleMapDataFormat.bytesBinaryJEDEC]: ['B', 'KB', 'MB', 'GB'],
   [InfraWaffleMapDataFormat.bitsDecimal]: [
     'bit',
     'kbit',
@@ -37,41 +25,23 @@ const LABELS = {
     'Zbit',
     'Ybit',
   ],
-  [InfraWaffleMapDataFormat.bitsBinaryIEC]: [
-    'bit',
-    'Kibit',
-    'Mibit',
-    'Gibit',
-    'Tibit',
-    'Pibit',
-    'Eibit',
-    'Zibit',
-    'Yibit',
-  ],
-  [InfraWaffleMapDataFormat.bitsBinaryJEDEC]: ['bit', 'Kbit', 'Mbit', 'Gbit'],
   [InfraWaffleMapDataFormat.abbreviatedNumber]: ['', 'K', 'M', 'B', 'T'],
 };
 
 const BASES = {
   [InfraWaffleMapDataFormat.bytesDecimal]: 1000,
-  [InfraWaffleMapDataFormat.bytesBinaryIEC]: 1024,
-  [InfraWaffleMapDataFormat.bytesBinaryJEDEC]: 1024,
   [InfraWaffleMapDataFormat.bitsDecimal]: 1000,
-  [InfraWaffleMapDataFormat.bitsBinaryIEC]: 1024,
-  [InfraWaffleMapDataFormat.bitsBinaryJEDEC]: 1024,
   [InfraWaffleMapDataFormat.abbreviatedNumber]: 1000,
 };
 
-const BIT_BASES = [
-  InfraWaffleMapDataFormat.bitsBinaryJEDEC,
-  InfraWaffleMapDataFormat.bitsBinaryIEC,
-  InfraWaffleMapDataFormat.bitsDecimal,
-];
-
+/*
+ * This formatter always assumes you're input is bytes and the output is a string
+ * in whatever format you've defined. Bytes in Format Out.
+ */
 export const createBytesFormatter = (format: InfraWaffleMapDataFormat) => (bytes: number) => {
   const labels = LABELS[format];
   const base = BASES[format];
-  const value = BIT_BASES.includes(format) ? bytes * 8 : bytes;
+  const value = InfraWaffleMapDataFormat.bitsDecimal ? bytes * 8 : bytes;
   // Use an exponetial equation to get the power to determine which label to use. If the power
   // is greater then the max label then use the max label.
   const power = Math.min(Math.floor(Math.log(Math.abs(value)) / Math.log(base)), labels.length - 1);

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/data.test.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/data.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraWaffleMapDataFormat } from '../../lib/lib';
+import { createDataFormatter } from './data';
+describe('createDataFormatter', () => {
+  it('should format bytes as bytesDecimal', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bytesDecimal);
+    expect(formatter(1000000)).toBe('1MB');
+  });
+  it('should format bytes as bytesBinaryIEC', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bytesBinaryIEC);
+    expect(formatter(1000000)).toBe('976.6Kib');
+  });
+  it('should format bytes as bytesBinaryJEDEC', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bytesBinaryJEDEC);
+    expect(formatter(1000000)).toBe('976.6KB');
+  });
+  it('should format bytes as bitsDecimal', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bitsDecimal);
+    expect(formatter(1000000)).toBe('8Mbit');
+  });
+  it('should format bytes as bitsBinaryIEC', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bitsBinaryIEC);
+    expect(formatter(1000000)).toBe('7.6Mibit');
+  });
+  it('should format bytes as bitsBinaryJEDEC', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.bitsBinaryJEDEC);
+    expect(formatter(1000000)).toBe('7.6Mbit');
+  });
+  it('should format bytes as abbreviatedNumber', () => {
+    const formatter = createDataFormatter(InfraWaffleMapDataFormat.abbreviatedNumber);
+    expect(formatter(1000000)).toBe('1M');
+  });
+});

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/data.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/data.ts
@@ -72,6 +72,8 @@ export const createDataFormatter = (format: InfraWaffleMapDataFormat) => (bytes:
   const labels = LABELS[format];
   const base = BASES[format];
   const value = BIT_BASES.includes(format) ? bytes * 8 : bytes;
+  // Use an exponetial equation to get the power to determine which label to use. If the power
+  // is greater then the max label then use the max label.
   const power = Math.min(Math.floor(Math.log(Math.abs(value)) / Math.log(base)), labels.length - 1);
   if (power < 0) {
     return `${formatNumber(value)}${labels[0]}`;

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/data.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/data.ts
@@ -62,12 +62,19 @@ const BASES = {
   [InfraWaffleMapDataFormat.abbreviatedNumber]: 1000,
 };
 
-export const createDataFormatter = (format: InfraWaffleMapDataFormat) => (val: number) => {
+const BIT_BASES = [
+  InfraWaffleMapDataFormat.bitsBinaryJEDEC,
+  InfraWaffleMapDataFormat.bitsBinaryIEC,
+  InfraWaffleMapDataFormat.bitsDecimal,
+];
+
+export const createDataFormatter = (format: InfraWaffleMapDataFormat) => (bytes: number) => {
   const labels = LABELS[format];
   const base = BASES[format];
-  const power = Math.min(Math.floor(Math.log(Math.abs(val)) / Math.log(base)), labels.length - 1);
+  const value = BIT_BASES.includes(format) ? bytes * 8 : bytes;
+  const power = Math.min(Math.floor(Math.log(Math.abs(value)) / Math.log(base)), labels.length - 1);
   if (power < 0) {
-    return `${formatNumber(val)}${labels[0]}`;
+    return `${formatNumber(value)}${labels[0]}`;
   }
-  return `${formatNumber(val / Math.pow(base, power))}${labels[power]}`;
+  return `${formatNumber(value / Math.pow(base, power))}${labels[power]}`;
 };

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/index.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/index.ts
@@ -6,17 +6,17 @@
 
 import Mustache from 'mustache';
 import { InfraFormatterType, InfraWaffleMapDataFormat } from '../../lib/lib';
-import { createDataFormatter } from './data';
+import { createBytesFormatter } from './bytes';
 import { formatNumber } from './number';
 import { formatPercent } from './percent';
 
 export const FORMATTERS = {
   [InfraFormatterType.number]: formatNumber,
-  [InfraFormatterType.abbreviatedNumber]: createDataFormatter(
+  [InfraFormatterType.abbreviatedNumber]: createBytesFormatter(
     InfraWaffleMapDataFormat.abbreviatedNumber
   ),
-  [InfraFormatterType.bytes]: createDataFormatter(InfraWaffleMapDataFormat.bytesDecimal),
-  [InfraFormatterType.bits]: createDataFormatter(InfraWaffleMapDataFormat.bitsDecimal),
+  [InfraFormatterType.bytes]: createBytesFormatter(InfraWaffleMapDataFormat.bytesDecimal),
+  [InfraFormatterType.bits]: createBytesFormatter(InfraWaffleMapDataFormat.bitsDecimal),
   [InfraFormatterType.percent]: formatPercent,
 };
 

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/index.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/index.ts
@@ -12,10 +12,14 @@ import { formatPercent } from './percent';
 
 export const FORMATTERS = {
   [InfraFormatterType.number]: formatNumber,
+  // Because the implimentation for formatting large numbers is the same as formatting
+  // bytes we are re-using the same code, we just format the number using the abbreviated number format.
   [InfraFormatterType.abbreviatedNumber]: createBytesFormatter(
     InfraWaffleMapDataFormat.abbreviatedNumber
   ),
+  // bytes in bytes formatted string out
   [InfraFormatterType.bytes]: createBytesFormatter(InfraWaffleMapDataFormat.bytesDecimal),
+  // bytes in bits formatted string out
   [InfraFormatterType.bits]: createBytesFormatter(InfraWaffleMapDataFormat.bitsDecimal),
   [InfraFormatterType.percent]: formatPercent,
 };


### PR DESCRIPTION
## Summary

This PR attempts to fix #40138 by converting bytes to bits when the formatter is using a bit format. This also attempts to make clear that the number being formatted is expected to be bytes by changing the `val` argument to `bytes`.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~