### PR TITLE
[APM] Fix indefinite loading state in agent settings for unauthorized user roles

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -13,7 +13,7 @@ import { TransactionDetails } from '../../TransactionDetails';
 import { Home } from '../../Home';
 import { BreadcrumbRoute } from '../ProvideBreadcrumbs';
 import { RouteName } from './route_names';
-import { SettingsList } from '../../Settings/SettingsList';
+import { Settings } from '../../Settings';
 import { toQuery } from '../../../shared/Links/url_helpers';
 
 interface RouteParams {
@@ -60,7 +60,7 @@ export const routes: BreadcrumbRoute[] = [
   {
     exact: true,
     path: '/settings',
-    component: SettingsList,
+    component: Settings,
     breadcrumb: i18n.translate('xpack.apm.breadcrumb.listSettingsTitle', {
       defaultMessage: 'Settings'
     }),

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -25,10 +25,10 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { isRight } from 'fp-ts/lib/Either';
 import { transactionSampleRateRt } from '../../../../../common/runtime_types/transaction_sample_rate_rt';
 import { AddSettingFlyoutBody } from './AddSettingFlyoutBody';
-import { Config } from '../SettingsList';
 import { useFetcher } from '../../../../hooks/useFetcher';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../../../common/environment_filter_values';
 import { callApmApi } from '../../../../services/rest/callApmApi';
+import { Config } from '..';
 
 interface Props {
   onClose: () => void;

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -18,9 +18,9 @@ import {
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 import { FETCH_STATUS } from '../../../../hooks/useFetcher';
-import { Config } from '../SettingsList';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../../../common/environment_filter_values';
 import { SelectWithPlaceholder } from '../../../shared/SelectWithPlaceholder';
+import { Config } from '..';
 
 const selectPlaceholderLabel = `- ${i18n.translate(
   'xpack.apm.settings.agentConf.flyOut.selectPlaceholder',

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
@@ -176,14 +176,6 @@ export function SettingsList() {
   const failurePrompt = (
     <EuiEmptyPrompt
       iconType="alert"
-      title={
-        <h2>
-          {i18n.translate(
-            'xpack.apm.settings.agentConf.configTable.failurePromptTitle',
-            { defaultMessage: 'Failed to initialize settings.' }
-          )}
-        </h2>
-      }
       body={
         <>
           <p>
@@ -191,7 +183,7 @@ export function SettingsList() {
               'xpack.apm.settings.agentConf.configTable.failurePromptText',
               {
                 defaultMessage:
-                  'Whoops! The settings management failed to initialize. This might be because the user that is logged in does not have permission to read or write the APM agent configuration index. The next time a user with adequate privileges loads this screen, Kibana will complete this step.'
+                  'The list of agent configurations could not be fetched'
               }
             )}
           </p>
@@ -321,20 +313,21 @@ export function SettingsList() {
         </EuiCallOut>
 
         <EuiSpacer size="m" />
-        {status === 'failure' ? (
-          failurePrompt
-        ) : hasConfigurations ? (
-          <ManagedTable
-            noItemsMessage={<LoadingStatePrompt />}
-            columns={COLUMNS}
-            items={data}
-            initialSortField="service.name"
-            initialSortDirection="asc"
-            initialPageSize={50}
-          />
-        ) : (
-          emptyStatePrompt
-        )}
+        {status === 'failure' ? failurePrompt : null}
+        {status === 'success' ? (
+          hasConfigurations ? (
+            <ManagedTable
+              noItemsMessage={<LoadingStatePrompt />}
+              columns={COLUMNS}
+              items={data}
+              initialSortField="service.name"
+              initialSortDirection="asc"
+              initialPageSize={50}
+            />
+          ) : (
+            emptyStatePrompt
+          )
+        ) : null}
       </EuiPanel>
     </>
   );

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
@@ -4,46 +4,29 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import moment from 'moment';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
-import {
-  EuiTitle,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButtonEmpty,
-  EuiPanel,
-  EuiBetaBadge,
-  EuiSpacer,
-  EuiCallOut,
-  EuiEmptyPrompt,
-  EuiButton,
-  EuiLink
-} from '@elastic/eui';
+import { EuiEmptyPrompt, EuiButton, EuiButtonEmpty } from '@elastic/eui';
 import { isEmpty } from 'lodash';
-import { useFetcher } from '../../../hooks/useFetcher';
+import { FETCH_STATUS } from '../../../hooks/useFetcher';
 import { ITableColumn, ManagedTable } from '../../shared/ManagedTable';
-import { AgentConfigurationListAPIResponse } from '../../../../server/lib/settings/agent_configuration/list_configurations';
-import { AddSettingsFlyout } from './AddSettings/AddSettingFlyout';
 import { LoadingStatePrompt } from '../../shared/LoadingStatePrompt';
-import { callApmApi } from '../../../services/rest/callApmApi';
-import { HomeLink } from '../../shared/Links/apm/HomeLink';
+import { AgentConfigurationListAPIResponse } from '../../../../server/lib/settings/agent_configuration/list_configurations';
+import { Config } from '.';
 
-export type Config = AgentConfigurationListAPIResponse[0];
-
-export function SettingsList() {
-  const { data = [], status, refresh } = useFetcher(
-    () =>
-      callApmApi({
-        pathname: `/api/apm/settings/agent-configuration`
-      }),
-    []
-  );
-  const [selectedConfig, setSelectedConfig] = useState<Config | null>(null);
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
-
-  const COLUMNS: Array<ITableColumn<Config>> = [
+export function SettingsList({
+  status,
+  data,
+  setIsFlyoutOpen,
+  setSelectedConfig
+}: {
+  status: FETCH_STATUS;
+  data: AgentConfigurationListAPIResponse;
+  setIsFlyoutOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setSelectedConfig: React.Dispatch<React.SetStateAction<Config | null>>;
+}) {
+  const columns: Array<ITableColumn<Config>> = [
     {
       field: 'service.name',
       name: i18n.translate(
@@ -127,15 +110,6 @@ export function SettingsList() {
     }
   ];
 
-  const RETURN_TO_OVERVIEW_LINK_LABEL = i18n.translate(
-    'xpack.apm.settings.agentConf.returnToOverviewLinkLabel',
-    {
-      defaultMessage: 'Return to overview'
-    }
-  );
-
-  const hasConfigurations = !isEmpty(data);
-
   const emptyStatePrompt = (
     <EuiEmptyPrompt
       iconType="controlsHorizontal"
@@ -183,7 +157,7 @@ export function SettingsList() {
               'xpack.apm.settings.agentConf.configTable.failurePromptText',
               {
                 defaultMessage:
-                  'The list of agent configurations could not be fetched'
+                  'The list of agent configurations could not be fetched. Your user may not have the sufficient permissions.'
               }
             )}
           </p>
@@ -191,144 +165,26 @@ export function SettingsList() {
       }
     />
   );
+  const hasConfigurations = !isEmpty(data);
 
-  return (
-    <>
-      <AddSettingsFlyout
-        isOpen={isFlyoutOpen}
-        selectedConfig={selectedConfig}
-        onClose={() => {
-          setSelectedConfig(null);
-          setIsFlyoutOpen(false);
-        }}
-        onSubmit={() => {
-          setSelectedConfig(null);
-          setIsFlyoutOpen(false);
-          refresh();
-        }}
-      />
-
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="l">
-            <h1>
-              {i18n.translate('xpack.apm.settings.agentConf.pageTitle', {
-                defaultMessage: 'Settings'
-              })}
-            </h1>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <HomeLink>
-            <EuiButtonEmpty size="s" color="primary" iconType="arrowLeft">
-              {RETURN_TO_OVERVIEW_LINK_LABEL}
-            </EuiButtonEmpty>
-          </HomeLink>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-
-      <EuiSpacer size="l" />
-
-      <EuiPanel>
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiTitle>
-              <h2>
-                {i18n.translate(
-                  'xpack.apm.settings.agentConf.configurationsPanelTitle',
-                  {
-                    defaultMessage: 'Configurations'
-                  }
-                )}
-              </h2>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiBetaBadge
-              label={i18n.translate(
-                'xpack.apm.settings.agentConf.betaBadgeLabel',
-                {
-                  defaultMessage: 'Beta'
-                }
-              )}
-              tooltipContent={i18n.translate(
-                'xpack.apm.settings.agentConf.betaBadgeText',
-                {
-                  defaultMessage:
-                    'This feature is still in development. If you have feedback, please reach out in our Discuss forum.'
-                }
-              )}
-            />
-          </EuiFlexItem>
-          {hasConfigurations ? (
-            <EuiFlexItem>
-              <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    color="primary"
-                    fill
-                    iconType="plusInCircle"
-                    onClick={() => setIsFlyoutOpen(true)}
-                  >
-                    {i18n.translate(
-                      'xpack.apm.settings.agentConf.createConfigButtonLabel',
-                      {
-                        defaultMessage: 'Create configuration'
-                      }
-                    )}
-                  </EuiButton>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          ) : null}
-        </EuiFlexGroup>
-
-        <EuiSpacer size="m" />
-
-        <EuiCallOut
-          title={i18n.translate(
-            'xpack.apm.settings.agentConf.betaCallOutTitle',
-            {
-              defaultMessage: 'APM Agent Configuration (BETA)'
-            }
-          )}
-          iconType="iInCircle"
-        >
-          <p>
-            <FormattedMessage
-              id="xpack.apm.settings.agentConf.betaCallOutText"
-              defaultMessage="We're excited to bring you a first look at APM Agent configuration. {agentConfigDocsLink}"
-              values={{
-                agentConfigDocsLink: (
-                  <EuiLink href="https://www.elastic.co/guide/en/kibana/current/agent-configuration.html">
-                    {i18n.translate(
-                      'xpack.apm.settings.agentConf.agentConfigDocsLinkLabel',
-                      { defaultMessage: 'Learn more in our docs.' }
-                    )}
-                  </EuiLink>
-                )
-              }}
-            />
-          </p>
-        </EuiCallOut>
-
-        <EuiSpacer size="m" />
-        {status === 'failure' ? failurePrompt : null}
-        {status === 'success' ? (
-          hasConfigurations ? (
-            <ManagedTable
-              noItemsMessage={<LoadingStatePrompt />}
-              columns={COLUMNS}
-              items={data}
-              initialSortField="service.name"
-              initialSortDirection="asc"
-              initialPageSize={50}
-            />
-          ) : (
-            emptyStatePrompt
-          )
-        ) : null}
-      </EuiPanel>
-    </>
-  );
+  if (status === 'failure') {
+    return failurePrompt;
+  }
+  if (status === 'success') {
+    if (hasConfigurations) {
+      return (
+        <ManagedTable
+          noItemsMessage={<LoadingStatePrompt />}
+          columns={columns}
+          items={data}
+          initialSortField="service.name"
+          initialSortDirection="asc"
+          initialPageSize={50}
+        />
+      );
+    } else {
+      return emptyStatePrompt;
+    }
+  }
+  return null;
 }

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/SettingsList.tsx
@@ -173,6 +173,33 @@ export function SettingsList() {
     />
   );
 
+  const failurePrompt = (
+    <EuiEmptyPrompt
+      iconType="alert"
+      title={
+        <h2>
+          {i18n.translate(
+            'xpack.apm.settings.agentConf.configTable.failurePromptTitle',
+            { defaultMessage: 'Failed to initialize settings.' }
+          )}
+        </h2>
+      }
+      body={
+        <>
+          <p>
+            {i18n.translate(
+              'xpack.apm.settings.agentConf.configTable.failurePromptText',
+              {
+                defaultMessage:
+                  'Whoops! The settings management failed to initialize. This might be because the user that is logged in does not have permission to read or write the APM agent configuration index. The next time a user with adequate privileges loads this screen, Kibana will complete this step.'
+              }
+            )}
+          </p>
+        </>
+      }
+    />
+  );
+
   return (
     <>
       <AddSettingsFlyout
@@ -294,10 +321,9 @@ export function SettingsList() {
         </EuiCallOut>
 
         <EuiSpacer size="m" />
-
-        {status === 'success' && !hasConfigurations ? (
-          emptyStatePrompt
-        ) : (
+        {status === 'failure' ? (
+          failurePrompt
+        ) : hasConfigurations ? (
           <ManagedTable
             noItemsMessage={<LoadingStatePrompt />}
             columns={COLUMNS}
@@ -306,6 +332,8 @@ export function SettingsList() {
             initialSortDirection="asc"
             initialPageSize={50}
           />
+        ) : (
+          emptyStatePrompt
         )}
       </EuiPanel>
     </>

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/index.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+import {
+  EuiTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  EuiPanel,
+  EuiBetaBadge,
+  EuiSpacer,
+  EuiCallOut,
+  EuiButton,
+  EuiLink
+} from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import { useFetcher } from '../../../hooks/useFetcher';
+import { AgentConfigurationListAPIResponse } from '../../../../server/lib/settings/agent_configuration/list_configurations';
+import { AddSettingsFlyout } from './AddSettings/AddSettingFlyout';
+import { callApmApi } from '../../../services/rest/callApmApi';
+import { HomeLink } from '../../shared/Links/apm/HomeLink';
+import { SettingsList } from './SettingsList';
+
+export type Config = AgentConfigurationListAPIResponse[0];
+
+export function Settings() {
+  const { data = [], status, refresh } = useFetcher(
+    () =>
+      callApmApi({
+        pathname: `/api/apm/settings/agent-configuration`
+      }),
+    []
+  );
+  const [selectedConfig, setSelectedConfig] = useState<Config | null>(null);
+  const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+
+  const RETURN_TO_OVERVIEW_LINK_LABEL = i18n.translate(
+    'xpack.apm.settings.agentConf.returnToOverviewLinkLabel',
+    {
+      defaultMessage: 'Return to overview'
+    }
+  );
+
+  const hasConfigurations = !isEmpty(data);
+
+  return (
+    <>
+      <AddSettingsFlyout
+        isOpen={isFlyoutOpen}
+        selectedConfig={selectedConfig}
+        onClose={() => {
+          setSelectedConfig(null);
+          setIsFlyoutOpen(false);
+        }}
+        onSubmit={() => {
+          setSelectedConfig(null);
+          setIsFlyoutOpen(false);
+          refresh();
+        }}
+      />
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="l">
+            <h1>
+              {i18n.translate('xpack.apm.settings.agentConf.pageTitle', {
+                defaultMessage: 'Settings'
+              })}
+            </h1>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <HomeLink>
+            <EuiButtonEmpty size="s" color="primary" iconType="arrowLeft">
+              {RETURN_TO_OVERVIEW_LINK_LABEL}
+            </EuiButtonEmpty>
+          </HomeLink>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiPanel>
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiTitle>
+              <h2>
+                {i18n.translate(
+                  'xpack.apm.settings.agentConf.configurationsPanelTitle',
+                  {
+                    defaultMessage: 'Configurations'
+                  }
+                )}
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiBetaBadge
+              label={i18n.translate(
+                'xpack.apm.settings.agentConf.betaBadgeLabel',
+                {
+                  defaultMessage: 'Beta'
+                }
+              )}
+              tooltipContent={i18n.translate(
+                'xpack.apm.settings.agentConf.betaBadgeText',
+                {
+                  defaultMessage:
+                    'This feature is still in development. If you have feedback, please reach out in our Discuss forum.'
+                }
+              )}
+            />
+          </EuiFlexItem>
+          {hasConfigurations ? (
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    color="primary"
+                    fill
+                    iconType="plusInCircle"
+                    onClick={() => setIsFlyoutOpen(true)}
+                  >
+                    {i18n.translate(
+                      'xpack.apm.settings.agentConf.createConfigButtonLabel',
+                      {
+                        defaultMessage: 'Create configuration'
+                      }
+                    )}
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+
+        <EuiSpacer size="m" />
+
+        <EuiCallOut
+          title={i18n.translate(
+            'xpack.apm.settings.agentConf.betaCallOutTitle',
+            {
+              defaultMessage: 'APM Agent Configuration (BETA)'
+            }
+          )}
+          iconType="iInCircle"
+        >
+          <p>
+            <FormattedMessage
+              id="xpack.apm.settings.agentConf.betaCallOutText"
+              defaultMessage="We're excited to bring you a first look at APM Agent configuration. {agentConfigDocsLink}"
+              values={{
+                agentConfigDocsLink: (
+                  <EuiLink href="https://www.elastic.co/guide/en/kibana/current/agent-configuration.html">
+                    {i18n.translate(
+                      'xpack.apm.settings.agentConf.agentConfigDocsLinkLabel',
+                      { defaultMessage: 'Learn more in our docs.' }
+                    )}
+                  </EuiLink>
+                )
+              }}
+            />
+          </p>
+        </EuiCallOut>
+
+        <EuiSpacer size="m" />
+
+        <SettingsList
+          status={status}
+          data={data}
+          setIsFlyoutOpen={setIsFlyoutOpen}
+          setSelectedConfig={setSelectedConfig}
+        />
+      </EuiPanel>
+    </>
+  );
+}

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/SettingsLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/apm/SettingsLink.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { APMLink, APMLinkExtendProps } from './APMLink';
 
 const SettingsLink = (props: APMLinkExtendProps) => {
-  return <APMLink path="/" {...props} />;
+  return <APMLink path="/settings" {...props} />;
 };
 
 export { SettingsLink };

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
@@ -4,10 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Server } from 'hapi';
+import { InternalCoreSetup } from 'src/core/server';
 import Boom from 'boom';
 
-export async function createApmAgentConfigurationIndex(server: Server) {
+export async function createApmAgentConfigurationIndex(
+  core: InternalCoreSetup
+) {
+  const { server } = core.http;
   const index = server
     .config()
     .get<string>('apm_oss.apmAgentConfigurationIndex');

--- a/x-pack/legacy/plugins/apm/server/new-platform/plugin.ts
+++ b/x-pack/legacy/plugins/apm/server/new-platform/plugin.ts
@@ -7,12 +7,13 @@
 import { InternalCoreSetup } from 'src/core/server';
 import { makeApmUsageCollector } from '../lib/apm_telemetry';
 import { CoreSetupWithUsageCollector } from '../lib/apm_telemetry/make_apm_usage_collector';
+import { createApmAgentConfigurationIndex } from '../lib/settings/agent_configuration/create_agent_config_index';
 import { createApmApi } from '../routes/create_apm_api';
 
 export class Plugin {
   public setup(core: InternalCoreSetup) {
     createApmApi().init(core);
-
+    createApmAgentConfigurationIndex(core);
     makeApmUsageCollector(core as CoreSetupWithUsageCollector);
   }
 }

--- a/x-pack/legacy/plugins/apm/server/routes/settings.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings.ts
@@ -13,26 +13,15 @@ import { searchConfigurations } from '../lib/settings/agent_configuration/search
 import { listConfigurations } from '../lib/settings/agent_configuration/list_configurations';
 import { getEnvironments } from '../lib/settings/agent_configuration/get_environments';
 import { deleteConfiguration } from '../lib/settings/agent_configuration/delete_configuration';
-import { createApmAgentConfigurationIndex } from '../lib/settings/agent_configuration/create_agent_config_index';
 import { createRoute } from './create_route';
 import { transactionSampleRateRt } from '../../common/runtime_types/transaction_sample_rate_rt';
 
 // get list of configurations
 export const agentConfigurationRoute = createRoute(core => ({
   path: '/api/apm/settings/agent-configuration',
-  handler: async (req, _, h) => {
-    try {
-      await createApmAgentConfigurationIndex(core.http.server);
-
-      const setup = await setupRequest(req);
-      return await listConfigurations({ setup });
-    } catch (error) {
-      if (error.statusCode === 403) {
-        // return an empty list if user is not authorized
-        return [];
-      }
-      throw error;
-    }
+  handler: async req => {
+    const setup = await setupRequest(req);
+    return await listConfigurations({ setup });
   }
 }));
 
@@ -147,11 +136,7 @@ export const agentConfigurationSearchRoute = createRoute(core => ({
     })
   },
   handler: async (req, { body }, h) => {
-    const [setup] = await Promise.all([
-      setupRequest(req),
-      createApmAgentConfigurationIndex(core.http.server)
-    ]);
-
+    const setup = await setupRequest(req);
     const config = await searchConfigurations({
       serviceName: body.service.name,
       environment: body.service.environment,

--- a/x-pack/legacy/plugins/apm/server/routes/settings.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings.ts
@@ -20,13 +20,19 @@ import { transactionSampleRateRt } from '../../common/runtime_types/transaction_
 // get list of configurations
 export const agentConfigurationRoute = createRoute(core => ({
   path: '/api/apm/settings/agent-configuration',
-  handler: async req => {
-    await createApmAgentConfigurationIndex(core.http.server);
+  handler: async (req, _, h) => {
+    try {
+      await createApmAgentConfigurationIndex(core.http.server);
 
-    const setup = await setupRequest(req);
-    return await listConfigurations({
-      setup
-    });
+      const setup = await setupRequest(req);
+      return await listConfigurations({ setup });
+    } catch (error) {
+      if (error.statusCode === 403) {
+        // return an empty list if user is not authorized
+        return [];
+      }
+      throw error;
+    }
   }
 }));
 


### PR DESCRIPTION
Addresses #43326 (in conjunction with https://github.com/elastic/elasticsearch/pull/46423)

- displays message to user when a failure occurred in settings initialization
- fixes incorrect settings link path
- moves agent config index creation to plugin setup step

<img width="851" alt="Screen Shot 2019-09-08 at 10 52 29 PM" src="https://user-images.githubusercontent.com/1967266/64506466-8deec280-d28c-11e9-9d52-d18ac809c0a1.png">
