### PR TITLE
FTR: fix testSubjects.missingOrFail

### DIFF
--- a/test/functional/page_objects/dashboard_page.js
+++ b/test/functional/page_objects/dashboard_page.js
@@ -434,6 +434,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
         // Note: this replacement of - to space is to preserve original logic but I'm not sure why or if it's needed.
         await searchFilter.type(dashName.replace('-', ' '));
         await PageObjects.common.pressEnterKey();
+        await find.waitForDeletedByCssSelector('.euiBasicTable-loading', 5000);
       });
 
       await PageObjects.header.waitUntilLoadingHasFinished();
@@ -464,7 +465,7 @@ export function DashboardPageProvider({ getService, getPageObjects }) {
         await this.selectDashboard(dashName);
         await PageObjects.header.waitUntilLoadingHasFinished();
         // check Dashboard landing page is not present
-        await testSubjects.missingOrFail('newItemButton');
+        await testSubjects.missingOrFail('dashboardLandingPage', { timeout: 10000 });
       });
     }
 

--- a/test/functional/page_objects/discover_page.js
+++ b/test/functional/page_objects/discover_page.js
@@ -248,7 +248,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
     }
 
     async expectMissingFieldListItemVisualize(field) {
-      await testSubjects.missingOrFail(`fieldVisualize-${field}`);
+      await testSubjects.missingOrFail(`fieldVisualize-${field}`, { allowHidden: true });
     }
 
     async clickFieldListPlusFilter(field, value) {
@@ -288,7 +288,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
       const fieldFilterFormExists = await testSubjects.exists('discoverFieldFilter');
       if (fieldFilterFormExists) {
         await testSubjects.click('toggleFieldFilterButton');
-        await testSubjects.missingOrFail('discoverFieldFilter');
+        await testSubjects.missingOrFail('discoverFieldFilter', { allowHidden: true });
       }
     }
 

--- a/test/functional/services/find.ts
+++ b/test/functional/services/find.ts
@@ -32,6 +32,7 @@ export async function FindProvider({ getService }: FtrProviderContext) {
   const browserType = webdriver.browserType;
 
   const WAIT_FOR_EXISTS_TIME = config.get('timeouts.waitForExists');
+  const POLLING_TIME = 500;
   const defaultFindTimeout = config.get('timeouts.find');
   const fixedHeaderHeight = config.get('layout.fixedHeaderHeight');
 
@@ -426,7 +427,7 @@ export async function FindProvider({ getService }: FtrProviderContext) {
       timeout: number = defaultFindTimeout
     ) {
       log.debug(`Find.waitForDeletedByCssSelector('${selector}') with timeout=${timeout}`);
-      await this._withTimeout(1000);
+      await this._withTimeout(POLLING_TIME);
       await driver.wait(
         async () => {
           const found = await driver.findElements(By.css(selector));

--- a/test/functional/services/test_subjects.ts
+++ b/test/functional/services/test_subjects.ts
@@ -59,10 +59,14 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
 
     public async missingOrFail(
       selector: string,
-      timeout: number = WAIT_FOR_EXISTS_TIME
+      options: ExistsOptions = {}
     ): Promise<void | never> {
+      const { timeout = WAIT_FOR_EXISTS_TIME, allowHidden = false } = options;
+
       log.debug(`TestSubjects.missingOrFail(${selector})`);
-      await find.waitForDeletedByCssSelector(testSubjSelector(selector), timeout);
+      return await (allowHidden
+        ? this.waitForHidden(selector, timeout)
+        : find.waitForDeletedByCssSelector(testSubjSelector(selector), timeout));
     }
 
     public async append(selector: string, text: string): Promise<void> {
@@ -242,6 +246,12 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
       value: string
     ): Promise<void> {
       await find.waitForAttributeToChange(testSubjSelector(selector), attribute, value);
+    }
+
+    public async waitForHidden(selector: string, timeout?: number): Promise<void> {
+      log.debug(`TestSubjects.waitForHidden(${selector})`);
+      const element = await this.find(selector);
+      await find.waitForElementHidden(element, timeout);
     }
 
     public getCssSelector(selector: string): string {

--- a/test/functional/services/test_subjects.ts
+++ b/test/functional/services/test_subjects.ts
@@ -59,11 +59,10 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
 
     public async missingOrFail(
       selector: string,
-      existsOptions?: ExistsOptions
+      timeout: number = WAIT_FOR_EXISTS_TIME
     ): Promise<void | never> {
-      if (await this.exists(selector, existsOptions)) {
-        throw new Error(`expected testSubject(${selector}) to not exist`);
-      }
+      log.debug(`TestSubjects.missingOrFail(${selector})`);
+      await find.waitForDeletedByCssSelector(testSubjSelector(selector), timeout);
     }
 
     public async append(selector: string, text: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes #42226

There is an issue with `testSubjects.missingOrFail` function using `testSubjects.exists` logic:
`exists` returns the result **as soon as the element is found & ignoring timeout** for `missingOrFail`

It means that `missingOrFail('#my_id', 1000)` or `missingOrFail('#my_id', 20000)` will both fail if element still be present right when function is called (1st second)

It was working fine for the case when element immediately goes away from DOM, but won't work if it sits in DOM for a while and then be gone.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

