### PR TITLE
[APM] Avoid APM failing to start when ml is disabled

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
@@ -14,6 +14,7 @@ import { i18n } from '@kbn/i18n';
 import { memoize } from 'lodash';
 import React, { Fragment } from 'react';
 import { InternalCoreStart } from 'src/core/public';
+import { idx } from '@kbn/elastic-idx';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { LicenseContext } from '../../../../context/LicenseContext';
 import { MachineLearningFlyout } from './MachineLearningFlyout';
@@ -33,7 +34,7 @@ export class ServiceIntegrations extends React.Component<Props, State> {
   static contextType = CoreContext;
   public state: State = { isPopoverOpen: false, activeFlyout: null };
 
-  public getPanelItems = memoize((mlAvailable: boolean) => {
+  public getPanelItems = memoize((mlAvailable: boolean | undefined) => {
     let panelItems: EuiContextMenuPanelItemDescriptor[] = [];
     if (mlAvailable) {
       panelItems = panelItems.concat(this.getMLPanelItems());
@@ -147,7 +148,9 @@ export class ServiceIntegrations extends React.Component<Props, State> {
                 panels={[
                   {
                     id: 0,
-                    items: this.getPanelItems(license.features.ml.is_available)
+                    items: this.getPanelItems(
+                      idx(license, _ => _.features.ml.is_available)
+                    )
                   }
                 ]}
               />

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
@@ -18,6 +18,7 @@ import { Location } from 'history';
 import React, { Component } from 'react';
 import { isEmpty, flatten } from 'lodash';
 import styled from 'styled-components';
+import { idx } from '@kbn/elastic-idx';
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
 import { Coordinate, TimeSeries } from '../../../../../typings/timeseries';
 import { ITransactionChartData } from '../../../../selectors/chartSelectors';
@@ -87,7 +88,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
       : NOT_AVAILABLE_LABEL;
   };
 
-  public renderMLHeader(hasValidMlLicense: boolean) {
+  public renderMLHeader(hasValidMlLicense: boolean | undefined) {
     const { hasMLJob } = this.props;
     if (!hasValidMlLicense || !hasMLJob) {
       return null;
@@ -161,7 +162,9 @@ export class TransactionCharts extends Component<TransactionChartProps> {
                 </EuiFlexItem>
                 <LicenseContext.Consumer>
                   {license =>
-                    this.renderMLHeader(license.features.ml.is_available)
+                    this.renderMLHeader(
+                      idx(license, _ => _.features.ml.is_available)
+                    )
                   }
                 </LicenseContext.Consumer>
               </EuiFlexGroup>

--- a/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
@@ -8,10 +8,12 @@ import { FETCH_STATUS, useFetcher } from '../../hooks/useFetcher';
 import { loadLicense, LicenseApiResponse } from '../../services/rest/xpack';
 import { InvalidLicenseNotification } from './InvalidLicenseNotification';
 
-const initialLicense = {
+const initialLicense: LicenseApiResponse = {
   features: {},
-  license: { is_active: false }
-} as LicenseApiResponse;
+  license: {
+    is_active: false
+  }
+};
 export const LicenseContext = React.createContext(initialLicense);
 
 export const LicenseProvider: React.FC = ({ children }) => {

--- a/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
@@ -5,16 +5,13 @@
  */
 import React from 'react';
 import { FETCH_STATUS, useFetcher } from '../../hooks/useFetcher';
-import { loadLicense } from '../../services/rest/xpack';
+import { loadLicense, LicenseApiResponse } from '../../services/rest/xpack';
 import { InvalidLicenseNotification } from './InvalidLicenseNotification';
 
 const initialLicense = {
-  features: {
-    watcher: { is_available: false },
-    ml: { is_available: false }
-  },
+  features: {},
   license: { is_active: false }
-};
+} as LicenseApiResponse;
 export const LicenseContext = React.createContext(initialLicense);
 
 export const LicenseProvider: React.FC = ({ children }) => {

--- a/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
@@ -6,7 +6,7 @@
 
 import React, { useContext, useEffect, useState, useMemo } from 'react';
 import { toastNotifications } from 'ui/notify';
-import { idx } from '@kbn/elastic-idx/target';
+import { idx } from '@kbn/elastic-idx';
 import { i18n } from '@kbn/i18n';
 import { LoadingIndicatorContext } from '../context/LoadingIndicatorContext';
 import { useComponentId } from './useComponentId';

--- a/x-pack/legacy/plugins/apm/public/services/rest/xpack.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/xpack.ts
@@ -14,25 +14,25 @@ export interface LicenseApiResponse {
     type: string;
   };
   features: {
-    beats_management: StringMap;
-    graph: StringMap;
-    grokdebugger: StringMap;
-    index_management: StringMap;
-    logstash: StringMap;
-    ml: {
+    beats_management?: StringMap;
+    graph?: StringMap;
+    grokdebugger?: StringMap;
+    index_management?: StringMap;
+    logstash?: StringMap;
+    ml?: {
       is_available: boolean;
       license_type: number;
       has_expired: boolean;
       enable_links: boolean;
       show_links: boolean;
     };
-    reporting: StringMap;
-    rollup: StringMap;
-    searchprofiler: StringMap;
-    security: StringMap;
-    spaces: StringMap;
-    tilemap: StringMap;
-    watcher: {
+    reporting?: StringMap;
+    rollup?: StringMap;
+    searchprofiler?: StringMap;
+    security?: StringMap;
+    spaces?: StringMap;
+    tilemap?: StringMap;
+    watcher?: {
       is_available: boolean;
       enable_links: boolean;
       show_links: boolean;

--- a/x-pack/legacy/plugins/apm/public/services/rest/xpack.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/xpack.ts
@@ -9,9 +9,7 @@ import { callApi } from './callApi';
 
 export interface LicenseApiResponse {
   license: {
-    expiry_date_in_millis: number;
     is_active: boolean;
-    type: string;
   };
   features: {
     beats_management?: StringMap;

--- a/x-pack/legacy/plugins/apm/server/lib/helpers/convert_ui_filters/get_kuery_ui_filter_es.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/helpers/convert_ui_filters/get_kuery_ui_filter_es.ts
@@ -6,7 +6,7 @@
 
 import { ESFilter } from 'elasticsearch';
 import { Server } from 'hapi';
-import { idx } from '@kbn/elastic-idx/target';
+import { idx } from '@kbn/elastic-idx';
 import { toElasticsearchQuery, fromKueryExpression } from '@kbn/es-query';
 import { ISavedObject } from '../../../../public/services/rest/savedObjects';
 import { StaticIndexPattern } from '../../../../../../../../src/legacy/core_plugins/data/public';


### PR DESCRIPTION
Closes #39747

Our types for the license endpoint were incorrect which was the reason the bug could slip through.