### PR TITLE
Task manager to queue calls that require it to be initialized

### DIFF
--- a/x-pack/legacy/plugins/task_manager/task_manager.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.test.ts
@@ -42,26 +42,6 @@ describe('TaskManager', () => {
 
   afterEach(() => clock.restore());
 
-  test('disallows schedule before init', async () => {
-    const client = new TaskManager(taskManagerOpts);
-    const task = {
-      taskType: 'foo',
-      params: {},
-      state: {},
-    };
-    await expect(client.schedule(task)).rejects.toThrow(/^NotInitialized: .*/i);
-  });
-
-  test('disallows fetch before init', async () => {
-    const client = new TaskManager(taskManagerOpts);
-    await expect(client.fetch({})).rejects.toThrow(/^NotInitialized: .*/i);
-  });
-
-  test('disallows remove before init', async () => {
-    const client = new TaskManager(taskManagerOpts);
-    await expect(client.remove('23')).rejects.toThrow(/^NotInitialized: .*/i);
-  });
-
   test('allows middleware registration before init', () => {
     const client = new TaskManager(taskManagerOpts);
     const middleware = {

--- a/x-pack/legacy/plugins/task_manager/task_manager.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.ts
@@ -136,6 +136,7 @@ export class TaskManager {
    * Stops the task manager and cancels running tasks.
    */
   public stop() {
+    this.poller.stop();
     this.pool.cancelRunningTasks();
   }
 

--- a/x-pack/legacy/plugins/task_manager/task_manager.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.ts
@@ -38,7 +38,7 @@ export interface TaskManagerOpts {
  * The public interface into the task manager system.
  */
 export class TaskManager {
-  private isInitialized = false;
+  private isStarted = false;
   private maxWorkers: number;
   private overrideNumWorkers: { [taskType: string]: number };
   private readonly pollerInterval: number;
@@ -47,6 +47,7 @@ export class TaskManager {
   private poller: TaskPoller;
   private logger: Logger;
   private pool: TaskPool;
+  private startQueue: Array<() => void> = [];
   private middleware = {
     beforeSave: async (saveOpts: BeforeSaveMiddlewareParams) => saveOpts,
     beforeRun: async (runOpts: RunContext) => runOpts,
@@ -103,7 +104,10 @@ export class TaskManager {
    * Starts up the task manager and starts picking up tasks.
    */
   public start() {
-    this.isInitialized = true;
+    this.isStarted = true;
+    // Some calls are waiting until task manager is started
+    this.startQueue.forEach(fn => fn());
+    this.startQueue = [];
     const startPoller = async () => {
       try {
         await this.poller.start();
@@ -118,6 +122,14 @@ export class TaskManager {
       }
     };
     startPoller();
+  }
+
+  private async waitUntilStarted() {
+    if (!this.isStarted) {
+      await new Promise(resolve => {
+        this.startQueue.push(resolve);
+      });
+    }
   }
 
   /**
@@ -169,7 +181,7 @@ export class TaskManager {
    * @returns {Promise<ConcreteTaskInstance>}
    */
   public async schedule(taskInstance: TaskInstance, options?: any): Promise<ConcreteTaskInstance> {
-    this.assertInitialized('Tasks cannot be scheduled until after task manager is initialized!');
+    await this.waitUntilStarted();
     const { taskInstance: modifiedTask } = await this.middleware.beforeSave({
       ...options,
       taskInstance,
@@ -186,7 +198,7 @@ export class TaskManager {
    * @returns {Promise<FetchResult>}
    */
   public async fetch(opts: FetchOpts): Promise<FetchResult> {
-    this.assertInitialized('Tasks cannot be fetched before task manager is initialized!');
+    await this.waitUntilStarted();
     return this.store.fetch(opts);
   }
 
@@ -197,7 +209,7 @@ export class TaskManager {
    * @returns {Promise<RemoveResult>}
    */
   public async remove(id: string): Promise<void> {
-    this.assertInitialized('Tasks cannot be removed before task manager is initialized!');
+    await this.waitUntilStarted();
     return this.store.remove(id);
   }
 
@@ -208,20 +220,8 @@ export class TaskManager {
    * @returns void
    */
   private assertUninitialized(message: string) {
-    if (this.isInitialized) {
+    if (this.isStarted) {
       throw new Error(`Cannot ${message} after the task manager is initialized!`);
-    }
-  }
-
-  /**
-   * Ensures task manager IS already initialized
-   *
-   * @param {string} message shown if task manager is not initialized
-   * @returns void
-   */
-  private assertInitialized(message: string) {
-    if (!this.isInitialized) {
-      throw new Error(`NotInitialized: ${message}`);
     }
   }
 }


### PR DESCRIPTION
In this PR, I'm making task manager queue up calls that require task manager to be initialized. Previously task manager would throw an error and it would be up to the user to find out when is appropriate to `schedule`, `fetch` and `remove`.

I've also added `this.poller.stop();` within the task manager `stop()` function.