### PR TITLE
Fix task manager flaky middleware test

### DIFF
--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_manager_integration.js
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_manager_integration.js
@@ -22,12 +22,16 @@ export default function ({ getService }) {
       .set('kbn-xsrf', 'xxx')
       .expect(200));
 
-    beforeEach(async () =>
-      (await es.indices.exists({ index: testHistoryIndex })) && es.deleteByQuery({
-        index: testHistoryIndex,
-        q: 'type:task',
-        refresh: true,
-      }));
+    beforeEach(async () => {
+      const exists = await es.indices.exists({ index: testHistoryIndex });
+      if (exists) {
+        await es.deleteByQuery({
+          index: testHistoryIndex,
+          q: 'type:task',
+          refresh: true,
+        });
+      }
+    });
 
     function currentTasks() {
       return supertest.get('/api/sample_tasks')


### PR DESCRIPTION
Fixes #42098. 

After attempting to reproduce the issue with multiple Jenkins instances running in parallel and running the test 100 times in a row, I was not able to reproduce the issue. What we'll do for now is re-enable the test suite, cleanup the code (no longer asserting on the `attempts` attribute) and add debug logs in case the flakiness happens again.