### PR TITLE
[lens] More cleanup from QueryBar changes in master

### DIFF
--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.test.tsx
@@ -12,11 +12,11 @@ import { toastNotifications } from 'ui/notify';
 import { Storage } from 'ui/storage';
 import { Document, SavedObjectStore } from '../persistence';
 import { mount } from 'enzyme';
-import { QueryBar } from '../../../../../../src/legacy/core_plugins/data/public/query';
+import { QueryBarTopRow } from '../../../../../../src/legacy/core_plugins/data/public/query/query_bar';
 import { SavedObjectsClientContract } from 'src/core/public';
 
-jest.mock('../../../../../../src/legacy/core_plugins/data/public/query', () => ({
-  QueryBar: jest.fn(() => null),
+jest.mock('../../../../../../src/legacy/core_plugins/data/public/query/query_bar', () => ({
+  QueryBarTopRow: jest.fn(() => null),
 }));
 
 jest.mock('ui/new_platform');
@@ -69,7 +69,7 @@ function makeDefaultArgs(): jest.Mocked<{
       load: jest.fn(),
       save: jest.fn(),
     },
-    QueryBar: jest.fn(() => <div />),
+    QueryBarTopRow: jest.fn(() => <div />),
     redirectTo: jest.fn(id => {}),
     savedObjectsClient: jest.fn(),
   } as unknown) as jest.Mocked<{
@@ -186,7 +186,7 @@ describe('Lens App', () => {
       await waitForPromises();
 
       expect(args.docStorage.load).toHaveBeenCalledWith('1234');
-      expect(QueryBar).toHaveBeenCalledWith(
+      expect(QueryBarTopRow).toHaveBeenCalledWith(
         expect.objectContaining({
           dateRangeFrom: 'now-7d',
           dateRangeTo: 'now',
@@ -355,7 +355,7 @@ describe('Lens App', () => {
 
       mount(<App {...args} />);
 
-      expect(QueryBar).toHaveBeenCalledWith(
+      expect(QueryBarTopRow).toHaveBeenCalledWith(
         expect.objectContaining({
           dateRangeFrom: 'now-7d',
           dateRangeTo: 'now',
@@ -378,7 +378,7 @@ describe('Lens App', () => {
 
       const instance = mount(<App {...args} />);
 
-      expect(QueryBar).toHaveBeenCalledWith(
+      expect(QueryBarTopRow).toHaveBeenCalledWith(
         expect.objectContaining({
           indexPatterns: [],
         }),
@@ -393,7 +393,7 @@ describe('Lens App', () => {
 
       instance.update();
 
-      expect(QueryBar).toHaveBeenCalledWith(
+      expect(QueryBarTopRow).toHaveBeenCalledWith(
         expect.objectContaining({
           indexPatterns: ['newIndex'],
         }),
@@ -417,7 +417,7 @@ describe('Lens App', () => {
 
       instance.update();
 
-      expect(QueryBar).toHaveBeenCalledWith(
+      expect(QueryBarTopRow).toHaveBeenCalledWith(
         expect.objectContaining({
           dateRangeFrom: 'now-14d',
           dateRangeTo: 'now-7d',

--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
@@ -13,7 +13,8 @@ import { Storage } from 'ui/storage';
 import { toastNotifications } from 'ui/notify';
 import { Chrome } from 'ui/chrome';
 import { SavedObjectsClientContract } from 'src/core/public';
-import { Query, QueryBar } from '../../../../../../src/legacy/core_plugins/data/public/query';
+import { Query } from '../../../../../../src/legacy/core_plugins/data/public/query';
+import { QueryBarTopRow } from '../../../../../../src/legacy/core_plugins/data/public/query/query_bar';
 import { Document, SavedObjectStore } from '../persistence';
 import { EditorFrameInstance } from '../types';
 import { NativeRenderer } from '../native_renderer';
@@ -199,7 +200,7 @@ export function App({
               </EuiFlexItem>
             </EuiFlexGroup>
           </nav>
-          <QueryBar
+          <QueryBarTopRow
             data-test-subj="lnsApp_queryBar"
             screenTitle={'lens'}
             onSubmit={payload => {

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.ts
@@ -5,8 +5,8 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { ExpressionFunction } from 'src/legacy/core_plugins/interpreter/types';
-import { KibanaDatatable } from '../../../../../../src/legacy/core_plugins/interpreter/public';
+import { ExpressionFunction } from '../../../../../../src/legacy/core_plugins/interpreter/types';
+import { KibanaDatatable } from '../../../../../../src/legacy/core_plugins/interpreter/common';
 import { LensMultiTable } from '../types';
 
 interface MergeTables {

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/mocks.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/mocks.tsx
@@ -6,15 +6,12 @@
 
 import React from 'react';
 import { ExpressionRendererProps } from 'src/legacy/core_plugins/expressions/public';
-import { setup as dataSetup } from '../../../../../../src/legacy/core_plugins/data/public/legacy';
 import {
   ExpressionsSetup,
   ExpressionsStart,
 } from '../../../../../../src/legacy/core_plugins/expressions/public';
 import { DatasourcePublicAPI, FramePublicAPI, Visualization, Datasource } from '../types';
 import { EditorFrameSetupPlugins, EditorFrameStartPlugins } from './plugin';
-
-type DataSetup = typeof dataSetup;
 
 export function createMockVisualization(): jest.Mocked<Visualization> {
   return {
@@ -84,16 +81,12 @@ export function createMockFramePublicAPI(): FrameMock {
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export type MockedSetupDependencies = Omit<EditorFrameSetupPlugins, 'data'> & {
-  data: Omit<DataSetup, 'expressions'> & {
-    expressions: jest.Mocked<ExpressionsSetup>;
-  };
+export type MockedSetupDependencies = Omit<EditorFrameSetupPlugins, 'expressions'> & {
+  expressions: jest.Mocked<ExpressionsSetup>;
 };
 
-export type MockedStartDependencies = Omit<EditorFrameStartPlugins, 'data'> & {
-  data: Omit<DataSetup, 'expressions'> & {
-    expressions: jest.Mocked<ExpressionsStart>;
-  };
+export type MockedStartDependencies = Omit<EditorFrameStartPlugins, 'expressions'> & {
+  expressions: jest.Mocked<ExpressionsStart>;
 };
 
 export function createExpressionRendererMock(): jest.Mock<

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/filter_ratio.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/filter_ratio.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { calculateFilterRatio } from './filter_ratio';
-import { KibanaDatatable } from 'src/legacy/core_plugins/interpreter/public';
+import { KibanaDatatable } from 'src/legacy/core_plugins/interpreter/common';
 
 describe('calculate_filter_ratio', () => {
   it('should collapse two rows and columns into a single row and column', () => {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { renameColumns } from './rename_columns';
-import { KibanaDatatable } from 'src/legacy/core_plugins/interpreter/public';
+import { KibanaDatatable } from 'src/legacy/core_plugins/interpreter/common';
 
 describe('rename_columns', () => {
   it('should rename columns of a given datatable', () => {

--- a/x-pack/legacy/plugins/lens/public/types.ts
+++ b/x-pack/legacy/plugins/lens/public/types.ts
@@ -7,7 +7,7 @@
 import { Ast } from '@kbn/interpreter/common';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import { Query } from 'src/plugins/data/common';
-import { KibanaDatatable } from '../../../../../src/legacy/core_plugins/interpreter/public';
+import { KibanaDatatable } from '../../../../../src/legacy/core_plugins/interpreter/common';
 import { DragContextState } from './drag_drop';
 import { Document } from './persistence';
 


### PR DESCRIPTION
Fixes issues from renaming the QueryBar -> QueryBarTopRow (https://github.com/elastic/kibana/pull/45250)

Cleans up remaining comments from https://github.com/elastic/kibana/pull/45544