### PR TITLE
Disable alerting and actions plugin by default

### DIFF
--- a/x-pack/legacy/plugins/actions/index.ts
+++ b/x-pack/legacy/plugins/actions/index.ts
@@ -26,7 +26,7 @@ export function actions(kibana: any) {
     config(Joi: Root) {
       return Joi.object()
         .keys({
-          enabled: Joi.boolean().default(true),
+          enabled: Joi.boolean().default(false),
         })
         .default();
     },

--- a/x-pack/legacy/plugins/alerting/index.ts
+++ b/x-pack/legacy/plugins/alerting/index.ts
@@ -27,7 +27,7 @@ export function alerting(kibana: any) {
     config(Joi: Root) {
       return Joi.object()
         .keys({
-          enabled: Joi.boolean().default(true),
+          enabled: Joi.boolean().default(false),
         })
         .default();
     },

--- a/x-pack/test/alerting_api_integration/common/config.ts
+++ b/x-pack/test/alerting_api_integration/common/config.ts
@@ -53,6 +53,8 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
         ...xPackApiIntegrationTestsConfig.get('kbnTestServer'),
         serverArgs: [
           ...xPackApiIntegrationTestsConfig.get('kbnTestServer.serverArgs'),
+          '--xpack.actions.enabled=true',
+          '--xpack.alerting.enabled=true',
           ...disabledPlugins.map(key => `--xpack.${key}.enabled=false`),
           `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'alerts')}`,
           `--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'actions')}`,

--- a/x-pack/test/api_integration/apis/xpack_main/features/features.ts
+++ b/x-pack/test/api_integration/apis/xpack_main/features/features.ts
@@ -134,8 +134,6 @@ export default function({ getService }: FtrProviderContext) {
             'maps',
             'uptime',
             'siem',
-            'alerting',
-            'actions',
           ].sort()
         );
       });


### PR DESCRIPTION
I have noticed that `Alerting` and `Actions` show up under feature controls in the UI (when creating a role then assigning space privileges). This is caused by the security PR registering features in order to test different scenarios (#41389). We'll disable the plugins by default until the UI is ready.

Screenshot of what shows up in the assign spaces privileges UI without this change:
<img width="732" alt="Screen Shot 2019-08-26 at 4 32 53 PM" src="https://user-images.githubusercontent.com/3694571/63771892-06757c80-c8a6-11e9-9659-e5b96af9cc77.png">

In order to have this working by default again in a development environment. Create a `kibana.dev.yml` file under `/config` and add the following two lines:

```
xpack.actions.enabled: true
xpack.alerting.enabled: true
```