### PR TITLE
[Monitoring] Replace old kbn-top-nav with new one

### DIFF
--- a/src/legacy/ui/public/kbn_top_nav/kbn_top_nav2.js
+++ b/src/legacy/ui/public/kbn_top_nav/kbn_top_nav2.js
@@ -57,7 +57,7 @@ module.directive('kbnTopNavV2', () => {
 
         // Watch config changes
         $scope.$watch(() => {
-          const config = $scope.$eval($attr.config);
+          const config = $scope.$eval($attr.config) || [];
           return config.map((item) => {
             // Copy key into id, as it's a reserved react propery.
             // This is done for Angular directive backward compatibility.

--- a/x-pack/legacy/plugins/monitoring/public/directives/main/index.html
+++ b/x-pack/legacy/plugins/monitoring/public/directives/main/index.html
@@ -1,302 +1,303 @@
 <div class="app-container">
-  <kbn-top-nav name="{{ monitoringMain.name }}-nav" config="topNavMenu">
-    <!-- Transcluded elements. -->
-    <div data-transclude-slots>
-      <!-- Tabs -->
-      <div data-transclude-slot="bottomRow">
-        <div ng-if="monitoringMain.inElasticsearch" class="euiTabs" role="navigation">
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('elasticsearch')"
-            kbn-href="#/elasticsearch"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.esNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('elasticsearch')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.esNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance"
-            kbn-href="#/elasticsearch/nodes"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('nodes')}"
-            i18n-id="xpack.monitoring.esNavigation.nodesLinkText"
-            i18n-default-message="Nodes"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('elasticsearch')"
-            kbn-href="#/elasticsearch/indices"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('indices')}"
-            i18n-id="xpack.monitoring.esNavigation.indicesLinkText"
-            i18n-default-message="Indices"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('elasticsearch')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('indices')}"
-            i18n-id="xpack.monitoring.esNavigation.indicesLinkText"
-            i18n-default-message="Indices"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance && monitoringMain.isMlSupported()"
-            kbn-href="#/elasticsearch/ml_jobs"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('ml')}"
-            i18n-id="xpack.monitoring.esNavigation.jobsLinkText"
-            i18n-default-message="Jobs"
-          ></a>
-          <a
-            ng-if="(monitoringMain.isCcrEnabled || monitoringMain.isActiveTab('ccr')) && !monitoringMain.instance"
-            kbn-href="#/elasticsearch/ccr"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('ccr')}"
-            i18n-id="xpack.monitoring.esNavigation.ccrLinkText"
-            i18n-default-message="CCR"
-          ></a>
-          <a
-            ng-if="monitoringMain.instance && (monitoringMain.name === 'nodes' || monitoringMain.name === 'indices')"
-            kbn-href="#/elasticsearch/{{ monitoringMain.name }}/{{ monitoringMain.resolver }}"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.page === 'overview'}"
-          >
-            <span ng-if="monitoringMain.tabIconClass" class="fa {{ monitoringMain.tabIconClass }}" title="{{ monitoringMain.tabIconLabel }}"></span>
-            <span
-              i18n-id="xpack.monitoring.esNavigation.instance.overviewLinkText"
-              i18n-default-message="Overview"
-            ></span>
-          </a>
-          <a
-            ng-if="monitoringMain.instance && (monitoringMain.name === 'nodes' || monitoringMain.name === 'indices')"
-            kbn-href="#/elasticsearch/{{ monitoringMain.name }}/{{ monitoringMain.resolver }}/advanced"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.page === 'advanced'}"
-            i18n-id="xpack.monitoring.esNavigation.instance.advancedLinkText"
-            i18n-default-message="Advanced"
-          >
-          </a>
-            <!-- ML Instance (for use later) -->
-          <a
-            ng-if="monitoringMain.instance && monitoringMain.name !== 'nodes' && monitoringMain.name !== 'indices'"
-            class="euiTab">{{ monitoringMain.instance }}</a>
-        </div>
+  <kbn-top-nav-v2
+    name="{{ monitoringMain.name }}-nav"
+    config="topNavMenu"
+    show-search-bar="true"
+    show-date-picker="true"
+  >
+  </kbn-top-nav-v2>
+  <div>
+    <div ng-if="monitoringMain.inElasticsearch" class="euiTabs" role="navigation">
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('elasticsearch')"
+        kbn-href="#/elasticsearch"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.esNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('elasticsearch')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.esNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance"
+        kbn-href="#/elasticsearch/nodes"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('nodes')}"
+        i18n-id="xpack.monitoring.esNavigation.nodesLinkText"
+        i18n-default-message="Nodes"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('elasticsearch')"
+        kbn-href="#/elasticsearch/indices"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('indices')}"
+        i18n-id="xpack.monitoring.esNavigation.indicesLinkText"
+        i18n-default-message="Indices"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('elasticsearch')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('indices')}"
+        i18n-id="xpack.monitoring.esNavigation.indicesLinkText"
+        i18n-default-message="Indices"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance && monitoringMain.isMlSupported()"
+        kbn-href="#/elasticsearch/ml_jobs"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('ml')}"
+        i18n-id="xpack.monitoring.esNavigation.jobsLinkText"
+        i18n-default-message="Jobs"
+      ></a>
+      <a
+        ng-if="(monitoringMain.isCcrEnabled || monitoringMain.isActiveTab('ccr')) && !monitoringMain.instance"
+        kbn-href="#/elasticsearch/ccr"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('ccr')}"
+        i18n-id="xpack.monitoring.esNavigation.ccrLinkText"
+        i18n-default-message="CCR"
+      ></a>
+      <a
+        ng-if="monitoringMain.instance && (monitoringMain.name === 'nodes' || monitoringMain.name === 'indices')"
+        kbn-href="#/elasticsearch/{{ monitoringMain.name }}/{{ monitoringMain.resolver }}"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.page === 'overview'}"
+      >
+        <span ng-if="monitoringMain.tabIconClass" class="fa {{ monitoringMain.tabIconClass }}" title="{{ monitoringMain.tabIconLabel }}"></span>
+        <span
+          i18n-id="xpack.monitoring.esNavigation.instance.overviewLinkText"
+          i18n-default-message="Overview"
+        ></span>
+      </a>
+      <a
+        ng-if="monitoringMain.instance && (monitoringMain.name === 'nodes' || monitoringMain.name === 'indices')"
+        kbn-href="#/elasticsearch/{{ monitoringMain.name }}/{{ monitoringMain.resolver }}/advanced"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.page === 'advanced'}"
+        i18n-id="xpack.monitoring.esNavigation.instance.advancedLinkText"
+        i18n-default-message="Advanced"
+      >
+      </a>
+        <!-- ML Instance (for use later) -->
+      <a
+        ng-if="monitoringMain.instance && monitoringMain.name !== 'nodes' && monitoringMain.name !== 'indices'"
+        class="euiTab">{{ monitoringMain.instance }}</a>
+    </div>
 
-        <div ng-if="monitoringMain.inKibana" class="euiTabs" role="navigation">
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('kibana')"
-            kbn-href="#/kibana"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.kibanaNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('kibana')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{
-              'euiTab-isSelected': monitoringMain.isActiveTab('overview'),
-            }"
-            i18n-id="xpack.monitoring.kibanaNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance"
-            kbn-href="#/kibana/instances"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('kibanas')}"
-            i18n-id="xpack.monitoring.kibanaNavigation.instancesLinkText"
-            i18n-default-message="Instances"
-          ></a>
-          <a ng-if="monitoringMain.instance" class="euiTab">{{ monitoringMain.instance }}</a>
-        </div>
+    <div ng-if="monitoringMain.inKibana" class="euiTabs" role="navigation">
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('kibana')"
+        kbn-href="#/kibana"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.kibanaNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('kibana')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{
+          'euiTab-isSelected': monitoringMain.isActiveTab('overview'),
+        }"
+        i18n-id="xpack.monitoring.kibanaNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance"
+        kbn-href="#/kibana/instances"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('kibanas')}"
+        i18n-id="xpack.monitoring.kibanaNavigation.instancesLinkText"
+        i18n-default-message="Instances"
+      ></a>
+      <a ng-if="monitoringMain.instance" class="euiTab">{{ monitoringMain.instance }}</a>
+    </div>
 
-        <div ng-if="monitoringMain.inApm" class="euiTabs" role="navigation">
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('apm')"
-            kbn-href="#/apm"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.apmNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('apm')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.apmNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          ></a>
-          <a
-            ng-if="!monitoringMain.instance"
-            kbn-href="#/apm/instances"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('apms')}"
-            i18n-id="xpack.monitoring.apmNavigation.instancesLinkText"
-            i18n-default-message="Instances"
-          ></a>
-          <a ng-if="monitoringMain.instance" class="euiTab">{{ monitoringMain.instance }}</a>
-        </div>
+    <div ng-if="monitoringMain.inApm" class="euiTabs" role="navigation">
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('apm')"
+        kbn-href="#/apm"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.apmNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('apm')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.apmNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      ></a>
+      <a
+        ng-if="!monitoringMain.instance"
+        kbn-href="#/apm/instances"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('apms')}"
+        i18n-id="xpack.monitoring.apmNavigation.instancesLinkText"
+        i18n-default-message="Instances"
+      ></a>
+      <a ng-if="monitoringMain.instance" class="euiTab">{{ monitoringMain.instance }}</a>
+    </div>
 
-        <div ng-if="monitoringMain.inBeats" class="euiTabs" role="navigation">
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('beats')"
-            kbn-href="#/beats"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.beatsNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          >
-          </a>
-          <a
-            ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('beats')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.beatsNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          >
-          </a>
-          <a
-            ng-if="!monitoringMain.instance"
-            kbn-href="#/beats/beats"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('beats')}"
-            i18n-id="xpack.monitoring.beatsNavigation.instancesLinkText"
-            i18n-default-message="Instances"
-          >
-          </a>
-          <a
-            ng-if="monitoringMain.instance"
-            kbn-href="#/beats/beat/{{ monitoringMain.resolver }}"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.page === 'overview'}"
-            i18n-id="xpack.monitoring.beatsNavigation.instance.overviewLinkText"
-            i18n-default-message="Overview"
-          >
-          </a>
-        </div>
+    <div ng-if="monitoringMain.inBeats" class="euiTabs" role="navigation">
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.isDisabledTab('beats')"
+        kbn-href="#/beats"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.beatsNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      >
+      </a>
+      <a
+        ng-if="!monitoringMain.instance && monitoringMain.isDisabledTab('beats')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.beatsNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      >
+      </a>
+      <a
+        ng-if="!monitoringMain.instance"
+        kbn-href="#/beats/beats"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('beats')}"
+        i18n-id="xpack.monitoring.beatsNavigation.instancesLinkText"
+        i18n-default-message="Instances"
+      >
+      </a>
+      <a
+        ng-if="monitoringMain.instance"
+        kbn-href="#/beats/beat/{{ monitoringMain.resolver }}"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.page === 'overview'}"
+        i18n-id="xpack.monitoring.beatsNavigation.instance.overviewLinkText"
+        i18n-default-message="Overview"
+      >
+      </a>
+    </div>
 
-        <div ng-if="monitoringMain.inLogstash" class="euiTabs" role="navigation">
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && !monitoringMain.isDisabledTab('logstash')"
-            kbn-href="#/logstash"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.logstashNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          >
-          </a>
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && monitoringMain.isDisabledTab('logstash')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
-            i18n-id="xpack.monitoring.logstashNavigation.overviewLinkText"
-            i18n-default-message="Overview"
-          >
-          </a>
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.pipelineId"
-            kbn-href="#/logstash/nodes"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('nodes')}"
-            i18n-id="xpack.monitoring.logstashNavigation.nodesLinkText"
-            i18n-default-message="Nodes"
-          >
-          </a>
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && !monitoringMain.isDisabledTab('logstash')"
-            kbn-href="#/logstash/pipelines"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('pipelines')}"
-          >
-            <span
-              i18n-id="xpack.monitoring.logstashNavigation.pipelinesLinkText"
-              i18n-default-message="Pipelines"
-            ></span>
-            <span class="kuiIcon fa-flask monTabs--icon" tooltip="Beta feature" />
-          </a>
-          <a
-            ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && monitoringMain.isDisabledTab('logstash')"
-            kbn-href=""
-            class="euiTab euiTab-isDisabled"
-            ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('pipelines')}"
-          >
-            <span
-              i18n-id="xpack.monitoring.logstashNavigation.pipelinesLinkText"
-              i18n-default-message="Pipelines"
-            ></span>
-            <span class="kuiIcon fa-flask monTabs--icon" tooltip="Beta feature" />
-          </a>
-          <a
-            ng-if="monitoringMain.instance"
-            kbn-href="#/logstash/node/{{ monitoringMain.resolver }}"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.page === 'overview'}"
-            i18n-id="xpack.monitoring.logstashNavigation.instance.overviewLinkText"
-            i18n-default-message="Overview"
-          >
-          </a>
-          <a
-            ng-if="monitoringMain.instance"
-            kbn-href="#/logstash/node/{{ monitoringMain.resolver }}/pipelines"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.page === 'pipelines'}"
-          >
-            <span
-              i18n-id="xpack.monitoring.logstashNavigation.instance.pipelinesLinkText"
-              i18n-default-message="Pipelines"
-            ></span>
-            <span class="kuiIcon fa-flask fa-sm monTabs--icon" tooltip="Beta feature" />
-          </a>
-          <a
-            ng-if="monitoringMain.instance"
-            kbn-href="#/logstash/node/{{ monitoringMain.resolver }}/advanced"
-            class="euiTab"
-            ng-class="{'euiTab-isSelected': monitoringMain.page === 'advanced'}"
-            i18n-id="xpack.monitoring.logstashNavigation.instance.advancedLinkText"
-            i18n-default-message="Advanced"
-          >
-          </a>
-          <div
-            class="euiTab"
-            ng-if="monitoringMain.pipelineVersions.length"
-            id="dropdown-elm"
-            ng-init="monitoringMain.dropdownLoadedHandler()">
-          </div>
-        </div>
-
-        <div ng-if="monitoringMain.inOverview" class="euiTabs" role="navigation">
-          <a class="euiTab" data-test-subj="clusterName">{{ pageData.cluster_name }}</a>
-        </div>
-
-        <div ng-if="monitoringMain.inAlerts" class="euiTabs" role="navigation">
-          <a
-            class="euiTab"
-            data-test-subj="clusterAlertsListingPage"
-            i18n-id="xpack.monitoring.clusterAlertsNavigation.clusterAlertsLinkText"
-            i18n-default-message="Cluster Alerts"
-          ></a>
-        </div>
-
-        <div ng-if="monitoringMain.inListing" class="euiTabs" role="navigation">
-         <a
-          class="euiTab"
-          i18n-id="xpack.monitoring.clustersNavigation.clustersLinkText"
-          i18n-default-message="Clusters"
-        ></a>
-       </div>
+    <div ng-if="monitoringMain.inLogstash" class="euiTabs" role="navigation">
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && !monitoringMain.isDisabledTab('logstash')"
+        kbn-href="#/logstash"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.logstashNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      >
+      </a>
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && monitoringMain.isDisabledTab('logstash')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('overview')}"
+        i18n-id="xpack.monitoring.logstashNavigation.overviewLinkText"
+        i18n-default-message="Overview"
+      >
+      </a>
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.pipelineId"
+        kbn-href="#/logstash/nodes"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('nodes')}"
+        i18n-id="xpack.monitoring.logstashNavigation.nodesLinkText"
+        i18n-default-message="Nodes"
+      >
+      </a>
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && !monitoringMain.isDisabledTab('logstash')"
+        kbn-href="#/logstash/pipelines"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('pipelines')}"
+      >
+        <span
+          i18n-id="xpack.monitoring.logstashNavigation.pipelinesLinkText"
+          i18n-default-message="Pipelines"
+        ></span>
+        <span class="kuiIcon fa-flask monTabs--icon" tooltip="Beta feature" />
+      </a>
+      <a
+        ng-if="!monitoringMain.instance && !monitoringMain.pipelineId && monitoringMain.isDisabledTab('logstash')"
+        kbn-href=""
+        class="euiTab euiTab-isDisabled"
+        ng-class="{'euiTab-isSelected': monitoringMain.isActiveTab('pipelines')}"
+      >
+        <span
+          i18n-id="xpack.monitoring.logstashNavigation.pipelinesLinkText"
+          i18n-default-message="Pipelines"
+        ></span>
+        <span class="kuiIcon fa-flask monTabs--icon" tooltip="Beta feature" />
+      </a>
+      <a
+        ng-if="monitoringMain.instance"
+        kbn-href="#/logstash/node/{{ monitoringMain.resolver }}"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.page === 'overview'}"
+        i18n-id="xpack.monitoring.logstashNavigation.instance.overviewLinkText"
+        i18n-default-message="Overview"
+      >
+      </a>
+      <a
+        ng-if="monitoringMain.instance"
+        kbn-href="#/logstash/node/{{ monitoringMain.resolver }}/pipelines"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.page === 'pipelines'}"
+      >
+        <span
+          i18n-id="xpack.monitoring.logstashNavigation.instance.pipelinesLinkText"
+          i18n-default-message="Pipelines"
+        ></span>
+        <span class="kuiIcon fa-flask fa-sm monTabs--icon" tooltip="Beta feature" />
+      </a>
+      <a
+        ng-if="monitoringMain.instance"
+        kbn-href="#/logstash/node/{{ monitoringMain.resolver }}/advanced"
+        class="euiTab"
+        ng-class="{'euiTab-isSelected': monitoringMain.page === 'advanced'}"
+        i18n-id="xpack.monitoring.logstashNavigation.instance.advancedLinkText"
+        i18n-default-message="Advanced"
+      >
+      </a>
+      <div
+        class="euiTab"
+        ng-if="monitoringMain.pipelineVersions.length"
+        id="dropdown-elm"
+        ng-init="monitoringMain.dropdownLoadedHandler()">
       </div>
     </div>
-  </kbn-top-nav>
+
+    <div ng-if="monitoringMain.inOverview" class="euiTabs" role="navigation">
+      <a class="euiTab" data-test-subj="clusterName">{{ pageData.cluster_name }}</a>
+    </div>
+
+    <div ng-if="monitoringMain.inAlerts" class="euiTabs" role="navigation">
+      <a
+        class="euiTab"
+        data-test-subj="clusterAlertsListingPage"
+        i18n-id="xpack.monitoring.clusterAlertsNavigation.clusterAlertsLinkText"
+        i18n-default-message="Cluster Alerts"
+      ></a>
+    </div>
+
+    <div ng-if="monitoringMain.inListing" class="euiTabs" role="navigation">
+      <a
+      class="euiTab"
+      i18n-id="xpack.monitoring.clustersNavigation.clustersLinkText"
+      i18n-default-message="Clusters"
+    ></a>
+    </div>
+  </div>
   <div ng-transclude></div>
 </div>

--- a/x-pack/legacy/plugins/monitoring/public/directives/main/index.html
+++ b/x-pack/legacy/plugins/monitoring/public/directives/main/index.html
@@ -1,9 +1,16 @@
 <div class="app-container">
   <kbn-top-nav-v2
-    name="{{ monitoringMain.name }}-nav"
+    name="monitoringMain.navName"
     config="topNavMenu"
+    app-name="'monitoring'"
     show-search-bar="true"
     show-date-picker="true"
+    date-range-from="monitoringMain.datePicker.timeRange.from"
+    date-range-to="monitoringMain.datePicker.timeRange.to"
+    is-refresh-paused="monitoringMain.datePicker.refreshInterval.pause"
+    refresh-interval="monitoringMain.datePicker.refreshInterval.value"
+    on-refresh-change="monitoringMain.datePicker.onRefreshChange"
+    on-query-submit="monitoringMain.datePicker.onTimeUpdate"
   >
   </kbn-top-nav-v2>
   <div>

--- a/x-pack/legacy/plugins/monitoring/public/directives/main/index.js
+++ b/x-pack/legacy/plugins/monitoring/public/directives/main/index.js
@@ -15,6 +15,7 @@ import { i18n } from '@kbn/i18n';
 import { get } from 'lodash';
 import { uiModules } from 'ui/modules';
 import template from './index.html';
+import { timefilter } from 'ui/timefilter';
 import { shortenPipelineHash } from '../../../common/formatting';
 import 'ui/directives/kbn_href';
 import { getSetupModeState } from '../../lib/setup_mode';
@@ -84,6 +85,8 @@ export class MonitoringMainController {
 
     Object.assign(this, options.attributes);
 
+    this.navName = `${this.name}-nav`;
+
     // set the section we're navigated in
     if (this.product) {
       this.inElasticsearch = this.product === 'elasticsearch';
@@ -108,6 +111,28 @@ export class MonitoringMainController {
         return this._kbnUrlService.changePath(`/logstash/pipelines/${this.pipelineId}/${this.pipelineHash}`);
       };
     }
+
+    this.datePicker = {
+      timeRange: timefilter.getTime(),
+      refreshInterval: timefilter.getRefreshInterval(),
+      onRefreshChange: ({ isPaused, refreshInterval }) => {
+        this.datePicker.refreshInterval = {
+          pause: isPaused,
+          value: refreshInterval,
+        };
+
+        timefilter.setRefreshInterval({
+          pause: isPaused,
+          value: refreshInterval ? refreshInterval : this.datePicker.refreshInterval.value
+        });
+      },
+      onTimeUpdate: ({ dateRange }) => {
+        this.datePicker.timeRange = {
+          ...dateRange
+        };
+        timefilter.setTime(dateRange);
+      }
+    };
   }
 
   // check whether to "highlight" a tab


### PR DESCRIPTION
Relates to #39981
Blocked by https://github.com/elastic/kibana/pull/43255

This PR removes the `kbn-top-nav` and replaces it with the new `kbn-top-nav-v2`. There is no functional change - everything should work as expected.