### PR TITLE
[APM] Breakdown: use transaction type from URL instead of hardcoded 'request'

### DIFF
--- a/x-pack/legacy/plugins/apm/public/hooks/useTransactionBreakdown.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useTransactionBreakdown.ts
@@ -11,7 +11,7 @@ import { loadTransactionBreakdown } from '../services/rest/apm/transaction_group
 
 export function useTransactionBreakdown() {
   const {
-    urlParams: { serviceName, start, end, transactionName },
+    urlParams: { serviceName, start, end, transactionName, transactionType },
     uiFilters
   } = useUrlParams();
 
@@ -20,12 +20,13 @@ export function useTransactionBreakdown() {
     error,
     status
   } = useFetcher(() => {
-    if (serviceName && start && end) {
+    if (serviceName && start && end && transactionType) {
       return loadTransactionBreakdown({
         start,
         end,
         serviceName,
         transactionName,
+        transactionType,
         uiFilters
       });
     }

--- a/x-pack/legacy/plugins/apm/public/services/rest/apm/transaction_groups.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/apm/transaction_groups.ts
@@ -101,12 +101,14 @@ export async function loadTransactionBreakdown({
   start,
   end,
   transactionName,
+  transactionType,
   uiFilters
 }: {
   serviceName: string;
   start: string;
   end: string;
   transactionName?: string;
+  transactionType: string;
   uiFilters: UIFilters;
 }) {
   return callApi<TransactionBreakdownAPIResponse>({
@@ -115,6 +117,7 @@ export async function loadTransactionBreakdown({
       start,
       end,
       transactionName,
+      transactionType,
       uiFiltersES: await getUiFiltersES(uiFilters)
     }
   });

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.test.ts
@@ -15,6 +15,7 @@ describe('getTransactionBreakdown', () => {
 
     const response = await getTransactionBreakdown({
       serviceName: 'myServiceName',
+      transactionType: 'request',
       setup: {
         start: 0,
         end: 500000,
@@ -37,6 +38,7 @@ describe('getTransactionBreakdown', () => {
 
     const response = await getTransactionBreakdown({
       serviceName: 'myServiceName',
+      transactionType: 'request',
       setup: {
         start: 0,
         end: 500000,
@@ -76,6 +78,7 @@ describe('getTransactionBreakdown', () => {
 
     const response = await getTransactionBreakdown({
       serviceName: 'myServiceName',
+      transactionType: 'request',
       setup: {
         start: 0,
         end: 500000,
@@ -114,6 +117,7 @@ describe('getTransactionBreakdown', () => {
 
     const response = await getTransactionBreakdown({
       serviceName: 'myServiceName',
+      transactionType: 'request',
       setup: {
         start: 0,
         end: 500000,

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -27,11 +27,13 @@ export type TransactionBreakdownAPIResponse = PromiseReturnType<
 export async function getTransactionBreakdown({
   setup,
   serviceName,
-  transactionName
+  transactionName,
+  transactionType
 }: {
   setup: Setup;
   serviceName: string;
   transactionName?: string;
+  transactionType: string;
 }) {
   const { uiFiltersES, client, config, start, end } = setup;
 
@@ -93,7 +95,7 @@ export async function getTransactionBreakdown({
             {
               term: {
                 [TRANSACTION_TYPE]: {
-                  value: 'request'
+                  value: transactionType
                 }
               }
             },

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -78,41 +78,36 @@ export async function getTransactionBreakdown({
     }
   };
 
+  const filters = [
+    {
+      term: {
+        [SERVICE_NAME]: {
+          value: serviceName
+        }
+      }
+    },
+    {
+      term: {
+        [TRANSACTION_TYPE]: {
+          value: transactionType
+        }
+      }
+    },
+    { range: rangeFilter(start, end) },
+    ...uiFiltersES
+  ];
+
+  if (transactionName) {
+    filters.push({ term: { [TRANSACTION_NAME]: { value: transactionName } } });
+  }
+
   const params = {
     index: config.get<string>('apm_oss.metricsIndices'),
     body: {
       size: 0,
       query: {
         bool: {
-          must: [
-            {
-              term: {
-                [SERVICE_NAME]: {
-                  value: serviceName
-                }
-              }
-            },
-            {
-              term: {
-                [TRANSACTION_TYPE]: {
-                  value: transactionType
-                }
-              }
-            },
-            { range: rangeFilter(start, end) },
-            ...uiFiltersES,
-            ...(transactionName
-              ? [
-                  {
-                    term: {
-                      [TRANSACTION_NAME]: {
-                        value: transactionName
-                      }
-                    }
-                  }
-                ]
-              : [])
-          ]
+          must: filters
         }
       },
       aggs: {

--- a/x-pack/legacy/plugins/apm/server/routes/transaction_groups.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/transaction_groups.ts
@@ -122,20 +122,23 @@ export function initTransactionGroupsApi(core: InternalCoreSetup) {
     options: {
       validate: {
         query: withDefaultValidators({
-          transactionName: Joi.string()
+          transactionName: Joi.string(),
+          transactionType: Joi.string().required()
         })
       }
     },
     handler: req => {
       const setup = setupRequest(req);
       const { serviceName } = req.params;
-      const { transactionName } = req.query as {
+      const { transactionName, transactionType } = req.query as {
         transactionName?: string;
+        transactionType: string;
       };
 
       return getTransactionBreakdown({
         serviceName,
         transactionName,
+        transactionType,
         setup
       }).catch(defaultErrorHandler);
     }


### PR DESCRIPTION
Removes the hardcoded reference to `request` as transaction type, in favor of using whatever transaction type is selected in the UI.