### PR TITLE
[APM] Agent Configuration bug fixes & enhancements

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -59,10 +59,10 @@ export function AddSettingsFlyout({
   const [serviceName, setServiceName] = useState<string | undefined>(
     selectedConfig ? selectedConfig.service.name : undefined
   );
-  const [sampleRate, setSampleRate] = useState<string | undefined>(
+  const [sampleRate, setSampleRate] = useState<string>(
     selectedConfig
       ? selectedConfig.settings.transaction_sample_rate.toString()
-      : undefined
+      : ''
   );
   const { data: serviceNames = [], status: serviceNamesStatus } = useFetcher<
     string[]
@@ -84,11 +84,10 @@ export function AddSettingsFlyout({
     env =>
       env.name === environment && (Boolean(selectedConfig) || env.available)
   );
-  const sampleRateFloat = parseFloat(sampleRate || '');
+  const sampleRateFloat = parseFloat(sampleRate);
+  const hasCorrectDecimals = Number.isInteger(sampleRateFloat * 1000);
   const isSampleRateValid =
-    sampleRateFloat >= 0 &&
-    sampleRateFloat <= 1 &&
-    sampleRateFloat - parseFloat(sampleRateFloat.toFixed(3)) === 0;
+    sampleRateFloat >= 0 && sampleRateFloat <= 1 && hasCorrectDecimals;
   return (
     <EuiPortal>
       <EuiFlyout size="s" onClose={onClose} ownFocus={true}>
@@ -148,7 +147,6 @@ export function AddSettingsFlyout({
             serviceName={serviceName}
             setServiceName={setServiceName}
             sampleRate={sampleRate}
-            sampleRateFloat={sampleRateFloat}
             setSampleRate={setSampleRate}
             serviceNames={serviceNames}
             serviceNamesStatus={serviceNamesStatus}

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -59,9 +59,6 @@ export function AddSettingsFlyout({
   const [serviceName, setServiceName] = useState<string | undefined>(
     selectedConfig ? selectedConfig.service.name : undefined
   );
-  // const [sampleRate, setSampleRate] = useState<number>(
-  //   selectedConfig ? parseFloat(selectedConfig.settings.transaction_sample_rate) : NaN
-  // );
   const [sampleRate, setSampleRate] = useState<string | undefined>(
     selectedConfig ? selectedConfig.settings.transaction_sample_rate : undefined
   );

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -60,7 +60,9 @@ export function AddSettingsFlyout({
     selectedConfig ? selectedConfig.service.name : undefined
   );
   const [sampleRate, setSampleRate] = useState<string | undefined>(
-    selectedConfig ? selectedConfig.settings.transaction_sample_rate : undefined
+    selectedConfig
+      ? selectedConfig.settings.transaction_sample_rate.toString()
+      : undefined
   );
   const { data: serviceNames = [], status: serviceNamesStatus } = useFetcher<
     string[]
@@ -83,8 +85,10 @@ export function AddSettingsFlyout({
       env.name === environment && (Boolean(selectedConfig) || env.available)
   );
   const sampleRateFloat = parseFloat(sampleRate || '');
-  const isSampleRateValid = sampleRateFloat >= 0 && sampleRateFloat <= 1;
-
+  const isSampleRateValid =
+    sampleRateFloat >= 0 &&
+    sampleRateFloat <= 1 &&
+    sampleRateFloat - parseFloat(sampleRateFloat.toFixed(3)) === 0;
   return (
     <EuiPortal>
       <EuiFlyout size="s" onClose={onClose} ownFocus={true}>
@@ -266,7 +270,7 @@ async function saveConfig({
 
     const configuration = {
       settings: {
-        transaction_sample_rate: sampleRate.toString(10)
+        transaction_sample_rate: sampleRate
       },
       service: {
         name: serviceName,

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -59,8 +59,11 @@ export function AddSettingsFlyout({
   const [serviceName, setServiceName] = useState<string | undefined>(
     selectedConfig ? selectedConfig.service.name : undefined
   );
-  const [sampleRate, setSampleRate] = useState<number>(
-    selectedConfig ? parseFloat(selectedConfig.settings.sample_rate) : NaN
+  // const [sampleRate, setSampleRate] = useState<number>(
+  //   selectedConfig ? parseFloat(selectedConfig.settings.transaction_sample_rate) : NaN
+  // );
+  const [sampleRate, setSampleRate] = useState<string | undefined>(
+    selectedConfig ? selectedConfig.settings.transaction_sample_rate : undefined
   );
   const { data: serviceNames = [], status: serviceNamesStatus } = useFetcher<
     string[]
@@ -82,7 +85,8 @@ export function AddSettingsFlyout({
     env =>
       env.name === environment && (Boolean(selectedConfig) || env.available)
   );
-  const isSampleRateValid = sampleRate >= 0 && sampleRate <= 1;
+  const sampleRateFloat = parseFloat(sampleRate || '');
+  const isSampleRateValid = sampleRateFloat >= 0 && sampleRateFloat <= 1;
 
   return (
     <EuiPortal>
@@ -143,6 +147,7 @@ export function AddSettingsFlyout({
             serviceName={serviceName}
             setServiceName={setServiceName}
             sampleRate={sampleRate}
+            sampleRateFloat={sampleRateFloat}
             setSampleRate={setSampleRate}
             serviceNames={serviceNames}
             serviceNamesStatus={serviceNamesStatus}
@@ -182,7 +187,7 @@ export function AddSettingsFlyout({
                   await saveConfig({
                     environment,
                     serviceName,
-                    sampleRate,
+                    sampleRate: sampleRateFloat,
                     configurationId: selectedConfig
                       ? selectedConfig.id
                       : undefined
@@ -264,7 +269,7 @@ async function saveConfig({
 
     const configuration = {
       settings: {
-        sample_rate: sampleRate.toString(10)
+        transaction_sample_rate: sampleRate.toString(10)
       },
       service: {
         name: serviceName,

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -10,16 +10,48 @@ import {
   EuiForm,
   EuiFormRow,
   EuiButton,
-  EuiFieldNumber,
+  EuiFieldText,
   EuiTitle,
   EuiSpacer,
   EuiHorizontalRule,
   EuiText
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { isEmpty } from 'lodash';
 import { FETCH_STATUS } from '../../../../hooks/useFetcher';
 import { Config } from '../SettingsList';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../../../common/environment_filter_values';
+
+const NO_SELECTION = 'NO_SELECTION';
+const EuiSelectWithPlaceholder: typeof EuiSelect = props => (
+  <EuiSelect
+    {...props}
+    options={[
+      { text: props.placeholder, value: NO_SELECTION },
+      ...props.options
+    ]}
+    value={isEmpty(props.value) ? NO_SELECTION : props.value}
+    onChange={e => {
+      if (props.onChange) {
+        props.onChange(
+          Object.assign(e, {
+            target: Object.assign(e.target, {
+              value:
+                e.target.value === NO_SELECTION ? undefined : e.target.value
+            })
+          })
+        );
+      }
+    }}
+  />
+);
+
+const selectPlaceholderLabel = `- ${i18n.translate(
+  'xpack.apm.settings.agentConf.flyOut.selectPlaceholder',
+  {
+    defaultMessage: 'Select'
+  }
+)} -`;
 
 export function AddSettingFlyoutBody({
   selectedConfig,
@@ -30,6 +62,7 @@ export function AddSettingFlyoutBody({
   setServiceName,
   sampleRate,
   setSampleRate,
+  sampleRateFloat,
   serviceNames,
   serviceNamesStatus,
   environments,
@@ -43,8 +76,11 @@ export function AddSettingFlyoutBody({
   setEnvironment: React.Dispatch<React.SetStateAction<string | undefined>>;
   serviceName?: string;
   setServiceName: React.Dispatch<React.SetStateAction<string | undefined>>;
-  sampleRate: number;
-  setSampleRate: React.Dispatch<React.SetStateAction<number>>;
+  // sampleRate: number;
+  // setSampleRate: React.Dispatch<React.SetStateAction<number>>;
+  sampleRate?: string;
+  setSampleRate: React.Dispatch<React.SetStateAction<string | undefined>>;
+  sampleRateFloat: number;
   serviceNames: string[];
   serviceNamesStatus?: FETCH_STATUS;
   environments: Array<{
@@ -99,9 +135,9 @@ export function AddSettingFlyoutBody({
             }
           )}
         >
-          <EuiSelect
+          <EuiSelectWithPlaceholder
+            placeholder={selectPlaceholderLabel}
             isLoading={serviceNamesStatus === 'loading'}
-            hasNoInitialSelection
             options={serviceNames.map(text => ({ text }))}
             value={serviceName}
             disabled={Boolean(selectedConfig)}
@@ -141,14 +177,13 @@ export function AddSettingFlyoutBody({
                 environment &&
                 isSelectedEnvironmentValid &&
                 environmentStatus === 'success') ||
-              isNaN(sampleRate)
+              isNaN(sampleRateFloat)
             )
           }
         >
-          <EuiSelect
-            key={serviceName} // rerender when serviceName changes to mitigate initial selection bug in EuiSelect
+          <EuiSelectWithPlaceholder
+            placeholder={selectPlaceholderLabel}
             isLoading={environmentStatus === 'loading'}
-            hasNoInitialSelection
             options={environmentOptions}
             value={environment}
             disabled={!serviceName || Boolean(selectedConfig)}
@@ -195,28 +230,31 @@ export function AddSettingFlyoutBody({
           isInvalid={
             !(
               (Boolean(selectedConfig) &&
-                (isNaN(sampleRate) || isSampleRateValid)) ||
+                (isNaN(sampleRateFloat) || isSampleRateValid)) ||
               (!selectedConfig &&
                 (!(serviceName || environment) ||
-                  (isNaN(sampleRate) || isSampleRateValid)))
+                  (isNaN(sampleRateFloat) || isSampleRateValid)))
             )
           }
         >
-          <EuiFieldNumber
-            min={0}
-            max={1}
-            step={0.001}
+          <EuiFieldText
+            // min={0}
+            // max={1}
+            // step={0.001}
             placeholder={i18n.translate(
               'xpack.apm.settings.agentConf.flyOut.sampleRateConfigurationInputPlaceholderText',
               {
                 defaultMessage: 'Set sample rate'
               }
             )}
-            value={isNaN(sampleRate) ? '' : sampleRate}
+            // value={isNaN(sampleRate) ? '' : sampleRate}
+            value={sampleRate === undefined ? '' : sampleRate}
             onChange={e => {
               e.preventDefault();
-              setSampleRate(parseFloat(e.target.value));
+              // setSampleRate(parseFloat(e.target.value));
+              setSampleRate(e.target.value);
             }}
+            disabled={!(serviceName && environment) || !selectedConfig}
           />
         </EuiFormRow>
 

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import {
-  EuiSelect,
   EuiForm,
   EuiFormRow,
   EuiButton,
@@ -21,30 +20,7 @@ import { isEmpty } from 'lodash';
 import { FETCH_STATUS } from '../../../../hooks/useFetcher';
 import { Config } from '../SettingsList';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../../../common/environment_filter_values';
-
-const NO_SELECTION = 'NO_SELECTION';
-const EuiSelectWithPlaceholder: typeof EuiSelect = props => (
-  <EuiSelect
-    {...props}
-    options={[
-      { text: props.placeholder, value: NO_SELECTION },
-      ...props.options
-    ]}
-    value={isEmpty(props.value) ? NO_SELECTION : props.value}
-    onChange={e => {
-      if (props.onChange) {
-        props.onChange(
-          Object.assign(e, {
-            target: Object.assign(e.target, {
-              value:
-                e.target.value === NO_SELECTION ? undefined : e.target.value
-            })
-          })
-        );
-      }
-    }}
-  />
-);
+import { SelectWithPlaceholder } from '../../../shared/SelectWithPlaceholder';
 
 const selectPlaceholderLabel = `- ${i18n.translate(
   'xpack.apm.settings.agentConf.flyOut.selectPlaceholder',
@@ -62,7 +38,6 @@ export function AddSettingFlyoutBody({
   setServiceName,
   sampleRate,
   setSampleRate,
-  sampleRateFloat,
   serviceNames,
   serviceNamesStatus,
   environments,
@@ -73,12 +48,11 @@ export function AddSettingFlyoutBody({
   selectedConfig: Config | null;
   onDelete: () => void;
   environment?: string;
-  setEnvironment: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setEnvironment: (env: string | undefined) => void;
   serviceName?: string;
-  setServiceName: React.Dispatch<React.SetStateAction<string | undefined>>;
-  sampleRate?: string;
-  setSampleRate: React.Dispatch<React.SetStateAction<string | undefined>>;
-  sampleRateFloat: number;
+  setServiceName: (env: string | undefined) => void;
+  sampleRate: string;
+  setSampleRate: (env: string) => void;
   serviceNames: string[];
   serviceNamesStatus?: FETCH_STATUS;
   environments: Array<{
@@ -133,7 +107,7 @@ export function AddSettingFlyoutBody({
             }
           )}
         >
-          <EuiSelectWithPlaceholder
+          <SelectWithPlaceholder
             placeholder={selectPlaceholderLabel}
             isLoading={serviceNamesStatus === 'loading'}
             options={serviceNames.map(text => ({ text }))}
@@ -175,11 +149,11 @@ export function AddSettingFlyoutBody({
                 environment &&
                 isSelectedEnvironmentValid &&
                 environmentStatus === 'success') ||
-              isNaN(sampleRateFloat)
+              isEmpty(sampleRate)
             )
           }
         >
-          <EuiSelectWithPlaceholder
+          <SelectWithPlaceholder
             placeholder={selectPlaceholderLabel}
             isLoading={environmentStatus === 'loading'}
             options={environmentOptions}
@@ -228,10 +202,10 @@ export function AddSettingFlyoutBody({
           isInvalid={
             !(
               (Boolean(selectedConfig) &&
-                (isNaN(sampleRateFloat) || isSampleRateValid)) ||
+                (isEmpty(sampleRate) || isSampleRateValid)) ||
               (!selectedConfig &&
                 (!(serviceName || environment) ||
-                  (isNaN(sampleRateFloat) || isSampleRateValid)))
+                  (isEmpty(sampleRate) || isSampleRateValid)))
             )
           }
         >
@@ -242,7 +216,7 @@ export function AddSettingFlyoutBody({
                 defaultMessage: 'Set sample rate'
               }
             )}
-            value={sampleRate === undefined ? '' : sampleRate}
+            value={sampleRate}
             onChange={e => {
               e.preventDefault();
               setSampleRate(e.target.value);

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -76,8 +76,6 @@ export function AddSettingFlyoutBody({
   setEnvironment: React.Dispatch<React.SetStateAction<string | undefined>>;
   serviceName?: string;
   setServiceName: React.Dispatch<React.SetStateAction<string | undefined>>;
-  // sampleRate: number;
-  // setSampleRate: React.Dispatch<React.SetStateAction<number>>;
   sampleRate?: string;
   setSampleRate: React.Dispatch<React.SetStateAction<string | undefined>>;
   sampleRateFloat: number;
@@ -238,20 +236,15 @@ export function AddSettingFlyoutBody({
           }
         >
           <EuiFieldText
-            // min={0}
-            // max={1}
-            // step={0.001}
             placeholder={i18n.translate(
               'xpack.apm.settings.agentConf.flyOut.sampleRateConfigurationInputPlaceholderText',
               {
                 defaultMessage: 'Set sample rate'
               }
             )}
-            // value={isNaN(sampleRate) ? '' : sampleRate}
             value={sampleRate === undefined ? '' : sampleRate}
             onChange={e => {
               e.preventDefault();
-              // setSampleRate(parseFloat(e.target.value));
               setSampleRate(e.target.value);
             }}
             disabled={!(serviceName && environment) || !selectedConfig}

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -247,7 +247,7 @@ export function AddSettingFlyoutBody({
               e.preventDefault();
               setSampleRate(e.target.value);
             }}
-            disabled={!(serviceName && environment) || !selectedConfig}
+            disabled={!(serviceName && environment) && !selectedConfig}
           />
         </EuiFormRow>
 

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
@@ -75,7 +75,7 @@ export function SettingsList() {
       render: (value: string) => value
     },
     {
-      field: 'settings.sample_rate',
+      field: 'settings.transaction_sample_rate',
       name: i18n.translate(
         'xpack.apm.settings.agentConf.configTable.sampleRateColumnLabel',
         {

--- a/x-pack/legacy/plugins/apm/public/components/shared/SelectWithPlaceholder/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/SelectWithPlaceholder/index.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { EuiSelect } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+
+const NO_SELECTION = 'NO_SELECTION';
+
+/**
+ * This component addresses some cross-browser inconsistencies of `EuiSelect`
+ * with `hasNoInitialSelection`. It uses the `placeholder` prop to populate
+ * the first option as the initial, not selected option.
+ */
+export const SelectWithPlaceholder: typeof EuiSelect = props => (
+  <EuiSelect
+    {...props}
+    options={[
+      { text: props.placeholder, value: NO_SELECTION },
+      ...props.options
+    ]}
+    value={isEmpty(props.value) ? NO_SELECTION : props.value}
+    onChange={e => {
+      if (props.onChange) {
+        props.onChange(
+          Object.assign(e, {
+            target: Object.assign(e.target, {
+              value:
+                e.target.value === NO_SELECTION ? undefined : e.target.value
+            })
+          })
+        );
+      }
+    }}
+  />
+);

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/configuration_types.d.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/configuration_types.d.ts
@@ -6,7 +6,7 @@
 
 export interface AgentConfigurationIntake {
   settings: {
-    sample_rate: string;
+    transaction_sample_rate: string;
   };
   service: {
     name: string;

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/configuration_types.d.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/configuration_types.d.ts
@@ -6,7 +6,7 @@
 
 export interface AgentConfigurationIntake {
   settings: {
-    transaction_sample_rate: string;
+    transaction_sample_rate: number;
   };
   service: {
     name: string;

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
@@ -19,6 +19,9 @@ export async function createApmAgentConfigurationIndex(server: Server) {
     const result = await callWithInternalUser('indices.create', {
       index,
       body: {
+        settings: {
+          'index.auto_expand_replicas': '0-1'
+        },
         mappings: {
           properties: {
             '@timestamp': {
@@ -26,7 +29,7 @@ export async function createApmAgentConfigurationIndex(server: Server) {
             },
             settings: {
               properties: {
-                sample_rate: {
+                transaction_sample_rate: {
                   type: 'text'
                 }
               }

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
@@ -30,7 +30,10 @@ export async function createApmAgentConfigurationIndex(server: Server) {
             settings: {
               properties: {
                 transaction_sample_rate: {
-                  type: 'text'
+                  type: 'scaled_float',
+                  scaling_factor: 1000,
+                  ignore_malformed: true,
+                  coerce: false
                 }
               }
             },

--- a/x-pack/legacy/plugins/apm/server/routes/settings.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings.ts
@@ -200,6 +200,8 @@ export function initSettingsApi(core: InternalCoreSetup) {
           };
         }
 
+        await createApmAgentConfigurationIndex(server);
+
         const setup = setupRequest(req);
         const payload = req.payload as Payload;
         const serviceName = payload.service.name;

--- a/x-pack/legacy/plugins/apm/server/routes/settings.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings.ts
@@ -27,8 +27,6 @@ const defaultErrorHandler = (err: Error) => {
 export function initSettingsApi(core: InternalCoreSetup) {
   const { server } = core.http;
 
-  createApmAgentConfigurationIndex(server);
-
   // get list of configurations
   server.route({
     method: 'GET',
@@ -42,6 +40,8 @@ export function initSettingsApi(core: InternalCoreSetup) {
       tags: ['access:apm']
     },
     handler: async req => {
+      await createApmAgentConfigurationIndex(server);
+
       const setup = setupRequest(req);
       return await listConfigurations({
         setup

--- a/x-pack/legacy/plugins/apm/server/routes/settings.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings.ts
@@ -113,6 +113,21 @@ export function initSettingsApi(core: InternalCoreSetup) {
     }
   });
 
+  const agentConfigPayloadValidation = {
+    settings: Joi.object({
+      transaction_sample_rate: Joi.number()
+        .min(0)
+        .max(1)
+        .precision(3)
+        .required()
+        .options({ convert: false })
+    }),
+    service: Joi.object({
+      name: Joi.string().required(),
+      environment: Joi.string()
+    })
+  };
+
   // create configuration
   server.route({
     method: 'POST',
@@ -121,7 +136,8 @@ export function initSettingsApi(core: InternalCoreSetup) {
       validate: {
         query: {
           _debug: Joi.bool()
-        }
+        },
+        payload: agentConfigPayloadValidation
       },
       tags: ['access:apm']
     },
@@ -143,7 +159,8 @@ export function initSettingsApi(core: InternalCoreSetup) {
       validate: {
         query: {
           _debug: Joi.bool()
-        }
+        },
+        payload: agentConfigPayloadValidation
       },
       tags: ['access:apm']
     },


### PR DESCRIPTION
  - added api validation for creating/updating configurations
  - store `transaction_sample_rate` as a number rather than a string
  - improved ui validation for `transaction_sample_rate` precision
  - fixed inconsistent number input from localized input
  - fixed dropdown initial empty selection cross browser issue
  - renamed `settings.sample_rate` to `settings.transaction_sample_rate`
  - fixed yellow cluster state by setting `index.auto_expand_replicas` to `'0-1'`
  - create `.apm-agent-configuration` index on settings page load if it doesn't already exist

![agent-remote-config-ui-4](https://user-images.githubusercontent.com/1967266/61170236-e6b70e80-a51a-11e9-9c1d-6af263245b94.gif)
