### PR TITLE
[APM] Agent config: fix typo in validation error message for environment

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -131,7 +131,7 @@ export function AddSettingFlyoutBody({
             'xpack.apm.settings.agentConf.flyOut.serviceEnvironmentSelectErrorText',
             {
               defaultMessage:
-                'Must select a valid environement to save a configuration.'
+                'Must select a valid environment to save a configuration.'
             }
           )}
           isInvalid={


### PR DESCRIPTION
Closes #40726.

Before:
![image](https://user-images.githubusercontent.com/352732/60963634-99b41c00-a311-11e9-9e25-f94da1d00d0a.png)

After:
![image](https://user-images.githubusercontent.com/352732/60964074-ae44e400-a312-11e9-93f4-d9fbad237a3e.png)

