### PR TITLE
[Infra UI] Throw Error object instead of response object from TSVB for any non 200 response

### DIFF
--- a/x-pack/legacy/plugins/infra/server/lib/adapters/framework/kibana_framework_adapter.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/framework/kibana_framework_adapter.ts
@@ -9,6 +9,7 @@ import { GraphQLSchema } from 'graphql';
 import { Legacy } from 'kibana';
 
 import { KibanaConfig } from 'src/legacy/server/kbn_server';
+import { i18n } from '@kbn/i18n';
 import { InfraMetricModel } from '../metrics/adapter_types';
 import {
   InfraBackendFrameworkAdapter,
@@ -185,8 +186,16 @@ export class InfraKibanaBackendFrameworkAdapter implements InfraBackendFramework
     };
 
     const res = await server.inject(request);
-    if (res.statusCode !== 200) {
-      throw res;
+    if (res.statusCode >= 300) {
+      const message = i18n.translate('xpack.infra.TSVBRequest.error', {
+        defaultMessage: 'Internal request: {method} {path} returned status code {statusCode}',
+        values: {
+          method: 'POST',
+          path: url,
+          statusCode: res.statusCode,
+        },
+      });
+      throw new Error(message);
     }
 
     return res.result as InfraTSVBResponse;


### PR DESCRIPTION
## Summary

This PR possibly fixes #45112 by throwing an actual error instead of the response object from the TSVB request for the Metrics Explorer. This will also affect the node detail page since it use the same interface for request metric data.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~