### PR TITLE
Ftr/tsfy doc table

### DIFF
--- a/test/functional/apps/context/_date_nanos.js
+++ b/test/functional/apps/context/_date_nanos.js
@@ -47,12 +47,11 @@ export default function ({ getService, getPageObjects }) {
     it('displays predessors - anchor - successors in right order ', async function () {
       await PageObjects.context.navigateTo(TEST_INDEX_PATTERN, TEST_ANCHOR_TYPE, 'AU_x3-TaGFA8no6Qj999Z');
       const table = await docTable.getTable();
-      const rows = await docTable.getBodyRows(table);
-      const actualRowsText = await Promise.all(rows.map(row => row.getVisibleText()));
+      const actualRowsText = await docTable.getRowsText(table);
       const expectedRowsText = [
-        'Sep 18, 2019 @ 06:50:13.000000000\n-2',
-        'Sep 18, 2019 @ 06:50:12.999999999\n-3',
-        'Sep 19, 2015 @ 06:50:13.000100001\n1'
+        'Sep 18, 2019 @ 06:50:13.000000000-2',
+        'Sep 18, 2019 @ 06:50:12.999999999-3',
+        'Sep 19, 2015 @ 06:50:13.0001000011'
       ];
       expect(actualRowsText).to.eql(expectedRowsText);
     });
@@ -62,18 +61,17 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.context.clickPredecessorLoadMoreButton();
       await PageObjects.context.clickSuccessorLoadMoreButton();
       const table = await docTable.getTable();
-      const rows = await docTable.getBodyRows(table);
-      const actualRowsText = await Promise.all(rows.map(row => row.getVisibleText()));
+      const actualRowsText = await docTable.getRowsText(table);
       const expectedRowsText = [
-        'Sep 22, 2019 @ 23:50:13.253123345\n5',
-        'Sep 18, 2019 @ 06:50:13.000000104\n4',
-        'Sep 18, 2019 @ 06:50:13.000000103\n2',
-        'Sep 18, 2019 @ 06:50:13.000000102\n1',
-        'Sep 18, 2019 @ 06:50:13.000000101\n0',
-        'Sep 18, 2019 @ 06:50:13.000000001\n-1',
-        'Sep 18, 2019 @ 06:50:13.000000000\n-2',
-        'Sep 18, 2019 @ 06:50:12.999999999\n-3',
-        'Sep 19, 2015 @ 06:50:13.000100001\n1'
+        'Sep 22, 2019 @ 23:50:13.2531233455',
+        'Sep 18, 2019 @ 06:50:13.0000001044',
+        'Sep 18, 2019 @ 06:50:13.0000001032',
+        'Sep 18, 2019 @ 06:50:13.0000001021',
+        'Sep 18, 2019 @ 06:50:13.0000001010',
+        'Sep 18, 2019 @ 06:50:13.000000001-1',
+        'Sep 18, 2019 @ 06:50:13.000000000-2',
+        'Sep 18, 2019 @ 06:50:12.999999999-3',
+        'Sep 19, 2015 @ 06:50:13.0001000011'
       ];
       expect(actualRowsText).to.eql(expectedRowsText);
 

--- a/test/functional/apps/context/_date_nanos.js
+++ b/test/functional/apps/context/_date_nanos.js
@@ -46,8 +46,7 @@ export default function ({ getService, getPageObjects }) {
 
     it('displays predessors - anchor - successors in right order ', async function () {
       await PageObjects.context.navigateTo(TEST_INDEX_PATTERN, TEST_ANCHOR_TYPE, 'AU_x3-TaGFA8no6Qj999Z');
-      const table = await docTable.getTable();
-      const actualRowsText = await docTable.getRowsText(table);
+      const actualRowsText = await docTable.getRowsText();
       const expectedRowsText = [
         'Sep 18, 2019 @ 06:50:13.000000000-2',
         'Sep 18, 2019 @ 06:50:12.999999999-3',
@@ -60,8 +59,7 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.context.navigateTo(TEST_INDEX_PATTERN, TEST_ANCHOR_TYPE, 'AU_x3-TaGFA8no6Qjisd');
       await PageObjects.context.clickPredecessorLoadMoreButton();
       await PageObjects.context.clickSuccessorLoadMoreButton();
-      const table = await docTable.getTable();
-      const actualRowsText = await docTable.getRowsText(table);
+      const actualRowsText = await docTable.getRowsText();
       const expectedRowsText = [
         'Sep 22, 2019 @ 23:50:13.2531233455',
         'Sep 18, 2019 @ 06:50:13.0000001044',

--- a/test/functional/apps/context/_discover_navigation.js
+++ b/test/functional/apps/context/_discover_navigation.js
@@ -45,8 +45,7 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should open the context view with the selected document as anchor', async function () {
-      const discoverDocTable = await docTable.getTable();
-      const firstRow = (await docTable.getBodyRows(discoverDocTable))[0];
+      const firstRow = (await docTable.getBodyRows())[0];
 
       // get the timestamp of the first row
       const firstTimestamp = await (await docTable.getFields(firstRow))[0]
@@ -54,13 +53,12 @@ export default function ({ getService, getPageObjects }) {
 
       // navigate to the context view
       await (await docTable.getRowExpandToggle(firstRow)).click();
-      const firstDetailsRow = (await docTable.getDetailsRows(discoverDocTable))[0];
+      const firstDetailsRow = (await docTable.getDetailsRows())[0];
       await (await docTable.getRowActions(firstDetailsRow))[0].click();
 
       // check the anchor timestamp in the context view
       await retry.try(async () => {
-        const contextDocTable = await docTable.getTable();
-        const anchorRow = await docTable.getAnchorRow(contextDocTable);
+        const anchorRow = await docTable.getAnchorRow();
         const anchorTimestamp = await (await docTable.getFields(anchorRow))[0]
           .getVisibleText();
         expect(anchorTimestamp).to.equal(firstTimestamp);
@@ -68,9 +66,8 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should open the context view with the same columns', async function () {
-      const table = await docTable.getTable();
       await retry.try(async () => {
-        const headerFields = await docTable.getHeaderFields(table);
+        const headerFields = await docTable.getHeaderFields();
         const columnNames = await Promise.all(headerFields.map((headerField) => (
           headerField.getVisibleText()
         )));

--- a/test/functional/apps/context/_discover_navigation.js
+++ b/test/functional/apps/context/_discover_navigation.js
@@ -45,22 +45,16 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should open the context view with the selected document as anchor', async function () {
-      const firstRow = (await docTable.getBodyRows())[0];
-
       // get the timestamp of the first row
-      const firstTimestamp = await (await docTable.getFields(firstRow))[0]
-        .getVisibleText();
+      const firstTimestamp = (await docTable.getFields())[0][0];
 
       // navigate to the context view
-      await (await docTable.getRowExpandToggle(firstRow)).click();
-      const firstDetailsRow = (await docTable.getDetailsRows())[0];
-      await (await docTable.getRowActions(firstDetailsRow))[0].click();
+      await docTable.clickRowToggle({ rowIndex: 0 });
+      await (await docTable.getRowActions({ rowIndex: 0 }))[0].click();
 
       // check the anchor timestamp in the context view
       await retry.try(async () => {
-        const anchorRow = await docTable.getAnchorRow();
-        const anchorTimestamp = await (await docTable.getFields(anchorRow))[0]
-          .getVisibleText();
+        const anchorTimestamp = (await docTable.getFields({ isAnchorRow: true }))[0][0];
         expect(anchorTimestamp).to.equal(firstTimestamp);
       });
     });

--- a/test/functional/apps/context/_discover_navigation.js
+++ b/test/functional/apps/context/_discover_navigation.js
@@ -60,16 +60,11 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should open the context view with the same columns', async function () {
-      await retry.try(async () => {
-        const headerFields = await docTable.getHeaderFields();
-        const columnNames = await Promise.all(headerFields.map((headerField) => (
-          headerField.getVisibleText()
-        )));
-        expect(columnNames).to.eql([
-          'Time',
-          ...TEST_COLUMN_NAMES,
-        ]);
-      });
+      const columnNames = await docTable.getHeaderFields();
+      expect(columnNames).to.eql([
+        'Time',
+        ...TEST_COLUMN_NAMES,
+      ]);
     });
 
     it('should open the context view with the filters disabled', async function () {

--- a/test/functional/apps/context/_filters.js
+++ b/test/functional/apps/context/_filters.js
@@ -40,12 +40,11 @@ export default function ({ getService, getPageObjects }) {
 
     // FLAKY: https://github.com/elastic/kibana/issues/39927
     it.skip('should be addable via expanded doc table rows', async function () {
-      const table = await docTable.getTable();
-      const anchorRow = await docTable.getAnchorRow(table);
+      const anchorRow = await docTable.getAnchorRow();
 
       await docTable.toggleRowExpanded(anchorRow);
 
-      const anchorDetailsRow = await docTable.getAnchorDetailsRow(table);
+      const anchorDetailsRow = await docTable.getAnchorDetailsRow();
       await docTable.addInclusiveFilter(anchorDetailsRow, TEST_ANCHOR_FILTER_FIELD);
       await PageObjects.context.waitUntilContextLoadingHasFinished();
 
@@ -53,7 +52,7 @@ export default function ({ getService, getPageObjects }) {
 
       expect(await filterBar.hasFilter(TEST_ANCHOR_FILTER_FIELD, TEST_ANCHOR_FILTER_VALUE, true)).to.be(true);
 
-      const rows = await docTable.getBodyRows(table);
+      const rows = await docTable.getBodyRows();
       const hasOnlyFilteredRows = (
         await Promise.all(rows.map(
           async (row) => await (await docTable.getFields(row))[2].getVisibleText()
@@ -63,7 +62,6 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should be toggleable via the filter bar', async function () {
-      const table = await docTable.getTable();
       await filterBar.addFilter(TEST_ANCHOR_FILTER_FIELD, 'IS', TEST_ANCHOR_FILTER_VALUE);
       await PageObjects.context.waitUntilContextLoadingHasFinished();
       // disable filter
@@ -72,7 +70,7 @@ export default function ({ getService, getPageObjects }) {
 
       expect(await filterBar.hasFilter(TEST_ANCHOR_FILTER_FIELD, TEST_ANCHOR_FILTER_VALUE, false)).to.be(true);
 
-      const rows = await docTable.getBodyRows(table);
+      const rows = await docTable.getBodyRows();
       const hasOnlyFilteredRows = (
         await Promise.all(rows.map(
           async (row) => await (await docTable.getFields(row))[2].getVisibleText()

--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -42,9 +42,8 @@ export default function ({ getService, getPageObjects }) {
     it('should default to the `context:defaultSize` setting', async function () {
       await PageObjects.context.navigateTo(TEST_INDEX_PATTERN, TEST_ANCHOR_TYPE, TEST_ANCHOR_ID);
 
-      const table = await docTable.getTable();
       await retry.try(async function () {
-        expect(await docTable.getRowsText(table)).to.have.length(2 * TEST_DEFAULT_CONTEXT_SIZE + 1);
+        expect(await docTable.getRowsText()).to.have.length(2 * TEST_DEFAULT_CONTEXT_SIZE + 1);
       });
       await retry.try(async function () {
         const predecessorCountPicker = await PageObjects.context.getPredecessorCountPicker();
@@ -58,12 +57,10 @@ export default function ({ getService, getPageObjects }) {
 
     it('should increase according to the `context:step` setting when clicking the `load newer` button', async function () {
       await PageObjects.context.navigateTo(TEST_INDEX_PATTERN, TEST_ANCHOR_TYPE, TEST_ANCHOR_ID);
-
-      const table = await docTable.getTable();
       await PageObjects.context.clickPredecessorLoadMoreButton();
 
       await retry.try(async function () {
-        expect(await docTable.getRowsText(table)).to.have.length(
+        expect(await docTable.getRowsText()).to.have.length(
           2 * TEST_DEFAULT_CONTEXT_SIZE + TEST_STEP_SIZE + 1
         );
       });
@@ -71,12 +68,10 @@ export default function ({ getService, getPageObjects }) {
 
     it('should increase according to the `context:step` setting when clicking the `load older` button', async function () {
       await PageObjects.context.navigateTo(TEST_INDEX_PATTERN, TEST_ANCHOR_TYPE, TEST_ANCHOR_ID);
-
-      const table = await docTable.getTable();
       await PageObjects.context.clickSuccessorLoadMoreButton();
 
       await retry.try(async function () {
-        expect(await docTable.getRowsText(table)).to.have.length(
+        expect(await docTable.getRowsText()).to.have.length(
           2 * TEST_DEFAULT_CONTEXT_SIZE + TEST_STEP_SIZE + 1
         );
       });

--- a/test/functional/apps/context/_size.js
+++ b/test/functional/apps/context/_size.js
@@ -44,7 +44,7 @@ export default function ({ getService, getPageObjects }) {
 
       const table = await docTable.getTable();
       await retry.try(async function () {
-        expect(await docTable.getBodyRows(table)).to.have.length(2 * TEST_DEFAULT_CONTEXT_SIZE + 1);
+        expect(await docTable.getRowsText(table)).to.have.length(2 * TEST_DEFAULT_CONTEXT_SIZE + 1);
       });
       await retry.try(async function () {
         const predecessorCountPicker = await PageObjects.context.getPredecessorCountPicker();
@@ -63,7 +63,7 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.context.clickPredecessorLoadMoreButton();
 
       await retry.try(async function () {
-        expect(await docTable.getBodyRows(table)).to.have.length(
+        expect(await docTable.getRowsText(table)).to.have.length(
           2 * TEST_DEFAULT_CONTEXT_SIZE + TEST_STEP_SIZE + 1
         );
       });
@@ -76,7 +76,7 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.context.clickSuccessorLoadMoreButton();
 
       await retry.try(async function () {
-        expect(await docTable.getBodyRows(table)).to.have.length(
+        expect(await docTable.getRowsText(table)).to.have.length(
           2 * TEST_DEFAULT_CONTEXT_SIZE + TEST_STEP_SIZE + 1
         );
       });

--- a/test/functional/apps/discover/_doc_navigation.js
+++ b/test/functional/apps/discover/_doc_navigation.js
@@ -46,12 +46,9 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should open the doc view of the selected document', async function () {
-      const firstRow = (await docTable.getBodyRows())[0];
-
       // navigate to the doc view
-      await (await docTable.getRowExpandToggle(firstRow)).click();
-      const firstDetailsRow = (await docTable.getDetailsRows())[0];
-      await (await docTable.getRowActions(firstDetailsRow))[1].click();
+      await docTable.clickRowToggle({ rowIndex: 0 });
+      await (await docTable.getRowActions({ rowIndex: 0 }))[1].click();
 
       const hasDocHit = await testSubjects.exists('doc-hit');
       expect(hasDocHit).to.be(true);

--- a/test/functional/apps/discover/_doc_navigation.js
+++ b/test/functional/apps/discover/_doc_navigation.js
@@ -46,12 +46,11 @@ export default function ({ getService, getPageObjects }) {
     });
 
     it('should open the doc view of the selected document', async function () {
-      const discoverDocTable = await docTable.getTable();
-      const firstRow = (await docTable.getBodyRows(discoverDocTable))[0];
+      const firstRow = (await docTable.getBodyRows())[0];
 
       // navigate to the doc view
       await (await docTable.getRowExpandToggle(firstRow)).click();
-      const firstDetailsRow = (await docTable.getDetailsRows(discoverDocTable))[0];
+      const firstDetailsRow = (await docTable.getDetailsRows())[0];
       await (await docTable.getRowActions(firstDetailsRow))[1].click();
 
       const hasDocHit = await testSubjects.exists('doc-hit');

--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -95,7 +95,7 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
 
     public async getFields(
       options: { isAnchorRow: boolean } = { isAnchorRow: false }
-    ): Promise<WebElementWrapper[]> {
+    ): Promise<string[][]> {
       const table = await this.getTable();
       const $ = await table.parseDomContent();
       const rowLocator = options.isAnchorRow
@@ -111,9 +111,16 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
       return fields;
     }
 
-    public async getHeaderFields(): Promise<WebElementWrapper[]> {
+    public async getHeaderFields(): Promise<string[]> {
       const table = await this.getTable();
-      return await table.findAllByCssSelector('[data-test-subj~="docTableHeaderField"]');
+      const $ = await table.parseDomContent();
+      return $('[data-test-subj~="docTableHeaderField"]')
+        .toArray()
+        .map((field: any) =>
+          $(field)
+            .text()
+            .trim()
+        );
     }
 
     public async getTableDocViewRow(

--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -16,71 +16,99 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { FtrProviderContext } from '../ftr_provider_context';
+import { WebElementWrapper } from './lib/web_element_wrapper';
 
-export function DocTableProvider({ getService, getPageObjects }) {
+export function DocTableProvider({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
   const PageObjects = getPageObjects(['common', 'header']);
 
-
   class DocTable {
-    async getTable() {
+    public async getTable() {
       return await testSubjects.find('docTable');
     }
 
-    async getBodyRows(table) {
+    public async getRowsText(table: WebElementWrapper): Promise<string[]> {
+      const $ = await table.parseDomContent();
+      return $('[data-test-subj~="docTableRow"]')
+        .toArray()
+        .map((row: any) =>
+          $(row)
+            .text()
+            .trim()
+        );
+    }
+
+    public async getBodyRows(table: WebElementWrapper): Promise<WebElementWrapper[]> {
       return await table.findAllByCssSelector('[data-test-subj~="docTableRow"]');
     }
 
-    async getAnchorRow(table) {
+    public async getAnchorRow(table: WebElementWrapper): Promise<WebElementWrapper> {
       return await table.findByCssSelector('[data-test-subj~="docTableAnchorRow"]');
     }
 
-    async getAnchorDetailsRow(table) {
-      return await table.findByCssSelector('[data-test-subj~="docTableAnchorRow"] + [data-test-subj~="docTableDetailsRow"]');
+    public async getAnchorDetailsRow(table: WebElementWrapper): Promise<WebElementWrapper> {
+      return await table.findByCssSelector(
+        '[data-test-subj~="docTableAnchorRow"] + [data-test-subj~="docTableDetailsRow"]'
+      );
     }
 
-    async getRowExpandToggle(row) {
+    public async getRowExpandToggle(row: WebElementWrapper): Promise<WebElementWrapper> {
       return await row.findByCssSelector('[data-test-subj~="docTableExpandToggleColumn"]');
     }
 
-    async getDetailsRows(table) {
-      return await table.findAllByCssSelector('[data-test-subj~="docTableRow"] + [data-test-subj~="docTableDetailsRow"]');
+    public async getDetailsRows(table: WebElementWrapper): Promise<WebElementWrapper[]> {
+      return await table.findAllByCssSelector(
+        '[data-test-subj~="docTableRow"] + [data-test-subj~="docTableDetailsRow"]'
+      );
     }
 
-    async getRowActions(row) {
+    public async getRowActions(row: WebElementWrapper): Promise<WebElementWrapper[]> {
       return await row.findAllByCssSelector('[data-test-subj~="docTableRowAction"]');
     }
 
-    async getFields(row) {
+    public async getFields(row: WebElementWrapper): Promise<WebElementWrapper[]> {
       return await row.findAllByCssSelector('[data-test-subj~="docTableField"]');
     }
 
-    async getHeaderFields(table) {
+    public async getHeaderFields(table: WebElementWrapper): Promise<WebElementWrapper[]> {
       return await table.findAllByCssSelector('[data-test-subj~="docTableHeaderField"]');
     }
 
-    async getTableDocViewRow(detailsRow, fieldName) {
+    public async getTableDocViewRow(
+      detailsRow: WebElementWrapper,
+      fieldName: WebElementWrapper
+    ): Promise<WebElementWrapper> {
       return await detailsRow.findByCssSelector(`[data-test-subj~="tableDocViewRow-${fieldName}"]`);
     }
 
-    async getAddInclusiveFilterButton(tableDocViewRow) {
-      return await tableDocViewRow.findByCssSelector(`[data-test-subj~="addInclusiveFilterButton"]`);
+    public async getAddInclusiveFilterButton(
+      tableDocViewRow: WebElementWrapper
+    ): Promise<WebElementWrapper> {
+      return await tableDocViewRow.findByCssSelector(
+        `[data-test-subj~="addInclusiveFilterButton"]`
+      );
     }
 
-    async addInclusiveFilter(detailsRow, fieldName) {
+    async addInclusiveFilter(
+      detailsRow: WebElementWrapper,
+      fieldName: WebElementWrapper
+    ): Promise<void> {
       const tableDocViewRow = await this.getTableDocViewRow(detailsRow, fieldName);
       const addInclusiveFilterButton = await this.getAddInclusiveFilterButton(tableDocViewRow);
       await addInclusiveFilterButton.click();
       await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
     }
 
-    async toggleRowExpanded(row) {
+    public async toggleRowExpanded(row: WebElementWrapper): Promise<WebElementWrapper> {
       const rowExpandToggle = await this.getRowExpandToggle(row);
       await rowExpandToggle.click();
       await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
 
-      const detailsRow = await row.findByXpath('./following-sibling::*[@data-test-subj="docTableDetailsRow"]');
+      const detailsRow = await row.findByXpath(
+        './following-sibling::*[@data-test-subj="docTableDetailsRow"]'
+      );
       return await retry.try(async () => {
         return detailsRow.findByCssSelector('[data-test-subj~="docViewer"]');
       });

--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -29,7 +29,8 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
       return await testSubjects.find('docTable');
     }
 
-    public async getRowsText(table: WebElementWrapper): Promise<string[]> {
+    public async getRowsText(): Promise<string[]> {
+      const table = await this.getTable();
       const $ = await table.parseDomContent();
       return $('[data-test-subj~="docTableRow"]')
         .toArray()
@@ -40,15 +41,18 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
         );
     }
 
-    public async getBodyRows(table: WebElementWrapper): Promise<WebElementWrapper[]> {
+    public async getBodyRows(): Promise<WebElementWrapper[]> {
+      const table = await this.getTable();
       return await table.findAllByCssSelector('[data-test-subj~="docTableRow"]');
     }
 
-    public async getAnchorRow(table: WebElementWrapper): Promise<WebElementWrapper> {
+    public async getAnchorRow(): Promise<WebElementWrapper> {
+      const table = await this.getTable();
       return await table.findByCssSelector('[data-test-subj~="docTableAnchorRow"]');
     }
 
-    public async getAnchorDetailsRow(table: WebElementWrapper): Promise<WebElementWrapper> {
+    public async getAnchorDetailsRow(): Promise<WebElementWrapper> {
+      const table = await this.getTable();
       return await table.findByCssSelector(
         '[data-test-subj~="docTableAnchorRow"] + [data-test-subj~="docTableDetailsRow"]'
       );
@@ -58,7 +62,8 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
       return await row.findByCssSelector('[data-test-subj~="docTableExpandToggleColumn"]');
     }
 
-    public async getDetailsRows(table: WebElementWrapper): Promise<WebElementWrapper[]> {
+    public async getDetailsRows(): Promise<WebElementWrapper[]> {
+      const table = await this.getTable();
       return await table.findAllByCssSelector(
         '[data-test-subj~="docTableRow"] + [data-test-subj~="docTableDetailsRow"]'
       );
@@ -72,7 +77,8 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
       return await row.findAllByCssSelector('[data-test-subj~="docTableField"]');
     }
 
-    public async getHeaderFields(table: WebElementWrapper): Promise<WebElementWrapper[]> {
+    public async getHeaderFields(): Promise<WebElementWrapper[]> {
+      const table = await this.getTable();
       return await table.findAllByCssSelector('[data-test-subj~="docTableHeaderField"]');
     }
 

--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -131,7 +131,7 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
       );
     }
 
-    async addInclusiveFilter(
+    public async addInclusiveFilter(
       detailsRow: WebElementWrapper,
       fieldName: WebElementWrapper
     ): Promise<void> {


### PR DESCRIPTION
## Summary

TSfy doc_table service with changes that improve functional tests stability.

One of the main problems that caused tests to fail is passing the table/row element as an argument throughout the test: loading force DOM to change and element reference becomes stale.
 
fixes https://github.com/elastic/kibana/issues/39960

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

