### PR TITLE
[7.x] [Infra UI] Convert bytes to bits before formatting for bits (#40523)

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/helpers/create_formatter_for_metrics.test.ts
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/helpers/create_formatter_for_metrics.test.ts
@@ -28,7 +28,7 @@ describe('createFormatterForMetric()', () => {
       field: 'system.network.out.bytes',
     };
     const format = createFormatterForMetric(metric);
-    expect(format(103929292)).toBe('103.9Mbit/s');
+    expect(format(103929292)).toBe('831.4Mbit/s');
   });
   it('should just work for bytes', () => {
     const metric = {

--- a/x-pack/legacy/plugins/infra/public/lib/lib.ts
+++ b/x-pack/legacy/plugins/infra/public/lib/lib.ts
@@ -194,11 +194,7 @@ export enum InfraFormatterType {
 
 export enum InfraWaffleMapDataFormat {
   bytesDecimal = 'bytesDecimal',
-  bytesBinaryIEC = 'bytesBinaryIEC',
-  bytesBinaryJEDEC = 'bytesBinaryJEDEC',
   bitsDecimal = 'bitsDecimal',
-  bitsBinaryIEC = 'bitsBinaryIEC',
-  bitsBinaryJEDEC = 'bitsBinaryJEDEC',
   abbreviatedNumber = 'abbreviatedNumber',
 }
 

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.test.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InfraWaffleMapDataFormat } from '../../lib/lib';
+import { createBytesFormatter } from './bytes';
+describe('createDataFormatter', () => {
+  it('should format bytes as bytesDecimal', () => {
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bytesDecimal);
+    expect(formatter(1000000)).toBe('1MB');
+  });
+  it('should format bytes as bitsDecimal', () => {
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.bitsDecimal);
+    expect(formatter(1000000)).toBe('8Mbit');
+  });
+  it('should format bytes as abbreviatedNumber', () => {
+    const formatter = createBytesFormatter(InfraWaffleMapDataFormat.abbreviatedNumber);
+    expect(formatter(1000000)).toBe('1M');
+  });
+});

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/bytes.ts
@@ -14,18 +14,6 @@ import { formatNumber } from './number';
  */
 const LABELS = {
   [InfraWaffleMapDataFormat.bytesDecimal]: ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-  [InfraWaffleMapDataFormat.bytesBinaryIEC]: [
-    'b',
-    'Kib',
-    'Mib',
-    'Gib',
-    'Tib',
-    'Pib',
-    'Eib',
-    'Zib',
-    'Yib',
-  ],
-  [InfraWaffleMapDataFormat.bytesBinaryJEDEC]: ['B', 'KB', 'MB', 'GB'],
   [InfraWaffleMapDataFormat.bitsDecimal]: [
     'bit',
     'kbit',
@@ -37,37 +25,28 @@ const LABELS = {
     'Zbit',
     'Ybit',
   ],
-  [InfraWaffleMapDataFormat.bitsBinaryIEC]: [
-    'bit',
-    'Kibit',
-    'Mibit',
-    'Gibit',
-    'Tibit',
-    'Pibit',
-    'Eibit',
-    'Zibit',
-    'Yibit',
-  ],
-  [InfraWaffleMapDataFormat.bitsBinaryJEDEC]: ['bit', 'Kbit', 'Mbit', 'Gbit'],
   [InfraWaffleMapDataFormat.abbreviatedNumber]: ['', 'K', 'M', 'B', 'T'],
 };
 
 const BASES = {
   [InfraWaffleMapDataFormat.bytesDecimal]: 1000,
-  [InfraWaffleMapDataFormat.bytesBinaryIEC]: 1024,
-  [InfraWaffleMapDataFormat.bytesBinaryJEDEC]: 1024,
   [InfraWaffleMapDataFormat.bitsDecimal]: 1000,
-  [InfraWaffleMapDataFormat.bitsBinaryIEC]: 1024,
-  [InfraWaffleMapDataFormat.bitsBinaryJEDEC]: 1024,
   [InfraWaffleMapDataFormat.abbreviatedNumber]: 1000,
 };
 
-export const createDataFormatter = (format: InfraWaffleMapDataFormat) => (val: number) => {
+/*
+ * This formatter always assumes you're input is bytes and the output is a string
+ * in whatever format you've defined. Bytes in Format Out.
+ */
+export const createBytesFormatter = (format: InfraWaffleMapDataFormat) => (bytes: number) => {
   const labels = LABELS[format];
   const base = BASES[format];
-  const power = Math.min(Math.floor(Math.log(Math.abs(val)) / Math.log(base)), labels.length - 1);
+  const value = format === InfraWaffleMapDataFormat.bitsDecimal ? bytes * 8 : bytes;
+  // Use an exponetial equation to get the power to determine which label to use. If the power
+  // is greater then the max label then use the max label.
+  const power = Math.min(Math.floor(Math.log(Math.abs(value)) / Math.log(base)), labels.length - 1);
   if (power < 0) {
-    return `${formatNumber(val)}${labels[0]}`;
+    return `${formatNumber(value)}${labels[0]}`;
   }
-  return `${formatNumber(val / Math.pow(base, power))}${labels[power]}`;
+  return `${formatNumber(value / Math.pow(base, power))}${labels[power]}`;
 };

--- a/x-pack/legacy/plugins/infra/public/utils/formatters/index.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/formatters/index.ts
@@ -6,17 +6,21 @@
 
 import Mustache from 'mustache';
 import { InfraFormatterType, InfraWaffleMapDataFormat } from '../../lib/lib';
-import { createDataFormatter } from './data';
+import { createBytesFormatter } from './bytes';
 import { formatNumber } from './number';
 import { formatPercent } from './percent';
 
 export const FORMATTERS = {
   [InfraFormatterType.number]: formatNumber,
-  [InfraFormatterType.abbreviatedNumber]: createDataFormatter(
+  // Because the implimentation for formatting large numbers is the same as formatting
+  // bytes we are re-using the same code, we just format the number using the abbreviated number format.
+  [InfraFormatterType.abbreviatedNumber]: createBytesFormatter(
     InfraWaffleMapDataFormat.abbreviatedNumber
   ),
-  [InfraFormatterType.bytes]: createDataFormatter(InfraWaffleMapDataFormat.bytesDecimal),
-  [InfraFormatterType.bits]: createDataFormatter(InfraWaffleMapDataFormat.bitsDecimal),
+  // bytes in bytes formatted string out
+  [InfraFormatterType.bytes]: createBytesFormatter(InfraWaffleMapDataFormat.bytesDecimal),
+  // bytes in bits formatted string out
+  [InfraFormatterType.bits]: createBytesFormatter(InfraWaffleMapDataFormat.bitsDecimal),
   [InfraFormatterType.percent]: formatPercent,
 };
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixes #40138 - Convert bytes to bits before formatting for bits  (#40523)