### PR TITLE
Remove kbnServer from task manager RunContext

### DIFF
--- a/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js
+++ b/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js
@@ -8,7 +8,7 @@ import _ from 'lodash';
 import { TASK_ID, scheduleTask, registerMapsTelemetryTask } from './telemetry_task';
 
 export function initTelemetryCollection(server) {
-  registerMapsTelemetryTask(server.taskManager);
+  registerMapsTelemetryTask(server);
   scheduleTask(server, server.taskManager);
   registerMapsUsageCollector(server);
 }

--- a/x-pack/legacy/plugins/maps/server/maps_telemetry/telemetry_task.js
+++ b/x-pack/legacy/plugins/maps/server/maps_telemetry/telemetry_task.js
@@ -34,24 +34,24 @@ export function scheduleTask(server, taskManager) {
   });
 }
 
-export function registerMapsTelemetryTask(taskManager) {
+export function registerMapsTelemetryTask(server) {
+  const taskManager = server.taskManager;
   taskManager.registerTaskDefinitions({
     [TELEMETRY_TASK_TYPE]: {
       title: 'Maps telemetry fetch task',
       type: TELEMETRY_TASK_TYPE,
       timeout: '1m',
       numWorkers: 2,
-      createTaskRunner: telemetryTaskRunner(),
+      createTaskRunner: telemetryTaskRunner(server),
     },
   });
 }
 
-export function telemetryTaskRunner() {
+export function telemetryTaskRunner(server) {
 
-  return ({ kbnServer, taskInstance }) => {
+  return ({ taskInstance }) => {
     const { state } = taskInstance;
     const prevState = state;
-    const { server } = kbnServer;
     let mapsTelemetry = {};
 
     const callCluster = server.plugins.elasticsearch.getCluster('admin')

--- a/x-pack/legacy/plugins/maps/server/maps_telemetry/telemetry_task.test.js
+++ b/x-pack/legacy/plugins/maps/server/maps_telemetry/telemetry_task.test.js
@@ -20,16 +20,15 @@ describe('telemetryTaskRunner', () => {
   });
 
   test('Returns empty stats on error', async () => {
-    const kbnServer = { server: mockKbnServer };
     const getNextMidnight = () =>
       moment()
         .add(1, 'days')
         .startOf('day')
         .toDate();
 
-    const getRunner = telemetryTaskRunner();
+    const getRunner = telemetryTaskRunner(mockKbnServer);
     const runResult = await getRunner(
-      { kbnServer, taskInstance: mockTaskInstance }
+      { taskInstance: mockTaskInstance }
     ).run();
 
     expect(runResult).toMatchObject({

--- a/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/index.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/index.ts
@@ -16,9 +16,9 @@ export function registerTasks(server: HapiServer) {
       title: 'X-Pack telemetry calculator for Visualizations',
       type: VIS_TELEMETRY_TASK,
       numWorkers: VIS_TELEMETRY_TASK_NUM_WORKERS, // by default it's 100% their workers
-      createTaskRunner({ taskInstance, kbnServer }: { kbnServer: any; taskInstance: any }) {
+      createTaskRunner({ taskInstance }: { taskInstance: any }) {
         return {
-          run: visualizationsTaskRunner(taskInstance, kbnServer),
+          run: visualizationsTaskRunner(taskInstance, server),
         };
       },
     },

--- a/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/visualizations/task_runner.test.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/visualizations/task_runner.test.ts
@@ -26,7 +26,7 @@ describe('visualizationsTaskRunner', () => {
       const mockCallWithInternal = () => Promise.reject(new Error('Things did not go well!'));
       mockKbnServer = getMockKbnServer(mockCallWithInternal);
 
-      const runner = visualizationsTaskRunner(mockTaskInstance, { server: mockKbnServer });
+      const runner = visualizationsTaskRunner(mockTaskInstance, mockKbnServer);
       const result = await runner();
       expect(result).toMatchObject({
         error: 'Things did not go well!',
@@ -45,7 +45,7 @@ describe('visualizationsTaskRunner', () => {
         .startOf('day')
         .toDate();
 
-    const runner = visualizationsTaskRunner(mockTaskInstance, { server: mockKbnServer });
+    const runner = visualizationsTaskRunner(mockTaskInstance, mockKbnServer);
     const result = await runner();
 
     expect(result).toMatchObject({
@@ -125,7 +125,7 @@ describe('visualizationsTaskRunner', () => {
     ]);
     mockKbnServer = getMockKbnServer(mockCallWithInternal);
 
-    const runner = visualizationsTaskRunner(mockTaskInstance, { server: mockKbnServer });
+    const runner = visualizationsTaskRunner(mockTaskInstance, mockKbnServer);
     const result = await runner();
 
     expect(result).toMatchObject({

--- a/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/visualizations/task_runner.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/visualizations/task_runner.ts
@@ -72,11 +72,7 @@ async function getStats(callCluster: (method: string, params: any) => Promise<an
   });
 }
 
-export function visualizationsTaskRunner(
-  taskInstance: TaskInstance,
-  kbnServer: { server: HapiServer }
-) {
-  const { server } = kbnServer;
+export function visualizationsTaskRunner(taskInstance: TaskInstance, server: HapiServer) {
   const { callWithInternalUser: callCluster } = server.plugins.elasticsearch.getCluster('data');
   const config = server.config();
   const index = config.get('kibana.index').toString(); // cast to string for TypeScript

--- a/x-pack/legacy/plugins/task_manager/README.md
+++ b/x-pack/legacy/plugins/task_manager/README.md
@@ -80,7 +80,7 @@ taskManager.registerTaskDefinitions({
     numWorkers: 2,
 
     // The createTaskRunner function / method returns an object that is responsible for
-    // performing the work of the task. context: { taskInstance, kbnServer }, is documented below.
+    // performing the work of the task. context: { taskInstance }, is documented below.
     createTaskRunner(context) {
       return {
         // Perform the work of the task. The return value should fit the TaskResult interface, documented
@@ -106,9 +106,6 @@ When Kibana attempts to claim and run a task instance, it looks its definition u
 
 ```js
 {
-  // An instance of the Kibana server object.
-  kbnServer,
-
   // The data associated with this instance of the task, with two properties being most notable:
   //
   // params:

--- a/x-pack/legacy/plugins/task_manager/task.ts
+++ b/x-pack/legacy/plugins/task_manager/task.ts
@@ -21,12 +21,6 @@ export type ElasticJs = (action: string, args: any) => Promise<any>;
  */
 export interface RunContext {
   /**
-   * The Kibana server object. This gives tasks full-access to the server object,
-   * including the various ES options client functions
-   */
-  kbnServer: object;
-
-  /**
    * The document describing the task instance, its params, state, id, etc.
    */
   taskInstance: ConcreteTaskInstance;

--- a/x-pack/legacy/plugins/task_manager/task_manager.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.ts
@@ -78,7 +78,6 @@ export class TaskManager {
     const createRunner = (instance: ConcreteTaskInstance) =>
       new TaskManagerRunner({
         logger,
-        kbnServer: opts.kbnServer,
         instance,
         store,
         definitions: this.definitions,

--- a/x-pack/legacy/plugins/task_manager/task_runner.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_runner.test.ts
@@ -604,7 +604,6 @@ describe('TaskManagerRunner', () => {
       maxAttempts: 5,
     };
     const runner = new TaskManagerRunner({
-      kbnServer: sinon.stub(),
       beforeRun: context => Promise.resolve(context),
       logger,
       store,

--- a/x-pack/legacy/plugins/task_manager/task_runner.ts
+++ b/x-pack/legacy/plugins/task_manager/task_runner.ts
@@ -47,7 +47,6 @@ interface Opts {
   definitions: TaskDictionary<SanitizedTaskDefinition>;
   instance: ConcreteTaskInstance;
   store: Updatable;
-  kbnServer: any;
   beforeRun: BeforeRunFunction;
 }
 
@@ -65,7 +64,6 @@ export class TaskManagerRunner implements TaskRunner {
   private definitions: TaskDictionary<SanitizedTaskDefinition>;
   private logger: Logger;
   private store: Updatable;
-  private kbnServer: any;
   private beforeRun: BeforeRunFunction;
 
   /**
@@ -75,7 +73,6 @@ export class TaskManagerRunner implements TaskRunner {
    * @prop {TaskDefinition} definition - The definition of the task being run
    * @prop {ConcreteTaskInstance} instance - The record describing this particular task instance
    * @prop {Updatable} store - The store used to read / write tasks instance info
-   * @prop {kbnServer} kbnServer - An async function that provides the task's run context
    * @prop {BeforeRunFunction} beforeRun - A function that adjusts the run context prior to running the task
    * @memberof TaskManagerRunner
    */
@@ -84,7 +81,6 @@ export class TaskManagerRunner implements TaskRunner {
     this.definitions = opts.definitions;
     this.logger = opts.logger;
     this.store = opts.store;
-    this.kbnServer = opts.kbnServer;
     this.beforeRun = opts.beforeRun;
   }
 
@@ -142,7 +138,6 @@ export class TaskManagerRunner implements TaskRunner {
   public async run(): Promise<RunResult> {
     this.logger.debug(`Running task ${this}`);
     const modifiedContext = await this.beforeRun({
-      kbnServer: this.kbnServer,
       taskInstance: this.instance,
     });
 

--- a/x-pack/test/plugin_api_integration/plugins/task_manager/index.js
+++ b/x-pack/test/plugin_api_integration/plugins/task_manager/index.js
@@ -31,7 +31,7 @@ export default function (kibana) {
           // taskInstance.params has the following optional fields:
           // nextRunMilliseconds: number - If specified, the run method will return a runAt that is now + nextRunMilliseconds
           // failWith: string - If specified, the task will throw an error with the specified message
-          createTaskRunner: ({ kbnServer, taskInstance }) => ({
+          createTaskRunner: ({ taskInstance }) => ({
             async run() {
               const { params, state } = taskInstance;
               const prevState = state || { count: 0 };
@@ -40,7 +40,7 @@ export default function (kibana) {
                 throw new Error(params.failWith);
               }
 
-              const callCluster = kbnServer.server.plugins.elasticsearch.getCluster('admin').callWithInternalUser;
+              const callCluster = server.plugins.elasticsearch.getCluster('admin').callWithInternalUser;
               await callCluster('index', {
                 index: '.task_manager_test_result',
                 body: {


### PR DESCRIPTION
As we're preparing task manager to be migrated to new platform. The removal of `kbnServer` from the `RunContext` is necessary. The registration of tasks occurs within the initialization phase where developers can access `kbnServer` and extract whatever is needed from there within their plugin.