### PR TITLE
Changes "fire" to "execute" in actions

### DIFF
--- a/x-pack/legacy/plugins/actions/README.md
+++ b/x-pack/legacy/plugins/actions/README.md
@@ -21,7 +21,7 @@ action types.
 
 1. Develop and register an action type (see action types -> example).
 2. Create an action by using the RESTful API (see actions -> create action).
-3. Use alerts to fire actions or fire manually (see firing actions).
+3. Use alerts to execute actions or execute manually (see firing actions).
 
 ## Action types
 
@@ -51,7 +51,7 @@ This is the primary function for an action type. Whenever the action needs to ex
 |Property|Description|
 |---|---|
 |config|The decrypted configuration given to an action. This comes from the action saved object that is partially or fully encrypted within the data store. If you would like to validate the config before being passed to the executor, define `validate.config` within the action type.|
-|params|Parameters for the execution. These will be given at fire time by either an alert or manually provided when calling the plugin provided fire function.|
+|params|Parameters for the execution. These will be given at execution time by either an alert or manually provided when calling the plugin provided execute function.|
 |services.callCluster(path, opts)|Use this to do Elasticsearch queries on the cluster Kibana connects to. This function is the same as any other `callCluster` in Kibana.<br><br>**NOTE**: This currently authenticates as the Kibana internal user, but will change in a future PR.|
 |services.savedObjectsClient|This is an instance of the saved objects client. This provides the ability to do CRUD on any saved objects within the same space the alert lives in.<br><br>**NOTE**: This currently only works when security is disabled. A future PR will add support for enabling security using Elasticsearch API tokens.|
 |services.log(tags, [data], [timestamp])|Use this to create server logs. (This is the same function as server.log)|
@@ -119,13 +119,13 @@ Payload:
 |config|The configuration the action type expects. See related action type to see what attributes are expected. This will also validate against the action type if config validation is defined.|object|
 |secrets|The secrets the action type expects. See related action type to see what attributes are expected. This will also validate against the action type if secrets validation is defined.|object|
 
-#### `POST /api/action/{id}/_fire`: Fire action
+#### `POST /api/action/{id}/_execute`: Execute action
 
 Params:
 
 |Property|Description|Type|
 |---|---|---|
-|id|The id of the action you're trying to fire.|string|
+|id|The id of the action you're trying to execute.|string|
 
 Payload:
 
@@ -135,24 +135,24 @@ Payload:
 
 ## Firing actions
 
-The plugin exposes a fire function that you can use to fire actions.
+The plugin exposes an execute function that you can use to run actions.
 
-**server.plugins.actions.fire(options)**
+**server.plugins.actions.execute(options)**
 
 The following table describes the properties of the `options` object.
 
 |Property|Description|Type|
 |---|---|---|
-|id|The id of the action you want to fire.|string|
+|id|The id of the action you want to execute.|string|
 |params|The `params` value to give the action type executor.|object|
 |spaceId|The space id the action is within.|string|
 
 ### Example
 
-This example makes action `3c5b2bd4-5424-4e4b-8cf5-c0a58c762cc5` fire an email. The action plugin will load the saved object and find what action type to call with `params`.
+This example makes action `3c5b2bd4-5424-4e4b-8cf5-c0a58c762cc5` send an email. The action plugin will load the saved object and find what action type to call with `params`.
 
 ```
-server.plugins.actions.fire({
+server.plugins.actions.execute({
   id: '3c5b2bd4-5424-4e4b-8cf5-c0a58c762cc5',
   spaceId: 'default', // The spaceId of the action
   params: {

--- a/x-pack/legacy/plugins/actions/server/create_execute_function.test.ts
+++ b/x-pack/legacy/plugins/actions/server/create_execute_function.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { taskManagerMock } from '../../task_manager/task_manager.mock';
-import { createFireFunction } from './create_fire_function';
+import { createExecuteFunction } from './create_execute_function';
 import { SavedObjectsClientMock } from '../../../../../src/core/server/mocks';
 
 const mockTaskManager = taskManagerMock.create();
@@ -14,9 +14,9 @@ const spaceIdToNamespace = jest.fn();
 
 beforeEach(() => jest.resetAllMocks());
 
-describe('fire()', () => {
+describe('execute()', () => {
   test('schedules the action with all given parameters', async () => {
-    const fireFn = createFireFunction({
+    const executeFn = createExecuteFunction({
       taskManager: mockTaskManager,
       internalSavedObjectsRepository: savedObjectsClient,
       spaceIdToNamespace,
@@ -30,7 +30,7 @@ describe('fire()', () => {
       references: [],
     });
     spaceIdToNamespace.mockReturnValueOnce('namespace1');
-    await fireFn({
+    await executeFn({
       id: '123',
       params: { baz: false },
       spaceId: 'default',

--- a/x-pack/legacy/plugins/actions/server/create_execute_function.ts
+++ b/x-pack/legacy/plugins/actions/server/create_execute_function.ts
@@ -8,24 +8,24 @@ import { SavedObjectsClientContract } from 'src/core/server';
 import { TaskManager } from '../../task_manager';
 import { SpacesPlugin } from '../../spaces';
 
-interface CreateFireFunctionOptions {
+interface CreateExecuteFunctionOptions {
   taskManager: TaskManager;
   internalSavedObjectsRepository: SavedObjectsClientContract;
   spaceIdToNamespace: SpacesPlugin['spaceIdToNamespace'];
 }
 
-export interface FireOptions {
+export interface ExecuteOptions {
   id: string;
   params: Record<string, any>;
   spaceId: string;
 }
 
-export function createFireFunction({
+export function createExecuteFunction({
   taskManager,
   internalSavedObjectsRepository,
   spaceIdToNamespace,
-}: CreateFireFunctionOptions) {
-  return async function fire({ id, params, spaceId }: FireOptions) {
+}: CreateExecuteFunctionOptions) {
+  return async function execute({ id, params, spaceId }: ExecuteOptions) {
     const namespace = spaceIdToNamespace(spaceId);
     const actionSavedObject = await internalSavedObjectsRepository.get('action', id, { namespace });
     await taskManager.schedule({

--- a/x-pack/legacy/plugins/actions/server/init.ts
+++ b/x-pack/legacy/plugins/actions/server/init.ts
@@ -7,7 +7,7 @@
 import { Legacy } from 'kibana';
 import { ActionsClient } from './actions_client';
 import { ActionTypeRegistry } from './action_type_registry';
-import { createFireFunction } from './create_fire_function';
+import { createExecuteFunction } from './create_execute_function';
 import { ActionsPlugin, Services } from './types';
 import {
   createRoute,
@@ -16,7 +16,7 @@ import {
   getRoute,
   updateRoute,
   listActionTypesRoute,
-  fireRoute,
+  executeRoute,
 } from './routes';
 import { registerBuiltInActionTypes } from './builtin_action_types';
 import { SpacesPlugin } from '../../spaces';
@@ -86,13 +86,13 @@ export function init(server: Legacy.Server) {
   findRoute(server);
   updateRoute(server);
   listActionTypesRoute(server);
-  fireRoute({
+  executeRoute({
     server,
     actionTypeRegistry,
     getServices,
   });
 
-  const fireFn = createFireFunction({
+  const executeFn = createExecuteFunction({
     taskManager: taskManager!,
     internalSavedObjectsRepository: savedObjectsRepositoryWithInternalUser,
     spaceIdToNamespace(...args) {
@@ -111,7 +111,7 @@ export function init(server: Legacy.Server) {
     return actionsClient;
   });
   const exposedFunctions: ActionsPlugin = {
-    fire: fireFn,
+    execute: executeFn,
     registerType: actionTypeRegistry.register.bind(actionTypeRegistry),
     listTypes: actionTypeRegistry.list.bind(actionTypeRegistry),
   };

--- a/x-pack/legacy/plugins/actions/server/routes/execute.test.ts
+++ b/x-pack/legacy/plugins/actions/server/routes/execute.test.ts
@@ -9,22 +9,22 @@ jest.mock('../lib/execute', () => ({
 }));
 
 import { createMockServer } from './_mock_server';
-import { fireRoute } from './fire';
+import { executeRoute } from './execute';
 
 const getServices = jest.fn();
 
 const { server, actionTypeRegistry, savedObjectsClient } = createMockServer();
-fireRoute({ server, actionTypeRegistry, getServices });
+executeRoute({ server, actionTypeRegistry, getServices });
 
 beforeEach(() => jest.resetAllMocks());
 
-it('fires an action with proper parameters', async () => {
+it('executes an action with proper parameters', async () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { execute } = require('../lib/execute');
 
   const request = {
     method: 'POST',
-    url: '/api/action/1/_fire',
+    url: '/api/action/1/_execute',
     payload: {
       params: {
         foo: true,

--- a/x-pack/legacy/plugins/actions/server/routes/execute.ts
+++ b/x-pack/legacy/plugins/actions/server/routes/execute.ts
@@ -9,7 +9,7 @@ import Hapi from 'hapi';
 import { execute } from '../lib';
 import { ActionTypeRegistryContract, GetServicesFunction } from '../types';
 
-interface FireRequest extends Hapi.Request {
+interface ExecuteRequest extends Hapi.Request {
   params: {
     id: string;
   };
@@ -18,16 +18,16 @@ interface FireRequest extends Hapi.Request {
   };
 }
 
-interface FireRouteOptions {
+interface ExecuteRouteOptions {
   server: Hapi.Server;
   actionTypeRegistry: ActionTypeRegistryContract;
   getServices: GetServicesFunction;
 }
 
-export function fireRoute({ server, actionTypeRegistry, getServices }: FireRouteOptions) {
+export function executeRoute({ server, actionTypeRegistry, getServices }: ExecuteRouteOptions) {
   server.route({
     method: 'POST',
-    path: '/api/action/{id}/_fire',
+    path: '/api/action/{id}/_execute',
     options: {
       response: {
         emptyStatusCode: 204,
@@ -48,7 +48,7 @@ export function fireRoute({ server, actionTypeRegistry, getServices }: FireRoute
           .required(),
       },
     },
-    async handler(request: FireRequest, h: Hapi.ResponseToolkit) {
+    async handler(request: ExecuteRequest, h: Hapi.ResponseToolkit) {
       const { id } = request.params;
       const { params } = request.payload;
       const namespace = server.plugins.spaces && server.plugins.spaces.getSpaceId(request);

--- a/x-pack/legacy/plugins/actions/server/routes/index.ts
+++ b/x-pack/legacy/plugins/actions/server/routes/index.ts
@@ -10,4 +10,4 @@ export { findRoute } from './find';
 export { getRoute } from './get';
 export { updateRoute } from './update';
 export { listActionTypesRoute } from './list_action_types';
-export { fireRoute } from './fire';
+export { executeRoute } from './execute';

--- a/x-pack/legacy/plugins/actions/server/types.ts
+++ b/x-pack/legacy/plugins/actions/server/types.ts
@@ -6,7 +6,7 @@
 
 import { SavedObjectsClientContract } from 'src/core/server';
 import { ActionTypeRegistry } from './action_type_registry';
-import { FireOptions } from './create_fire_function';
+import { ExecuteOptions } from './create_execute_function';
 
 export type WithoutQueryAndParams<T> = Pick<T, Exclude<keyof T, 'query' | 'params'>>;
 export type GetServicesFunction = (basePath: string, overwrites?: Partial<Services>) => Services;
@@ -21,7 +21,7 @@ export interface Services {
 export interface ActionsPlugin {
   registerType: ActionTypeRegistry['register'];
   listTypes: ActionTypeRegistry['list'];
-  fire(options: FireOptions): Promise<void>;
+  execute(options: ExecuteOptions): Promise<void>;
 }
 
 // the parameters passed to an action type executor function

--- a/x-pack/legacy/plugins/alerting/server/alert_type_registry.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/alert_type_registry.test.ts
@@ -23,7 +23,7 @@ const alertTypeRegistryParams = {
     };
   },
   taskManager,
-  fireAction: jest.fn(),
+  executeAction: jest.fn(),
   internalSavedObjectsRepository: SavedObjectsClientMock.create(),
   spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
   getBasePath: jest.fn().mockReturnValue(undefined),
@@ -83,7 +83,7 @@ Object {
     expect(firstCall.internalSavedObjectsRepository).toBeTruthy();
     expect(firstCall.getBasePath).toBeTruthy();
     expect(firstCall.spaceIdToNamespace).toBeTruthy();
-    expect(firstCall.fireAction).toMatchInlineSnapshot(`[MockFunction]`);
+    expect(firstCall.executeAction).toMatchInlineSnapshot(`[MockFunction]`);
   });
 
   test('should throw an error if type is already registered', () => {

--- a/x-pack/legacy/plugins/alerting/server/alert_type_registry.ts
+++ b/x-pack/legacy/plugins/alerting/server/alert_type_registry.ts
@@ -16,7 +16,7 @@ import { SpacesPlugin } from '../../spaces';
 interface ConstructorOptions {
   getServices: (basePath: string) => Services;
   taskManager: TaskManager;
-  fireAction: ActionsPlugin['fire'];
+  executeAction: ActionsPlugin['execute'];
   internalSavedObjectsRepository: SavedObjectsClientContract;
   spaceIdToNamespace: SpacesPlugin['spaceIdToNamespace'];
   getBasePath: SpacesPlugin['getBasePath'];
@@ -25,7 +25,7 @@ interface ConstructorOptions {
 export class AlertTypeRegistry {
   private readonly getServices: (basePath: string) => Services;
   private readonly taskManager: TaskManager;
-  private readonly fireAction: ActionsPlugin['fire'];
+  private readonly executeAction: ActionsPlugin['execute'];
   private readonly alertTypes: Map<string, AlertType> = new Map();
   private readonly internalSavedObjectsRepository: SavedObjectsClientContract;
   private readonly spaceIdToNamespace: SpacesPlugin['spaceIdToNamespace'];
@@ -33,14 +33,14 @@ export class AlertTypeRegistry {
 
   constructor({
     internalSavedObjectsRepository,
-    fireAction,
+    executeAction,
     taskManager,
     getServices,
     spaceIdToNamespace,
     getBasePath,
   }: ConstructorOptions) {
     this.taskManager = taskManager;
-    this.fireAction = fireAction;
+    this.executeAction = executeAction;
     this.internalSavedObjectsRepository = internalSavedObjectsRepository;
     this.getServices = getServices;
     this.getBasePath = getBasePath;
@@ -70,7 +70,7 @@ export class AlertTypeRegistry {
         createTaskRunner: getCreateTaskRunnerFunction({
           alertType,
           getServices: this.getServices,
-          fireAction: this.fireAction,
+          executeAction: this.executeAction,
           internalSavedObjectsRepository: this.internalSavedObjectsRepository,
           getBasePath: this.getBasePath,
           spaceIdToNamespace: this.spaceIdToNamespace,

--- a/x-pack/legacy/plugins/alerting/server/init.ts
+++ b/x-pack/legacy/plugins/alerting/server/init.ts
@@ -51,7 +51,7 @@ export function init(server: Legacy.Server) {
   const alertTypeRegistry = new AlertTypeRegistry({
     getServices,
     taskManager: taskManager!,
-    fireAction: server.plugins.actions!.fire,
+    executeAction: server.plugins.actions!.execute,
     internalSavedObjectsRepository: savedObjectsRepositoryWithInternalUser,
     getBasePath(...args) {
       return spaces.isEnabled

--- a/x-pack/legacy/plugins/alerting/server/lib/create_fire_handler.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/lib/create_fire_handler.test.ts
@@ -7,7 +7,7 @@
 import { createFireHandler } from './create_fire_handler';
 
 const createFireHandlerParams = {
-  fireAction: jest.fn(),
+  executeAction: jest.fn(),
   spaceId: 'default',
   spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
   getBasePath: jest.fn().mockReturnValue(undefined),
@@ -44,11 +44,11 @@ const createFireHandlerParams = {
 
 beforeEach(() => jest.resetAllMocks());
 
-test('calls fireAction per selected action', async () => {
+test('calls executeAction per selected action', async () => {
   const fireHandler = createFireHandler(createFireHandlerParams);
   await fireHandler('default', {}, {});
-  expect(createFireHandlerParams.fireAction).toHaveBeenCalledTimes(1);
-  expect(createFireHandlerParams.fireAction.mock.calls[0]).toMatchInlineSnapshot(`
+  expect(createFireHandlerParams.executeAction).toHaveBeenCalledTimes(1);
+  expect(createFireHandlerParams.executeAction.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
       Object {
         "id": "1",
@@ -63,17 +63,17 @@ test('calls fireAction per selected action', async () => {
   `);
 });
 
-test('limits fireAction per action group', async () => {
+test('limits executeAction per action group', async () => {
   const fireHandler = createFireHandler(createFireHandlerParams);
   await fireHandler('other-group', {}, {});
-  expect(createFireHandlerParams.fireAction).toMatchInlineSnapshot(`[MockFunction]`);
+  expect(createFireHandlerParams.executeAction).toMatchInlineSnapshot(`[MockFunction]`);
 });
 
 test('context attribute gets parameterized', async () => {
   const fireHandler = createFireHandler(createFireHandlerParams);
   await fireHandler('default', { value: 'context-val' }, {});
-  expect(createFireHandlerParams.fireAction).toHaveBeenCalledTimes(1);
-  expect(createFireHandlerParams.fireAction.mock.calls[0]).toMatchInlineSnapshot(`
+  expect(createFireHandlerParams.executeAction).toHaveBeenCalledTimes(1);
+  expect(createFireHandlerParams.executeAction.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
       Object {
         "id": "1",
@@ -91,8 +91,8 @@ test('context attribute gets parameterized', async () => {
 test('state attribute gets parameterized', async () => {
   const fireHandler = createFireHandler(createFireHandlerParams);
   await fireHandler('default', {}, { value: 'state-val' });
-  expect(createFireHandlerParams.fireAction).toHaveBeenCalledTimes(1);
-  expect(createFireHandlerParams.fireAction.mock.calls[0]).toMatchInlineSnapshot(`
+  expect(createFireHandlerParams.executeAction).toHaveBeenCalledTimes(1);
+  expect(createFireHandlerParams.executeAction.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
       Object {
         "id": "1",
@@ -110,7 +110,7 @@ test('state attribute gets parameterized', async () => {
 test('throws error if reference not found', async () => {
   const params = {
     spaceId: 'default',
-    fireAction: jest.fn(),
+    executeAction: jest.fn(),
     alertSavedObject: {
       id: '1',
       type: 'alert',

--- a/x-pack/legacy/plugins/alerting/server/lib/create_fire_handler.ts
+++ b/x-pack/legacy/plugins/alerting/server/lib/create_fire_handler.ts
@@ -10,13 +10,13 @@ import { ActionsPlugin } from '../../../actions';
 import { transformActionParams } from './transform_action_params';
 
 interface CreateFireHandlerOptions {
-  fireAction: ActionsPlugin['fire'];
+  executeAction: ActionsPlugin['execute'];
   alertSavedObject: SavedObject;
   spaceId: string;
 }
 
 export function createFireHandler({
-  fireAction,
+  executeAction,
   alertSavedObject,
   spaceId,
 }: CreateFireHandlerOptions) {
@@ -40,7 +40,7 @@ export function createFireHandler({
         };
       });
     for (const action of actions) {
-      await fireAction({
+      await executeAction({
         id: action.id,
         params: action.params,
         spaceId,

--- a/x-pack/legacy/plugins/alerting/server/lib/get_create_task_runner_function.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/lib/get_create_task_runner_function.test.ts
@@ -52,7 +52,7 @@ const getCreateTaskRunnerFunctionParams = {
     name: 'My test alert',
     executor: jest.fn(),
   },
-  fireAction: jest.fn(),
+  executeAction: jest.fn(),
   internalSavedObjectsRepository: savedObjectsClient,
   spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
   getBasePath: jest.fn().mockReturnValue(undefined),
@@ -128,8 +128,8 @@ test('fireAction is called per alert instance that fired', async () => {
   savedObjectsClient.get.mockResolvedValueOnce(mockedAlertTypeSavedObject);
   const runner = createTaskRunner({ taskInstance: mockedTaskInstance });
   await runner.run();
-  expect(getCreateTaskRunnerFunctionParams.fireAction).toHaveBeenCalledTimes(1);
-  expect(getCreateTaskRunnerFunctionParams.fireAction.mock.calls[0]).toMatchInlineSnapshot(`
+  expect(getCreateTaskRunnerFunctionParams.executeAction).toHaveBeenCalledTimes(1);
+  expect(getCreateTaskRunnerFunctionParams.executeAction.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
       Object {
         "id": "1",

--- a/x-pack/legacy/plugins/alerting/server/lib/get_create_task_runner_function.ts
+++ b/x-pack/legacy/plugins/alerting/server/lib/get_create_task_runner_function.ts
@@ -18,7 +18,7 @@ import { SpacesPlugin } from '../../../spaces';
 interface CreateTaskRunnerFunctionOptions {
   getServices: (basePath: string) => Services;
   alertType: AlertType;
-  fireAction: ActionsPlugin['fire'];
+  executeAction: ActionsPlugin['execute'];
   internalSavedObjectsRepository: SavedObjectsClientContract;
   spaceIdToNamespace: SpacesPlugin['spaceIdToNamespace'];
   getBasePath: SpacesPlugin['getBasePath'];
@@ -31,7 +31,7 @@ interface TaskRunnerOptions {
 export function getCreateTaskRunnerFunction({
   getServices,
   alertType,
-  fireAction,
+  executeAction,
   internalSavedObjectsRepository,
   spaceIdToNamespace,
   getBasePath,
@@ -54,7 +54,7 @@ export function getCreateTaskRunnerFunction({
 
         const fireHandler = createFireHandler({
           alertSavedObject,
-          fireAction,
+          executeAction,
           spaceId: taskInstance.params.spaceId,
         });
         const alertInstances: Record<string, AlertInstance> = {};

--- a/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/email.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/email.ts
@@ -71,7 +71,7 @@ export default function emailTest({ getService }: FtrProviderContext) {
 
     it('should return the message data when firing the __json service', async () => {
       await supertest
-        .post(`/api/action/${createdActionId}/_fire`)
+        .post(`/api/action/${createdActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -114,7 +114,7 @@ export default function emailTest({ getService }: FtrProviderContext) {
 
     it('should render html from markdown', async () => {
       await supertest
-        .post(`/api/action/${createdActionId}/_fire`)
+        .post(`/api/action/${createdActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {

--- a/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/es_index.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/es_index.ts
@@ -115,9 +115,9 @@ export default function indexTest({ getService }: FtrProviderContext) {
         });
     });
 
-    it('should fire successly when expected for a single body', async () => {
+    it('should execute successly when expected for a single body', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${createdActionID}/_fire`)
+        .post(`/api/action/${createdActionID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -134,9 +134,9 @@ export default function indexTest({ getService }: FtrProviderContext) {
       expect(items[0]._source).to.eql({ testing: [1, 2, 3] });
     });
 
-    it('should fire successly when expected for with multiple bodies', async () => {
+    it('should execute successly when expected for with multiple bodies', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${createdActionID}/_fire`)
+        .post(`/api/action/${createdActionID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -167,9 +167,9 @@ export default function indexTest({ getService }: FtrProviderContext) {
       expect(passed2).to.be(true);
     });
 
-    it('should fire successly with refresh false', async () => {
+    it('should execute successly with refresh false', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${createdActionID}/_fire`)
+        .post(`/api/action/${createdActionID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -185,7 +185,7 @@ export default function indexTest({ getService }: FtrProviderContext) {
       expect(items.length).to.be.lessThan(2);
 
       const { body: result2 } = await supertest
-        .post(`/api/action/${createdActionID}/_fire`)
+        .post(`/api/action/${createdActionID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -201,12 +201,12 @@ export default function indexTest({ getService }: FtrProviderContext) {
       expect(items.length).to.eql(2);
     });
 
-    it('should fire unsuccessfully when expected', async () => {
+    it('should execute unsuccessfully when expected', async () => {
       let response;
       let result;
 
       response = await supertest
-        .post(`/api/action/${createdActionID}/_fire`)
+        .post(`/api/action/${createdActionID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -222,7 +222,7 @@ export default function indexTest({ getService }: FtrProviderContext) {
       );
 
       response = await supertest
-        .post(`/api/action/${createdActionID}/_fire`)
+        .post(`/api/action/${createdActionID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {

--- a/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/server_log.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/server_log.ts
@@ -51,7 +51,7 @@ export default function serverLogTest({ getService }: FtrProviderContext) {
 
     it('should handle firing the action', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${serverLogActionId}/_fire`)
+        .post(`/api/action/${serverLogActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {

--- a/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/slack.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/builtin_action_types/slack.ts
@@ -99,7 +99,7 @@ export default function slackTest({ getService }: FtrProviderContext) {
 
     it('should handle firing with a simulated success', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${simulatedActionId}/_fire`)
+        .post(`/api/action/${simulatedActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -112,7 +112,7 @@ export default function slackTest({ getService }: FtrProviderContext) {
 
     it('should handle a 40x slack error', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${simulatedActionId}/_fire`)
+        .post(`/api/action/${simulatedActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -127,7 +127,7 @@ export default function slackTest({ getService }: FtrProviderContext) {
     it('should handle a 429 slack error', async () => {
       const dateStart = new Date().getTime();
       const { body: result } = await supertest
-        .post(`/api/action/${simulatedActionId}/_fire`)
+        .post(`/api/action/${simulatedActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
@@ -146,7 +146,7 @@ export default function slackTest({ getService }: FtrProviderContext) {
 
     it('should handle a 500 slack error', async () => {
       const { body: result } = await supertest
-        .post(`/api/action/${simulatedActionId}/_fire`)
+        .post(`/api/action/${simulatedActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {

--- a/x-pack/test/alerting_api_integration/apis/actions/execute.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/execute.ts
@@ -16,7 +16,7 @@ export default function({ getService }: FtrProviderContext) {
 
   const esTestIndexName = '.kibaka-alerting-test-data';
 
-  describe('fire', () => {
+  describe('execute', () => {
     beforeEach(() => esArchiver.load('actions/basic'));
     afterEach(() => esArchiver.unload('actions/basic'));
 
@@ -52,14 +52,14 @@ export default function({ getService }: FtrProviderContext) {
     });
     after(() => es.indices.delete({ index: esTestIndexName }));
 
-    it('decrypts attributes when calling fire API', async () => {
+    it('decrypts attributes when calling execute API', async () => {
       await supertest
-        .post(`/api/action/${ES_ARCHIVER_ACTION_ID}/_fire`)
+        .post(`/api/action/${ES_ARCHIVER_ACTION_ID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
             index: esTestIndexName,
-            reference: 'actions-fire-1',
+            reference: 'actions-execute-1',
             message: 'Testing 123',
           },
         })
@@ -81,7 +81,7 @@ export default function({ getService }: FtrProviderContext) {
                   },
                   {
                     term: {
-                      reference: 'actions-fire-1',
+                      reference: 'actions-execute-1',
                     },
                   },
                 ],
@@ -95,7 +95,7 @@ export default function({ getService }: FtrProviderContext) {
       expect(indexedRecord._source).to.eql({
         params: {
           index: esTestIndexName,
-          reference: 'actions-fire-1',
+          reference: 'actions-execute-1',
           message: 'Testing 123',
         },
         config: {
@@ -104,33 +104,33 @@ export default function({ getService }: FtrProviderContext) {
         secrets: {
           encrypted: 'This value should be encrypted',
         },
-        reference: 'actions-fire-1',
+        reference: 'actions-execute-1',
         source: 'action:test.index-record',
       });
     });
 
-    it(`can't fire from another space`, async () => {
+    it(`can't execute from another space`, async () => {
       await supertest
-        .post(`/api/action/${SPACE_1_ES_ARCHIVER_ACTION_ID}/_fire`)
+        .post(`/api/action/${SPACE_1_ES_ARCHIVER_ACTION_ID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
             index: esTestIndexName,
-            reference: 'actions-fire-2',
+            reference: 'actions-execute-2',
             message: 'Testing 123',
           },
         })
         .expect(404);
     });
 
-    it('fire works in a space', async () => {
+    it('execute works in a space', async () => {
       await supertest
-        .post(`/s/space_1/api/action/${SPACE_1_ES_ARCHIVER_ACTION_ID}/_fire`)
+        .post(`/s/space_1/api/action/${SPACE_1_ES_ARCHIVER_ACTION_ID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
             index: esTestIndexName,
-            reference: 'actions-fire-3',
+            reference: 'actions-execute-3',
             message: 'Testing 123',
           },
         })
@@ -152,7 +152,7 @@ export default function({ getService }: FtrProviderContext) {
                   },
                   {
                     term: {
-                      reference: 'actions-fire-3',
+                      reference: 'actions-execute-3',
                     },
                   },
                 ],
@@ -166,7 +166,7 @@ export default function({ getService }: FtrProviderContext) {
       expect(indexedRecord._source).to.eql({
         params: {
           index: esTestIndexName,
-          reference: 'actions-fire-3',
+          reference: 'actions-execute-3',
           message: 'Testing 123',
         },
         config: {
@@ -175,12 +175,12 @@ export default function({ getService }: FtrProviderContext) {
         secrets: {
           encrypted: 'This value should be encrypted',
         },
-        reference: 'actions-fire-3',
+        reference: 'actions-execute-3',
         source: 'action:test.index-record',
       });
     });
 
-    it('fire still works with encrypted attributes after updating an action', async () => {
+    it('execute still works with encrypted attributes after updating an action', async () => {
       const { body: updatedAction } = await supertest
         .put(`/api/action/${ES_ARCHIVER_ACTION_ID}`)
         .set('kbn-xsrf', 'foo')
@@ -203,12 +203,12 @@ export default function({ getService }: FtrProviderContext) {
         },
       });
       await supertest
-        .post(`/api/action/${ES_ARCHIVER_ACTION_ID}/_fire`)
+        .post(`/api/action/${ES_ARCHIVER_ACTION_ID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {
             index: esTestIndexName,
-            reference: 'actions-fire-4',
+            reference: 'actions-execute-4',
             message: 'Testing 123',
           },
         })
@@ -230,7 +230,7 @@ export default function({ getService }: FtrProviderContext) {
                   },
                   {
                     term: {
-                      reference: 'actions-fire-4',
+                      reference: 'actions-execute-4',
                     },
                   },
                 ],
@@ -244,7 +244,7 @@ export default function({ getService }: FtrProviderContext) {
       expect(indexedRecord._source).to.eql({
         params: {
           index: esTestIndexName,
-          reference: 'actions-fire-4',
+          reference: 'actions-execute-4',
           message: 'Testing 123',
         },
         config: {
@@ -253,14 +253,14 @@ export default function({ getService }: FtrProviderContext) {
         secrets: {
           encrypted: 'This value should be encrypted',
         },
-        reference: 'actions-fire-4',
+        reference: 'actions-execute-4',
         source: 'action:test.index-record',
       });
     });
 
     it(`should return 404 when action doesn't exist`, async () => {
       const { body: response } = await supertest
-        .post('/api/action/1/_fire')
+        .post('/api/action/1/_execute')
         .set('kbn-xsrf', 'foo')
         .send({
           params: { foo: true },
@@ -275,7 +275,7 @@ export default function({ getService }: FtrProviderContext) {
 
     it('should return 400 when payload is empty and invalid', async () => {
       const { body: response } = await supertest
-        .post(`/api/action/${ES_ARCHIVER_ACTION_ID}/_fire`)
+        .post(`/api/action/${ES_ARCHIVER_ACTION_ID}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({})
         .expect(400);

--- a/x-pack/test/alerting_api_integration/apis/actions/index.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/index.ts
@@ -14,7 +14,7 @@ export default function actionsTests({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./list_action_types'));
     loadTestFile(require.resolve('./update'));
-    loadTestFile(require.resolve('./fire'));
+    loadTestFile(require.resolve('./execute'));
     loadTestFile(require.resolve('./builtin_action_types/server_log'));
     loadTestFile(require.resolve('./builtin_action_types/slack'));
     loadTestFile(require.resolve('./builtin_action_types/email'));

--- a/x-pack/test/alerting_api_integration/apis/actions/manual/pr_40694.js
+++ b/x-pack/test/alerting_api_integration/apis/actions/manual/pr_40694.js
@@ -53,7 +53,7 @@ async function main() {
   response = await httpGet(`api/action/${actionId}`);
   console.log(`action after update: ${JSON.stringify(response, null, 4)}`);
 
-  response = await httpPost(`api/action/${actionId}/_fire`, {
+  response = await httpPost(`api/action/${actionId}/_execute`, {
     params: {
       to: ['patrick.mueller@elastic.co'],
       subject: 'the email subject',
@@ -61,7 +61,7 @@ async function main() {
     }
   });
 
-  console.log(`fire result: ${JSON.stringify(response, null, 4)}`);
+  console.log(`execute result: ${JSON.stringify(response, null, 4)}`);
 }
 
 async function httpGet(uri) {

--- a/x-pack/test/alerting_api_integration/apis/actions/update.ts
+++ b/x-pack/test/alerting_api_integration/apis/actions/update.ts
@@ -244,9 +244,9 @@ export default function updateActionTests({ getService }: FtrProviderContext) {
         })
         .expect(200);
 
-      // fire the action
+      // execute the action
       await supertest
-        .post(`/api/action/${emailActionId}/_fire`)
+        .post(`/api/action/${emailActionId}/_execute`)
         .set('kbn-xsrf', 'foo')
         .send({
           params: {


### PR DESCRIPTION
Change references of "fire" in the actions plugin to "execute".  Some of this bled through to alerting, but left other references to "fire" in alerting alone.  Strikes me that actions should be executed, but perhaps leaving alerts as fired would be a reasonable distinction.  Alerts aren't really "executed" ...