### PR TITLE
[lens] Promote Lens to the front of the new visualization dialog

### DIFF
--- a/src/legacy/core_plugins/kibana/public/visualize/wizard/type_selection/type_selection.tsx
+++ b/src/legacy/core_plugins/kibana/public/visualize/wizard/type_selection/type_selection.tsx
@@ -201,7 +201,7 @@ class TypeSelection extends React.Component<TypeSelectionProps, TypeSelectionSta
       });
     }
 
-    return sortByOrder(entries, ['highlighted', 'title'], ['desc', 'asc']);
+    return sortByOrder(entries, ['highlighted', 'isPromoted', 'title'], ['desc', 'asc', 'asc']);
   }
 
   private renderVisType = (visType: VisTypeListEntry | VisTypeAliasListEntry) => {

--- a/src/legacy/core_plugins/visualizations/public/np_ready/types/vis_type_alias_registry.ts
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/types/vis_type_alias_registry.ts
@@ -42,6 +42,7 @@ export interface VisTypeAlias {
   name: string;
   title: string;
   icon: string;
+  isPromoted?: boolean;
   description: string;
 
   appExtensions?: {

--- a/x-pack/legacy/plugins/lens/public/register_vis_type_alias.ts
+++ b/x-pack/legacy/plugins/lens/public/register_vis_type_alias.ts
@@ -11,6 +11,7 @@ import { BASE_APP_URL, getEditPath } from '../common';
 visualizations.types.visTypeAliasRegistry.add({
   aliasUrl: BASE_APP_URL,
   name: 'lens',
+  isPromoted: true,
   title: i18n.translate('xpack.lens.visTypeAlias.title', {
     defaultMessage: 'Lens Visualizations',
   }),


### PR DESCRIPTION
This adds an `isPromoted` property to registered visualizations. If true, these visualizations show up before others, but still after any visualizations that match the current search criteria.

![image](https://user-images.githubusercontent.com/833377/65176703-536eed80-da23-11e9-99e2-e6f3a463e862.png)
