### PR TITLE
Change http result of action/alerts find api

### DIFF
--- a/x-pack/legacy/plugins/actions/server/actions_client.test.ts
+++ b/x-pack/legacy/plugins/actions/server/actions_client.test.ts
@@ -246,7 +246,11 @@ describe('find()', () => {
         {
           id: '1',
           type: 'type',
-          attributes: {},
+          attributes: {
+            config: {
+              foo: 'bar',
+            },
+          },
           references: [],
         },
       ],
@@ -258,7 +262,19 @@ describe('find()', () => {
     });
     savedObjectsClient.find.mockResolvedValueOnce(expectedResult);
     const result = await actionsClient.find({});
-    expect(result).toEqual(expectedResult);
+    expect(result).toEqual({
+      total: 1,
+      perPage: 10,
+      page: 1,
+      data: [
+        {
+          id: '1',
+          config: {
+            foo: 'bar',
+          },
+        },
+      ],
+    });
     expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.find.mock.calls[0]).toMatchInlineSnapshot(`
       Array [

--- a/x-pack/legacy/plugins/actions/server/routes/find.test.ts
+++ b/x-pack/legacy/plugins/actions/server/routes/find.test.ts
@@ -29,9 +29,9 @@ it('sends proper arguments to action find function', async () => {
   };
   const expectedResult = {
     total: 0,
-    per_page: 10,
+    perPage: 10,
     page: 1,
-    saved_objects: [],
+    data: [],
   };
 
   actionsClient.find.mockResolvedValueOnce(expectedResult);

--- a/x-pack/legacy/plugins/alerting/server/alerts_client.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/alerts_client.test.ts
@@ -119,98 +119,98 @@ describe('create()', () => {
     });
     const result = await alertsClient.create({ data });
     expect(result).toMatchInlineSnapshot(`
-                        Object {
-                          "actions": Array [
-                            Object {
-                              "group": "default",
-                              "id": "1",
-                              "params": Object {
-                                "foo": true,
-                              },
-                            },
-                          ],
-                          "alertTypeId": "123",
-                          "alertTypeParams": Object {
-                            "bar": true,
-                          },
-                          "id": "1",
-                          "interval": "10s",
-                          "scheduledTaskId": "task-123",
-                        }
-                `);
+                              Object {
+                                "actions": Array [
+                                  Object {
+                                    "group": "default",
+                                    "id": "1",
+                                    "params": Object {
+                                      "foo": true,
+                                    },
+                                  },
+                                ],
+                                "alertTypeId": "123",
+                                "alertTypeParams": Object {
+                                  "bar": true,
+                                },
+                                "id": "1",
+                                "interval": "10s",
+                                "scheduledTaskId": "task-123",
+                              }
+                    `);
     expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.create.mock.calls[0]).toHaveLength(3);
     expect(savedObjectsClient.create.mock.calls[0][0]).toEqual('alert');
     expect(savedObjectsClient.create.mock.calls[0][1]).toMatchInlineSnapshot(`
-                        Object {
-                          "actions": Array [
-                            Object {
-                              "actionRef": "action_0",
-                              "group": "default",
-                              "params": Object {
-                                "foo": true,
-                              },
-                            },
-                          ],
-                          "alertTypeId": "123",
-                          "alertTypeParams": Object {
-                            "bar": true,
-                          },
-                          "enabled": true,
-                          "interval": "10s",
-                        }
-                `);
+                              Object {
+                                "actions": Array [
+                                  Object {
+                                    "actionRef": "action_0",
+                                    "group": "default",
+                                    "params": Object {
+                                      "foo": true,
+                                    },
+                                  },
+                                ],
+                                "alertTypeId": "123",
+                                "alertTypeParams": Object {
+                                  "bar": true,
+                                },
+                                "enabled": true,
+                                "interval": "10s",
+                              }
+                    `);
     expect(savedObjectsClient.create.mock.calls[0][2]).toMatchInlineSnapshot(`
-                                    Object {
-                                      "references": Array [
-                                        Object {
-                                          "id": "1",
-                                          "name": "action_0",
-                                          "type": "action",
-                                        },
-                                      ],
-                                    }
-                        `);
+                                          Object {
+                                            "references": Array [
+                                              Object {
+                                                "id": "1",
+                                                "name": "action_0",
+                                                "type": "action",
+                                              },
+                                            ],
+                                          }
+                            `);
     expect(taskManager.schedule).toHaveBeenCalledTimes(1);
     expect(taskManager.schedule.mock.calls[0]).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "params": Object {
-            "alertId": "1",
-            "basePath": "/s/default",
-          },
-          "scope": Array [
-            "alerting",
-          ],
-          "state": Object {
-            "alertInstances": Object {},
-            "alertTypeState": Object {},
-            "previousStartedAt": null,
-          },
-          "taskType": "alerting:123",
-        },
-      ]
-    `);
+            Array [
+              Object {
+                "params": Object {
+                  "alertId": "1",
+                  "basePath": "/s/default",
+                },
+                "scope": Array [
+                  "alerting",
+                ],
+                "state": Object {
+                  "alertInstances": Object {},
+                  "alertTypeState": Object {},
+                  "previousStartedAt": null,
+                },
+                "taskType": "alerting:123",
+              },
+            ]
+        `);
     expect(savedObjectsClient.update).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.update.mock.calls[0]).toHaveLength(4);
     expect(savedObjectsClient.update.mock.calls[0][0]).toEqual('alert');
     expect(savedObjectsClient.update.mock.calls[0][1]).toEqual('1');
     expect(savedObjectsClient.update.mock.calls[0][2]).toMatchInlineSnapshot(`
-                                    Object {
-                                      "scheduledTaskId": "task-123",
-                                    }
-                        `);
+                                          Object {
+                                            "scheduledTaskId": "task-123",
+                                          }
+                            `);
     expect(savedObjectsClient.update.mock.calls[0][3]).toMatchInlineSnapshot(`
-                                    Object {
-                                      "references": Array [
-                                        Object {
-                                          "id": "1",
-                                          "name": "action_0",
-                                          "type": "action",
-                                        },
-                                      ],
-                                    }
-                        `);
+                                          Object {
+                                            "references": Array [
+                                              Object {
+                                                "id": "1",
+                                                "name": "action_0",
+                                                "type": "action",
+                                              },
+                                            ],
+                                          }
+                            `);
   });
 
   test('creates a disabled alert', async () => {
@@ -251,25 +251,25 @@ describe('create()', () => {
     });
     const result = await alertsClient.create({ data });
     expect(result).toMatchInlineSnapshot(`
-                                    Object {
-                                      "actions": Array [
-                                        Object {
-                                          "group": "default",
-                                          "id": "1",
-                                          "params": Object {
-                                            "foo": true,
-                                          },
-                                        },
-                                      ],
-                                      "alertTypeId": "123",
-                                      "alertTypeParams": Object {
-                                        "bar": true,
-                                      },
-                                      "enabled": false,
-                                      "id": "1",
-                                      "interval": 10000,
-                                    }
-                        `);
+                                          Object {
+                                            "actions": Array [
+                                              Object {
+                                                "group": "default",
+                                                "id": "1",
+                                                "params": Object {
+                                                  "foo": true,
+                                                },
+                                              },
+                                            ],
+                                            "alertTypeId": "123",
+                                            "alertTypeParams": Object {
+                                              "bar": true,
+                                            },
+                                            "enabled": false,
+                                            "id": "1",
+                                            "interval": 10000,
+                                          }
+                            `);
     expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
     expect(taskManager.schedule).toHaveBeenCalledTimes(0);
   });
@@ -350,11 +350,11 @@ describe('create()', () => {
     );
     expect(savedObjectsClient.delete).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.delete.mock.calls[0]).toMatchInlineSnapshot(`
-                                    Array [
-                                      "alert",
-                                      "1",
-                                    ]
-                        `);
+                                          Array [
+                                            "alert",
+                                            "1",
+                                          ]
+                            `);
   });
 
   test('returns task manager error if cleanup fails, logs to console', async () => {
@@ -399,14 +399,14 @@ describe('create()', () => {
     );
     expect(alertsClientParams.log).toHaveBeenCalledTimes(1);
     expect(alertsClientParams.log.mock.calls[0]).toMatchInlineSnapshot(`
-                                    Array [
-                                      Array [
-                                        "alerting",
-                                        "error",
-                                      ],
-                                      "Failed to cleanup alert \\"1\\" after scheduling task failed. Error: Saved object delete error",
-                                    ]
-                        `);
+                                          Array [
+                                            Array [
+                                              "alerting",
+                                              "error",
+                                            ],
+                                            "Failed to cleanup alert \\"1\\" after scheduling task failed. Error: Saved object delete error",
+                                          ]
+                            `);
   });
 
   test('throws an error if alert type not registerd', async () => {
@@ -575,31 +575,31 @@ describe('get()', () => {
     });
     const result = await alertsClient.get({ id: '1' });
     expect(result).toMatchInlineSnapshot(`
-                        Object {
-                          "actions": Array [
-                            Object {
-                              "group": "default",
-                              "id": "1",
-                              "params": Object {
-                                "foo": true,
-                              },
-                            },
-                          ],
-                          "alertTypeId": "123",
-                          "alertTypeParams": Object {
-                            "bar": true,
-                          },
-                          "id": "1",
-                          "interval": "10s",
-                        }
-                `);
+                              Object {
+                                "actions": Array [
+                                  Object {
+                                    "group": "default",
+                                    "id": "1",
+                                    "params": Object {
+                                      "foo": true,
+                                    },
+                                  },
+                                ],
+                                "alertTypeId": "123",
+                                "alertTypeParams": Object {
+                                  "bar": true,
+                                },
+                                "id": "1",
+                                "interval": "10s",
+                              }
+                    `);
     expect(savedObjectsClient.get).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.get.mock.calls[0]).toMatchInlineSnapshot(`
-                                    Array [
-                                      "alert",
-                                      "1",
-                                    ]
-                        `);
+                                          Array [
+                                            "alert",
+                                            "1",
+                                          ]
+                            `);
   });
 
   test(`throws an error when references aren't found`, async () => {
@@ -670,34 +670,39 @@ describe('find()', () => {
     });
     const result = await alertsClient.find();
     expect(result).toMatchInlineSnapshot(`
-                        Array [
-                          Object {
-                            "actions": Array [
-                              Object {
-                                "group": "default",
-                                "id": "1",
-                                "params": Object {
-                                  "foo": true,
-                                },
-                              },
-                            ],
-                            "alertTypeId": "123",
-                            "alertTypeParams": Object {
-                              "bar": true,
-                            },
-                            "id": "1",
-                            "interval": "10s",
-                          },
-                        ]
-                `);
+      Object {
+        "data": Array [
+          Object {
+            "actions": Array [
+              Object {
+                "group": "default",
+                "id": "1",
+                "params": Object {
+                  "foo": true,
+                },
+              },
+            ],
+            "alertTypeId": "123",
+            "alertTypeParams": Object {
+              "bar": true,
+            },
+            "id": "1",
+            "interval": "10s",
+          },
+        ],
+        "page": 1,
+        "perPage": 10,
+        "total": 1,
+      }
+    `);
     expect(savedObjectsClient.find).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.find.mock.calls[0]).toMatchInlineSnapshot(`
-                                    Array [
-                                      Object {
-                                        "type": "alert",
-                                      },
-                                    ]
-                        `);
+                                          Array [
+                                            Object {
+                                              "type": "alert",
+                                            },
+                                          ]
+                            `);
   });
 });
 
@@ -739,17 +744,17 @@ describe('delete()', () => {
     expect(result).toEqual({ success: true });
     expect(savedObjectsClient.delete).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.delete.mock.calls[0]).toMatchInlineSnapshot(`
-                                    Array [
-                                      "alert",
-                                      "1",
-                                    ]
-                        `);
+                                          Array [
+                                            "alert",
+                                            "1",
+                                          ]
+                            `);
     expect(taskManager.remove).toHaveBeenCalledTimes(1);
     expect(taskManager.remove.mock.calls[0]).toMatchInlineSnapshot(`
-                                    Array [
-                                      "task-123",
-                                    ]
-                        `);
+                                          Array [
+                                            "task-123",
+                                          ]
+                            `);
   });
 });
 
@@ -821,58 +826,58 @@ describe('update()', () => {
       },
     });
     expect(result).toMatchInlineSnapshot(`
-                        Object {
-                          "actions": Array [
-                            Object {
-                              "group": "default",
-                              "id": "1",
-                              "params": Object {
-                                "foo": true,
-                              },
-                            },
-                          ],
-                          "alertTypeParams": Object {
-                            "bar": true,
-                          },
-                          "enabled": true,
-                          "id": "1",
-                          "interval": "10s",
-                          "scheduledTaskId": "task-123",
-                        }
-                `);
+                              Object {
+                                "actions": Array [
+                                  Object {
+                                    "group": "default",
+                                    "id": "1",
+                                    "params": Object {
+                                      "foo": true,
+                                    },
+                                  },
+                                ],
+                                "alertTypeParams": Object {
+                                  "bar": true,
+                                },
+                                "enabled": true,
+                                "id": "1",
+                                "interval": "10s",
+                                "scheduledTaskId": "task-123",
+                              }
+                    `);
     expect(savedObjectsClient.update).toHaveBeenCalledTimes(1);
     expect(savedObjectsClient.update.mock.calls[0]).toHaveLength(4);
     expect(savedObjectsClient.update.mock.calls[0][0]).toEqual('alert');
     expect(savedObjectsClient.update.mock.calls[0][1]).toEqual('1');
     expect(savedObjectsClient.update.mock.calls[0][2]).toMatchInlineSnapshot(`
-            Object {
-              "actions": Array [
-                Object {
-                  "actionRef": "action_0",
-                  "group": "default",
-                  "params": Object {
-                    "foo": true,
-                  },
-                },
-              ],
-              "alertTypeParams": Object {
-                "bar": true,
-              },
-              "interval": "10s",
-            }
-        `);
+                  Object {
+                    "actions": Array [
+                      Object {
+                        "actionRef": "action_0",
+                        "group": "default",
+                        "params": Object {
+                          "foo": true,
+                        },
+                      },
+                    ],
+                    "alertTypeParams": Object {
+                      "bar": true,
+                    },
+                    "interval": "10s",
+                  }
+            `);
     expect(savedObjectsClient.update.mock.calls[0][3]).toMatchInlineSnapshot(`
-                                    Object {
-                                      "references": Array [
-                                        Object {
-                                          "id": "1",
-                                          "name": "action_0",
-                                          "type": "action",
-                                        },
-                                      ],
-                                      "version": "123",
-                                    }
-                        `);
+                                          Object {
+                                            "references": Array [
+                                              Object {
+                                                "id": "1",
+                                                "name": "action_0",
+                                                "type": "action",
+                                              },
+                                            ],
+                                            "version": "123",
+                                          }
+                            `);
   });
 
   it('should validate alertTypeParams', async () => {

--- a/x-pack/legacy/plugins/alerting/server/alerts_client.ts
+++ b/x-pack/legacy/plugins/alerting/server/alerts_client.ts
@@ -34,6 +34,13 @@ interface FindOptions {
   };
 }
 
+interface FindResult {
+  page: number;
+  perPage: number;
+  total: number;
+  data: object[];
+}
+
 interface CreateOptions {
   data: Alert;
   options?: {
@@ -124,14 +131,22 @@ export class AlertsClient {
     return this.getAlertFromRaw(result.id, result.attributes, result.references);
   }
 
-  public async find({ options = {} }: FindOptions = {}) {
+  public async find({ options = {} }: FindOptions = {}): Promise<FindResult> {
     const results = await this.savedObjectsClient.find({
       ...options,
       type: 'alert',
     });
-    return results.saved_objects.map(result =>
+
+    const data = results.saved_objects.map(result =>
       this.getAlertFromRaw(result.id, result.attributes, result.references)
     );
+
+    return {
+      page: results.page,
+      perPage: results.per_page,
+      total: results.total,
+      data,
+    };
   }
 
   public async delete({ id }: { id: string }) {

--- a/x-pack/legacy/plugins/alerting/server/routes/find.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/routes/find.test.ts
@@ -26,11 +26,18 @@ test('sends proper arguments to alert find function', async () => {
       'fields=description',
   };
 
-  alertsClient.find.mockResolvedValueOnce([]);
+  const expectedResult = {
+    page: 1,
+    perPage: 1,
+    total: 0,
+    data: [],
+  };
+
+  alertsClient.find.mockResolvedValueOnce(expectedResult);
   const { payload, statusCode } = await server.inject(request);
   expect(statusCode).toBe(200);
   const response = JSON.parse(payload);
-  expect(response).toEqual([]);
+  expect(response).toEqual(expectedResult);
   expect(alertsClient.find).toHaveBeenCalledTimes(1);
   expect(alertsClient.find.mock.calls[0]).toMatchInlineSnapshot(`
 Array [

--- a/x-pack/test/api_integration/apis/actions/find.ts
+++ b/x-pack/test/api_integration/apis/actions/find.ts
@@ -26,17 +26,12 @@ export default function findActionTests({ getService }: KibanaFunctionalTestDefa
         .then((resp: any) => {
           expect(resp.body).to.eql({
             page: 1,
-            per_page: 20,
+            perPage: 20,
             total: 1,
-            saved_objects: [
+            data: [
               {
                 id: ES_ARCHIVER_ACTION_ID,
-                type: 'action',
-                version: resp.body.saved_objects[0].version,
-                references: [],
-                attributes: {
-                  description: 'My action',
-                },
+                description: 'My action',
               },
             ],
           });
@@ -50,20 +45,15 @@ export default function findActionTests({ getService }: KibanaFunctionalTestDefa
         .then((resp: any) => {
           expect(resp.body).to.eql({
             page: 1,
-            per_page: 20,
+            perPage: 20,
             total: 1,
-            saved_objects: [
+            data: [
               {
                 id: ES_ARCHIVER_ACTION_ID,
-                type: 'action',
-                version: resp.body.saved_objects[0].version,
-                references: [],
-                attributes: {
-                  description: 'My action',
-                  actionTypeId: 'test.index-record',
-                  config: {
-                    unencrypted: `This value shouldn't get encrypted`,
-                  },
+                description: 'My action',
+                actionTypeId: 'test.index-record',
+                config: {
+                  unencrypted: `This value shouldn't get encrypted`,
                 },
               },
             ],

--- a/x-pack/test/api_integration/apis/alerting/find.ts
+++ b/x-pack/test/api_integration/apis/alerting/find.ts
@@ -41,7 +41,11 @@ export default function createFindTests({ getService }: KibanaFunctionalTestDefa
         .get('/api/alert/_find')
         .expect(200)
         .then((resp: any) => {
-          const match = resp.body.find((obj: any) => obj.id === alertId);
+          const body = resp.body;
+          expect(body.page).to.equal(1);
+          expect(body.perPage).to.be.greaterThan(0);
+          expect(body.total).to.be.greaterThan(0);
+          const match = body.data.find((obj: any) => obj.id === alertId);
           expect(match).to.eql({
             id: alertId,
             alertTypeId: 'test.noop',


### PR DESCRIPTION
This PR changes the shape of the result of the HTTP find endpoints
for actions and alerts, from the raw result from saved object find,
to:

    {
      page: 1,
      perPage: 10000,
      total: 1,
      data: [ {item}, {item} ... ],
    }

The changes are:

- `per_page` renamed to `perPage`
- `saved_objects` renamed to `data`
- each item is an object with the `id` of the item, and the
  properties from the `saved_objects[x].attributes` copied into
  that (eg, for actions, that will be `description`, `actionTypeId`
  and `config`)

see: issue https://github.com/elastic/kibana/issues/41828#issuecomment-514398058

