### PR TITLE
Registers webhook action and enables function tests

### DIFF
--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/index.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/index.ts
@@ -10,10 +10,12 @@ import { actionType as serverLogActionType } from './server_log';
 import { actionType as slackActionType } from './slack';
 import { actionType as emailActionType } from './email';
 import { actionType as indexActionType } from './es_index';
+import { actionType as webhookActionType } from './webhook';
 
 export function registerBuiltInActionTypes(actionTypeRegistry: ActionTypeRegistry) {
   actionTypeRegistry.register(serverLogActionType);
   actionTypeRegistry.register(slackActionType);
   actionTypeRegistry.register(emailActionType);
   actionTypeRegistry.register(indexActionType);
+  actionTypeRegistry.register(webhookActionType);
 }

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/actions/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/actions/index.ts
@@ -20,5 +20,6 @@ export default function actionsTests({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./builtin_action_types/slack'));
     loadTestFile(require.resolve('./builtin_action_types/email'));
     loadTestFile(require.resolve('./builtin_action_types/es_index'));
+    loadTestFile(require.resolve('./builtin_action_types/webhook'));
   });
 }


### PR DESCRIPTION
I tried running Kibana with the new webhook action, and the `api/actions/ls-type` endpoint didn't return the webhook action!  So I checked, and ya, it never got registered.  But happened to wonder, how did the function tests ever work, they shouldn't have been able to create webhook actions?  Turns out they weren't running hahahaha.

Not sure how many more builtin actions we're planning on - probably not a ton?  Is it worthwhile to see if we can make it easier to add a new builtin, without remembering all the places you need to update, like these?

The tests ran fine for me with the others, on my box.
