### PR TITLE
[6.8] bump chromedriver version to 76 (#42468)

### DIFF
--- a/package.json
+++ b/package.json
@@ -340,7 +340,7 @@
     "chance": "1.0.10",
     "cheerio": "0.22.0",
     "chokidar": "1.6.0",
-    "chromedriver": "^75.1.0",
+    "chromedriver": "^76.0.0",
     "classnames": "2.2.5",
     "dedent": "^0.7.0",
     "delete-empty": "^2.0.0",

--- a/test/functional/apps/dashboard/_time_zones.js
+++ b/test/functional/apps/dashboard/_time_zones.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
   const pieChart = getService('pieChart');
   const PageObjects = getPageObjects(['dashboard', 'header', 'settings', 'common']);
 
-  describe('dashboard time zones', () => {
+  describe.skip('dashboard time zones', () => {
     before(async () => {
       await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickKibanaSavedObjects();

--- a/test/functional/apps/dashboard/_time_zones.js
+++ b/test/functional/apps/dashboard/_time_zones.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
   const pieChart = getService('pieChart');
   const PageObjects = getPageObjects(['dashboard', 'header', 'settings', 'common']);
 
-  describe.skip('dashboard time zones', () => {
+  describe('dashboard time zones', () => {
     before(async () => {
       await PageObjects.settings.navigateTo();
       await PageObjects.settings.clickKibanaSavedObjects();

--- a/test/functional/apps/management/_index_pattern_filter.js
+++ b/test/functional/apps/management/_index_pattern_filter.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
   const retry = getService('retry');
   const PageObjects = getPageObjects(['settings']);
 
-  describe.skip('index pattern filter', function describeIndexTests() {
+  describe('index pattern filter', function describeIndexTests() {
     before(async function () {
       // delete .kibana index and then wait for Kibana to re-create it
       await kibanaServer.uiSettings.replace({});

--- a/test/functional/apps/management/_index_pattern_filter.js
+++ b/test/functional/apps/management/_index_pattern_filter.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
   const retry = getService('retry');
   const PageObjects = getPageObjects(['settings']);
 
-  describe('index pattern filter', function describeIndexTests() {
+  describe.skip('index pattern filter', function describeIndexTests() {
     before(async function () {
       // delete .kibana index and then wait for Kibana to re-create it
       await kibanaServer.uiSettings.replace({});

--- a/test/functional/apps/management/_kibana_settings.js
+++ b/test/functional/apps/management/_kibana_settings.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
   const browser = getService('browser');
   const PageObjects = getPageObjects(['settings', 'common', 'dashboard', 'header']);
 
-  describe('kibana settings', function describeIndexTests() {
+  describe.skip('kibana settings', function describeIndexTests() {
     before(async function () {
       // delete .kibana index and then wait for Kibana to re-create it
       await kibanaServer.uiSettings.replace({});

--- a/test/functional/apps/management/_kibana_settings.js
+++ b/test/functional/apps/management/_kibana_settings.js
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }) {
   const browser = getService('browser');
   const PageObjects = getPageObjects(['settings', 'common', 'dashboard', 'header']);
 
-  describe.skip('kibana settings', function describeIndexTests() {
+  describe('kibana settings', function describeIndexTests() {
     before(async function () {
       // delete .kibana index and then wait for Kibana to re-create it
       await kibanaServer.uiSettings.replace({});

--- a/test/functional/apps/visualize/_line_chart.js
+++ b/test/functional/apps/visualize/_line_chart.js
@@ -25,7 +25,7 @@ export default function ({ getService, getPageObjects }) {
   const retry = getService('retry');
   const PageObjects = getPageObjects(['common', 'visualize', 'header']);
 
-  describe('line charts', function () {
+  describe.skip('line charts', function () {
     const vizName1 = 'Visualization LineChart';
 
     const initLineChart = async function () {

--- a/test/functional/apps/visualize/_line_chart.js
+++ b/test/functional/apps/visualize/_line_chart.js
@@ -25,7 +25,7 @@ export default function ({ getService, getPageObjects }) {
   const retry = getService('retry');
   const PageObjects = getPageObjects(['common', 'visualize', 'header']);
 
-  describe.skip('line charts', function () {
+  describe('line charts', function () {
     const vizName1 = 'Visualization LineChart';
 
     const initLineChart = async function () {

--- a/test/functional/apps/visualize/_tag_cloud.js
+++ b/test/functional/apps/visualize/_tag_cloud.js
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }) {
   const find = getService('find');
   const PageObjects = getPageObjects(['common', 'visualize', 'header', 'settings']);
 
-  describe('tag cloud chart', function () {
+  describe.skip('tag cloud chart', function () {
     const vizName1 = 'Visualization tagCloud';
     const fromTime = '2015-09-19 06:31:44.000';
     const toTime = '2015-09-23 18:31:44.000';

--- a/test/functional/apps/visualize/_tag_cloud.js
+++ b/test/functional/apps/visualize/_tag_cloud.js
@@ -28,7 +28,7 @@ export default function ({ getService, getPageObjects }) {
   const find = getService('find');
   const PageObjects = getPageObjects(['common', 'visualize', 'header', 'settings']);
 
-  describe.skip('tag cloud chart', function () {
+  describe('tag cloud chart', function () {
     const vizName1 = 'Visualization tagCloud';
     const fromTime = '2015-09-19 06:31:44.000';
     const toTime = '2015-09-23 18:31:44.000';

--- a/test/functional/services/find.js
+++ b/test/functional/services/find.js
@@ -285,7 +285,7 @@ export function FindProvider({ getService }) {
       log.debug(`clickByCssSelector(${selector})`);
       await retry.try(async () => {
         const element = await this.byCssSelector(selector, timeout);
-        await element.moveMouseTo();
+        // await element.moveMouseTo();
         await element.click();
       });
     }

--- a/test/plugin_functional/test_suites/embedding_visualizations/index.js
+++ b/test/plugin_functional/test_suites/embedding_visualizations/index.js
@@ -23,7 +23,7 @@ export default function ({ getService, getPageObjects, loadTestFile }) {
   const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['common', 'header']);
 
-  describe.skip('embedding visualizations', function () {
+  describe('embedding visualizations', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('../functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('../functional/fixtures/es_archiver/visualize_embedding');

--- a/test/plugin_functional/test_suites/embedding_visualizations/index.js
+++ b/test/plugin_functional/test_suites/embedding_visualizations/index.js
@@ -23,7 +23,7 @@ export default function ({ getService, getPageObjects, loadTestFile }) {
   const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['common', 'header']);
 
-  describe('embedding visualizations', function () {
+  describe.skip('embedding visualizations', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('../functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.load('../functional/fixtures/es_archiver/visualize_embedding');

--- a/x-pack/test/functional/apps/logstash/pipeline_list.js
+++ b/x-pack/test/functional/apps/logstash/pipeline_list.js
@@ -167,7 +167,7 @@ export default function ({ getService, getPageObjects }) {
       });
     });
 
-    describe.skip('clone button', () => {
+    describe('clone button', () => {
       it('links to the pipeline editor with cloned pipeline details', async () => {
         // First, create a random pipeline
         await PageObjects.logstash.gotoNewPipelineEditor();

--- a/x-pack/test/functional/apps/logstash/pipeline_list.js
+++ b/x-pack/test/functional/apps/logstash/pipeline_list.js
@@ -167,7 +167,7 @@ export default function ({ getService, getPageObjects }) {
       });
     });
 
-    describe('clone button', () => {
+    describe.skip('clone button', () => {
       it('links to the pipeline editor with cloned pipeline details', async () => {
         // First, create a random pipeline
         await PageObjects.logstash.gotoNewPipelineEditor();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5442,10 +5442,10 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^75.1.0:
-  version "75.1.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-75.1.0.tgz#edfef5d7a9b16b6f8a12ddb58cbac76ae52732fd"
-  integrity sha512-N2P0fg6FS4c+tTG0R7cCOD5qiVo+E6uAz6xVjmbZesYv1xs1iGdcCUo0IqOY+ppD/4OOObG+XWV1CFWXT6UIgA==
+chromedriver@^76.0.0:
+  version "76.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-76.0.0.tgz#cbf618c5b370799ff6e15b23de07e80f67f89025"
+  integrity sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==
   dependencies:
     del "^4.1.1"
     extract-zip "^1.6.7"


### PR DESCRIPTION
Backports the following commits to 6.8:
 - bump chromedriver version to 76 (#42468)