### PR TITLE
Creates structured result of running an action

### DIFF
--- a/x-pack/legacy/plugins/actions/server/action_type_registry.test.ts
+++ b/x-pack/legacy/plugins/actions/server/action_type_registry.test.ts
@@ -11,6 +11,7 @@ jest.mock('./lib/get_create_task_runner_function', () => ({
 import { taskManagerMock } from '../../task_manager/task_manager.mock';
 import { encryptedSavedObjectsMock } from '../../encrypted_saved_objects/server/plugin.mock';
 import { ActionTypeRegistry } from './action_type_registry';
+import { ExecutorType } from './types';
 import { SavedObjectsClientMock } from '../../../../../src/core/server/mocks';
 
 const mockTaskManager = taskManagerMock.create();
@@ -30,9 +31,12 @@ const actionTypeRegistryParams = {
 
 beforeEach(() => jest.resetAllMocks());
 
+const executor: ExecutorType = async options => {
+  return { status: 'ok' };
+};
+
 describe('register()', () => {
   test('able to register action types', () => {
-    const executor = jest.fn();
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { getCreateTaskRunnerFunction } = require('./lib/get_create_task_runner_function');
     getCreateTaskRunnerFunction.mockReturnValueOnce(jest.fn());
@@ -64,7 +68,6 @@ Array [
   });
 
   test('throws error if action type already registered', () => {
-    const executor = jest.fn();
     const actionTypeRegistry = new ActionTypeRegistry(actionTypeRegistryParams);
     actionTypeRegistry.register({
       id: 'my-action-type',
@@ -92,7 +95,7 @@ describe('get()', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: [],
-      async executor() {},
+      executor,
     });
     const actionType = actionTypeRegistry.get('my-action-type');
     expect(actionType).toMatchInlineSnapshot(`
@@ -120,7 +123,7 @@ describe('list()', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: [],
-      async executor() {},
+      executor,
     });
     const actionTypes = actionTypeRegistry.list();
     expect(actionTypes).toEqual([
@@ -139,7 +142,6 @@ describe('has()', () => {
   });
 
   test('returns true after registering an action type', () => {
-    const executor = jest.fn();
     const actionTypeRegistry = new ActionTypeRegistry(actionTypeRegistryParams);
     actionTypeRegistry.register({
       id: 'my-action-type',

--- a/x-pack/legacy/plugins/actions/server/actions_client.test.ts
+++ b/x-pack/legacy/plugins/actions/server/actions_client.test.ts
@@ -8,6 +8,7 @@ import { schema } from '@kbn/config-schema';
 
 import { ActionTypeRegistry } from './action_type_registry';
 import { ActionsClient } from './actions_client';
+import { ExecutorType } from './types';
 import { taskManagerMock } from '../../task_manager/task_manager.mock';
 import { EncryptedSavedObjectsPlugin } from '../../encrypted_saved_objects';
 import { SavedObjectsClientMock } from '../../../../../src/core/server/mocks';
@@ -34,6 +35,10 @@ const actionTypeRegistryParams = {
   encryptedSavedObjectsPlugin: mockEncryptedSavedObjectsPlugin,
 };
 
+const executor: ExecutorType = async options => {
+  return { status: 'ok' };
+};
+
 beforeEach(() => jest.resetAllMocks());
 
 describe('create()', () => {
@@ -49,7 +54,7 @@ describe('create()', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: [],
-      async executor() {},
+      executor,
     });
     const actionsClient = new ActionsClient({
       actionTypeRegistry,
@@ -101,7 +106,7 @@ describe('create()', () => {
           param1: schema.string(),
         }),
       },
-      async executor() {},
+      executor,
     });
     await expect(
       actionsClient.create({
@@ -147,7 +152,7 @@ describe('create()', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: ['a', 'c'],
-      async executor() {},
+      executor,
     });
     const actionsClient = new ActionsClient({
       actionTypeRegistry,
@@ -281,7 +286,7 @@ describe('update()', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: [],
-      async executor() {},
+      executor,
     });
     const actionsClient = new ActionsClient({
       actionTypeRegistry,
@@ -343,7 +348,7 @@ describe('update()', () => {
           param1: schema.string(),
         }),
       },
-      async executor() {},
+      executor,
     });
     savedObjectsClient.get.mockResolvedValueOnce({
       id: 'my-action',
@@ -379,7 +384,7 @@ describe('update()', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: ['a', 'c'],
-      async executor() {},
+      executor,
     });
     const actionsClient = new ActionsClient({
       actionTypeRegistry,

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/email.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/email.ts
@@ -8,7 +8,7 @@ import { schema, TypeOf, Type } from '@kbn/config-schema';
 import nodemailerServices from 'nodemailer/lib/well-known/services.json';
 
 import { sendEmail, JSON_TRANSPORT_SERVICE } from './lib/send_email';
-import { ActionType, ActionTypeExecutorOptions } from '../types';
+import { ActionType, ActionTypeExecutorOptions, ActionTypeExecutorResult } from '../types';
 
 const PORT_MAX = 256 * 256 - 1;
 
@@ -107,7 +107,7 @@ export const actionType: ActionType = {
 
 // action executor
 
-async function executor(execOptions: ActionTypeExecutorOptions): Promise<any> {
+async function executor(execOptions: ActionTypeExecutorOptions): Promise<ActionTypeExecutorResult> {
   const config = execOptions.config as ActionTypeConfigType;
   const params = execOptions.params as ActionParamsType;
   const services = execOptions.services;
@@ -139,7 +139,18 @@ async function executor(execOptions: ActionTypeExecutorOptions): Promise<any> {
     },
   };
 
-  return await sendEmail(services, sendEmailOptions);
+  let result;
+
+  try {
+    result = await sendEmail(services, sendEmailOptions);
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `error sending email: ${err.message}`,
+    };
+  }
+
+  return { status: 'ok', data: result };
 }
 
 // utilities

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/server_log.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/server_log.ts
@@ -6,7 +6,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 
-import { ActionType, ActionTypeExecutorOptions } from '../types';
+import { ActionType, ActionTypeExecutorOptions, ActionTypeExecutorResult } from '../types';
 
 const DEFAULT_TAGS = ['info', 'alerting'];
 
@@ -40,9 +40,18 @@ export const actionType: ActionType = {
 
 // action executor
 
-async function executor(execOptions: ActionTypeExecutorOptions): Promise<any> {
+async function executor(execOptions: ActionTypeExecutorOptions): Promise<ActionTypeExecutorResult> {
   const params = execOptions.params as ActionParamsType;
   const services = execOptions.services;
 
-  services.log(params.tags, params.message);
+  try {
+    services.log(params.tags, params.message);
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `error logging message: ${err.message}`,
+    };
+  }
+
+  return { status: 'ok' };
 }

--- a/x-pack/legacy/plugins/actions/server/lib/execute.ts
+++ b/x-pack/legacy/plugins/actions/server/lib/execute.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Services, ActionTypeRegistryContract } from '../types';
+import { Services, ActionTypeRegistryContract, ActionTypeExecutorResult } from '../types';
 import { validateActionTypeConfig } from './validate_action_type_config';
 import { validateActionTypeParams } from './validate_action_type_params';
 import { EncryptedSavedObjectsPlugin } from '../../../encrypted_saved_objects';
@@ -25,7 +25,7 @@ export async function execute({
   services,
   params,
   encryptedSavedObjectsPlugin,
-}: ExecuteOptions) {
+}: ExecuteOptions): Promise<ActionTypeExecutorResult> {
   // TODO: Ensure user can read the action before processing
   const action = await encryptedSavedObjectsPlugin.getDecryptedAsInternalUser('action', actionId, {
     namespace,
@@ -38,8 +38,11 @@ export async function execute({
   const validatedConfig = validateActionTypeConfig(actionType, mergedActionTypeConfig);
   const validatedParams = validateActionTypeParams(actionType, params);
 
-  let result;
-  let error;
+  let result: ActionTypeExecutorResult | null = null;
+
+  const { actionTypeId, description } = action.attributes;
+  const actionLabel = `${actionId} - ${actionTypeId} - ${description}`;
+
   try {
     result = await actionType.executor({
       services,
@@ -47,33 +50,17 @@ export async function execute({
       params: validatedParams,
     });
   } catch (err) {
-    error = err;
-  }
-
-  const { actionTypeId, description } = action.attributes;
-  const actionLabel = `${actionId} - ${actionTypeId} - ${description}`;
-
-  if (error != null) {
     services.log(
       ['warning', 'x-pack', 'actions'],
-      `action executed unsuccessfully: ${actionLabel} - ${error.message}`
+      `action executed unsuccessfully: ${actionLabel} - ${err.message}`
     );
-    throw error;
+    throw err;
   }
 
   services.log(['debug', 'x-pack', 'actions'], `action executed successfully: ${actionLabel}`);
 
-  // return result if it's JSONable, otherwise a simple success object
-  const simpleResult = { status: 'ok' };
+  // return basic response if none provided
+  if (result == null) return { status: 'ok' };
 
-  if (result == null || typeof result !== 'object') {
-    return simpleResult;
-  }
-
-  try {
-    JSON.stringify(result);
-    return result;
-  } catch (err) {
-    return simpleResult;
-  }
+  return result;
 }

--- a/x-pack/legacy/plugins/actions/server/lib/validate_action_type_config.test.ts
+++ b/x-pack/legacy/plugins/actions/server/lib/validate_action_type_config.test.ts
@@ -6,6 +6,11 @@
 
 import { schema } from '@kbn/config-schema';
 import { validateActionTypeConfig } from './validate_action_type_config';
+import { ExecutorType } from '../types';
+
+const executor: ExecutorType = async options => {
+  return { status: 'ok' };
+};
 
 test('should return passed in config when validation not defined', () => {
   const result = validateActionTypeConfig(
@@ -13,7 +18,7 @@ test('should return passed in config when validation not defined', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: [],
-      async executor() {},
+      executor,
     },
     {
       foo: true,
@@ -34,7 +39,7 @@ test('should validate and apply defaults when actionTypeConfig is valid', () => 
           param2: schema.string({ defaultValue: 'default-value' }),
         }),
       },
-      async executor() {},
+      executor,
     },
     { param1: 'value' }
   );
@@ -58,7 +63,7 @@ test('should validate and throw error when actionTypeConfig is invalid', () => {
             }),
           }),
         },
-        async executor() {},
+        executor,
       },
       {
         obj: {},

--- a/x-pack/legacy/plugins/actions/server/lib/validate_action_type_params.test.ts
+++ b/x-pack/legacy/plugins/actions/server/lib/validate_action_type_params.test.ts
@@ -6,6 +6,11 @@
 
 import { schema } from '@kbn/config-schema';
 import { validateActionTypeParams } from './validate_action_type_params';
+import { ExecutorType } from '../types';
+
+const executor: ExecutorType = async options => {
+  return { status: 'ok' };
+};
 
 test('should return passed in params when validation not defined', () => {
   const result = validateActionTypeParams(
@@ -13,7 +18,7 @@ test('should return passed in params when validation not defined', () => {
       id: 'my-action-type',
       name: 'My action type',
       unencryptedAttributes: [],
-      async executor() {},
+      executor,
     },
     {
       foo: true,
@@ -36,7 +41,7 @@ test('should validate and apply defaults when params is valid', () => {
           param2: schema.string({ defaultValue: 'default-value' }),
         }),
       },
-      async executor() {},
+      executor,
     },
     { param1: 'value' }
   );
@@ -58,7 +63,7 @@ test('should validate and throw error when params is invalid', () => {
             param1: schema.string(),
           }),
         },
-        async executor() {},
+        executor,
       },
       {}
     )

--- a/x-pack/legacy/plugins/actions/server/types.ts
+++ b/x-pack/legacy/plugins/actions/server/types.ts
@@ -29,13 +29,25 @@ export interface ActionsPlugin {
   fire(options: { id: string; params: Record<string, any>; basePath: string }): Promise<void>;
 }
 
+// the parameters passed to an action type executor function
 export interface ActionTypeExecutorOptions {
   services: Services;
   config: Record<string, any>;
   params: Record<string, any>;
 }
 
-export type ExecutorType = (options: ActionTypeExecutorOptions) => Promise<any>;
+// the result returned from an action type executor function
+export interface ActionTypeExecutorResult {
+  status: 'ok' | 'error';
+  message?: string;
+  data?: any;
+  retry?: null | boolean | Date;
+}
+
+// signature of the action type executor function
+export type ExecutorType = (
+  options: ActionTypeExecutorOptions
+) => Promise<ActionTypeExecutorResult>;
 
 export interface ActionType {
   id: string;

--- a/x-pack/test/api_integration/apis/actions/builtin_action_types/email.ts
+++ b/x-pack/test/api_integration/apis/actions/builtin_action_types/email.ts
@@ -80,13 +80,13 @@ export default function emailTest({ getService }: KibanaFunctionalTestDefaultPro
         })
         .expect(200)
         .then((resp: any) => {
-          expect(resp.body.message.messageId).to.be.a('string');
-          expect(resp.body.messageId).to.be.a('string');
+          expect(resp.body.data.message.messageId).to.be.a('string');
+          expect(resp.body.data.messageId).to.be.a('string');
 
-          delete resp.body.message.messageId;
-          delete resp.body.messageId;
+          delete resp.body.data.message.messageId;
+          delete resp.body.data.messageId;
 
-          expect(resp.body).to.eql({
+          expect(resp.body.data).to.eql({
             envelope: {
               from: 'bob@example.com',
               to: ['kibana-action-test@elastic.co'],
@@ -123,7 +123,7 @@ export default function emailTest({ getService }: KibanaFunctionalTestDefaultPro
         })
         .expect(200)
         .then((resp: any) => {
-          const { text, html } = resp.body.message;
+          const { text, html } = resp.body.data.message;
           expect(text).to.eql('_italic_ **bold** https://elastic.co link');
           expect(html).to.eql(
             '<p><em>italic</em> <strong>bold</strong> <a href="https://elastic.co">https://elastic.co</a> link</p>\n'

--- a/x-pack/test/api_integration/apis/actions/builtin_action_types/slack.ts
+++ b/x-pack/test/api_integration/apis/actions/builtin_action_types/slack.ts
@@ -8,12 +8,24 @@ import expect from '@kbn/expect';
 
 import { KibanaFunctionalTestDefaultProviders } from '../../../../types/providers';
 
+import { SLACK_ACTION_SIMULATOR_URI } from '../../../fixtures/plugins/actions';
+
 // eslint-disable-next-line import/no-default-export
 export default function slackTest({ getService }: KibanaFunctionalTestDefaultProviders) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  describe('create slack action', () => {
+  describe('slack action', () => {
+    let simulatedActionId = '';
+    let slackSimulatorURL: string = '<could not determine kibana url>';
+
+    // need to wait for kibanaServer to settle ...
+    before(() => {
+      const kibanaServer = getService('kibanaServer');
+      const kibanaUrl = kibanaServer.status && kibanaServer.status.kibanaServerUrl;
+      slackSimulatorURL = `${kibanaUrl}${SLACK_ACTION_SIMULATOR_URI}`;
+    });
+
     after(() => esArchiver.unload('empty_kibana'));
 
     it('should return 200 when creating a slack action successfully', async () => {
@@ -76,8 +88,86 @@ export default function slackTest({ getService }: KibanaFunctionalTestDefaultPro
           });
         });
     });
-  });
 
-  // TODO: once we have the HTTP API fire action, test that with a webhook url pointing
-  // back to the Kibana server
+    it('should create our slack simulator action successfully', async () => {
+      const { body: createdSimulatedAction } = await supertest
+        .post('/api/action')
+        .set('kbn-xsrf', 'foo')
+        .send({
+          attributes: {
+            description: 'A slack simulator',
+            actionTypeId: '.slack',
+            actionTypeConfig: {
+              webhookUrl: slackSimulatorURL,
+            },
+          },
+        })
+        .expect(200);
+
+      simulatedActionId = createdSimulatedAction.id;
+    });
+
+    it('should handle firing with a simulated success', async () => {
+      const { body: result } = await supertest
+        .post(`/api/action/${simulatedActionId}/_fire`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            message: 'success',
+          },
+        })
+        .expect(200);
+      expect(result.status).to.eql('ok');
+    });
+
+    it('should handle a 40x slack error', async () => {
+      const { body: result } = await supertest
+        .post(`/api/action/${simulatedActionId}/_fire`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            message: 'invalid_payload',
+          },
+        })
+        .expect(200);
+      expect(result.status).to.equal('error');
+      expect(result.message).to.match(/an error occurred posting a slack message/);
+    });
+
+    it('should handle a 429 slack error', async () => {
+      const dateStart = new Date().getTime();
+      const { body: result } = await supertest
+        .post(`/api/action/${simulatedActionId}/_fire`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            message: 'rate_limit',
+          },
+        })
+        .expect(200);
+
+      expect(result.status).to.equal('error');
+      expect(result.message).to.match(/an error occurred posting a slack message/);
+      expect(result.message).to.match(/retry at/);
+
+      const dateRetry = new Date(result.retry).getTime();
+      expect(dateRetry).to.greaterThan(dateStart);
+    });
+
+    it('should handle a 500 slack error', async () => {
+      const { body: result } = await supertest
+        .post(`/api/action/${simulatedActionId}/_fire`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          params: {
+            message: 'status_500',
+          },
+        })
+        .expect(200);
+
+      expect(result.status).to.equal('error');
+      expect(result.message).to.match(/an error occurred posting a slack message/);
+      expect(result.retry).to.equal(true);
+    });
+  });
 }

--- a/x-pack/test/api_integration/config.js
+++ b/x-pack/test/api_integration/config.js
@@ -22,6 +22,8 @@ import {
   SpacesServiceProvider,
 } from '../common/services';
 
+import { SLACK_ACTION_SIMULATOR_URI } from './fixtures/plugins/actions';
+
 export async function getApiIntegrationConfig({ readConfigFile }) {
 
   const kibanaAPITestsConfig = await readConfigFile(require.resolve('../../../test/api_integration/config.js'));
@@ -60,6 +62,8 @@ export async function getApiIntegrationConfig({ readConfigFile }) {
         ...xPackFunctionalTestsConfig.get('kbnTestServer.serverArgs'),
         '--optimize.enabled=false',
         `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'alerts')}`,
+        `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'actions')}`,
+        `--server.xsrf.whitelist=${JSON.stringify([SLACK_ACTION_SIMULATOR_URI])}`,
       ],
     },
     esTestCluster: {

--- a/x-pack/test/api_integration/fixtures/plugins/actions/README.md
+++ b/x-pack/test/api_integration/fixtures/plugins/actions/README.md
@@ -1,0 +1,73 @@
+functional test server slack simulator
+================================================================================
+
+The code in this directory will run a Slack HTTP simulator; it will return
+different responses based on the content of the text message sent to the
+endpoint.
+
+This will be used during functional testing runner tests for actions; an
+action will be created pointing to the simulator, and then messages posted
+to test handling different error conditions.
+
+
+what a Slack server returns
+--------------------------------------------------------------------------------
+
+Here's some examples of `curl`'ing a Slack webhook to see the different
+responses it will return:
+
+```console
+$ curl -v $SLACK_WEBHOOK_URL -d '{"text":"Hello, World!"}'
+< HTTP/2 200
+< content-type: text/html
+ok
+
+$ curl -v $SLACK_WEBHOOK_URL -d '{"txt":"Hello, World!"}'
+< HTTP/2 400
+< content-type: text/html
+no_text
+
+$ curl -v $SLACK_WEBHOOK_URL -d '[]'
+< HTTP/2 400
+< content-type: text/html
+invalid_payload
+
+
+$ curl -v $SLACK_WEBHOOK_URL_LESS_ONE_CHAR -d '{"text":"Hello, World!"}'
+< HTTP/2 403
+< content-type: text/html
+invalid_token
+
+$ curl -v $SLACK_WEBHOOK_URL -d '{"text":"rate limited yet?"}'
+< HTTP/2 429
+< content-type: application/json; charset=utf-8
+< retry-after: 1
+{"retry_after":1,"ok":false,"error":"rate_limited"}
+```
+
+abuse a server
+--------------------------------------------------------------------------------
+
+To get a rate limiting response, run this in one terminal window, and while
+that is running, run a normal curl command to post a message.  You may need to
+try a few times.
+
+You should probably do this with a personal slack instance, not a company one :-)
+
+```console
+$ autocannon --amount 10000 --method POST --body '{"text":"Hello, World!"}' $SLACK_WEBHOOK_URL
+```
+
+simulator usage
+--------------------------------------------------------------------------------
+
+These may get out of date, consult the code for exact urls and inputs:
+
+```console
+$ export SLACK_URL=http://localhost:5620/api/_actions-FTS-external-service-simulators/slack
+
+$ curl -v $SLACK_URL -H 'content-type: application/json' -d '{"text":"slack-success"}'
+< HTTP/1.1 200 OK
+< content-type: text/html; charset=utf-8
+ok
+```

--- a/x-pack/test/api_integration/fixtures/plugins/actions/index.ts
+++ b/x-pack/test/api_integration/fixtures/plugins/actions/index.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import Joi from 'joi';
+import Hapi from 'hapi';
+
+const NAME = 'actions-FTS-external-service-simulators';
+
+export const SLACK_ACTION_SIMULATOR_URI = `/api/_${NAME}/slack`;
+
+interface SlackRequest extends Hapi.Request {
+  payload: {
+    text: string;
+  };
+}
+
+// eslint-disable-next-line import/no-default-export
+export default function(kibana: any) {
+  return new kibana.Plugin({
+    require: ['actions'],
+    name: NAME,
+    init: initPlugin,
+  });
+}
+
+function initPlugin(server: any) {
+  server.route({
+    method: 'POST',
+    path: `${SLACK_ACTION_SIMULATOR_URI}`,
+    options: {
+      auth: false,
+      validate: {
+        options: { abortEarly: false },
+        payload: Joi.object().keys({
+          text: Joi.string(),
+        }),
+      },
+    },
+    handler: slackHandler,
+  });
+}
+
+// Slack simulator: create a slack action pointing here, and you can get
+// different responses based on the message posted. See the README.md for
+// more info.
+
+function slackHandler(request: SlackRequest, h: any) {
+  const body = request.payload;
+  const text = body && body.text;
+
+  if (text == null) {
+    return htmlResponse(h, 400, 'bad request to slack simulator');
+  }
+
+  switch (text) {
+    case 'success':
+      return htmlResponse(h, 200, 'ok');
+
+    case 'no_text':
+      return htmlResponse(h, 400, 'no_text');
+
+    case 'invalid_payload':
+      return htmlResponse(h, 400, 'invalid_payload');
+
+    case 'invalid_token':
+      return htmlResponse(h, 403, 'invalid_token');
+
+    case 'status_500':
+      return htmlResponse(h, 500, 'simulated slack 500 response');
+
+    case 'rate_limit':
+      const response = {
+        retry_after: 1,
+        ok: false,
+        error: 'rate_limited',
+      };
+
+      return h
+        .response(response)
+        .type('application/json')
+        .header('retry-after', '1')
+        .code(429);
+  }
+
+  return htmlResponse(h, 400, 'unknown request to slack simulator');
+}
+
+function htmlResponse(h: any, code: number, text: string) {
+  return h
+    .response(text)
+    .type('text/html')
+    .code(code);
+}

--- a/x-pack/test/api_integration/fixtures/plugins/actions/package.json
+++ b/x-pack/test/api_integration/fixtures/plugins/actions/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "actions-fixtures",
+  "version": "0.0.0",
+  "kibana": {
+    "version": "kibana"
+  }
+}


### PR DESCRIPTION
Prior to this PR, the result of running an action returned an object shape determined by the action.  This PR changes that to return a structured action, which allows an action to return an ok/error status, and in the case of an error, whether or not to retry the action, and optionally a time to retry the action (eg, the case of a 429 HTTP response with a `Retry-After` header).  Also in the case of an error, a message can be returned.  And finally, there's a property for an action to return specialized data.

https://github.com/elastic/kibana/blob/0e7827bf616046c29ba99450e4670d836db16906/x-pack/legacy/plugins/actions/server/types.ts#L40-L45

In addition, a Slack simulator is available in the functional test server, which exercises some of these results, and is used as the target of slack actions tested in the functional test runner.