### PR TITLE
[Infra UI] Fix section mapping bug in node detail page

### DIFF
--- a/x-pack/legacy/plugins/infra/common/graphql/types.ts
+++ b/x-pack/legacy/plugins/infra/common/graphql/types.ts
@@ -560,6 +560,7 @@ export enum InfraMetric {
   nginxRequestRate = 'nginxRequestRate',
   nginxActiveConnections = 'nginxActiveConnections',
   nginxRequestsPerConnection = 'nginxRequestsPerConnection',
+  custom = 'custom',
 }
 
 // ====================================================

--- a/x-pack/legacy/plugins/infra/public/graphql/introspection.json
+++ b/x-pack/legacy/plugins/infra/public/graphql/introspection.json
@@ -2383,7 +2383,8 @@
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
-          }
+          },
+          { "name": "custom", "description": "", "isDeprecated": false, "deprecationReason": null }
         ],
         "possibleTypes": null
       },

--- a/x-pack/legacy/plugins/infra/public/graphql/types.ts
+++ b/x-pack/legacy/plugins/infra/public/graphql/types.ts
@@ -560,6 +560,7 @@ export enum InfraMetric {
   nginxRequestRate = 'nginxRequestRate',
   nginxActiveConnections = 'nginxActiveConnections',
   nginxRequestsPerConnection = 'nginxRequestsPerConnection',
+  custom = 'custom',
 }
 
 // ====================================================

--- a/x-pack/legacy/plugins/infra/server/graphql/metrics/schema.gql.ts
+++ b/x-pack/legacy/plugins/infra/server/graphql/metrics/schema.gql.ts
@@ -35,6 +35,7 @@ export const metricsSchema: any = gql`
     nginxRequestRate
     nginxActiveConnections
     nginxRequestsPerConnection
+    custom
   }
 
   type InfraMetricData {

--- a/x-pack/legacy/plugins/infra/server/graphql/types.ts
+++ b/x-pack/legacy/plugins/infra/server/graphql/types.ts
@@ -588,6 +588,7 @@ export enum InfraMetric {
   nginxRequestRate = 'nginxRequestRate',
   nginxActiveConnections = 'nginxActiveConnections',
   nginxRequestsPerConnection = 'nginxRequestsPerConnection',
+  custom = 'custom',
 }
 
 // ====================================================

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
@@ -29,6 +29,11 @@ export interface InfraMetricsAdapter {
   ): Promise<InfraMetricData[]>;
 }
 
+export enum InfraMetricsQueryType {
+  lucene = 'lucene',
+  kuery = 'kuery',
+}
+
 export enum InfraMetricModelMetricType {
   avg = 'avg',
   max = 'max',
@@ -61,7 +66,7 @@ export interface InfraMetricModelSeries {
   terms_field?: string;
   terms_size?: number;
   terms_order_by?: string;
-  filter?: { query: string; language: string };
+  filter?: { query: string; language: InfraMetricsQueryType };
 }
 
 export interface InfraMetricModelBasicMetric {

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
@@ -42,7 +42,6 @@ export enum InfraMetricModelMetricType {
   cardinality = 'cardinality',
   series_agg = 'series_agg', // eslint-disable-line @typescript-eslint/camelcase
   positive_only = 'positive_only', // eslint-disable-line @typescript-eslint/camelcase
-  cumulative_sum = 'cumulative_sum', // eslint-disable-line @typescript-eslint/camelcase
   derivative = 'derivative',
   count = 'count',
 }

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
@@ -37,6 +37,7 @@ export enum InfraMetricModelMetricType {
   cardinality = 'cardinality',
   series_agg = 'series_agg', // eslint-disable-line @typescript-eslint/camelcase
   positive_only = 'positive_only', // eslint-disable-line @typescript-eslint/camelcase
+  cumulative_sum = 'cumulative_sum', // eslint-disable-line @typescript-eslint/camelcase
   derivative = 'derivative',
   count = 'count',
 }
@@ -60,7 +61,7 @@ export interface InfraMetricModelSeries {
   terms_field?: string;
   terms_size?: number;
   terms_order_by?: string;
-  filter?: string;
+  filter?: { query: string; language: string };
 }
 
 export interface InfraMetricModelBasicMetric {

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/adapter_types.ts
@@ -29,7 +29,7 @@ export interface InfraMetricsAdapter {
   ): Promise<InfraMetricData[]>;
 }
 
-export enum InfraMetricsQueryType {
+export enum InfraMetricModelQueryType {
   lucene = 'lucene',
   kuery = 'kuery',
 }
@@ -47,7 +47,7 @@ export enum InfraMetricModelMetricType {
 }
 
 export interface InfraMetricModel {
-  id: string;
+  id: InfraMetric;
   requires: string[];
   index_pattern: string | string[];
   interval: string;
@@ -65,7 +65,7 @@ export interface InfraMetricModelSeries {
   terms_field?: string;
   terms_size?: number;
   terms_order_by?: string;
-  filter?: { query: string; language: InfraMetricsQueryType };
+  filter?: { query: string; language: InfraMetricModelQueryType };
 }
 
 export interface InfraMetricModelBasicMetric {

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/kibana_metrics_adapter.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/kibana_metrics_adapter.ts
@@ -56,7 +56,9 @@ export class KibanaMetricsAdapter implements InfraMetricsAdapter {
 
     const requests = options.metrics.map(metricId => {
       const model = metricModels[metricId](timeField, indexPattern, interval);
-      const filters = [{ match: { [nodeField]: options.nodeId } }];
+      const filters = model.map_field_to
+        ? [{ match: { [model.map_field_to]: options.nodeId } }]
+        : [{ match: { [nodeField]: options.nodeId } }];
       return this.framework.makeTSVBRequest(req, model, timerange, filters);
     });
     return Promise.all(requests)

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_cpu_kernel.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_cpu_kernel.ts
@@ -5,9 +5,10 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerCpuKernel: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
-  id: 'containerCpuKernel',
+  id: InfraMetric.containerCpuKernel,
   requires: ['docker.cpu'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_cpu_usage.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_cpu_usage.ts
@@ -5,9 +5,10 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerCpuUsage: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
-  id: 'containerCpuUsage',
+  id: InfraMetric.containerCpuUsage,
   requires: ['docker.cpu'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_disk_io_bytes.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_disk_io_bytes.ts
@@ -5,13 +5,14 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerDiskIOBytes: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ) => ({
-  id: 'containerDiskIOBytes',
+  id: InfraMetric.containerDiskIOBytes,
   requires: ['docker.disk'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_diskio_ops.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_diskio_ops.ts
@@ -5,9 +5,10 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerDiskIOOps: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
-  id: 'containerDiskIOOps',
+  id: InfraMetric.containerDiskIOOps,
   requires: ['docker.disk'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_memory.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_memory.ts
@@ -5,9 +5,10 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerMemory: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
-  id: 'containerMemory',
+  id: InfraMetric.containerMemory,
   requires: ['docker.memory'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_network_traffic.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_network_traffic.ts
@@ -5,13 +5,14 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerNetworkTraffic: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ) => ({
-  id: 'containerNetworkTraffic',
+  id: InfraMetric.containerNetworkTraffic,
   requires: ['docker.network'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_overview.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/container/container_overview.ts
@@ -5,9 +5,10 @@
  */
 
 import { InfraMetricModelCreator, InfraMetricModelMetricType } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const containerOverview: InfraMetricModelCreator = (timeField, indexPattern, interval) => ({
-  id: 'containerOverview',
+  id: InfraMetric.containerOverview,
   requires: ['docker'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_cpu_usage.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_cpu_usage.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostCpuUsage: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostCpuUsage',
+  id: InfraMetric.hostCpuUsage,
   requires: ['system.cpu'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_filesystem.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_filesystem.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostFilesystem: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostFilesystem',
+  id: InfraMetric.hostFilesystem,
   requires: ['system.filesystem'],
   filter: 'system.filesystem.device_name:\\/*',
   index_pattern: indexPattern,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_cpu_cap.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_cpu_cap.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostK8sCpuCap: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostK8sCpuCap',
+  id: InfraMetric.hostK8sCpuCap,
   map_field_to: 'kubernetes.node.name',
   requires: ['kubernetes.node'],
   index_pattern: indexPattern,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_disk_cap.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_disk_cap.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostK8sDiskCap: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostK8sDiskCap',
+  id: InfraMetric.hostK8sDiskCap,
   map_field_to: 'kubernetes.node.name',
   requires: ['kubernetes.node'],
   index_pattern: indexPattern,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_memory_cap.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_memory_cap.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostK8sMemoryCap: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostK8sMemoryCap',
+  id: InfraMetric.hostK8sMemoryCap,
   map_field_to: 'kubernetes.node.name',
   requires: ['kubernetes.node'],
   index_pattern: indexPattern,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_overview.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_overview.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostK8sOverview: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostK8sOverview',
+  id: InfraMetric.hostK8sOverview,
   requires: ['kubernetes'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_pod_cap.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_k8s_pod_cap.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostK8sPodCap: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostK8sPodCap',
+  id: InfraMetric.hostK8sPodCap,
   requires: ['kubernetes.node'],
   map_field_to: 'kubernetes.node.name',
   index_pattern: indexPattern,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_load.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_load.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostLoad: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostLoad',
+  id: InfraMetric.hostLoad,
   requires: ['system.cpu'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_memory_usage.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_memory_usage.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostMemoryUsage: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostMemoryUsage',
+  id: InfraMetric.hostMemoryUsage,
   requires: ['system.memory'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_network_traffic.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_network_traffic.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostNetworkTraffic: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostNetworkTraffic',
+  id: InfraMetric.hostNetworkTraffic,
   requires: ['system.network'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_system_overview.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/host/host_system_overview.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const hostSystemOverview: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'hostSystemOverview',
+  id: InfraMetric.hostSystemOverview,
   requires: ['system.cpu', 'system.memory', 'system.load', 'system.network'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_active_connections.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_active_connections.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const nginxActiveConnections: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'nginxActiveConnections',
+  id: InfraMetric.nginxActiveConnections,
   requires: ['nginx.stubstatus'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_hits.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_hits.ts
@@ -8,14 +8,17 @@ import {
   InfraMetricModelCreator,
   InfraMetricModelMetricType,
   InfraMetricModel,
+  InfraMetricModelQueryType,
 } from '../../adapter_types';
+
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const nginxHits: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'nginxHits',
+  id: InfraMetric.nginxHits,
   requires: ['nginx.access'],
   index_pattern: indexPattern,
   interval,
@@ -31,7 +34,10 @@ export const nginxHits: InfraMetricModelCreator = (
         },
       ],
       split_mode: 'filter',
-      filter: 'http.response.status_code:[200 TO 299]',
+      filter: {
+        query: 'http.response.status_code:[200 TO 299]',
+        language: InfraMetricModelQueryType.lucene,
+      },
     },
     {
       id: '300s',
@@ -42,7 +48,10 @@ export const nginxHits: InfraMetricModelCreator = (
         },
       ],
       split_mode: 'filter',
-      filter: 'http.response.status_code:[300 TO 399]',
+      filter: {
+        query: 'http.response.status_code:[300 TO 399]',
+        language: InfraMetricModelQueryType.lucene,
+      },
     },
     {
       id: '400s',
@@ -53,7 +62,10 @@ export const nginxHits: InfraMetricModelCreator = (
         },
       ],
       split_mode: 'filter',
-      filter: 'http.response.status_code:[400 TO 499]',
+      filter: {
+        query: 'http.response.status_code:[400 TO 499]',
+        language: InfraMetricModelQueryType.lucene,
+      },
     },
     {
       id: '500s',
@@ -64,7 +76,10 @@ export const nginxHits: InfraMetricModelCreator = (
         },
       ],
       split_mode: 'filter',
-      filter: 'http.response.status_code:[500 TO 599]',
+      filter: {
+        query: 'http.response.status_code:[500 TO 599]',
+        language: InfraMetricModelQueryType.lucene,
+      },
     },
   ],
 });

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_request_rate.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_request_rate.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const nginxRequestRate: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'nginxRequestRate',
+  id: InfraMetric.nginxRequestRate,
   requires: ['nginx.stubstatus'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_requests_per_connection.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/nginx/nginx_requests_per_connection.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const nginxRequestsPerConnection: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'nginxRequestsPerConnection',
+  id: InfraMetric.nginxRequestsPerConnection,
   requires: ['nginx.stubstatus'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_cpu_usage.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_cpu_usage.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const podCpuUsage: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'podCpuUsage',
+  id: InfraMetric.podCpuUsage,
   requires: ['kubernetes.pod'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_log_usage.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_log_usage.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const podLogUsage: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'podLogUsage',
+  id: InfraMetric.podLogUsage,
   requires: ['kubernetes.pod'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_memory_usage.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_memory_usage.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const podMemoryUsage: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'podMemoryUsage',
+  id: InfraMetric.podMemoryUsage,
   requires: ['kubernetes.pod'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_network_traffic.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_network_traffic.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const podNetworkTraffic: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'podNetworkTraffic',
+  id: InfraMetric.podNetworkTraffic,
   requires: ['kubernetes.pod'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_overview.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/metrics/models/pod/pod_overview.ts
@@ -9,13 +9,14 @@ import {
   InfraMetricModelMetricType,
   InfraMetricModel,
 } from '../../adapter_types';
+import { InfraMetric } from '../../../../../graphql/types';
 
 export const podOverview: InfraMetricModelCreator = (
   timeField,
   indexPattern,
   interval
 ): InfraMetricModel => ({
-  id: 'podOverview',
+  id: InfraMetric.podOverview,
   requires: ['kubernetes.pod'],
   index_pattern: indexPattern,
   interval,

--- a/x-pack/legacy/plugins/infra/server/routes/metrics_explorer/lib/create_metrics_model.ts
+++ b/x-pack/legacy/plugins/infra/server/routes/metrics_explorer/lib/create_metrics_model.ts
@@ -6,9 +6,10 @@
 
 import { InfraMetricModel, InfraMetricModelMetricType } from '../../../lib/adapters/metrics';
 import { MetricsExplorerAggregation, MetricsExplorerRequest } from '../types';
+import { InfraMetric } from '../../../graphql/types';
 export const createMetricModel = (options: MetricsExplorerRequest): InfraMetricModel => {
   return {
-    id: 'custom',
+    id: InfraMetric.custom,
     requires: [],
     index_pattern: options.indexPattern,
     interval: options.timerange.interval,


### PR DESCRIPTION
## Summary

This PR fixes a bug #29497 with the node detail page (metrics view). For sections with a foreign key (docker, nginx, kubernetes), the `model.map_field_to` setting was not being set correctly. For `host` pages instead of using `kubernetes.node.name` for the TSVB model filter it was using `host.name` which returned the wrong data.

This PR also fixes a bug with the series filter for the TSVB model. Previously, TSVB filters could just be string but now they are required to be objects that indicate the language (`kuery` or `lucene`). For example, `{ query: 'some.field: example', language: 'lucene' }`

I also changed the `InfraMetricModel` type to require the `id` for the model be an `InfraMetric` enum value. This helps avoid mistakes when creating new models because it forces you to add the new ID's to the `InfraMetricModel` via the GraphQL schema file (and generation script).

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~