### PR TITLE
[APM] Surface http errors to users

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/NoServicesMessage.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/NoServicesMessage.tsx
@@ -10,16 +10,22 @@ import React from 'react';
 import { KibanaLink } from '../../shared/Links/KibanaLink';
 import { SetupInstructionsLink } from '../../shared/Links/SetupInstructionsLink';
 import { LoadingStatePrompt } from '../../shared/LoadingStatePrompt';
+import { FETCH_STATUS } from '../../../hooks/useFetcher';
+import { ErrorStatePrompt } from '../../shared/ErrorStatePrompt';
 
 interface Props {
   // any data submitted from APM agents found (not just in the given time range)
   historicalDataFound: boolean;
-  isLoading: boolean;
+  status: FETCH_STATUS | undefined;
 }
 
-export function NoServicesMessage({ historicalDataFound, isLoading }: Props) {
-  if (isLoading) {
+export function NoServicesMessage({ historicalDataFound, status }: Props) {
+  if (status === 'loading') {
     return <LoadingStatePrompt />;
+  }
+
+  if (status === 'failure') {
+    return <ErrorStatePrompt />;
   }
 
   if (historicalDataFound) {

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/NoServicesMessage.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/NoServicesMessage.test.tsx
@@ -7,19 +7,20 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import { NoServicesMessage } from '../NoServicesMessage';
+import { FETCH_STATUS } from '../../../../hooks/useFetcher';
 
 describe('NoServicesMessage', () => {
-  it('should show only a "not found" message when historical data is found', () => {
-    const wrapper = shallow(
-      <NoServicesMessage isLoading={false} historicalDataFound={true} />
-    );
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it('should show a "no services installed" message, a link to the set up instructions page, a message about upgrading APM server, and a link to the upgrade assistant when NO historical data is found', () => {
-    const wrapper = shallow(
-      <NoServicesMessage isLoading={false} historicalDataFound={false} />
-    );
-    expect(wrapper).toMatchSnapshot();
+  Object.values(FETCH_STATUS).forEach(status => {
+    [true, false].forEach(historicalDataFound => {
+      it(`status: ${status} and historicalDataFound: ${historicalDataFound}`, () => {
+        const wrapper = shallow(
+          <NoServicesMessage
+            status={status}
+            historicalDataFound={historicalDataFound}
+          />
+        );
+        expect(wrapper).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/NoServicesMessage.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/NoServicesMessage.test.tsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NoServicesMessage should show a "no services installed" message, a link to the set up instructions page, a message about upgrading APM server, and a link to the upgrade assistant when NO historical data is found 1`] = `
+exports[`NoServicesMessage status: failure and historicalDataFound: false 1`] = `<ErrorStatePrompt />`;
+
+exports[`NoServicesMessage status: failure and historicalDataFound: true 1`] = `<ErrorStatePrompt />`;
+
+exports[`NoServicesMessage status: loading and historicalDataFound: false 1`] = `<LoadingStatePrompt />`;
+
+exports[`NoServicesMessage status: loading and historicalDataFound: true 1`] = `<LoadingStatePrompt />`;
+
+exports[`NoServicesMessage status: success and historicalDataFound: false 1`] = `
 <EuiEmptyPrompt
   actions={
     <SetupInstructionsLink
@@ -35,7 +43,7 @@ exports[`NoServicesMessage should show a "no services installed" message, a link
 />
 `;
 
-exports[`NoServicesMessage should show only a "not found" message when historical data is found 1`] = `
+exports[`NoServicesMessage status: success and historicalDataFound: true 1`] = `
 <EuiEmptyPrompt
   iconColor="subdued"
   title={

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/index.tsx
@@ -82,7 +82,7 @@ export function ServiceOverview() {
         noItemsMessage={
           <NoServicesMessage
             historicalDataFound={data.hasHistoricalData}
-            isLoading={status === 'loading'}
+            status={status}
           />
         }
       />

--- a/x-pack/legacy/plugins/apm/public/components/shared/ErrorStatePrompt.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/ErrorStatePrompt.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiEmptyPrompt } from '@elastic/eui';
+
+export function ErrorStatePrompt() {
+  return (
+    <EuiEmptyPrompt
+      title={
+        <div>
+          {i18n.translate('xpack.apm.error.prompt.title', {
+            defaultMessage: `Sorry, an error occured :(`
+          })}
+        </div>
+      }
+      body={i18n.translate('xpack.apm.error.prompt.body', {
+        defaultMessage: `Please inspect your browser's developer console for details.`
+      })}
+      titleSize="s"
+    />
+  );
+}

--- a/x-pack/legacy/plugins/apm/public/context/UrlParamsContext/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/UrlParamsContext/index.tsx
@@ -23,16 +23,8 @@ interface TimeRange {
   rangeTo: string;
 }
 
-function useUiFilters({
-  kuery,
-  environment,
-  transactionType
-}: IUrlParams): UIFilters {
-  return useMemo(() => ({ kuery, environment, transactionType }), [
-    kuery,
-    environment,
-    transactionType
-  ]);
+function useUiFilters({ kuery, environment }: IUrlParams): UIFilters {
+  return useMemo(() => ({ kuery, environment }), [kuery, environment]);
 }
 
 const defaultRefresh = (time: TimeRange) => {};

--- a/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { useContext, useEffect, useState, useMemo } from 'react';
+import React, { useContext, useEffect, useState, useMemo } from 'react';
 import { toastNotifications } from 'ui/notify';
 import { idx } from '@kbn/elastic-idx/target';
 import { i18n } from '@kbn/i18n';
@@ -67,7 +67,23 @@ export function useFetcher<Response>(
             title: i18n.translate('xpack.apm.fetcher.error.title', {
               defaultMessage: `Error while fetching resource`
             }),
-            text: `${idx(err.res, r => r.status)}: ${idx(err.res, r => r.url)}`
+            text: (
+              <div>
+                <h5>
+                  {i18n.translate('xpack.apm.fetcher.error.status', {
+                    defaultMessage: `Error`
+                  })}
+                </h5>
+                {idx(err.res, r => r.statusText)} ({idx(err.res, r => r.status)}
+                )
+                <h5>
+                  {i18n.translate('xpack.apm.fetcher.error.url', {
+                    defaultMessage: `URL`
+                  })}
+                </h5>
+                {idx(err.res, r => r.url)}
+              </div>
+            )
           });
           dispatchStatus({ id, isLoading: false });
           setResult({

--- a/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
@@ -5,8 +5,12 @@
  */
 
 import { useContext, useEffect, useState, useMemo } from 'react';
+import { toastNotifications } from 'ui/notify';
+import { idx } from '@kbn/elastic-idx/target';
+import { i18n } from '@kbn/i18n';
 import { LoadingIndicatorContext } from '../context/LoadingIndicatorContext';
 import { useComponentId } from './useComponentId';
+import { KFetchError } from '../../../../../../src/legacy/ui/public/kfetch/kfetch_error';
 
 export enum FETCH_STATUS {
   LOADING = 'loading',
@@ -16,7 +20,7 @@ export enum FETCH_STATUS {
 
 export function useFetcher<Response>(
   fn: () => Promise<Response> | undefined,
-  effectKey: any[],
+  fnDeps: any[],
   options: { preservePreviousResponse?: boolean } = {}
 ) {
   const { preservePreviousResponse = true } = options;
@@ -40,11 +44,11 @@ export function useFetcher<Response>(
 
       dispatchStatus({ id, isLoading: true });
 
-      setResult({
-        data: preservePreviousResponse ? result.data : undefined, // preserve data from previous state while loading next state
+      setResult(prevResult => ({
+        data: preservePreviousResponse ? prevResult.data : undefined, // preserve data from previous state while loading next state
         status: FETCH_STATUS.LOADING,
         error: undefined
-      });
+      }));
 
       try {
         const data = await promise;
@@ -57,7 +61,14 @@ export function useFetcher<Response>(
           });
         }
       } catch (e) {
+        const err = e as KFetchError;
         if (!didCancel) {
+          toastNotifications.addWarning({
+            title: i18n.translate('xpack.apm.fetcher.error.title', {
+              defaultMessage: `Error while fetching resource`
+            }),
+            text: `${idx(err.res, r => r.status)}: ${idx(err.res, r => r.url)}`
+          });
           dispatchStatus({ id, isLoading: false });
           setResult({
             data: undefined,
@@ -80,7 +91,7 @@ export function useFetcher<Response>(
     id,
     preservePreviousResponse,
     dispatchStatus,
-    ...effectKey
+    ...fnDeps
     /* eslint-enable react-hooks/exhaustive-deps */
   ]);
 
@@ -88,7 +99,7 @@ export function useFetcher<Response>(
     () => ({
       ...result,
       refresh: () => {
-        // this will invalidate the effectKey and will result in a new request
+        // this will invalidate the deps to `useEffect` and will result in a new request
         setCounter(count => count + 1);
       }
     }),


### PR DESCRIPTION
Closes #40986 

**For components that don't handle errors explicitly a generic toast error will be displayed**
<img width="1164" alt="Screen Shot 2019-07-29 at 17 33 03" src="https://user-images.githubusercontent.com/209966/62061885-4eae6a00-b228-11e9-932a-8d81088734a1.png">

**The only component that handle errors explicitly is the service overview (this being the first page the users see, it's probably a bit more important)**
<img width="1183" alt="Screen Shot 2019-07-29 at 16 27 20" src="https://user-images.githubusercontent.com/209966/62061880-4bb37980-b228-11e9-9653-05e295021349.png">