### PR TITLE
Update EUI to 14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@babel/register": "^7.5.5",
     "@elastic/charts": "^11.1.1",
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "8.1.1-kibana2",
     "@elastic/numeral": "2.3.3",

--- a/src/legacy/core_plugins/data/public/query/query_bar/components/__snapshots__/language_switcher.test.tsx.snap
+++ b/src/legacy/core_plugins/data/public/query/query_bar/components/__snapshots__/language_switcher.test.tsx.snap
@@ -2,9 +2,11 @@
 
 exports[`LanguageSwitcher should toggle off if language is lucene 1`] = `
 <EuiPopover
+  anchorClassName="euiFormControlLayout__append"
   anchorPosition="downRight"
   button={
     <EuiButtonEmpty
+      className="euiFormControlLayout__append"
       onClick={[Function]}
       size="xs"
     >
@@ -15,7 +17,6 @@ exports[`LanguageSwitcher should toggle off if language is lucene 1`] = `
       />
     </EuiButtonEmpty>
   }
-  className="eui-displayBlock"
   closePopover={[Function]}
   display="inlineBlock"
   hasArrow={true}
@@ -69,6 +70,7 @@ exports[`LanguageSwitcher should toggle off if language is lucene 1`] = `
     <EuiForm>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -102,9 +104,11 @@ exports[`LanguageSwitcher should toggle off if language is lucene 1`] = `
 
 exports[`LanguageSwitcher should toggle on if language is kuery 1`] = `
 <EuiPopover
+  anchorClassName="euiFormControlLayout__append"
   anchorPosition="downRight"
   button={
     <EuiButtonEmpty
+      className="euiFormControlLayout__append"
       onClick={[Function]}
       size="xs"
     >
@@ -115,7 +119,6 @@ exports[`LanguageSwitcher should toggle on if language is kuery 1`] = `
       />
     </EuiButtonEmpty>
   }
-  className="eui-displayBlock"
   closePopover={[Function]}
   display="inlineBlock"
   hasArrow={true}
@@ -169,6 +172,7 @@ exports[`LanguageSwitcher should toggle on if language is kuery 1`] = `
     <EuiForm>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={

--- a/src/legacy/core_plugins/data/public/query/query_bar/components/__snapshots__/query_bar_input.test.tsx.snap
+++ b/src/legacy/core_plugins/data/public/query/query_bar/components/__snapshots__/query_bar_input.test.tsx.snap
@@ -262,9 +262,7 @@ exports[`QueryBarInput Should disable autoFocus on EuiFieldText when disableAuto
                 <div
                   className="euiFormControlLayout__childrenWrapper"
                 >
-                  <EuiValidatableControl
-                    className="undefined euiFormControlLayout__child--noStyle"
-                  >
+                  <EuiValidatableControl>
                     <input
                       aria-activedescendant=""
                       aria-autocomplete="list"
@@ -296,9 +294,11 @@ exports[`QueryBarInput Should disable autoFocus on EuiFieldText when disableAuto
                   onSelectLanguage={[Function]}
                 >
                   <EuiPopover
+                    anchorClassName="euiFormControlLayout__append"
                     anchorPosition="downRight"
                     button={
                       <EuiButtonEmpty
+                        className="euiFormControlLayout__append"
                         onClick={[Function]}
                         size="xs"
                       >
@@ -309,7 +309,6 @@ exports[`QueryBarInput Should disable autoFocus on EuiFieldText when disableAuto
                         />
                       </EuiButtonEmpty>
                     }
-                    className="eui-displayBlock"
                     closePopover={[Function]}
                     display="inlineBlock"
                     hasArrow={true}
@@ -324,7 +323,7 @@ exports[`QueryBarInput Should disable autoFocus on EuiFieldText when disableAuto
                       onOutsideClick={[Function]}
                     >
                       <div
-                        className="euiPopover euiPopover--anchorDownRight euiPopover--withTitle eui-displayBlock"
+                        className="euiPopover euiPopover--anchorDownRight euiPopover--withTitle"
                         id="popover"
                         onKeyDown={[Function]}
                         onMouseDown={[Function]}
@@ -333,14 +332,15 @@ exports[`QueryBarInput Should disable autoFocus on EuiFieldText when disableAuto
                         onTouchStart={[Function]}
                       >
                         <div
-                          className="euiPopover__anchor"
+                          className="euiPopover__anchor euiFormControlLayout__append"
                         >
                           <EuiButtonEmpty
+                            className="euiFormControlLayout__append"
                             onClick={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__append"
                               onClick={[Function]}
                               type="button"
                             >
@@ -645,9 +645,7 @@ exports[`QueryBarInput Should pass the query language to the language switcher 1
                 <div
                   className="euiFormControlLayout__childrenWrapper"
                 >
-                  <EuiValidatableControl
-                    className="undefined euiFormControlLayout__child--noStyle"
-                  >
+                  <EuiValidatableControl>
                     <input
                       aria-activedescendant=""
                       aria-autocomplete="list"
@@ -679,9 +677,11 @@ exports[`QueryBarInput Should pass the query language to the language switcher 1
                   onSelectLanguage={[Function]}
                 >
                   <EuiPopover
+                    anchorClassName="euiFormControlLayout__append"
                     anchorPosition="downRight"
                     button={
                       <EuiButtonEmpty
+                        className="euiFormControlLayout__append"
                         onClick={[Function]}
                         size="xs"
                       >
@@ -692,7 +692,6 @@ exports[`QueryBarInput Should pass the query language to the language switcher 1
                         />
                       </EuiButtonEmpty>
                     }
-                    className="eui-displayBlock"
                     closePopover={[Function]}
                     display="inlineBlock"
                     hasArrow={true}
@@ -707,7 +706,7 @@ exports[`QueryBarInput Should pass the query language to the language switcher 1
                       onOutsideClick={[Function]}
                     >
                       <div
-                        className="euiPopover euiPopover--anchorDownRight euiPopover--withTitle eui-displayBlock"
+                        className="euiPopover euiPopover--anchorDownRight euiPopover--withTitle"
                         id="popover"
                         onKeyDown={[Function]}
                         onMouseDown={[Function]}
@@ -716,14 +715,15 @@ exports[`QueryBarInput Should pass the query language to the language switcher 1
                         onTouchStart={[Function]}
                       >
                         <div
-                          className="euiPopover__anchor"
+                          className="euiPopover__anchor euiFormControlLayout__append"
                         >
                           <EuiButtonEmpty
+                            className="euiFormControlLayout__append"
                             onClick={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__append"
                               onClick={[Function]}
                               type="button"
                             >
@@ -1028,9 +1028,7 @@ exports[`QueryBarInput Should render the given query 1`] = `
                 <div
                   className="euiFormControlLayout__childrenWrapper"
                 >
-                  <EuiValidatableControl
-                    className="undefined euiFormControlLayout__child--noStyle"
-                  >
+                  <EuiValidatableControl>
                     <input
                       aria-activedescendant=""
                       aria-autocomplete="list"
@@ -1062,9 +1060,11 @@ exports[`QueryBarInput Should render the given query 1`] = `
                   onSelectLanguage={[Function]}
                 >
                   <EuiPopover
+                    anchorClassName="euiFormControlLayout__append"
                     anchorPosition="downRight"
                     button={
                       <EuiButtonEmpty
+                        className="euiFormControlLayout__append"
                         onClick={[Function]}
                         size="xs"
                       >
@@ -1075,7 +1075,6 @@ exports[`QueryBarInput Should render the given query 1`] = `
                         />
                       </EuiButtonEmpty>
                     }
-                    className="eui-displayBlock"
                     closePopover={[Function]}
                     display="inlineBlock"
                     hasArrow={true}
@@ -1090,7 +1089,7 @@ exports[`QueryBarInput Should render the given query 1`] = `
                       onOutsideClick={[Function]}
                     >
                       <div
-                        className="euiPopover euiPopover--anchorDownRight euiPopover--withTitle eui-displayBlock"
+                        className="euiPopover euiPopover--anchorDownRight euiPopover--withTitle"
                         id="popover"
                         onKeyDown={[Function]}
                         onMouseDown={[Function]}
@@ -1099,14 +1098,15 @@ exports[`QueryBarInput Should render the given query 1`] = `
                         onTouchStart={[Function]}
                       >
                         <div
-                          className="euiPopover__anchor"
+                          className="euiPopover__anchor euiFormControlLayout__append"
                         >
                           <EuiButtonEmpty
+                            className="euiFormControlLayout__append"
                             onClick={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__append"
                               onClick={[Function]}
                               type="button"
                             >

--- a/src/legacy/core_plugins/data/public/query/query_bar/components/language_switcher.tsx
+++ b/src/legacy/core_plugins/data/public/query/query_bar/components/language_switcher.tsx
@@ -65,7 +65,11 @@ export class QueryLanguageSwitcher extends Component<Props, State> {
     );
 
     const button = (
-      <EuiButtonEmpty size="xs" onClick={this.togglePopover}>
+      <EuiButtonEmpty
+        size="xs"
+        onClick={this.togglePopover}
+        className="euiFormControlLayout__append"
+      >
         {this.props.language === 'lucene' ? luceneLabel : kqlLabel}
       </EuiButtonEmpty>
     );
@@ -73,7 +77,7 @@ export class QueryLanguageSwitcher extends Component<Props, State> {
     return (
       <EuiPopover
         id="popover"
-        className="eui-displayBlock"
+        anchorClassName="euiFormControlLayout__append"
         ownFocus
         anchorPosition={this.props.anchorPosition || 'downRight'}
         button={button}

--- a/src/legacy/core_plugins/data/public/search/search_bar/components/saved_query_management/saved_query_management_component.tsx
+++ b/src/legacy/core_plugins/data/public/search/search_bar/components/saved_query_management/saved_query_management_component.tsx
@@ -164,6 +164,7 @@ export const SavedQueryManagementComponent: FunctionComponent<Props> = ({
     <Fragment>
       <EuiPopover
         id="savedQueryPopover"
+        anchorClassName="euiFormControlLayout__prepend"
         button={savedQueryPopoverButton}
         isOpen={isOpen}
         closePopover={() => {

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/controls_tab.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/controls_tab.test.js.snap
@@ -78,6 +78,7 @@ exports[`renders ControlsTab 1`] = `
       <EuiFlexItem>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           id="selectControlType"
@@ -112,6 +113,7 @@ exports[`renders ControlsTab 1`] = `
       >
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           id="addControl"

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/list_control_editor.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/list_control_editor.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders dynamic options should display disabled dynamic options with tooltip for non-string fields 1`] = `
-<div>
+<Fragment>
   <InjectIntl(IndexPatternSelectFormRowUi)
     controlIndex={0}
     indexPatternId="mockIndexPattern"
@@ -107,11 +107,11 @@ exports[`renders dynamic options should display disabled dynamic options with to
       value={5}
     />
   </EuiFormRow>
-</div>
+</Fragment>
 `;
 
 exports[`renders dynamic options should display dynamic options for string fields 1`] = `
-<div>
+<Fragment>
   <InjectIntl(IndexPatternSelectFormRowUi)
     controlIndex={0}
     indexPatternId="mockIndexPattern"
@@ -184,11 +184,11 @@ exports[`renders dynamic options should display dynamic options for string field
       onChange={[Function]}
     />
   </EuiFormRow>
-</div>
+</Fragment>
 `;
 
 exports[`renders dynamic options should display size field when dynamic options is disabled 1`] = `
-<div>
+<Fragment>
   <InjectIntl(IndexPatternSelectFormRowUi)
     controlIndex={0}
     indexPatternId="mockIndexPattern"
@@ -294,11 +294,11 @@ exports[`renders dynamic options should display size field when dynamic options 
       value={5}
     />
   </EuiFormRow>
-</div>
+</Fragment>
 `;
 
 exports[`renders should display chaining input when parents are provided 1`] = `
-<div>
+<Fragment>
   <InjectIntl(IndexPatternSelectFormRowUi)
     controlIndex={0}
     indexPatternId="indexPattern1"
@@ -451,11 +451,11 @@ exports[`renders should display chaining input when parents are provided 1`] = `
       value={10}
     />
   </EuiFormRow>
-</div>
+</Fragment>
 `;
 
 exports[`renders should not display any options until field is selected 1`] = `
-<div>
+<Fragment>
   <InjectIntl(IndexPatternSelectFormRowUi)
     controlIndex={0}
     indexPatternId="mockIndexPattern"
@@ -469,5 +469,5 @@ exports[`renders should not display any options until field is selected 1`] = `
     indexPatternId="mockIndexPattern"
     onChange={[Function]}
   />
-</div>
+</Fragment>
 `;

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/list_control_editor.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/list_control_editor.test.js.snap
@@ -17,6 +17,7 @@ exports[`renders dynamic options should display disabled dynamic options with to
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -45,6 +46,7 @@ exports[`renders dynamic options should display disabled dynamic options with to
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -74,6 +76,7 @@ exports[`renders dynamic options should display disabled dynamic options with to
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -124,6 +127,7 @@ exports[`renders dynamic options should display dynamic options for string field
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -152,6 +156,7 @@ exports[`renders dynamic options should display dynamic options for string field
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -199,6 +204,7 @@ exports[`renders dynamic options should display size field when dynamic options 
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -227,6 +233,7 @@ exports[`renders dynamic options should display size field when dynamic options 
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -256,6 +263,7 @@ exports[`renders dynamic options should display size field when dynamic options 
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -306,6 +314,7 @@ exports[`renders should display chaining input when parents are provided 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -352,6 +361,7 @@ exports[`renders should display chaining input when parents are provided 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -380,6 +390,7 @@ exports[`renders should display chaining input when parents are provided 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -409,6 +420,7 @@ exports[`renders should display chaining input when parents are provided 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/options_tab.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/options_tab.test.js.snap
@@ -4,6 +4,7 @@ exports[`OptionsTab should renders OptionsTab 1`] = `
 <EuiForm>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     id="updateFiltersOnChange"
@@ -24,6 +25,7 @@ exports[`OptionsTab should renders OptionsTab 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     id="useTimeFilter"
@@ -44,6 +46,7 @@ exports[`OptionsTab should renders OptionsTab 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     id="pinFilters"

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/range_control_editor.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/range_control_editor.test.js.snap
@@ -17,6 +17,7 @@ exports[`renders RangeControlEditor 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     id="stepSize-0"
@@ -40,6 +41,7 @@ exports[`renders RangeControlEditor 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     id="decimalPlaces-0"

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/range_control_editor.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/__snapshots__/range_control_editor.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders RangeControlEditor 1`] = `
-<div>
+<Fragment>
   <InjectIntl(IndexPatternSelectFormRowUi)
     controlIndex={0}
     indexPatternId="indexPattern1"
@@ -64,5 +64,5 @@ exports[`renders RangeControlEditor 1`] = `
       value={0}
     />
   </EuiFormRow>
-</div>
+</Fragment>
 `;

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/control_editor.js
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/control_editor.js
@@ -35,30 +35,29 @@ import {
 } from '@elastic/eui';
 
 class ControlEditorUi extends Component {
-
-  changeLabel = (evt) => {
+  changeLabel = evt => {
     this.props.handleLabelChange(this.props.controlIndex, evt);
-  }
+  };
 
   removeControl = () => {
     this.props.handleRemoveControl(this.props.controlIndex);
-  }
+  };
 
   moveUpControl = () => {
     this.props.moveControl(this.props.controlIndex, -1);
-  }
+  };
 
   moveDownControl = () => {
     this.props.moveControl(this.props.controlIndex, 1);
-  }
+  };
 
-  changeIndexPattern = (evt) => {
+  changeIndexPattern = evt => {
     this.props.handleIndexPatternChange(this.props.controlIndex, evt);
-  }
+  };
 
-  changeFieldName = (evt) => {
+  changeFieldName = evt => {
     this.props.handleFieldNameChange(this.props.controlIndex, evt);
-  }
+  };
 
   renderEditor() {
     let controlEditor = null;
@@ -99,12 +98,14 @@ class ControlEditorUi extends Component {
       <EuiForm>
         <EuiFormRow
           id={labelId}
-          label={<FormattedMessage id="inputControl.editor.controlEditor.controlLabel" defaultMessage="Control Label"/>}
+          label={
+            <FormattedMessage
+              id="inputControl.editor.controlEditor.controlLabel"
+              defaultMessage="Control Label"
+            />
+          }
         >
-          <EuiFieldText
-            value={this.props.controlParams.label}
-            onChange={this.changeLabel}
-          />
+          <EuiFieldText value={this.props.controlParams.label} onChange={this.changeLabel} />
         </EuiFormRow>
 
         {controlEditor}
@@ -118,7 +119,7 @@ class ControlEditorUi extends Component {
         <EuiButtonIcon
           aria-label={this.props.intl.formatMessage({
             id: 'inputControl.editor.controlEditor.moveControlUpAriaLabel',
-            defaultMessage: 'Move control up'
+            defaultMessage: 'Move control up',
           })}
           color="primary"
           onClick={this.moveUpControl}
@@ -128,7 +129,7 @@ class ControlEditorUi extends Component {
         <EuiButtonIcon
           aria-label={this.props.intl.formatMessage({
             id: 'inputControl.editor.controlEditor.moveControlDownAriaLabel',
-            defaultMessage: 'Move control down'
+            defaultMessage: 'Move control down',
           })}
           color="primary"
           onClick={this.moveDownControl}
@@ -138,7 +139,7 @@ class ControlEditorUi extends Component {
         <EuiButtonIcon
           aria-label={this.props.intl.formatMessage({
             id: 'inputControl.editor.controlEditor.removeControlAriaLabel',
-            defaultMessage: 'Remove control'
+            defaultMessage: 'Remove control',
           })}
           color="danger"
           onClick={this.removeControl}
@@ -152,7 +153,6 @@ class ControlEditorUi extends Component {
   render() {
     return (
       <EuiPanel grow={false} className="icvControlEditor__panel">
-
         <EuiAccordion
           id="controlEditorAccordion"
           buttonContent={getTitle(this.props.controlParams, this.props.controlIndex)}
@@ -162,7 +162,6 @@ class ControlEditorUi extends Component {
           <EuiSpacer size="s" />
           {this.renderEditor()}
         </EuiAccordion>
-
       </EuiPanel>
     );
   }
@@ -179,10 +178,12 @@ ControlEditorUi.propTypes = {
   getIndexPattern: PropTypes.func.isRequired,
   handleCheckboxOptionChange: PropTypes.func.isRequired,
   handleNumberOptionChange: PropTypes.func.isRequired,
-  parentCandidates: PropTypes.arrayOf(PropTypes.shape({
-    value: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired,
-  })).isRequired,
+  parentCandidates: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   handleParentChange: PropTypes.func.isRequired,
 };
 

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/list_control_editor.js
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/list_control_editor.js
@@ -18,17 +18,12 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component }  from 'react';
+import React, { Component, Fragment } from 'react';
 import { IndexPatternSelectFormRow } from './index_pattern_select_form_row';
 import { FieldSelect } from './field_select';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import {
-  EuiFormRow,
-  EuiFieldNumber,
-  EuiSwitch,
-  EuiSelect,
-} from '@elastic/eui';
+import { EuiFormRow, EuiFieldNumber, EuiSwitch, EuiSelect } from '@elastic/eui';
 
 function filterField(field) {
   return field.aggregatable && ['number', 'boolean', 'date', 'ip', 'string'].includes(field.type);
@@ -60,13 +55,13 @@ export class ListControlEditor extends Component {
     }
 
     return null;
-  }
+  };
 
   componentDidUpdate = () => {
     if (this.state.isLoadingFieldType) {
       this.loadIsStringField();
     }
-  }
+  };
 
   loadIsStringField = async () => {
     if (!this.props.controlParams.indexPattern || !this.props.controlParams.fieldName) {
@@ -86,7 +81,7 @@ export class ListControlEditor extends Component {
       return;
     }
 
-    const field = indexPattern.fields.find((field) => {
+    const field = indexPattern.fields.find(field => {
       return field.name === this.props.controlParams.fieldName;
     });
     if (!field) {
@@ -94,9 +89,9 @@ export class ListControlEditor extends Component {
     }
     this.setState({
       isLoadingFieldType: false,
-      isStringField: field.type === 'string'
+      isStringField: field.type === 'string',
     });
-  }
+  };
 
   renderOptions = () => {
     if (this.state.isLoadingFieldType || !this.props.controlParams.fieldName) {
@@ -105,24 +100,28 @@ export class ListControlEditor extends Component {
 
     const options = [];
     if (this.props.parentCandidates && this.props.parentCandidates.length > 0) {
-      const parentCandidatesOptions = [
-        { value: '', text: '' },
-        ...this.props.parentCandidates,
-      ];
+      const parentCandidatesOptions = [{ value: '', text: '' }, ...this.props.parentCandidates];
       options.push(
         <EuiFormRow
           id={`parentSelect-${this.props.controlIndex}`}
-          label={<FormattedMessage id="inputControl.editor.listControl.parentLabel" defaultMessage="Parent control" />}
-          helpText={<FormattedMessage
-            id="inputControl.editor.listControl.parentDescription"
-            defaultMessage="Options are based on the value of parent control. Disabled if parent is not set."
-          />}
+          label={
+            <FormattedMessage
+              id="inputControl.editor.listControl.parentLabel"
+              defaultMessage="Parent control"
+            />
+          }
+          helpText={
+            <FormattedMessage
+              id="inputControl.editor.listControl.parentDescription"
+              defaultMessage="Options are based on the value of parent control. Disabled if parent is not set."
+            />
+          }
           key="parentSelect"
         >
           <EuiSelect
             options={parentCandidatesOptions}
             value={this.props.controlParams.parent}
-            onChange={(evt) => {
+            onChange={evt => {
               this.props.handleParentChange(this.props.controlIndex, evt);
             }}
           />
@@ -134,15 +133,22 @@ export class ListControlEditor extends Component {
       <EuiFormRow
         id={`multiselect-${this.props.controlIndex}`}
         key="multiselect"
-        helpText={<FormattedMessage
-          id="inputControl.editor.listControl.multiselectDescription"
-          defaultMessage="Allow multiple selection"
-        />}
+        helpText={
+          <FormattedMessage
+            id="inputControl.editor.listControl.multiselectDescription"
+            defaultMessage="Allow multiple selection"
+          />
+        }
       >
         <EuiSwitch
-          label={<FormattedMessage id="inputControl.editor.listControl.multiselectLabel" defaultMessage="Multiselect" />}
+          label={
+            <FormattedMessage
+              id="inputControl.editor.listControl.multiselectLabel"
+              defaultMessage="Multiselect"
+            />
+          }
           checked={this.props.controlParams.options.multiselect}
-          onChange={(evt) => {
+          onChange={evt => {
             this.props.handleCheckboxOptionChange(this.props.controlIndex, 'multiselect', evt);
           }}
           data-test-subj="listControlMultiselectInput"
@@ -150,18 +156,17 @@ export class ListControlEditor extends Component {
       </EuiFormRow>
     );
 
-    const dynamicOptionsHelpText = this.state.isStringField
-      ? (
-        <FormattedMessage
-          id="inputControl.editor.listControl.dynamicOptions.updateDescription"
-          defaultMessage="Update options in response to user input"
-        />
-      ) : (
-        <FormattedMessage
-          id="inputControl.editor.listControl.dynamicOptions.stringFieldDescription"
-          defaultMessage="Only available for &quot;string&quot; fields"
-        />
-      );
+    const dynamicOptionsHelpText = this.state.isStringField ? (
+      <FormattedMessage
+        id="inputControl.editor.listControl.dynamicOptions.updateDescription"
+        defaultMessage="Update options in response to user input"
+      />
+    ) : (
+      <FormattedMessage
+        id="inputControl.editor.listControl.dynamicOptions.stringFieldDescription"
+        defaultMessage='Only available for "string" fields'
+      />
+    );
     options.push(
       <EuiFormRow
         id={`dynamicOptions-${this.props.controlIndex}`}
@@ -169,9 +174,14 @@ export class ListControlEditor extends Component {
         helpText={dynamicOptionsHelpText}
       >
         <EuiSwitch
-          label={<FormattedMessage id="inputControl.editor.listControl.dynamicOptionsLabel" defaultMessage="Dynamic Options" />}
+          label={
+            <FormattedMessage
+              id="inputControl.editor.listControl.dynamicOptionsLabel"
+              defaultMessage="Dynamic Options"
+            />
+          }
           checked={this.props.controlParams.options.dynamicOptions}
-          onChange={(evt) => {
+          onChange={evt => {
             this.props.handleCheckboxOptionChange(this.props.controlIndex, 'dynamicOptions', evt);
           }}
           disabled={this.state.isStringField ? false : true}
@@ -185,14 +195,24 @@ export class ListControlEditor extends Component {
       options.push(
         <EuiFormRow
           id={`size-${this.props.controlIndex}`}
-          label={<FormattedMessage id="inputControl.editor.listControl.sizeLabel" defaultMessage="Size" />}
+          label={
+            <FormattedMessage
+              id="inputControl.editor.listControl.sizeLabel"
+              defaultMessage="Size"
+            />
+          }
           key="size"
-          helpText={<FormattedMessage id="inputControl.editor.listControl.sizeDescription" defaultMessage="Number of options" />}
+          helpText={
+            <FormattedMessage
+              id="inputControl.editor.listControl.sizeDescription"
+              defaultMessage="Number of options"
+            />
+          }
         >
           <EuiFieldNumber
             min={1}
             value={this.props.controlParams.options.size}
-            onChange={(evt) => {
+            onChange={evt => {
               this.props.handleNumberOptionChange(this.props.controlIndex, 'size', evt);
             }}
             data-test-subj="listControlSizeInput"
@@ -202,12 +222,11 @@ export class ListControlEditor extends Component {
     }
 
     return options;
-  }
+  };
 
   render() {
     return (
-      <div>
-
+      <Fragment>
         <IndexPatternSelectFormRow
           indexPatternId={this.props.controlParams.indexPattern}
           onChange={this.props.handleIndexPatternChange}
@@ -224,8 +243,7 @@ export class ListControlEditor extends Component {
         />
 
         {this.renderOptions()}
-
-      </div>
+      </Fragment>
     );
   }
 }
@@ -238,10 +256,11 @@ ListControlEditor.propTypes = {
   handleIndexPatternChange: PropTypes.func.isRequired,
   handleCheckboxOptionChange: PropTypes.func.isRequired,
   handleNumberOptionChange: PropTypes.func.isRequired,
-  parentCandidates: PropTypes.arrayOf(PropTypes.shape({
-    value: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired,
-  })).isRequired,
+  parentCandidates: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   handleParentChange: PropTypes.func.isRequired,
 };
-

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/range_control_editor.js
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/range_control_editor.js
@@ -18,14 +18,11 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { IndexPatternSelectFormRow } from './index_pattern_select_form_row';
 import { FieldSelect } from './field_select';
 
-import {
-  EuiFormRow,
-  EuiFieldNumber,
-} from '@elastic/eui';
+import { EuiFormRow, EuiFieldNumber } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -36,15 +33,14 @@ function filterField(field) {
 export function RangeControlEditor(props) {
   const stepSizeId = `stepSize-${props.controlIndex}`;
   const decimalPlacesId = `decimalPlaces-${props.controlIndex}`;
-  const handleDecimalPlacesChange = (evt) => {
+  const handleDecimalPlacesChange = evt => {
     props.handleNumberOptionChange(props.controlIndex, 'decimalPlaces', evt);
   };
-  const handleStepChange = (evt) => {
+  const handleStepChange = evt => {
     props.handleNumberOptionChange(props.controlIndex, 'step', evt);
   };
   return (
-    <div>
-
+    <Fragment>
       <IndexPatternSelectFormRow
         indexPatternId={props.controlParams.indexPattern}
         onChange={props.handleIndexPatternChange}
@@ -62,10 +58,12 @@ export function RangeControlEditor(props) {
 
       <EuiFormRow
         id={stepSizeId}
-        label={<FormattedMessage
-          id="inputControl.editor.rangeControl.stepSizeLabel"
-          defaultMessage="Step Size"
-        />}
+        label={
+          <FormattedMessage
+            id="inputControl.editor.rangeControl.stepSizeLabel"
+            defaultMessage="Step Size"
+          />
+        }
       >
         <EuiFieldNumber
           value={props.controlParams.options.step}
@@ -76,10 +74,12 @@ export function RangeControlEditor(props) {
 
       <EuiFormRow
         id={decimalPlacesId}
-        label={<FormattedMessage
-          id="inputControl.editor.rangeControl.decimalPlacesLabel"
-          defaultMessage="Decimal Places"
-        />}
+        label={
+          <FormattedMessage
+            id="inputControl.editor.rangeControl.decimalPlacesLabel"
+            defaultMessage="Decimal Places"
+          />
+        }
       >
         <EuiFieldNumber
           min={0}
@@ -88,8 +88,7 @@ export function RangeControlEditor(props) {
           data-test-subj={`rangeControlDecimalPlacesInput${props.controlIndex}`}
         />
       </EuiFormRow>
-
-    </div>
+    </Fragment>
   );
 }
 
@@ -99,5 +98,5 @@ RangeControlEditor.propTypes = {
   controlParams: PropTypes.object.isRequired,
   handleFieldNameChange: PropTypes.func.isRequired,
   handleIndexPatternChange: PropTypes.func.isRequired,
-  handleNumberOptionChange: PropTypes.func.isRequired
+  handleNumberOptionChange: PropTypes.func.isRequired,
 };

--- a/src/legacy/core_plugins/input_control_vis/public/components/vis/__snapshots__/form_row.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/vis/__snapshots__/form_row.test.js.snap
@@ -42,6 +42,7 @@ exports[`renders disabled control with tooltip 1`] = `
   labelType="label"
 >
   <EuiToolTip
+    anchorClassName="eui-displayBlock"
     content="I am disabled for testing purposes"
     delay="regular"
     placement="top"

--- a/src/legacy/core_plugins/input_control_vis/public/components/vis/__snapshots__/form_row.test.js.snap
+++ b/src/legacy/core_plugins/input_control_vis/public/components/vis/__snapshots__/form_row.test.js.snap
@@ -4,6 +4,7 @@ exports[`renders control with warning 1`] = `
 <EuiFormRow
   data-test-subj="inputControl0"
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   id="controlId"
@@ -33,6 +34,7 @@ exports[`renders disabled control with tooltip 1`] = `
 <EuiFormRow
   data-test-subj="inputControl0"
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   id="controlId"
@@ -56,6 +58,7 @@ exports[`renders enabled control 1`] = `
 <EuiFormRow
   data-test-subj="inputControl0"
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   id="controlId"

--- a/src/legacy/core_plugins/input_control_vis/public/components/vis/form_row.js
+++ b/src/legacy/core_plugins/input_control_vis/public/components/vis/form_row.js
@@ -26,7 +26,7 @@ export function FormRow(props) {
   let control = props.children;
   if (props.disableMsg) {
     control = (
-      <EuiToolTip placement="top" content={props.disableMsg}>
+      <EuiToolTip placement="top" content={props.disableMsg} anchorClassName="eui-displayBlock">
         {control}
       </EuiToolTip>
     );
@@ -44,11 +44,7 @@ export function FormRow(props) {
   );
 
   return (
-    <EuiFormRow
-      label={label}
-      id={props.id}
-      data-test-subj={'inputControl' + props.controlIndex}
-    >
+    <EuiFormRow label={label} id={props.id} data-test-subj={'inputControl' + props.controlIndex}>
       {control}
     </EuiFormRow>
   );

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/number_input.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/number_input.tsx
@@ -52,6 +52,7 @@ function NumberInputOption<ParamName extends string>({
       <EuiFieldNumber
         data-test-subj={dataTestSubj}
         disabled={disabled}
+        compressed
         fullWidth
         isInvalid={isInvalid}
         step={step}

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/range.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/range.tsx
@@ -64,6 +64,7 @@ function RangeOption<ParamName extends string>({
   return (
     <EuiFormRow label={label} fullWidth={true} isInvalid={!isValidState} error={error} compressed>
       <EuiRange
+        compressed
         fullWidth
         showValue
         max={max}

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/select.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/select.tsx
@@ -55,6 +55,7 @@ function SelectOption<ParamName extends string, ValidParamValues extends string 
       labelAppend={labelAppend}
     >
       <EuiSelect
+        compressed
         disabled={disabled}
         options={[emptyValue, ...options]}
         value={value === undefined ? emptyValue.value : value}

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/text_input.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/text_input.tsx
@@ -42,6 +42,7 @@ function TextInputOption<ParamName extends string>({
   return (
     <EuiFormRow helpText={helpText} label={label} fullWidth compressed>
       <EuiFieldText
+        compressed
         fullWidth
         data-test-subj={dataTestSubj}
         disabled={disabled}

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/truncate_labels.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/common/truncate_labels.tsx
@@ -44,6 +44,7 @@ function TruncateLabelsOption({ disabled, value, setValue }: TruncateLabelsOptio
         value={value === null ? '' : value}
         onChange={onChange}
         fullWidth
+        compressed
       />
     </EuiFormRow>
   );

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/options/point_series/threshold_panel.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/options/point_series/threshold_panel.tsx
@@ -112,6 +112,7 @@ function ThresholdPanel({ stateParams, setValue, vis }: VisOptionsProps<BasicVis
             compressed
           >
             <EuiColorPicker
+              compressed
               color={stateParams.thresholdLine.color}
               fullWidth
               onChange={setThresholdLineColor}

--- a/src/legacy/core_plugins/kibana/public/dashboard/top_nav/__snapshots__/save_modal.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/dashboard/top_nav/__snapshots__/save_modal.test.js.snap
@@ -9,6 +9,7 @@ exports[`renders DashboardSaveModal 1`] = `
     <React.Fragment>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -30,6 +31,7 @@ exports[`renders DashboardSaveModal 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         helpText={

--- a/src/legacy/core_plugins/kibana/public/index.scss
+++ b/src/legacy/core_plugins/kibana/public/index.scss
@@ -1,5 +1,11 @@
 @import 'src/legacy/ui/public/styles/styling_constants';
 
+// Temporary shim to help with EuiFormRow spacing
+// Will move to EUI
+.euiFormRow + .euiButton {
+  margin-top: $euiSize;
+}
+
 // Public UI styles
 @import 'src/legacy/ui/public/index';
 

--- a/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_index_pattern/components/header/__jest__/__snapshots__/header.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_index_pattern/components/header/__jest__/__snapshots__/header.test.js.snap
@@ -28,6 +28,7 @@ exports[`Header should mark the input as invalid 1`] = `
       >
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           error={
             Array [
               "Input is invalid",
@@ -137,6 +138,7 @@ exports[`Header should render normally 1`] = `
       >
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           error={Array []}
           fullWidth={false}
           hasEmptyLabelSpace={false}

--- a/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_time_field/components/time_field/__jest__/__snapshots__/time_field.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_time_field/components/time_field/__jest__/__snapshots__/time_field.test.js.snap
@@ -4,6 +4,7 @@ exports[`TimeField should render a loading state 1`] = `
 <EuiForm>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -77,6 +78,7 @@ exports[`TimeField should render a selected time field 1`] = `
 <EuiForm>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -161,6 +163,7 @@ exports[`TimeField should render normally 1`] = `
 <EuiForm>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/__jest__/__snapshots__/objects_table.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/__jest__/__snapshots__/objects_table.test.js.snap
@@ -97,6 +97,7 @@ exports[`ObjectsTable export should allow the user to choose when exporting all 
   <EuiModalBody>
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/__jest__/__snapshots__/objects_table.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/__jest__/__snapshots__/objects_table.test.js.snap
@@ -141,6 +141,9 @@ exports[`ObjectsTable export should allow the user to choose when exporting all 
         }
       />
     </EuiFormRow>
+    <EuiSpacer
+      size="m"
+    />
     <EuiSwitch
       checked={true}
       label={

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/components/flyout/__jest__/__snapshots__/flyout.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/components/flyout/__jest__/__snapshots__/flyout.test.js.snap
@@ -597,6 +597,7 @@ exports[`Flyout should render import step 1`] = `
     <EuiForm>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -623,6 +624,7 @@ exports[`Flyout should render import step 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/components/table/__jest__/__snapshots__/table.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/components/table/__jest__/__snapshots__/table.test.js.snap
@@ -65,6 +65,7 @@ exports[`Table prevents saved objects from being deleted 1`] = `
         >
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={false}
             hasEmptyLabelSpace={false}
             label={
@@ -91,6 +92,7 @@ exports[`Table prevents saved objects from being deleted 1`] = `
           </EuiFormRow>
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={false}
             hasEmptyLabelSpace={false}
             labelType="label"
@@ -268,6 +270,7 @@ exports[`Table should render normally 1`] = `
         >
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={false}
             hasEmptyLabelSpace={false}
             label={
@@ -294,6 +297,7 @@ exports[`Table should render normally 1`] = `
           </EuiFormRow>
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={false}
             hasEmptyLabelSpace={false}
             labelType="label"

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/objects_table.js
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/components/objects_table/objects_table.js
@@ -613,6 +613,7 @@ class ObjectsTableUI extends Component {
                 }}
               />
             </EuiFormRow>
+            <EuiSpacer size="m" />
             <EuiSwitch
               name="includeReferencesDeep"
               label={(

--- a/src/legacy/core_plugins/kibana/public/management/sections/settings/components/field/__snapshots__/field.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/settings/components/field/__snapshots__/field.test.js.snap
@@ -38,6 +38,7 @@ exports[`Field for array setting should render as read only if saving is disable
             "array:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -126,6 +127,7 @@ exports[`Field for array setting should render as read only with help text if ov
             "array:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -213,6 +215,7 @@ exports[`Field for array setting should render custom setting icon if it is cust
             "array:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -279,6 +282,7 @@ exports[`Field for array setting should render default value if there is no user
             "array:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -367,6 +371,7 @@ exports[`Field for array setting should render user value if there is user value
             "array:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -452,6 +457,7 @@ exports[`Field for boolean setting should render as read only if saving is disab
             "boolean:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -544,6 +550,7 @@ exports[`Field for boolean setting should render as read only with help text if 
             "boolean:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -635,6 +642,7 @@ exports[`Field for boolean setting should render custom setting icon if it is cu
             "boolean:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -705,6 +713,7 @@ exports[`Field for boolean setting should render default value if there is no us
             "boolean:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -797,6 +806,7 @@ exports[`Field for boolean setting should render user value if there is user val
             "boolean:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -886,6 +896,7 @@ exports[`Field for image setting should render as read only if saving is disable
             "image:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -973,6 +984,7 @@ exports[`Field for image setting should render as read only with help text if ov
             "image:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1057,6 +1069,7 @@ exports[`Field for image setting should render custom setting icon if it is cust
             "image:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1122,6 +1135,7 @@ exports[`Field for image setting should render default value if there is no user
             "image:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1209,6 +1223,7 @@ exports[`Field for image setting should render user value if there is user value
             "image:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1332,6 +1347,7 @@ exports[`Field for json setting should render as read only if saving is disabled
             "json:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1441,6 +1457,7 @@ exports[`Field for json setting should render as read only with help text if ove
             "json:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1545,6 +1562,7 @@ exports[`Field for json setting should render custom setting icon if it is custo
             "json:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1654,6 +1672,7 @@ exports[`Field for json setting should render default value if there is no user 
             "json:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1782,6 +1801,7 @@ exports[`Field for json setting should render user value if there is user value 
             "json:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1884,6 +1904,7 @@ exports[`Field for markdown setting should render as read only if saving is disa
             "markdown:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -1989,6 +2010,7 @@ exports[`Field for markdown setting should render as read only with help text if
             "markdown:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2093,6 +2115,7 @@ exports[`Field for markdown setting should render custom setting icon if it is c
             "markdown:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2176,6 +2199,7 @@ exports[`Field for markdown setting should render default value if there is no u
             "markdown:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2281,6 +2305,7 @@ exports[`Field for markdown setting should render user value if there is user va
             "markdown:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2383,6 +2408,7 @@ exports[`Field for number setting should render as read only if saving is disabl
             "number:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2471,6 +2497,7 @@ exports[`Field for number setting should render as read only with help text if o
             "number:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2558,6 +2585,7 @@ exports[`Field for number setting should render custom setting icon if it is cus
             "number:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2624,6 +2652,7 @@ exports[`Field for number setting should render default value if there is no use
             "number:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2712,6 +2741,7 @@ exports[`Field for number setting should render user value if there is user valu
             "number:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2797,6 +2827,7 @@ exports[`Field for select setting should render as read only if saving is disabl
             "select:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -2902,6 +2933,7 @@ exports[`Field for select setting should render as read only with help text if o
             "select:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3006,6 +3038,7 @@ exports[`Field for select setting should render custom setting icon if it is cus
             "select:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3089,6 +3122,7 @@ exports[`Field for select setting should render default value if there is no use
             "select:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3194,6 +3228,7 @@ exports[`Field for select setting should render user value if there is user valu
             "select:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3296,6 +3331,7 @@ exports[`Field for string setting should render as read only if saving is disabl
             "string:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3384,6 +3420,7 @@ exports[`Field for string setting should render as read only with help text if o
             "string:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3471,6 +3508,7 @@ exports[`Field for string setting should render custom setting icon if it is cus
             "string:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3537,6 +3575,7 @@ exports[`Field for string setting should render default value if there is no use
             "string:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -3625,6 +3664,7 @@ exports[`Field for string setting should render user value if there is user valu
             "string:test:setting-aria",
           ]
         }
+        display="row"
         error={null}
         fullWidth={false}
         hasEmptyLabelSpace={false}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/calculation.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/calculation.js
@@ -38,6 +38,7 @@ import {
   EuiTextArea,
   EuiFormRow,
   EuiCode,
+  EuiSpacer,
 } from '@elastic/eui';
 
 export class CalculationAgg extends Component {
@@ -80,6 +81,7 @@ export class CalculationAgg extends Component {
                 defaultMessage="Aggregation"
               />
             </EuiFormLabel>
+            <EuiSpacer size="xs" />
             <AggSelect
               id={htmlId('aggregation')}
               panelType={this.props.panel.type}
@@ -91,8 +93,12 @@ export class CalculationAgg extends Component {
 
           <EuiFlexItem>
             <EuiFormLabel htmlFor={htmlId('variables')}>
-              <FormattedMessage id="visTypeTimeseries.calculation.variablesLabel" defaultMessage="Variables" />
+              <FormattedMessage
+                id="visTypeTimeseries.calculation.variablesLabel"
+                defaultMessage="Variables"
+              />
             </EuiFormLabel>
+            <EuiSpacer size="xs" />
             <CalculationVars
               id={htmlId('variables')}
               metrics={siblings}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/cumulative_sum.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/cumulative_sum.js
@@ -25,7 +25,14 @@ import { MetricSelect } from './metric_select';
 import { createChangeHandler } from '../lib/create_change_handler';
 import { createSelectHandler } from '../lib/create_select_handler';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { htmlIdGenerator, EuiFlexGroup, EuiFlexItem, EuiFormLabel, EuiFormRow } from '@elastic/eui';
+import {
+  htmlIdGenerator,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormLabel,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
 
 export function CumulativeSumAgg(props) {
   const { model, siblings } = props;
@@ -49,6 +56,7 @@ export function CumulativeSumAgg(props) {
               defaultMessage="Aggregation"
             />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -60,7 +68,12 @@ export function CumulativeSumAgg(props) {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('metric')}
-            label={<FormattedMessage id="visTypeTimeseries.cumulativeSum.metricLabel" defaultMessage="Metric" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.cumulativeSum.metricLabel"
+                defaultMessage="Metric"
+              />
+            }
           >
             <MetricSelect
               onChange={handleSelectChange('field')}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/derivative.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/derivative.js
@@ -32,6 +32,7 @@ import {
   EuiFormLabel,
   EuiFieldText,
   EuiFormRow,
+  EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -59,8 +60,12 @@ export const DerivativeAgg = props => {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.derivative.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.derivative.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -73,7 +78,12 @@ export const DerivativeAgg = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('metric')}
-            label={<FormattedMessage id="visTypeTimeseries.derivative.metricLabel" defaultMessage="Metric" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.derivative.metricLabel"
+                defaultMessage="Metric"
+              />
+            }
             fullWidth
           >
             <MetricSelect

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/filter_ratio.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/filter_ratio.js
@@ -70,8 +70,12 @@ export const FilterRatioAgg = props => {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.filterRatio.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.filterRatio.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -85,7 +89,10 @@ export const FilterRatioAgg = props => {
           <EuiFormRow
             id={htmlId('numerator')}
             label={
-              <FormattedMessage id="visTypeTimeseries.filterRatio.numeratorLabel" defaultMessage="Numerator" />
+              <FormattedMessage
+                id="visTypeTimeseries.filterRatio.numeratorLabel"
+                defaultMessage="Numerator"
+              />
             }
           >
             <EuiFieldText onChange={handleTextChange('numerator')} value={model.numerator} />
@@ -117,6 +124,7 @@ export const FilterRatioAgg = props => {
               defaultMessage="Metric Aggregation"
             />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('metric')}
             siblings={props.siblings}
@@ -130,7 +138,12 @@ export const FilterRatioAgg = props => {
           <EuiFlexItem>
             <EuiFormRow
               id={htmlId('aggField')}
-              label={<FormattedMessage id="visTypeTimeseries.filterRatio.fieldLabel" defaultMessage="Field" />}
+              label={
+                <FormattedMessage
+                  id="visTypeTimeseries.filterRatio.fieldLabel"
+                  defaultMessage="Field"
+                />
+              }
             >
               <FieldSelect
                 fields={fields}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/math.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/math.js
@@ -37,6 +37,7 @@ import {
   EuiLink,
   EuiFormRow,
   EuiCode,
+  EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -74,8 +75,12 @@ export class MathAgg extends Component {
         <EuiFlexGroup direction="column" gutterSize="l">
           <EuiFlexItem>
             <EuiFormLabel htmlFor={htmlId('aggregation')}>
-              <FormattedMessage id="visTypeTimeseries.math.aggregationLabel" defaultMessage="Aggregation" />
+              <FormattedMessage
+                id="visTypeTimeseries.math.aggregationLabel"
+                defaultMessage="Aggregation"
+              />
             </EuiFormLabel>
+            <EuiSpacer size="xs" />
             <AggSelect
               id={htmlId('aggregation')}
               siblings={this.props.siblings}
@@ -86,8 +91,12 @@ export class MathAgg extends Component {
 
           <EuiFlexItem>
             <EuiFormLabel htmlFor={htmlId('variables')}>
-              <FormattedMessage id="visTypeTimeseries.math.variablesLabel" defaultMessage="Variables" />
+              <FormattedMessage
+                id="visTypeTimeseries.math.variablesLabel"
+                defaultMessage="Variables"
+              />
             </EuiFormLabel>
+            <EuiSpacer size="xs" />
             <CalculationVars
               id={htmlId('variables')}
               metrics={siblings}
@@ -102,7 +111,10 @@ export class MathAgg extends Component {
             <EuiFormRow
               id="mathExpressionInput"
               label={
-                <FormattedMessage id="visTypeTimeseries.math.expressionLabel" defaultMessage="Expression" />
+                <FormattedMessage
+                  id="visTypeTimeseries.math.expressionLabel"
+                  defaultMessage="Expression"
+                />
               }
               fullWidth
               helpText={

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/moving_average.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/moving_average.js
@@ -69,9 +69,12 @@ export const MovingAverageAgg = props => {
       value: MODEL_TYPES.WEIGHTED_LINEAR,
     },
     {
-      label: i18n.translate('visTypeTimeseries.movingAverage.modelOptions.exponentiallyWeightedLabel', {
-        defaultMessage: 'Exponentially Weighted',
-      }),
+      label: i18n.translate(
+        'visTypeTimeseries.movingAverage.modelOptions.exponentiallyWeightedLabel',
+        {
+          defaultMessage: 'Exponentially Weighted',
+        }
+      ),
       value: MODEL_TYPES.WEIGHTED_EXPONENTIAL,
     },
     {
@@ -129,6 +132,7 @@ export const MovingAverageAgg = props => {
               defaultMessage: 'Aggregation',
             })}
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -166,9 +170,12 @@ export const MovingAverageAgg = props => {
           >
             <EuiComboBox
               isClearable={false}
-              placeholder={i18n.translate('visTypeTimeseries.movingAverage.model.selectPlaceholder', {
-                defaultMessage: 'Select',
-              })}
+              placeholder={i18n.translate(
+                'visTypeTimeseries.movingAverage.model.selectPlaceholder',
+                {
+                  defaultMessage: 'Select',
+                }
+              )}
               options={modelOptions}
               selectedOptions={selectedModelOption ? [selectedModelOption] : []}
               onChange={handleSelectChange('model_type')}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/percentile.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/percentile.js
@@ -78,6 +78,7 @@ export class PercentileAgg extends Component {
                 defaultMessage="Aggregation"
               />
             </EuiFormLabel>
+            <EuiSpacer size="xs" />
             <AggSelect
               id={htmlId('aggregation')}
               panelType={this.props.panel.type}
@@ -89,7 +90,12 @@ export class PercentileAgg extends Component {
           <EuiFlexItem>
             <EuiFormRow
               id={htmlId('field')}
-              label={<FormattedMessage id="visTypeTimeseries.percentile.fieldLabel" defaultMessage="Field" />}
+              label={
+                <FormattedMessage
+                  id="visTypeTimeseries.percentile.fieldLabel"
+                  defaultMessage="Field"
+                />
+              }
             >
               <FieldSelect
                 fields={fields}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/percentile_rank/percentile_rank.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/percentile_rank/percentile_rank.js
@@ -77,6 +77,7 @@ export const PercentileRankAgg = props => {
               defaultMessage="Aggregation"
             />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -88,7 +89,12 @@ export const PercentileRankAgg = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('field')}
-            label={<FormattedMessage id="visTypeTimeseries.percentileRank.fieldLabel" defaultMessage="Field" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.percentileRank.fieldLabel"
+                defaultMessage="Field"
+              />
+            }
           >
             <FieldSelect
               fields={fields}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/positive_only.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/positive_only.js
@@ -24,7 +24,14 @@ import { MetricSelect } from './metric_select';
 import { AggRow } from './agg_row';
 import { createChangeHandler } from '../lib/create_change_handler';
 import { createSelectHandler } from '../lib/create_select_handler';
-import { htmlIdGenerator, EuiFlexGroup, EuiFlexItem, EuiFormLabel, EuiFormRow } from '@elastic/eui';
+import {
+  htmlIdGenerator,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormLabel,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 export const PositiveOnlyAgg = props => {
@@ -54,6 +61,7 @@ export const PositiveOnlyAgg = props => {
               defaultMessage="Aggregation"
             />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -65,7 +73,12 @@ export const PositiveOnlyAgg = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('metric')}
-            label={<FormattedMessage id="visTypeTimeseries.positiveOnly.metricLabel" defaultMessage="Metric" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.positiveOnly.metricLabel"
+                defaultMessage="Metric"
+              />
+            }
           >
             <MetricSelect
               onChange={handleSelectChange('field')}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/serial_diff.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/serial_diff.js
@@ -25,7 +25,14 @@ import { AggRow } from './agg_row';
 import { createChangeHandler } from '../lib/create_change_handler';
 import { createSelectHandler } from '../lib/create_select_handler';
 import { createNumberHandler } from '../lib/create_number_handler';
-import { htmlIdGenerator, EuiFlexGroup, EuiFlexItem, EuiFormLabel, EuiFormRow } from '@elastic/eui';
+import {
+  htmlIdGenerator,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormLabel,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 export const SerialDiffAgg = props => {
@@ -51,8 +58,12 @@ export const SerialDiffAgg = props => {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.serialDiff.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.serialDiff.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -64,7 +75,12 @@ export const SerialDiffAgg = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('metric')}
-            label={<FormattedMessage id="visTypeTimeseries.serialDiff.metricLabel" defaultMessage="Metric" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.serialDiff.metricLabel"
+                defaultMessage="Metric"
+              />
+            }
           >
             <MetricSelect
               onChange={handleSelectChange('field')}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/series_agg.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/series_agg.js
@@ -31,6 +31,7 @@ import {
   EuiComboBox,
   EuiTitle,
   EuiFormRow,
+  EuiSpacer,
 } from '@elastic/eui';
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 
@@ -145,8 +146,12 @@ function SeriesAggUi(props) {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.seriesAgg.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.seriesAgg.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={panel.type}
@@ -158,7 +163,12 @@ function SeriesAggUi(props) {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('function')}
-            label={<FormattedMessage id="visTypeTimeseries.seriesAgg.functionLabel" defaultMessage="Function" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.seriesAgg.functionLabel"
+                defaultMessage="Function"
+              />
+            }
           >
             <EuiComboBox
               options={functionOptions}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/static.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/static.js
@@ -31,6 +31,7 @@ import {
   EuiFormLabel,
   EuiFieldNumber,
   EuiFormRow,
+  EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -61,8 +62,12 @@ export const Static = props => {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.static.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.static.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -75,7 +80,10 @@ export const Static = props => {
           <EuiFormRow
             id={htmlId('staticValue')}
             label={
-              <FormattedMessage id="visTypeTimeseries.static.staticValuesLabel" defaultMessage="Static Value" />
+              <FormattedMessage
+                id="visTypeTimeseries.static.staticValuesLabel"
+                defaultMessage="Static Value"
+              />
             }
           >
             <EuiFieldNumber

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/std_agg.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/std_agg.js
@@ -24,7 +24,14 @@ import { FieldSelect } from './field_select';
 import { AggRow } from './agg_row';
 import { createChangeHandler } from '../lib/create_change_handler';
 import { createSelectHandler } from '../lib/create_select_handler';
-import { htmlIdGenerator, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFormLabel } from '@elastic/eui';
+import {
+  htmlIdGenerator,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiFormLabel,
+  EuiSpacer,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { ES_TYPES } from '../../../common/es_types';
 import { METRIC_TYPES } from '../../../common/metric_types';
@@ -51,8 +58,12 @@ export function StandardAgg(props) {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.stdAgg.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.stdAgg.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -68,7 +79,9 @@ export function StandardAgg(props) {
           <EuiFlexItem>
             <EuiFormRow
               id={htmlId('field')}
-              label={<FormattedMessage id="visTypeTimeseries.stdAgg.fieldLabel" defaultMessage="Field" />}
+              label={
+                <FormattedMessage id="visTypeTimeseries.stdAgg.fieldLabel" defaultMessage="Field" />
+              }
               fullWidth
             >
               <FieldSelect

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/std_deviation.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/std_deviation.js
@@ -33,6 +33,7 @@ import {
   EuiComboBox,
   EuiFieldText,
   EuiFormRow,
+  EuiSpacer,
 } from '@elastic/eui';
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 import { ES_TYPES } from '../../../common/es_types';
@@ -106,6 +107,7 @@ const StandardDeviationAggUi = props => {
               defaultMessage="Aggregation"
             />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -117,7 +119,12 @@ const StandardDeviationAggUi = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('field')}
-            label={<FormattedMessage id="visTypeTimeseries.stdDeviation.fieldLabel" defaultMessage="Field" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.stdDeviation.fieldLabel"
+                defaultMessage="Field"
+              />
+            }
           >
             <FieldSelect
               fields={fields}
@@ -132,7 +139,12 @@ const StandardDeviationAggUi = props => {
         <EuiFlexItem grow={false}>
           <EuiFormRow
             id={htmlId('sigma')}
-            label={<FormattedMessage id="visTypeTimeseries.stdDeviation.sigmaLabel" defaultMessage="Sigma" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.stdDeviation.sigmaLabel"
+                defaultMessage="Sigma"
+              />
+            }
           >
             <EuiFieldText value={model.sigma} onChange={handleTextChange('sigma')} />
           </EuiFormRow>
@@ -140,7 +152,12 @@ const StandardDeviationAggUi = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('mode')}
-            label={<FormattedMessage id="visTypeTimeseries.stdDeviation.modeLabel" defaultMessage="Mode" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.stdDeviation.modeLabel"
+                defaultMessage="Mode"
+              />
+            }
           >
             <EuiComboBox
               options={modeOptions}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/std_sibling.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/std_sibling.js
@@ -33,6 +33,7 @@ import {
   EuiComboBox,
   EuiFormLabel,
   EuiFormRow,
+  EuiSpacer,
 } from '@elastic/eui';
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 
@@ -52,7 +53,9 @@ const StandardSiblingAggUi = props => {
       <EuiFlexItem grow={false}>
         <EuiFormRow
           id={htmlId('sigma')}
-          label={<FormattedMessage id="visTypeTimeseries.stdSibling.sigmaLabel" defaultMessage="Sigma" />}
+          label={
+            <FormattedMessage id="visTypeTimeseries.stdSibling.sigmaLabel" defaultMessage="Sigma" />
+          }
         >
           <EuiFieldText value={model.sigma} onChange={handleTextChange('sigma')} />
         </EuiFormRow>
@@ -97,7 +100,9 @@ const StandardSiblingAggUi = props => {
       <EuiFlexItem>
         <EuiFormRow
           id={htmlId('mode')}
-          label={<FormattedMessage id="visTypeTimeseries.stdSibling.modeLabel" defaultMessage="Mode" />}
+          label={
+            <FormattedMessage id="visTypeTimeseries.stdSibling.modeLabel" defaultMessage="Mode" />
+          }
         >
           <EuiComboBox
             options={modeOptions}
@@ -122,8 +127,12 @@ const StandardSiblingAggUi = props => {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.stdSibling.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.stdSibling.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -136,7 +145,12 @@ const StandardSiblingAggUi = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('metric')}
-            label={<FormattedMessage id="visTypeTimeseries.stdSibling.metricLabel" defaultMessage="Metric" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.stdSibling.metricLabel"
+                defaultMessage="Metric"
+              />
+            }
           >
             <MetricSelect
               onChange={handleSelectChange('field')}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/top_hit.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/aggs/top_hit.js
@@ -153,8 +153,12 @@ const TopHitAggUi = props => {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
           <EuiFormLabel htmlFor={htmlId('aggregation')}>
-            <FormattedMessage id="visTypeTimeseries.topHit.aggregationLabel" defaultMessage="Aggregation" />
+            <FormattedMessage
+              id="visTypeTimeseries.topHit.aggregationLabel"
+              defaultMessage="Aggregation"
+            />
           </EuiFormLabel>
+          <EuiSpacer size="xs" />
           <AggSelect
             id={htmlId('aggregation')}
             panelType={props.panel.type}
@@ -166,7 +170,9 @@ const TopHitAggUi = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('field')}
-            label={<FormattedMessage id="visTypeTimeseries.topHit.fieldLabel" defaultMessage="Field" />}
+            label={
+              <FormattedMessage id="visTypeTimeseries.topHit.fieldLabel" defaultMessage="Field" />
+            }
           >
             <FieldSelect
               fields={fields}
@@ -186,7 +192,9 @@ const TopHitAggUi = props => {
         <EuiFlexItem grow={false}>
           <EuiFormRow
             id={htmlId('size')}
-            label={<FormattedMessage id="visTypeTimeseries.topHit.sizeLabel" defaultMessage="Size" />}
+            label={
+              <FormattedMessage id="visTypeTimeseries.topHit.sizeLabel" defaultMessage="Size" />
+            }
           >
             {/*
               EUITODO: The following input couldn't be converted to EUI because of type mis-match.
@@ -211,9 +219,12 @@ const TopHitAggUi = props => {
           >
             <EuiComboBox
               isClearable={false}
-              placeholder={i18n.translate('visTypeTimeseries.topHit.aggregateWith.selectPlaceholder', {
-                defaultMessage: 'Select...',
-              })}
+              placeholder={i18n.translate(
+                'visTypeTimeseries.topHit.aggregateWith.selectPlaceholder',
+                {
+                  defaultMessage: 'Select...',
+                }
+              )}
               options={aggWithOptions}
               selectedOptions={selectedAggWithOption ? [selectedAggWithOption] : []}
               onChange={handleSelectChange('agg_with')}
@@ -224,7 +235,12 @@ const TopHitAggUi = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('order_by')}
-            label={<FormattedMessage id="visTypeTimeseries.topHit.orderByLabel" defaultMessage="Order by" />}
+            label={
+              <FormattedMessage
+                id="visTypeTimeseries.topHit.orderByLabel"
+                defaultMessage="Order by"
+              />
+            }
           >
             <FieldSelect
               restrict={ORDER_DATE_RESTRICT_FIELDS}
@@ -238,7 +254,9 @@ const TopHitAggUi = props => {
         <EuiFlexItem>
           <EuiFormRow
             id={htmlId('order')}
-            label={<FormattedMessage id="visTypeTimeseries.topHit.orderLabel" defaultMessage="Order" />}
+            label={
+              <FormattedMessage id="visTypeTimeseries.topHit.orderLabel" defaultMessage="Order" />
+            }
           >
             <EuiComboBox
               isClearable={false}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/annotations_editor.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/annotations_editor.js
@@ -186,7 +186,7 @@ export class AnnotationsEditor extends Component {
                     defaultMessage="Ignore global filters?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   value={model.ignore_global_filters}
                   name="ignore_global_filters"
@@ -200,7 +200,7 @@ export class AnnotationsEditor extends Component {
                     defaultMessage="Ignore panel filters?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="xs" />
                 <YesNo
                   value={model.ignore_panel_filters}
                   name="ignore_panel_filters"

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/gauge.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/gauge.js
@@ -122,7 +122,10 @@ class GaugePanelConfigUi extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.gauge.optionsTab.dataLabel" defaultMessage="Data" />
+                <FormattedMessage
+                  id="visTypeTimeseries.gauge.optionsTab.dataLabel"
+                  defaultMessage="Data"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
@@ -164,7 +167,7 @@ class GaugePanelConfigUi extends Component {
                     defaultMessage="Ignore global filter?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   value={model.ignore_global_filter}
                   name="ignore_global_filter"
@@ -179,7 +182,10 @@ class GaugePanelConfigUi extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.gauge.optionsTab.styleLabel" defaultMessage="Style" />
+                <FormattedMessage
+                  id="visTypeTimeseries.gauge.optionsTab.styleLabel"
+                  defaultMessage="Style"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
@@ -265,7 +271,7 @@ class GaugePanelConfigUi extends Component {
 
             <EuiFlexGroup responsive={false} wrap={true} alignItems="center">
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.gauge.optionsTab.backgroundColorLabel"
                     defaultMessage="Background color:"
@@ -280,7 +286,7 @@ class GaugePanelConfigUi extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.gauge.optionsTab.innerColorLabel"
                     defaultMessage="Inner color:"
@@ -324,7 +330,10 @@ class GaugePanelConfigUi extends Component {
       <div>
         <EuiTabs size="s">
           <EuiTab isSelected={selectedTab === 'data'} onClick={() => this.switchTab('data')}>
-            <FormattedMessage id="visTypeTimeseries.gauge.dataTab.dataButtonLabel" defaultMessage="Data" />
+            <FormattedMessage
+              id="visTypeTimeseries.gauge.dataTab.dataButtonLabel"
+              defaultMessage="Data"
+            />
           </EuiTab>
           <EuiTab isSelected={selectedTab === 'options'} onClick={() => this.switchTab('options')}>
             <FormattedMessage

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/markdown.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/markdown.js
@@ -131,7 +131,10 @@ class MarkdownPanelConfigUi extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.markdown.optionsTab.dataLabel" defaultMessage="Data" />
+                <FormattedMessage
+                  id="visTypeTimeseries.markdown.optionsTab.dataLabel"
+                  defaultMessage="Data"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
@@ -175,7 +178,7 @@ class MarkdownPanelConfigUi extends Component {
                     defaultMessage="Ignore global filter?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   value={model.ignore_global_filter}
                   name="ignore_global_filter"
@@ -190,14 +193,17 @@ class MarkdownPanelConfigUi extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.markdown.optionsTab.styleLabel" defaultMessage="Style" />
+                <FormattedMessage
+                  id="visTypeTimeseries.markdown.optionsTab.styleLabel"
+                  defaultMessage="Style"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
 
             <EuiFlexGroup responsive={false} wrap={true} alignItems="center">
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.markdown.optionsTab.backgroundColorLabel"
                     defaultMessage="Background color:"
@@ -212,7 +218,7 @@ class MarkdownPanelConfigUi extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.markdown.optionsTab.showScrollbarsLabel"
                     defaultMessage="Show scrollbars?"
@@ -228,7 +234,7 @@ class MarkdownPanelConfigUi extends Component {
               </EuiFlexItem>
 
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.markdown.optionsTab.openLinksInNewTab"
                     defaultMessage="Open links in new tab?"
@@ -243,7 +249,7 @@ class MarkdownPanelConfigUi extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }} htmlFor={htmlId('valign')}>
+                <EuiFormLabel htmlFor={htmlId('valign')}>
                   <FormattedMessage
                     id="visTypeTimeseries.markdown.optionsTab.verticalAlignmentLabel"
                     defaultMessage="Vertical alignment:"
@@ -302,7 +308,10 @@ class MarkdownPanelConfigUi extends Component {
             isSelected={selectedTab === 'data'}
             onClick={() => this.switchTab('data')}
           >
-            <FormattedMessage id="visTypeTimeseries.markdown.dataTab.dataButtonLabel" defaultMessage="Data" />
+            <FormattedMessage
+              id="visTypeTimeseries.markdown.dataTab.dataButtonLabel"
+              defaultMessage="Data"
+            />
           </EuiTab>
           <EuiTab
             isSelected={selectedTab === 'options'}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/metric.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/metric.js
@@ -129,7 +129,7 @@ export class MetricPanelConfig extends Component {
                     defaultMessage="Ignore global filter?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   value={model.ignore_global_filter}
                   name="ignore_global_filter"

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/table.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/table.js
@@ -249,7 +249,7 @@ export class TablePanelConfig extends Component {
                     defaultMessage="Ignore global filter?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   id={htmlId('globalFilterOption')}
                   value={model.ignore_global_filter}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/timeseries.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/timeseries.js
@@ -159,7 +159,10 @@ class TimeseriesPanelConfigUi extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.timeseries.optionsTab.dataLabel" defaultMessage="Data" />
+                <FormattedMessage
+                  id="visTypeTimeseries.timeseries.optionsTab.dataLabel"
+                  defaultMessage="Data"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
@@ -201,7 +204,7 @@ class TimeseriesPanelConfigUi extends Component {
                     defaultMessage="Ignore global filter?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   value={model.ignore_global_filter}
                   name="ignore_global_filter"
@@ -295,7 +298,7 @@ class TimeseriesPanelConfigUi extends Component {
 
             <EuiFlexGroup responsive={false} wrap={true} alignItems="center">
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.timeseries.optionsTab.backgroundColorLabel"
                     defaultMessage="Background color:"
@@ -310,7 +313,7 @@ class TimeseriesPanelConfigUi extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.timeseries.optionsTab.showLegendLabel"
                     defaultMessage="Show legend?"
@@ -325,7 +328,7 @@ class TimeseriesPanelConfigUi extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }} htmlFor={htmlId('legendPos')}>
+                <EuiFormLabel htmlFor={htmlId('legendPos')}>
                   <FormattedMessage
                     id="visTypeTimeseries.timeseries.optionsTab.legendPositionLabel"
                     defaultMessage="Legend position"
@@ -343,7 +346,7 @@ class TimeseriesPanelConfigUi extends Component {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.timeseries.optionsTab.displayGridLabel"
                     defaultMessage="Display grid"
@@ -362,7 +365,10 @@ class TimeseriesPanelConfigUi extends Component {
       <div>
         <EuiTabs size="s">
           <EuiTab isSelected={selectedTab === 'data'} onClick={() => this.switchTab('data')}>
-            <FormattedMessage id="visTypeTimeseries.timeseries.dataTab.dataButtonLabel" defaultMessage="Data" />
+            <FormattedMessage
+              id="visTypeTimeseries.timeseries.dataTab.dataButtonLabel"
+              defaultMessage="Data"
+            />
           </EuiTab>
           <EuiTab
             isSelected={selectedTab === 'options'}

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/top_n.js
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/panel_config/top_n.js
@@ -90,7 +90,10 @@ export class TopNPanelConfig extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.topN.optionsTab.dataLabel" defaultMessage="Data" />
+                <FormattedMessage
+                  id="visTypeTimeseries.topN.optionsTab.dataLabel"
+                  defaultMessage="Data"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
@@ -159,7 +162,7 @@ export class TopNPanelConfig extends Component {
                     defaultMessage="Ignore global filter?"
                   />
                 </EuiFormLabel>
-                <EuiSpacer size="s" />
+                <EuiSpacer size="m" />
                 <YesNo
                   value={model.ignore_global_filter}
                   name="ignore_global_filter"
@@ -174,14 +177,17 @@ export class TopNPanelConfig extends Component {
           <EuiPanel>
             <EuiTitle size="s">
               <span>
-                <FormattedMessage id="visTypeTimeseries.topN.optionsTab.styleLabel" defaultMessage="Style" />
+                <FormattedMessage
+                  id="visTypeTimeseries.topN.optionsTab.styleLabel"
+                  defaultMessage="Style"
+                />
               </span>
             </EuiTitle>
             <EuiSpacer size="m" />
 
             <EuiFlexGroup responsive={false} wrap={true} alignItems="center">
               <EuiFlexItem grow={false}>
-                <EuiFormLabel style={{ marginBottom: 0 }}>
+                <EuiFormLabel>
                   <FormattedMessage
                     id="visTypeTimeseries.topN.optionsTab.backgroundColorLabel"
                     defaultMessage="Background color:"
@@ -224,7 +230,10 @@ export class TopNPanelConfig extends Component {
       <div>
         <EuiTabs size="s">
           <EuiTab isSelected={selectedTab === 'data'} onClick={() => this.switchTab('data')}>
-            <FormattedMessage id="visTypeTimeseries.topN.dataTab.dataButtonLabel" defaultMessage="Data" />
+            <FormattedMessage
+              id="visTypeTimeseries.topN.dataTab.dataButtonLabel"
+              defaultMessage="Data"
+            />
           </EuiTab>
           <EuiTab isSelected={selectedTab === 'options'} onClick={() => this.switchTab('options')}>
             <FormattedMessage

--- a/src/legacy/core_plugins/vis_type_timeseries/public/components/splits/__snapshots__/terms.test.js.snap
+++ b/src/legacy/core_plugins/vis_type_timeseries/public/components/splits/__snapshots__/terms.test.js.snap
@@ -6,6 +6,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"
@@ -26,6 +27,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"
@@ -68,6 +70,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"
@@ -91,6 +94,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"
@@ -116,6 +120,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"
@@ -140,6 +145,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"
@@ -175,6 +181,7 @@ exports[`src/legacy/core_plugins/metrics/public/components/splits/terms.test.js 
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         id="42"

--- a/src/legacy/ui/public/field_editor/__snapshots__/field_editor.test.js.snap
+++ b/src/legacy/ui/public/field_editor/__snapshots__/field_editor.test.js.snap
@@ -1243,6 +1243,9 @@ exports[`FieldEditor should show multiple type field warning with a table contai
       />
     </eui-form-row>
     <div>
+      <eui-spacer
+        size="m"
+      />
       <eui-call-out
         color="warning"
         iconType="alert"

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/bytes/__snapshots__/bytes.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/bytes/__snapshots__/bytes.test.js.snap
@@ -4,6 +4,7 @@ exports[`BytesFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/date/__snapshots__/date.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/date/__snapshots__/date.test.js.snap
@@ -4,6 +4,7 @@ exports[`DateFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/date_nanos/__snapshots__/date_nanos.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/date_nanos/__snapshots__/date_nanos.test.js.snap
@@ -4,6 +4,7 @@ exports[`DateFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/duration/__snapshots__/duration.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/duration/__snapshots__/duration.test.js.snap
@@ -4,6 +4,7 @@ exports[`DurationFormatEditor should render human readable output normally 1`] =
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -36,6 +37,7 @@ exports[`DurationFormatEditor should render human readable output normally 1`] =
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     isInvalid={false}
@@ -118,6 +120,7 @@ exports[`DurationFormatEditor should render non-human readable output normally 1
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -150,6 +153,7 @@ exports[`DurationFormatEditor should render non-human readable output normally 1
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     isInvalid={false}
@@ -185,6 +189,7 @@ exports[`DurationFormatEditor should render non-human readable output normally 1
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/number/__snapshots__/number.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/number/__snapshots__/number.test.js.snap
@@ -4,6 +4,7 @@ exports[`NumberFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/percent/__snapshots__/percent.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/percent/__snapshots__/percent.test.js.snap
@@ -4,6 +4,7 @@ exports[`PercentFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/static_lookup/__snapshots__/static_lookup.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/static_lookup/__snapshots__/static_lookup.test.js.snap
@@ -71,6 +71,7 @@ exports[`StaticLookupFormatEditorComponent should render multiple lookup entries
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -162,6 +163,7 @@ exports[`StaticLookupFormatEditorComponent should render normally 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/string/__snapshots__/string.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/string/__snapshots__/string.test.js.snap
@@ -4,6 +4,7 @@ exports[`StringFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/truncate/__snapshots__/truncate.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/truncate/__snapshots__/truncate.test.js.snap
@@ -4,6 +4,7 @@ exports[`TruncateFormatEditor should render normally 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/editors/url/__snapshots__/url.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/editors/url/__snapshots__/url.test.js.snap
@@ -12,6 +12,7 @@ exports[`UrlFormatEditor should render label template help 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -50,6 +51,7 @@ exports[`UrlFormatEditor should render label template help 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -87,6 +89,7 @@ exports[`UrlFormatEditor should render label template help 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -140,6 +143,7 @@ exports[`UrlFormatEditor should render normally 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -178,6 +182,7 @@ exports[`UrlFormatEditor should render normally 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -215,6 +220,7 @@ exports[`UrlFormatEditor should render normally 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -268,6 +274,7 @@ exports[`UrlFormatEditor should render url template help 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -306,6 +313,7 @@ exports[`UrlFormatEditor should render url template help 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -343,6 +351,7 @@ exports[`UrlFormatEditor should render url template help 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={null}
     fullWidth={false}
     hasEmptyLabelSpace={false}

--- a/src/legacy/ui/public/field_editor/components/field_format_editor/samples/__snapshots__/samples.test.js.snap
+++ b/src/legacy/ui/public/field_editor/components/field_format_editor/samples/__snapshots__/samples.test.js.snap
@@ -3,6 +3,7 @@
 exports[`FormatEditorSamples should render normally 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={

--- a/src/legacy/ui/public/field_editor/field_editor.js
+++ b/src/legacy/ui/public/field_editor/field_editor.js
@@ -367,6 +367,7 @@ export class FieldEditorComponent extends PureComponent {
 
     return (
       <div>
+        <EuiSpacer size="m" />
         <EuiCallOut
           color="warning"
           iconType="alert"

--- a/src/legacy/ui/public/share/components/__snapshots__/url_panel_content.test.js.snap
+++ b/src/legacy/ui/public/share/components/__snapshots__/url_panel_content.test.js.snap
@@ -7,6 +7,7 @@ exports[`render 1`] = `
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -110,6 +111,7 @@ exports[`render 1`] = `
   <EuiFormRow
     data-test-subj="createShortUrl"
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     labelType="label"
@@ -165,6 +167,7 @@ exports[`should enable saved object export option when objectId is provided 1`] 
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -257,6 +260,7 @@ exports[`should enable saved object export option when objectId is provided 1`] 
   <EuiFormRow
     data-test-subj="createShortUrl"
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     labelType="label"
@@ -312,6 +316,7 @@ exports[`should hide short url section when allowShortUrl is false 1`] = `
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={

--- a/src/legacy/ui/public/share/components/__snapshots__/url_panel_content.test.js.snap
+++ b/src/legacy/ui/public/share/components/__snapshots__/url_panel_content.test.js.snap
@@ -150,6 +150,9 @@ exports[`render 1`] = `
       </EuiFlexItem>
     </EuiFlexGroup>
   </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
   <EuiCopy
     afterMessage="Copied"
     anchorClassName="kbnShareContextMenu__copyAnchor"
@@ -299,6 +302,9 @@ exports[`should enable saved object export option when objectId is provided 1`] 
       </EuiFlexItem>
     </EuiFlexGroup>
   </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
   <EuiCopy
     afterMessage="Copied"
     anchorClassName="kbnShareContextMenu__copyAnchor"
@@ -406,6 +412,9 @@ exports[`should hide short url section when allowShortUrl is false 1`] = `
       }
     />
   </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
   <EuiCopy
     afterMessage="Copied"
     anchorClassName="kbnShareContextMenu__copyAnchor"

--- a/src/legacy/ui/public/share/components/url_panel_content.tsx
+++ b/src/legacy/ui/public/share/components/url_panel_content.tsx
@@ -23,6 +23,7 @@ import {
   EuiButton,
   EuiCopy,
   EuiFlexGroup,
+  EuiSpacer,
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
@@ -99,6 +100,8 @@ class UrlPanelContentUI extends Component<Props, State> {
         {this.renderExportAsRadioGroup()}
 
         {this.renderShortUrlSwitch()}
+
+        <EuiSpacer size="m" />
 
         <EuiCopy
           textToCopy={this.state.url || ''}

--- a/src/legacy/ui/public/vis/editors/default/_agg_params.scss
+++ b/src/legacy/ui/public/vis/editors/default/_agg_params.scss
@@ -1,4 +1,5 @@
 .visEditorAggParam--half {
+  margin-top: $euiSize;
   display: inline-block;
   width: calc(50% - #{$euiSizeS / 2});
 }

--- a/src/legacy/ui/public/vis/editors/default/components/__snapshots__/agg_params.test.tsx.snap
+++ b/src/legacy/ui/public/vis/editors/default/components/__snapshots__/agg_params.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`DefaultEditorAggParams component should init with the default set of pa
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     labelType="label"

--- a/src/legacy/ui/public/vis/editors/default/components/agg_select.tsx
+++ b/src/legacy/ui/public/vis/editors/default/components/agg_select.tsx
@@ -142,7 +142,7 @@ function DefaultEditorAggSelect({
         isClearable={false}
         isInvalid={showValidation ? !isValid : false}
         fullWidth={true}
-        compressed
+        // compressed
       />
     </EuiFormRow>
   );

--- a/src/legacy/ui/public/vis/editors/default/components/agg_select.tsx
+++ b/src/legacy/ui/public/vis/editors/default/components/agg_select.tsx
@@ -142,6 +142,7 @@ function DefaultEditorAggSelect({
         isClearable={false}
         isInvalid={showValidation ? !isValid : false}
         fullWidth={true}
+        compressed
       />
     </EuiFormRow>
   );

--- a/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/size.test.tsx.snap
+++ b/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/size.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`SizeParamEditor should init with the default set of props 1`] = `
   labelType="label"
 >
   <EuiFieldNumber
-    compressed={false}
+    compressed={true}
     data-test-subj="sizeParamEditor"
     fullWidth={true}
     isInvalid={false}

--- a/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/size.test.tsx.snap
+++ b/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/size.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`SizeParamEditor should init with the default set of props 1`] = `
 <EuiFormRow
   compressed={true}
   describedByIds={Array []}
+  display="row"
   fullWidth={true}
   hasEmptyLabelSpace={false}
   isInvalid={false}

--- a/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/top_aggregate.test.tsx.snap
+++ b/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/top_aggregate.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`TopAggregateParamEditor should init with the default set of props 1`] =
 <EuiFormRow
   compressed={true}
   describedByIds={Array []}
+  display="row"
   fullWidth={true}
   hasEmptyLabelSpace={false}
   isInvalid={false}

--- a/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/top_aggregate.test.tsx.snap
+++ b/src/legacy/ui/public/vis/editors/default/controls/__snapshots__/top_aggregate.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`TopAggregateParamEditor should init with the default set of props 1`] =
   labelType="label"
 >
   <EuiSelect
-    compressed={false}
+    compressed={true}
     data-test-subj="visDefaultEditorAggregateWith"
     disabled={false}
     fullWidth={true}

--- a/src/legacy/ui/public/vis/editors/default/controls/field.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/field.tsx
@@ -110,6 +110,7 @@ function FieldParamEditor({
       compressed
     >
       <EuiComboBox
+        // compressed
         placeholder={i18n.translate('common.ui.aggTypes.field.selectFieldPlaceholder', {
           defaultMessage: 'Select a field',
         })}

--- a/src/legacy/ui/public/vis/editors/default/controls/filter.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/filter.tsx
@@ -18,14 +18,7 @@
  */
 
 import React, { useState } from 'react';
-import {
-  EuiForm,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButtonIcon,
-  EuiFieldText,
-  EuiFormRow,
-} from '@elastic/eui';
+import { EuiForm, EuiButtonIcon, EuiFieldText, EuiFormRow, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Query, QueryBarInput } from 'plugins/data';
 import { AggConfig } from '../../..';
@@ -67,30 +60,26 @@ function FilterRow({
   });
 
   const FilterControl = (
-    <EuiFlexGroup gutterSize="s" responsive={false}>
-      <EuiFlexItem>
-        <EuiButtonIcon
-          iconType="tag"
-          aria-label={i18n.translate('common.ui.aggTypes.filters.toggleFilterButtonAriaLabel', {
-            defaultMessage: 'Toggle filter label',
-          })}
-          aria-expanded={showCustomLabel}
-          aria-controls={`visEditorFilterLabel${arrayIndex}`}
-          onClick={() => setShowCustomLabel(!showCustomLabel)}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiButtonIcon
-          iconType="trash"
-          color="danger"
-          disabled={disableRemove}
-          aria-label={i18n.translate('common.ui.aggTypes.filters.removeFilterButtonAriaLabel', {
-            defaultMessage: 'Remove this filter',
-          })}
-          onClick={() => onRemoveFilter(id)}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <div>
+      <EuiButtonIcon
+        iconType="tag"
+        aria-label={i18n.translate('common.ui.aggTypes.filters.toggleFilterButtonAriaLabel', {
+          defaultMessage: 'Toggle filter label',
+        })}
+        aria-expanded={showCustomLabel}
+        aria-controls={`visEditorFilterLabel${arrayIndex}`}
+        onClick={() => setShowCustomLabel(!showCustomLabel)}
+      />
+      <EuiButtonIcon
+        iconType="trash"
+        color="danger"
+        disabled={disableRemove}
+        aria-label={i18n.translate('common.ui.aggTypes.filters.removeFilterButtonAriaLabel', {
+          defaultMessage: 'Remove this filter',
+        })}
+        onClick={() => onRemoveFilter(id)}
+      />
+    </div>
   );
 
   return (
@@ -99,7 +88,6 @@ function FilterRow({
         label={`${filterLabel}${customLabel ? ` - ${customLabel}` : ''}`}
         labelAppend={FilterControl}
         fullWidth={true}
-        compressed
       >
         <QueryBarInput
           query={value}
@@ -136,9 +124,11 @@ function FilterRow({
             })}
             onChange={ev => onChangeValue(id, value, ev.target.value)}
             fullWidth={true}
+            compressed
           />
         </EuiFormRow>
       ) : null}
+      <EuiSpacer />
     </EuiForm>
   );
 }

--- a/src/legacy/ui/public/vis/editors/default/controls/filters.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/filters.tsx
@@ -86,6 +86,7 @@ function FiltersParamEditor({ agg, value = [], setValue }: AggParamEditorProps<F
 
   return (
     <>
+      <EuiSpacer size="m" />
       {filters.map(({ input, label, id }, arrayIndex) => (
         <FilterRow
           key={id}

--- a/src/legacy/ui/public/vis/editors/default/controls/metric_agg.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/metric_agg.tsx
@@ -97,6 +97,7 @@ function MetricAggParamEditor({
         value={value || EMPTY_VALUE}
         onChange={ev => setValue(ev.target.value)}
         fullWidth={true}
+        compressed
         isInvalid={showValidation ? !isValid : false}
         onBlur={setTouched}
         data-test-subj={`visEditorSubAggMetric${agg.id}`}

--- a/src/legacy/ui/public/vis/editors/default/controls/number_interval.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/number_interval.tsx
@@ -84,6 +84,7 @@ function NumberIntervalParamEditor({
         onChange={onChange}
         onBlur={setTouched}
         fullWidth={true}
+        compressed
         placeholder={i18n.translate('common.ui.aggTypes.numberInterval.selectIntervalPlaceholder', {
           defaultMessage: 'Enter an interval',
         })}

--- a/src/legacy/ui/public/vis/editors/default/controls/order.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/order.tsx
@@ -58,6 +58,7 @@ function OrderParamEditor({
           setValue(aggParam.options.find((opt: OptionedValueProp) => opt.value === ev.target.value))
         }
         fullWidth={true}
+        compressed
         isInvalid={showValidation ? !isValid : false}
         onBlur={setTouched}
       />

--- a/src/legacy/ui/public/vis/editors/default/controls/order_by.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/order_by.tsx
@@ -123,6 +123,7 @@ function OrderByParamEditor({
         value={value}
         onChange={ev => setValue(ev.target.value)}
         fullWidth={true}
+        compressed
         isInvalid={showValidation ? !isValid : false}
         onBlur={setTouched}
         data-test-subj={`visEditorOrderBy${agg.id}`}

--- a/src/legacy/ui/public/vis/editors/default/controls/precision.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/precision.tsx
@@ -46,6 +46,7 @@ function PrecisionParamEditor({ agg, value, setValue }: AggParamEditorProps<numb
         }
         data-test-subj={`visEditorMapPrecision${agg.id}`}
         showValue
+        compressed
       />
     </EuiFormRow>
   );

--- a/src/legacy/ui/public/vis/editors/default/controls/radius_ratio_option.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/radius_ratio_option.tsx
@@ -50,7 +50,7 @@ function RadiusRatioOptionControl({ editorStateParams, setValue }: AggControlPro
   }, []);
 
   return (
-    <EuiFormRow fullWidth={true} label={label}>
+    <EuiFormRow fullWidth={true} label={label} compressed>
       <EuiRange
         compressed
         fullWidth={true}

--- a/src/legacy/ui/public/vis/editors/default/controls/raw_json.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/raw_json.tsx
@@ -73,6 +73,7 @@ function RawJsonParamEditor({
         rows={2}
         fullWidth={true}
         onBlur={setTouched}
+        compressed
       />
     </EuiFormRow>
   );

--- a/src/legacy/ui/public/vis/editors/default/controls/size.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/size.tsx
@@ -60,7 +60,6 @@ function SizeParamEditor({
         value={isUndefined(value) ? '' : value}
         onChange={ev => setValue(ev.target.value === '' ? '' : parseFloat(ev.target.value))}
         fullWidth={true}
-        compressed
         isInvalid={showValidation ? !isValid : false}
         onBlur={setTouched}
         min={1}

--- a/src/legacy/ui/public/vis/editors/default/controls/size.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/size.tsx
@@ -60,6 +60,7 @@ function SizeParamEditor({
         value={isUndefined(value) ? '' : value}
         onChange={ev => setValue(ev.target.value === '' ? '' : parseFloat(ev.target.value))}
         fullWidth={true}
+        compressed
         isInvalid={showValidation ? !isValid : false}
         onBlur={setTouched}
         min={1}

--- a/src/legacy/ui/public/vis/editors/default/controls/string.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/string.tsx
@@ -49,6 +49,7 @@ function StringParamEditor({
         data-test-subj={`visEditorStringInput${agg.id}${aggParam.name}`}
         onChange={ev => setValue(ev.target.value)}
         fullWidth={true}
+        compressed
         onBlur={setTouched}
         isInvalid={showValidation ? !isValid : false}
       />

--- a/src/legacy/ui/public/vis/editors/default/controls/sub_metric.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/sub_metric.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiFormLabel } from '@elastic/eui';
+import { EuiFormLabel, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { AggParamType } from '../../../../agg_types/param_types/agg';
 import { AggConfig } from '../../..';
@@ -65,6 +65,7 @@ function SubMetricParamEditor({
   return (
     <>
       <EuiFormLabel>{aggTitle}</EuiFormLabel>
+      <EuiSpacer size="s" />
       <DefaultEditorAggParams
         agg={agg.params[type]}
         groupName={aggGroup}

--- a/src/legacy/ui/public/vis/editors/default/controls/switch.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/switch.tsx
@@ -39,7 +39,12 @@ function SwitchParamEditor({
 }: SwitchParamEditorProps) {
   return (
     <div className="visEditorSidebar__aggParamFormRow">
-      <EuiToolTip content={displayToolTip} delay="long" position="right">
+      <EuiToolTip
+        content={displayToolTip}
+        delay="long"
+        position="right"
+        anchorClassName="eui-displayBlock"
+      >
         <EuiSwitch
           label={displayLabel}
           checked={value}

--- a/src/legacy/ui/public/vis/editors/default/controls/time_interval.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/time_interval.tsx
@@ -131,6 +131,7 @@ function TimeIntervalParamEditor({
       })}
     >
       <EuiComboBox
+        // compressed
         fullWidth={true}
         data-test-subj="visEditorInterval"
         isInvalid={showValidation ? !isValid : false}

--- a/src/legacy/ui/public/vis/editors/default/controls/top_aggregate.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/top_aggregate.tsx
@@ -123,6 +123,7 @@ export function TopAggregateParamEditor({
         value={value ? value.value : emptyValue.value}
         onChange={handleChange}
         fullWidth={true}
+        compressed
         isInvalid={showValidation ? !isValid : false}
         disabled={disabled}
         onBlur={setTouched}

--- a/src/plugins/kibana_react/public/saved_objects/__snapshots__/saved_object_save_modal.test.tsx.snap
+++ b/src/plugins/kibana_react/public/saved_objects/__snapshots__/saved_object_save_modal.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`SavedObjectSaveModal should render matching snapshot 1`] = `
           </EuiFormRow>
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={true}
             hasEmptyLabelSpace={false}
             label={

--- a/src/plugins/kibana_react/public/saved_objects/__snapshots__/saved_object_save_modal.test.tsx.snap
+++ b/src/plugins/kibana_react/public/saved_objects/__snapshots__/saved_object_save_modal.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`SavedObjectSaveModal should render matching snapshot 1`] = `
         <EuiForm>
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={true}
             hasEmptyLabelSpace={false}
             label={

--- a/test/interpreter_functional/plugins/kbn_tp_run_pipeline/package.json
+++ b/test/interpreter_functional/plugins/kbn_tp_run_pipeline/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/test/plugin_functional/plugins/kbn_tp_custom_visualizations/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_custom_visualizations/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "react": "^16.8.0"
   }
 }

--- a/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "react": "^16.8.0"
   },
   "scripts": {

--- a/test/plugin_functional/plugins/kbn_tp_sample_panel_action/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_sample_panel_action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "react": "^16.8.0"
   },
   "scripts": {

--- a/test/plugin_functional/plugins/kbn_tp_visualize_embedding/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_visualize_embedding/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
@@ -355,6 +355,7 @@ export class WatcherFlyout extends Component<
               onChange={this.onChangeThreshold}
             />
           </EuiFormRow>
+          <EuiSpacer size="m" />
           <h4>
             {i18n.translate(
               'xpack.apm.serviceDetails.enableErrorReportsPanel.triggerScheduleTitle',
@@ -403,6 +404,7 @@ export class WatcherFlyout extends Component<
               disabled={this.state.schedule !== 'daily'}
             />
           </EuiFormRow>
+          <EuiSpacer size="m" />
           <EuiRadio
             id="interval"
             label={i18n.translate(
@@ -428,6 +430,7 @@ export class WatcherFlyout extends Component<
                   compressed
                 >
                   <EuiFieldNumber
+                    compressed
                     icon="clock"
                     min={1}
                     value={this.state.interval.value}
@@ -442,6 +445,7 @@ export class WatcherFlyout extends Component<
                 <EuiSelect
                   value={this.state.interval.unit}
                   onChange={this.onChangeIntervalUnit}
+                  compressed
                   options={[
                     {
                       value: 'm',
@@ -531,12 +535,14 @@ export class WatcherFlyout extends Component<
               }
             >
               <EuiFieldText
+                compressed
                 icon="user"
                 value={this.state.emails}
                 onChange={this.onChangeEmails}
               />
             </EuiFormRow>
           )}
+          <EuiSpacer size="m" />
           <EuiSwitch
             label={i18n.translate(
               'xpack.apm.serviceDetails.enableErrorReportsPanel.sendSlackNotificationLabel',
@@ -582,6 +588,7 @@ export class WatcherFlyout extends Component<
               }
             >
               <EuiFieldText
+                compressed
                 icon="link"
                 value={this.state.slackUrl}
                 onChange={this.onChangeSlackUrl}

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -166,6 +166,8 @@ export function AddSettingFlyoutBody({
           />
         </EuiFormRow>
 
+        <EuiSpacer />
+
         <EuiTitle size="xs">
           <h3>
             {i18n.translate(

--- a/x-pack/legacy/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiSelect, EuiFormLabel } from '@elastic/eui';
+import { EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useFetcher } from '../../../hooks/useFetcher';
@@ -96,13 +96,9 @@ export const EnvironmentFilter: React.FC = () => {
 
   return (
     <EuiSelect
-      prepend={
-        <EuiFormLabel>
-          {i18n.translate('xpack.apm.filter.environment.label', {
-            defaultMessage: 'environment'
-          })}
-        </EuiFormLabel>
-      }
+      prepend={i18n.translate('xpack.apm.filter.environment.label', {
+        defaultMessage: 'environment'
+      })}
       options={getOptions(environments)}
       value={environment || ENVIRONMENT_ALL}
       onChange={event => {

--- a/x-pack/legacy/plugins/beats_management/public/components/tag/config_view/index.tsx
+++ b/x-pack/legacy/plugins/beats_management/public/components/tag/config_view/index.tsx
@@ -17,6 +17,7 @@ import {
   EuiFormRow,
   EuiHorizontalRule,
   EuiSelect,
+  EuiSpacer,
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -119,6 +120,7 @@ class ConfigViewUi extends React.Component<ComponentProps, ComponentState> {
               )}
             />
           </EuiFormRow>
+          <EuiSpacer />
           <h3>
             {i18n.translate('xpack.beatsManagement.tagConfig.configurationTypeText', {
               defaultMessage: '{configType} configuration',

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/uis/arguments/axis_config/__examples__/__snapshots__/extended_template.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/uis/arguments/axis_config/__examples__/__snapshots__/extended_template.examples.storyshot
@@ -14,57 +14,63 @@ exports[`Storyshots arguments/AxisConfig extended 1`] = `
     className="euiFormRow euiFormRow--compressed"
     id="generated-id-row"
   >
-    <div>
+    <div
+      className="euiFormRow__labelWrapper"
+    >
       <label
-        className="euiFormLabel"
+        className="euiFormLabel euiFormRow__label"
         htmlFor="generated-id"
       >
         Position
       </label>
     </div>
     <div
-      className="euiFormControlLayout euiFormControlLayout--compressed"
+      className="euiFormRow__fieldWrapper"
     >
       <div
-        className="euiFormControlLayout__childrenWrapper"
+        className="euiFormControlLayout"
       >
-        <select
-          className="euiSelect euiSelect--compressed"
-          id="generated-id"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onMouseUp={[Function]}
-          value="bottom"
+        <div
+          className="euiFormControlLayout__childrenWrapper"
         >
-          <option
+          <select
+            className="euiSelect"
+            id="generated-id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onMouseUp={[Function]}
             value="bottom"
           >
-            bottom
-          </option>
-          <option
-            value="top"
+            <option
+              value="bottom"
+            >
+              bottom
+            </option>
+            <option
+              value="top"
+            >
+              top
+            </option>
+          </select>
+          <div
+            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
-            top
-          </option>
-        </select>
-        <div
-          className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-        >
-          <span
-            className="euiFormControlLayoutCustomIcon"
-          >
-            <svg
-              aria-hidden="true"
-              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height={16}
-              style={null}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
-            />
-          </span>
+            <span
+              className="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -86,57 +92,63 @@ exports[`Storyshots arguments/AxisConfig/components extended 1`] = `
     className="euiFormRow euiFormRow--compressed"
     id="generated-id-row"
   >
-    <div>
+    <div
+      className="euiFormRow__labelWrapper"
+    >
       <label
-        className="euiFormLabel"
+        className="euiFormLabel euiFormRow__label"
         htmlFor="generated-id"
       >
         Position
       </label>
     </div>
     <div
-      className="euiFormControlLayout euiFormControlLayout--compressed"
+      className="euiFormRow__fieldWrapper"
     >
       <div
-        className="euiFormControlLayout__childrenWrapper"
+        className="euiFormControlLayout"
       >
-        <select
-          className="euiSelect euiSelect--compressed"
-          id="generated-id"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onMouseUp={[Function]}
-          value="left"
+        <div
+          className="euiFormControlLayout__childrenWrapper"
         >
-          <option
+          <select
+            className="euiSelect"
+            id="generated-id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onMouseUp={[Function]}
             value="left"
           >
-            left
-          </option>
-          <option
-            value="right"
+            <option
+              value="left"
+            >
+              left
+            </option>
+            <option
+              value="right"
+            >
+              right
+            </option>
+          </select>
+          <div
+            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
-            right
-          </option>
-        </select>
-        <div
-          className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-        >
-          <span
-            className="euiFormControlLayoutCustomIcon"
-          >
-            <svg
-              aria-hidden="true"
-              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height={16}
-              style={null}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
-            />
-          </span>
+            <span
+              className="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/uis/datasources/timelion.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/uis/datasources/timelion.js
@@ -81,6 +81,8 @@ const TimelionDatasource = ({ args, updateArgs, defaultIndex }) => {
         <EuiFieldText value={getInterval()} onChange={e => setArg('interval', e.target.value)} />
       </EuiFormRow>
 
+      <EuiSpacer size="m" />
+
       <EuiCallOut color="warning" title="Some tips" size="s">
         <ul>
           <li>

--- a/x-pack/legacy/plugins/canvas/public/components/arg_form/advanced_failure.js
+++ b/x-pack/legacy/plugins/canvas/public/components/arg_form/advanced_failure.js
@@ -7,7 +7,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compose, withProps, withPropsOnChange } from 'recompose';
-import { EuiForm, EuiTextArea, EuiButton, EuiButtonEmpty, EuiFormRow } from '@elastic/eui';
+import {
+  EuiForm,
+  EuiTextArea,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
 import { fromExpression, toExpression } from '@kbn/interpreter/common';
 import { createStatefulPropHoc } from '../../components/enhance/stateful_prop';
 
@@ -49,6 +56,7 @@ export const AdvancedFailureComponent = props => {
           rows={3}
         />
       </EuiFormRow>
+      <EuiSpacer size="s" />
       <div>
         <EuiButton disabled={!valid} onClick={e => valueChange(e)} size="s" type="submit">
           Apply

--- a/x-pack/legacy/plugins/canvas/public/components/custom_element_modal/__examples__/__snapshots__/custom_element_modal.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/components/custom_element_modal/__examples__/__snapshots__/custom_element_modal.examples.storyshot
@@ -95,116 +95,134 @@ Array [
                   className="euiFormRow euiFormRow--compressed"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Name
                     </label>
                   </div>
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--compressed"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFormControlLayout__childrenWrapper"
+                      className="euiFormControlLayout"
                     >
-                      <input
-                        aria-describedby="generated-id-help"
-                        className="euiFieldText canvasCustomElementForm__name euiFieldText--compressed"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={true}
-                        type="text"
-                        value=""
-                      />
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <input
+                          aria-describedby="generated-id-help"
+                          className="euiFieldText canvasCustomElementForm__name"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
-                  >
-                    40 characters remaining
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      40 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Description
                     </label>
                   </div>
-                  <textarea
-                    aria-describedby="generated-id-help"
-                    className="euiTextArea euiTextArea--resizeVertical"
-                    id="generated-id"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    rows={2}
-                    value="best element ever"
-                  />
                   <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
+                    className="euiFormRow__fieldWrapper"
                   >
-                    83 characters remaining
+                    <textarea
+                      aria-describedby="generated-id-help"
+                      className="euiTextArea euiTextArea--resizeVertical"
+                      id="generated-id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      rows={2}
+                      value="best element ever"
+                    />
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      83 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow euiFormRow--compressed canvasCustomElementForm__thumbnail"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Thumbnail image
                     </label>
                   </div>
                   <div
-                    className="euiFilePicker euiFilePicker--compressed canvasImageUpload"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFilePicker__wrap"
+                      className="euiFilePicker euiFilePicker--large canvasImageUpload"
                     >
-                      <input
-                        accept="image/*"
-                        className="euiFilePicker__input"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onDragLeave={[Function]}
-                        onDragOver={[Function]}
-                        onDrop={[Function]}
-                        onFocus={[Function]}
-                        type="file"
-                      />
                       <div
-                        className="euiFilePicker__prompt"
+                        className="euiFilePicker__wrap"
                       >
-                        <svg
-                          aria-hidden="true"
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFilePicker__icon"
-                          focusable="false"
-                          height={16}
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <input
+                          accept="image/*"
+                          className="euiFilePicker__input"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onDragLeave={[Function]}
+                          onDragOver={[Function]}
+                          onDrop={[Function]}
+                          onFocus={[Function]}
+                          type="file"
                         />
                         <div
-                          className="euiFilePicker__promptText"
+                          className="euiFilePicker__prompt"
                         >
-                          Select or drag and drop an image
+                          <svg
+                            aria-hidden="true"
+                            className="euiIcon euiIcon--large euiIcon-isLoading euiFilePicker__icon"
+                            focusable="false"
+                            height={16}
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                          <div
+                            className="euiFilePicker__promptText"
+                          >
+                            Select or drag and drop an image
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -433,116 +451,134 @@ Array [
                   className="euiFormRow euiFormRow--compressed"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Name
                     </label>
                   </div>
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--compressed"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFormControlLayout__childrenWrapper"
+                      className="euiFormControlLayout"
                     >
-                      <input
-                        aria-describedby="generated-id-help"
-                        className="euiFieldText canvasCustomElementForm__name euiFieldText--compressed"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={true}
-                        type="text"
-                        value=""
-                      />
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <input
+                          aria-describedby="generated-id-help"
+                          className="euiFieldText canvasCustomElementForm__name"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
-                  >
-                    40 characters remaining
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      40 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Description
                     </label>
                   </div>
-                  <textarea
-                    aria-describedby="generated-id-help"
-                    className="euiTextArea euiTextArea--resizeVertical"
-                    id="generated-id"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    rows={2}
-                    value=""
-                  />
                   <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
+                    className="euiFormRow__fieldWrapper"
                   >
-                    100 characters remaining
+                    <textarea
+                      aria-describedby="generated-id-help"
+                      className="euiTextArea euiTextArea--resizeVertical"
+                      id="generated-id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      rows={2}
+                      value=""
+                    />
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      100 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow euiFormRow--compressed canvasCustomElementForm__thumbnail"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Thumbnail image
                     </label>
                   </div>
                   <div
-                    className="euiFilePicker euiFilePicker--compressed canvasImageUpload"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFilePicker__wrap"
+                      className="euiFilePicker euiFilePicker--large canvasImageUpload"
                     >
-                      <input
-                        accept="image/*"
-                        className="euiFilePicker__input"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onDragLeave={[Function]}
-                        onDragOver={[Function]}
-                        onDrop={[Function]}
-                        onFocus={[Function]}
-                        type="file"
-                      />
                       <div
-                        className="euiFilePicker__prompt"
+                        className="euiFilePicker__wrap"
                       >
-                        <svg
-                          aria-hidden="true"
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFilePicker__icon"
-                          focusable="false"
-                          height={16}
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <input
+                          accept="image/*"
+                          className="euiFilePicker__input"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onDragLeave={[Function]}
+                          onDragOver={[Function]}
+                          onDrop={[Function]}
+                          onFocus={[Function]}
+                          type="file"
                         />
                         <div
-                          className="euiFilePicker__promptText"
+                          className="euiFilePicker__prompt"
                         >
-                          Select or drag and drop an image
+                          <svg
+                            aria-hidden="true"
+                            className="euiIcon euiIcon--large euiIcon-isLoading euiFilePicker__icon"
+                            focusable="false"
+                            height={16}
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                          <div
+                            className="euiFilePicker__promptText"
+                          >
+                            Select or drag and drop an image
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -768,116 +804,134 @@ Array [
                   className="euiFormRow euiFormRow--compressed"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Name
                     </label>
                   </div>
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--compressed"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFormControlLayout__childrenWrapper"
+                      className="euiFormControlLayout"
                     >
-                      <input
-                        aria-describedby="generated-id-help"
-                        className="euiFieldText canvasCustomElementForm__name euiFieldText--compressed"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={true}
-                        type="text"
-                        value="My Chart"
-                      />
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <input
+                          aria-describedby="generated-id-help"
+                          className="euiFieldText canvasCustomElementForm__name"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          required={true}
+                          type="text"
+                          value="My Chart"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
-                  >
-                    32 characters remaining
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      32 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Description
                     </label>
                   </div>
-                  <textarea
-                    aria-describedby="generated-id-help"
-                    className="euiTextArea euiTextArea--resizeVertical"
-                    id="generated-id"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    rows={2}
-                    value=""
-                  />
                   <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
+                    className="euiFormRow__fieldWrapper"
                   >
-                    100 characters remaining
+                    <textarea
+                      aria-describedby="generated-id-help"
+                      className="euiTextArea euiTextArea--resizeVertical"
+                      id="generated-id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      rows={2}
+                      value=""
+                    />
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      100 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow euiFormRow--compressed canvasCustomElementForm__thumbnail"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Thumbnail image
                     </label>
                   </div>
                   <div
-                    className="euiFilePicker euiFilePicker--compressed canvasImageUpload"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFilePicker__wrap"
+                      className="euiFilePicker euiFilePicker--large canvasImageUpload"
                     >
-                      <input
-                        accept="image/*"
-                        className="euiFilePicker__input"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onDragLeave={[Function]}
-                        onDragOver={[Function]}
-                        onDrop={[Function]}
-                        onFocus={[Function]}
-                        type="file"
-                      />
                       <div
-                        className="euiFilePicker__prompt"
+                        className="euiFilePicker__wrap"
                       >
-                        <svg
-                          aria-hidden="true"
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFilePicker__icon"
-                          focusable="false"
-                          height={16}
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <input
+                          accept="image/*"
+                          className="euiFilePicker__input"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onDragLeave={[Function]}
+                          onDragOver={[Function]}
+                          onDrop={[Function]}
+                          onFocus={[Function]}
+                          type="file"
                         />
                         <div
-                          className="euiFilePicker__promptText"
+                          className="euiFilePicker__prompt"
                         >
-                          Select or drag and drop an image
+                          <svg
+                            aria-hidden="true"
+                            className="euiIcon euiIcon--large euiIcon-isLoading euiFilePicker__icon"
+                            focusable="false"
+                            height={16}
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                          <div
+                            className="euiFilePicker__promptText"
+                          >
+                            Select or drag and drop an image
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1105,116 +1159,134 @@ Array [
                   className="euiFormRow euiFormRow--compressed"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Name
                     </label>
                   </div>
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--compressed"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFormControlLayout__childrenWrapper"
+                      className="euiFormControlLayout"
                     >
-                      <input
-                        aria-describedby="generated-id-help"
-                        className="euiFieldText canvasCustomElementForm__name euiFieldText--compressed"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        required={true}
-                        type="text"
-                        value=""
-                      />
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <input
+                          aria-describedby="generated-id-help"
+                          className="euiFieldText canvasCustomElementForm__name"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
-                  >
-                    40 characters remaining
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      40 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Description
                     </label>
                   </div>
-                  <textarea
-                    aria-describedby="generated-id-help"
-                    className="euiTextArea euiTextArea--resizeVertical"
-                    id="generated-id"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    rows={2}
-                    value=""
-                  />
                   <div
-                    className="euiFormHelpText euiFormRow__text"
-                    id="generated-id-help"
+                    className="euiFormRow__fieldWrapper"
                   >
-                    100 characters remaining
+                    <textarea
+                      aria-describedby="generated-id-help"
+                      className="euiTextArea euiTextArea--resizeVertical"
+                      id="generated-id"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      rows={2}
+                      value=""
+                    />
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      100 characters remaining
+                    </div>
                   </div>
                 </div>
                 <div
                   className="euiFormRow euiFormRow--compressed canvasCustomElementForm__thumbnail"
                   id="generated-id-row"
                 >
-                  <div>
+                  <div
+                    className="euiFormRow__labelWrapper"
+                  >
                     <label
-                      className="euiFormLabel"
+                      className="euiFormLabel euiFormRow__label"
                       htmlFor="generated-id"
                     >
                       Thumbnail image
                     </label>
                   </div>
                   <div
-                    className="euiFilePicker euiFilePicker--compressed canvasImageUpload"
+                    className="euiFormRow__fieldWrapper"
                   >
                     <div
-                      className="euiFilePicker__wrap"
+                      className="euiFilePicker euiFilePicker--large canvasImageUpload"
                     >
-                      <input
-                        accept="image/*"
-                        className="euiFilePicker__input"
-                        id="generated-id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onDragLeave={[Function]}
-                        onDragOver={[Function]}
-                        onDrop={[Function]}
-                        onFocus={[Function]}
-                        type="file"
-                      />
                       <div
-                        className="euiFilePicker__prompt"
+                        className="euiFilePicker__wrap"
                       >
-                        <svg
-                          aria-hidden="true"
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFilePicker__icon"
-                          focusable="false"
-                          height={16}
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <input
+                          accept="image/*"
+                          className="euiFilePicker__input"
+                          id="generated-id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onDragLeave={[Function]}
+                          onDragOver={[Function]}
+                          onDrop={[Function]}
+                          onFocus={[Function]}
+                          type="file"
                         />
                         <div
-                          className="euiFilePicker__promptText"
+                          className="euiFilePicker__prompt"
                         >
-                          Select or drag and drop an image
+                          <svg
+                            aria-hidden="true"
+                            className="euiIcon euiIcon--large euiIcon-isLoading euiFilePicker__icon"
+                            focusable="false"
+                            height={16}
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                          <div
+                            className="euiFilePicker__promptText"
+                          >
+                            Select or drag and drop an image
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/x-pack/legacy/plugins/canvas/public/components/expression_input/__examples__/__snapshots__/expression_input.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/components/expression_input/__examples__/__snapshots__/expression_input.examples.storyshot
@@ -9,21 +9,25 @@ exports[`Storyshots components/ExpressionInput default 1`] = `
     id="generated-id-row"
   >
     <div
-      className="canvasExpressionInput__editor"
-      id="generated-id"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      className="euiFormRow__fieldWrapper"
     >
       <div
-        className="react-monaco-editor-container"
-        style={
-          Object {
-            "height": "100%",
-            "width": "100%",
+        className="canvasExpressionInput__editor"
+        id="generated-id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <div
+          className="react-monaco-editor-container"
+          style={
+            Object {
+              "height": "100%",
+              "width": "100%",
+            }
           }
-        }
-      />
-      <div />
+        />
+        <div />
+      </div>
     </div>
   </div>
 </div>

--- a/x-pack/legacy/plugins/canvas/public/components/file_upload/__snapshots__/file_upload.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/components/file_upload/__snapshots__/file_upload.examples.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots components/FileUpload default 1`] = `
 <div
-  className="euiFilePicker euiFilePicker--compressed canvasFileUpload"
+  className="euiFilePicker euiFilePicker--large euiFilePicker--compressed canvasFileUpload"
 >
   <div
     className="euiFilePicker__wrap"
@@ -21,7 +21,7 @@ exports[`Storyshots components/FileUpload default 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="euiIcon euiIcon--medium euiIcon-isLoading euiFilePicker__icon"
+        className="euiIcon euiIcon--large euiIcon-isLoading euiFilePicker__icon"
         focusable="false"
         height={16}
         style={null}

--- a/x-pack/legacy/plugins/canvas/public/components/page_config/page_config.js
+++ b/x-pack/legacy/plugins/canvas/public/components/page_config/page_config.js
@@ -30,7 +30,7 @@ export const PageConfig = ({
         switching between pages (for example, when moving from the first page to the second
         page, we use the second page's transition) */}
       {pageIndex > 0 ? (
-        <div>
+        <Fragment>
           <EuiFormRow label="Transition" compressed>
             <EuiSelect
               value={transition ? transition.name : ''}
@@ -55,7 +55,7 @@ export const PageConfig = ({
           ) : (
             ''
           )}
-        </div>
+        </Fragment>
       ) : (
         ''
       )}

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_config/workpad_config.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_config/workpad_config.js
@@ -74,6 +74,8 @@ export class WorkpadConfig extends PureComponent {
           <EuiFieldText value={name} onChange={e => setName(e.target.value)} />
         </EuiFormRow>
 
+        <EuiSpacer size="s" />
+
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem>
             <EuiFormRow label="Width" compressed>

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/control_settings/custom_interval.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/control_settings/custom_interval.js
@@ -30,7 +30,12 @@ export const CustomInterval = ({ gutterSize, buttonSize, onSubmit, defaultValue 
             helpText="Use shorthand notation, like 30s, 10m, or 1h"
             compressed
           >
-            <EuiFieldText isInvalid={isInvalid} value={customInterval} onChange={handleChange} />
+            <EuiFieldText
+              isInvalid={isInvalid}
+              value={customInterval}
+              onChange={handleChange}
+              compressed
+            />
           </EuiFormRow>
         </EuiFlexItem>
 

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_loader/workpad_loader.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_loader/workpad_loader.js
@@ -311,6 +311,7 @@ export class WorkpadLoader extends React.PureComponent {
 
     let uploadButton = (
       <EuiFilePicker
+        display="default"
         compressed
         className="canvasWorkpad__upload--compressed"
         initialPromptText="Import workpad JSON file"

--- a/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/container_style/__examples__/__snapshots__/extended_template.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/container_style/__examples__/__snapshots__/extended_template.examples.storyshot
@@ -33,29 +33,35 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Padding
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <input
-                className="euiFieldNumber euiFieldNumber--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="number"
-                value={0}
-              />
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  className="euiFieldNumber"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value={0}
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -67,28 +73,520 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Opacity
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiFormControlLayout"
+            >
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
+                  value={1}
+                >
+                  <option
+                    value={1}
+                  >
+                    100%
+                  </option>
+                  <option
+                    value={0.9}
+                  >
+                    90%
+                  </option>
+                  <option
+                    value={0.7}
+                  >
+                    70%
+                  </option>
+                  <option
+                    value={0.5}
+                  >
+                    50%
+                  </option>
+                  <option
+                    value={0.3}
+                  >
+                    30%
+                  </option>
+                  <option
+                    value={0.1}
+                  >
+                    10%
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrow3"
+      >
+        <div
+          className="euiFormRow euiFormRow--compressed"
+          id="generated-id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+            >
+              Overflow
+            </label>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiFormControlLayout"
+            >
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
+                  value="visible"
+                >
+                  <option
+                    value="hidden"
+                  >
+                    Hidden
+                  </option>
+                  <option
+                    value="visible"
+                  >
+                    Visible
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiSpacer euiSpacer--m"
+    />
+    <h6
+      className="euiTitle euiTitle--xxxsmall euiTitle--uppercase"
+    >
+      Border
+    </h6>
+    <div
+      className="euiSpacer euiSpacer--xs"
+    />
+    <div
+      className="euiSpacer euiSpacer--xs"
+    />
+    <div
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        className="euiFlexItem euiFlexItem--flexGrow2"
+      >
+        <div
+          className="euiFormRow euiFormRow--compressed"
+          id="generated-id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+            >
+              Thickness
+            </label>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiFormControlLayout"
+            >
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  className="euiFieldNumber"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value={1}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrow3"
+      >
+        <div
+          className="euiFormRow euiFormRow--compressed"
+          id="generated-id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+            >
+              Style
+            </label>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+            >
+              <div
+                className="euiPopover__anchor"
+              >
+                <input
+                  id="generated-id"
+                  type="hidden"
+                  value="solid"
+                />
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <span
+                      className="euiScreenReaderOnly"
+                      id="generated-id"
+                    >
+                      Select an option: 
+                      <div
+                        style={
+                          Object {
+                            "border": "4px solid",
+                            "height": 16,
+                          }
+                        }
+                      />
+                      , is selected
+                    </span>
+                    <button
+                      aria-haspopup="true"
+                      aria-labelledby="generated-id generated-id"
+                      aria-selected={true}
+                      className="euiSuperSelectControl"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      role="option"
+                      type="button"
+                    >
+                      <div
+                        style={
+                          Object {
+                            "border": "4px solid",
+                            "height": 16,
+                          }
+                        }
+                      />
+                    </button>
+                    <div
+                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <span
+                        className="euiFormControlLayoutCustomIcon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height={16}
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrow2"
+      >
+        <div
+          className="euiFormRow euiFormRow--compressed"
+          id="generated-id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+            >
+              Radius
+            </label>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiFormControlLayout"
+            >
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  className="euiFieldNumber"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value={0}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrow1"
+      >
+        <div
+          className="euiFormRow"
+          id="generated-id-row"
+          style={
+            Object {
+              "fontSize": 0,
+            }
+          }
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+            >
+              Color
+            </label>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiPopover euiPopover--anchorUpCenter"
+              container={null}
+              id="color-picker-popover"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+            >
+              <div
+                className="euiPopover__anchor"
+              >
+                <button
+                  className="euiLink euiLink--primary"
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "fontSize": 0,
+                    }
+                  }
+                  type="button"
+                >
+                  <div
+                    className="canvasColorDot"
+                  >
+                    <div
+                      className="canvasColorDot__background canvasCheckered"
+                    />
+                    <div
+                      className="canvasColorDot__foreground"
+                      style={
+                        Object {
+                          "background": "#fff",
+                        }
+                      }
+                    />
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots arguments/ContainerStyle/components appearance form 1`] = `
+<div
+  style={
+    Object {
+      "background": "#fff",
+      "padding": "16px",
+      "width": "323px",
+    }
+  }
+>
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+    justify-content="spaceBetween"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrow2"
+    >
+      <div
+        className="euiFormRow euiFormRow--compressed"
+        id="generated-id-row"
+      >
+        <div
+          className="euiFormRow__labelWrapper"
+        >
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Padding
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
+          <div
+            className="euiFormControlLayout"
+          >
+            <div
+              className="euiFormControlLayout__childrenWrapper"
+            >
+              <input
+                className="euiFieldNumber"
+                id="generated-id"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="number"
+                value={4}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrow3"
+    >
+      <div
+        className="euiFormRow euiFormRow--compressed"
+        id="generated-id-row"
+      >
+        <div
+          className="euiFormRow__labelWrapper"
+        >
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Opacity
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
+          <div
+            className="euiFormControlLayout"
           >
             <div
               className="euiFormControlLayout__childrenWrapper"
             >
               <select
-                className="euiSelect euiSelect--compressed"
+                className="euiSelect"
                 id="generated-id"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
                 onMouseUp={[Function]}
-                value={1}
+                value="1"
               >
                 <option
                   value={1}
@@ -143,29 +641,35 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrow3"
+    >
       <div
-        className="euiFlexItem euiFlexItem--flexGrow3"
+        className="euiFormRow euiFormRow--compressed"
+        id="generated-id-row"
       >
         <div
-          className="euiFormRow euiFormRow--compressed"
-          id="generated-id-row"
+          className="euiFormRow__labelWrapper"
         >
-          <div>
-            <label
-              className="euiFormLabel"
-              htmlFor="generated-id"
-            >
-              Overflow
-            </label>
-          </div>
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Overflow
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormControlLayout"
           >
             <div
               className="euiFormControlLayout__childrenWrapper"
             >
               <select
-                className="euiSelect euiSelect--compressed"
+                className="euiSelect"
                 id="generated-id"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -207,46 +711,51 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
         </div>
       </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots arguments/ContainerStyle/components border form 1`] = `
+<div
+  style={
+    Object {
+      "background": "#fff",
+      "padding": "16px",
+      "width": "323px",
+    }
+  }
+>
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+  >
     <div
-      className="euiSpacer euiSpacer--m"
-    />
-    <h6
-      className="euiTitle euiTitle--xxxsmall euiTitle--uppercase"
-    >
-      Border
-    </h6>
-    <div
-      className="euiSpacer euiSpacer--xs"
-    />
-    <div
-      className="euiSpacer euiSpacer--xs"
-    />
-    <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+      className="euiFlexItem euiFlexItem--flexGrow2"
     >
       <div
-        className="euiFlexItem euiFlexItem--flexGrow2"
+        className="euiFormRow euiFormRow--compressed"
+        id="generated-id-row"
       >
         <div
-          className="euiFormRow euiFormRow--compressed"
-          id="generated-id-row"
+          className="euiFormRow__labelWrapper"
         >
-          <div>
-            <label
-              className="euiFormLabel"
-              htmlFor="generated-id"
-            >
-              Thickness
-            </label>
-          </div>
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Thickness
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormControlLayout"
           >
             <div
               className="euiFormControlLayout__childrenWrapper"
             >
               <input
-                className="euiFieldNumber euiFieldNumber--compressed"
+                className="euiFieldNumber"
                 id="generated-id"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -258,21 +767,27 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrow3"
+    >
       <div
-        className="euiFlexItem euiFlexItem--flexGrow3"
+        className="euiFormRow euiFormRow--compressed"
+        id="generated-id-row"
       >
         <div
-          className="euiFormRow euiFormRow--compressed"
-          id="generated-id-row"
+          className="euiFormRow__labelWrapper"
         >
-          <div>
-            <label
-              className="euiFormLabel"
-              htmlFor="generated-id"
-            >
-              Style
-            </label>
-          </div>
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Style
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
           <div
             className="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
             onKeyDown={[Function]}
@@ -287,10 +802,10 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
               <input
                 id="generated-id"
                 type="hidden"
-                value="solid"
+                value="dotted"
               />
               <div
-                className="euiFormControlLayout euiFormControlLayout--compressed"
+                className="euiFormControlLayout"
               >
                 <div
                   className="euiFormControlLayout__childrenWrapper"
@@ -303,7 +818,7 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
                     <div
                       style={
                         Object {
-                          "border": "4px solid",
+                          "border": "4px dotted",
                           "height": 16,
                         }
                       }
@@ -314,7 +829,7 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
                     aria-haspopup="true"
                     aria-labelledby="generated-id generated-id"
                     aria-selected={true}
-                    className="euiSuperSelectControl euiSuperSelectControl--compressed"
+                    className="euiSuperSelectControl"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -325,7 +840,7 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
                     <div
                       style={
                         Object {
-                          "border": "4px solid",
+                          "border": "4px dotted",
                           "height": 16,
                         }
                       }
@@ -355,60 +870,72 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrow2"
+    >
       <div
-        className="euiFlexItem euiFlexItem--flexGrow2"
+        className="euiFormRow euiFormRow--compressed"
+        id="generated-id-row"
       >
         <div
-          className="euiFormRow euiFormRow--compressed"
-          id="generated-id-row"
+          className="euiFormRow__labelWrapper"
         >
-          <div>
-            <label
-              className="euiFormLabel"
-              htmlFor="generated-id"
-            >
-              Radius
-            </label>
-          </div>
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Radius
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormControlLayout"
           >
             <div
               className="euiFormControlLayout__childrenWrapper"
             >
               <input
-                className="euiFieldNumber euiFieldNumber--compressed"
+                className="euiFieldNumber"
                 id="generated-id"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
                 type="number"
-                value={0}
+                value={1}
               />
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrow1"
+    >
       <div
-        className="euiFlexItem euiFlexItem--flexGrow1"
+        className="euiFormRow"
+        id="generated-id-row"
+        style={
+          Object {
+            "fontSize": 0,
+          }
+        }
       >
         <div
-          className="euiFormRow"
-          id="generated-id-row"
-          style={
-            Object {
-              "fontSize": 0,
-            }
-          }
+          className="euiFormRow__labelWrapper"
         >
-          <div>
-            <label
-              className="euiFormLabel"
-              htmlFor="generated-id"
-            >
-              Color
-            </label>
-          </div>
+          <label
+            className="euiFormLabel euiFormRow__label"
+            htmlFor="generated-id"
+          >
+            Color
+          </label>
+        </div>
+        <div
+          className="euiFormRow__fieldWrapper"
+        >
           <div
             className="euiPopover euiPopover--anchorUpCenter"
             container={null}
@@ -442,456 +969,13 @@ exports[`Storyshots arguments/ContainerStyle extended 1`] = `
                     className="canvasColorDot__foreground"
                     style={
                       Object {
-                        "background": "#fff",
+                        "background": "#000",
                       }
                     }
                   />
                 </div>
               </button>
             </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots arguments/ContainerStyle/components appearance form 1`] = `
-<div
-  style={
-    Object {
-      "background": "#fff",
-      "padding": "16px",
-      "width": "323px",
-    }
-  }
->
-  <div
-    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-    justify-content="spaceBetween"
-  >
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow2"
-    >
-      <div
-        className="euiFormRow euiFormRow--compressed"
-        id="generated-id-row"
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Padding
-          </label>
-        </div>
-        <div
-          className="euiFormControlLayout euiFormControlLayout--compressed"
-        >
-          <div
-            className="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              className="euiFieldNumber euiFieldNumber--compressed"
-              id="generated-id"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              type="number"
-              value={4}
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow3"
-    >
-      <div
-        className="euiFormRow euiFormRow--compressed"
-        id="generated-id-row"
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Opacity
-          </label>
-        </div>
-        <div
-          className="euiFormControlLayout euiFormControlLayout--compressed"
-        >
-          <div
-            className="euiFormControlLayout__childrenWrapper"
-          >
-            <select
-              className="euiSelect euiSelect--compressed"
-              id="generated-id"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onMouseUp={[Function]}
-              value="1"
-            >
-              <option
-                value={1}
-              >
-                100%
-              </option>
-              <option
-                value={0.9}
-              >
-                90%
-              </option>
-              <option
-                value={0.7}
-              >
-                70%
-              </option>
-              <option
-                value={0.5}
-              >
-                50%
-              </option>
-              <option
-                value={0.3}
-              >
-                30%
-              </option>
-              <option
-                value={0.1}
-              >
-                10%
-              </option>
-            </select>
-            <div
-              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-            >
-              <span
-                className="euiFormControlLayoutCustomIcon"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                  focusable="false"
-                  height={16}
-                  style={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                />
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow3"
-    >
-      <div
-        className="euiFormRow euiFormRow--compressed"
-        id="generated-id-row"
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Overflow
-          </label>
-        </div>
-        <div
-          className="euiFormControlLayout euiFormControlLayout--compressed"
-        >
-          <div
-            className="euiFormControlLayout__childrenWrapper"
-          >
-            <select
-              className="euiSelect euiSelect--compressed"
-              id="generated-id"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onMouseUp={[Function]}
-              value="visible"
-            >
-              <option
-                value="hidden"
-              >
-                Hidden
-              </option>
-              <option
-                value="visible"
-              >
-                Visible
-              </option>
-            </select>
-            <div
-              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-            >
-              <span
-                className="euiFormControlLayoutCustomIcon"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                  focusable="false"
-                  height={16}
-                  style={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                />
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots arguments/ContainerStyle/components border form 1`] = `
-<div
-  style={
-    Object {
-      "background": "#fff",
-      "padding": "16px",
-      "width": "323px",
-    }
-  }
->
-  <div
-    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-  >
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow2"
-    >
-      <div
-        className="euiFormRow euiFormRow--compressed"
-        id="generated-id-row"
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Thickness
-          </label>
-        </div>
-        <div
-          className="euiFormControlLayout euiFormControlLayout--compressed"
-        >
-          <div
-            className="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              className="euiFieldNumber euiFieldNumber--compressed"
-              id="generated-id"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              type="number"
-              value={1}
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow3"
-    >
-      <div
-        className="euiFormRow euiFormRow--compressed"
-        id="generated-id-row"
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Style
-          </label>
-        </div>
-        <div
-          className="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchStart={[Function]}
-        >
-          <div
-            className="euiPopover__anchor"
-          >
-            <input
-              id="generated-id"
-              type="hidden"
-              value="dotted"
-            />
-            <div
-              className="euiFormControlLayout euiFormControlLayout--compressed"
-            >
-              <div
-                className="euiFormControlLayout__childrenWrapper"
-              >
-                <span
-                  className="euiScreenReaderOnly"
-                  id="generated-id"
-                >
-                  Select an option: 
-                  <div
-                    style={
-                      Object {
-                        "border": "4px dotted",
-                        "height": 16,
-                      }
-                    }
-                  />
-                  , is selected
-                </span>
-                <button
-                  aria-haspopup="true"
-                  aria-labelledby="generated-id generated-id"
-                  aria-selected={true}
-                  className="euiSuperSelectControl euiSuperSelectControl--compressed"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  role="option"
-                  type="button"
-                >
-                  <div
-                    style={
-                      Object {
-                        "border": "4px dotted",
-                        "height": 16,
-                      }
-                    }
-                  />
-                </button>
-                <div
-                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                >
-                  <span
-                    className="euiFormControlLayoutCustomIcon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                      focusable="false"
-                      height={16}
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow2"
-    >
-      <div
-        className="euiFormRow euiFormRow--compressed"
-        id="generated-id-row"
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Radius
-          </label>
-        </div>
-        <div
-          className="euiFormControlLayout euiFormControlLayout--compressed"
-        >
-          <div
-            className="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              className="euiFieldNumber euiFieldNumber--compressed"
-              id="generated-id"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              type="number"
-              value={1}
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="euiFlexItem euiFlexItem--flexGrow1"
-    >
-      <div
-        className="euiFormRow"
-        id="generated-id-row"
-        style={
-          Object {
-            "fontSize": 0,
-          }
-        }
-      >
-        <div>
-          <label
-            className="euiFormLabel"
-            htmlFor="generated-id"
-          >
-            Color
-          </label>
-        </div>
-        <div
-          className="euiPopover euiPopover--anchorUpCenter"
-          container={null}
-          id="color-picker-popover"
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchStart={[Function]}
-        >
-          <div
-            className="euiPopover__anchor"
-          >
-            <button
-              className="euiLink euiLink--primary"
-              onClick={[Function]}
-              style={
-                Object {
-                  "fontSize": 0,
-                }
-              }
-              type="button"
-            >
-              <div
-                className="canvasColorDot"
-              >
-                <div
-                  className="canvasColorDot__background canvasCheckered"
-                />
-                <div
-                  className="canvasColorDot__foreground"
-                  style={
-                    Object {
-                      "background": "#000",
-                    }
-                  }
-                />
-              </div>
-            </button>
           </div>
         </div>
       </div>
@@ -933,111 +1017,34 @@ exports[`Storyshots arguments/ContainerStyle/components extended template 1`] = 
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Padding
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <input
-                className="euiFieldNumber euiFieldNumber--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="number"
-                value={0}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="euiFlexItem euiFlexItem--flexGrow3"
-      >
-        <div
-          className="euiFormRow euiFormRow--compressed"
-          id="generated-id-row"
-        >
-          <div>
-            <label
-              className="euiFormLabel"
-              htmlFor="generated-id"
-            >
-              Opacity
-            </label>
-          </div>
-          <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
-          >
-            <div
-              className="euiFormControlLayout__childrenWrapper"
-            >
-              <select
-                className="euiSelect euiSelect--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onMouseUp={[Function]}
-                value={1}
-              >
-                <option
-                  value={1}
-                >
-                  100%
-                </option>
-                <option
-                  value={0.9}
-                >
-                  90%
-                </option>
-                <option
-                  value={0.7}
-                >
-                  70%
-                </option>
-                <option
-                  value={0.5}
-                >
-                  50%
-                </option>
-                <option
-                  value={0.3}
-                >
-                  30%
-                </option>
-                <option
-                  value={0.1}
-                >
-                  10%
-                </option>
-              </select>
               <div
-                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                className="euiFormControlLayout__childrenWrapper"
               >
-                <span
-                  className="euiFormControlLayoutCustomIcon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                    focusable="false"
-                    height={16}
-                    style={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                </span>
+                <input
+                  className="euiFieldNumber"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value={0}
+                />
               </div>
             </div>
           </div>
@@ -1050,57 +1057,152 @@ exports[`Storyshots arguments/ContainerStyle/components extended template 1`] = 
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
+              htmlFor="generated-id"
+            >
+              Opacity
+            </label>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <div
+              className="euiFormControlLayout"
+            >
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
+                  value={1}
+                >
+                  <option
+                    value={1}
+                  >
+                    100%
+                  </option>
+                  <option
+                    value={0.9}
+                  >
+                    90%
+                  </option>
+                  <option
+                    value={0.7}
+                  >
+                    70%
+                  </option>
+                  <option
+                    value={0.5}
+                  >
+                    50%
+                  </option>
+                  <option
+                    value={0.3}
+                  >
+                    30%
+                  </option>
+                  <option
+                    value={0.1}
+                  >
+                    10%
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrow3"
+      >
+        <div
+          className="euiFormRow euiFormRow--compressed"
+          id="generated-id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <label
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Overflow
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <select
-                className="euiSelect euiSelect--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onMouseUp={[Function]}
-                value="visible"
+              <div
+                className="euiFormControlLayout__childrenWrapper"
               >
-                <option
-                  value="hidden"
-                >
-                  Hidden
-                </option>
-                <option
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
                   value="visible"
                 >
-                  Visible
-                </option>
-              </select>
-              <div
-                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-              >
-                <span
-                  className="euiFormControlLayoutCustomIcon"
+                  <option
+                    value="hidden"
+                  >
+                    Hidden
+                  </option>
+                  <option
+                    value="visible"
+                  >
+                    Visible
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                    focusable="false"
-                    height={16}
-                    style={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                </span>
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -1131,29 +1233,35 @@ exports[`Storyshots arguments/ContainerStyle/components extended template 1`] = 
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Thickness
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <input
-                className="euiFieldNumber euiFieldNumber--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="number"
-                value={1}
-              />
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  className="euiFieldNumber"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value={1}
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -1165,89 +1273,95 @@ exports[`Storyshots arguments/ContainerStyle/components extended template 1`] = 
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Style
             </label>
           </div>
           <div
-            className="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
-            onKeyDown={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchStart={[Function]}
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiPopover__anchor"
+              className="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
             >
-              <input
-                id="generated-id"
-                type="hidden"
-                value="solid"
-              />
               <div
-                className="euiFormControlLayout euiFormControlLayout--compressed"
+                className="euiPopover__anchor"
               >
+                <input
+                  id="generated-id"
+                  type="hidden"
+                  value="solid"
+                />
                 <div
-                  className="euiFormControlLayout__childrenWrapper"
+                  className="euiFormControlLayout"
                 >
-                  <span
-                    className="euiScreenReaderOnly"
-                    id="generated-id"
-                  >
-                    Select an option: 
-                    <div
-                      style={
-                        Object {
-                          "border": "4px solid",
-                          "height": 16,
-                        }
-                      }
-                    />
-                    , is selected
-                  </span>
-                  <button
-                    aria-haspopup="true"
-                    aria-labelledby="generated-id generated-id"
-                    aria-selected={true}
-                    className="euiSuperSelectControl euiSuperSelectControl--compressed"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    role="option"
-                    type="button"
-                  >
-                    <div
-                      style={
-                        Object {
-                          "border": "4px solid",
-                          "height": 16,
-                        }
-                      }
-                    />
-                  </button>
                   <div
-                    className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    className="euiFormControlLayout__childrenWrapper"
                   >
                     <span
-                      className="euiFormControlLayoutCustomIcon"
+                      className="euiScreenReaderOnly"
+                      id="generated-id"
                     >
-                      <svg
-                        aria-hidden="true"
-                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                        focusable="false"
-                        height={16}
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
+                      Select an option: 
+                      <div
+                        style={
+                          Object {
+                            "border": "4px solid",
+                            "height": 16,
+                          }
+                        }
                       />
+                      , is selected
                     </span>
+                    <button
+                      aria-haspopup="true"
+                      aria-labelledby="generated-id generated-id"
+                      aria-selected={true}
+                      className="euiSuperSelectControl"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      role="option"
+                      type="button"
+                    >
+                      <div
+                        style={
+                          Object {
+                            "border": "4px solid",
+                            "height": 16,
+                          }
+                        }
+                      />
+                    </button>
+                    <div
+                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <span
+                        className="euiFormControlLayoutCustomIcon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height={16}
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1262,29 +1376,35 @@ exports[`Storyshots arguments/ContainerStyle/components extended template 1`] = 
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Radius
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <input
-                className="euiFieldNumber euiFieldNumber--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="number"
-                value={0}
-              />
+              <div
+                className="euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  className="euiFieldNumber"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="number"
+                  value={0}
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -1301,53 +1421,59 @@ exports[`Storyshots arguments/ContainerStyle/components extended template 1`] = 
             }
           }
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Color
             </label>
           </div>
           <div
-            className="euiPopover euiPopover--anchorUpCenter"
-            container={null}
-            id="color-picker-popover"
-            onKeyDown={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchStart={[Function]}
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiPopover__anchor"
+              className="euiPopover euiPopover--anchorUpCenter"
+              container={null}
+              id="color-picker-popover"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
             >
-              <button
-                className="euiLink euiLink--primary"
-                onClick={[Function]}
-                style={
-                  Object {
-                    "fontSize": 0,
-                  }
-                }
-                type="button"
+              <div
+                className="euiPopover__anchor"
               >
-                <div
-                  className="canvasColorDot"
+                <button
+                  className="euiLink euiLink--primary"
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "fontSize": 0,
+                    }
+                  }
+                  type="button"
                 >
                   <div
-                    className="canvasColorDot__background canvasCheckered"
-                  />
-                  <div
-                    className="canvasColorDot__foreground"
-                    style={
-                      Object {
-                        "background": "#fff",
+                    className="canvasColorDot"
+                  >
+                    <div
+                      className="canvasColorDot__background canvasCheckered"
+                    />
+                    <div
+                      className="canvasColorDot__foreground"
+                      style={
+                        Object {
+                          "background": "#fff",
+                        }
                       }
-                    }
-                  />
-                </div>
-              </button>
+                    />
+                  </div>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/series_style/__examples__/__snapshots__/extended_template.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/series_style/__examples__/__snapshots__/extended_template.examples.storyshot
@@ -82,6 +82,9 @@ exports[`Storyshots arguments/SeriesStyle extended 1`] = `
       </div>
     </div>
     <div
+      className="euiSpacer euiSpacer--s"
+    />
+    <div
       className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div

--- a/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/series_style/__examples__/__snapshots__/extended_template.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/series_style/__examples__/__snapshots__/extended_template.examples.storyshot
@@ -15,62 +15,68 @@ exports[`Storyshots arguments/SeriesStyle extended 1`] = `
       className="euiFormRow euiFormRow--compressed"
       id="generated-id-row"
     >
-      <div>
+      <div
+        className="euiFormRow__labelWrapper"
+      >
         <label
-          className="euiFormLabel"
+          className="euiFormLabel euiFormRow__label"
           htmlFor="generated-id"
         >
           Series Identifier
         </label>
       </div>
       <div
-        className="euiFormControlLayout euiFormControlLayout--compressed"
+        className="euiFormRow__fieldWrapper"
       >
         <div
-          className="euiFormControlLayout__childrenWrapper"
+          className="euiFormControlLayout"
         >
-          <select
-            className="euiSelect euiSelect--compressed"
-            id="generated-id"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onMouseUp={[Function]}
-            value=""
+          <div
+            className="euiFormControlLayout__childrenWrapper"
           >
-            <option
+            <select
+              className="euiSelect"
+              id="generated-id"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onMouseUp={[Function]}
               value=""
             >
-              Select Series
-            </option>
-            <option
-              value="label1"
+              <option
+                value=""
+              >
+                Select Series
+              </option>
+              <option
+                value="label1"
+              >
+                label1
+              </option>
+              <option
+                value="label2"
+              >
+                label2
+              </option>
+            </select>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
             >
-              label1
-            </option>
-            <option
-              value="label2"
-            >
-              label2
-            </option>
-          </select>
-          <div
-            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-          >
-            <span
-              className="euiFormControlLayoutCustomIcon"
-            >
-              <svg
-                aria-hidden="true"
-                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                focusable="false"
-                height={16}
-                style={null}
-                viewBox="0 0 16 16"
-                width={16}
-                xmlns="http://www.w3.org/2000/svg"
-              />
-            </span>
+              <span
+                className="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -85,77 +91,83 @@ exports[`Storyshots arguments/SeriesStyle extended 1`] = `
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Line
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <select
-                className="euiSelect euiSelect--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onMouseUp={[Function]}
-                value={0}
+              <div
+                className="euiFormControlLayout__childrenWrapper"
               >
-                <option
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
                   value={0}
                 >
-                  None
-                </option>
-                <option
-                  value={1}
+                  <option
+                    value={0}
+                  >
+                    None
+                  </option>
+                  <option
+                    value={1}
+                  >
+                    1
+                  </option>
+                  <option
+                    value={2}
+                  >
+                    2
+                  </option>
+                  <option
+                    value={3}
+                  >
+                    3
+                  </option>
+                  <option
+                    value={4}
+                  >
+                    4
+                  </option>
+                  <option
+                    value={5}
+                  >
+                    5
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
                 >
-                  1
-                </option>
-                <option
-                  value={2}
-                >
-                  2
-                </option>
-                <option
-                  value={3}
-                >
-                  3
-                </option>
-                <option
-                  value={4}
-                >
-                  4
-                </option>
-                <option
-                  value={5}
-                >
-                  5
-                </option>
-              </select>
-              <div
-                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-              >
-                <span
-                  className="euiFormControlLayoutCustomIcon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                    focusable="false"
-                    height={16}
-                    style={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                </span>
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -168,77 +180,83 @@ exports[`Storyshots arguments/SeriesStyle extended 1`] = `
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Bar
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <select
-                className="euiSelect euiSelect--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onMouseUp={[Function]}
-                value={0}
+              <div
+                className="euiFormControlLayout__childrenWrapper"
               >
-                <option
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
                   value={0}
                 >
-                  None
-                </option>
-                <option
-                  value={1}
+                  <option
+                    value={0}
+                  >
+                    None
+                  </option>
+                  <option
+                    value={1}
+                  >
+                    1
+                  </option>
+                  <option
+                    value={2}
+                  >
+                    2
+                  </option>
+                  <option
+                    value={3}
+                  >
+                    3
+                  </option>
+                  <option
+                    value={4}
+                  >
+                    4
+                  </option>
+                  <option
+                    value={5}
+                  >
+                    5
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
                 >
-                  1
-                </option>
-                <option
-                  value={2}
-                >
-                  2
-                </option>
-                <option
-                  value={3}
-                >
-                  3
-                </option>
-                <option
-                  value={4}
-                >
-                  4
-                </option>
-                <option
-                  value={5}
-                >
-                  5
-                </option>
-              </select>
-              <div
-                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-              >
-                <span
-                  className="euiFormControlLayoutCustomIcon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                    focusable="false"
-                    height={16}
-                    style={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                </span>
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -251,77 +269,83 @@ exports[`Storyshots arguments/SeriesStyle extended 1`] = `
           className="euiFormRow euiFormRow--compressed"
           id="generated-id-row"
         >
-          <div>
+          <div
+            className="euiFormRow__labelWrapper"
+          >
             <label
-              className="euiFormLabel"
+              className="euiFormLabel euiFormRow__label"
               htmlFor="generated-id"
             >
               Point
             </label>
           </div>
           <div
-            className="euiFormControlLayout euiFormControlLayout--compressed"
+            className="euiFormRow__fieldWrapper"
           >
             <div
-              className="euiFormControlLayout__childrenWrapper"
+              className="euiFormControlLayout"
             >
-              <select
-                className="euiSelect euiSelect--compressed"
-                id="generated-id"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onMouseUp={[Function]}
-                value={0}
+              <div
+                className="euiFormControlLayout__childrenWrapper"
               >
-                <option
+                <select
+                  className="euiSelect"
+                  id="generated-id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseUp={[Function]}
                   value={0}
                 >
-                  None
-                </option>
-                <option
-                  value={1}
+                  <option
+                    value={0}
+                  >
+                    None
+                  </option>
+                  <option
+                    value={1}
+                  >
+                    1
+                  </option>
+                  <option
+                    value={2}
+                  >
+                    2
+                  </option>
+                  <option
+                    value={3}
+                  >
+                    3
+                  </option>
+                  <option
+                    value={4}
+                  >
+                    4
+                  </option>
+                  <option
+                    value={5}
+                  >
+                    5
+                  </option>
+                </select>
+                <div
+                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
                 >
-                  1
-                </option>
-                <option
-                  value={2}
-                >
-                  2
-                </option>
-                <option
-                  value={3}
-                >
-                  3
-                </option>
-                <option
-                  value={4}
-                >
-                  4
-                </option>
-                <option
-                  value={5}
-                >
-                  5
-                </option>
-              </select>
-              <div
-                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-              >
-                <span
-                  className="euiFormControlLayoutCustomIcon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                    focusable="false"
-                    height={16}
-                    style={null}
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                </span>
+                  <span
+                    className="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/series_style/extended_template.tsx
+++ b/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/series_style/extended_template.tsx
@@ -4,9 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { FunctionComponent, ChangeEvent } from 'react';
+import React, { FunctionComponent, ChangeEvent, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect, EuiSpacer } from '@elastic/eui';
 import immutable from 'object-path-immutable';
 import { get } from 'lodash';
 import { ExpressionAST } from '../../../../types';
@@ -82,41 +82,44 @@ export const ExtendedTemplate: FunctionComponent<Props> = props => {
         </EuiFormRow>
       )}
       {hasPropFields && (
-        <EuiFlexGroup gutterSize="s">
-          {fields.includes('lines') && (
-            <EuiFlexItem>
-              <EuiFormRow label="Line" compressed>
-                <EuiSelect
-                  value={get(chainArgs, 'lines.0', 0)}
-                  options={values}
-                  onChange={ev => handleChange('lines', ev)}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-          )}
-          {fields.includes('bars') && (
-            <EuiFlexItem>
-              <EuiFormRow label="Bar" compressed>
-                <EuiSelect
-                  value={get(chainArgs, 'bars.0', 0)}
-                  options={values}
-                  onChange={ev => handleChange('bars', ev)}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-          )}
-          {fields.includes('points') && (
-            <EuiFlexItem>
-              <EuiFormRow label="Point" compressed>
-                <EuiSelect
-                  value={get(chainArgs, 'points.0', 0)}
-                  options={values}
-                  onChange={ev => handleChange('points', ev)}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
+        <Fragment>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup gutterSize="s">
+            {fields.includes('lines') && (
+              <EuiFlexItem>
+                <EuiFormRow label="Line" compressed>
+                  <EuiSelect
+                    value={get(chainArgs, 'lines.0', 0)}
+                    options={values}
+                    onChange={ev => handleChange('lines', ev)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            )}
+            {fields.includes('bars') && (
+              <EuiFlexItem>
+                <EuiFormRow label="Bar" compressed>
+                  <EuiSelect
+                    value={get(chainArgs, 'bars.0', 0)}
+                    options={values}
+                    onChange={ev => handleChange('bars', ev)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            )}
+            {fields.includes('points') && (
+              <EuiFlexItem>
+                <EuiFormRow label="Point" compressed>
+                  <EuiSelect
+                    value={get(chainArgs, 'points.0', 0)}
+                    options={values}
+                    onChange={ev => handleChange('points', ev)}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </Fragment>
       )}
     </div>
   );

--- a/x-pack/legacy/plugins/graph/public/components/graph_save_modal.tsx
+++ b/x-pack/legacy/plugins/graph/public/components/graph_save_modal.tsx
@@ -90,6 +90,7 @@ export function GraphSaveModal({
           )}
           {savePolicy === 'config' && hasData && (
             <>
+              <EuiSpacer />
               <EuiCallOut data-test-subj="graphNoDataSavedMsg">
                 <p>
                   {i18n.translate('xpack.graph.topNavMenu.save.saveConfigurationOnlyText', {

--- a/x-pack/legacy/plugins/grokdebugger/public/sections/grokdebugger/components/grok_debugger/grok_debugger.js
+++ b/x-pack/legacy/plugins/grokdebugger/public/sections/grokdebugger/components/grok_debugger/grok_debugger.js
@@ -12,7 +12,7 @@ import {
   EuiPageBody,
   EuiPageContent,
   EuiPageContentBody,
-  EuiSpacer
+  EuiSpacer,
 } from '@elastic/eui';
 import { EventInput } from '../event_input';
 import { PatternInput } from '../pattern_input';
@@ -113,6 +113,7 @@ export class GrokDebugger extends React.Component {
                   value={this.state.pattern}
                   onChange={this.onPatternChange}
                 />
+                <EuiSpacer />
                 <CustomPatternsInput
                   value={this.state.customPatterns}
                   onChange={this.onCustomPatternsChange}

--- a/x-pack/legacy/plugins/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.js
+++ b/x-pack/legacy/plugins/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.js
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { get } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import {
@@ -18,6 +18,7 @@ import {
   EuiModalBody,
   EuiModalHeader,
   EuiCallOut,
+  EuiSpacer,
   EuiModalHeaderTitle,
 } from '@elastic/eui';
 import { BASE_PATH } from '../../../common/constants';
@@ -38,9 +39,12 @@ export class AddLifecyclePolicyConfirmModal extends Component {
     const { indexName, httpClient, closeModal, reloadIndices } = this.props;
     const { selectedPolicyName, selectedAlias } = this.state;
     if (!selectedPolicyName) {
-      this.setState({ policyError: i18n.translate(
-        'xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.noPolicySelectedErrorMessage',
-        { defaultMessage: 'You must select a policy.' }) });
+      this.setState({
+        policyError: i18n.translate(
+          'xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.noPolicySelectedErrorMessage',
+          { defaultMessage: 'You must select a policy.' }
+        ),
+      });
       return;
     }
     try {
@@ -87,26 +91,29 @@ export class AddLifecyclePolicyConfirmModal extends Component {
     const { aliases } = index;
     if (aliases === 'none') {
       return (
-        <EuiCallOut
-          style={{ maxWidth: 400 }}
-          title={
+        <Fragment>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            style={{ maxWidth: 400 }}
+            title={
+              <FormattedMessage
+                id="xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.indexHasNoAliasesWarningTitle"
+                defaultMessage="Index has no aliases"
+              />
+            }
+            color="warning"
+          >
             <FormattedMessage
-              id="xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.indexHasNoAliasesWarningTitle"
-              defaultMessage="Index has no aliases"
+              id="xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.indexHasNoAliasesWarningMessage"
+              defaultMessage="Policy {policyName} is configured for rollover,
+                but index {indexName} does not have an alias, which is required for rollover."
+              values={{
+                policyName: selectedPolicy.name,
+                indexName: index.name,
+              }}
             />
-          }
-          color="warning"
-        >
-          <FormattedMessage
-            id="xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.indexHasNoAliasesWarningMessage"
-            defaultMessage="Policy {policyName} is configured for rollover,
-              but index {indexName} does not have an alias, which is required for rollover."
-            values={{
-              policyName: selectedPolicy.name,
-              indexName: index.name,
-            }}
-          />
-        </EuiCallOut>
+          </EuiCallOut>
+        </Fragment>
       );
     }
     const aliasOptions = aliases.map(alias => {
@@ -211,7 +218,7 @@ export class AddLifecyclePolicyConfirmModal extends Component {
     const title = (
       <FormattedMessage
         id="xpack.indexLifecycleMgmt.indexManagementTable.addLifecyclePolicyConfirmModal.modalTitle"
-        defaultMessage="Add lifecycle policy to &quot;{indexName}&quot;"
+        defaultMessage='Add lifecycle policy to "{indexName}"'
         values={{
           indexName,
         }}
@@ -220,13 +227,9 @@ export class AddLifecyclePolicyConfirmModal extends Component {
     if (!policies.length) {
       return (
         <EuiOverlayMask>
-          <EuiModal
-            onClose={closeModal}
-          >
+          <EuiModal onClose={closeModal}>
             <EuiModalHeader>
-              <EuiModalHeaderTitle>
-                {title}
-              </EuiModalHeaderTitle>
+              <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
             </EuiModalHeader>
 
             <EuiModalBody>

--- a/x-pack/legacy/plugins/index_lifecycle_management/public/sections/edit_policy/components/warm_phase/warm_phase.js
+++ b/x-pack/legacy/plugins/index_lifecycle_management/public/sections/edit_policy/components/warm_phase/warm_phase.js
@@ -55,16 +55,22 @@ export class WarmPhase extends PureComponent {
     } = this.props;
 
     const shrinkLabel = i18n.translate('xpack.indexLifecycleMgmt.warmPhase.shrinkIndexLabel', {
-      defaultMessage: 'Shrink index'
+      defaultMessage: 'Shrink index',
     });
 
-    const moveToWarmPhaseOnRolloverLabel = i18n.translate('xpack.indexLifecycleMgmt.warmPhase.moveToWarmPhaseOnRolloverLabel', {
-      defaultMessage: 'Move to warm phase on rollover'
-    });
+    const moveToWarmPhaseOnRolloverLabel = i18n.translate(
+      'xpack.indexLifecycleMgmt.warmPhase.moveToWarmPhaseOnRolloverLabel',
+      {
+        defaultMessage: 'Move to warm phase on rollover',
+      }
+    );
 
-    const forcemergeLabel = i18n.translate('xpack.indexLifecycleMgmt.warmPhase.forceMergeDataLabel', {
-      defaultMessage: 'Force merge data'
-    });
+    const forcemergeLabel = i18n.translate(
+      'xpack.indexLifecycleMgmt.warmPhase.forceMergeDataLabel',
+      {
+        defaultMessage: 'Force merge data',
+      }
+    );
 
     return (
       <div id="warmPhaseContent" aria-live="polite" role="region" aria-relevant="additions">
@@ -115,9 +121,7 @@ export class WarmPhase extends PureComponent {
             {phaseData[PHASE_ENABLED] ? (
               <Fragment>
                 {hotPhaseRolloverEnabled ? (
-                  <EuiFormRow
-                    id={`${PHASE_WARM}-${WARM_PHASE_ON_ROLLOVER}`}
-                  >
+                  <EuiFormRow id={`${PHASE_WARM}-${WARM_PHASE_ON_ROLLOVER}`}>
                     <EuiSwitch
                       data-test-subj="warmPhaseOnRolloverSwitch"
                       label={moveToWarmPhaseOnRolloverLabel}
@@ -130,14 +134,17 @@ export class WarmPhase extends PureComponent {
                   </EuiFormRow>
                 ) : null}
                 {!phaseData[WARM_PHASE_ON_ROLLOVER] ? (
-                  <MinAgeInput
-                    errors={errors}
-                    phaseData={phaseData}
-                    phase={PHASE_WARM}
-                    isShowingErrors={isShowingErrors}
-                    setPhaseData={setPhaseData}
-                    rolloverEnabled={hotPhaseRolloverEnabled}
-                  />
+                  <Fragment>
+                    <EuiSpacer size="m" />
+                    <MinAgeInput
+                      errors={errors}
+                      phaseData={phaseData}
+                      phase={PHASE_WARM}
+                      isShowingErrors={isShowingErrors}
+                      setPhaseData={setPhaseData}
+                      rolloverEnabled={hotPhaseRolloverEnabled}
+                    />
+                  </Fragment>
                 ) : null}
 
                 <EuiSpacer />
@@ -167,11 +174,12 @@ export class WarmPhase extends PureComponent {
                       errorKey={PHASE_REPLICA_COUNT}
                       isShowingErrors={isShowingErrors}
                       errors={errors}
-                      helpText={
-                        i18n.translate('xpack.indexLifecycleMgmt.warmPhase.replicaCountHelpText', {
-                          defaultMessage: 'By default, the number of replicas remains the same.'
-                        })
-                      }
+                      helpText={i18n.translate(
+                        'xpack.indexLifecycleMgmt.warmPhase.replicaCountHelpText',
+                        {
+                          defaultMessage: 'By default, the number of replicas remains the same.',
+                        }
+                      )}
                     >
                       <EuiFieldNumber
                         id={`${PHASE_WARM}-${PHASE_REPLICA_COUNT}`}
@@ -187,7 +195,7 @@ export class WarmPhase extends PureComponent {
 
                 <EuiSpacer size="m" />
               </Fragment>
-            ) : null }
+            ) : null}
           </Fragment>
         </EuiDescribedFormGroup>
         {phaseData[PHASE_ENABLED] ? (
@@ -233,9 +241,12 @@ export class WarmPhase extends PureComponent {
                         <EuiFlexItem grow={false}>
                           <ErrableFormRow
                             id={`${PHASE_WARM}-${PHASE_PRIMARY_SHARD_COUNT}`}
-                            label={i18n.translate('xpack.indexLifecycleMgmt.warmPhase.numberOfPrimaryShardsLabel', {
-                              defaultMessage: 'Number of primary shards'
-                            })}
+                            label={i18n.translate(
+                              'xpack.indexLifecycleMgmt.warmPhase.numberOfPrimaryShardsLabel',
+                              {
+                                defaultMessage: 'Number of primary shards',
+                              }
+                            )}
                             errorKey={PHASE_PRIMARY_SHARD_COUNT}
                             isShowingErrors={isShowingErrors}
                             errors={errors}
@@ -294,9 +305,12 @@ export class WarmPhase extends PureComponent {
                 {phaseData[PHASE_FORCE_MERGE_ENABLED] ? (
                   <ErrableFormRow
                     id={`${PHASE_WARM}-${PHASE_FORCE_MERGE_SEGMENTS}`}
-                    label={i18n.translate('xpack.indexLifecycleMgmt.warmPhase.numberOfSegmentsLabel', {
-                      defaultMessage: 'Number of segments'
-                    })}
+                    label={i18n.translate(
+                      'xpack.indexLifecycleMgmt.warmPhase.numberOfSegmentsLabel',
+                      {
+                        defaultMessage: 'Number of segments',
+                      }
+                    )}
                     errorKey={PHASE_FORCE_MERGE_SEGMENTS}
                     isShowingErrors={isShowingErrors}
                     errors={errors}

--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart_options.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart_options.tsx
@@ -127,6 +127,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
           })}
         >
           <EuiRadioGroup
+            // compressed
             options={typeRadios}
             idSelected={chartOptions.type}
             onChange={handleTypeChange}
@@ -153,6 +154,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
           })}
         >
           <EuiRadioGroup
+            // compressed
             options={yAxisRadios}
             idSelected={chartOptions.yAxisMode}
             onChange={handleYAxisChange}

--- a/x-pack/legacy/plugins/infra/public/components/waffle/custom_field_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/waffle/custom_field_panel.tsx
@@ -48,6 +48,7 @@ export const CustomFieldPanel = injectI18n(
               compressed
             >
               <EuiComboBox
+                // compressed
                 placeholder={intl.formatMessage({
                   id: 'xpack.infra.waffle.customGroupByDropdownPlacehoder',
                   defaultMessage: 'Select one',

--- a/x-pack/legacy/plugins/infra/public/components/waffle/legend_controls.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/waffle/legend_controls.tsx
@@ -14,6 +14,7 @@ import {
   EuiFormRow,
   EuiPopover,
   EuiPopoverTitle,
+  EuiSpacer,
   EuiSwitch,
   EuiText,
 } from '@elastic/eui';
@@ -95,6 +96,7 @@ export const LegendControls = injectI18n(
                 onChange={handleAutoChange}
               />
             </EuiFormRow>
+            <EuiSpacer />
             {(!boundsValidRange && (
               <EuiText color="danger" grow={false} size="s">
                 <p>

--- a/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/__snapshots__/flex_item_setting.test.js.snap
+++ b/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/__snapshots__/flex_item_setting.test.js.snap
@@ -6,6 +6,7 @@ exports[`FlexItemSetting component renders a null label if label/tooltip text no
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={true}
     label={null}
@@ -24,6 +25,7 @@ exports[`FlexItemSetting component renders component and children as expected 1`
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={

--- a/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
+++ b/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
@@ -35,6 +35,7 @@ exports[`PipelineEditor component includes required error message for falsy pipe
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -60,6 +61,7 @@ exports[`PipelineEditor component includes required error message for falsy pipe
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -83,6 +85,7 @@ exports[`PipelineEditor component includes required error message for falsy pipe
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -115,6 +118,7 @@ exports[`PipelineEditor component includes required error message for falsy pipe
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -349,6 +353,7 @@ exports[`PipelineEditor component invalidates form for invalid pipeline id input
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -374,6 +379,7 @@ exports[`PipelineEditor component invalidates form for invalid pipeline id input
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -397,6 +403,7 @@ exports[`PipelineEditor component invalidates form for invalid pipeline id input
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -429,6 +436,7 @@ exports[`PipelineEditor component invalidates form for invalid pipeline id input
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -663,6 +671,7 @@ exports[`PipelineEditor component invalidates form for pipeline id with spaces 1
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -688,6 +697,7 @@ exports[`PipelineEditor component invalidates form for pipeline id with spaces 1
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -711,6 +721,7 @@ exports[`PipelineEditor component invalidates form for pipeline id with spaces 1
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -743,6 +754,7 @@ exports[`PipelineEditor component invalidates form for pipeline id with spaces 1
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -973,6 +985,7 @@ exports[`PipelineEditor component matches snapshot for clone pipeline 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -996,6 +1009,7 @@ exports[`PipelineEditor component matches snapshot for clone pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -1028,6 +1042,7 @@ exports[`PipelineEditor component matches snapshot for clone pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -1273,6 +1288,7 @@ exports[`PipelineEditor component matches snapshot for create pipeline 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -1298,6 +1314,7 @@ exports[`PipelineEditor component matches snapshot for create pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -1321,6 +1338,7 @@ exports[`PipelineEditor component matches snapshot for create pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -1353,6 +1371,7 @@ exports[`PipelineEditor component matches snapshot for create pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -1583,6 +1602,7 @@ exports[`PipelineEditor component matches snapshot for edit pipeline 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -1606,6 +1626,7 @@ exports[`PipelineEditor component matches snapshot for edit pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         label={
@@ -1638,6 +1659,7 @@ exports[`PipelineEditor component matches snapshot for edit pipeline 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={

--- a/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
+++ b/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/__snapshots__/pipeline_editor.test.js.snap
@@ -140,6 +140,7 @@ Default value: Number of the host’s CPU cores"
           value={1}
         />
       </EuiFormRow>
+      <EuiSpacer />
       <EuiFlexGroup>
         <FlexItemSetting
           formRowLabelText="Pipeline batch size"
@@ -458,6 +459,7 @@ Default value: Number of the host’s CPU cores"
           value={1}
         />
       </EuiFormRow>
+      <EuiSpacer />
       <EuiFlexGroup>
         <FlexItemSetting
           formRowLabelText="Pipeline batch size"
@@ -776,6 +778,7 @@ Default value: Number of the host’s CPU cores"
           value={1}
         />
       </EuiFormRow>
+      <EuiSpacer />
       <EuiFlexGroup>
         <FlexItemSetting
           formRowLabelText="Pipeline batch size"
@@ -1064,6 +1067,7 @@ Default value: Number of the host’s CPU cores"
           value={1}
         />
       </EuiFormRow>
+      <EuiSpacer />
       <EuiFlexGroup>
         <FlexItemSetting
           formRowLabelText="Pipeline batch size"
@@ -1393,6 +1397,7 @@ Default value: Number of the host’s CPU cores"
           value={1}
         />
       </EuiFormRow>
+      <EuiSpacer />
       <EuiFlexGroup>
         <FlexItemSetting
           formRowLabelText="Pipeline batch size"
@@ -1681,6 +1686,7 @@ Default value: Number of the host’s CPU cores"
           value={1}
         />
       </EuiFormRow>
+      <EuiSpacer />
       <EuiFlexGroup>
         <FlexItemSetting
           formRowLabelText="Pipeline batch size"

--- a/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/pipeline_editor.js
+++ b/x-pack/legacy/plugins/logstash/public/components/pipeline_editor/pipeline_editor.js
@@ -348,6 +348,7 @@ class PipelineEditorUi extends React.Component {
                 value={this.state.pipeline.settings['pipeline.workers']}
               />
             </EuiFormRow>
+            <EuiSpacer />
             <EuiFlexGroup>
               <FlexItemSetting
                 formRowLabelText={intl.formatMessage({

--- a/x-pack/legacy/plugins/maps/public/components/__snapshots__/geometry_filter_form.test.js.snap
+++ b/x-pack/legacy/plugins/maps/public/components/__snapshots__/geometry_filter_form.test.js.snap
@@ -15,7 +15,7 @@ exports[`should not render relation select when geo field is geo_point 1`] = `
     labelType="label"
   >
     <EuiFieldText
-      compressed={false}
+      compressed={true}
       fullWidth={false}
       isLoading={false}
       onChange={[Function]}
@@ -86,7 +86,7 @@ exports[`should not show "within" relation when filter geometry is not closed 1`
     labelType="label"
   >
     <EuiFieldText
-      compressed={false}
+      compressed={true}
       fullWidth={false}
       isLoading={false}
       onChange={[Function]}
@@ -142,7 +142,7 @@ exports[`should not show "within" relation when filter geometry is not closed 1`
     labelType="label"
   >
     <EuiSelect
-      compressed={false}
+      compressed={true}
       fullWidth={false}
       hasNoInitialSelection={false}
       isLoading={false}
@@ -187,7 +187,7 @@ exports[`should render relation select when geo field is geo_shape 1`] = `
     labelType="label"
   >
     <EuiFieldText
-      compressed={false}
+      compressed={true}
       fullWidth={false}
       isLoading={false}
       onChange={[Function]}
@@ -243,7 +243,7 @@ exports[`should render relation select when geo field is geo_shape 1`] = `
     labelType="label"
   >
     <EuiSelect
-      compressed={false}
+      compressed={true}
       fullWidth={false}
       hasNoInitialSelection={false}
       isLoading={false}

--- a/x-pack/legacy/plugins/maps/public/components/__snapshots__/geometry_filter_form.test.js.snap
+++ b/x-pack/legacy/plugins/maps/public/components/__snapshots__/geometry_filter_form.test.js.snap
@@ -8,6 +8,7 @@ exports[`should not render relation select when geo field is geo_point 1`] = `
   <EuiFormRow
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Geometry label"
@@ -25,6 +26,7 @@ exports[`should not render relation select when geo field is geo_point 1`] = `
     className="mapGeometryFilter__geoFieldSuperSelectWrapper"
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Filtered field"
@@ -77,6 +79,7 @@ exports[`should not show "within" relation when filter geometry is not closed 1`
   <EuiFormRow
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Geometry label"
@@ -94,6 +97,7 @@ exports[`should not show "within" relation when filter geometry is not closed 1`
     className="mapGeometryFilter__geoFieldSuperSelectWrapper"
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Filtered field"
@@ -131,6 +135,7 @@ exports[`should not show "within" relation when filter geometry is not closed 1`
   <EuiFormRow
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Spatial relation"
@@ -175,6 +180,7 @@ exports[`should render relation select when geo field is geo_shape 1`] = `
   <EuiFormRow
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Geometry label"
@@ -192,6 +198,7 @@ exports[`should render relation select when geo field is geo_shape 1`] = `
     className="mapGeometryFilter__geoFieldSuperSelectWrapper"
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Filtered field"
@@ -229,6 +236,7 @@ exports[`should render relation select when geo field is geo_shape 1`] = `
   <EuiFormRow
     compressed={true}
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label="Spatial relation"

--- a/x-pack/legacy/plugins/maps/public/components/__snapshots__/tooltip_selector.test.js.snap
+++ b/x-pack/legacy/plugins/maps/public/components/__snapshots__/tooltip_selector.test.js.snap
@@ -3,6 +3,7 @@
 exports[`TooltipSelector should create eui row component 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label="Fields to display in tooltip"

--- a/x-pack/legacy/plugins/maps/public/components/geometry_filter_form.js
+++ b/x-pack/legacy/plugins/maps/public/components/geometry_filter_form.js
@@ -135,6 +135,7 @@ export class GeometryFilterForm extends Component {
         compressed
       >
         <EuiSelect
+          compressed
           options={options}
           value={this.state.relation}
           onChange={this._onRelationChange}
@@ -170,6 +171,7 @@ export class GeometryFilterForm extends Component {
           compressed
         >
           <EuiFieldText
+            compressed
             value={this.state.geometryLabel}
             onChange={this._onGeometryLabelChange}
           />

--- a/x-pack/legacy/plugins/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_control.js
+++ b/x-pack/legacy/plugins/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_control.js
@@ -80,6 +80,7 @@ export class SetViewControl extends Component {
           compressed
         >
           <EuiFieldNumber
+            compressed
             value={value}
             onChange={onChange}
             isInvalid={isInvalid}

--- a/x-pack/legacy/plugins/maps/public/connected_components/widget_overlay/attribution_control/_attribution_control.scss
+++ b/x-pack/legacy/plugins/maps/public/connected_components/widget_overlay/attribution_control/_attribution_control.scss
@@ -1,6 +1,6 @@
 .mapAttributionControl {
   @include mapOverlayIsTextOnly;
-  @include euiTextOverflowWrap;
+  @include euiTextBreakWord;
   pointer-events: all;
   padding-left: $euiSizeM;
 }

--- a/x-pack/legacy/plugins/maps/public/layers/styles/components/heatmap/__snapshots__/heatmap_style_editor.test.js.snap
+++ b/x-pack/legacy/plugins/maps/public/layers/styles/components/heatmap/__snapshots__/heatmap_style_editor.test.js.snap
@@ -3,6 +3,7 @@
 exports[`HeatmapStyleEditor is rendered 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label="Color range"

--- a/x-pack/legacy/plugins/maps/public/layers/styles/components/vector/__snapshots__/vector_style_symbol_editor.test.js.snap
+++ b/x-pack/legacy/plugins/maps/public/layers/styles/components/vector/__snapshots__/vector_style_symbol_editor.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Should render icon select when symbolized as Icon 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label="Symbol type"
@@ -65,6 +66,7 @@ exports[`Should render icon select when symbolized as Icon 1`] = `
 exports[`Should render symbol select when symbolized as Circle 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label="Symbol type"

--- a/x-pack/legacy/plugins/maps/public/layers/styles/components/vector/vector_style_editor.js
+++ b/x-pack/legacy/plugins/maps/public/layers/styles/components/vector/vector_style_editor.js
@@ -15,12 +15,9 @@ import { OrientationEditor } from './orientation/orientation_editor';
 import {
   getDefaultDynamicProperties,
   getDefaultStaticProperties,
-  vectorStyles
+  vectorStyles,
 } from '../../vector_style_defaults';
-import {
-  DEFAULT_FILL_COLORS,
-  DEFAULT_LINE_COLORS
-} from '../../color_utils';
+import { DEFAULT_FILL_COLORS, DEFAULT_LINE_COLORS } from '../../color_utils';
 import { VECTOR_SHAPE_TYPES } from '../../../sources/vector_feature_types';
 import { SYMBOLIZE_AS_ICON } from '../../vector_constants';
 import { i18n } from '@kbn/i18n';
@@ -35,7 +32,7 @@ export class VectorStyleEditor extends Component {
     defaultStaticProperties: getDefaultStaticProperties(),
     supportedFeatures: undefined,
     selectedFeatureType: undefined,
-  }
+  };
 
   componentWillUnmount() {
     this._isMounted = false;
@@ -71,9 +68,11 @@ export class VectorStyleEditor extends Component {
       return;
     }
 
-    if (_.isEqual(supportedFeatures, this.state.supportedFeatures)
-      && isPointsOnly === this.state.isPointsOnly
-      && isLinesOnly === this.state.isLinesOnly) {
+    if (
+      _.isEqual(supportedFeatures, this.state.supportedFeatures) &&
+      isPointsOnly === this.state.isPointsOnly &&
+      isLinesOnly === this.state.isLinesOnly
+    ) {
       return;
     }
 
@@ -84,8 +83,10 @@ export class VectorStyleEditor extends Component {
       selectedFeature = VECTOR_SHAPE_TYPES.LINE;
     }
 
-    if (!_.isEqual(supportedFeatures, this.state.supportedFeatures) ||
-      selectedFeature !== this.state.selectedFeature) {
+    if (
+      !_.isEqual(supportedFeatures, this.state.supportedFeatures) ||
+      selectedFeature !== this.state.selectedFeature
+    ) {
       this.setState({
         supportedFeatures,
         selectedFeature,
@@ -151,7 +152,7 @@ export class VectorStyleEditor extends Component {
 
   _renderPointProperties() {
     let iconOrientation;
-    if (this.props.styleProperties.symbol.options.symbolizeAs === SYMBOLIZE_AS_ICON)  {
+    if (this.props.styleProperties.symbol.options.symbolizeAs === SYMBOLIZE_AS_ICON) {
       iconOrientation = (
         <Fragment>
           <OrientationEditor
@@ -169,13 +170,13 @@ export class VectorStyleEditor extends Component {
 
     return (
       <Fragment>
-
         <VectorStyleSymbolEditor
           styleOptions={this.props.styleProperties.symbol.options}
           handlePropertyChange={this.props.handlePropertyChange}
           symbolOptions={SYMBOL_OPTIONS}
           isDarkMode={chrome.getUiSettingsClient().get('theme:darkMode', false)}
         />
+        <EuiSpacer size="m" />
 
         {this._renderFillColor()}
         <EuiSpacer size="m" />
@@ -189,7 +190,6 @@ export class VectorStyleEditor extends Component {
         {iconOrientation}
 
         {this._renderSymbolSize()}
-
       </Fragment>
     );
   }
@@ -221,13 +221,10 @@ export class VectorStyleEditor extends Component {
 
   _handleSelectedFeatureChange = selectedFeature => {
     this.setState({ selectedFeature });
-  }
+  };
 
   render() {
-    const {
-      supportedFeatures,
-      selectedFeature,
-    } = this.state;
+    const { supportedFeatures, selectedFeature } = this.state;
 
     if (!supportedFeatures) {
       return null;
@@ -248,21 +245,21 @@ export class VectorStyleEditor extends Component {
       {
         id: VECTOR_SHAPE_TYPES.POINT,
         label: i18n.translate('xpack.maps.vectorStyleEditor.pointLabel', {
-          defaultMessage: 'Points'
-        })
+          defaultMessage: 'Points',
+        }),
       },
       {
         id: VECTOR_SHAPE_TYPES.LINE,
         label: i18n.translate('xpack.maps.vectorStyleEditor.lineLabel', {
-          defaultMessage: 'Lines'
-        })
+          defaultMessage: 'Lines',
+        }),
       },
       {
         id: VECTOR_SHAPE_TYPES.POLYGON,
         label: i18n.translate('xpack.maps.vectorStyleEditor.polygonLabel', {
-          defaultMessage: 'Polygons'
-        })
-      }
+          defaultMessage: 'Polygons',
+        }),
+      },
     ];
 
     let styleProperties = this._renderPolygonProperties();
@@ -276,7 +273,7 @@ export class VectorStyleEditor extends Component {
       <Fragment>
         <EuiButtonGroup
           legend={i18n.translate('xpack.maps.vectorStyleEditor.featureTypeButtonGroupLegend', {
-            defaultMessage: 'vector feature button group'
+            defaultMessage: 'vector feature button group',
           })}
           options={featureButtons}
           idSelected={selectedFeature}

--- a/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/aggregation_list/__snapshots__/popover_form.test.tsx.snap
+++ b/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/aggregation_list/__snapshots__/popover_form.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Data Frame: Aggregation <PopoverForm /> Minimal initialization 1`] = `
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={false}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -29,6 +30,7 @@ exports[`Data Frame: Aggregation <PopoverForm /> Minimal initialization 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={true}
     labelType="label"

--- a/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/group_by_list/__snapshots__/popover_form.test.tsx.snap
+++ b/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/group_by_list/__snapshots__/popover_form.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Data Frame: Group By <PopoverForm /> Minimal initialization 1`] = `
 >
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={false}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -29,6 +30,7 @@ exports[`Data Frame: Group By <PopoverForm /> Minimal initialization 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={false}
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -79,6 +81,7 @@ exports[`Data Frame: Group By <PopoverForm /> Minimal initialization 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={true}
     labelType="label"

--- a/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/group_by_list/popover_form.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/group_by_list/popover_form.tsx
@@ -15,6 +15,7 @@ import {
   EuiForm,
   EuiFormRow,
   EuiSelect,
+  EuiSpacer,
 } from '@elastic/eui';
 
 import { dictionaryToArray } from '../../../../../../common/types/common';
@@ -259,16 +260,19 @@ export const PopoverForm: React.SFC<Props> = ({
         </EuiFormRow>
       )}
       {isUnsupportedAgg && (
-        <EuiCodeEditor
-          mode="json"
-          theme="github"
-          width="100%"
-          height="200px"
-          value={JSON.stringify(getEsAggFromGroupByConfig(defaultData), null, 2)}
-          setOptions={{ fontSize: '12px', showLineNumbers: false }}
-          isReadOnly
-          aria-label="Read only code editor"
-        />
+        <Fragment>
+          <EuiSpacer size="m" />
+          <EuiCodeEditor
+            mode="json"
+            theme="github"
+            width="100%"
+            height="200px"
+            value={JSON.stringify(getEsAggFromGroupByConfig(defaultData), null, 2)}
+            setOptions={{ fontSize: '12px', showLineNumbers: false }}
+            isReadOnly
+            aria-label="Read only code editor"
+          />
+        </Fragment>
       )}
       <EuiFormRow hasEmptyLabelSpace>
         <EuiButton isDisabled={!formValid} onClick={() => onChange(getUpdatedItem())}>

--- a/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/group_by_list/popover_form.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/group_by_list/popover_form.tsx
@@ -15,7 +15,6 @@ import {
   EuiForm,
   EuiFormRow,
   EuiSelect,
-  EuiSpacer,
 } from '@elastic/eui';
 
 import { dictionaryToArray } from '../../../../../../common/types/common';
@@ -260,19 +259,16 @@ export const PopoverForm: React.SFC<Props> = ({
         </EuiFormRow>
       )}
       {isUnsupportedAgg && (
-        <Fragment>
-          <EuiSpacer size="m" />
-          <EuiCodeEditor
-            mode="json"
-            theme="github"
-            width="100%"
-            height="200px"
-            value={JSON.stringify(getEsAggFromGroupByConfig(defaultData), null, 2)}
-            setOptions={{ fontSize: '12px', showLineNumbers: false }}
-            isReadOnly
-            aria-label="Read only code editor"
-          />
-        </Fragment>
+        <EuiCodeEditor
+          mode="json"
+          theme="github"
+          width="100%"
+          height="200px"
+          value={JSON.stringify(getEsAggFromGroupByConfig(defaultData), null, 2)}
+          setOptions={{ fontSize: '12px', showLineNumbers: false }}
+          isReadOnly
+          aria-label="Read only code editor"
+        />
       )}
       <EuiFormRow hasEmptyLabelSpace>
         <EuiButton isDisabled={!formValid} onClick={() => onChange(getUpdatedItem())}>

--- a/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/step_define/step_define_form.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/step_define/step_define_form.tsx
@@ -817,7 +817,6 @@ export const StepDefineForm: SFC<Props> = React.memo(({ overrides = {}, onChange
           </EuiFormRow>
           {!valid && (
             <Fragment>
-              <EuiSpacer size="m" />
               <EuiFormHelpText style={{ maxWidth: '320px' }}>
                 {i18n.translate('xpack.ml.dataframe.stepDefineForm.formHelp', {
                   defaultMessage:

--- a/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/step_define/step_define_form.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame/pages/data_frame_new_pivot/components/step_define/step_define_form.tsx
@@ -817,6 +817,7 @@ export const StepDefineForm: SFC<Props> = React.memo(({ overrides = {}, onChange
           </EuiFormRow>
           {!valid && (
             <Fragment>
+              <EuiSpacer size="m" />
               <EuiFormHelpText style={{ maxWidth: '320px' }}>
                 {i18n.translate('xpack.ml.dataframe.stepDefineForm.formHelp', {
                   defaultMessage:

--- a/x-pack/legacy/plugins/ml/public/data_frame_analytics/pages/analytics_management/components/create_analytics_advanced_editor/create_analytics_advanced_editor.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame_analytics/pages/analytics_management/components/create_analytics_advanced_editor/create_analytics_advanced_editor.tsx
@@ -135,9 +135,9 @@ export const CreateAnalyticsAdvancedEditor: FC<CreateAnalyticsFormProps> = ({ ac
               )}
             />
           </EuiFormRow>
+          <EuiSpacer />
           {advancedEditorMessages.map((advancedEditorMessage, i) => (
             <Fragment key={i}>
-              <EuiSpacer />
               <EuiCallOut
                 title={
                   advancedEditorMessage.message !== ''

--- a/x-pack/legacy/plugins/ml/public/data_frame_analytics/pages/analytics_management/components/create_analytics_advanced_editor/create_analytics_advanced_editor.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame_analytics/pages/analytics_management/components/create_analytics_advanced_editor/create_analytics_advanced_editor.tsx
@@ -137,6 +137,7 @@ export const CreateAnalyticsAdvancedEditor: FC<CreateAnalyticsFormProps> = ({ ac
           </EuiFormRow>
           {advancedEditorMessages.map((advancedEditorMessage, i) => (
             <Fragment key={i}>
+              <EuiSpacer />
               <EuiCallOut
                 title={
                   advancedEditorMessage.message !== ''
@@ -154,7 +155,7 @@ export const CreateAnalyticsAdvancedEditor: FC<CreateAnalyticsFormProps> = ({ ac
                   <p>{advancedEditorMessage.error}</p>
                 ) : null}
               </EuiCallOut>
-              <EuiSpacer size="s" />
+              <EuiSpacer />
             </Fragment>
           ))}
           <EuiFormRow

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/edit_flyout/__snapshots__/overrides.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/edit_flyout/__snapshots__/overrides.test.js.snap
@@ -4,6 +4,7 @@ exports[`Overrides render overrides 1`] = `
 <EuiForm>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error="Value must be greater than 3 and less than or equal to 1000000"
     fullWidth={false}
     hasEmptyLabelSpace={false}
@@ -27,6 +28,7 @@ exports[`Overrides render overrides 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -72,6 +74,7 @@ exports[`Overrides render overrides 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText={
@@ -323,6 +326,7 @@ exports[`Overrides render overrides 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/advanced.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/advanced.js
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
 
@@ -37,6 +38,7 @@ function AdvancedSettingsUi({
   indexPatternNameError,
   intl,
 }) {
+
   return (
     <React.Fragment>
       <EuiFormRow
@@ -52,20 +54,18 @@ function AdvancedSettingsUi({
         <EuiFieldText
           placeholder={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.advancedImportSettings.indexNamePlaceholder',
-            defaultMessage: 'index name',
+            defaultMessage: 'index name'
           })}
           value={index}
-          disabled={initialized === true}
+          disabled={(initialized === true)}
           onChange={onIndexChange}
           isInvalid={indexNameError !== ''}
           aria-label={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.advancedImportSettings.indexNameAriaLabel',
-            defaultMessage: 'Index name, required field',
+            defaultMessage: 'Index name, required field'
           })}
         />
       </EuiFormRow>
-
-      <EuiSpacer size="m" />
 
       <EuiCheckbox
         id="createIndexPattern"
@@ -75,8 +75,8 @@ function AdvancedSettingsUi({
             defaultMessage="Create index pattern"
           />
         }
-        checked={createIndexPattern === true}
-        disabled={initialized === true}
+        checked={(createIndexPattern === true)}
+        disabled={(initialized === true)}
         onChange={onCreateIndexPatternChange}
       />
 
@@ -89,13 +89,13 @@ function AdvancedSettingsUi({
             defaultMessage="Index pattern name"
           />
         }
-        disabled={createIndexPattern === false || initialized === true}
+        disabled={(createIndexPattern === false || initialized === true)}
         isInvalid={indexPatternNameError !== ''}
         error={[indexPatternNameError]}
       >
         <EuiFieldText
-          disabled={createIndexPattern === false || initialized === true}
-          placeholder={createIndexPattern === true ? index : ''}
+          disabled={(createIndexPattern === false || initialized === true)}
+          placeholder={(createIndexPattern === true) ? index : ''}
           value={indexPattern}
           onChange={onIndexPatternChange}
           isInvalid={indexPatternNameError !== ''}
@@ -103,6 +103,7 @@ function AdvancedSettingsUi({
       </EuiFormRow>
 
       <EuiFlexGroup>
+
         <EuiFlexItem>
           <IndexSettings
             initialized={initialized}
@@ -126,6 +127,7 @@ function AdvancedSettingsUi({
             onChange={onPipelineStringChange}
           />
         </EuiFlexItem>
+
       </EuiFlexGroup>
     </React.Fragment>
   );
@@ -143,12 +145,12 @@ function IndexSettings({ initialized, data, onChange }) {
             defaultMessage="Index settings"
           />
         }
-        disabled={initialized === true}
+        disabled={(initialized === true)}
         fullWidth
       >
         <MLJobEditor
           mode={EDITOR_MODE.JSON}
-          readOnly={initialized === true}
+          readOnly={(initialized === true)}
           value={data}
           height={EDITOR_HEIGHT}
           syntaxChecking={false}
@@ -169,12 +171,12 @@ function Mappings({ initialized, data, onChange }) {
             defaultMessage="Mappings"
           />
         }
-        disabled={initialized === true}
+        disabled={(initialized === true)}
         fullWidth
       >
         <MLJobEditor
           mode={EDITOR_MODE.JSON}
-          readOnly={initialized === true}
+          readOnly={(initialized === true)}
           value={data}
           height={EDITOR_HEIGHT}
           syntaxChecking={false}
@@ -195,12 +197,12 @@ function IngestPipeline({ initialized, data, onChange }) {
             defaultMessage="Ingest pipeline"
           />
         }
-        disabled={initialized === true}
+        disabled={(initialized === true)}
         fullWidth
       >
         <MLJobEditor
           mode={EDITOR_MODE.JSON}
-          readOnly={initialized === true}
+          readOnly={(initialized === true)}
           value={data}
           height={EDITOR_HEIGHT}
           syntaxChecking={false}

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/advanced.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/advanced.js
@@ -67,6 +67,8 @@ function AdvancedSettingsUi({
         />
       </EuiFormRow>
 
+      <EuiSpacer size="m" />
+
       <EuiCheckbox
         id="createIndexPattern"
         label={

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/advanced.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/advanced.js
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
 
@@ -38,7 +37,6 @@ function AdvancedSettingsUi({
   indexPatternNameError,
   intl,
 }) {
-
   return (
     <React.Fragment>
       <EuiFormRow
@@ -54,18 +52,20 @@ function AdvancedSettingsUi({
         <EuiFieldText
           placeholder={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.advancedImportSettings.indexNamePlaceholder',
-            defaultMessage: 'index name'
+            defaultMessage: 'index name',
           })}
           value={index}
-          disabled={(initialized === true)}
+          disabled={initialized === true}
           onChange={onIndexChange}
           isInvalid={indexNameError !== ''}
           aria-label={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.advancedImportSettings.indexNameAriaLabel',
-            defaultMessage: 'Index name, required field'
+            defaultMessage: 'Index name, required field',
           })}
         />
       </EuiFormRow>
+
+      <EuiSpacer size="m" />
 
       <EuiCheckbox
         id="createIndexPattern"
@@ -75,8 +75,8 @@ function AdvancedSettingsUi({
             defaultMessage="Create index pattern"
           />
         }
-        checked={(createIndexPattern === true)}
-        disabled={(initialized === true)}
+        checked={createIndexPattern === true}
+        disabled={initialized === true}
         onChange={onCreateIndexPatternChange}
       />
 
@@ -89,13 +89,13 @@ function AdvancedSettingsUi({
             defaultMessage="Index pattern name"
           />
         }
-        disabled={(createIndexPattern === false || initialized === true)}
+        disabled={createIndexPattern === false || initialized === true}
         isInvalid={indexPatternNameError !== ''}
         error={[indexPatternNameError]}
       >
         <EuiFieldText
-          disabled={(createIndexPattern === false || initialized === true)}
-          placeholder={(createIndexPattern === true) ? index : ''}
+          disabled={createIndexPattern === false || initialized === true}
+          placeholder={createIndexPattern === true ? index : ''}
           value={indexPattern}
           onChange={onIndexPatternChange}
           isInvalid={indexPatternNameError !== ''}
@@ -103,7 +103,6 @@ function AdvancedSettingsUi({
       </EuiFormRow>
 
       <EuiFlexGroup>
-
         <EuiFlexItem>
           <IndexSettings
             initialized={initialized}
@@ -127,7 +126,6 @@ function AdvancedSettingsUi({
             onChange={onPipelineStringChange}
           />
         </EuiFlexItem>
-
       </EuiFlexGroup>
     </React.Fragment>
   );
@@ -145,12 +143,12 @@ function IndexSettings({ initialized, data, onChange }) {
             defaultMessage="Index settings"
           />
         }
-        disabled={(initialized === true)}
+        disabled={initialized === true}
         fullWidth
       >
         <MLJobEditor
           mode={EDITOR_MODE.JSON}
-          readOnly={(initialized === true)}
+          readOnly={initialized === true}
           value={data}
           height={EDITOR_HEIGHT}
           syntaxChecking={false}
@@ -171,12 +169,12 @@ function Mappings({ initialized, data, onChange }) {
             defaultMessage="Mappings"
           />
         }
-        disabled={(initialized === true)}
+        disabled={initialized === true}
         fullWidth
       >
         <MLJobEditor
           mode={EDITOR_MODE.JSON}
-          readOnly={(initialized === true)}
+          readOnly={initialized === true}
           value={data}
           height={EDITOR_HEIGHT}
           syntaxChecking={false}
@@ -197,12 +195,12 @@ function IngestPipeline({ initialized, data, onChange }) {
             defaultMessage="Ingest pipeline"
           />
         }
-        disabled={(initialized === true)}
+        disabled={initialized === true}
         fullWidth
       >
         <MLJobEditor
           mode={EDITOR_MODE.JSON}
-          readOnly={(initialized === true)}
+          readOnly={initialized === true}
           value={data}
           height={EDITOR_HEIGHT}
           syntaxChecking={false}

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
@@ -50,6 +50,8 @@ export const SimpleSettings = injectI18n(function ({
         />
       </EuiFormRow>
 
+      <EuiSpacer size="m" />
+
       <EuiCheckbox
         id="createIndexPattern"
         label={

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
@@ -7,11 +7,7 @@
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
 
-import {
-  EuiFieldText,
-  EuiFormRow,
-  EuiCheckbox,
-} from '@elastic/eui';
+import { EuiFieldText, EuiFormRow, EuiCheckbox, EuiSpacer } from '@elastic/eui';
 
 export const SimpleSettings = injectI18n(function ({
   index,
@@ -37,18 +33,20 @@ export const SimpleSettings = injectI18n(function ({
         <EuiFieldText
           placeholder={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.simpleImportSettings.indexNamePlaceholder',
-            defaultMessage: 'index name'
+            defaultMessage: 'index name',
           })}
           value={index}
-          disabled={(initialized === true)}
+          disabled={initialized === true}
           onChange={onIndexChange}
           isInvalid={indexNameError !== ''}
           aria-label={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.simpleImportSettings.indexNameAriaLabel',
-            defaultMessage: 'Index name, required field'
+            defaultMessage: 'Index name, required field',
           })}
         />
       </EuiFormRow>
+
+      <EuiSpacer size="m" />
 
       <EuiCheckbox
         id="createIndexPattern"
@@ -58,8 +56,8 @@ export const SimpleSettings = injectI18n(function ({
             defaultMessage="Create index pattern"
           />
         }
-        checked={(createIndexPattern === true)}
-        disabled={(initialized === true)}
+        checked={createIndexPattern === true}
+        disabled={initialized === true}
         onChange={onCreateIndexPatternChange}
       />
     </React.Fragment>

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
@@ -7,7 +7,11 @@
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
 
-import { EuiFieldText, EuiFormRow, EuiCheckbox, EuiSpacer } from '@elastic/eui';
+import {
+  EuiFieldText,
+  EuiFormRow,
+  EuiCheckbox,
+} from '@elastic/eui';
 
 export const SimpleSettings = injectI18n(function ({
   index,
@@ -33,20 +37,18 @@ export const SimpleSettings = injectI18n(function ({
         <EuiFieldText
           placeholder={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.simpleImportSettings.indexNamePlaceholder',
-            defaultMessage: 'index name',
+            defaultMessage: 'index name'
           })}
           value={index}
-          disabled={initialized === true}
+          disabled={(initialized === true)}
           onChange={onIndexChange}
           isInvalid={indexNameError !== ''}
           aria-label={intl.formatMessage({
             id: 'xpack.ml.fileDatavisualizer.simpleImportSettings.indexNameAriaLabel',
-            defaultMessage: 'Index name, required field',
+            defaultMessage: 'Index name, required field'
           })}
         />
       </EuiFormRow>
-
-      <EuiSpacer size="m" />
 
       <EuiCheckbox
         id="createIndexPattern"
@@ -56,8 +58,8 @@ export const SimpleSettings = injectI18n(function ({
             defaultMessage="Create index pattern"
           />
         }
-        checked={createIndexPattern === true}
-        disabled={initialized === true}
+        checked={(createIndexPattern === true)}
+        disabled={(initialized === true)}
         onChange={onCreateIndexPatternChange}
       />
     </React.Fragment>

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/file_based/components/import_settings/simple.js
@@ -11,6 +11,7 @@ import {
   EuiFieldText,
   EuiFormRow,
   EuiCheckbox,
+  EuiSpacer,
 } from '@elastic/eui';
 
 export const SimpleSettings = injectI18n(function ({

--- a/x-pack/legacy/plugins/ml/public/jobs/components/custom_url_editor/__snapshots__/editor.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/jobs/components/custom_url_editor/__snapshots__/editor.test.js.snap
@@ -23,6 +23,7 @@ exports[`CustomUrlEditor renders the editor for a dashboard type URL with a labe
       className="url-label"
       compressed={true}
       describedByIds={Array []}
+      display="row"
       error={Array []}
       fullWidth={false}
       hasEmptyLabelSpace={false}
@@ -48,6 +49,7 @@ exports[`CustomUrlEditor renders the editor for a dashboard type URL with a labe
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -84,6 +86,7 @@ exports[`CustomUrlEditor renders the editor for a dashboard type URL with a labe
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -118,6 +121,7 @@ exports[`CustomUrlEditor renders the editor for a dashboard type URL with a labe
     </EuiFormRow>
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -154,6 +158,7 @@ exports[`CustomUrlEditor renders the editor for a dashboard type URL with a labe
           className="url-time-range"
           compressed={true}
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={
@@ -215,6 +220,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with an enti
       className="url-label"
       compressed={true}
       describedByIds={Array []}
+      display="row"
       error={Array []}
       fullWidth={false}
       hasEmptyLabelSpace={false}
@@ -240,6 +246,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with an enti
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -276,6 +283,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with an enti
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -310,6 +318,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with an enti
     </EuiFormRow>
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -352,6 +361,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with an enti
           className="url-time-range"
           compressed={true}
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={
@@ -390,6 +400,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with an enti
           className="url-time-range"
           compressed={true}
           describedByIds={Array []}
+          display="row"
           error={
             Array [
               "Invalid interval format",
@@ -445,6 +456,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with valid t
       className="url-label"
       compressed={true}
       describedByIds={Array []}
+      display="row"
       error={Array []}
       fullWidth={false}
       hasEmptyLabelSpace={false}
@@ -470,6 +482,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with valid t
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -506,6 +519,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with valid t
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -540,6 +554,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with valid t
     </EuiFormRow>
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -582,6 +597,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with valid t
           className="url-time-range"
           compressed={true}
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={
@@ -620,6 +636,7 @@ exports[`CustomUrlEditor renders the editor for a discover type URL with valid t
           className="url-time-range"
           compressed={true}
           describedByIds={Array []}
+          display="row"
           error={Array []}
           fullWidth={false}
           hasEmptyLabelSpace={false}
@@ -671,6 +688,7 @@ exports[`CustomUrlEditor renders the editor for a new dashboard type URL with no
       className="url-label"
       compressed={true}
       describedByIds={Array []}
+      display="row"
       error={
         Array [
           "A unique label must be supplied",
@@ -700,6 +718,7 @@ exports[`CustomUrlEditor renders the editor for a new dashboard type URL with no
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -736,6 +755,7 @@ exports[`CustomUrlEditor renders the editor for a new dashboard type URL with no
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -770,6 +790,7 @@ exports[`CustomUrlEditor renders the editor for a new dashboard type URL with no
     </EuiFormRow>
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -806,6 +827,7 @@ exports[`CustomUrlEditor renders the editor for a new dashboard type URL with no
           className="url-time-range"
           compressed={true}
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={
@@ -867,6 +889,7 @@ exports[`CustomUrlEditor renders the editor for other type of URL with duplicate
       className="url-label"
       compressed={true}
       describedByIds={Array []}
+      display="row"
       error={
         Array [
           "A unique label must be supplied",
@@ -896,6 +919,7 @@ exports[`CustomUrlEditor renders the editor for other type of URL with duplicate
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -932,6 +956,7 @@ exports[`CustomUrlEditor renders the editor for other type of URL with duplicate
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={true}
       hasEmptyLabelSpace={false}
       label={
@@ -979,6 +1004,7 @@ exports[`CustomUrlEditor renders the editor for other type of URL with unique la
       className="url-label"
       compressed={true}
       describedByIds={Array []}
+      display="row"
       error={Array []}
       fullWidth={false}
       hasEmptyLabelSpace={false}
@@ -1004,6 +1030,7 @@ exports[`CustomUrlEditor renders the editor for other type of URL with unique la
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label={
@@ -1040,6 +1067,7 @@ exports[`CustomUrlEditor renders the editor for other type of URL with unique la
     <EuiFormRow
       compressed={true}
       describedByIds={Array []}
+      display="row"
       fullWidth={true}
       hasEmptyLabelSpace={false}
       label={

--- a/x-pack/legacy/plugins/ml/public/jobs/components/custom_url_editor/__snapshots__/list.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/jobs/components/custom_url_editor/__snapshots__/list.test.js.snap
@@ -10,6 +10,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         error={Array []}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -36,6 +37,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -61,6 +63,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         error={Array []}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -90,6 +93,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"
@@ -120,6 +124,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"
@@ -154,6 +159,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         error={Array []}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -180,6 +186,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -205,6 +212,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         error={Array []}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -234,6 +242,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"
@@ -264,6 +273,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"
@@ -298,6 +308,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         error={Array []}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -324,6 +335,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     <EuiFlexItem>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -349,6 +361,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         error={Array []}
         fullWidth={false}
         hasEmptyLabelSpace={false}
@@ -378,6 +391,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"
@@ -408,6 +422,7 @@ exports[`CustomUrlList renders a list of custom URLs 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"

--- a/x-pack/legacy/plugins/ml/public/settings/calendars/edit/calendar_form/__snapshots__/calendar_form.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/settings/calendars/edit/calendar_form/__snapshots__/calendar_form.test.js.snap
@@ -36,6 +36,7 @@ exports[`CalendarForm Renders calendar form 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={
       Array [
         "Use lowercase alphanumerics (a-z and 0-9), hyphens or underscores; must start and end with an alphanumeric character",
@@ -65,6 +66,7 @@ exports[`CalendarForm Renders calendar form 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -88,6 +90,7 @@ exports[`CalendarForm Renders calendar form 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -112,6 +115,7 @@ exports[`CalendarForm Renders calendar form 1`] = `
   </EuiFormRow>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     label={
@@ -140,6 +144,7 @@ exports[`CalendarForm Renders calendar form 1`] = `
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={true}
     hasEmptyLabelSpace={false}
     label={

--- a/x-pack/legacy/plugins/ml/public/settings/calendars/edit/new_event_modal/new_event_modal.js
+++ b/x-pack/legacy/plugins/ml/public/settings/calendars/edit/new_event_modal/new_event_modal.js
@@ -291,6 +291,9 @@ export const NewEventModal = injectI18n(class NewEventModal extends Component {
                   fullWidth
                 />
               </EuiFormRow>
+
+              <EuiSpacer size="m" />
+
               {this.renderRangedDatePicker()}
 
             </EuiForm>

--- a/x-pack/legacy/plugins/ml/public/settings/calendars/edit/new_event_modal/new_event_modal.js
+++ b/x-pack/legacy/plugins/ml/public/settings/calendars/edit/new_event_modal/new_event_modal.js
@@ -4,7 +4,11 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { Component, Fragment } from 'react';
+
+import React, {
+  Component,
+  Fragment
+} from 'react';
 import { PropTypes } from 'prop-types';
 import {
   EuiButton,
@@ -31,284 +35,289 @@ import { FormattedMessage, injectI18n } from '@kbn/i18n/react';
 
 const VALID_DATE_STRING_LENGTH = 19;
 
-export const NewEventModal = injectI18n(
-  class NewEventModal extends Component {
-    static propTypes = {
-      closeModal: PropTypes.func.isRequired,
-      addEvent: PropTypes.func.isRequired,
+export const NewEventModal = injectI18n(class NewEventModal extends Component {
+  static propTypes = {
+    closeModal: PropTypes.func.isRequired,
+    addEvent: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    const startDate = moment().startOf('day');
+    const endDate = moment().startOf('day').add(1, 'days');
+
+    this.state = {
+      startDate,
+      endDate,
+      description: '',
+      startDateString: startDate.format(TIME_FORMAT),
+      endDateString: endDate.format(TIME_FORMAT)
+    };
+  }
+
+  onDescriptionChange = (e) => {
+    this.setState({
+      description: e.target.value,
+    });
+  };
+
+  handleAddEvent = () => {
+    const { description, startDate, endDate } = this.state;
+    // Temp reference to unsaved events to allow removal from table
+    const tempId = generateTempId();
+
+    const event = {
+      description,
+      start_time: startDate.valueOf(),
+      end_time: endDate.valueOf(),
+      event_id: tempId
     };
 
-    constructor(props) {
-      super(props);
+    this.props.addEvent(event);
+  }
 
-      const startDate = moment().startOf('day');
-      const endDate = moment()
-        .startOf('day')
-        .add(1, 'days');
+  handleChangeStart = (date) => {
+    let start = null;
+    let end = this.state.endDate;
 
-      this.state = {
-        startDate,
-        endDate,
-        description: '',
-        startDateString: startDate.format(TIME_FORMAT),
-        endDateString: endDate.format(TIME_FORMAT),
-      };
+    const startMoment = moment(date);
+    const endMoment = moment(date);
+
+    start = startMoment.startOf('day');
+
+    if (start > end) {
+      end = endMoment.startOf('day').add(1, 'days');
+    }
+    this.setState({
+      startDate: start,
+      endDate: end,
+      startDateString: start.format(TIME_FORMAT),
+      endDateString: end.format(TIME_FORMAT)
+    });
+  }
+
+  handleChangeEnd = (date) => {
+    let start = this.state.startDate;
+    let end = null;
+
+    const startMoment = moment(date);
+    const endMoment = moment(date);
+
+    end = endMoment.startOf('day');
+
+    if (start > end) {
+      start = startMoment.startOf('day').subtract(1, 'days');
+    }
+    this.setState({
+      startDate: start,
+      endDate: end,
+      startDateString: start.format(TIME_FORMAT),
+      endDateString: end.format(TIME_FORMAT)
+    });
+  }
+
+  handleTimeStartChange = (event) => {
+    const dateString = event.target.value;
+    let isValidDate = false;
+
+    if (dateString.length === VALID_DATE_STRING_LENGTH) {
+      isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
+    } else {
+      this.setState({
+        startDateString: dateString,
+      });
     }
 
-    onDescriptionChange = e => {
+    if (isValidDate) {
       this.setState({
-        description: e.target.value,
+        startDateString: dateString,
+        startDate: moment(dateString)
       });
-    };
-
-    handleAddEvent = () => {
-      const { description, startDate, endDate } = this.state;
-      // Temp reference to unsaved events to allow removal from table
-      const tempId = generateTempId();
-
-      const event = {
-        description,
-        start_time: startDate.valueOf(),
-        end_time: endDate.valueOf(),
-        event_id: tempId,
-      };
-
-      this.props.addEvent(event);
-    };
-
-    handleChangeStart = date => {
-      let start = null;
-      let end = this.state.endDate;
-
-      const startMoment = moment(date);
-      const endMoment = moment(date);
-
-      start = startMoment.startOf('day');
-
-      if (start > end) {
-        end = endMoment.startOf('day').add(1, 'days');
-      }
-      this.setState({
-        startDate: start,
-        endDate: end,
-        startDateString: start.format(TIME_FORMAT),
-        endDateString: end.format(TIME_FORMAT),
-      });
-    };
-
-    handleChangeEnd = date => {
-      let start = this.state.startDate;
-      let end = null;
-
-      const startMoment = moment(date);
-      const endMoment = moment(date);
-
-      end = endMoment.startOf('day');
-
-      if (start > end) {
-        start = startMoment.startOf('day').subtract(1, 'days');
-      }
-      this.setState({
-        startDate: start,
-        endDate: end,
-        startDateString: start.format(TIME_FORMAT),
-        endDateString: end.format(TIME_FORMAT),
-      });
-    };
-
-    handleTimeStartChange = event => {
-      const dateString = event.target.value;
-      let isValidDate = false;
-
-      if (dateString.length === VALID_DATE_STRING_LENGTH) {
-        isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
-      } else {
-        this.setState({
-          startDateString: dateString,
-        });
-      }
-
-      if (isValidDate) {
-        this.setState({
-          startDateString: dateString,
-          startDate: moment(dateString),
-        });
-      }
-    };
-
-    handleTimeEndChange = event => {
-      const dateString = event.target.value;
-      let isValidDate = false;
-
-      if (dateString.length === VALID_DATE_STRING_LENGTH) {
-        isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
-      } else {
-        this.setState({
-          endDateString: dateString,
-        });
-      }
-
-      if (isValidDate) {
-        this.setState({
-          endDateString: dateString,
-          endDate: moment(dateString),
-        });
-      }
-    };
-
-    renderRangedDatePicker = () => {
-      const { startDate, endDate, startDateString, endDateString } = this.state;
-
-      const { intl } = this.props;
-
-      const timeInputs = (
-        <Fragment>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiFormRow
-                label={
-                  <FormattedMessage
-                    id="xpack.ml.calendarsEdit.newEventModal.fromLabel"
-                    defaultMessage="From:"
-                  />
-                }
-                helpText={TIME_FORMAT}
-              >
-                <EuiFieldText
-                  name="startTime"
-                  onChange={this.handleTimeStartChange}
-                  placeholder={TIME_FORMAT}
-                  value={startDateString}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFormRow
-                label={
-                  <FormattedMessage
-                    id="xpack.ml.calendarsEdit.newEventModal.toLabel"
-                    defaultMessage="To:"
-                  />
-                }
-                helpText={TIME_FORMAT}
-              >
-                <EuiFieldText
-                  name="endTime"
-                  onChange={this.handleTimeEndChange}
-                  placeholder={TIME_FORMAT}
-                  value={endDateString}
-                />
-              </EuiFormRow>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </Fragment>
-      );
-
-      return (
-        <Fragment>
-          <EuiSpacer size="s" />
-          {timeInputs}
-          <EuiSpacer size="s" />
-          <EuiFormRow fullWidth>
-            <EuiDatePickerRange
-              fullWidth
-              iconType={false}
-              startDateControl={
-                <EuiDatePicker
-                  fullWidth
-                  inline
-                  selected={startDate}
-                  onChange={this.handleChangeStart}
-                  startDate={startDate}
-                  endDate={endDate}
-                  isInvalid={startDate > endDate}
-                  aria-label={intl.formatMessage({
-                    id: 'xpack.ml.calendarsEdit.newEventModal.startDateAriaLabel',
-                    defaultMessage: 'Start date',
-                  })}
-                  timeFormat={TIME_FORMAT}
-                  dateFormat={TIME_FORMAT}
-                />
-              }
-              endDateControl={
-                <EuiDatePicker
-                  fullWidth
-                  inline
-                  selected={endDate}
-                  onChange={this.handleChangeEnd}
-                  startDate={startDate}
-                  endDate={endDate}
-                  isInvalid={startDate > endDate}
-                  aria-label={intl.formatMessage({
-                    id: 'xpack.ml.calendarsEdit.newEventModal.endDateAriaLabel',
-                    defaultMessage: 'End date',
-                  })}
-                  timeFormat={TIME_FORMAT}
-                  dateFormat={TIME_FORMAT}
-                />
-              }
-            />
-          </EuiFormRow>
-        </Fragment>
-      );
-    };
-
-    render() {
-      const { closeModal } = this.props;
-      const { description } = this.state;
-
-      return (
-        <Fragment>
-          <EuiModal onClose={closeModal} initialFocus="[name=eventDescription]" maxWidth={false}>
-            <EuiModalHeader>
-              <EuiModalHeaderTitle>
-                <FormattedMessage
-                  id="xpack.ml.calendarsEdit.newEventModal.createNewEventTitle"
-                  defaultMessage="Create new event"
-                />
-              </EuiModalHeaderTitle>
-            </EuiModalHeader>
-
-            <EuiModalBody>
-              <EuiForm>
-                <EuiFormRow
-                  label={
-                    <FormattedMessage
-                      id="xpack.ml.calendarsEdit.newEventModal.descriptionLabel"
-                      defaultMessage="Description"
-                    />
-                  }
-                  fullWidth
-                >
-                  <EuiFieldText
-                    name="eventDescription"
-                    onChange={this.onDescriptionChange}
-                    isInvalid={!description}
-                    fullWidth
-                  />
-                </EuiFormRow>
-                <EuiSpacer size="m" />
-                {this.renderRangedDatePicker()}
-              </EuiForm>
-            </EuiModalBody>
-
-            <EuiModalFooter>
-              <EuiButtonEmpty onClick={closeModal}>
-                <FormattedMessage
-                  id="xpack.ml.calendarsEdit.newEventModal.cancelButtonLabel"
-                  defaultMessage="Cancel"
-                />
-              </EuiButtonEmpty>
-              <EuiButton onClick={this.handleAddEvent} fill disabled={!description}>
-                <FormattedMessage
-                  id="xpack.ml.calendarsEdit.newEventModal.addButtonLabel"
-                  defaultMessage="Add"
-                />
-              </EuiButton>
-            </EuiModalFooter>
-          </EuiModal>
-        </Fragment>
-      );
     }
   }
-);
+
+  handleTimeEndChange = (event) => {
+    const dateString = event.target.value;
+    let isValidDate = false;
+
+    if (dateString.length === VALID_DATE_STRING_LENGTH) {
+      isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
+    } else {
+      this.setState({
+        endDateString: dateString,
+      });
+    }
+
+    if (isValidDate) {
+      this.setState({
+        endDateString: dateString,
+        endDate: moment(dateString)
+      });
+    }
+  }
+
+  renderRangedDatePicker = () => {
+    const {
+      startDate,
+      endDate,
+      startDateString,
+      endDateString,
+    } = this.state;
+
+    const { intl } = this.props;
+
+    const timeInputs = (
+      <Fragment>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiFormRow
+              label={<FormattedMessage
+                id="xpack.ml.calendarsEdit.newEventModal.fromLabel"
+                defaultMessage="From:"
+              />}
+              helpText={TIME_FORMAT}
+            >
+              <EuiFieldText
+                name="startTime"
+                onChange={this.handleTimeStartChange}
+                placeholder={TIME_FORMAT}
+                value={startDateString}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow
+              label={<FormattedMessage
+                id="xpack.ml.calendarsEdit.newEventModal.toLabel"
+                defaultMessage="To:"
+              />}
+              helpText={TIME_FORMAT}
+            >
+              <EuiFieldText
+                name="endTime"
+                onChange={this.handleTimeEndChange}
+                placeholder={TIME_FORMAT}
+                value={endDateString}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </Fragment>
+    );
+
+    return (
+      <Fragment>
+        <EuiSpacer size="s" />
+        {timeInputs}
+        <EuiSpacer size="s" />
+        <EuiFormRow fullWidth>
+          <EuiDatePickerRange
+            fullWidth
+            iconType={false}
+            startDateControl={
+              <EuiDatePicker
+                fullWidth
+                inline
+                selected={startDate}
+                onChange={this.handleChangeStart}
+                startDate={startDate}
+                endDate={endDate}
+                isInvalid={startDate > endDate}
+                aria-label={intl.formatMessage({
+                  id: 'xpack.ml.calendarsEdit.newEventModal.startDateAriaLabel',
+                  defaultMessage: 'Start date'
+                })}
+                timeFormat={TIME_FORMAT}
+                dateFormat={TIME_FORMAT}
+              />
+            }
+            endDateControl={
+              <EuiDatePicker
+                fullWidth
+                inline
+                selected={endDate}
+                onChange={this.handleChangeEnd}
+                startDate={startDate}
+                endDate={endDate}
+                isInvalid={startDate > endDate}
+                aria-label={intl.formatMessage({
+                  id: 'xpack.ml.calendarsEdit.newEventModal.endDateAriaLabel',
+                  defaultMessage: 'End date'
+                })}
+                timeFormat={TIME_FORMAT}
+                dateFormat={TIME_FORMAT}
+              />
+            }
+          />
+        </EuiFormRow>
+      </Fragment>
+    );
+  }
+
+  render() {
+    const { closeModal } = this.props;
+    const { description } = this.state;
+
+    return (
+      <Fragment>
+        <EuiModal
+          onClose={closeModal}
+          initialFocus="[name=eventDescription]"
+          maxWidth={false}
+        >
+          <EuiModalHeader>
+            <EuiModalHeaderTitle >
+              <FormattedMessage
+                id="xpack.ml.calendarsEdit.newEventModal.createNewEventTitle"
+                defaultMessage="Create new event"
+              />
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            <EuiForm>
+              <EuiFormRow
+                label={<FormattedMessage
+                  id="xpack.ml.calendarsEdit.newEventModal.descriptionLabel"
+                  defaultMessage="Description"
+                />}
+                fullWidth
+              >
+                <EuiFieldText
+                  name="eventDescription"
+                  onChange={this.onDescriptionChange}
+                  isInvalid={!description}
+                  fullWidth
+                />
+              </EuiFormRow>
+              {this.renderRangedDatePicker()}
+
+            </EuiForm>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiButtonEmpty
+              onClick={closeModal}
+            >
+              <FormattedMessage
+                id="xpack.ml.calendarsEdit.newEventModal.cancelButtonLabel"
+                defaultMessage="Cancel"
+              />
+            </EuiButtonEmpty>
+            <EuiButton
+              onClick={this.handleAddEvent}
+              fill
+              disabled={!description}
+            >
+              <FormattedMessage
+                id="xpack.ml.calendarsEdit.newEventModal.addButtonLabel"
+                defaultMessage="Add"
+              />
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      </Fragment>
+    );
+  }
+});

--- a/x-pack/legacy/plugins/ml/public/settings/calendars/edit/new_event_modal/new_event_modal.js
+++ b/x-pack/legacy/plugins/ml/public/settings/calendars/edit/new_event_modal/new_event_modal.js
@@ -4,11 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-
-import React, {
-  Component,
-  Fragment
-} from 'react';
+import React, { Component, Fragment } from 'react';
 import { PropTypes } from 'prop-types';
 import {
   EuiButton,
@@ -35,289 +31,284 @@ import { FormattedMessage, injectI18n } from '@kbn/i18n/react';
 
 const VALID_DATE_STRING_LENGTH = 19;
 
-export const NewEventModal = injectI18n(class NewEventModal extends Component {
-  static propTypes = {
-    closeModal: PropTypes.func.isRequired,
-    addEvent: PropTypes.func.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-
-    const startDate = moment().startOf('day');
-    const endDate = moment().startOf('day').add(1, 'days');
-
-    this.state = {
-      startDate,
-      endDate,
-      description: '',
-      startDateString: startDate.format(TIME_FORMAT),
-      endDateString: endDate.format(TIME_FORMAT)
-    };
-  }
-
-  onDescriptionChange = (e) => {
-    this.setState({
-      description: e.target.value,
-    });
-  };
-
-  handleAddEvent = () => {
-    const { description, startDate, endDate } = this.state;
-    // Temp reference to unsaved events to allow removal from table
-    const tempId = generateTempId();
-
-    const event = {
-      description,
-      start_time: startDate.valueOf(),
-      end_time: endDate.valueOf(),
-      event_id: tempId
+export const NewEventModal = injectI18n(
+  class NewEventModal extends Component {
+    static propTypes = {
+      closeModal: PropTypes.func.isRequired,
+      addEvent: PropTypes.func.isRequired,
     };
 
-    this.props.addEvent(event);
-  }
+    constructor(props) {
+      super(props);
 
-  handleChangeStart = (date) => {
-    let start = null;
-    let end = this.state.endDate;
+      const startDate = moment().startOf('day');
+      const endDate = moment()
+        .startOf('day')
+        .add(1, 'days');
 
-    const startMoment = moment(date);
-    const endMoment = moment(date);
-
-    start = startMoment.startOf('day');
-
-    if (start > end) {
-      end = endMoment.startOf('day').add(1, 'days');
+      this.state = {
+        startDate,
+        endDate,
+        description: '',
+        startDateString: startDate.format(TIME_FORMAT),
+        endDateString: endDate.format(TIME_FORMAT),
+      };
     }
-    this.setState({
-      startDate: start,
-      endDate: end,
-      startDateString: start.format(TIME_FORMAT),
-      endDateString: end.format(TIME_FORMAT)
-    });
-  }
 
-  handleChangeEnd = (date) => {
-    let start = this.state.startDate;
-    let end = null;
-
-    const startMoment = moment(date);
-    const endMoment = moment(date);
-
-    end = endMoment.startOf('day');
-
-    if (start > end) {
-      start = startMoment.startOf('day').subtract(1, 'days');
-    }
-    this.setState({
-      startDate: start,
-      endDate: end,
-      startDateString: start.format(TIME_FORMAT),
-      endDateString: end.format(TIME_FORMAT)
-    });
-  }
-
-  handleTimeStartChange = (event) => {
-    const dateString = event.target.value;
-    let isValidDate = false;
-
-    if (dateString.length === VALID_DATE_STRING_LENGTH) {
-      isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
-    } else {
+    onDescriptionChange = e => {
       this.setState({
-        startDateString: dateString,
+        description: e.target.value,
       });
-    }
+    };
 
-    if (isValidDate) {
+    handleAddEvent = () => {
+      const { description, startDate, endDate } = this.state;
+      // Temp reference to unsaved events to allow removal from table
+      const tempId = generateTempId();
+
+      const event = {
+        description,
+        start_time: startDate.valueOf(),
+        end_time: endDate.valueOf(),
+        event_id: tempId,
+      };
+
+      this.props.addEvent(event);
+    };
+
+    handleChangeStart = date => {
+      let start = null;
+      let end = this.state.endDate;
+
+      const startMoment = moment(date);
+      const endMoment = moment(date);
+
+      start = startMoment.startOf('day');
+
+      if (start > end) {
+        end = endMoment.startOf('day').add(1, 'days');
+      }
       this.setState({
-        startDateString: dateString,
-        startDate: moment(dateString)
+        startDate: start,
+        endDate: end,
+        startDateString: start.format(TIME_FORMAT),
+        endDateString: end.format(TIME_FORMAT),
       });
-    }
-  }
+    };
 
-  handleTimeEndChange = (event) => {
-    const dateString = event.target.value;
-    let isValidDate = false;
+    handleChangeEnd = date => {
+      let start = this.state.startDate;
+      let end = null;
 
-    if (dateString.length === VALID_DATE_STRING_LENGTH) {
-      isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
-    } else {
+      const startMoment = moment(date);
+      const endMoment = moment(date);
+
+      end = endMoment.startOf('day');
+
+      if (start > end) {
+        start = startMoment.startOf('day').subtract(1, 'days');
+      }
       this.setState({
-        endDateString: dateString,
+        startDate: start,
+        endDate: end,
+        startDateString: start.format(TIME_FORMAT),
+        endDateString: end.format(TIME_FORMAT),
       });
-    }
+    };
 
-    if (isValidDate) {
-      this.setState({
-        endDateString: dateString,
-        endDate: moment(dateString)
-      });
-    }
-  }
+    handleTimeStartChange = event => {
+      const dateString = event.target.value;
+      let isValidDate = false;
 
-  renderRangedDatePicker = () => {
-    const {
-      startDate,
-      endDate,
-      startDateString,
-      endDateString,
-    } = this.state;
+      if (dateString.length === VALID_DATE_STRING_LENGTH) {
+        isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
+      } else {
+        this.setState({
+          startDateString: dateString,
+        });
+      }
 
-    const { intl } = this.props;
+      if (isValidDate) {
+        this.setState({
+          startDateString: dateString,
+          startDate: moment(dateString),
+        });
+      }
+    };
 
-    const timeInputs = (
-      <Fragment>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiFormRow
-              label={<FormattedMessage
-                id="xpack.ml.calendarsEdit.newEventModal.fromLabel"
-                defaultMessage="From:"
-              />}
-              helpText={TIME_FORMAT}
-            >
-              <EuiFieldText
-                name="startTime"
-                onChange={this.handleTimeStartChange}
-                placeholder={TIME_FORMAT}
-                value={startDateString}
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFormRow
-              label={<FormattedMessage
-                id="xpack.ml.calendarsEdit.newEventModal.toLabel"
-                defaultMessage="To:"
-              />}
-              helpText={TIME_FORMAT}
-            >
-              <EuiFieldText
-                name="endTime"
-                onChange={this.handleTimeEndChange}
-                placeholder={TIME_FORMAT}
-                value={endDateString}
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </Fragment>
-    );
+    handleTimeEndChange = event => {
+      const dateString = event.target.value;
+      let isValidDate = false;
 
-    return (
-      <Fragment>
-        <EuiSpacer size="s" />
-        {timeInputs}
-        <EuiSpacer size="s" />
-        <EuiFormRow fullWidth>
-          <EuiDatePickerRange
-            fullWidth
-            iconType={false}
-            startDateControl={
-              <EuiDatePicker
-                fullWidth
-                inline
-                selected={startDate}
-                onChange={this.handleChangeStart}
-                startDate={startDate}
-                endDate={endDate}
-                isInvalid={startDate > endDate}
-                aria-label={intl.formatMessage({
-                  id: 'xpack.ml.calendarsEdit.newEventModal.startDateAriaLabel',
-                  defaultMessage: 'Start date'
-                })}
-                timeFormat={TIME_FORMAT}
-                dateFormat={TIME_FORMAT}
-              />
-            }
-            endDateControl={
-              <EuiDatePicker
-                fullWidth
-                inline
-                selected={endDate}
-                onChange={this.handleChangeEnd}
-                startDate={startDate}
-                endDate={endDate}
-                isInvalid={startDate > endDate}
-                aria-label={intl.formatMessage({
-                  id: 'xpack.ml.calendarsEdit.newEventModal.endDateAriaLabel',
-                  defaultMessage: 'End date'
-                })}
-                timeFormat={TIME_FORMAT}
-                dateFormat={TIME_FORMAT}
-              />
-            }
-          />
-        </EuiFormRow>
-      </Fragment>
-    );
-  }
+      if (dateString.length === VALID_DATE_STRING_LENGTH) {
+        isValidDate = moment(dateString).isValid(TIME_FORMAT, true);
+      } else {
+        this.setState({
+          endDateString: dateString,
+        });
+      }
 
-  render() {
-    const { closeModal } = this.props;
-    const { description } = this.state;
+      if (isValidDate) {
+        this.setState({
+          endDateString: dateString,
+          endDate: moment(dateString),
+        });
+      }
+    };
 
-    return (
-      <Fragment>
-        <EuiModal
-          onClose={closeModal}
-          initialFocus="[name=eventDescription]"
-          maxWidth={false}
-        >
-          <EuiModalHeader>
-            <EuiModalHeaderTitle >
-              <FormattedMessage
-                id="xpack.ml.calendarsEdit.newEventModal.createNewEventTitle"
-                defaultMessage="Create new event"
-              />
-            </EuiModalHeaderTitle>
-          </EuiModalHeader>
+    renderRangedDatePicker = () => {
+      const { startDate, endDate, startDateString, endDateString } = this.state;
 
-          <EuiModalBody>
-            <EuiForm>
+      const { intl } = this.props;
+
+      const timeInputs = (
+        <Fragment>
+          <EuiFlexGroup>
+            <EuiFlexItem>
               <EuiFormRow
-                label={<FormattedMessage
-                  id="xpack.ml.calendarsEdit.newEventModal.descriptionLabel"
-                  defaultMessage="Description"
-                />}
-                fullWidth
+                label={
+                  <FormattedMessage
+                    id="xpack.ml.calendarsEdit.newEventModal.fromLabel"
+                    defaultMessage="From:"
+                  />
+                }
+                helpText={TIME_FORMAT}
               >
                 <EuiFieldText
-                  name="eventDescription"
-                  onChange={this.onDescriptionChange}
-                  isInvalid={!description}
-                  fullWidth
+                  name="startTime"
+                  onChange={this.handleTimeStartChange}
+                  placeholder={TIME_FORMAT}
+                  value={startDateString}
                 />
               </EuiFormRow>
-              {this.renderRangedDatePicker()}
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormattedMessage
+                    id="xpack.ml.calendarsEdit.newEventModal.toLabel"
+                    defaultMessage="To:"
+                  />
+                }
+                helpText={TIME_FORMAT}
+              >
+                <EuiFieldText
+                  name="endTime"
+                  onChange={this.handleTimeEndChange}
+                  placeholder={TIME_FORMAT}
+                  value={endDateString}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </Fragment>
+      );
 
-            </EuiForm>
-          </EuiModalBody>
+      return (
+        <Fragment>
+          <EuiSpacer size="s" />
+          {timeInputs}
+          <EuiSpacer size="s" />
+          <EuiFormRow fullWidth>
+            <EuiDatePickerRange
+              fullWidth
+              iconType={false}
+              startDateControl={
+                <EuiDatePicker
+                  fullWidth
+                  inline
+                  selected={startDate}
+                  onChange={this.handleChangeStart}
+                  startDate={startDate}
+                  endDate={endDate}
+                  isInvalid={startDate > endDate}
+                  aria-label={intl.formatMessage({
+                    id: 'xpack.ml.calendarsEdit.newEventModal.startDateAriaLabel',
+                    defaultMessage: 'Start date',
+                  })}
+                  timeFormat={TIME_FORMAT}
+                  dateFormat={TIME_FORMAT}
+                />
+              }
+              endDateControl={
+                <EuiDatePicker
+                  fullWidth
+                  inline
+                  selected={endDate}
+                  onChange={this.handleChangeEnd}
+                  startDate={startDate}
+                  endDate={endDate}
+                  isInvalid={startDate > endDate}
+                  aria-label={intl.formatMessage({
+                    id: 'xpack.ml.calendarsEdit.newEventModal.endDateAriaLabel',
+                    defaultMessage: 'End date',
+                  })}
+                  timeFormat={TIME_FORMAT}
+                  dateFormat={TIME_FORMAT}
+                />
+              }
+            />
+          </EuiFormRow>
+        </Fragment>
+      );
+    };
 
-          <EuiModalFooter>
-            <EuiButtonEmpty
-              onClick={closeModal}
-            >
-              <FormattedMessage
-                id="xpack.ml.calendarsEdit.newEventModal.cancelButtonLabel"
-                defaultMessage="Cancel"
-              />
-            </EuiButtonEmpty>
-            <EuiButton
-              onClick={this.handleAddEvent}
-              fill
-              disabled={!description}
-            >
-              <FormattedMessage
-                id="xpack.ml.calendarsEdit.newEventModal.addButtonLabel"
-                defaultMessage="Add"
-              />
-            </EuiButton>
-          </EuiModalFooter>
-        </EuiModal>
-      </Fragment>
-    );
+    render() {
+      const { closeModal } = this.props;
+      const { description } = this.state;
+
+      return (
+        <Fragment>
+          <EuiModal onClose={closeModal} initialFocus="[name=eventDescription]" maxWidth={false}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <FormattedMessage
+                  id="xpack.ml.calendarsEdit.newEventModal.createNewEventTitle"
+                  defaultMessage="Create new event"
+                />
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+
+            <EuiModalBody>
+              <EuiForm>
+                <EuiFormRow
+                  label={
+                    <FormattedMessage
+                      id="xpack.ml.calendarsEdit.newEventModal.descriptionLabel"
+                      defaultMessage="Description"
+                    />
+                  }
+                  fullWidth
+                >
+                  <EuiFieldText
+                    name="eventDescription"
+                    onChange={this.onDescriptionChange}
+                    isInvalid={!description}
+                    fullWidth
+                  />
+                </EuiFormRow>
+                <EuiSpacer size="m" />
+                {this.renderRangedDatePicker()}
+              </EuiForm>
+            </EuiModalBody>
+
+            <EuiModalFooter>
+              <EuiButtonEmpty onClick={closeModal}>
+                <FormattedMessage
+                  id="xpack.ml.calendarsEdit.newEventModal.cancelButtonLabel"
+                  defaultMessage="Cancel"
+                />
+              </EuiButtonEmpty>
+              <EuiButton onClick={this.handleAddEvent} fill disabled={!description}>
+                <FormattedMessage
+                  id="xpack.ml.calendarsEdit.newEventModal.addButtonLabel"
+                  defaultMessage="Add"
+                />
+              </EuiButton>
+            </EuiModalFooter>
+          </EuiModal>
+        </Fragment>
+      );
+    }
   }
-});
+);

--- a/x-pack/legacy/plugins/ml/public/settings/filter_lists/components/add_item_popover/__snapshots__/add_item_popover.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/settings/filter_lists/components/add_item_popover/__snapshots__/add_item_popover.test.js.snap
@@ -32,6 +32,7 @@ exports[`AddItemPopover calls addItems with multiple items on clicking Add butto
     <EuiForm>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -117,6 +118,7 @@ exports[`AddItemPopover opens the popover onButtonClick 1`] = `
     <EuiForm>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -202,6 +204,7 @@ exports[`AddItemPopover renders the popover 1`] = `
     <EuiForm>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={

--- a/x-pack/legacy/plugins/ml/public/settings/filter_lists/components/edit_description_popover/__snapshots__/edit_description_popover.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/settings/filter_lists/components/edit_description_popover/__snapshots__/edit_description_popover.test.js.snap
@@ -32,6 +32,7 @@ exports[`FilterListUsagePopover opens the popover onButtonClick 1`] = `
       <EuiForm>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={
@@ -90,6 +91,7 @@ exports[`FilterListUsagePopover renders the popover with a description 1`] = `
       <EuiForm>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={
@@ -148,6 +150,7 @@ exports[`FilterListUsagePopover renders the popover with no description 1`] = `
       <EuiForm>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={false}
           hasEmptyLabelSpace={false}
           label={

--- a/x-pack/legacy/plugins/ml/public/settings/filter_lists/edit/__snapshots__/header.test.js.snap
+++ b/x-pack/legacy/plugins/ml/public/settings/filter_lists/edit/__snapshots__/header.test.js.snap
@@ -54,6 +54,7 @@ exports[`EditFilterListHeader renders the header when creating a new filter list
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={false}
     hasEmptyLabelSpace={false}
     helpText="Use lowercase alphanumerics (a-z and 0-9), hyphens or underscores; must start and end with an alphanumeric character"
@@ -161,6 +162,7 @@ exports[`EditFilterListHeader renders the header when creating a new filter list
   />
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     error={
       Array [
         "Use lowercase alphanumerics (a-z and 0-9), hyphens or underscores; must start and end with an alphanumeric character",

--- a/x-pack/legacy/plugins/remote_clusters/public/app/sections/components/remote_cluster_form/__snapshots__/remote_cluster_form.test.js.snap
+++ b/x-pack/legacy/plugins/remote_clusters/public/app/sections/components/remote_cluster_form/__snapshots__/remote_cluster_form.test.js.snap
@@ -42,36 +42,42 @@ Array [
             data-test-subj="remoteClusterFormNameFormRow"
             id="mockId-row"
           >
-            <div>
+            <div
+              class="euiFormRow__labelWrapper"
+            >
               <label
                 aria-invalid="false"
-                class="euiFormLabel"
+                class="euiFormLabel euiFormRow__label"
                 for="mockId"
               >
                 Name
               </label>
             </div>
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormControlLayout__childrenWrapper"
+                class="euiFormControlLayout euiFormControlLayout--fullWidth"
               >
-                <input
-                  aria-describedby="mockId-help"
-                  class="euiFieldText euiFieldText--fullWidth"
-                  data-test-subj="remoteClusterFormNameInput"
-                  id="mockId"
-                  type="text"
-                  value=""
-                />
+                <div
+                  class="euiFormControlLayout__childrenWrapper"
+                >
+                  <input
+                    aria-describedby="mockId-help"
+                    class="euiFieldText euiFieldText--fullWidth"
+                    data-test-subj="remoteClusterFormNameInput"
+                    id="mockId"
+                    type="text"
+                    value=""
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="mockId-help"
-            >
-              Name can only contain letters, numbers, underscores, and dashes.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="mockId-help"
+              >
+                Name can only contain letters, numbers, underscores, and dashes.
+              </div>
             </div>
           </div>
         </div>
@@ -114,70 +120,76 @@ Array [
             data-test-subj="remoteClusterFormSeedNodesFormRow"
             id="mockId-row"
           >
-            <div>
+            <div
+              class="euiFormRow__labelWrapper"
+            >
               <label
                 aria-invalid="false"
-                class="euiFormLabel"
+                class="euiFormLabel euiFormRow__label"
                 for="mockId"
               >
                 Seed nodes
               </label>
             </div>
             <div
-              aria-describedby="mockId-help"
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              class="euiComboBox euiComboBox--fullWidth"
-              data-test-subj="remoteClusterFormSeedsInput"
-              role="combobox"
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                aria-describedby="mockId-help"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="euiComboBox euiComboBox--fullWidth"
+                data-test-subj="remoteClusterFormSeedsInput"
+                role="combobox"
               >
                 <div
-                  class="euiFormControlLayout__childrenWrapper"
+                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
                 >
                   <div
-                    class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
-                    data-test-subj="comboBoxInput"
-                    tabindex="-1"
+                    class="euiFormControlLayout__childrenWrapper"
                   >
-                    <p
-                      class="euiComboBoxPlaceholder"
-                    >
-                      host:port
-                    </p>
                     <div
-                      class="euiComboBox__input"
-                      style="font-size:14px;display:inline-block"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
+                      data-test-subj="comboBoxInput"
+                      tabindex="-1"
                     >
-                      <input
-                        data-test-subj="comboBoxSearchInput"
-                        id="mockId"
-                        role="textbox"
-                        style="box-sizing:content-box;width:1px"
-                        value=""
-                      />
+                      <p
+                        class="euiComboBoxPlaceholder"
+                      >
+                        host:port
+                      </p>
                       <div
-                        style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                      />
+                        class="euiComboBox__input"
+                        style="font-size:14px;display:inline-block"
+                      >
+                        <input
+                          data-test-subj="comboBoxSearchInput"
+                          id="mockId"
+                          role="textbox"
+                          style="box-sizing:content-box;width:1px"
+                          value=""
+                        />
+                        <div
+                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="mockId-help"
-            >
-              An IP address or host name, followed by the 
-              <button
-                class="euiLink euiLink--primary"
-                type="button"
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="mockId-help"
               >
-                transport port
-              </button>
-               of the remote cluster.
+                An IP address or host name, followed by the 
+                <button
+                  class="euiLink euiLink--primary"
+                  type="button"
+                >
+                  transport port
+                </button>
+                 of the remote cluster.
+              </div>
             </div>
           </div>
         </div>
@@ -233,47 +245,51 @@ Array [
             id="mockId-row"
           >
             <div
-              class="euiSwitch"
+              class="euiFormRow__fieldWrapper"
             >
-              <input
-                class="euiSwitch__input"
-                data-test-subj="remoteClusterFormSkipUnavailableFormToggle"
-                id="mockId"
-                type="checkbox"
-              />
-              <span
-                class="euiSwitch__body"
+              <div
+                class="euiSwitch"
               >
-                <span
-                  class="euiSwitch__thumb"
+                <input
+                  class="euiSwitch__input"
+                  data-test-subj="remoteClusterFormSkipUnavailableFormToggle"
+                  id="mockId"
+                  type="checkbox"
                 />
                 <span
-                  class="euiSwitch__track"
+                  class="euiSwitch__body"
                 >
-                  <svg
-                    class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
-                    focusable="false"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    class="euiSwitch__thumb"
                   />
-                  <svg
-                    class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
-                    focusable="false"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  <span
+                    class="euiSwitch__track"
+                  >
+                    <svg
+                      class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <svg
+                      class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
+                      focusable="false"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </span>
                 </span>
-              </span>
-              <label
-                class="euiSwitch__label"
-                for="mockId"
-              >
-                Skip if unavailable
-              </label>
+                <label
+                  class="euiSwitch__label"
+                  for="mockId"
+                >
+                  Skip if unavailable
+                </label>
+              </div>
             </div>
           </div>
         </div>
@@ -352,66 +368,19 @@ Array [
     data-test-subj="remoteClusterFormNameFormRow"
     id="mockId-row"
   >
-    <div>
+    <div
+      class="euiFormRow__labelWrapper"
+    >
       <label
         aria-invalid="true"
-        class="euiFormLabel euiFormLabel-isInvalid"
+        class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
         for="mockId"
       >
         Name
       </label>
     </div>
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <input
-          aria-describedby="mockId-help mockId-error-0"
-          class="euiFieldText euiFieldText--fullWidth"
-          data-test-subj="remoteClusterFormNameInput"
-          id="mockId"
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      aria-live="polite"
-      class="euiFormErrorText euiFormRow__text"
-      id="mockId-error-0"
-    >
-      Name is required.
-    </div>
-    <div
-      class="euiFormHelpText euiFormRow__text"
-      id="mockId-help"
-    >
-      Name can only contain letters, numbers, underscores, and dashes.
-    </div>
-  </div>,
-  <div
-    class="euiFormRow euiFormRow--fullWidth"
-    data-test-subj="remoteClusterFormSeedNodesFormRow"
-    id="mockId-row"
-  >
-    <div>
-      <label
-        aria-invalid="true"
-        class="euiFormLabel euiFormLabel-isInvalid"
-        for="mockId"
-      >
-        Seed nodes
-      </label>
-    </div>
-    <div
-      aria-describedby="mockId-help mockId-error-0"
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      class="euiComboBox euiComboBox-isInvalid euiComboBox--fullWidth"
-      data-test-subj="remoteClusterFormSeedsInput"
-      role="combobox"
+      class="euiFormRow__fieldWrapper"
     >
       <div
         class="euiFormControlLayout euiFormControlLayout--fullWidth"
@@ -419,54 +388,113 @@ Array [
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
+          <input
+            aria-describedby="mockId-help mockId-error-0"
+            class="euiFieldText euiFieldText--fullWidth"
+            data-test-subj="remoteClusterFormNameInput"
+            id="mockId"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        aria-live="polite"
+        class="euiFormErrorText euiFormRow__text"
+        id="mockId-error-0"
+      >
+        Name is required.
+      </div>
+      <div
+        class="euiFormHelpText euiFormRow__text"
+        id="mockId-help"
+      >
+        Name can only contain letters, numbers, underscores, and dashes.
+      </div>
+    </div>
+  </div>,
+  <div
+    class="euiFormRow euiFormRow--fullWidth"
+    data-test-subj="remoteClusterFormSeedNodesFormRow"
+    id="mockId-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="true"
+        class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+        for="mockId"
+      >
+        Seed nodes
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="mockId-help mockId-error-0"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        class="euiComboBox euiComboBox-isInvalid euiComboBox--fullWidth"
+        data-test-subj="remoteClusterFormSeedsInput"
+        role="combobox"
+      >
+        <div
+          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+        >
           <div
-            class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
-            data-test-subj="comboBoxInput"
-            tabindex="-1"
+            class="euiFormControlLayout__childrenWrapper"
           >
-            <p
-              class="euiComboBoxPlaceholder"
-            >
-              host:port
-            </p>
             <div
-              class="euiComboBox__input"
-              style="font-size: 14px; display: inline-block;"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
+              data-test-subj="comboBoxInput"
+              tabindex="-1"
             >
-              <input
-                data-test-subj="comboBoxSearchInput"
-                id="mockId"
-                role="textbox"
-                style="box-sizing: content-box; width: 2px;"
-                value=""
-              />
+              <p
+                class="euiComboBoxPlaceholder"
+              >
+                host:port
+              </p>
               <div
-                style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
-              />
+                class="euiComboBox__input"
+                style="font-size: 14px; display: inline-block;"
+              >
+                <input
+                  data-test-subj="comboBoxSearchInput"
+                  id="mockId"
+                  role="textbox"
+                  style="box-sizing: content-box; width: 2px;"
+                  value=""
+                />
+                <div
+                  style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      aria-live="polite"
-      class="euiFormErrorText euiFormRow__text"
-      id="mockId-error-0"
-    >
-      At least one seed node is required.
-    </div>
-    <div
-      class="euiFormHelpText euiFormRow__text"
-      id="mockId-help"
-    >
-      An IP address or host name, followed by the 
-      <button
-        class="euiLink euiLink--primary"
-        type="button"
+      <div
+        aria-live="polite"
+        class="euiFormErrorText euiFormRow__text"
+        id="mockId-error-0"
       >
-        transport port
-      </button>
-       of the remote cluster.
+        At least one seed node is required.
+      </div>
+      <div
+        class="euiFormHelpText euiFormRow__text"
+        id="mockId-help"
+      >
+        An IP address or host name, followed by the 
+        <button
+          class="euiLink euiLink--primary"
+          type="button"
+        >
+          transport port
+        </button>
+         of the remote cluster.
+      </div>
     </div>
   </div>,
   <div
@@ -475,47 +503,51 @@ Array [
     id="mockId-row"
   >
     <div
-      class="euiSwitch"
+      class="euiFormRow__fieldWrapper"
     >
-      <input
-        class="euiSwitch__input"
-        data-test-subj="remoteClusterFormSkipUnavailableFormToggle"
-        id="mockId"
-        type="checkbox"
-      />
-      <span
-        class="euiSwitch__body"
+      <div
+        class="euiSwitch"
       >
-        <span
-          class="euiSwitch__thumb"
+        <input
+          class="euiSwitch__input"
+          data-test-subj="remoteClusterFormSkipUnavailableFormToggle"
+          id="mockId"
+          type="checkbox"
         />
         <span
-          class="euiSwitch__track"
+          class="euiSwitch__body"
         >
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="euiSwitch__thumb"
           />
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
+          <span
+            class="euiSwitch__track"
+          >
+            <svg
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
+            <svg
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
         </span>
-      </span>
-      <label
-        class="euiSwitch__label"
-        for="mockId"
-      >
-        Skip if unavailable
-      </label>
+        <label
+          class="euiSwitch__label"
+          for="mockId"
+        >
+          Skip if unavailable
+        </label>
+      </div>
     </div>
   </div>,
   <div

--- a/x-pack/legacy/plugins/rollup/public/crud_app/sections/job_create/steps/step_logistics.js
+++ b/x-pack/legacy/plugins/rollup/public/crud_app/sections/job_create/steps/step_logistics.js
@@ -179,6 +179,8 @@ export class StepLogisticsUi extends Component {
             />
           </EuiFormRow>
 
+          <EuiSpacer size="m" />
+
           <EuiText size="s">
             <EuiLink onClick={this.hideAdvancedCron}>
               <FormattedMessage

--- a/x-pack/legacy/plugins/security/public/views/login/components/basic_login_form/__snapshots__/basic_login_form.test.tsx.snap
+++ b/x-pack/legacy/plugins/security/public/views/login/components/basic_login_form/__snapshots__/basic_login_form.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`BasicLoginForm renders as expected 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={
@@ -36,6 +37,7 @@ exports[`BasicLoginForm renders as expected 1`] = `
       </EuiFormRow>
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         label={

--- a/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/es/__snapshots__/elasticsearch_privileges.test.tsx.snap
+++ b/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/es/__snapshots__/elasticsearch_privileges.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`it renders without crashing 1`] = `
   >
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={true}
       hasEmptyLabelSpace={true}
       labelType="label"
@@ -109,6 +110,7 @@ exports[`it renders without crashing 1`] = `
   >
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={true}
       labelType="label"

--- a/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/es/__snapshots__/index_privilege_form.test.tsx.snap
+++ b/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/es/__snapshots__/index_privilege_form.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`it renders without crashing 1`] = `
         <EuiFlexItem>
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={true}
             hasEmptyLabelSpace={false}
             isInvalid={false}
@@ -40,6 +41,7 @@ exports[`it renders without crashing 1`] = `
         <EuiFlexItem>
           <EuiFormRow
             describedByIds={Array []}
+            display="row"
             fullWidth={true}
             hasEmptyLabelSpace={false}
             label={
@@ -127,6 +129,7 @@ exports[`it renders without crashing 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={true}
         labelType="label"

--- a/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/kibana/simple_privilege_section/__snapshots__/simple_privilege_section.test.tsx.snap
+++ b/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/kibana/simple_privilege_section/__snapshots__/simple_privilege_section.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`<SimplePrivilegeForm> renders without crashing 1`] = `
   >
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={true}
       labelType="label"

--- a/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/kibana/space_aware_privilege_section/__snapshots__/privilege_space_form.test.tsx.snap
+++ b/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/kibana/space_aware_privilege_section/__snapshots__/privilege_space_form.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`<PrivilegeSpaceForm> renders without crashing 1`] = `
       <EuiForm>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={true}
           hasEmptyLabelSpace={false}
           label="Spaces"
@@ -160,6 +161,7 @@ exports[`<PrivilegeSpaceForm> renders without crashing 1`] = `
         </EuiFormRow>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           fullWidth={true}
           hasEmptyLabelSpace={false}
           label="Privilege"

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/components/policy_form/steps/step_logistics.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/components/policy_form/steps/step_logistics.tsx
@@ -405,6 +405,8 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
             />
           </EuiFormRow>
 
+          <EuiSpacer size="m" />
+
           <EuiText size="s">
             <EuiLink
               onClick={() => {

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/__snapshots__/confirm_delete_modal.test.tsx.snap
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/__snapshots__/confirm_delete_modal.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`ConfirmDeleteModal renders as expected 1`] = `
         </p>
         <EuiFormRow
           describedByIds={Array []}
+          display="row"
           error="Space names do not match."
           fullWidth={false}
           hasEmptyLabelSpace={false}

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/__snapshots__/confirm_delete_modal.test.tsx.snap
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/__snapshots__/confirm_delete_modal.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`ConfirmDeleteModal renders as expected 1`] = `
             value=""
           />
         </EuiFormRow>
+        <EuiSpacer />
         <EuiCallOut
           color="warning"
           size="m"

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/confirm_delete_modal.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/confirm_delete_modal.tsx
@@ -20,6 +20,7 @@ import {
   EuiModalHeaderTitle,
   EuiModalProps,
   EuiOverlayMask,
+  EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import { FormattedMessage, InjectedIntl, injectI18n } from '@kbn/i18n/react';
@@ -61,15 +62,18 @@ class ConfirmDeleteModalUI extends Component<Props, State> {
         </span>
       );
       warning = (
-        <EuiCallOut color="warning">
-          <EuiText>
-            <FormattedMessage
-              id="xpack.spaces.management.confirmDeleteModal.redirectAfterDeletingCurrentSpaceWarningMessage"
-              defaultMessage="You are about to delete your current space {name}. You will be redirected to choose a different space if you continue."
-              values={{ name }}
-            />
-          </EuiText>
-        </EuiCallOut>
+        <>
+          <EuiSpacer />
+          <EuiCallOut color="warning">
+            <EuiText>
+              <FormattedMessage
+                id="xpack.spaces.management.confirmDeleteModal.redirectAfterDeletingCurrentSpaceWarningMessage"
+                defaultMessage="You are about to delete your current space {name}. You will be redirected to choose a different space if you continue."
+                values={{ name }}
+              />
+            </EuiText>
+          </EuiCallOut>
+        </>
       );
     }
 

--- a/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/__snapshots__/customize_space_avatar.test.tsx.snap
+++ b/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/__snapshots__/customize_space_avatar.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders without crashing 1`] = `
   >
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       label="Initials (2 max)"
@@ -30,6 +31,7 @@ exports[`renders without crashing 1`] = `
   >
     <EuiFormRow
       describedByIds={Array []}
+      display="row"
       fullWidth={false}
       hasEmptyLabelSpace={false}
       isInvalid={false}

--- a/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/__snapshots__/customize_space_avatar.test.tsx.snap
+++ b/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/__snapshots__/customize_space_avatar.test.tsx.snap
@@ -4,46 +4,41 @@ exports[`renders without crashing 1`] = `
 <form
   onSubmit={[Function]}
 >
-  <EuiFlexItem
-    grow={false}
+  <EuiFormRow
+    describedByIds={Array []}
+    display="row"
+    fullWidth={false}
+    hasEmptyLabelSpace={false}
+    label="Initials (2 max)"
+    labelType="label"
   >
-    <EuiFormRow
-      describedByIds={Array []}
-      display="row"
+    <EuiFieldText
+      compressed={false}
       fullWidth={false}
-      hasEmptyLabelSpace={false}
-      label="Initials (2 max)"
-      labelType="label"
-    >
-      <EuiFieldText
-        compressed={false}
-        fullWidth={false}
-        inputRef={[Function]}
-        isLoading={false}
-        name="spaceInitials"
-        onChange={[Function]}
-        value=""
-      />
-    </EuiFormRow>
-  </EuiFlexItem>
-  <EuiFlexItem
-    grow={true}
+      inputRef={[Function]}
+      isLoading={false}
+      name="spaceInitials"
+      onChange={[Function]}
+      value=""
+    />
+  </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiFormRow
+    describedByIds={Array []}
+    display="row"
+    fullWidth={false}
+    hasEmptyLabelSpace={false}
+    isInvalid={false}
+    label="Color"
+    labelType="label"
   >
-    <EuiFormRow
-      describedByIds={Array []}
-      display="row"
-      fullWidth={false}
-      hasEmptyLabelSpace={false}
+    <EuiColorPicker
+      color="#BFA180"
       isInvalid={false}
-      label="Color"
-      labelType="label"
-    >
-      <EuiColorPicker
-        color="#BFA180"
-        isInvalid={false}
-        onChange={[Function]}
-      />
-    </EuiFormRow>
-  </EuiFlexItem>
+      onChange={[Function]}
+    />
+  </EuiFormRow>
 </form>
 `;

--- a/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/__snapshots__/space_identifier.test.tsx.snap
+++ b/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/__snapshots__/space_identifier.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders without crashing 1`] = `
 <Fragment>
   <EuiFormRow
     describedByIds={Array []}
+    display="row"
     fullWidth={true}
     hasEmptyLabelSpace={false}
     helpText={

--- a/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/customize_space_avatar.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/edit_space/customize_space/customize_space_avatar.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiColorPicker, EuiFieldText, EuiFlexItem, EuiFormRow, isValidHex } from '@elastic/eui';
+import { EuiColorPicker, EuiFieldText, EuiSpacer, EuiFormRow, isValidHex } from '@elastic/eui';
 import { InjectedIntl, injectI18n } from '@kbn/i18n/react';
 import React, { ChangeEvent, Component } from 'react';
 import { MAX_SPACE_INITIALS } from '../../../../../common/constants';
@@ -42,38 +42,35 @@ class CustomizeSpaceAvatarUI extends Component<Props, State> {
 
     return (
       <form onSubmit={() => false}>
-        <EuiFlexItem grow={false}>
-          <EuiFormRow
-            label={intl.formatMessage({
-              id: 'xpack.spaces.management.customizeSpaceAvatar.initialItemsFormRowLabel',
-              defaultMessage: 'Initials (2 max)',
-            })}
-          >
-            <EuiFieldText
-              inputRef={this.initialsInputRef}
-              name="spaceInitials"
-              // allows input to be cleared or otherwise invalidated while user is editing the initials,
-              // without defaulting to the derived initials provided by `getSpaceInitials`
-              value={initialsHasFocus ? pendingInitials || '' : getSpaceInitials(space)}
-              onChange={this.onInitialsChange}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={true}>
-          <EuiFormRow
-            label={intl.formatMessage({
-              id: 'xpack.spaces.management.customizeSpaceAvatar.colorFormRowLabel',
-              defaultMessage: 'Color',
-            })}
+        <EuiFormRow
+          label={intl.formatMessage({
+            id: 'xpack.spaces.management.customizeSpaceAvatar.initialItemsFormRowLabel',
+            defaultMessage: 'Initials (2 max)',
+          })}
+        >
+          <EuiFieldText
+            inputRef={this.initialsInputRef}
+            name="spaceInitials"
+            // allows input to be cleared or otherwise invalidated while user is editing the initials,
+            // without defaulting to the derived initials provided by `getSpaceInitials`
+            value={initialsHasFocus ? pendingInitials || '' : getSpaceInitials(space)}
+            onChange={this.onInitialsChange}
+          />
+        </EuiFormRow>
+        <EuiSpacer size="m" />
+        <EuiFormRow
+          label={intl.formatMessage({
+            id: 'xpack.spaces.management.customizeSpaceAvatar.colorFormRowLabel',
+            defaultMessage: 'Color',
+          })}
+          isInvalid={isInvalidSpaceColor}
+        >
+          <EuiColorPicker
+            color={spaceColor}
+            onChange={this.onColorChange}
             isInvalid={isInvalidSpaceColor}
-          >
-            <EuiColorPicker
-              color={spaceColor}
-              onChange={this.onColorChange}
-              isInvalid={isInvalidSpaceColor}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
+          />
+        </EuiFormRow>
       </form>
     );
   }

--- a/x-pack/legacy/plugins/uptime/public/components/functional/__tests__/__snapshots__/ping_list.test.tsx.snap
+++ b/x-pack/legacy/plugins/uptime/public/components/functional/__tests__/__snapshots__/ping_list.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`PingList component renders sorted list without errors 1`] = `
                 <EuiFormRow
                   aria-label="Status"
                   describedByIds={Array []}
+                  display="row"
                   fullWidth={false}
                   hasEmptyLabelSpace={false}
                   label="Status"
@@ -83,6 +84,7 @@ exports[`PingList component renders sorted list without errors 1`] = `
                 <EuiFormRow
                   aria-label="Location"
                   describedByIds={Array []}
+                  display="row"
                   fullWidth={false}
                   hasEmptyLabelSpace={false}
                   label="Location"

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -184,7 +184,7 @@
     "@babel/runtime": "^7.5.5",
     "@elastic/ctags-langserver": "^0.1.9",
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "13.8.1",
+    "@elastic/eui": "14.0.0",
     "@elastic/javascript-typescript-langserver": "^0.2.2",
     "@elastic/lsp-extension": "^0.1.2",
     "@elastic/maki": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,10 +983,10 @@
     tabbable "^1.1.0"
     uuid "^3.1.0"
 
-"@elastic/eui@13.8.1":
-  version "13.8.1"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-13.8.1.tgz#17bc50c634145a242be9fd4cdc78b857eadf60f3"
-  integrity sha512-4GbNpN3SIOFYviE2cfqIMCUmMf2KNSwEdMHP7cMwwa4u/W708NKOLB52Ipn0raWnWHAuIu9k5v9CrbaZfd1gdA==
+"@elastic/eui@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-14.0.0.tgz#4af6e687aec7b981a87dc4da15699f0d92ad17de"
+  integrity sha512-kU3WNPysOYZkgsrQOO1RmLgQmJWYmjVHw4w4HoliwLka2N9AtEYtNu+rFprkDwO7Pvd1lxb/mRPGdJ6NZtZdvA==
   dependencies:
     "@types/lodash" "^4.14.116"
     "@types/numeral" "^0.0.25"


### PR DESCRIPTION
## [`14.0.0`](https://github.com/elastic/eui/tree/v14.0.0)

### Feature: Compressed Form Controls ([#2167](https://github.com/elastic/eui/pull/2167))

- Altered the look of `compressed` form controls to look more subtle
- Created `EuiFormControlLayoutDelimited` for dual inputs indicating a range
- Added compressed and column style layouts to `EuiFormRow` via `display` prop
- Reduced overall height of `compressed` `EuiRange` and `EuiDualRange`
- Added `showInput = 'inputWithPopover'` option for `compressed` `EuiRange` and `EuiDualRange` to display the slider in a popover
- Made all inputs in the `EuiSuperDatePicker` popover `compressed`
- Added `controlOnly` prop to `EuiFieldText` and `EuiFieldNumber`
- Allow `style` prop to be passed down in `EuiColorPickerSwatch`
- `EuiFilePicker` now has `default` and `large` display sizes that both have `compressed` alternatives
- Allow strings to be passed as `append`/`prepend` props and added a11y support
- Added a max height with overflow to `EuiSuperSelect`

**Bug fixes**

- Fixed `EuiColorPicker` padding on right to accomodate down caret
- Fixed sizings of `EuiComboBox` and pills
- Fixed truncation on `EuiContextMenuItem`
- Fixed style of more `append`/`prepend` options of `EuiFormControlLayout`

**Deprecations**

- `EuiFormRow`'s `compressed` prop deprecated in favor of `display: rowCompressed`
- `EuiFormRow`'s `displayOnly` prop deprecated in favor of `display: center`

**Breaking changes**

- SASS mixin `euiTextOverflowWrap()` has been removed in favor of `euiTextBreakWord()`
- `EuiFormLabel` no longer has a bottom margin
- `EuiFormRow` no longer has bottom padding, nor does it add margin to any `+ *` siblings only sibling `EuiFormRow`s

## [`13.8.2`](https://github.com/elastic/eui/tree/v13.8.2)

**Bug fixes**

- Corrected `EuiCodeBlock`'s proptype for `children` to be string or array of strings. ([#2324](https://github.com/elastic/eui/pull/2324))
- Fixed `onClick` TypeScript definition for `EuiPanel` ([#2330](https://github.com/elastic/eui/pull/2330))
- Fixed `EuiComboBox` list reopening after closing on option selection in IE11 ([#2326](https://github.com/elastic/eui/pull/2326))


---

# The checklist

- [x] Fixed any **EuiFormRow** sibling spacing issues.
- [x] Fixed any compressed **EuiFormRow** children that didn't also have the `compressed` prop.
- [x] Fixed any **EuiFormLabel** sibling spacing issues
- [x] Fixed any **EuiFilePicker** `compressed` issues


---

# Follow up todos

- [ ] Uncomment `compressed` props on EuiCombBox because of missing TS type. Will be fixed in https://github.com/elastic/eui/pull/2338