### PR TITLE
[APM] Support legacy encoding for `kuery` URL param

### DIFF
--- a/x-pack/legacy/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts
+++ b/x-pack/legacy/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts
@@ -73,7 +73,7 @@ export function resolveUrlParams(location: Location, state: TimeUrlParams) {
     detailTab: toString(detailTab),
     flyoutDetailTab: toString(flyoutDetailTab),
     spanId: toNumber(spanId),
-    kuery: kuery && decodeURIComponent(kuery),
+    kuery: kuery && legacyDecodeURIComponent(kuery),
     // path params
     processorEvent,
     serviceName,


### PR DESCRIPTION
leverages `legacyDecodeURIComponent` to support encoding such as `/app/apm#/traces?_g=()&kuery=container.id~20~3A~20~228e3625c7c26c168013a110789382bcd602b63359788cc6e50447d2562aca0dbd~22` for the kuery filter.