### PR TITLE
[7.3] run chained_controls on Firefox to catch regression (#43044)

### DIFF
--- a/test/functional/apps/visualize/input_control_vis/chained_controls.js
+++ b/test/functional/apps/visualize/input_control_vis/chained_controls.js
@@ -26,7 +26,8 @@ export default function ({ getService, getPageObjects }) {
   const find = getService('find');
   const comboBox = getService('comboBox');
 
-  describe('chained controls', () => {
+  describe('chained controls', function () {
+    this.tags('smoke');
 
     before(async () => {
       await PageObjects.common.navigateToApp('visualize');


### PR DESCRIPTION
Backports the following commits to 7.3:
 - run chained_controls on Firefox to catch regression (#43044)