### PR TITLE
Don't assert error messages from Elasticsearch in alerting tests

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/actions/execute.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/actions/execute.ts
@@ -419,7 +419,6 @@ export default function({ getService }: FtrProviderContext) {
                 savedObjectsClientSuccess: false,
                 callClusterError: {
                   ...indexedRecord._source.state.callClusterError,
-                  msg: `[security_exception] action [indices:data/write/bulk[s]] is unauthorized for user [${user.username}]`,
                   statusCode: 403,
                 },
                 savedObjectsClientError: {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/alerts.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/alerts.ts
@@ -305,7 +305,6 @@ export default function alertTests({ getService }: FtrProviderContext) {
                 savedObjectsClientSuccess: false,
                 callClusterError: {
                   ...alertTestRecord._source.state.callClusterError,
-                  msg: `[security_exception] action [indices:data/write/bulk[s]] is unauthorized for user [${user.username}]`,
                   statusCode: 403,
                 },
                 savedObjectsClientError: {
@@ -397,7 +396,6 @@ export default function alertTests({ getService }: FtrProviderContext) {
                 savedObjectsClientSuccess: false,
                 callClusterError: {
                   ...actionTestRecord._source.state.callClusterError,
-                  msg: `[security_exception] action [indices:data/write/bulk[s]] is unauthorized for user [${user.username}]`,
                   statusCode: 403,
                 },
                 savedObjectsClientError: {


### PR DESCRIPTION
Fixes #44245.

Elasticsearch error messages changed in the latest snapshot. This PR removes the assertion on the message when using API keys and focuses on `403` being returned.