### PR TITLE
Display server error message when SO import fails

### DIFF
--- a/src/core/server/saved_objects/import/create_limit_stream.ts
+++ b/src/core/server/saved_objects/import/create_limit_stream.ts
@@ -26,7 +26,7 @@ export function createLimitStream(limit: number) {
     objectMode: true,
     async transform(obj, enc, done) {
       if (counter >= limit) {
-        return done(Boom.badRequest(`Can't import more than ${limit} objects`));
+        return done(Boom.badRequest(`Can't import more than ${limit} objects.`));
       }
       counter++;
       done(undefined, obj);

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/components/flyout/flyout.js
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/components/flyout/flyout.js
@@ -140,7 +140,9 @@ class FlyoutUI extends Component {
         status: 'error',
         error: intl.formatMessage({
           id: 'kbn.management.objects.objectsTable.flyout.importFileErrorMessage',
-          defaultMessage: 'The file could not be processed.',
+          defaultMessage: 'The file could not be processed. Error: {errorMessage}',
+        }, {
+          errorMessage: e.body && e.body.message || e.message
         }),
       });
       return;
@@ -206,8 +208,10 @@ class FlyoutUI extends Component {
       this.setState({
         status: 'error',
         error: intl.formatMessage({
-          id: 'kbn.management.objects.objectsTable.flyout.resolveImportErrorsFileErrorMessage',
-          defaultMessage: 'The file could not be processed.',
+          id: 'kbn.management.objects.objectsTable.flyout.importFileErrorMessage',
+          defaultMessage: 'The file could not be processed. Error: {errorMessage}',
+        }, {
+          errorMessage: e.body && e.body.message || e.message
         }),
       });
     }
@@ -229,8 +233,10 @@ class FlyoutUI extends Component {
       this.setState({
         status: 'error',
         error: intl.formatMessage({
-          id: 'kbn.management.objects.objectsTable.flyout.importLegacyFileErrorMessage',
-          defaultMessage: 'The file could not be processed.',
+          id: 'kbn.management.objects.objectsTable.flyout.importFileErrorMessage',
+          defaultMessage: 'The file could not be processed. Error: {errorMessage}',
+        }, {
+          errorMessage: e.body && e.body.message || e.message
         }),
       });
       return;

--- a/src/legacy/server/saved_objects/routes/import.ts
+++ b/src/legacy/server/saved_objects/routes/import.ts
@@ -77,7 +77,7 @@ export const createImportRoute = (
     const { filename } = request.payload.file.hapi;
     const fileExtension = extname(filename).toLowerCase();
     if (fileExtension !== '.ndjson') {
-      return Boom.badRequest(`Invalid file extension ${fileExtension}`);
+      return Boom.badRequest(`Invalid file extension ${fileExtension}.`);
     }
 
     return await importSavedObjects({

--- a/src/legacy/server/saved_objects/routes/resolve_import_errors.ts
+++ b/src/legacy/server/saved_objects/routes/resolve_import_errors.ts
@@ -98,7 +98,7 @@ export const createResolveImportErrorsRoute = (
     const fileExtension = extname(filename).toLowerCase();
 
     if (fileExtension !== '.ndjson') {
-      return Boom.badRequest(`Invalid file extension ${fileExtension}`);
+      return Boom.badRequest(`Invalid file extension ${fileExtension}.`);
     }
 
     return await resolveImportErrors({


### PR DESCRIPTION
## Summary

Display server error message when Saved Objects import fails

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

