### PR TITLE
fix logging 'undefined' on tests completion

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/reporter.js
@@ -121,7 +121,7 @@ export function MochaReporterProvider({ getService }) {
 
     onSuiteEnd = () => {
       if (log.indent(-2) === 0) {
-        log.write();
+        log.write('');
       }
     };
 

--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/write_epilogue.js
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/write_epilogue.js
@@ -22,7 +22,7 @@ import { ms } from './ms';
 
 export function writeEpilogue(log, stats) {
   // header
-  log.write();
+  log.write('');
 
   // passes
   log.write(`${colors.pass('%d passing')} (%s)`, stats.passes || 0, ms(stats.duration));
@@ -38,5 +38,5 @@ export function writeEpilogue(log, stats) {
   }
 
   // footer
-  log.write();
+  log.write('');
 }


### PR DESCRIPTION
## Summary

Fixing FTR output printing `undefined` on tests completion
```
13:24:48              └-> "after all" hook
13:24:48            └-> "after all" hook
13:24:48          └-> "after all" hook
13:24:48      │undefined
13:24:48      │7 passing (47.0s)
13:24:48      │10 pending
13:24:48      │undefined
13:24:48      │ debg Sending "SIGTERM" to proc "kibana"
13:24:48      │ proc [kibana]   log   [11:24:48.958] [info][plugins-system] Stopping all plugins.
13:24:48      │ proc [kibana]   log   [11:24:48.959] [info][data][plugins] Stopping plugin
```

