### PR TITLE
[7.3] [Infra UI] Sync state with localStorage for Metrics Explorer (#40099)

### DIFF
--- a/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/use_metrics_explorer_options.test.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/use_metrics_explorer_options.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { renderHook, act } from 'react-hooks-testing-library';
+import {
+  useMetricsExplorerOptions,
+  MetricsExplorerOptionsContainer,
+  MetricsExplorerOptions,
+  MetricsExplorerTimeOptions,
+  DEFAULT_OPTIONS,
+  DEFAULT_TIMERANGE,
+} from './use_metrics_explorer_options';
+import { MetricsExplorerAggregation } from '../../../server/routes/metrics_explorer/types';
+
+const renderUseMetricsExplorerOptionsHook = () =>
+  renderHook(() => useMetricsExplorerOptions(), {
+    initialProps: {},
+    wrapper: ({ children }) => (
+      <MetricsExplorerOptionsContainer.Provider>
+        {children}
+      </MetricsExplorerOptionsContainer.Provider>
+    ),
+  });
+
+interface LocalStore {
+  [key: string]: string;
+}
+
+interface LocalStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+const STORE: LocalStore = {};
+const localStorageMock: LocalStorage = {
+  getItem: (key: string) => {
+    return STORE[key] || null;
+  },
+  setItem: (key: string, value: any) => {
+    STORE[key] = value.toString();
+  },
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('useMetricExplorerOptions', () => {
+  beforeEach(() => {
+    delete STORE.MetricsExplorerOptions;
+    delete STORE.MetricsExplorerTimeRange;
+  });
+
+  it('should just work', () => {
+    const { result } = renderUseMetricsExplorerOptionsHook();
+    expect(result.current.options).toEqual(DEFAULT_OPTIONS);
+    expect(result.current.currentTimerange).toEqual(DEFAULT_TIMERANGE);
+    expect(result.current.isAutoReloading).toEqual(false);
+    expect(STORE.MetricsExplorerOptions).toEqual(JSON.stringify(DEFAULT_OPTIONS));
+    expect(STORE.MetricsExplorerTimeRange).toEqual(JSON.stringify(DEFAULT_TIMERANGE));
+  });
+
+  it('should change the store when options update', () => {
+    const { result, waitForNextUpdate } = renderUseMetricsExplorerOptionsHook();
+    const newOptions: MetricsExplorerOptions = {
+      ...DEFAULT_OPTIONS,
+      metrics: [{ aggregation: MetricsExplorerAggregation.count }],
+    };
+    act(() => {
+      result.current.setOptions(newOptions);
+    });
+    waitForNextUpdate();
+    expect(result.current.options).toEqual(newOptions);
+    expect(STORE.MetricsExplorerOptions).toEqual(JSON.stringify(newOptions));
+  });
+
+  it('should change the store when timerange update', () => {
+    const { result, waitForNextUpdate } = renderUseMetricsExplorerOptionsHook();
+    const newTimeRange: MetricsExplorerTimeOptions = {
+      ...DEFAULT_TIMERANGE,
+      from: 'now-15m',
+    };
+    act(() => {
+      result.current.setTimeRange(newTimeRange);
+    });
+    waitForNextUpdate();
+    expect(result.current.currentTimerange).toEqual(newTimeRange);
+    expect(STORE.MetricsExplorerTimeRange).toEqual(JSON.stringify(newTimeRange));
+  });
+
+  it('should load from store when available', () => {
+    const newOptions: MetricsExplorerOptions = {
+      ...DEFAULT_OPTIONS,
+      metrics: [{ aggregation: MetricsExplorerAggregation.avg, field: 'system.load.1' }],
+    };
+    STORE.MetricsExplorerOptions = JSON.stringify(newOptions);
+    const { result } = renderUseMetricsExplorerOptionsHook();
+    expect(result.current.options).toEqual(newOptions);
+  });
+});

--- a/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/use_metrics_explorer_options.ts
+++ b/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/use_metrics_explorer_options.ts
@@ -5,7 +5,7 @@
  */
 
 import createContainer from 'constate-latest';
-import { useState } from 'react';
+import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import { MetricsExplorerColor } from '../../../common/color_palette';
 import {
   MetricsExplorerAggregation,
@@ -31,13 +31,13 @@ export interface MetricsExplorerTimeOptions {
   interval: string;
 }
 
-const DEFAULT_TIMERANGE: MetricsExplorerTimeOptions = {
+export const DEFAULT_TIMERANGE: MetricsExplorerTimeOptions = {
   from: 'now-1h',
   to: 'now',
   interval: '>=10s',
 };
 
-const DEFAULT_METRICS: MetricsExplorerOptionsMetric[] = [
+export const DEFAULT_METRICS: MetricsExplorerOptionsMetric[] = [
   {
     aggregation: MetricsExplorerAggregation.avg,
     field: 'system.cpu.user.pct',
@@ -55,14 +55,43 @@ const DEFAULT_METRICS: MetricsExplorerOptionsMetric[] = [
   },
 ];
 
-const DEFAULT_OPTIONS: MetricsExplorerOptions = {
+export const DEFAULT_OPTIONS: MetricsExplorerOptions = {
   aggregation: MetricsExplorerAggregation.avg,
   metrics: DEFAULT_METRICS,
 };
 
+function parseJsonOrDefault<Obj>(value: string | null, defaultValue: Obj): Obj {
+  if (!value) {
+    return defaultValue;
+  }
+  try {
+    return JSON.parse(value) as Obj;
+  } catch (e) {
+    return defaultValue;
+  }
+}
+
+function useStateWithLocalStorage<State>(
+  key: string,
+  defaultState: State
+): [State, Dispatch<SetStateAction<State>>] {
+  const storageState = localStorage.getItem(key);
+  const [state, setState] = useState<State>(parseJsonOrDefault<State>(storageState, defaultState));
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [state]);
+  return [state, setState];
+}
+
 export const useMetricsExplorerOptions = () => {
-  const [options, setOptions] = useState<MetricsExplorerOptions>(DEFAULT_OPTIONS);
-  const [currentTimerange, setTimeRange] = useState<MetricsExplorerTimeOptions>(DEFAULT_TIMERANGE);
+  const [options, setOptions] = useStateWithLocalStorage<MetricsExplorerOptions>(
+    'MetricsExplorerOptions',
+    DEFAULT_OPTIONS
+  );
+  const [currentTimerange, setTimeRange] = useStateWithLocalStorage<MetricsExplorerTimeOptions>(
+    'MetricsExplorerTimeRange',
+    DEFAULT_TIMERANGE
+  );
   const [isAutoReloading, setAutoReloading] = useState<boolean>(false);
   return {
     options,

--- a/x-pack/legacy/plugins/infra/public/pages/infrastructure/metrics_explorer/use_metric_explorer_state.test.tsx
+++ b/x-pack/legacy/plugins/infra/public/pages/infrastructure/metrics_explorer/use_metric_explorer_state.test.tsx
@@ -30,8 +30,35 @@ const renderUseMetricsExplorerStateHook = () =>
 jest.mock('../../../utils/fetch');
 const mockedFetch = fetch as jest.Mocked<typeof fetch>;
 
+interface LocalStore {
+  [key: string]: string;
+}
+
+interface LocalStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+const STORE: LocalStore = {};
+const localStorageMock: LocalStorage = {
+  getItem: (key: string) => {
+    return STORE[key] || null;
+  },
+  setItem: (key: string, value: any) => {
+    STORE[key] = value.toString();
+  },
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
 describe('useMetricsExplorerState', () => {
-  beforeEach(() => mockedFetch.post.mockResolvedValue({ data: resp } as any));
+  beforeEach(() => {
+    mockedFetch.post.mockResolvedValue({ data: resp } as any);
+    delete STORE.MetricsExplorerOptions;
+    delete STORE.MetricsExplorerTimeRange;
+  });
 
   it('should just work', async () => {
     const { result, waitForNextUpdate } = renderUseMetricsExplorerStateHook();


### PR DESCRIPTION
Backports the following commits to 7.3:
 - [Infra UI] Fixes #39809 - Sync state with localStorage for Metrics Explorer  (#40099)