### PR TITLE
fix flaky TSVB test

### DIFF
--- a/test/functional/apps/visualize/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/_tsvb_time_series.ts
@@ -108,7 +108,6 @@ export default function({ getPageObjects, getService }: FtrProviderContext) {
         expect(actualCount).to.be(expectedLegendValue);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/40458
       it('should show the correct count in the legend with "Human readable" duration formatter', async () => {
         await visualBuilder.clickSeriesOption();
         await visualBuilder.changeDataFormatter('Duration');

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -239,7 +239,7 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }: FtrPro
       formatter: 'Bytes' | 'Number' | 'Percent' | 'Duration' | 'Custom'
     ) {
       const formatterEl = await find.byCssSelector('[id$="row"] .euiComboBox');
-      await comboBox.setElement(formatterEl, formatter);
+      await comboBox.setElement(formatterEl, formatter, { clickWithMouse: true });
     }
 
     /**
@@ -260,11 +260,11 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }: FtrPro
     }) {
       if (from) {
         const fromCombobox = await find.byCssSelector('[id$="from-row"] .euiComboBox');
-        await comboBox.setElement(fromCombobox, from);
+        await comboBox.setElement(fromCombobox, from, { clickWithMouse: true });
       }
       if (to) {
         const toCombobox = await find.byCssSelector('[id$="to-row"] .euiComboBox');
-        await comboBox.setElement(toCombobox, to);
+        await comboBox.setElement(toCombobox, to, { clickWithMouse: true });
       }
       if (decimalPlaces) {
         const decimalPlacesInput = await find.byCssSelector('[id$="decimal"]');

--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -46,13 +46,21 @@ export function ComboBoxProvider({ getService, getPageObjects }: FtrProviderCont
       await this.setElement(comboBox, value);
     }
 
+    private async clickOption(isMouseClick: boolean, element: WebElementWrapper) {
+      return isMouseClick ? await browser.clickMouseButton(element) : await element.click();
+    }
+
     /**
      * set value inside combobox element
      *
      * @param comboBoxElement
      * @param value
      */
-    public async setElement(comboBoxElement: WebElementWrapper, value: string): Promise<void> {
+    public async setElement(
+      comboBoxElement: WebElementWrapper,
+      value: string,
+      options = { clickWithMouse: false }
+    ): Promise<void> {
       log.debug(`comboBox.setElement, value: ${value}`);
       const isOptionSelected = await this.isOptionSelected(comboBoxElement, value);
 
@@ -65,21 +73,22 @@ export function ComboBoxProvider({ getService, getPageObjects }: FtrProviderCont
       await this.openOptionsList(comboBoxElement);
 
       if (value !== undefined) {
-        const options = await find.allByCssSelector(
+        const selectOptions = await find.allByCssSelector(
           `.euiFilterSelectItem[title^="${value.toString().trim()}"]`,
           WAIT_FOR_EXISTS_TIME
         );
 
-        if (options.length > 0) {
-          await options[0].click();
+        if (selectOptions.length > 0) {
+          await this.clickOption(options.clickWithMouse, selectOptions[0]);
         } else {
           // if it doesn't find the item which text starts with value, it will choose the first option
-          await find.clickByCssSelector('.euiFilterSelectItem');
+          const firstOption = await find.byCssSelector('.euiFilterSelectItem');
+          await this.clickOption(options.clickWithMouse, firstOption);
         }
       } else {
-        await find.clickByCssSelector('.euiFilterSelectItem');
+        const firstOption = await find.byCssSelector('.euiFilterSelectItem');
+        await this.clickOption(options.clickWithMouse, firstOption);
       }
-
       await this.closeOptionsList(comboBoxElement);
     }
 
@@ -241,11 +250,11 @@ export function ComboBoxProvider({ getService, getPageObjects }: FtrProviderCont
       value: string
     ): Promise<boolean> {
       log.debug(`comboBox.isOptionSelected, value: ${value}`);
-      const selectedOptions = await comboBoxElement.findAllByClassName(
-        'euiComboBoxPill',
-        WAIT_FOR_EXISTS_TIME
-      );
-      return selectedOptions.length === 1 && (await selectedOptions[0].getVisibleText()) === value;
+      const $ = await comboBoxElement.parseDomContent();
+      const selectedOptions = $('.euiComboBoxPill')
+        .toArray()
+        .map(option => $(option).text());
+      return selectedOptions.length === 1 && selectedOptions[0] === value;
     }
   }
 


### PR DESCRIPTION
## Summary

There is a test that constantly fails locally and somehow more stable on CI.

The issue is failing click on dropdown option on TSVB Series Option tab, it fails with StaleElementException. 
<img width="548" alt="Kibana 2019-08-30 18-48-43" src="https://user-images.githubusercontent.com/10977896/64037810-da345700-cb56-11e9-921f-c9f803d1ad47.png">
```
           └- ✖ fail: "visualize app  visual builder Time Series should show the correct count in the legend with "Human readable" duration formatter"
           │      StaleElementReferenceError: stale element reference: element is not attached to the page document
           │   (Session info: chrome=76.0.3809.100)
           │   (Driver info: chromedriver=76.0.3809.68 (420c9498db8ce8fcd190a954d51297672c1515d5-refs/branch-heads/3809@{#864}),platform=Mac OS X 10.14.6 x86_64)
```
The only working option for me was to click with a mouse (works on both Chrome and Firefox)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

