### PR TITLE
[APM] Add support for very high durations (minutes and hours)

### DIFF
--- a/x-pack/legacy/plugins/apm/public/utils/__test__/formatters.test.ts
+++ b/x-pack/legacy/plugins/apm/public/utils/__test__/formatters.test.ts
@@ -22,7 +22,7 @@ describe('formatters', () => {
       expect(asTime(1000 * 1000)).toEqual('1,000 ms');
       expect(asTime(1000 * 1000 * 10)).toEqual('10,000 ms');
       expect(asTime(1000 * 1000 * 20)).toEqual('20.0 s');
-      expect(asTime(60000000 * 10)).toEqual('10.0 m');
+      expect(asTime(60000000 * 10)).toEqual('10.0 min');
       expect(asTime(3600000000 * 1.5)).toEqual('1.5 h');
     });
 

--- a/x-pack/legacy/plugins/apm/public/utils/__test__/formatters.test.ts
+++ b/x-pack/legacy/plugins/apm/public/utils/__test__/formatters.test.ts
@@ -22,6 +22,8 @@ describe('formatters', () => {
       expect(asTime(1000 * 1000)).toEqual('1,000 ms');
       expect(asTime(1000 * 1000 * 10)).toEqual('10,000 ms');
       expect(asTime(1000 * 1000 * 20)).toEqual('20.0 s');
+      expect(asTime(60000000 * 10)).toEqual('10.0 m');
+      expect(asTime(3600000000 * 1.5)).toEqual('1.5 h');
     });
 
     it('formats without unit', () => {

--- a/x-pack/legacy/plugins/apm/public/utils/formatters.ts
+++ b/x-pack/legacy/plugins/apm/public/utils/formatters.ts
@@ -9,6 +9,8 @@ import { i18n } from '@kbn/i18n';
 import { memoize } from 'lodash';
 import { NOT_AVAILABLE_LABEL } from '../../common/i18n';
 
+const HOURS_CUT_OFF = 3600000000; // 1 hour (in microseconds)
+const MINUTES_CUT_OFF = 60000000; // 1 minute (in microseconds)
 const SECONDS_CUT_OFF = 10 * 1000000; // 10 seconds (in microseconds)
 const MILLISECONDS_CUT_OFF = 10 * 1000; // 10 milliseconds (in microseconds)
 const SPACE = ' ';
@@ -22,6 +24,38 @@ type FormatterValue = number | undefined | null;
 interface FormatterOptions {
   withUnit?: boolean;
   defaultValue?: string;
+}
+
+export function asHours(
+  value: FormatterValue,
+  { withUnit = true, defaultValue = NOT_AVAILABLE_LABEL }: FormatterOptions = {}
+) {
+  if (value == null) {
+    return defaultValue;
+  }
+  const hoursLabel =
+    SPACE +
+    i18n.translate('xpack.apm.formatters.hoursTimeUnitLabel', {
+      defaultMessage: 'h'
+    });
+  const formatted = asDecimal(value / 3600000000);
+  return `${formatted}${withUnit ? hoursLabel : ''}`;
+}
+
+export function asMinutes(
+  value: FormatterValue,
+  { withUnit = true, defaultValue = NOT_AVAILABLE_LABEL }: FormatterOptions = {}
+) {
+  if (value == null) {
+    return defaultValue;
+  }
+  const minutesLabel =
+    SPACE +
+    i18n.translate('xpack.apm.formatters.minutesTimeUnitLabel', {
+      defaultMessage: 'm'
+    });
+  const formatted = asDecimal(value / 60000000);
+  return `${formatted}${withUnit ? minutesLabel : ''}`;
 }
 
 export function asSeconds(
@@ -81,6 +115,10 @@ type TimeFormatter = (
 export const getTimeFormatter: TimeFormatter = memoize((max: number) => {
   const unit = timeUnit(max);
   switch (unit) {
+    case 'h':
+      return asHours;
+    case 'm':
+      return asMinutes;
     case 's':
       return asSeconds;
     case 'ms':
@@ -91,7 +129,11 @@ export const getTimeFormatter: TimeFormatter = memoize((max: number) => {
 });
 
 export function timeUnit(max: number) {
-  if (max > SECONDS_CUT_OFF) {
+  if (max > HOURS_CUT_OFF) {
+    return 'h';
+  } else if (max > MINUTES_CUT_OFF) {
+    return 'm';
+  } else if (max > SECONDS_CUT_OFF) {
     return 's';
   } else if (max > MILLISECONDS_CUT_OFF) {
     return 'ms';

--- a/x-pack/legacy/plugins/apm/public/utils/formatters.ts
+++ b/x-pack/legacy/plugins/apm/public/utils/formatters.ts
@@ -52,7 +52,7 @@ export function asMinutes(
   const minutesLabel =
     SPACE +
     i18n.translate('xpack.apm.formatters.minutesTimeUnitLabel', {
-      defaultMessage: 'm'
+      defaultMessage: 'min'
     });
   const formatted = asDecimal(value / 60000000);
   return `${formatted}${withUnit ? minutesLabel : ''}`;

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -3757,6 +3757,8 @@
     "xpack.apm.formatters.millisTimeUnitLabel": "ミリ秒",
     "xpack.apm.formatters.requestsPerMinLabel": "1分あたりリクエスト数",
     "xpack.apm.formatters.secondsTimeUnitLabel": "秒",
+    "xpack.apm.formatters.minutesTimeUnitLabel": "分",
+    "xpack.apm.formatters.hoursTimeUnitLabel": "時",
     "xpack.apm.formatters.transactionsPerMinLabel": "1分あたりトランザクション数",
     "xpack.apm.header.badge.readOnly.text": "読み込み専用",
     "xpack.apm.header.badge.readOnly.tooltip": "を保存できませんでした",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3757,6 +3757,8 @@
     "xpack.apm.formatters.millisTimeUnitLabel": "ms",
     "xpack.apm.formatters.requestsPerMinLabel": "rpm",
     "xpack.apm.formatters.secondsTimeUnitLabel": "s",
+    "xpack.apm.formatters.minutesTimeUnitLabel": "m",
+    "xpack.apm.formatters.hoursTimeUnitLabel": "h",
     "xpack.apm.formatters.transactionsPerMinLabel": "tpm",
     "xpack.apm.header.badge.readOnly.text": "只读",
     "xpack.apm.header.badge.readOnly.tooltip": "无法保存",


### PR DESCRIPTION
## Summary
Fixes #41566
Adds time formatting support for high duration transactions. 
Formatting will be moved up to minutes if the transaction took longer than 1 minute and to hours if it took longer than 1 hour. 

i18n for JPN was done using google, I do not speak Japanese.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

