### PR TITLE
[7.x] [Infra UI] Load initial page state into the URL when empty for Metrics Explorer (#45683)

### DIFF
--- a/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/with_metrics_explorer_options_url_state.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/with_metrics_explorer_options_url_state.tsx
@@ -67,6 +67,7 @@ export const WithMetricsExplorerOptionsUrlState = () => {
       mapToUrlState={mapToUrlState}
       onChange={handleChange}
       onInitialize={handleChange}
+      populateWithInitialState={true}
     />
   );
 };

--- a/x-pack/legacy/plugins/infra/public/utils/url_state.tsx
+++ b/x-pack/legacy/plugins/infra/public/utils/url_state.tsx
@@ -18,6 +18,7 @@ interface UrlStateContainerProps<UrlState> {
   mapToUrlState?: (value: any) => UrlState | undefined;
   onChange?: (urlState: UrlState, previousUrlState: UrlState | undefined) => void;
   onInitialize?: (urlState: UrlState | undefined) => void;
+  populateWithInitialState?: boolean;
 }
 
 interface UrlStateContainerLifecycleProps<UrlState> extends UrlStateContainerProps<UrlState> {
@@ -68,7 +69,7 @@ class UrlStateContainerLifecycle<UrlState> extends React.Component<
   });
 
   private handleInitialize = (location: Location) => {
-    const { onInitialize, mapToUrlState, urlStateKey } = this.props;
+    const { onInitialize, mapToUrlState, urlStateKey, urlState } = this.props;
 
     if (!onInitialize || !mapToUrlState) {
       return;
@@ -80,7 +81,16 @@ class UrlStateContainerLifecycle<UrlState> extends React.Component<
     );
     const newUrlState = mapToUrlState(decodeRisonUrlState(newUrlStateString));
 
-    onInitialize(newUrlState);
+    // When the newURLState is empty we can assume that the state will becoming
+    // from the urlState initially. By setting populateWithIntialState to true
+    // this will now serialize the initial urlState into the URL when the page is
+    // loaded.
+    if (!newUrlState && this.props.populateWithInitialState) {
+      this.replaceStateInLocation(urlState);
+      onInitialize(urlState);
+    } else {
+      onInitialize(newUrlState);
+    }
   };
 
   private handleLocationChange = (prevLocation: Location, newLocation: Location) => {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Infra UI] Load initial page state into the URL when empty for Metrics Explorer (#45683)