### PR TITLE
Expose task manager as plugin instead of server argument

### DIFF
--- a/x-pack/legacy/plugins/actions/server/init.ts
+++ b/x-pack/legacy/plugins/actions/server/init.ts
@@ -62,7 +62,7 @@ export function init(server: Legacy.Server) {
     };
   }
 
-  const { taskManager } = server;
+  const taskManager = server.plugins.task_manager!;
   const actionTypeRegistry = new ActionTypeRegistry({
     getServices,
     taskManager: taskManager!,

--- a/x-pack/legacy/plugins/alerting/server/init.ts
+++ b/x-pack/legacy/plugins/alerting/server/init.ts
@@ -47,7 +47,7 @@ export function init(server: Legacy.Server) {
     };
   }
 
-  const { taskManager } = server;
+  const taskManager = server.plugins.task_manager!;
   const alertTypeRegistry = new AlertTypeRegistry({
     getServices,
     taskManager: taskManager!,

--- a/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js
+++ b/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js
@@ -9,7 +9,7 @@ import { TASK_ID, scheduleTask, registerMapsTelemetryTask } from './telemetry_ta
 
 export function initTelemetryCollection(server) {
   registerMapsTelemetryTask(server);
-  scheduleTask(server, server.taskManager);
+  scheduleTask(server, server.plugins.task_manager);
   registerMapsUsageCollector(server);
 }
 
@@ -20,8 +20,9 @@ async function isTaskManagerReady(server) {
 
 async function fetch(server) {
   let docs;
+  const taskManager = server.plugins.task_manager;
   try {
-    ({ docs } = await server.taskManager.fetch({
+    ({ docs } = await taskManager.fetch({
       query: {
         bool: {
           filter: {

--- a/x-pack/legacy/plugins/maps/server/maps_telemetry/telemetry_task.js
+++ b/x-pack/legacy/plugins/maps/server/maps_telemetry/telemetry_task.js
@@ -35,7 +35,7 @@ export function scheduleTask(server, taskManager) {
 }
 
 export function registerMapsTelemetryTask(server) {
-  const taskManager = server.taskManager;
+  const taskManager = server.plugins.task_manager;
   taskManager.registerTaskDefinitions({
     [TELEMETRY_TASK_TYPE]: {
       title: 'Maps telemetry fetch task',

--- a/x-pack/legacy/plugins/maps/server/test_utils/index.js
+++ b/x-pack/legacy/plugins/maps/server/test_utils/index.js
@@ -27,11 +27,6 @@ export const getMockTaskFetch = (docs = defaultMockTaskDocs) => {
 export const getMockKbnServer = (
   mockCallWithInternal = getMockCallWithInternal(),
   mockTaskFetch = getMockTaskFetch()) => ({
-  taskManager: {
-    registerTaskDefinitions: () => undefined,
-    schedule: () => Promise.resolve(),
-    fetch: mockTaskFetch,
-  },
   plugins: {
     elasticsearch: {
       getCluster: () => ({
@@ -39,6 +34,11 @@ export const getMockKbnServer = (
       }),
     },
     xpack_main: {},
+    task_manager: {
+      registerTaskDefinitions: () => undefined,
+      schedule: () => Promise.resolve(),
+      fetch: mockTaskFetch,
+    },
   },
   usage: {
     collectorSet: {

--- a/x-pack/legacy/plugins/oss_telemetry/index.d.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/index.d.ts
@@ -35,15 +35,6 @@ export interface TaskInstance {
 }
 
 export interface HapiServer {
-  taskManager: {
-    registerTaskDefinitions: (opts: any) => void;
-    schedule: (opts: any) => Promise<void>;
-    fetch: (
-      opts: any
-    ) => Promise<{
-      docs: TaskInstance[];
-    }>;
-  };
   plugins: {
     xpack_main: any;
     elasticsearch: {
@@ -52,6 +43,15 @@ export interface HapiServer {
       ) => {
         callWithInternalUser: () => Promise<ESQueryResponse>;
       };
+    };
+    task_manager: {
+      registerTaskDefinitions: (opts: any) => void;
+      schedule: (opts: any) => Promise<void>;
+      fetch: (
+        opts: any
+      ) => Promise<{
+        docs: TaskInstance[];
+      }>;
     };
   };
   usage: {

--- a/x-pack/legacy/plugins/oss_telemetry/server/lib/collectors/visualizations/get_usage_collector.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/server/lib/collectors/visualizations/get_usage_collector.ts
@@ -14,7 +14,7 @@ async function isTaskManagerReady(server: HapiServer) {
 }
 
 async function fetch(server: HapiServer) {
-  const { taskManager } = server;
+  const taskManager = server.plugins.task_manager!;
 
   let docs;
   try {

--- a/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/index.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/server/lib/tasks/index.ts
@@ -9,7 +9,7 @@ import { PLUGIN_ID, VIS_TELEMETRY_TASK, VIS_TELEMETRY_TASK_NUM_WORKERS } from '.
 import { visualizationsTaskRunner } from './visualizations/task_runner';
 
 export function registerTasks(server: HapiServer) {
-  const { taskManager } = server;
+  const taskManager = server.plugins.task_manager;
 
   taskManager.registerTaskDefinitions({
     [VIS_TELEMETRY_TASK]: {
@@ -26,7 +26,7 @@ export function registerTasks(server: HapiServer) {
 }
 
 export function scheduleTasks(server: HapiServer) {
-  const { taskManager } = server;
+  const taskManager = server.plugins.task_manager;
   const { kbnServer } = server.plugins.xpack_main.status.plugin;
 
   kbnServer.afterPluginsInit(() => {

--- a/x-pack/legacy/plugins/oss_telemetry/test_utils/index.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/test_utils/index.ts
@@ -34,11 +34,6 @@ export const getMockKbnServer = (
   mockCallWithInternal = getMockCallWithInternal(),
   mockTaskFetch = getMockTaskFetch()
 ): HapiServer => ({
-  taskManager: {
-    registerTaskDefinitions: (opts: any) => undefined,
-    schedule: (opts: any) => Promise.resolve(),
-    fetch: mockTaskFetch,
-  },
   plugins: {
     elasticsearch: {
       getCluster: (cluster: string) => ({
@@ -46,6 +41,11 @@ export const getMockKbnServer = (
       }),
     },
     xpack_main: {},
+    task_manager: {
+      registerTaskDefinitions: (opts: any) => undefined,
+      schedule: (opts: any) => Promise.resolve(),
+      fetch: mockTaskFetch,
+    },
   },
   usage: {
     collectorSet: {

--- a/x-pack/legacy/plugins/task_manager/README.md
+++ b/x-pack/legacy/plugins/task_manager/README.md
@@ -50,12 +50,12 @@ The task_manager can be configured via `taskManager` config options (e.g. `taskM
 
 ## Task definitions
 
-Plugins define tasks by calling the `registerTaskDefinitions` method on the `server.taskManager` object.
+Plugins define tasks by calling the `registerTaskDefinitions` method on the `server.plugins.task_manager` object.
 
 A sample task can be found in the [x-pack/test/plugin_api_integration/plugins/task_manager](../../test/plugin_api_integration/plugins/task_manager/index.js) folder.
 
 ```js
-const { taskManager } = server;
+const taskManager = server.plugins.task_manager;
 taskManager.registerTaskDefinitions({
   // clusterMonitoring is the task type, and must be unique across the entire system
   clusterMonitoring: {
@@ -215,7 +215,7 @@ The data stored for a task instance looks something like this:
 The task manager mixin exposes a taskManager object on the Kibana server which plugins can use to manage scheduled tasks. Each method takes an optional `scope` argument and ensures that only tasks with the specified scope(s) will be affected.
 
 ```js
-const { taskManager } = server;
+const taskManager = server.plugins.task_manager;
 // Schedules a task. All properties are as documented in the previous
 // storage section, except that here, params is an object, not a JSON
 // string.
@@ -258,7 +258,7 @@ For example:
 
 ```js
 // In your plugin's init
-server.taskManager.addMiddleware({
+server.plugins.task_manager.addMiddleware({
   async beforeSave({ taskInstance, ...opts }) {
     console.log(`About to save a task of type ${taskInstance.taskType}`);
 

--- a/x-pack/legacy/plugins/task_manager/index.d.ts
+++ b/x-pack/legacy/plugins/task_manager/index.d.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
-
-export { TaskManager } from './types';
-export { TaskInstance, ConcreteTaskInstance, TaskRunCreatorFunction } from './task';

--- a/x-pack/legacy/plugins/task_manager/index.ts
+++ b/x-pack/legacy/plugins/task_manager/index.ts
@@ -67,13 +67,11 @@ export function taskManager(kibana: any) {
         serializer,
       });
       const exposedFunctions: TaskManager = {
-        fetch: taskManagerInstance.fetch.bind(taskManagerInstance),
-        remove: taskManagerInstance.remove.bind(taskManagerInstance),
-        schedule: taskManagerInstance.schedule.bind(taskManagerInstance),
-        addMiddleware: taskManagerInstance.addMiddleware.bind(taskManagerInstance),
-        registerTaskDefinitions: taskManagerInstance.registerTaskDefinitions.bind(
-          taskManagerInstance
-        ),
+        fetch: (...args) => taskManagerInstance.fetch(...args),
+        remove: (...args) => taskManagerInstance.remove(...args),
+        schedule: (...args) => taskManagerInstance.schedule(...args),
+        addMiddleware: (...args) => taskManagerInstance.addMiddleware(...args),
+        registerTaskDefinitions: (...args) => taskManagerInstance.registerTaskDefinitions(...args),
       };
       server.expose(exposedFunctions);
     },

--- a/x-pack/legacy/plugins/task_manager/index.ts
+++ b/x-pack/legacy/plugins/task_manager/index.ts
@@ -7,7 +7,7 @@
 import { Root } from 'joi';
 import { Legacy } from 'kibana';
 import { SavedObjectsSerializer, SavedObjectsSchema } from '../../../../src/core/server';
-import { TaskManager as TaskMaangerClass } from './task_manager';
+import { TaskManager as TaskManagerClass } from './task_manager';
 import mappings from './mappings.json';
 import { migrations } from './migrations';
 import { TaskManager } from './types';
@@ -60,7 +60,7 @@ export function taskManager(kibana: any) {
         ['task']
       );
 
-      const taskManagerInstance = new TaskMaangerClass({
+      const taskManagerInstance = new TaskManagerClass({
         kbnServer: this.kbnServer,
         config,
         savedObjectsRepository,

--- a/x-pack/legacy/plugins/task_manager/index.ts
+++ b/x-pack/legacy/plugins/task_manager/index.ts
@@ -4,21 +4,29 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { Root } from 'joi';
+import { Legacy } from 'kibana';
 import { SavedObjectsSerializer, SavedObjectsSchema } from '../../../../src/core/server';
-import { TaskManager } from './task_manager';
+import { TaskManager as TaskMaangerClass } from './task_manager';
 import mappings from './mappings.json';
 import { migrations } from './migrations';
+import { TaskManager } from './types';
 
-export function taskManager(kibana) {
+export { TaskManager };
+export { TaskInstance, ConcreteTaskInstance, TaskRunCreatorFunction } from './task';
+
+export function taskManager(kibana: any) {
   return new kibana.Plugin({
     id: 'task_manager',
     require: ['kibana', 'elasticsearch', 'xpack_main'],
     configPrefix: 'xpack.task_manager',
-    config(Joi) {
+    config(Joi: Root) {
       return Joi.object({
         enabled: Joi.boolean().default(true),
         max_attempts: Joi.number()
-          .description('The maximum number of times a task will be attempted before being abandoned as failed')
+          .description(
+            'The maximum number of times a task will be attempted before being abandoned as failed'
+          )
           .min(1)
           .default(3),
         poll_interval: Joi.number()
@@ -29,16 +37,20 @@ export function taskManager(kibana) {
           .description('The name of the index used to store task information.')
           .default('.kibana_task_manager'),
         max_workers: Joi.number()
-          .description('The maximum number of tasks that this Kibana instance will run simultaneously.')
+          .description(
+            'The maximum number of tasks that this Kibana instance will run simultaneously.'
+          )
           .min(1) // disable the task manager rather than trying to specify it with 0 workers
           .default(10),
         override_num_workers: Joi.object()
           .pattern(/.*/, Joi.number().greater(0))
-          .description('Customize the number of workers occupied by specific tasks (e.g. override_num_workers.reporting: 2)')
-          .default({})
+          .description(
+            'Customize the number of workers occupied by specific tasks (e.g. override_num_workers.reporting: 2)'
+          )
+          .default({}),
       }).default();
     },
-    init(server) {
+    init(server: Legacy.Server) {
       const config = server.config();
       const schema = new SavedObjectsSchema(this.kbnServer.uiExports.savedObjectSchemas);
       const serializer = new SavedObjectsSerializer(schema);
@@ -48,13 +60,22 @@ export function taskManager(kibana) {
         ['task']
       );
 
-      const taskManager = new TaskManager({
+      const taskManagerInstance = new TaskMaangerClass({
         kbnServer: this.kbnServer,
         config,
         savedObjectsRepository,
         serializer,
       });
-      server.decorate('server', 'taskManager', taskManager);
+      const exposedFunctions: TaskManager = {
+        fetch: taskManagerInstance.fetch.bind(taskManagerInstance),
+        remove: taskManagerInstance.remove.bind(taskManagerInstance),
+        schedule: taskManagerInstance.schedule.bind(taskManagerInstance),
+        addMiddleware: taskManagerInstance.addMiddleware.bind(taskManagerInstance),
+        registerTaskDefinitions: taskManagerInstance.registerTaskDefinitions.bind(
+          taskManagerInstance
+        ),
+      };
+      server.expose(exposedFunctions);
     },
     uiExports: {
       mappings,
@@ -64,7 +85,7 @@ export function taskManager(kibana) {
           hidden: true,
           isNamespaceAgnostic: true,
           convertToAliasScript: `ctx._id = ctx._source.type + ':' + ctx._id`,
-          indexPattern(config) {
+          indexPattern(config: any) {
             return config.get('xpack.task_manager.index');
           },
         },

--- a/x-pack/legacy/plugins/task_manager/task_manager.mock.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.mock.ts
@@ -4,12 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { TaskManager } from './task_manager';
-
-type Schema = PublicMethodsOf<TaskManager>;
+import { TaskManager } from './types';
 
 const createTaskManagerMock = () => {
-  const mocked: jest.Mocked<Schema> = {
+  const mocked: jest.Mocked<TaskManager> = {
     registerTaskDefinitions: jest.fn(),
     addMiddleware: jest.fn(),
     schedule: jest.fn(),

--- a/x-pack/test/plugin_api_integration/plugins/task_manager/index.js
+++ b/x-pack/test/plugin_api_integration/plugins/task_manager/index.js
@@ -18,7 +18,7 @@ export default function (kibana) {
     },
 
     init(server) {
-      const { taskManager } = server;
+      const taskManager = server.plugins.task_manager;
 
       taskManager.registerTaskDefinitions({
         sampleTask: {

--- a/x-pack/test/plugin_api_integration/plugins/task_manager/init_routes.js
+++ b/x-pack/test/plugin_api_integration/plugins/task_manager/init_routes.js
@@ -24,7 +24,7 @@ const taskManagerQuery = {
 };
 
 export function initRoutes(server) {
-  const { taskManager } = server;
+  const taskManager = server.plugins.task_manager;
 
   server.route({
     path: '/api/sample_tasks',

--- a/x-pack/test/typings/hapi.d.ts
+++ b/x-pack/test/typings/hapi.d.ts
@@ -15,9 +15,6 @@ import { TaskManager } from '../../legacy/plugins/task_manager';
 import { AlertingPlugin, AlertsClient } from '../../legacy/plugins/alerting';
 
 declare module 'hapi' {
-  interface Server {
-    taskManager?: TaskManager;
-  }
   interface Request {
     getActionsClient?: () => ActionsClient;
     getAlertsClient?: () => AlertsClient;
@@ -29,5 +26,6 @@ declare module 'hapi' {
     encrypted_saved_objects?: EncryptedSavedObjectsPlugin;
     actions?: ActionsPlugin;
     alerting?: AlertingPlugin;
+    task_manager?: TaskManager;
   }
 }

--- a/x-pack/typings/hapi.d.ts
+++ b/x-pack/typings/hapi.d.ts
@@ -15,9 +15,6 @@ import { TaskManager } from '../legacy/plugins/task_manager';
 import { AlertingPlugin, AlertsClient } from '../legacy/plugins/alerting';
 
 declare module 'hapi' {
-  interface Server {
-    taskManager?: TaskManager;
-  }
   interface Request {
     getActionsClient?: () => ActionsClient;
     getAlertsClient?: () => AlertsClient;
@@ -29,5 +26,6 @@ declare module 'hapi' {
     encrypted_saved_objects?: EncryptedSavedObjectsPlugin;
     actions?: ActionsPlugin;
     alerting?: AlertingPlugin;
+    task_manager?: TaskManager;
   }
 }


### PR DESCRIPTION
Part of the new platform migration, task manager should be exposed as a plugin instead of an attribute on the server (`server.plugins.task_manager` instead of `server.taskManager`).

This PR converts the task manager to be exposed as a plugin. This also converts `task_manager/index.js` to typescript to leverage typescript checks to ensure all task manager functions are exposed.