### PR TITLE
[APM] Move apm links into apm folder

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/StickyErrorProperties.tsx
@@ -18,15 +18,15 @@ import {
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
 import { APMError } from '../../../../../typings/es_schemas/ui/APMError';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
-import { APMLink } from '../../../shared/Links/APMLink';
 import { StickyProperties } from '../../../shared/StickyProperties';
+import { TransactionLink } from '../../../shared/Links/apm/TransactionLink';
 
 interface Props {
   error: APMError;
   transaction: Transaction | undefined;
 }
 
-function TransactionLink({
+function TransactionLinkWrapper({
   transaction
 }: {
   transaction: Transaction | undefined;
@@ -41,17 +41,9 @@ function TransactionLink({
   }
 
   return (
-    <APMLink
-      path={`/services/${transaction.service.name}/transactions/view`}
-      query={{
-        transactionId: transaction.transaction.id,
-        traceId: transaction.trace.id,
-        transactionName: transaction.transaction.name,
-        transactionType: transaction.transaction.type
-      }}
-    >
+    <TransactionLink transaction={transaction}>
       {transaction.transaction.id}
-    </APMLink>
+    </TransactionLink>
   );
 }
 
@@ -100,7 +92,7 @@ export function StickyErrorProperties({ error, transaction }: Props) {
           defaultMessage: 'Transaction sample ID'
         }
       ),
-      val: <TransactionLink transaction={transaction} />,
+      val: <TransactionLinkWrapper transaction={transaction} />,
       width: '25%'
     },
     {

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__snapshots__/StickyErrorProperties.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/__snapshots__/StickyErrorProperties.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`StickyErrorProperties should render StickyProperties 1`] = `
       Object {
         "fieldName": "transaction.id",
         "label": "Transaction sample ID",
-        "val": <TransactionLink
+        "val": <TransactionLinkWrapper
           transaction={
             Object {
               "http": Object {

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -19,7 +19,7 @@ import {
   truncate,
   unit
 } from '../../../../style/variables';
-import { APMLink } from '../../../shared/Links/APMLink';
+import { APMLink } from '../../../shared/Links/apm/APMLink';
 import { useUrlParams } from '../../../../hooks/useUrlParams';
 import { ManagedTable } from '../../../shared/ManagedTable';
 

--- a/x-pack/legacy/plugins/apm/public/components/app/Home/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Home/index.tsx
@@ -17,7 +17,7 @@ import { HistoryTabs, IHistoryTab } from '../../shared/HistoryTabs';
 import { SetupInstructionsLink } from '../../shared/Links/SetupInstructionsLink';
 import { ServiceOverview } from '../ServiceOverview';
 import { TraceOverview } from '../TraceOverview';
-import { APMLink } from '../../shared/Links/APMLink';
+import { APMLink } from '../../shared/Links/apm/APMLink';
 
 const homeTabs: IHistoryTab[] = [
   {

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/UpdateBreadcrumbs.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/UpdateBreadcrumbs.tsx
@@ -9,7 +9,7 @@ import { last } from 'lodash';
 import React from 'react';
 import { InternalCoreStart } from 'src/core/public';
 import { useCore } from '../../../hooks/useCore';
-import { getAPMHref } from '../../shared/Links/APMLink';
+import { getAPMHref } from '../../shared/Links/apm/APMLink';
 import { Breadcrumb, ProvideBreadcrumbs } from './ProvideBreadcrumbs';
 import { routes } from './route_config';
 

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
@@ -12,7 +12,7 @@ import { ServiceListAPIResponse } from '../../../../../server/lib/services/get_s
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
 import { fontSizes, truncate } from '../../../../style/variables';
 import { asDecimal, asMillis } from '../../../../utils/formatters';
-import { APMLink } from '../../../shared/Links/APMLink';
+import { APMLink } from '../../../shared/Links/apm/APMLink';
 import { ManagedTable } from '../../../shared/ManagedTable';
 import { EnvironmentBadge } from '../../../shared/EnvironmentBadge';
 

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
@@ -27,7 +27,7 @@ import { useFetcher } from '../../../hooks/useFetcher';
 import { ITableColumn, ManagedTable } from '../../shared/ManagedTable';
 import { AgentConfigurationListAPIResponse } from '../../../../server/lib/settings/agent_configuration/list_configurations';
 import { AddSettingsFlyout } from './AddSettings/AddSettingFlyout';
-import { APMLink } from '../../shared/Links/APMLink';
+import { APMLink } from '../../shared/Links/apm/APMLink';
 import { LoadingStatePrompt } from '../../shared/LoadingStatePrompt';
 
 export type Config = AgentConfigurationListAPIResponse[0];

--- a/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -13,7 +13,7 @@ import { fontSizes, truncate } from '../../../style/variables';
 import { asMillis } from '../../../utils/formatters';
 import { EmptyMessage } from '../../shared/EmptyMessage';
 import { ImpactBar } from '../../shared/ImpactBar';
-import { TransactionLink } from '../../shared/Links/TransactionLink';
+import { TransactionLink } from '../../shared/Links/apm/TransactionLink';
 import { ITableColumn, ManagedTable } from '../../shared/ManagedTable';
 import { LoadingStatePrompt } from '../../shared/LoadingStatePrompt';
 

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/ErrorCountBadge.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/ErrorCountBadge.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import { idx } from '@kbn/elastic-idx';
 import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import { fontSize } from '../../../../style/variables';
-import { APMLink } from '../../../shared/Links/APMLink';
+import { APMLink } from '../../../shared/Links/apm/APMLink';
 
 const LinkLabel = styled.span`
   font-size: ${fontSize};

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/FlyoutTopLevelProperties.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/FlyoutTopLevelProperties.tsx
@@ -11,8 +11,8 @@ import {
   TRANSACTION_NAME
 } from '../../../../../../../common/elasticsearch_fieldnames';
 import { Transaction } from '../../../../../../../typings/es_schemas/ui/Transaction';
-import { APMLink } from '../../../../../shared/Links/APMLink';
-import { TransactionLink } from '../../../../../shared/Links/TransactionLink';
+import { APMLink } from '../../../../../shared/Links/apm/APMLink';
+import { TransactionLink } from '../../../../../shared/Links/apm/TransactionLink';
 import { StickyProperties } from '../../../../../shared/StickyProperties';
 
 interface Props {

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
@@ -18,7 +18,7 @@ import { Location } from 'history';
 import React from 'react';
 import { Transaction as ITransaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
-import { TransactionLink } from '../../../shared/Links/TransactionLink';
+import { TransactionLink } from '../../../shared/Links/apm/TransactionLink';
 import { TransactionActionMenu } from '../../../shared/TransactionActionMenu/TransactionActionMenu';
 import { StickyTransactionProperties } from './StickyTransactionProperties';
 import { TransactionTabs } from './TransactionTabs';

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -16,7 +16,7 @@ import { ImpactBar } from '../../../shared/ImpactBar';
 import { ITableColumn, ManagedTable } from '../../../shared/ManagedTable';
 import { LoadingStatePrompt } from '../../../shared/LoadingStatePrompt';
 import { EmptyMessage } from '../../../shared/EmptyMessage';
-import { TransactionLink } from '../../../shared/Links/TransactionLink';
+import { TransactionLink } from '../../../shared/Links/apm/TransactionLink';
 
 const TransactionNameLink = styled(TransactionLink)`
   ${truncate('100%')};

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -118,7 +118,7 @@ export function TransactionOverview({ urlParams }: Props) {
             onChange={event => {
               history.push({
                 ...location,
-                pathname: `/${urlParams.serviceName}/transactions`,
+                pathname: `/services/${urlParams.serviceName}/transactions`,
                 search: fromQuery({
                   ...toQuery(location.search),
                   transactionType: event.target.value

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/APMLink.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/APMLink.test.tsx
@@ -6,7 +6,7 @@
 
 import { Location } from 'history';
 import React from 'react';
-import { getRenderedHref } from '../../../utils/testHelpers';
+import { getRenderedHref } from '../../../../utils/testHelpers';
 import { APMLink } from './APMLink';
 
 test('APMLink should produce the correct URL', async () => {

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/APMLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/APMLink.tsx
@@ -8,9 +8,9 @@ import { EuiLink, EuiLinkAnchorProps } from '@elastic/eui';
 import React from 'react';
 import url from 'url';
 import { pick } from 'lodash';
-import { useLocation } from '../../../hooks/useLocation';
-import { APMQueryParams, toQuery, fromQuery } from './url_helpers';
-import { TIMEPICKER_DEFAULTS } from '../../../context/UrlParamsContext/constants';
+import { useLocation } from '../../../../hooks/useLocation';
+import { APMQueryParams, toQuery, fromQuery } from '../url_helpers';
+import { TIMEPICKER_DEFAULTS } from '../../../../context/UrlParamsContext/constants';
 
 interface Props extends EuiLinkAnchorProps {
   path?: string;

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/TransactionLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/TransactionLink.tsx
@@ -5,11 +5,11 @@
  */
 
 import React from 'react';
-import { Transaction } from '../../../../typings/es_schemas/ui/Transaction';
+import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 import { APMLink } from './APMLink';
 
 interface TransactionLinkProps {
-  transaction?: Transaction;
+  transaction: Transaction | undefined;
 }
 
 export const TransactionLink: React.SFC<TransactionLinkProps> = ({

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -79,26 +79,14 @@ export async function getTransactionBreakdown({
   };
 
   const filters = [
-    {
-      term: {
-        [SERVICE_NAME]: {
-          value: serviceName
-        }
-      }
-    },
-    {
-      term: {
-        [TRANSACTION_TYPE]: {
-          value: transactionType
-        }
-      }
-    },
+    { term: { [SERVICE_NAME]: serviceName } },
+    { term: { [TRANSACTION_TYPE]: transactionType } },
     { range: rangeFilter(start, end) },
     ...uiFiltersES
   ];
 
   if (transactionName) {
-    filters.push({ term: { [TRANSACTION_NAME]: { value: transactionName } } });
+    filters.push({ term: { [TRANSACTION_NAME]: transactionName } });
   }
 
   const params = {
@@ -107,7 +95,7 @@ export async function getTransactionBreakdown({
       size: 0,
       query: {
         bool: {
-          must: filters
+          filter: filters
         }
       },
       aggs: {


### PR DESCRIPTION
 - Use `filter` instead of `must` for breakdown queries (Closes #41322)
 - Move APM links into `apm` link folder.
 - Use `TransactionLink` instead of `APMLink` when link to transaction details page