### PR TITLE
[7.x] Functional tests: make sure clicked dashboard is opened (#42006)

### DIFF
--- a/test/functional/page_objects/dashboard_page.js
+++ b/test/functional/page_objects/dashboard_page.js
@@ -460,9 +460,12 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
       await this.gotoDashboardLandingPage();
 
       await this.searchForDashboardWithName(dashName);
-      await this.selectDashboard(dashName);
-      await PageObjects.header.waitUntilLoadingHasFinished();
-
+      await retry.try(async () => {
+        await this.selectDashboard(dashName);
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        // check Dashboard landing page is not present
+        await testSubjects.missingOrFail('newItemButton');
+      });
     }
 
     async getPanelTitles() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Functional tests: make sure clicked dashboard is opened (#42006)