### PR TITLE
[APM] parse _debug query parameter from JSON before validating

### DIFF
--- a/x-pack/legacy/plugins/apm/server/routes/create_api/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_api/index.test.ts
@@ -98,7 +98,7 @@ describe('createApi', () => {
       expect(() =>
         route.handler({
           query: {
-            _debug: true
+            _debug: 'true'
           }
         })
       ).not.toThrow();
@@ -124,7 +124,7 @@ describe('createApi', () => {
       expect(() =>
         route.handler({
           query: {
-            _debug: true,
+            _debug: 'true',
             extra: ''
           }
         })
@@ -227,7 +227,7 @@ describe('createApi', () => {
         route.handler({
           query: {
             bar: '',
-            _debug: true
+            _debug: 'true'
           }
         })
       ).not.toThrow();

--- a/x-pack/legacy/plugins/apm/server/routes/create_api/index.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_api/index.ts
@@ -16,6 +16,7 @@ import {
   Route,
   Params
 } from '../typings';
+import { jsonRt } from '../../../common/runtime_types/json_rt';
 
 export function createApi() {
   const factoryFns: Array<RouteFactoryFn<any, any, any, any>> = [];
@@ -39,9 +40,15 @@ export function createApi() {
           // add _debug query parameter to all routes
           query: params.query
             ? t.exact(
-                t.intersection([params.query, t.partial({ _debug: t.boolean })])
+                t.intersection([
+                  params.query,
+                  t.partial({ _debug: jsonRt.pipe(t.boolean) })
+                ])
               )
-            : t.union([t.strict({}), t.strict({ _debug: t.boolean })]),
+            : t.union([
+                t.strict({}),
+                t.strict({ _debug: jsonRt.pipe(t.boolean) })
+              ]),
           path: params.path || t.strict({}),
           body: params.body || t.null
         };

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -31,7 +31,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
 
   const endpoints = [
     {
-      url: `/api/apm/services/foo/errors?start=${start}&end=${end}&uiFilters=%7B%7D`,
+      url: `/api/apm/services/foo/errors?start=${start}&end=${end}&uiFilters=%7B%7D&_debug=true`,
       expectForbidden: expect404,
       expectResponse: expect200,
     },


### PR DESCRIPTION
Broke the `_debug` query parameter because it needs to be parsed first. Woops. Well, here's a fix, and I've added the query parameter to the API integration tests to make sure it doesn't happen again.