### PR TITLE
[APM] Clear KueryBar when query param is not set

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/Typeahead/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/Typeahead/index.js
@@ -30,8 +30,8 @@ export class Typeahead extends Component {
   };
 
   static getDerivedStateFromProps(props, state) {
-    const { initialValue } = props;
-    if (initialValue && initialValue !== state.initialValue) {
+    const initialValue = props.initialValue ? props.initialValue : '';
+    if (initialValue !== state.initialValue) {
       return {
         value: initialValue,
         initialValue


### PR DESCRIPTION
Via https://github.com/elastic/kibana/pull/43773#issuecomment-524781697.

Could also fix it by defaulting to an empty string in `x-pack/legacy/plugins/apm/public/context/UrlParamsContext/resolveUrlParams.ts`. Opted for the more simple fix.