### PR TITLE
[7.3] [apps/dashboard] skip part of filtering tests on FF (#43047)

### DIFF
--- a/test/functional/apps/dashboard/dashboard_filtering.js
+++ b/test/functional/apps/dashboard/dashboard_filtering.js
@@ -170,7 +170,10 @@ export default function ({ getService, getPageObjects }) {
       });
     });
 
-    describe('disabling a filter unfilters the data on', () => {
+    describe('disabling a filter unfilters the data on', function () {
+      // Flaky test
+      // https://github.com/elastic/kibana/issues/41087
+      this.tags('skipFirefox');
       before(async () => {
         await filterBar.toggleFilterEnabled('bytes');
         await PageObjects.header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
Backports the following commits to 7.3:
 - [apps/dashboard] skip part of filtering tests on FF (#43047)