### PR TITLE
[APM] Fill in vertical gaps in breakdown metrics data

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/TransactionBreakdownGraph/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/TransactionBreakdownGraph/index.tsx
@@ -21,8 +21,8 @@ const tickFormatY = (y: number | null | undefined) => {
   return numeral(y || 0).format('0 %');
 };
 
-const formatTooltipValue = (coordinate: Coordinate & { hasData?: boolean }) => {
-  return coordinate.hasData && isValidCoordinateValue(coordinate.y)
+const formatTooltipValue = (coordinate: Coordinate) => {
+  return isValidCoordinateValue(coordinate.y)
     ? asPercent(coordinate.y, 1)
     : NOT_AVAILABLE_LABEL;
 };

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/TransactionBreakdownGraph/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/TransactionBreakdownGraph/index.tsx
@@ -21,8 +21,8 @@ const tickFormatY = (y: number | null | undefined) => {
   return numeral(y || 0).format('0 %');
 };
 
-const formatTooltipValue = (coordinate: Coordinate) => {
-  return isValidCoordinateValue(coordinate.y)
+const formatTooltipValue = (coordinate: Coordinate & { hasData?: boolean }) => {
+  return coordinate.hasData && isValidCoordinateValue(coordinate.y)
     ? asPercent(coordinate.y, 1)
     : NOT_AVAILABLE_LABEL;
 };

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.test.ts
@@ -157,12 +157,9 @@ describe('getTransactionBreakdown', () => {
 
     const appTimeseries = timeseries.find(series => series.title === 'app');
 
+    // missing values should be 0 if other span types do have data for that timestamp
     expect((appTimeseries as NonNullable<typeof appTimeseries>).data[1].y).toBe(
       0
     );
-
-    expect(
-      (appTimeseries as NonNullable<typeof appTimeseries>).data[1].hasData
-    ).toBe(false);
   });
 });

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.test.ts
@@ -134,4 +134,35 @@ describe('getTransactionBreakdown', () => {
 
     expect(timeseries.map(serie => serie.title)).toEqual(['app', 'http']);
   });
+
+  it('fills in gaps for a given timestamp', async () => {
+    const clientSpy = jest.fn().mockReturnValueOnce(dataResponse);
+
+    const response = await getTransactionBreakdown({
+      serviceName: 'myServiceName',
+      transactionType: 'request',
+      setup: {
+        start: 0,
+        end: 500000,
+        client: { search: clientSpy } as any,
+        config: {
+          get: () => 'myIndex' as any,
+          has: () => true
+        },
+        uiFiltersES: []
+      }
+    });
+
+    const { timeseries } = response;
+
+    const appTimeseries = timeseries.find(series => series.title === 'app');
+
+    expect((appTimeseries as NonNullable<typeof appTimeseries>).data[1].y).toBe(
+      0
+    );
+
+    expect(
+      (appTimeseries as NonNullable<typeof appTimeseries>).data[1].hasData
+    ).toBe(false);
+  });
 });

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -174,8 +174,7 @@ export async function getTransactionBreakdown({
           ...p,
           [name]: p[name].concat({
             x: time,
-            y: percentage,
-            hasData: percentage !== null
+            y: percentage
           })
         };
       }, prev);
@@ -195,6 +194,7 @@ export async function getTransactionBreakdown({
           const value = series[series.length - 1];
           const isEmpty = value.y === null;
           if (isEmpty) {
+            // local mutation to prevent complicated map/reduce calls
             value.y = 0;
           }
         });
@@ -202,10 +202,7 @@ export async function getTransactionBreakdown({
 
       return updatedSeries;
     },
-    {} as Record<
-      string,
-      Array<{ x: number; y: number | null; hasData: boolean }>
-    >
+    {} as Record<string, Array<{ x: number; y: number | null }>>
   );
 
   const timeseries = kpis.map(kpi => ({

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { flatten, sortByOrder } from 'lodash';
+import { flatten, sortByOrder, last } from 'lodash';
 import { idx } from '@kbn/elastic-idx';
 import {
   SERVICE_NAME,
@@ -159,7 +159,7 @@ export async function getTransactionBreakdown({
       const formattedValues = formatBucket(bucket);
       const time = bucket.key;
 
-      return kpiNames.reduce((p, kpiName) => {
+      const updatedSeries = kpiNames.reduce((p, kpiName) => {
         const { name, percentage } = formattedValues.find(
           val => val.name === kpiName
         ) || {
@@ -174,12 +174,38 @@ export async function getTransactionBreakdown({
           ...p,
           [name]: p[name].concat({
             x: time,
-            y: percentage
+            y: percentage,
+            hasData: percentage !== null
           })
         };
       }, prev);
+
+      const lastValues = Object.values(updatedSeries).map(last);
+
+      // If for a given timestamp, some series have data, but others do not,
+      // we have to set any null values to 0 to make sure the stacked area chart
+      // is drawn correctly.
+      // If we set all values to 0, the chart always displays null values as 0,
+      // and the chart looks weird.
+      const hasAnyValues = lastValues.some(value => value.y !== null);
+      const hasNullValues = lastValues.some(value => value.y === null);
+
+      if (hasAnyValues && hasNullValues) {
+        Object.values(updatedSeries).forEach(series => {
+          const value = series[series.length - 1];
+          const isEmpty = value.y === null;
+          if (isEmpty) {
+            value.y = 0;
+          }
+        });
+      }
+
+      return updatedSeries;
     },
-    {} as Record<string, Array<{ x: number; y: number | null }>>
+    {} as Record<
+      string,
+      Array<{ x: number; y: number | null; hasData: boolean }>
+    >
   );
 
   const timeseries = kpis.map(kpi => ({

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/mock-responses/data.json
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/mock-responses/data.json
@@ -92,21 +92,6 @@
             "sum_other_doc_count": 0,
             "buckets": [
               {
-                "key": "app",
-                "doc_count": 16,
-                "subtypes": {
-                  "doc_count_error_upper_bound": 0,
-                  "sum_other_doc_count": 0,
-                  "buckets": [
-                    {
-                      "key": "",
-                      "doc_count": 16,
-                      "total_self_time_per_subtype": { "value": 73798 }
-                    }
-                  ]
-                }
-              },
-              {
                 "key": "db",
                 "doc_count": 11,
                 "subtypes": {


### PR DESCRIPTION
Closes #43650.

This is maybe kinda a bug in `react-vis`, but given the response to [our last issue](https://github.com/uber/react-vis/issues/1214) I have little hope of getting it fixed there (quickly). We can add a workaround though.

Before:
![image](https://user-images.githubusercontent.com/352732/64102822-062b2480-cd71-11e9-96ba-9edb636dd00c.png)


After:
![image](https://user-images.githubusercontent.com/352732/64102427-3e7e3300-cd70-11e9-8368-246dd95f2d8c.png)
