### PR TITLE
[7.x] add await for browser calls (#42515)

### DIFF
--- a/x-pack/test/functional/apps/dashboard_mode/dashboard_view_mode.js
+++ b/x-pack/test/functional/apps/dashboard_mode/dashboard_view_mode.js
@@ -40,7 +40,7 @@ export default function ({ getService, getPageObjects }) {
       await kibanaServer.uiSettings.replace({
         'defaultIndex': 'logstash-*'
       });
-      browser.setWindowSize(1600, 1000);
+      await browser.setWindowSize(1600, 1000);
 
       await PageObjects.common.navigateToApp('discover');
       await PageObjects.dashboard.setTimepickerInHistoricalDataRange();

--- a/x-pack/test/functional/apps/grok_debugger/grok_debugger.js
+++ b/x-pack/test/functional/apps/grok_debugger/grok_debugger.js
@@ -17,7 +17,7 @@ export default function ({ getService, getPageObjects }) {
       await esArchiver.load('empty_kibana');
       // Increase window height to ensure "Simulate" button is shown above the
       // fold. Otherwise it can't be clicked by the browser driver.
-      browser.setWindowSize(1600, 1000);
+      await browser.setWindowSize(1600, 1000);
 
       await PageObjects.grokDebugger.gotoGrokDebugger();
     });

--- a/x-pack/test/functional/apps/maps/index.js
+++ b/x-pack/test/functional/apps/maps/index.js
@@ -19,8 +19,7 @@ export default function ({ loadTestFile, getService }) {
       await kibanaServer.uiSettings.replace({
         'defaultIndex': 'logstash-*'
       });
-      browser.setWindowSize(1600, 1000);
-
+      await browser.setWindowSize(1600, 1000);
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/security/doc_level_security_roles.js
+++ b/x-pack/test/functional/apps/security/doc_level_security_roles.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
     before('initialize tests', async () => {
       await esArchiver.load('empty_kibana');
       await esArchiver.loadIfNeeded('security/dlstest');
-      browser.setWindowSize(1600, 1000);
+      await browser.setWindowSize(1600, 1000);
 
       await PageObjects.settings.createIndexPattern('dlstest', null);
 

--- a/x-pack/test/functional/apps/security/field_level_security.js
+++ b/x-pack/test/functional/apps/security/field_level_security.js
@@ -18,7 +18,7 @@ export default function ({ getService, getPageObjects }) {
     before('initialize tests', async () => {
       await esArchiver.loadIfNeeded('security/flstest/data'); //( data)
       await esArchiver.load('security/flstest/kibana'); //(savedobject)
-      browser.setWindowSize(1600, 1000);
+      await browser.setWindowSize(1600, 1000);
     });
 
     it('should add new role a_viewssnrole', async function () {

--- a/x-pack/test/functional/page_objects/security_page.js
+++ b/x-pack/test/functional/page_objects/security_page.js
@@ -79,7 +79,7 @@ export function SecurityPageProvider({ getService, getPageObjects }) {
       log.debug('SecurityPage:initTests');
       await esArchiver.load('empty_kibana');
       await esArchiver.loadIfNeeded('logstash_functional');
-      browser.setWindowSize(1600, 1000);
+      await browser.setWindowSize(1600, 1000);
     }
 
     async login(username, password, options = {}) {

--- a/x-pack/test/visual_regression/tests/maps/index.js
+++ b/x-pack/test/visual_regression/tests/maps/index.js
@@ -17,7 +17,7 @@ export default function ({ loadTestFile, getService }) {
       await kibanaServer.uiSettings.replace({
         'defaultIndex': 'logstash-*'
       });
-      browser.setWindowSize(1600, 1000);
+      await browser.setWindowSize(1600, 1000);
 
     });
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - add await for browser calls (#42515)