### PR TITLE
Switch the order of primaries and total in legend

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
@@ -278,7 +278,6 @@ NodeList [
       >
         <span
           class="euiBadge euiBadge--iconLeft euiBadge--hollow"
-          title="test"
         >
           <span
             class="euiBadge__content"
@@ -292,7 +291,6 @@ NodeList [
         </span>
         <span
           class="euiBadge euiBadge--iconLeft euiBadge--hollow"
-          title="dev"
         >
           <span
             class="euiBadge__content"

--- a/x-pack/legacy/plugins/monitoring/server/routes/api/v1/elasticsearch/metric_set_index_detail.js
+++ b/x-pack/legacy/plugins/monitoring/server/routes/api/v1/elasticsearch/metric_set_index_detail.js
@@ -97,7 +97,7 @@ export const metricSet = {
     },
     'index_document_count',
     {
-      keys: ['index_segment_count_primaries', 'index_segment_count_total'],
+      keys: ['index_segment_count_total', 'index_segment_count_primaries'],
       name: 'index_segment_count'
     }
   ]


### PR DESCRIPTION
## Summary

This resolves https://github.com/elastic/kibana/issues/43721

The previous behavior is described in the email. The new behavior is shown below. To test this, simply ensure that the items in the Segments legend on the Index Overview page are ordered as you see below, with `Total` in green and `Primaries` in blue:

<img width="1581" alt="order" src="https://user-images.githubusercontent.com/111616/63507468-57146080-c4c7-11e9-9440-a5a850303d4a.png">



### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

