### PR TITLE
[APM] Remove dependency on ui/chrome in favor of newer core APIs

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/GlobalHelpExtension/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/GlobalHelpExtension/index.tsx
@@ -8,15 +8,17 @@ import { EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import chrome from 'ui/chrome';
 import url from 'url';
 import { px, units } from '../../../style/variables';
+import { useCore } from '../../../hooks/useCore';
 
 const Container = styled.div`
   margin: ${px(units.minus)} 0;
 `;
 
 export const GlobalHelpExtension: React.SFC = () => {
+  const core = useCore();
+
   return (
     <Fragment>
       <Container>
@@ -33,7 +35,7 @@ export const GlobalHelpExtension: React.SFC = () => {
       <Container>
         <EuiLink
           href={url.format({
-            pathname: chrome.addBasePath('/app/kibana'),
+            pathname: core.http.basePath.prepend('/app/kibana'),
             hash: '/management/elasticsearch/upgrade_assistant'
           })}
         >

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/UpdateBreadcrumbs.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/UpdateBreadcrumbs.tsx
@@ -7,7 +7,8 @@
 import { Location } from 'history';
 import { last } from 'lodash';
 import React from 'react';
-import chrome from 'ui/chrome';
+import { InternalCoreStart } from 'src/core/public';
+import { useCore } from '../../../hooks/useCore';
 import { getAPMHref } from '../../shared/Links/APMLink';
 import { Breadcrumb, ProvideBreadcrumbs } from './ProvideBreadcrumbs';
 import { routes } from './route_config';
@@ -15,6 +16,7 @@ import { routes } from './route_config';
 interface Props {
   location: Location;
   breadcrumbs: Breadcrumb[];
+  core: InternalCoreStart;
 }
 
 class UpdateBreadcrumbsComponent extends React.Component<Props> {
@@ -26,7 +28,7 @@ class UpdateBreadcrumbsComponent extends React.Component<Props> {
 
     const current = last(breadcrumbs) || { text: '' };
     document.title = current.text;
-    chrome.breadcrumbs.set(breadcrumbs);
+    this.props.core.chrome.setBreadcrumbs(breadcrumbs);
   }
 
   public componentDidMount() {
@@ -43,6 +45,7 @@ class UpdateBreadcrumbsComponent extends React.Component<Props> {
 }
 
 export function UpdateBreadcrumbs() {
+  const core = useCore();
   return (
     <ProvideBreadcrumbs
       routes={routes}
@@ -50,6 +53,7 @@ export function UpdateBreadcrumbs() {
         <UpdateBreadcrumbsComponent
           breadcrumbs={breadcrumbs}
           location={location}
+          core={core}
         />
       )}
     />

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
@@ -7,35 +7,18 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import chrome from 'ui/chrome';
 import { UpdateBreadcrumbs } from '../UpdateBreadcrumbs';
+import * as hooks from '../../../../hooks/useCore';
 
 jest.mock('ui/kfetch');
 
-jest.mock(
-  'ui/chrome',
-  () => ({
-    breadcrumbs: {
-      set: jest.fn()
-    },
-    getBasePath: () => `/some/base/path`,
-    getUiSettingsClient: () => {
-      return {
-        get: key => {
-          switch (key) {
-            case 'timepicker:timeDefaults':
-              return { from: 'now-15m', to: 'now', mode: 'quick' };
-            case 'timepicker:refreshIntervalDefaults':
-              return { pause: false, value: 0 };
-            default:
-              throw new Error(`Unexpected config key: ${key}`);
-          }
-        }
-      };
-    }
-  }),
-  { virtual: true }
-);
+const coreMock = {
+  chrome: {
+    setBreadcrumbs: jest.fn()
+  }
+};
+
+jest.spyOn(hooks, 'useCore').mockReturnValue(coreMock);
 
 function expectBreadcrumbToMatchSnapshot(route) {
   mount(
@@ -43,8 +26,8 @@ function expectBreadcrumbToMatchSnapshot(route) {
       <UpdateBreadcrumbs />
     </MemoryRouter>
   );
-  expect(chrome.breadcrumbs.set).toHaveBeenCalledTimes(1);
-  expect(chrome.breadcrumbs.set.mock.calls[0][0]).toMatchSnapshot();
+  expect(coreMock.chrome.setBreadcrumbs).toHaveBeenCalledTimes(1);
+  expect(coreMock.chrome.setBreadcrumbs.mock.calls[0][0]).toMatchSnapshot();
 }
 
 describe('Breadcrumbs', () => {
@@ -55,7 +38,7 @@ describe('Breadcrumbs', () => {
     global.document = {
       title: 'Kibana'
     };
-    chrome.breadcrumbs.set.mockReset();
+    coreMock.chrome.setBreadcrumbs.mockReset();
   });
 
   afterEach(() => {

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/useUpdateBadgeEffect.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/useUpdateBadgeEffect.ts
@@ -7,12 +7,13 @@
 import { i18n } from '@kbn/i18n';
 import { useEffect } from 'react';
 import { capabilities } from 'ui/capabilities';
-import chrome from 'ui/chrome';
+import { useCore } from '../../../hooks/useCore';
 
 export const useUpdateBadgeEffect = () => {
+  const { chrome } = useCore();
   useEffect(() => {
     const uiCapabilities = capabilities.get();
-    chrome.badge.set(
+    chrome.setBadge(
       !uiCapabilities.apm.save
         ? {
             text: i18n.translate('xpack.apm.header.badge.readOnly.text', {

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/__test__/createErrorGroupWatch.test.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/__test__/createErrorGroupWatch.test.ts
@@ -6,7 +6,6 @@
 
 import { isArray, isObject, isString } from 'lodash';
 import mustache from 'mustache';
-import chrome from 'ui/chrome';
 import uuid from 'uuid';
 import { StringMap } from '../../../../../../typings/common';
 // @ts-ignore
@@ -23,7 +22,6 @@ describe('createErrorGroupWatch', () => {
   let createWatchResponse: string;
   let tmpl: any;
   beforeEach(async () => {
-    chrome.getInjected = jest.fn().mockReturnValue('myIndexPattern');
     jest.spyOn(uuid, 'v4').mockReturnValue(new Buffer('mocked-uuid'));
     jest.spyOn(rest, 'createWatch').mockReturnValue(undefined);
 
@@ -37,7 +35,8 @@ describe('createErrorGroupWatch', () => {
       serviceName: 'opbeans-node',
       slackUrl: 'https://hooks.slack.com/services/slackid1/slackid2/slackid3',
       threshold: 10,
-      timeRange: { value: 24, unit: 'h' }
+      timeRange: { value: 24, unit: 'h' },
+      apmIndexPatternTitle: 'myIndexPattern'
     });
 
     const watchBody = rest.createWatch.mock.calls[0][1];

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
@@ -6,7 +6,6 @@
 
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
-import chrome from 'ui/chrome';
 import url from 'url';
 import uuid from 'uuid';
 import {
@@ -46,6 +45,7 @@ interface Arguments {
     value: number;
     unit: string;
   };
+  apmIndexPatternTitle: string;
 }
 
 interface Actions {
@@ -60,10 +60,10 @@ export async function createErrorGroupWatch({
   serviceName,
   slackUrl,
   threshold,
-  timeRange
+  timeRange,
+  apmIndexPatternTitle
 }: Arguments) {
   const id = `apm-${uuid.v4()}`;
-  const apmIndexPatternTitle = chrome.getInjected('apmIndexPatternTitle');
 
   const slackUrlPath = getSlackPathUrl(slackUrl);
   const emailTemplate = i18n.translate(

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
@@ -13,11 +13,12 @@ import {
 import { i18n } from '@kbn/i18n';
 import { memoize } from 'lodash';
 import React, { Fragment } from 'react';
-import chrome from 'ui/chrome';
+import { InternalCoreStart } from 'src/core/public';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { LicenseContext } from '../../../../context/LicenseContext';
 import { MachineLearningFlyout } from './MachineLearningFlyout';
 import { WatcherFlyout } from './WatcherFlyout';
+import { CoreContext } from '../../../../context/CoreContext';
 
 interface Props {
   transactionTypes: string[];
@@ -30,6 +31,7 @@ interface State {
 type FlyoutName = null | 'ML' | 'Watcher';
 
 export class ServiceIntegrations extends React.Component<Props, State> {
+  static contextType = CoreContext;
   public state: State = { isPopoverOpen: false, activeFlyout: null };
 
   public getPanelItems = memoize((mlAvailable: boolean) => {
@@ -65,6 +67,8 @@ export class ServiceIntegrations extends React.Component<Props, State> {
   };
 
   public getWatcherPanelItems = () => {
+    const core: InternalCoreStart = this.context;
+
     return [
       {
         name: i18n.translate(
@@ -87,7 +91,7 @@ export class ServiceIntegrations extends React.Component<Props, State> {
           }
         ),
         icon: 'watchesApp',
-        href: chrome.addBasePath(
+        href: core.http.basePath.prepend(
           '/app/kibana#/management/elasticsearch/watcher'
         ),
         target: '_blank',

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/ServiceOverview.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/ServiceOverview.test.tsx
@@ -10,7 +10,9 @@ import 'react-testing-library/cleanup-after-each';
 import { toastNotifications } from 'ui/notify';
 import * as apmRestServices from '../../../../services/rest/apm/services';
 import { ServiceOverview } from '..';
-import * as hooks from '../../../../hooks/useUrlParams';
+import * as urlParamsHooks from '../../../../hooks/useUrlParams';
+import * as coreHooks from '../../../../hooks/useCore';
+import { InternalCoreStart } from 'src/core/public';
 
 jest.mock('ui/kfetch');
 
@@ -20,13 +22,22 @@ function renderServiceOverview() {
 
 describe('Service Overview -> View', () => {
   beforeEach(() => {
+    const coreMock = ({
+      http: {
+        basePath: {
+          prepend: (path: string) => `/basepath${path}`
+        }
+      }
+    } as unknown) as InternalCoreStart;
+
     // mock urlParams
-    spyOn(hooks, 'useUrlParams').and.returnValue({
+    spyOn(urlParamsHooks, 'useUrlParams').and.returnValue({
       urlParams: {
         start: 'myStart',
         end: 'myEnd'
       }
     });
+    spyOn(coreHooks, 'useCore').and.returnValue(coreMock);
   });
 
   afterEach(() => {

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
@@ -79,7 +79,7 @@ NodeList [
                    
                   <a
                     class="euiLink euiLink--primary"
-                    href="/app/kibana#/management/elasticsearch/upgrade_assistant"
+                    href="/basepath/app/kibana#/management/elasticsearch/upgrade_assistant"
                     rel="noreferrer"
                   >
                     Learn more by visiting the Kibana Upgrade Assistant
@@ -96,7 +96,7 @@ NodeList [
             />
             <a
               class="euiLink euiLink--primary"
-              href="/app/kibana#/home/tutorial/apm"
+              href="/basepath/app/kibana#/home/tutorial/apm"
               rel="noreferrer"
             >
               <button

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/index.tsx
@@ -8,7 +8,6 @@ import { EuiPanel } from '@elastic/eui';
 import { EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect } from 'react';
-import chrome from 'ui/chrome';
 import { toastNotifications } from 'ui/notify';
 import url from 'url';
 import { useFetcher } from '../../../hooks/useFetcher';
@@ -17,6 +16,7 @@ import { NoServicesMessage } from './NoServicesMessage';
 import { ServiceList } from './ServiceList';
 import { useUrlParams } from '../../../hooks/useUrlParams';
 import { useTrackPageview } from '../../../../../infra/public';
+import { useCore } from '../../../hooks/useCore';
 
 const initalData = {
   items: [],
@@ -27,6 +27,7 @@ const initalData = {
 let hasDisplayedToast = false;
 
 export function ServiceOverview() {
+  const core = useCore();
   const {
     urlParams: { start, end },
     uiFilters
@@ -54,7 +55,7 @@ export function ServiceOverview() {
 
             <EuiLink
               href={url.format({
-                pathname: chrome.addBasePath('/app/kibana'),
+                pathname: core.http.basePath.prepend('/app/kibana'),
                 hash: '/management/elasticsearch/upgrade_assistant'
               })}
             >

--- a/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/index.tsx
@@ -7,7 +7,6 @@
 import React, { useState, useEffect } from 'react';
 import { uniqueId, startsWith } from 'lodash';
 import { EuiCallOut } from '@elastic/eui';
-import chrome from 'ui/chrome';
 import styled from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
@@ -29,6 +28,7 @@ import { useUrlParams } from '../../../hooks/useUrlParams';
 import { history } from '../../../utils/history';
 import { useMatchedRoutes } from '../../../hooks/useMatchedRoutes';
 import { RouteName } from '../../app/Main/route_config/route_names';
+import { useCore } from '../../../hooks/useCore';
 
 const Container = styled.div`
   margin-bottom: 10px;
@@ -42,6 +42,7 @@ interface State {
 }
 
 export function KueryBar() {
+  const core = useCore();
   const [state, setState] = useState<State>({
     indexPattern: null,
     suggestions: [],
@@ -52,7 +53,9 @@ export function KueryBar() {
   const location = useLocation();
   const matchedRoutes = useMatchedRoutes();
 
-  const apmIndexPatternTitle = chrome.getInjected('apmIndexPatternTitle');
+  const apmIndexPatternTitle = core.injectedMetadata.getInjectedVar(
+    'apmIndexPatternTitle'
+  );
   const indexPatternMissing =
     !state.isLoadingIndexPattern && !state.indexPattern;
   let currentRequestCheck;

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverLink.tsx
@@ -6,12 +6,12 @@
 
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
-import chrome from 'ui/chrome';
 import url from 'url';
 import rison, { RisonValue } from 'rison-node';
 import { useAPMIndexPattern } from '../../../../hooks/useAPMIndexPattern';
 import { useLocation } from '../../../../hooks/useLocation';
 import { getTimepickerRisonData } from '../rison_helpers';
+import { useCore } from '../../../../hooks/useCore';
 
 interface Props {
   query: {
@@ -31,6 +31,7 @@ interface Props {
 }
 
 export function DiscoverLink({ query = {}, ...rest }: Props) {
+  const core = useCore();
   const apmIndexPattern = useAPMIndexPattern();
   const location = useLocation();
 
@@ -47,7 +48,7 @@ export function DiscoverLink({ query = {}, ...rest }: Props) {
   };
 
   const href = url.format({
-    pathname: chrome.addBasePath('/app/kibana'),
+    pathname: core.http.basePath.prepend('/app/kibana'),
     hash: `/discover?_g=${rison.encode(risonQuery._g)}&_a=${rison.encode(
       risonQuery._a as RisonValue
     )}`

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/DiscoverLinks.integration.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/DiscoverLinks.integration.test.tsx
@@ -14,6 +14,8 @@ import { getRenderedHref } from '../../../../../utils/testHelpers';
 import { DiscoverErrorLink } from '../DiscoverErrorLink';
 import { DiscoverSpanLink } from '../DiscoverSpanLink';
 import { DiscoverTransactionLink } from '../DiscoverTransactionLink';
+import * as hooks from '../../../../../hooks/useCore';
+import { InternalCoreStart } from 'src/core/public';
 
 jest.mock('ui/kfetch');
 
@@ -25,6 +27,16 @@ jest
 
 beforeAll(() => {
   jest.spyOn(console, 'error').mockImplementation(() => null);
+
+  const coreMock = ({
+    http: {
+      basePath: {
+        prepend: (path: string) => `/basepath${path}`
+      }
+    }
+  } as unknown) as InternalCoreStart;
+
+  jest.spyOn(hooks, 'useCore').mockReturnValue(coreMock);
 });
 
 afterAll(() => {
@@ -49,7 +61,7 @@ test('DiscoverTransactionLink should produce the correct URL', async () => {
   );
 
   expect(href).toEqual(
-    `/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'processor.event:"transaction" AND transaction.id:"8b60bd32ecc6e150" AND trace.id:"8b60bd32ecc6e1506735a8b6cfcf175c"'))`
+    `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'processor.event:"transaction" AND transaction.id:"8b60bd32ecc6e150" AND trace.id:"8b60bd32ecc6e1506735a8b6cfcf175c"'))`
   );
 });
 
@@ -65,7 +77,7 @@ test('DiscoverSpanLink should produce the correct URL', async () => {
   } as Location);
 
   expect(href).toEqual(
-    `/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'span.id:"test-span-id"'))`
+    `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'span.id:"test-span-id"'))`
   );
 });
 
@@ -86,7 +98,7 @@ test('DiscoverErrorLink should produce the correct URL', async () => {
   );
 
   expect(href).toEqual(
-    `/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'service.name:"service-name" AND error.grouping_key:"grouping-key"'),sort:('@timestamp':desc))`
+    `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'service.name:"service-name" AND error.grouping_key:"grouping-key"'),sort:('@timestamp':desc))`
   );
 });
 
@@ -108,6 +120,6 @@ test('DiscoverErrorLink should include optional kuery string in URL', async () =
   );
 
   expect(href).toEqual(
-    `/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'service.name:"service-name" AND error.grouping_key:"grouping-key" AND some:kuery-string'),sort:('@timestamp':desc))`
+    `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'service.name:"service-name" AND error.grouping_key:"grouping-key" AND some:kuery-string'),sort:('@timestamp':desc))`
   );
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/InfraLink.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/InfraLink.test.tsx
@@ -8,11 +8,18 @@ import { Location } from 'history';
 import React from 'react';
 import { getRenderedHref } from '../../../utils/testHelpers';
 import { InfraLink } from './InfraLink';
-import chrome from 'ui/chrome';
+import * as hooks from '../../../hooks/useCore';
+import { InternalCoreStart } from 'src/core/public';
 
-jest
-  .spyOn(chrome, 'addBasePath')
-  .mockImplementation(path => `/basepath${path}`);
+const coreMock = ({
+  http: {
+    basePath: {
+      prepend: (path: string) => `/basepath${path}`
+    }
+  }
+} as unknown) as InternalCoreStart;
+
+jest.spyOn(hooks, 'useCore').mockReturnValue(coreMock);
 
 test('InfraLink produces the correct URL', async () => {
   const href = await getRenderedHref(

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/InfraLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/InfraLink.tsx
@@ -7,9 +7,9 @@
 import { EuiLink, EuiLinkAnchorProps } from '@elastic/eui';
 import { compact } from 'lodash';
 import React from 'react';
-import chrome from 'ui/chrome';
 import url from 'url';
 import { fromQuery } from './url_helpers';
+import { useCore } from '../../../hooks/useCore';
 
 interface InfraQueryParams {
   time?: number;
@@ -24,9 +24,10 @@ interface Props extends EuiLinkAnchorProps {
 }
 
 export function InfraLink({ path, query = {}, ...rest }: Props) {
+  const core = useCore();
   const nextSearch = fromQuery(query);
   const href = url.format({
-    pathname: chrome.addBasePath('/app/infra'),
+    pathname: core.http.basePath.prepend('/app/infra'),
     hash: compact([path, nextSearch]).join('?')
   });
   return <EuiLink {...rest} href={href} />;

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/KibanaLink.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/KibanaLink.test.tsx
@@ -8,16 +8,30 @@ import { Location } from 'history';
 import React from 'react';
 import { getRenderedHref } from '../../../utils/testHelpers';
 import { KibanaLink } from './KibanaLink';
-import chrome from 'ui/chrome';
+import * as hooks from '../../../hooks/useCore';
+import { InternalCoreStart } from 'src/core/public';
 
-jest
-  .spyOn(chrome, 'addBasePath')
-  .mockImplementation(path => `/basepath${path}`);
+describe('KibanaLink', () => {
+  beforeEach(() => {
+    const coreMock = ({
+      http: {
+        basePath: {
+          prepend: (path: string) => `/basepath${path}`
+        }
+      }
+    } as unknown) as InternalCoreStart;
 
-test('KibanaLink produces the correct URL', async () => {
-  const href = await getRenderedHref(() => <KibanaLink path="/some/path" />, {
-    search: '?rangeFrom=now-5h&rangeTo=now-2h'
-  } as Location);
+    jest.spyOn(hooks, 'useCore').mockReturnValue(coreMock);
+  });
 
-  expect(href).toMatchInlineSnapshot(`"/basepath/app/kibana#/some/path"`);
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('produces the correct URL', async () => {
+    const href = await getRenderedHref(() => <KibanaLink path="/some/path" />, {
+      search: '?rangeFrom=now-5h&rangeTo=now-2h'
+    } as Location);
+    expect(href).toMatchInlineSnapshot(`"/basepath/app/kibana#/some/path"`);
+  });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/KibanaLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/KibanaLink.tsx
@@ -6,8 +6,8 @@
 
 import { EuiLink, EuiLinkAnchorProps } from '@elastic/eui';
 import React from 'react';
-import chrome from 'ui/chrome';
 import url from 'url';
+import { useCore } from '../../../hooks/useCore';
 
 interface Props extends EuiLinkAnchorProps {
   path?: string;
@@ -15,8 +15,9 @@ interface Props extends EuiLinkAnchorProps {
 }
 
 export function KibanaLink({ path, ...rest }: Props) {
+  const core = useCore();
   const href = url.format({
-    pathname: chrome.addBasePath('/app/kibana'),
+    pathname: core.http.basePath.prepend('/app/kibana'),
     hash: path
   });
   return <EuiLink {...rest} href={href} />;

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/MachineLearningLinks/MLJobLink.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/MachineLearningLinks/MLJobLink.test.tsx
@@ -8,8 +8,25 @@ import { Location } from 'history';
 import React from 'react';
 import { getRenderedHref } from '../../../../utils/testHelpers';
 import { MLJobLink } from './MLJobLink';
+import * as hooks from '../../../../hooks/useCore';
+import { InternalCoreStart } from 'src/core/public';
 
 describe('MLJobLink', () => {
+  beforeEach(() => {
+    const coreMock = ({
+      http: {
+        basePath: {
+          prepend: (path: string) => `/basepath${path}`
+        }
+      }
+    } as unknown) as InternalCoreStart;
+
+    spyOn(hooks, 'useCore').and.returnValue(coreMock);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
   it('should produce the correct URL', async () => {
     const href = await getRenderedHref(
       () => (
@@ -22,7 +39,7 @@ describe('MLJobLink', () => {
     );
 
     expect(href).toEqual(
-      `/app/ml#/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now-4h))`
+      `/basepath/app/ml#/timeseriesexplorer?_g=(ml:(jobIds:!(myservicename-mytransactiontype-high_mean_response_time)),refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now-4h))`
     );
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/MachineLearningLinks/MLLink.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/MachineLearningLinks/MLLink.test.tsx
@@ -8,14 +8,21 @@ import { Location } from 'history';
 import React from 'react';
 import { getRenderedHref } from '../../../../utils/testHelpers';
 import { MLLink } from './MLLink';
-import chrome from 'ui/chrome';
 import * as savedObjects from '../../../../services/rest/savedObjects';
+import * as hooks from '../../../../hooks/useCore';
+import { InternalCoreStart } from 'src/core/public';
 
 jest.mock('ui/kfetch');
 
-jest
-  .spyOn(chrome, 'addBasePath')
-  .mockImplementation(path => `/basepath${path}`);
+const coreMock = ({
+  http: {
+    basePath: {
+      prepend: (path: string) => `/basepath${path}`
+    }
+  }
+} as unknown) as InternalCoreStart;
+
+jest.spyOn(hooks, 'useCore').mockReturnValue(coreMock);
 
 jest
   .spyOn(savedObjects, 'getAPMIndexPattern')

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/MachineLearningLinks/MLLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/MachineLearningLinks/MLLink.tsx
@@ -6,11 +6,11 @@
 
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
-import chrome from 'ui/chrome';
 import url from 'url';
 import rison, { RisonValue } from 'rison-node';
 import { useLocation } from '../../../../hooks/useLocation';
 import { getTimepickerRisonData, TimepickerRisonData } from '../rison_helpers';
+import { useCore } from '../../../../hooks/useCore';
 
 interface MlRisonData {
   ml?: {
@@ -25,6 +25,7 @@ interface Props {
 }
 
 export function MLLink({ children, path = '', query = {} }: Props) {
+  const core = useCore();
   const location = useLocation();
 
   const risonQuery: MlRisonData & TimepickerRisonData = getTimepickerRisonData(
@@ -36,7 +37,7 @@ export function MLLink({ children, path = '', query = {} }: Props) {
   }
 
   const href = url.format({
-    pathname: chrome.addBasePath('/app/ml'),
+    pathname: core.http.basePath.prepend('/app/ml'),
     hash: `${path}?_g=${rison.encode(risonQuery as RisonValue)}`
   });
 

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -14,7 +14,6 @@ import {
   EuiPopover,
   EuiLink
 } from '@elastic/eui';
-import chrome from 'ui/chrome';
 import url from 'url';
 import { i18n } from '@kbn/i18n';
 import React, { useState, FunctionComponent } from 'react';
@@ -25,6 +24,7 @@ import { DiscoverTransactionLink } from '../Links/DiscoverLinks/DiscoverTransact
 import { InfraLink } from '../Links/InfraLink';
 import { useUrlParams } from '../../../hooks/useUrlParams';
 import { fromQuery } from '../Links/url_helpers';
+import { useCore } from '../../../hooks/useCore';
 
 function getInfraMetricsQuery(transaction: Transaction) {
   const plus5 = new Date(transaction['@timestamp']);
@@ -65,6 +65,8 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
   props: Props
 ) => {
   const { transaction } = props;
+
+  const core = useCore();
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -164,7 +166,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
   );
 
   const uptimeLink = url.format({
-    pathname: chrome.addBasePath('/app/uptime'),
+    pathname: core.http.basePath.prepend('/app/uptime'),
     hash: `/?${fromQuery(
       pick(
         {

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/__test__/TransactionActionMenu.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/__test__/TransactionActionMenu.test.tsx
@@ -10,8 +10,10 @@ import 'react-testing-library/cleanup-after-each';
 import { TransactionActionMenu } from '../TransactionActionMenu';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import * as Transactions from './mockData';
-import * as hooks from '../../../../hooks/useAPMIndexPattern';
+import * as apmIndexPatternHooks from '../../../../hooks/useAPMIndexPattern';
+import * as coreHoooks from '../../../../hooks/useCore';
 import { ISavedObject } from '../../../../services/rest/savedObjects';
+import { InternalCoreStart } from 'src/core/public';
 
 jest.mock('ui/kfetch');
 
@@ -27,9 +29,18 @@ const renderTransaction = async (transaction: Record<string, any>) => {
 
 describe('TransactionActionMenu component', () => {
   beforeEach(() => {
+    const coreMock = ({
+      http: {
+        basePath: {
+          prepend: (path: string) => `/basepath${path}`
+        }
+      }
+    } as unknown) as InternalCoreStart;
+
     jest
-      .spyOn(hooks, 'useAPMIndexPattern')
+      .spyOn(apmIndexPatternHooks, 'useAPMIndexPattern')
       .mockReturnValue({ id: 'foo' } as ISavedObject);
+    jest.spyOn(coreHoooks, 'useCore').mockReturnValue(coreMock);
   });
 
   afterEach(() => {

--- a/x-pack/legacy/plugins/apm/public/context/CoreContext.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/CoreContext.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { createContext } from 'react';
+import { InternalCoreStart } from 'src/core/public';
+
+const CoreContext = createContext<InternalCoreStart>({} as InternalCoreStart);
+const CoreProvider: React.SFC<{ core: InternalCoreStart }> = props => {
+  const { core, ...restProps } = props;
+  return <CoreContext.Provider value={core} {...restProps} />;
+};
+
+export { CoreContext, CoreProvider };

--- a/x-pack/legacy/plugins/apm/public/context/LicenseContext/InvalidLicenseNotification.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/LicenseContext/InvalidLicenseNotification.tsx
@@ -6,11 +6,14 @@
 import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import chrome from 'ui/chrome';
-
-const MANAGE_LICENSE_URL = `${chrome.getBasePath()}/app/kibana#/management/elasticsearch/license_management`;
+import { useCore } from '../../hooks/useCore';
 
 export function InvalidLicenseNotification() {
+  const core = useCore();
+  const manageLicenseURL = core.http.basePath.prepend(
+    '/app/kibana#/management/elasticsearch/license_management'
+  );
+
   return (
     <EuiEmptyPrompt
       iconType="alert"
@@ -31,7 +34,7 @@ export function InvalidLicenseNotification() {
         </p>
       }
       actions={[
-        <EuiButton href={MANAGE_LICENSE_URL}>
+        <EuiButton href={manageLicenseURL}>
           {i18n.translate('xpack.apm.invalidLicense.licenseManagementLink', {
             defaultMessage: 'Manage your license'
           })}

--- a/x-pack/legacy/plugins/apm/public/hooks/useCore.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useCore.tsx
@@ -4,11 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { npStart } from 'ui/new_platform';
+import { useContext } from 'react';
+import { CoreContext } from '../context/CoreContext';
 
-const { core } = npStart;
-const apmUiEnabled = core.injectedMetadata.getInjectedVar('apmUiEnabled');
-
-if (apmUiEnabled === false) {
-  core.chrome.navLinks.update('apm', { hidden: true });
+export function useCore() {
+  return useContext(CoreContext);
 }

--- a/x-pack/legacy/plugins/apm/public/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/index.tsx
@@ -6,12 +6,11 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { npStart } from 'ui/new_platform';
 import 'react-vis/dist/style.css';
-import { CoreStart } from 'src/core/public';
 import 'ui/autoload/all';
 import 'ui/autoload/styles';
 import chrome from 'ui/chrome';
-import { I18nContext } from 'ui/i18n';
 // @ts-ignore
 import { uiModules } from 'ui/modules';
 import 'uiExports/autocompleteProviders';
@@ -20,10 +19,19 @@ import { plugin } from './new-platform';
 import { REACT_APP_ROOT_ID } from './new-platform/plugin';
 import './style/global_overrides.css';
 import template from './templates/index.html';
+import { CoreProvider } from './context/CoreContext';
+
+const { core } = npStart;
+// console.log(npStart);
 
 // render APM feedback link in global help menu
-chrome.helpExtension.set(domElement => {
-  ReactDOM.render(<GlobalHelpExtension />, domElement);
+core.chrome.setHelpExtension(domElement => {
+  ReactDOM.render(
+    <CoreProvider core={core}>
+      <GlobalHelpExtension />
+    </CoreProvider>,
+    domElement
+  );
   return () => {
     ReactDOM.unmountComponentAtNode(domElement);
   };
@@ -42,12 +50,6 @@ const checkForRoot = () => {
     }
   });
 };
-
 checkForRoot().then(() => {
-  const core = {
-    i18n: {
-      Context: I18nContext
-    }
-  } as CoreStart;
   plugin().start(core);
 });

--- a/x-pack/legacy/plugins/apm/public/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/index.tsx
@@ -22,7 +22,6 @@ import template from './templates/index.html';
 import { CoreProvider } from './context/CoreContext';
 
 const { core } = npStart;
-// console.log(npStart);
 
 // render APM feedback link in global help menu
 core.chrome.setHelpExtension(domElement => {

--- a/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
+++ b/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
@@ -8,8 +8,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Route, Switch } from 'react-router-dom';
 import styled from 'styled-components';
-import { CoreStart } from 'src/core/public';
+import { InternalCoreStart } from 'src/core/public';
 import { history } from '../utils/history';
+import { CoreProvider } from '../context/CoreContext';
 import { LocationProvider } from '../context/LocationContext';
 import { UrlParamsProvider } from '../context/UrlParamsContext';
 import { px, unit, units } from '../style/variables';
@@ -53,16 +54,18 @@ const App = () => {
 };
 
 export class Plugin {
-  public start(core: CoreStart) {
+  public start(core: InternalCoreStart) {
     const { i18n } = core;
     ReactDOM.render(
-      <i18n.Context>
-        <Router history={history}>
-          <LocationProvider>
-            <App />
-          </LocationProvider>
-        </Router>
-      </i18n.Context>,
+      <CoreProvider core={core}>
+        <i18n.Context>
+          <Router history={history}>
+            <LocationProvider>
+              <App />
+            </LocationProvider>
+          </Router>
+        </i18n.Context>
+      </CoreProvider>,
       document.getElementById(REACT_APP_ROOT_ID)
     );
   }

--- a/x-pack/legacy/plugins/apm/public/register_feature.js
+++ b/x-pack/legacy/plugins/apm/public/register_feature.js
@@ -4,14 +4,17 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import chrome from 'ui/chrome';
+import { npStart } from 'ui/new_platform';
 import { i18n } from '@kbn/i18n';
 import {
   FeatureCatalogueRegistryProvider,
   FeatureCatalogueCategory
 } from 'ui/registry/feature_catalogue';
 
-if (chrome.getInjected('apmUiEnabled')) {
+const { core } = npStart;
+const apmUiEnabled = core.injectedMetadata.getInjectedVar('apmUiEnabled');
+
+if (apmUiEnabled) {
   FeatureCatalogueRegistryProvider.register(() => {
     return {
       id: 'apm',

--- a/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
@@ -4,8 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { npStart } from 'ui/new_platform';
 import { ESFilter } from 'elasticsearch';
-import chrome from 'ui/chrome';
 import {
   PROCESSOR_EVENT,
   SERVICE_NAME,
@@ -31,6 +31,8 @@ interface StartedMLJobApiResponse {
   jobs: MlResponseItem[];
 }
 
+const { core } = npStart;
+
 export async function startMLJob({
   serviceName,
   transactionType
@@ -38,7 +40,9 @@ export async function startMLJob({
   serviceName: string;
   transactionType: string;
 }) {
-  const indexPatternName = chrome.getInjected('apmIndexPatternTitle');
+  const indexPatternName = core.injectedMetadata.getInjectedVar(
+    'apmIndexPatternTitle'
+  );
   const groups = ['apm', serviceName.toLowerCase()];
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },


### PR DESCRIPTION
Closes #34444 

Created `useCore`/`CoreContext` to pass down a single instance of `core` to components which were previously using `ui/chrome`. Those components were updated to use `core` APIs instead of `ui/chrome`.