### PR TITLE
[lens] Fix usage of EUI after typescript upgrade

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.test.tsx
@@ -98,7 +98,7 @@ describe('suggestion_panel', () => {
     const wrapper = mount(<SuggestionPanel {...defaultProps} />);
 
     wrapper
-      .find('[data-test-subj="lnsSuggestion-target"]')
+      .find('[data-test-subj="lnsSuggestion"]')
       .first()
       .simulate('click');
 
@@ -116,7 +116,7 @@ describe('suggestion_panel', () => {
     const wrapper = mount(<SuggestionPanel {...defaultProps} activeVisualizationId="vis2" />);
 
     wrapper
-      .find('[data-test-subj="lnsSuggestion-target"]')
+      .find('[data-test-subj="lnsSuggestion"]')
       .first()
       .simulate('click');
 

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.test.tsx
@@ -98,7 +98,7 @@ describe('suggestion_panel', () => {
     const wrapper = mount(<SuggestionPanel {...defaultProps} />);
 
     wrapper
-      .find('[data-test-subj="lnsSuggestion"]')
+      .find('[data-test-subj="lnsSuggestion-target"]')
       .first()
       .simulate('click');
 
@@ -116,7 +116,7 @@ describe('suggestion_panel', () => {
     const wrapper = mount(<SuggestionPanel {...defaultProps} activeVisualizationId="vis2" />);
 
     wrapper
-      .find('[data-test-subj="lnsSuggestion"]')
+      .find('[data-test-subj="lnsSuggestion-target"]')
       .first()
       .simulate('click');
 

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.tsx
@@ -6,7 +6,14 @@
 
 import React, { useState, useEffect } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { EuiIcon, EuiTitle, EuiPanel, EuiIconTip, EuiToolTip } from '@elastic/eui';
+import {
+  EuiIcon,
+  EuiTitle,
+  EuiPanel,
+  EuiIconTip,
+  EuiToolTip,
+  EuiKeyboardAccessible,
+} from '@elastic/eui';
 import { toExpression, Ast } from '@kbn/interpreter/common';
 import { i18n } from '@kbn/i18n';
 import { Action } from './state_management';
@@ -55,45 +62,54 @@ const SuggestionPreview = ({
     setExpressionError(false);
   }, [previewExpression]);
 
+  const clickHandler = () => {
+    switchToSuggestion(frame, dispatch, suggestion);
+  };
+
   return (
     <EuiToolTip content={suggestion.title}>
       <EuiPanel
         className="lnsSuggestionPanel__button"
         paddingSize="none"
         data-test-subj="lnsSuggestion"
-        onClick={() => {
-          switchToSuggestion(frame, dispatch, suggestion);
-        }}
       >
-        {expressionError ? (
-          <div className="lnsSidebar__suggestionIcon">
-            <EuiIconTip
-              size="xxl"
-              color="danger"
-              type="cross"
-              aria-label={i18n.translate('xpack.lens.editorFrame.previewErrorLabel', {
-                defaultMessage: 'Preview rendering failed',
-              })}
-              content={i18n.translate('xpack.lens.editorFrame.previewErrorTooltip', {
-                defaultMessage: 'Preview rendering failed',
-              })}
-            />
+        <EuiKeyboardAccessible>
+          <div
+            onClick={clickHandler}
+            onKeyPress={clickHandler}
+            data-test-subj="lnsSuggestion-target"
+          >
+            {expressionError ? (
+              <div className="lnsSidebar__suggestionIcon">
+                <EuiIconTip
+                  size="xxl"
+                  color="danger"
+                  type="cross"
+                  aria-label={i18n.translate('xpack.lens.editorFrame.previewErrorLabel', {
+                    defaultMessage: 'Preview rendering failed',
+                  })}
+                  content={i18n.translate('xpack.lens.editorFrame.previewErrorTooltip', {
+                    defaultMessage: 'Preview rendering failed',
+                  })}
+                />
+              </div>
+            ) : previewExpression ? (
+              <ExpressionRendererComponent
+                className="lnsSuggestionChartWrapper"
+                expression={previewExpression}
+                onRenderFailure={(e: unknown) => {
+                  // eslint-disable-next-line no-console
+                  console.error(`Failed to render preview: `, e);
+                  setExpressionError(true);
+                }}
+              />
+            ) : (
+              <div className="lnsSidebar__suggestionIcon">
+                <EuiIcon size="xxl" type={suggestion.previewIcon} />
+              </div>
+            )}
           </div>
-        ) : previewExpression ? (
-          <ExpressionRendererComponent
-            className="lnsSuggestionChartWrapper"
-            expression={previewExpression}
-            onRenderFailure={(e: unknown) => {
-              // eslint-disable-next-line no-console
-              console.error(`Failed to render preview: `, e);
-              setExpressionError(true);
-            }}
-          />
-        ) : (
-          <div className="lnsSidebar__suggestionIcon">
-            <EuiIcon size="xxl" type={suggestion.previewIcon} />
-          </div>
-        )}
+        </EuiKeyboardAccessible>
       </EuiPanel>
     </EuiToolTip>
   );

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.tsx
@@ -6,14 +6,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
-import {
-  EuiIcon,
-  EuiTitle,
-  EuiPanel,
-  EuiIconTip,
-  EuiToolTip,
-  EuiKeyboardAccessible,
-} from '@elastic/eui';
+import { EuiIcon, EuiTitle, EuiPanel, EuiIconTip, EuiToolTip } from '@elastic/eui';
 import { toExpression, Ast } from '@kbn/interpreter/common';
 import { i18n } from '@kbn/i18n';
 import { Action } from './state_management';
@@ -24,6 +17,10 @@ import { prependDatasourceExpression, prependKibanaContext } from './expression_
 import { debouncedComponent } from '../../debounced_component';
 
 const MAX_SUGGESTIONS_DISPLAYED = 5;
+
+// TODO: Remove this <any> when upstream fix is merged https://github.com/elastic/eui/issues/2329
+// eslint-disable-next-line
+const EuiPanelFixed = EuiPanel as React.ComponentType<any>;
 
 export interface SuggestionPanelProps {
   activeDatasourceId: string | null;
@@ -68,49 +65,42 @@ const SuggestionPreview = ({
 
   return (
     <EuiToolTip content={suggestion.title}>
-      <EuiPanel
+      <EuiPanelFixed
         className="lnsSuggestionPanel__button"
         paddingSize="none"
         data-test-subj="lnsSuggestion"
+        onClick={clickHandler}
       >
-        <EuiKeyboardAccessible>
-          <div
-            onClick={clickHandler}
-            onKeyPress={clickHandler}
-            data-test-subj="lnsSuggestion-target"
-          >
-            {expressionError ? (
-              <div className="lnsSidebar__suggestionIcon">
-                <EuiIconTip
-                  size="xxl"
-                  color="danger"
-                  type="cross"
-                  aria-label={i18n.translate('xpack.lens.editorFrame.previewErrorLabel', {
-                    defaultMessage: 'Preview rendering failed',
-                  })}
-                  content={i18n.translate('xpack.lens.editorFrame.previewErrorTooltip', {
-                    defaultMessage: 'Preview rendering failed',
-                  })}
-                />
-              </div>
-            ) : previewExpression ? (
-              <ExpressionRendererComponent
-                className="lnsSuggestionChartWrapper"
-                expression={previewExpression}
-                onRenderFailure={(e: unknown) => {
-                  // eslint-disable-next-line no-console
-                  console.error(`Failed to render preview: `, e);
-                  setExpressionError(true);
-                }}
-              />
-            ) : (
-              <div className="lnsSidebar__suggestionIcon">
-                <EuiIcon size="xxl" type={suggestion.previewIcon} />
-              </div>
-            )}
+        {expressionError ? (
+          <div className="lnsSidebar__suggestionIcon">
+            <EuiIconTip
+              size="xxl"
+              color="danger"
+              type="cross"
+              aria-label={i18n.translate('xpack.lens.editorFrame.previewErrorLabel', {
+                defaultMessage: 'Preview rendering failed',
+              })}
+              content={i18n.translate('xpack.lens.editorFrame.previewErrorTooltip', {
+                defaultMessage: 'Preview rendering failed',
+              })}
+            />
           </div>
-        </EuiKeyboardAccessible>
-      </EuiPanel>
+        ) : previewExpression ? (
+          <ExpressionRendererComponent
+            className="lnsSuggestionChartWrapper"
+            expression={previewExpression}
+            onRenderFailure={(e: unknown) => {
+              // eslint-disable-next-line no-console
+              console.error(`Failed to render preview: `, e);
+              setExpressionError(true);
+            }}
+          />
+        ) : (
+          <div className="lnsSidebar__suggestionIcon">
+            <EuiIcon size="xxl" type={suggestion.previewIcon} />
+          </div>
+        )}
+      </EuiPanelFixed>
     </EuiToolTip>
   );
 };

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_config_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_config_panel.test.tsx
@@ -118,7 +118,7 @@ describe('XYConfigPanel', () => {
       .first()
       .prop('options') as EuiButtonGroupProps['options'];
 
-    expect(options.map(({ id }) => id)).toEqual([
+    expect(options!.map(({ id }) => id)).toEqual([
       'bar',
       'bar_stacked',
       'line',
@@ -126,7 +126,7 @@ describe('XYConfigPanel', () => {
       'area_stacked',
     ]);
 
-    expect(options.filter(({ isDisabled }) => isDisabled).map(({ id }) => id)).toEqual([]);
+    expect(options!.filter(({ isDisabled }) => isDisabled).map(({ id }) => id)).toEqual([]);
   });
 
   test('the x dimension panel accepts only bucketed operations', () => {


### PR DESCRIPTION
After https://github.com/elastic/kibana/pull/45052 was merged, our usage of EUI needs to be updated as well. There's a change to the EuiPanel types which causes a problem in our usage: https://github.com/elastic/eui/issues/2329
