### PR TITLE
[lens] Fix build and use new platform from entry points

### DIFF
--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
@@ -10,9 +10,7 @@ import { I18nProvider } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 import { EuiLink, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { Storage } from 'ui/storage';
-import { toastNotifications } from 'ui/notify';
-import { Chrome } from 'ui/chrome';
-import { SavedObjectsClientContract } from 'src/core/public';
+import { CoreStart, SavedObjectsClientContract } from 'src/core/public';
 import { Query } from '../../../../../../src/legacy/core_plugins/data/public/query';
 import { QueryBarTopRow } from '../../../../../../src/legacy/core_plugins/data/public/query/query_bar';
 import { Document, SavedObjectStore } from '../persistence';
@@ -52,24 +50,24 @@ function isLocalStateDirty(
 
 export function App({
   editorFrame,
+  core,
   store,
-  chrome,
   docId,
   docStorage,
   redirectTo,
   savedObjectsClient,
 }: {
   editorFrame: EditorFrameInstance;
-  chrome: Chrome;
+  core: CoreStart;
   store: Storage;
   docId?: string;
   docStorage: SavedObjectStore;
   redirectTo: (id?: string) => void;
   savedObjectsClient: SavedObjectsClientContract;
 }) {
-  const uiSettings = chrome.getUiSettingsClient();
-  const timeDefaults = uiSettings.get('timepicker:timeDefaults');
-  const language = store.get('kibana.userQueryLanguage') || uiSettings.get('search:queryLanguage');
+  const timeDefaults = core.uiSettings.get('timepicker:timeDefaults');
+  const language =
+    store.get('kibana.userQueryLanguage') || core.uiSettings.get('search:queryLanguage');
 
   const [state, setState] = useState<State>({
     isLoading: !!docId,
@@ -93,9 +91,9 @@ export function App({
 
   // Sync Kibana breadcrumbs any time the saved document's title changes
   useEffect(() => {
-    chrome.breadcrumbs.set([
+    core.chrome.setBreadcrumbs([
       {
-        href: chrome.addBasePath(`/app/kibana#/visualize`),
+        href: core.http.basePath.prepend(`/app/kibana#/visualize`),
         text: i18n.translate('xpack.lens.breadcrumbsTitle', {
           defaultMessage: 'Visualize',
         }),
@@ -131,7 +129,7 @@ export function App({
         .catch(() => {
           setState({ ...state, isLoading: false });
 
-          toastNotifications.addDanger(
+          core.notifications.toasts.addDanger(
             i18n.translate('xpack.lens.editorFrame.docLoadingError', {
               defaultMessage: 'Error loading saved document',
             })
@@ -149,7 +147,7 @@ export function App({
 
   const onError = useCallback(
     (e: { message: string }) =>
-      toastNotifications.addDanger({
+      core.notifications.toasts.addDanger({
         title: e.message,
       }),
     []
@@ -181,7 +179,7 @@ export function App({
                           }
                         })
                         .catch(reason => {
-                          toastNotifications.addDanger(
+                          core.notifications.toasts.addDanger(
                             i18n.translate('xpack.lens.editorFrame.docSavingError', {
                               defaultMessage: 'Error saving document {reason}',
                               values: { reason },
@@ -231,8 +229,9 @@ export function App({
             dateRangeTo={
               state.localQueryBarState.dateRange && state.localQueryBarState.dateRange.to
             }
-            uiSettings={uiSettings}
+            uiSettings={core.uiSettings}
             savedObjectsClient={savedObjectsClient}
+            http={core.http}
           />
         </div>
 

--- a/x-pack/legacy/plugins/lens/public/app_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/plugin.tsx
@@ -9,6 +9,8 @@ import { I18nProvider, FormattedMessage } from '@kbn/i18n/react';
 import { HashRouter, Switch, Route, RouteComponentProps } from 'react-router-dom';
 import chrome from 'ui/chrome';
 import { Storage } from 'ui/storage';
+import { CoreSetup, CoreStart } from 'src/core/public';
+import { npSetup, npStart } from 'ui/new_platform';
 import { editorFrameSetup, editorFrameStart, editorFrameStop } from '../editor_frame_plugin';
 import { indexPatternDatasourceSetup, indexPatternDatasourceStop } from '../indexpattern_plugin';
 import { SavedObjectIndexStore } from '../persistence';
@@ -27,7 +29,7 @@ export class AppPlugin {
 
   constructor() {}
 
-  setup() {
+  setup(core: CoreSetup) {
     // TODO: These plugins should not be called from the top level, but since this is the
     // entry point to the app we have no choice until the new platform is ready
     const indexPattern = indexPatternDatasourceSetup();
@@ -43,7 +45,7 @@ export class AppPlugin {
     editorFrameSetupInterface.registerVisualization(metricVisualization);
   }
 
-  start() {
+  start(core: CoreStart) {
     if (this.store === null) {
       throw new Error('Start lifecycle called before setup lifecycle');
     }
@@ -57,8 +59,8 @@ export class AppPlugin {
     const renderEditor = (routeProps: RouteComponentProps<{ id?: string }>) => {
       return (
         <App
+          core={core}
           editorFrame={this.instance!}
-          chrome={chrome}
           store={new Storage(localStorage)}
           savedObjectsClient={chrome.getSavedObjectsClient()}
           docId={routeProps.match.params.id}
@@ -107,6 +109,6 @@ export class AppPlugin {
 
 const app = new AppPlugin();
 
-export const appSetup = () => app.setup();
-export const appStart = () => app.start();
+export const appSetup = () => app.setup(npSetup.core);
+export const appStart = () => app.start(npStart.core);
 export const appStop = () => app.stop();

--- a/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/plugin.tsx
@@ -6,6 +6,7 @@
 
 import { CoreSetup } from 'src/core/public';
 import { getFormat, FormatFactory } from 'ui/visualize/loader/pipeline_helpers/utilities';
+import { npSetup } from 'ui/new_platform';
 import { datatableVisualization } from './visualization';
 import { ExpressionsSetup } from '../../../../../../src/legacy/core_plugins/expressions/public';
 import { setup as expressionsSetup } from '../../../../../../src/legacy/core_plugins/expressions/public/legacy';
@@ -40,7 +41,7 @@ class DatatableVisualizationPlugin {
 const plugin = new DatatableVisualizationPlugin();
 
 export const datatableVisualizationSetup = () =>
-  plugin.setup(null, {
+  plugin.setup(npSetup.core, {
     expressions: expressionsSetup,
     fieldFormat: {
       formatFactory: getFormat,

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/data_panel_wrapper.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/data_panel_wrapper.tsx
@@ -20,6 +20,7 @@ interface DataPanelWrapperProps {
   activeDatasource: string | null;
   datasourceIsLoading: boolean;
   dispatch: (action: Action) => void;
+  core: DatasourceDataPanelProps['core'];
   query: Query;
   dateRange: FramePublicAPI['dateRange'];
 }
@@ -40,6 +41,7 @@ export const DataPanelWrapper = memo((props: DataPanelWrapperProps) => {
     dragDropContext: useContext(DragContext),
     state: props.datasourceState,
     setState: setDatasourceState,
+    core: props.core,
     query: props.query,
     dateRange: props.dateRange,
   };

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/editor_frame.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/editor_frame.test.tsx
@@ -10,6 +10,7 @@ import { mountWithIntl as mount } from 'test_utils/enzyme_helpers';
 import { EditorFrame } from './editor_frame';
 import { Visualization, DatasourcePublicAPI, DatasourceSuggestion } from '../../types';
 import { act } from 'react-dom/test-utils';
+import { coreMock } from 'src/core/public/mocks';
 import {
   createMockVisualization,
   createMockDatasource,
@@ -47,6 +48,7 @@ function getDefaultProps() {
     onChange: jest.fn(),
     dateRange: { fromDate: '', toDate: '' },
     query: { query: '', language: 'lucene' },
+    core: coreMock.createSetup(),
   };
 }
 

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/editor_frame.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/editor_frame.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useEffect, useReducer } from 'react';
+import { CoreSetup, CoreStart } from 'src/core/public';
 import { Query } from '../../../../../../../src/legacy/core_plugins/data/public';
 import { ExpressionRenderer } from '../../../../../../../src/legacy/core_plugins/expressions/public';
 import { Datasource, DatasourcePublicAPI, FramePublicAPI, Visualization } from '../../types';
@@ -27,7 +28,7 @@ export interface EditorFrameProps {
   initialVisualizationId: string | null;
   ExpressionRenderer: ExpressionRenderer;
   onError: (e: { message: string }) => void;
-
+  core: CoreSetup | CoreStart;
   dateRange: {
     fromDate: string;
     toDate: string;
@@ -217,6 +218,7 @@ export function EditorFrame(props: EditorFrameProps) {
               : true
           }
           dispatch={dispatch}
+          core={props.core}
           query={props.query}
           dateRange={props.dateRange}
         />

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/state_management.test.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/state_management.test.ts
@@ -8,6 +8,7 @@ import { getInitialState, reducer } from './state_management';
 import { EditorFrameProps } from '.';
 import { Datasource, Visualization } from '../../types';
 import { createExpressionRendererMock } from '../mocks';
+import { coreMock } from 'src/core/public/mocks';
 
 describe('editor_frame state management', () => {
   describe('initialization', () => {
@@ -22,6 +23,7 @@ describe('editor_frame state management', () => {
         initialVisualizationId: 'testVis',
         ExpressionRenderer: createExpressionRendererMock(),
         onChange: jest.fn(),
+        core: coreMock.createSetup(),
         dateRange: { fromDate: 'now-7d', toDate: 'now' },
         query: { query: '', language: 'lucene' },
       };

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { EditorFramePlugin } from './plugin';
+import { coreMock } from 'src/core/public/mocks';
 import {
   MockedSetupDependencies,
   MockedStartDependencies,
@@ -12,6 +13,7 @@ import {
   createMockStartDependencies,
 } from './mocks';
 
+jest.mock('ui/new_platform');
 jest.mock('ui/chrome', () => ({
   getSavedObjectsClient: jest.fn(),
 }));
@@ -49,8 +51,8 @@ describe('editor_frame plugin', () => {
 
   it('should create an editor frame instance which mounts and unmounts', () => {
     expect(() => {
-      pluginInstance.setup(null, pluginSetupDependencies);
-      const publicAPI = pluginInstance.start(null, pluginStartDependencies);
+      pluginInstance.setup(coreMock.createSetup(), pluginSetupDependencies);
+      const publicAPI = pluginInstance.start(coreMock.createStart(), pluginStartDependencies);
       const instance = publicAPI.createInstance({});
       instance.mount(mountpoint, {
         onError: jest.fn(),
@@ -63,8 +65,8 @@ describe('editor_frame plugin', () => {
   });
 
   it('should not have child nodes after unmount', () => {
-    pluginInstance.setup(null, pluginSetupDependencies);
-    const publicAPI = pluginInstance.start(null, pluginStartDependencies);
+    pluginInstance.setup(coreMock.createSetup(), pluginSetupDependencies);
+    const publicAPI = pluginInstance.start(coreMock.createStart(), pluginStartDependencies);
     const instance = publicAPI.createInstance({});
     instance.mount(mountpoint, {
       onError: jest.fn(),

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.tsx
@@ -9,6 +9,7 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { I18nProvider } from '@kbn/i18n/react';
 import { CoreSetup, CoreStart } from 'src/core/public';
 import chrome, { Chrome } from 'ui/chrome';
+import { npSetup, npStart } from 'ui/new_platform';
 import { Plugin as EmbeddablePlugin } from '../../../../../../src/legacy/core_plugins/embeddable_api/public/np_ready/public';
 import { start as embeddablePlugin } from '../../../../../../src/legacy/core_plugins/embeddable_api/public/np_ready/public/legacy';
 import {
@@ -49,7 +50,7 @@ export class EditorFramePlugin {
   private readonly datasources: Record<string, Datasource> = {};
   private readonly visualizations: Record<string, Visualization> = {};
 
-  public setup(_core: CoreSetup | null, plugins: EditorFrameSetupPlugins): EditorFrameSetup {
+  public setup(core: CoreSetup, plugins: EditorFrameSetupPlugins): EditorFrameSetup {
     plugins.expressions.registerFunction(() => mergeTables);
 
     return {
@@ -62,7 +63,7 @@ export class EditorFramePlugin {
     };
   }
 
-  public start(_core: CoreStart | null, plugins: EditorFrameStartPlugins): EditorFrameStart {
+  public start(core: CoreStart, plugins: EditorFrameStartPlugins): EditorFrameStart {
     plugins.embeddables.registerEmbeddableFactory(
       'lens',
       new EmbeddableFactory(
@@ -91,6 +92,7 @@ export class EditorFramePlugin {
                 initialVisualizationId={
                   (doc && doc.visualizationType) || firstVisualizationId || null
                 }
+                core={core}
                 ExpressionRenderer={plugins.expressions.ExpressionRenderer}
                 doc={doc}
                 dateRange={dateRange}
@@ -122,13 +124,13 @@ export class EditorFramePlugin {
 const editorFrame = new EditorFramePlugin();
 
 export const editorFrameSetup = () =>
-  editorFrame.setup(null, {
+  editorFrame.setup(npSetup.core, {
     data: dataSetup,
     expressions: expressionsSetup,
   });
 
 export const editorFrameStart = () =>
-  editorFrame.start(null, {
+  editorFrame.start(npStart.core, {
     data: dataStart,
     expressions: expressionsStart,
     chrome,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -29,7 +29,6 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { npStart } from 'ui/new_platform';
 import { Query } from 'src/plugins/data/common';
 import { DatasourceDataPanelProps, DataType } from '../types';
 import { IndexPatternPrivateState, IndexPatternField, IndexPattern } from './indexpattern';
@@ -66,6 +65,7 @@ export function IndexPatternDataPanel({
   setState,
   state,
   dragDropContext,
+  core,
   query,
   dateRange,
 }: DatasourceDataPanelProps<IndexPatternPrivateState>) {
@@ -121,6 +121,7 @@ export function IndexPatternDataPanel({
       dragDropContext={dragDropContext}
       showEmptyFields={state.showEmptyFields}
       onToggleEmptyFields={onToggleEmptyFields}
+      core={core}
       // only pass in the state change callback if it's actually needed to avoid re-renders
       onChangeIndexPattern={showIndexPatternSwitcher ? onChangeIndexPattern : undefined}
       updateFieldsWithCounts={
@@ -157,11 +158,13 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   updateFieldsWithCounts,
   showEmptyFields,
   onToggleEmptyFields,
+  core,
 }: Partial<DatasourceDataPanelProps> & {
   currentIndexPatternId: string;
   indexPatterns: Record<string, IndexPattern>;
   dateRange: DatasourceDataPanelProps['dateRange'];
   query: Query;
+  core: DatasourceDataPanelProps['core'];
   dragDropContext: DragContextState;
   showIndexPatternSwitcher: boolean;
   setShowIndexPatternSwitcher: (show: boolean) => void;
@@ -275,11 +278,11 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
 
     setLocalState(s => ({ ...s, isLoading: true }));
 
-    npStart.core.http
+    core.http
       .post(`/api/lens/index_stats/${currentIndexPattern.title}`, {
         body: JSON.stringify({
-          earliest: dateRange.fromDate,
-          latest: dateRange.toDate,
+          fromDate: dateRange.fromDate,
+          toDate: dateRange.toDate,
           size: 500,
           timeFieldName: currentIndexPattern.timeFieldName,
           fields: allFields

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
@@ -14,7 +14,11 @@ import { IndexPatternDimensionPanel, IndexPatternDimensionPanelProps } from './d
 import { DropHandler, DragContextState } from '../../drag_drop';
 import { createMockedDragDropContext } from '../mocks';
 import { mountWithIntl as mount, shallowWithIntl as shallow } from 'test_utils/enzyme_helpers';
-import { UiSettingsClientContract, SavedObjectsClientContract } from 'src/core/public';
+import {
+  UiSettingsClientContract,
+  SavedObjectsClientContract,
+  HttpServiceBase,
+} from 'src/core/public';
 import { Storage } from 'ui/storage';
 
 jest.mock('ui/new_platform');
@@ -122,6 +126,7 @@ describe('IndexPatternDimensionPanel', () => {
       storage: {} as Storage,
       uiSettings: {} as UiSettingsClientContract,
       savedObjectsClient: {} as SavedObjectsClientContract,
+      http: {} as HttpServiceBase,
     };
 
     jest.clearAllMocks();

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
@@ -9,7 +9,11 @@ import React, { memo, useMemo } from 'react';
 import { EuiButtonIcon } from '@elastic/eui';
 import { Storage } from 'ui/storage';
 import { i18n } from '@kbn/i18n';
-import { UiSettingsClientContract, SavedObjectsClientContract } from 'src/core/public';
+import {
+  UiSettingsClientContract,
+  SavedObjectsClientContract,
+  HttpServiceBase,
+} from 'src/core/public';
 import { DatasourceDimensionPanelProps, StateSetter } from '../../types';
 import {
   IndexPatternColumn,
@@ -32,6 +36,7 @@ export type IndexPatternDimensionPanelProps = DatasourceDimensionPanelProps & {
   storage: Storage;
   savedObjectsClient: SavedObjectsClientContract;
   layerId: string;
+  http: HttpServiceBase;
 };
 
 export interface OperationFieldSupportMatrix {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
@@ -357,6 +357,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
                     uiSettings={props.uiSettings}
                     savedObjectsClient={props.savedObjectsClient}
                     layerId={layerId}
+                    http={props.http}
                   />
                 )}
                 {!incompatibleSelectedOperationType && selectedColumn && (

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
@@ -8,7 +8,6 @@ import chromeMock from 'ui/chrome';
 import { data as dataMock } from '../../../../../../src/legacy/core_plugins/data/public/setup';
 import { Storage } from 'ui/storage';
 import { functionsRegistry } from '../../../../../../src/legacy/core_plugins/interpreter/public/registries';
-import { toastNotifications as notificationsMock } from 'ui/notify';
 import { SavedObjectsClientContract } from 'src/core/public';
 import {
   getIndexPatternDatasource,
@@ -17,12 +16,12 @@ import {
   IndexPatternColumn,
 } from './indexpattern';
 import { DatasourcePublicAPI, Operation, Datasource } from '../types';
+import { coreMock } from 'src/core/public/mocks';
 
 jest.mock('./loader');
 jest.mock('../id_generator');
 // chrome, notify, storage are used by ./plugin
 jest.mock('ui/chrome');
-jest.mock('ui/notify');
 // Contains old and new platform data plugins, used for interpreter and filter ratio
 jest.mock('ui/new_platform');
 jest.mock('plugins/data/setup', () => ({ data: { query: { ui: {} } } }));
@@ -139,7 +138,7 @@ describe('IndexPattern Data Source', () => {
       chrome: chromeMock,
       storage: {} as Storage,
       interpreter: { functionsRegistry },
-      toastNotifications: notificationsMock,
+      core: coreMock.createSetup(),
       data: dataMock,
       savedObjectsClient: {} as SavedObjectsClientContract,
     });

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
@@ -8,7 +8,7 @@ import _ from 'lodash';
 import React from 'react';
 import { render } from 'react-dom';
 import { I18nProvider } from '@kbn/i18n/react';
-import { SavedObjectsClientContract } from 'src/core/public';
+import { CoreSetup, SavedObjectsClientContract } from 'src/core/public';
 import { Storage } from 'ui/storage';
 import {
   DatasourceDimensionPanelProps,
@@ -150,11 +150,12 @@ function removeProperty<T>(prop: string, object: Record<string, T>): Record<stri
 }
 
 export function getIndexPatternDatasource({
+  core,
   chrome,
-  toastNotifications,
   storage,
   savedObjectsClient,
 }: IndexPatternDatasourcePluginPlugins & {
+  core: CoreSetup;
   storage: Storage;
   savedObjectsClient: SavedObjectsClientContract;
 }) {
@@ -164,7 +165,7 @@ export function getIndexPatternDatasource({
     async initialize(state?: IndexPatternPersistedState) {
       // TODO: The initial request should only load index pattern names because each saved object is large
       //       Followup requests should load a single index pattern + existence information
-      const indexPatternObjects = await getIndexPatterns(chrome, toastNotifications);
+      const indexPatternObjects = await getIndexPatterns(chrome, core.notifications);
       const indexPatterns: Record<string, IndexPattern> = {};
 
       if (indexPatternObjects) {
@@ -274,6 +275,7 @@ export function getIndexPatternDatasource({
                 storage={storage}
                 savedObjectsClient={savedObjectsClient}
                 layerId={props.layerId}
+                http={core.http}
                 {...props}
               />
             </I18nProvider>,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern_suggestions.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern_suggestions.test.tsx
@@ -7,7 +7,6 @@
 import chromeMock from 'ui/chrome';
 import { data as dataMock } from '../../../../../../src/legacy/core_plugins/data/public/setup';
 import { functionsRegistry } from '../../../../../../src/legacy/core_plugins/interpreter/public/registries';
-import { toastNotifications as notificationsMock } from 'ui/notify';
 import { SavedObjectsClientContract } from 'src/core/public';
 import {
   getIndexPatternDatasource,
@@ -17,12 +16,12 @@ import {
 import { Datasource, DatasourceSuggestion } from '../types';
 import { generateId } from '../id_generator';
 import { Storage } from 'ui/storage';
+import { coreMock } from 'src/core/public/mocks';
 
 jest.mock('./loader');
 jest.mock('../id_generator');
 // chrome, notify, storage are used by ./plugin
 jest.mock('ui/chrome');
-jest.mock('ui/notify');
 // Contains old and new platform data plugins, used for interpreter and filter ratio
 jest.mock('ui/new_platform');
 jest.mock('plugins/data/setup', () => ({ data: { query: { ui: {} } } }));
@@ -136,10 +135,10 @@ describe('IndexPattern Data Source suggestions', () => {
 
   beforeEach(() => {
     indexPatternDatasource = getIndexPatternDatasource({
+      core: coreMock.createSetup(),
       chrome: chromeMock,
       storage: {} as Storage,
       interpreter: { functionsRegistry },
-      toastNotifications: notificationsMock,
       data: dataMock,
       savedObjectsClient: {} as SavedObjectsClientContract,
     });

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/loader.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/loader.ts
@@ -5,9 +5,9 @@
  */
 
 import { Chrome } from 'ui/chrome';
-import { ToastNotifications } from 'ui/notify/toasts/toast_notifications';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { SavedObjectAttributes } from 'src/core/server';
+import { NotificationsSetup } from 'src/core/public';
 import { IndexPatternField } from './indexpattern';
 
 interface SavedIndexPatternAttributes extends SavedObjectAttributes {
@@ -35,7 +35,7 @@ interface SavedRestrictionsObject {
 }
 type SavedRestrictionsInfo = SavedRestrictionsObject | undefined;
 
-export const getIndexPatterns = (chrome: Chrome, toastNotifications: ToastNotifications) => {
+export const getIndexPatterns = (chrome: Chrome, notifications: NotificationsSetup) => {
   const savedObjectsClient = chrome.getSavedObjectsClient();
   return savedObjectsClient
     .find<SavedIndexPatternAttributes>({
@@ -64,6 +64,6 @@ export const getIndexPatterns = (chrome: Chrome, toastNotifications: ToastNotifi
       });
     })
     .catch(err => {
-      toastNotifications.addDanger('Failed to load index patterns');
+      notifications.toasts.addDanger('Failed to load index patterns');
     });
 };

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/date_histogram.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/date_histogram.test.tsx
@@ -10,7 +10,11 @@ import { dateHistogramOperation } from '.';
 import { shallow } from 'enzyme';
 import { IndexPatternPrivateState } from '../../indexpattern';
 import { EuiRange, EuiSwitch } from '@elastic/eui';
-import { UiSettingsClientContract, SavedObjectsClientContract } from 'src/core/public';
+import {
+  UiSettingsClientContract,
+  SavedObjectsClientContract,
+  HttpServiceBase,
+} from 'src/core/public';
 import { Storage } from 'ui/storage';
 import { createMockedIndexPattern } from '../../mocks';
 
@@ -324,6 +328,7 @@ describe('date_histogram', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -342,6 +347,7 @@ describe('date_histogram', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -359,6 +365,7 @@ describe('date_histogram', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
       expect(instance.find(EuiRange).exists()).toBe(false);
@@ -377,6 +384,7 @@ describe('date_histogram', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
       instance.find(EuiSwitch).prop('onChange')!({
@@ -399,6 +407,7 @@ describe('date_histogram', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -458,6 +467,7 @@ describe('date_histogram', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/filter_ratio.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/filter_ratio.test.tsx
@@ -11,7 +11,11 @@ import { FilterRatioIndexPatternColumn } from './filter_ratio';
 import { filterRatioOperation } from '.';
 import { IndexPatternPrivateState } from '../../indexpattern';
 import { Storage } from 'ui/storage';
-import { UiSettingsClientContract, SavedObjectsClientContract } from 'src/core/public';
+import {
+  UiSettingsClientContract,
+  SavedObjectsClientContract,
+  HttpServiceBase,
+} from 'src/core/public';
 import { QueryBarInput } from '../../../../../../../../src/legacy/core_plugins/data/public/query';
 import { createMockedIndexPattern } from '../../mocks';
 
@@ -109,6 +113,7 @@ describe('filter_ratio', () => {
             storage={storageMock}
             uiSettings={{} as UiSettingsClientContract}
             savedObjectsClient={{} as SavedObjectsClientContract}
+            http={{} as HttpServiceBase}
           />
         );
       }).not.toThrow();
@@ -125,6 +130,7 @@ describe('filter_ratio', () => {
           storage={storageMock}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -144,6 +150,7 @@ describe('filter_ratio', () => {
           storage={storageMock}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -184,6 +191,7 @@ describe('filter_ratio', () => {
           storage={storageMock}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/filter_ratio.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/filter_ratio.tsx
@@ -85,6 +85,7 @@ export const filterRatioOperation: OperationDefinition<FilterRatioIndexPatternCo
     storage,
     layerId,
     savedObjectsClient,
+    http,
   }) => {
     const [hasDenominator, setDenominator] = useState(false);
 
@@ -103,6 +104,7 @@ export const filterRatioOperation: OperationDefinition<FilterRatioIndexPatternCo
             store={storage}
             uiSettings={uiSettings}
             savedObjectsClient={savedObjectsClient}
+            http={http}
             onChange={(newQuery: Query) => {
               setState(
                 updateColumnParam({
@@ -131,6 +133,7 @@ export const filterRatioOperation: OperationDefinition<FilterRatioIndexPatternCo
               store={storage}
               uiSettings={uiSettings}
               savedObjectsClient={savedObjectsClient}
+              http={http}
               onChange={(newQuery: Query) => {
                 setState(
                   updateColumnParam({

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
@@ -5,7 +5,11 @@
  */
 
 import { Storage } from 'ui/storage';
-import { UiSettingsClientContract, SavedObjectsClientContract } from 'src/core/public';
+import {
+  UiSettingsClientContract,
+  SavedObjectsClientContract,
+  HttpServiceBase,
+} from 'src/core/public';
 import { termsOperation } from './terms';
 import { minOperation, averageOperation, sumOperation, maxOperation } from './metrics';
 import { dateHistogramOperation } from './date_histogram';
@@ -47,6 +51,7 @@ export interface ParamEditorProps<C extends BaseIndexPatternColumn> {
   uiSettings: UiSettingsClientContract;
   storage: Storage;
   savedObjectsClient: SavedObjectsClientContract;
+  http: HttpServiceBase;
 }
 
 interface BaseOperationDefinitionProps<C extends BaseIndexPatternColumn> {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.test.tsx
@@ -8,7 +8,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { IndexPatternPrivateState } from '../../indexpattern';
 import { EuiRange, EuiSelect } from '@elastic/eui';
-import { UiSettingsClientContract, SavedObjectsClientContract } from 'src/core/public';
+import {
+  UiSettingsClientContract,
+  SavedObjectsClientContract,
+  HttpServiceBase,
+} from 'src/core/public';
 import { Storage } from 'ui/storage';
 import { createMockedIndexPattern } from '../../mocks';
 import { TermsIndexPatternColumn } from './terms';
@@ -313,6 +317,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -360,6 +365,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -380,6 +386,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -427,6 +434,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -450,6 +458,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -494,6 +503,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 
@@ -512,6 +522,7 @@ describe('terms', () => {
           storage={{} as Storage}
           uiSettings={{} as UiSettingsClientContract}
           savedObjectsClient={{} as SavedObjectsClientContract}
+          http={{} as HttpServiceBase}
         />
       );
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/plugin.tsx
@@ -8,8 +8,8 @@ import { Registry } from '@kbn/interpreter/target/common';
 import { CoreSetup } from 'src/core/public';
 // The following dependencies on ui/* and src/legacy/core_plugins must be mocked when testing
 import chrome, { Chrome } from 'ui/chrome';
-import { toastNotifications } from 'ui/notify';
 import { Storage } from 'ui/storage';
+import { npSetup } from 'ui/new_platform';
 import { ExpressionFunction } from '../../../../../../src/legacy/core_plugins/interpreter/public';
 import { functionsRegistry } from '../../../../../../src/legacy/core_plugins/interpreter/public/registries';
 import { getIndexPatternDatasource } from './indexpattern';
@@ -25,7 +25,6 @@ export interface IndexPatternDatasourcePluginPlugins {
   chrome: Chrome;
   interpreter: InterpreterSetup;
   data: typeof dataSetup;
-  toastNotifications: typeof toastNotifications;
 }
 
 export interface InterpreterSetup {
@@ -38,16 +37,13 @@ export interface InterpreterSetup {
 class IndexPatternDatasourcePlugin {
   constructor() {}
 
-  setup(
-    _core: CoreSetup | null,
-    { interpreter, data, toastNotifications: toast }: IndexPatternDatasourcePluginPlugins
-  ) {
+  setup(core: CoreSetup, { interpreter, data }: IndexPatternDatasourcePluginPlugins) {
     interpreter.functionsRegistry.register(() => renameColumns);
     interpreter.functionsRegistry.register(() => calculateFilterRatio);
     return getIndexPatternDatasource({
+      core,
       chrome,
       interpreter,
-      toastNotifications: toast,
       data,
       storage: new Storage(localStorage),
       savedObjectsClient: chrome.getSavedObjectsClient(),
@@ -60,12 +56,11 @@ class IndexPatternDatasourcePlugin {
 const plugin = new IndexPatternDatasourcePlugin();
 
 export const indexPatternDatasourceSetup = () =>
-  plugin.setup(null, {
+  plugin.setup(npSetup.core, {
     chrome,
     interpreter: {
       functionsRegistry,
     },
     data: dataSetup,
-    toastNotifications,
   });
 export const indexPatternDatasourceStop = () => plugin.stop();

--- a/x-pack/legacy/plugins/lens/public/types.ts
+++ b/x-pack/legacy/plugins/lens/public/types.ts
@@ -6,6 +6,7 @@
 
 import { Ast } from '@kbn/interpreter/common';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
+import { CoreSetup } from 'src/core/public';
 import { Query } from 'src/plugins/data/common';
 import { KibanaDatatable } from '../../../../../src/legacy/core_plugins/interpreter/common';
 import { DragContextState } from './drag_drop';
@@ -161,6 +162,7 @@ export interface DatasourceDataPanelProps<T = unknown> {
   state: T;
   dragDropContext: DragContextState;
   setState: StateSetter<T>;
+  core: Pick<CoreSetup, 'http' | 'notifications' | 'uiSettings'>;
   query: Query;
   dateRange: FramePublicAPI['dateRange'];
 }

--- a/x-pack/legacy/plugins/lens/server/routes/index_stats.ts
+++ b/x-pack/legacy/plugins/lens/server/routes/index_stats.ts
@@ -28,8 +28,8 @@ export async function initStatsRoute(setup: CoreSetup) {
           indexPatternTitle: schema.string(),
         }),
         body: schema.object({
-          earliest: schema.string(),
-          latest: schema.string(),
+          fromDate: schema.string(),
+          toDate: schema.string(),
           timeZone: schema.maybe(schema.string()),
           timeFieldName: schema.string(),
           size: schema.number(),
@@ -47,7 +47,7 @@ export async function initStatsRoute(setup: CoreSetup) {
 
       const indexPatternsService = new IndexPatternsService(requestClient.callAsCurrentUser);
 
-      const { earliest, latest, timeZone, timeFieldName, fields, size } = req.body;
+      const { fromDate, toDate, timeZone, timeFieldName, fields, size } = req.body;
 
       try {
         const indexPattern = await indexPatternsService.getFieldsForWildcard({
@@ -65,8 +65,8 @@ export async function initStatsRoute(setup: CoreSetup) {
                   {
                     range: {
                       [timeFieldName]: {
-                        gte: earliest,
-                        lte: latest,
+                        gte: fromDate,
+                        lte: toDate,
                         time_zone: timeZone,
                       },
                     },

--- a/x-pack/test/api_integration/apis/lens/index_stats.ts
+++ b/x-pack/test/api_integration/apis/lens/index_stats.ts
@@ -95,8 +95,8 @@ export default ({ getService }: FtrProviderContext) => {
           .post('/api/lens/index_stats/logstash-2015.09.22')
           .set(COMMON_HEADERS)
           .send({
-            earliest: TEST_START_TIME,
-            latest: TEST_END_TIME,
+            fromDate: TEST_START_TIME,
+            toDate: TEST_END_TIME,
             timeFieldName: '@timestamp',
             size: 500,
             fields: fieldsWithData.concat(fieldsNotInDocuments, fieldsNotInPattern),


### PR DESCRIPTION
The Lens build was broken by https://github.com/elastic/kibana/pull/45498, and this change was something we needed to do anyway, so these are combined.

The `QueryBarInput` component now requires the `http` service to be passed in as a dependency. We were previously using the chrome version, but a new platform version is now available. This PR moves all usage of new platform code to the `plugin` entry points and then passes down the needed services throughout Lens.