### PR TITLE
[APM] Make aggregations optional in ES response type definition

### DIFF
--- a/x-pack/legacy/plugins/apm/public/selectors/chartSelectors.ts
+++ b/x-pack/legacy/plugins/apm/public/selectors/chartSelectors.ts
@@ -42,7 +42,7 @@ const INITIAL_DATA = {
       p99: []
     },
     tpmBuckets: [],
-    overallAvgDuration: undefined
+    overallAvgDuration: null
   },
   anomalyTimeseries: undefined
 };

--- a/x-pack/legacy/plugins/apm/public/utils/formatters.ts
+++ b/x-pack/legacy/plugins/apm/public/utils/formatters.ts
@@ -187,40 +187,25 @@ export function asPercent(
   return numeral(decimal).format('0.0%');
 }
 
-type ByteFormatter = (value: number | null) => string;
+type ByteFormatter = (value: number | null | undefined) => string;
 
-function asKilobytes(value: number | null) {
-  if (value === null || isNaN(value)) {
-    return '';
-  }
+function asKilobytes(value: number) {
   return `${asDecimal(value / 1000)} KB`;
 }
 
-function asMegabytes(value: number | null) {
-  if (value === null || isNaN(value)) {
-    return '';
-  }
+function asMegabytes(value: number) {
   return `${asDecimal(value / 1e6)} MB`;
 }
 
-function asGigabytes(value: number | null) {
-  if (value === null || isNaN(value)) {
-    return '';
-  }
+function asGigabytes(value: number) {
   return `${asDecimal(value / 1e9)} GB`;
 }
 
-function asTerabytes(value: number | null) {
-  if (value === null || isNaN(value)) {
-    return '';
-  }
+function asTerabytes(value: number) {
   return `${asDecimal(value / 1e12)} TB`;
 }
 
-export function asBytes(value: number | null | undefined) {
-  if (value === null || value === undefined || isNaN(value)) {
-    return '';
-  }
+function asBytes(value: number) {
   return `${asDecimal(value)} B`;
 }
 
@@ -233,24 +218,33 @@ export function asDynamicBytes(value: number | null | undefined) {
 
 type GetByteFormatter = (max: number) => ByteFormatter;
 
+const bailIfNumberInvalid = (cb: (val: number) => string) => {
+  return (val: number | null | undefined) => {
+    if (val === null || val === undefined || isNaN(val)) {
+      return '';
+    }
+    return cb(val);
+  };
+};
+
 const unmemoizedFixedByteFormatter: GetByteFormatter = max => {
   if (max > 1e12) {
-    return asTerabytes;
+    return bailIfNumberInvalid(asTerabytes);
   }
 
   if (max > 1e9) {
-    return asGigabytes;
+    return bailIfNumberInvalid(asGigabytes);
   }
 
   if (max > 1e6) {
-    return asMegabytes;
+    return bailIfNumberInvalid(asMegabytes);
   }
 
   if (max > 1000) {
-    return asKilobytes;
+    return bailIfNumberInvalid(asKilobytes);
   }
 
-  return asBytes;
+  return bailIfNumberInvalid(asBytes);
 };
 
 export const getFixedByteFormatter = memoize(unmemoizedFixedByteFormatter);

--- a/x-pack/legacy/plugins/apm/server/lib/errors/distribution/get_buckets.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/distribution/get_buckets.ts
@@ -5,6 +5,7 @@
  */
 
 import { ESFilter } from 'elasticsearch';
+import { idx } from '@kbn/elastic-idx';
 import {
   ERROR_GROUP_ID,
   PROCESSOR_EVENT,
@@ -63,7 +64,9 @@ export async function getBuckets({
 
   const resp = await client.search(params);
 
-  const buckets = resp.aggregations.distribution.buckets.map(bucket => ({
+  const buckets = (
+    idx(resp.aggregations, _ => _.distribution.buckets) || []
+  ).map(bucket => ({
     key: bucket.key,
     count: bucket.doc_count
   }));

--- a/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { idx } from '@kbn/elastic-idx';
 import {
   PROCESSOR_EVENT,
   TRACE_ID,
@@ -47,7 +48,7 @@ export async function getTraceErrorsPerTransaction(
 
   const resp = await client.search(params);
 
-  return resp.aggregations.transactions.buckets.reduce(
+  return (idx(resp.aggregations, _ => _.transactions.buckets) || []).reduce(
     (acc, bucket) => ({
       ...acc,
       [bucket.key]: bucket.doc_count

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
@@ -5,6 +5,7 @@
  */
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 import { AggregationSearchResponse, AggregatedValue } from 'elasticsearch';
+import { idx } from '@kbn/elastic-idx';
 import { ChartBase } from './types';
 
 const colors = [
@@ -49,7 +50,7 @@ export function transformDataToMetricsChart<Params extends AggregatedParams>(
   chartBase: ChartBase
 ) {
   const { aggregations, hits } = result;
-  const { timeseriesData } = aggregations;
+  const timeseriesData = idx(aggregations, _ => _.timeseriesData);
 
   return {
     title: chartBase.title,
@@ -57,7 +58,7 @@ export function transformDataToMetricsChart<Params extends AggregatedParams>(
     yUnit: chartBase.yUnit,
     totalHits: hits.total,
     series: Object.keys(chartBase.series).map((seriesKey, i) => {
-      const agg = aggregations[seriesKey];
+      const agg = aggregations ? aggregations[seriesKey] : { value: null };
 
       return {
         title: chartBase.series[seriesKey].title,
@@ -65,7 +66,7 @@ export function transformDataToMetricsChart<Params extends AggregatedParams>(
         type: chartBase.type,
         color: chartBase.series[seriesKey].color || colors[i],
         overallValue: agg.value,
-        data: timeseriesData.buckets.map(bucket => {
+        data: (idx(timeseriesData, _ => _.buckets) || []).map(bucket => {
           const { value } = bucket[seriesKey] as AggregatedValue;
           const y = value === null || isNaN(value) ? null : value;
           return {

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
@@ -58,7 +58,7 @@ export function transformDataToMetricsChart<Params extends AggregatedParams>(
     yUnit: chartBase.yUnit,
     totalHits: hits.total,
     series: Object.keys(chartBase.series).map((seriesKey, i) => {
-      const overallValue = idx(aggregations, _ => _[seriesKey].value) || null;
+      const overallValue = idx(aggregations, _ => _[seriesKey].value);
 
       return {
         title: chartBase.series[seriesKey].title,

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
@@ -58,14 +58,14 @@ export function transformDataToMetricsChart<Params extends AggregatedParams>(
     yUnit: chartBase.yUnit,
     totalHits: hits.total,
     series: Object.keys(chartBase.series).map((seriesKey, i) => {
-      const agg = aggregations ? aggregations[seriesKey] : { value: null };
+      const overallValue = idx(aggregations, _ => _[seriesKey].value) || null;
 
       return {
         title: chartBase.series[seriesKey].title,
         key: seriesKey,
         type: chartBase.type,
         color: chartBase.series[seriesKey].color || colors[i],
-        overallValue: agg.value,
+        overallValue,
         data: (idx(timeseriesData, _ => _.buckets) || []).map(bucket => {
           const { value } = bucket[seriesKey] as AggregatedValue;
           const y = value === null || isNaN(value) ? null : value;

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_environments/get_all_environments.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_environments/get_all_environments.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { idx } from '@kbn/elastic-idx';
 import { Setup } from '../../../helpers/setup_request';
 import {
   PROCESSOR_EVENT,
@@ -52,6 +53,6 @@ export async function getAllEnvironments({
   };
 
   const resp = await client.search(params);
-  const buckets = resp.aggregations.environments.buckets;
+  const buckets = idx(resp.aggregations, _ => _.environments.buckets) || [];
   return buckets.map(bucket => bucket.key);
 }

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_environments/get_unavailable_environments.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_environments/get_unavailable_environments.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { idx } from '@kbn/elastic-idx';
 import { Setup } from '../../../helpers/setup_request';
 import {
   SERVICE_NAME,
@@ -42,6 +43,6 @@ export async function getUnavailableEnvironments({
   };
 
   const resp = await client.search(params);
-  const buckets = resp.aggregations.environments.buckets;
+  const buckets = idx(resp.aggregations, _ => _.environments.buckets) || [];
   return buckets.map(bucket => bucket.key);
 }

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { idx } from '@kbn/elastic-idx';
 import { Setup } from '../../helpers/setup_request';
 import { PromiseReturnType } from '../../../../typings/common';
 import {
@@ -44,6 +45,6 @@ export async function getServiceNames({ setup }: { setup: Setup }) {
   };
 
   const resp = await client.search(params);
-  const buckets = resp.aggregations.services.buckets;
+  const buckets = idx(resp.aggregations, _ => _.services.buckets) || [];
   return buckets.map(bucket => bucket.key);
 }

--- a/x-pack/legacy/plugins/apm/server/lib/transaction_groups/transform.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transaction_groups/transform.ts
@@ -28,7 +28,7 @@ function calculateRelativeImpacts(transactionGroups: ITransactionGroup[]) {
 
 export type ITransactionGroup = ReturnType<typeof getTransactionGroup>;
 function getTransactionGroup(
-  bucket: ESResponse['aggregations']['transactions']['buckets'][0],
+  bucket: Required<ESResponse>['aggregations']['transactions']['buckets'][0],
   minutes: number
 ) {
   const averageResponseTime = bucket.avg.value;

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -152,9 +152,9 @@ export async function getTransactionBreakdown({
 
   const kpiNames = kpis.map(kpi => kpi.name);
 
-  const timeseriesPerSubtype = (
-    idx(resp.aggregations, _ => _.by_date.buckets) || []
-  ).reduce(
+  const bucketsByDate = idx(resp.aggregations, _ => _.by_date.buckets) || [];
+
+  const timeseriesPerSubtype = bucketsByDate.reduce(
     (prev, bucket) => {
       const formattedValues = formatBucket(bucket);
       const time = bucket.key;

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_anomaly_data/transform.ts
@@ -11,7 +11,9 @@ import { ESResponse } from './fetcher';
 
 type IBucket = ReturnType<typeof getBucket>;
 function getBucket(
-  bucket: ESResponse['aggregations']['ml_avg_response_times']['buckets'][0]
+  bucket: Required<
+    ESResponse
+  >['aggregations']['ml_avg_response_times']['buckets'][0]
 ) {
   return {
     x: bucket.key,

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/transform.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/transform.ts
@@ -20,8 +20,9 @@ export function timeseriesTransformer({
   bucketSize: number;
 }) {
   const aggs = timeseriesResponse.aggregations;
-  const overallAvgDuration = idx(aggs, _ => _.overall_avg_duration.value);
-  const responseTimeBuckets = idx(aggs, _ => _.response_times.buckets);
+  const overallAvgDuration =
+    idx(aggs, _ => _.overall_avg_duration.value) || null;
+  const responseTimeBuckets = idx(aggs, _ => _.response_times.buckets) || [];
   const { avg, p95, p99 } = getResponseTime(responseTimeBuckets);
   const transactionResultBuckets = idx(
     aggs,
@@ -41,7 +42,9 @@ export function timeseriesTransformer({
 }
 
 export function getTpmBuckets(
-  transactionResultBuckets: ESResponse['aggregations']['transaction_results']['buckets'] = [],
+  transactionResultBuckets: Required<
+    ESResponse
+  >['aggregations']['transaction_results']['buckets'] = [],
   bucketSize: number
 ) {
   const buckets = transactionResultBuckets.map(
@@ -67,7 +70,9 @@ export function getTpmBuckets(
 }
 
 function getResponseTime(
-  responseTimeBuckets: ESResponse['aggregations']['response_times']['buckets'] = []
+  responseTimeBuckets: Required<
+    ESResponse
+  >['aggregations']['response_times']['buckets'] = []
 ) {
   return responseTimeBuckets.reduce(
     (acc, bucket) => {

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/transform.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/transform.ts
@@ -22,7 +22,7 @@ export function timeseriesTransformer({
   const aggs = timeseriesResponse.aggregations;
   const overallAvgDuration =
     idx(aggs, _ => _.overall_avg_duration.value) || null;
-  const responseTimeBuckets = idx(aggs, _ => _.response_times.buckets) || [];
+  const responseTimeBuckets = idx(aggs, _ => _.response_times.buckets);
   const { avg, p95, p99 } = getResponseTime(responseTimeBuckets);
   const transactionResultBuckets = idx(
     aggs,

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/transform.ts
@@ -13,7 +13,9 @@ type DistributionBucketResponse = PromiseReturnType<typeof bucketFetcher>;
 
 export type IBucket = ReturnType<typeof getBucket>;
 function getBucket(
-  bucket: DistributionBucketResponse['aggregations']['distribution']['buckets'][0]
+  bucket: Required<
+    DistributionBucketResponse
+  >['aggregations']['distribution']['buckets'][0]
 ) {
   const sampleSource = idx(bucket, _ => _.sample.hits.hits[0]._source) as
     | Transaction
@@ -32,7 +34,9 @@ function getBucket(
 }
 
 export function bucketTransformer(response: DistributionBucketResponse) {
-  const buckets = response.aggregations.distribution.buckets.map(getBucket);
+  const buckets = (
+    idx(response.aggregations, _ => _.distribution.buckets) || []
+  ).map(getBucket);
 
   return {
     totalHits: response.hits.total,

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_distribution_max.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_distribution_max.ts
@@ -56,5 +56,5 @@ export async function getDistributionMax(
   };
 
   const resp = await client.search(params);
-  return resp.aggregations.stats.max;
+  return resp.aggregations ? resp.aggregations.stats.max : null;
 }

--- a/x-pack/legacy/plugins/apm/server/lib/ui_filters/local_ui_filters/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/ui_filters/local_ui_filters/index.ts
@@ -53,14 +53,20 @@ export async function getLocalUIFilters({
 
   const response = await client.search(params);
 
+  const { aggregations } = response;
+
+  if (!aggregations) {
+    return [];
+  }
+
   return localFilterNames.map(key => {
-    const aggregations = response.aggregations[key];
+    const aggregationsForFilter = aggregations[key];
     const filter = localUIFilters[key];
 
     return {
       ...filter,
       options: sortByOrder(
-        aggregations.by_terms.buckets.map(bucket => {
+        aggregationsForFilter.by_terms.buckets.map(bucket => {
           return {
             name: bucket.key,
             count:

--- a/x-pack/legacy/plugins/apm/typings/elasticsearch.ts
+++ b/x-pack/legacy/plugins/apm/typings/elasticsearch.ts
@@ -138,7 +138,7 @@ declare module 'elasticsearch' {
   > &
     (SearchParams extends { body: Required<AggregationOptionMap> }
       ? {
-          aggregations: AggregationResultMap<SearchParams['body']['aggs']>;
+          aggregations?: AggregationResultMap<SearchParams['body']['aggs']>;
         }
       : {});
 

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -43,35 +43,17 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     {
       url: `/api/apm/services/foo/errors/distribution?start=${start}&end=${end}&groupId=bar`,
       expectForbidden: expect404,
-      expectResponse: (result: any) => {
-        expect(result.response).to.have.property('statusCode', 400);
-        expect(result.response.body).to.have.property(
-          'message',
-          "Cannot read property 'distribution' of undefined"
-        );
-      },
+      expectResponse: expect200,
     },
     {
       url: `/api/apm/services/foo/errors/distribution?start=${start}&end=${end}`,
       expectForbidden: expect404,
-      expectResponse: (result: any) => {
-        expect(result.response).to.have.property('statusCode', 400);
-        expect(result.response.body).to.have.property(
-          'message',
-          "Cannot read property 'distribution' of undefined"
-        );
-      },
+      expectResponse: expect200,
     },
     {
       url: `/api/apm/services/foo/metrics/charts?start=${start}&end=${end}&agentName=cool-agent`,
       expectForbidden: expect404,
-      expectResponse: (result: any) => {
-        expect(result.response).to.have.property('statusCode', 400);
-        expect(result.response.body).to.have.property(
-          'message',
-          "Cannot destructure property `timeseriesData` of 'undefined' or 'null'."
-        );
-      },
+      expectResponse: expect200,
     },
     {
       url: `/api/apm/services?start=${start}&end=${end}`,
@@ -96,13 +78,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     {
       url: `/api/apm/traces/foo?start=${start}&end=${end}`,
       expectForbidden: expect404,
-      expectResponse: (result: any) => {
-        expect(result.response).to.have.property('statusCode', 400);
-        expect(result.response.body).to.have.property(
-          'message',
-          "Cannot read property 'transactions' of undefined"
-        );
-      },
+      expectResponse: expect200,
     },
     {
       url: `/api/apm/services/foo/transaction_groups?start=${start}&end=${end}&transactionType=bar`,
@@ -127,13 +103,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     {
       url: `/api/apm/services/foo/transaction_groups/distribution?start=${start}&end=${end}&transactionType=bar&transactionName=baz`,
       expectForbidden: expect404,
-      expectResponse: (result: any) => {
-        expect(result.response).to.have.property('statusCode', 400);
-        expect(result.response.body).to.have.property(
-          'message',
-          "Cannot read property 'stats' of undefined"
-        );
-      },
+      expectResponse: expect200,
     },
   ];
 


### PR DESCRIPTION
Closes #43436.

Our type definition for ElasticSearch aggregations suggests that the aggregations key will always be defined if we request aggregations. However, that is not the case, as there is an edge case where if no matching indices were found, the aggregations key will be undefined.

