### PR TITLE
Create unit test for registerBuiltInActionTypes and move common code

### DIFF
--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/email.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/email.test.ts
@@ -9,13 +9,9 @@ jest.mock('./lib/send_email', () => ({
 }));
 
 import { ActionType, ActionTypeExecutorOptions } from '../types';
-import { ActionsConfigurationUtilities } from '../actions_config';
-import { ActionTypeRegistry } from '../action_type_registry';
-import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
-import { taskManagerMock } from '../../../task_manager/task_manager.mock';
-import { validateParams, validateConfig, validateSecrets } from '../lib';
+import { validateConfig, validateSecrets, validateParams } from '../lib';
 import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
-import { registerBuiltInActionTypes } from './index';
+import { createActionTypeRegistry } from './index.test';
 import { sendEmail } from './lib/send_email';
 import { ActionParamsType, ActionTypeConfigType, ActionTypeSecretsType } from './email';
 
@@ -23,12 +19,6 @@ const sendEmailMock = sendEmail as jest.Mock;
 
 const ACTION_TYPE_ID = '.email';
 const NO_OP_FN = () => {};
-const MOCK_KIBANA_CONFIG_UTILS: ActionsConfigurationUtilities = {
-  isWhitelistedHostname: _ => true,
-  isWhitelistedUri: _ => true,
-  ensureWhitelistedHostname: _ => {},
-  ensureWhitelistedUri: _ => {},
-};
 
 const services = {
   log: NO_OP_FN,
@@ -36,38 +26,15 @@ const services = {
   savedObjectsClient: SavedObjectsClientMock.create(),
 };
 
-function getServices() {
-  return services;
-}
-
-let actionTypeRegistry: ActionTypeRegistry;
 let actionType: ActionType;
 
-const mockEncryptedSavedObjectsPlugin = encryptedSavedObjectsMock.create();
-
 beforeAll(() => {
-  actionTypeRegistry = new ActionTypeRegistry({
-    getServices,
-    isSecurityEnabled: true,
-    taskManager: taskManagerMock.create(),
-    encryptedSavedObjectsPlugin: mockEncryptedSavedObjectsPlugin,
-    spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
-    getBasePath: jest.fn().mockReturnValue(undefined),
-  });
-
-  registerBuiltInActionTypes(actionTypeRegistry, MOCK_KIBANA_CONFIG_UTILS);
-
+  const actionTypeRegistry = createActionTypeRegistry();
   actionType = actionTypeRegistry.get(ACTION_TYPE_ID);
 });
 
 beforeEach(() => {
   jest.resetAllMocks();
-});
-
-describe('action is registered', () => {
-  test('gets registered with builtin actions', () => {
-    expect(actionTypeRegistry.has(ACTION_TYPE_ID)).toEqual(true);
-  });
 });
 
 describe('actionTypeRegistry.get() works', () => {

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/es_index.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/es_index.test.ts
@@ -9,23 +9,13 @@ jest.mock('./lib/send_email', () => ({
 }));
 
 import { ActionType, ActionTypeExecutorOptions } from '../types';
-import { ActionsConfigurationUtilities } from '../actions_config';
-import { ActionTypeRegistry } from '../action_type_registry';
-import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
-import { taskManagerMock } from '../../../task_manager/task_manager.mock';
 import { validateConfig, validateParams } from '../lib';
 import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
-import { registerBuiltInActionTypes } from './index';
+import { createActionTypeRegistry } from './index.test';
 import { ActionParamsType, ActionTypeConfigType } from './es_index';
 
 const ACTION_TYPE_ID = '.index';
 const NO_OP_FN = () => {};
-const MOCK_KIBANA_CONFIG_UTILS: ActionsConfigurationUtilities = {
-  isWhitelistedHostname: _ => true,
-  isWhitelistedUri: _ => true,
-  ensureWhitelistedHostname: _ => {},
-  ensureWhitelistedUri: _ => {},
-};
 
 const services = {
   log: NO_OP_FN,
@@ -33,38 +23,15 @@ const services = {
   savedObjectsClient: SavedObjectsClientMock.create(),
 };
 
-function getServices() {
-  return services;
-}
-
-let actionTypeRegistry: ActionTypeRegistry;
 let actionType: ActionType;
 
-const mockEncryptedSavedObjectsPlugin = encryptedSavedObjectsMock.create();
-
 beforeAll(() => {
-  actionTypeRegistry = new ActionTypeRegistry({
-    getServices,
-    isSecurityEnabled: true,
-    taskManager: taskManagerMock.create(),
-    encryptedSavedObjectsPlugin: mockEncryptedSavedObjectsPlugin,
-    spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
-    getBasePath: jest.fn().mockReturnValue(undefined),
-  });
-
-  registerBuiltInActionTypes(actionTypeRegistry, MOCK_KIBANA_CONFIG_UTILS);
-
+  const actionTypeRegistry = createActionTypeRegistry();
   actionType = actionTypeRegistry.get(ACTION_TYPE_ID);
 });
 
 beforeEach(() => {
   jest.resetAllMocks();
-});
-
-describe('action is registered', () => {
-  test('gets registered with builtin actions', () => {
-    expect(actionTypeRegistry.has(ACTION_TYPE_ID)).toEqual(true);
-  });
 });
 
 describe('actionTypeRegistry.get() works', () => {

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/index.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/index.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ActionsConfigurationUtilities } from '../actions_config';
+import { ActionTypeRegistry } from '../action_type_registry';
+import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
+import { taskManagerMock } from '../../../task_manager/task_manager.mock';
+import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { registerBuiltInActionTypes } from './index';
+
+const ACTION_TYPE_IDS = ['.index', '.email', '.pagerduty', '.server-log', '.slack', '.webhook'];
+const NO_OP_FN = () => {};
+const MOCK_KIBANA_CONFIG_UTILS: ActionsConfigurationUtilities = {
+  isWhitelistedHostname: _ => true,
+  isWhitelistedUri: _ => true,
+  ensureWhitelistedHostname: _ => {},
+  ensureWhitelistedUri: _ => {},
+};
+
+const services = {
+  log: NO_OP_FN,
+  callCluster: jest.fn(),
+  savedObjectsClient: SavedObjectsClientMock.create(),
+};
+
+function getServices() {
+  return services;
+}
+
+const mockEncryptedSavedObjectsPlugin = encryptedSavedObjectsMock.create();
+
+export function createActionTypeRegistry(): ActionTypeRegistry {
+  const actionTypeRegistry = new ActionTypeRegistry({
+    getServices,
+    isSecurityEnabled: true,
+    taskManager: taskManagerMock.create(),
+    encryptedSavedObjectsPlugin: mockEncryptedSavedObjectsPlugin,
+    spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
+    getBasePath: jest.fn().mockReturnValue(undefined),
+  });
+  registerBuiltInActionTypes(actionTypeRegistry, MOCK_KIBANA_CONFIG_UTILS);
+  return actionTypeRegistry;
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('action is registered', () => {
+  test('gets registered with builtin actions', () => {
+    const actionTypeRegistry = createActionTypeRegistry();
+    ACTION_TYPE_IDS.forEach(ACTION_TYPE_ID =>
+      expect(actionTypeRegistry.has(ACTION_TYPE_ID)).toEqual(true)
+    );
+  });
+});

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/pagerduty.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/pagerduty.test.ts
@@ -9,25 +9,15 @@ jest.mock('./lib/post_pagerduty', () => ({
 }));
 
 import { ActionType, Services, ActionTypeExecutorOptions } from '../types';
-import { ActionsConfigurationUtilities } from '../actions_config';
-import { ActionTypeRegistry } from '../action_type_registry';
-import { taskManagerMock } from '../../../task_manager/task_manager.mock';
-import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
 import { validateConfig, validateSecrets, validateParams } from '../lib';
 import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { postPagerduty } from './lib/post_pagerduty';
-import { registerBuiltInActionTypes } from './index';
+import { createActionTypeRegistry } from './index.test';
 
 const postPagerdutyMock = postPagerduty as jest.Mock;
 
 const ACTION_TYPE_ID = '.pagerduty';
 const NO_OP_FN = () => {};
-const MOCK_KIBANA_CONFIG_UTILS: ActionsConfigurationUtilities = {
-  isWhitelistedHostname: _ => true,
-  isWhitelistedUri: _ => true,
-  ensureWhitelistedHostname: _ => {},
-  ensureWhitelistedUri: _ => {},
-};
 
 const services: Services = {
   log: NO_OP_FN,
@@ -35,36 +25,15 @@ const services: Services = {
   savedObjectsClient: SavedObjectsClientMock.create(),
 };
 
-function getServices(): Services {
-  return services;
-}
-
 let actionType: ActionType;
-let actionTypeRegistry: ActionTypeRegistry;
-
-const mockEncryptedSavedObjectsPlugin = encryptedSavedObjectsMock.create();
 
 beforeAll(() => {
-  actionTypeRegistry = new ActionTypeRegistry({
-    getServices,
-    isSecurityEnabled: true,
-    taskManager: taskManagerMock.create(),
-    encryptedSavedObjectsPlugin: mockEncryptedSavedObjectsPlugin,
-    spaceIdToNamespace: jest.fn().mockReturnValue(undefined),
-    getBasePath: jest.fn().mockReturnValue(undefined),
-  });
-  registerBuiltInActionTypes(actionTypeRegistry, MOCK_KIBANA_CONFIG_UTILS);
+  const actionTypeRegistry = createActionTypeRegistry();
   actionType = actionTypeRegistry.get(ACTION_TYPE_ID);
 });
 
 beforeEach(() => {
   services.log = NO_OP_FN;
-});
-
-describe('action registation', () => {
-  test('should be successful', () => {
-    expect(actionTypeRegistry.has(ACTION_TYPE_ID)).toEqual(true);
-  });
 });
 
 describe('get()', () => {

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/webhook.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/webhook.test.ts
@@ -7,7 +7,10 @@
 import { getActionType } from './webhook';
 import { validateConfig, validateSecrets, validateParams } from '../lib';
 import { ActionsConfigurationUtilities } from '../actions_config';
+import { ActionType } from '../types';
+import { createActionTypeRegistry } from './index.test';
 
+const ACTION_TYPE_ID = '.webhook';
 const configUtilsMock: ActionsConfigurationUtilities = {
   isWhitelistedHostname: _ => true,
   isWhitelistedUri: _ => true,
@@ -15,9 +18,15 @@ const configUtilsMock: ActionsConfigurationUtilities = {
   ensureWhitelistedUri: _ => {},
 };
 
+let actionType: ActionType;
+
+beforeAll(() => {
+  const actionTypeRegistry = createActionTypeRegistry();
+  actionType = actionTypeRegistry.get(ACTION_TYPE_ID);
+});
+
 describe('actionType', () => {
   test('exposes the action as `webhook` on its Id and Name', () => {
-    const actionType = getActionType(configUtilsMock);
     expect(actionType.id).toEqual('.webhook');
     expect(actionType.name).toEqual('webhook');
   });
@@ -25,7 +34,6 @@ describe('actionType', () => {
 
 describe('secrets validation', () => {
   test('succeeds when secrets is valid', () => {
-    const actionType = getActionType(configUtilsMock);
     const secrets: Record<string, any> = {
       user: 'bob',
       password: 'supersecret',
@@ -35,7 +43,6 @@ describe('secrets validation', () => {
 
   test('fails when secret password is omitted', () => {
     expect(() => {
-      const actionType = getActionType(configUtilsMock);
       validateSecrets(actionType, { user: 'bob' });
     }).toThrowErrorMatchingInlineSnapshot(
       `"error validating action type secrets: [password]: expected value of type [string] but got [undefined]"`
@@ -44,7 +51,6 @@ describe('secrets validation', () => {
 
   test('fails when secret user is omitted', () => {
     expect(() => {
-      const actionType = getActionType(configUtilsMock);
       validateSecrets(actionType, {});
     }).toThrowErrorMatchingInlineSnapshot(
       `"error validating action type secrets: [user]: expected value of type [string] but got [undefined]"`
@@ -59,7 +65,6 @@ describe('config validation', () => {
   };
 
   test('config validation passes when only required fields are provided', () => {
-    const actionType = getActionType(configUtilsMock);
     const config: Record<string, any> = {
       url: 'http://mylisteningserver:9200/endpoint',
     };
@@ -70,7 +75,6 @@ describe('config validation', () => {
   });
 
   test('config validation passes when valid methods are provided', () => {
-    const actionType = getActionType(configUtilsMock);
     ['post', 'put'].forEach(method => {
       const config: Record<string, any> = {
         url: 'http://mylisteningserver:9200/endpoint',
@@ -84,7 +88,6 @@ describe('config validation', () => {
   });
 
   test('should validate and throw error when method on config is invalid', () => {
-    const actionType = getActionType(configUtilsMock);
     const config: Record<string, any> = {
       url: 'http://mylisteningserver:9200/endpoint',
       method: 'https',
@@ -99,7 +102,6 @@ describe('config validation', () => {
   });
 
   test('config validation passes when a url is specified', () => {
-    const actionType = getActionType(configUtilsMock);
     const config: Record<string, any> = {
       url: 'http://mylisteningserver:9200/endpoint',
     };
@@ -110,7 +112,6 @@ describe('config validation', () => {
   });
 
   test('config validation passes when valid headers are provided', () => {
-    const actionType = getActionType(configUtilsMock);
     const config: Record<string, any> = {
       url: 'http://mylisteningserver:9200/endpoint',
       headers: {
@@ -124,7 +125,6 @@ describe('config validation', () => {
   });
 
   test('should validate and throw error when headers on config is invalid', () => {
-    const actionType = getActionType(configUtilsMock);
     const config: Record<string, any> = {
       url: 'http://mylisteningserver:9200/endpoint',
       headers: 'application/json',
@@ -139,8 +139,6 @@ describe('config validation', () => {
   });
 
   test('config validation passes when kibana config whitelists the url', () => {
-    const actionType = getActionType(configUtilsMock);
-
     const config: Record<string, any> = {
       url: 'http://mylisteningserver.com:9200/endpoint',
       headers: {
@@ -155,7 +153,7 @@ describe('config validation', () => {
   });
 
   test('config validation returns an error if the specified URL isnt whitelisted', () => {
-    const actionType = getActionType({
+    actionType = getActionType({
       ...configUtilsMock,
       ensureWhitelistedUri: _ => {
         throw new Error(`target url is not whitelisted`);
@@ -179,13 +177,11 @@ describe('config validation', () => {
 
 describe('params validation', () => {
   test('param validation passes when no fields are provided as none are required', () => {
-    const actionType = getActionType(configUtilsMock);
     const params: Record<string, any> = {};
     expect(validateParams(actionType, params)).toEqual({});
   });
 
   test('params validation passes when a valid body is provided', () => {
-    const actionType = getActionType(configUtilsMock);
     const params: Record<string, any> = {
       body: 'count: {{ctx.payload.hits.total}}',
     };

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -155,6 +155,7 @@
     "pdf-image": "2.0.0",
     "pdfjs-dist": "^2.0.943",
     "pixelmatch": "4.0.2",
+    "pre-commit": "^1.2.2",
     "proxyquire": "1.8.0",
     "react-docgen-typescript-loader": "^3.1.1",
     "react-hooks-testing-library": "^0.3.8",

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -155,7 +155,6 @@
     "pdf-image": "2.0.0",
     "pdfjs-dist": "^2.0.943",
     "pixelmatch": "4.0.2",
-    "pre-commit": "^1.2.2",
     "proxyquire": "1.8.0",
     "react-docgen-typescript-loader": "^3.1.1",
     "react-hooks-testing-library": "^0.3.8",


### PR DESCRIPTION
Created unit test for x-pack/legacy/plugins/actions/server/builtin_action_types/index.ts and move common code from each action type tests. 

Fixes #45444