### PR TITLE
[service/remote] check env variable value for headless browser

### DIFF
--- a/tasks/config/karma.js
+++ b/tasks/config/karma.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
     if (grunt.option('browser')) {
       return grunt.option('browser');
     }
-    if (process.env.TEST_BROWSER_HEADLESS) {
+    if (process.env.TEST_BROWSER_HEADLESS === '1') {
       return 'Chrome_Headless';
     }
     return 'Chrome';

--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -38,7 +38,8 @@ import { preventParallelCalls } from './prevent_parallel_calls';
 
 import { Browsers } from './browsers';
 
-const throttleOption = process.env.TEST_THROTTLE_NETWORK;
+const throttleOption: string = process.env.TEST_THROTTLE_NETWORK as string;
+const headlessBrowser: string = process.env.TEST_BROWSER_HEADLESS as string;
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 const NO_QUEUE_COMMANDS = ['getLog', 'getStatus', 'newSession', 'quit'];
@@ -73,7 +74,7 @@ async function attemptToCreateCommand(log: ToolingLog, browserType: Browsers) {
           'use-fake-device-for-media-stream',
           'use-fake-ui-for-media-stream',
         ];
-        if (process.env.TEST_BROWSER_HEADLESS) {
+        if (headlessBrowser === '1') {
           // Use --disable-gpu to avoid an error from a missing Mesa library, as per
           // See: https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
           chromeOptions.push('headless', 'disable-gpu');
@@ -90,7 +91,7 @@ async function attemptToCreateCommand(log: ToolingLog, browserType: Browsers) {
           .build();
       case 'firefox':
         const firefoxOptions = new firefox.Options();
-        if (process.env.TEST_BROWSER_HEADLESS) {
+        if (headlessBrowser === '1') {
           // See: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode
           firefoxOptions.addArguments('-headless');
         }
@@ -106,7 +107,7 @@ async function attemptToCreateCommand(log: ToolingLog, browserType: Browsers) {
 
   const session = await buildDriverInstance();
 
-  if (throttleOption === 'true' && browserType === 'chrome') {
+  if (throttleOption === '1' && browserType === 'chrome') {
     // Only chrome supports this option.
     log.debug('NETWORK THROTTLED: 768k down, 256k up, 100ms latency.');
 


### PR DESCRIPTION
## Summary

Currently, you cannot unset TEST_BROWSER_HEADLESS with 0 as we check if any value set to env variable.
This PR fixes it.

How to test
In the same terminal window run the following commands:

- `node scripts/functional_test_runner.js` should run tests with head

- `export TEST_BROWSER_HEADLESS=1 && node scripts/functional_test_runner.js` should run tests with headless

- `export TEST_BROWSER_HEADLESS=0 && node scripts/functional_test_runner.js` should run tests with head again

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

