### PR TITLE
[APM] Fix bug related to “view full trace” by removing redirection logic

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -7,8 +7,7 @@
 import { EuiIconTip, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import d3 from 'd3';
-import React, { FunctionComponent, useEffect, useCallback } from 'react';
-import { omit } from 'lodash';
+import React, { FunctionComponent, useCallback } from 'react';
 import { ITransactionDistributionAPIResponse } from '../../../../../server/lib/transactions/distribution';
 import { IBucket } from '../../../../../server/lib/transactions/distribution/get_buckets/transform';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
@@ -111,54 +110,13 @@ export const TransactionDistribution: FunctionComponent<Props> = (
     transactionType
   ]);
 
-  const redirectToDefaultSample = useCallback(() => {
-    const defaultSample =
-      distribution && distribution.defaultSample
-        ? distribution.defaultSample
-        : {};
-
-    const parsedQueryParams = toQuery(history.location.search);
-
-    history.replace({
-      ...history.location,
-      search: fromQuery({
-        ...omit(parsedQueryParams, 'transactionId', 'traceId'),
-        ...defaultSample
-      })
-    });
-  }, [distribution, isLoading]);
-
-  useEffect(() => {
+  // no data in response
+  if (!distribution || !distribution.totalHits) {
+    // only show loading state if there is no data - else show stale data until new data has loaded
     if (isLoading) {
-      return;
+      return <LoadingStatePrompt />;
     }
-    const selectedSampleIsAvailable = distribution
-      ? !!distribution.buckets.find(
-          bucket =>
-            !!(
-              bucket.sample &&
-              bucket.sample.transactionId === transactionId &&
-              bucket.sample.traceId === traceId
-            )
-        )
-      : false;
 
-    if (!selectedSampleIsAvailable && !!distribution) {
-      redirectToDefaultSample();
-    }
-  }, [
-    distribution,
-    transactionId,
-    traceId,
-    redirectToDefaultSample,
-    isLoading
-  ]);
-
-  if (isLoading) {
-    return <LoadingStatePrompt />;
-  }
-
-  if (!distribution || !distribution.totalHits || !traceId || !transactionId) {
     return (
       <EmptyMessage
         heading={i18n.translate('xpack.apm.transactionDetails.notFoundLabel', {

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -13,13 +13,12 @@ import { ITransactionGroup } from '../../../../../server/lib/transaction_groups/
 import { fontFamilyCode, truncate } from '../../../../style/variables';
 import { asDecimal, asMillis } from '../../../../utils/formatters';
 import { ImpactBar } from '../../../shared/ImpactBar';
-import { APMLink } from '../../../shared/Links/APMLink';
-import { legacyEncodeURIComponent } from '../../../shared/Links/url_helpers';
 import { ITableColumn, ManagedTable } from '../../../shared/ManagedTable';
 import { LoadingStatePrompt } from '../../../shared/LoadingStatePrompt';
 import { EmptyMessage } from '../../../shared/EmptyMessage';
+import { TransactionLink } from '../../../shared/Links/TransactionLink';
 
-const TransactionNameLink = styled(APMLink)`
+const TransactionNameLink = styled(TransactionLink)`
   ${truncate('100%')};
   font-family: ${fontFamilyCode};
 `;
@@ -40,19 +39,13 @@ export function TransactionList({ items, serviceName, isLoading }: Props) {
         }),
         width: '50%',
         sortable: true,
-        render: (transactionName: string, data: typeof items[0]) => {
-          const encodedType = legacyEncodeURIComponent(
-            data.sample.transaction.type
-          );
-          const encodedName = legacyEncodeURIComponent(transactionName);
-          const transactionPath = `/${serviceName}/transactions/${encodedType}/${encodedName}`;
-
+        render: (transactionName: string, item: typeof items[0]) => {
           return (
             <EuiToolTip
               id="transaction-name-link-tooltip"
               content={transactionName || NOT_AVAILABLE_LABEL}
             >
-              <TransactionNameLink path={transactionPath}>
+              <TransactionNameLink transaction={item.sample}>
                 {transactionName || NOT_AVAILABLE_LABEL}
               </TransactionNameLink>
             </EuiToolTip>

--- a/x-pack/legacy/plugins/apm/public/hooks/useTransactionDistribution.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useTransactionDistribution.ts
@@ -12,8 +12,7 @@ import { useUiFilters } from '../context/UrlParamsContext';
 const INITIAL_DATA = {
   buckets: [],
   totalHits: 0,
-  bucketSize: 0,
-  defaultSample: undefined
+  bucketSize: 0
 };
 
 export function useTransactionDistribution(urlParams: IUrlParams) {

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
@@ -4,26 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { isEmpty } from 'lodash';
 import { idx } from '@kbn/elastic-idx';
 import { PromiseReturnType } from '../../../../../typings/common';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import { bucketFetcher } from './fetcher';
 
 type DistributionBucketResponse = PromiseReturnType<typeof bucketFetcher>;
-
-function getDefaultSample(buckets: IBucket[]) {
-  const samples = buckets
-    .filter(bucket => bucket.count > 0 && bucket.sample)
-    .map(bucket => bucket.sample);
-
-  if (isEmpty(samples)) {
-    return;
-  }
-
-  const middleIndex = Math.floor(samples.length / 2);
-  return samples[middleIndex];
-}
 
 export type IBucket = ReturnType<typeof getBucket>;
 function getBucket(
@@ -50,7 +36,6 @@ export function bucketTransformer(response: DistributionBucketResponse) {
 
   return {
     totalHits: response.hits.total,
-    buckets,
-    defaultSample: getDefaultSample(buckets)
+    buckets
   };
 }

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/index.ts
@@ -34,7 +34,7 @@ export async function getTransactionDistribution({
     setup
   );
 
-  const { defaultSample, buckets, totalHits } = await getBuckets(
+  const { buckets, totalHits } = await getBuckets(
     serviceName,
     transactionName,
     transactionType,
@@ -47,7 +47,6 @@ export async function getTransactionDistribution({
   return {
     totalHits,
     buckets,
-    bucketSize,
-    defaultSample
+    bucketSize
   };
 }


### PR DESCRIPTION
The bug caused the "View Full Trace" button to not work in certain scenarios. To work around this the error-prone redirect logic has been removed. The transaction list will now link to the default sample instead. There will be no automatic redirect if a sample is not found or if the kuery bar is used to filter.