### PR TITLE
Add codeowners for task manager to stack services team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 /x-pack/legacy/plugins/telemetry @elastic/kibana-stack-services
 /x-pack/legacy/plugins/alerting @elastic/kibana-stack-services
 /x-pack/legacy/plugins/actions @elastic/kibana-stack-services
+/x-pack/legacy/plugins/task_manager @elastic/kibana-stack-services
 
 # Design
 **/*.scss  @elastic/kibana-design


### PR DESCRIPTION
This PR makes the stack services team the code owner of task manager.