### PR TITLE
[APM]: use correct interval field key for histogram aggregation

### DIFF
--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
@@ -54,7 +54,7 @@ export function bucketFetcher(
         distribution: {
           histogram: {
             field: TRANSACTION_DURATION,
-            fixed_interval: bucketSize,
+            interval: bucketSize,
             min_doc_count: 0,
             extended_bounds: {
               min: 0,


### PR DESCRIPTION
Fixes an issue with distribution aggs failing because #39886 inadvertently changed the `interval` key for a histogram agg to `fixed_interval`, which only works on date_histogram aggs.