### PR TITLE
Upgrade EUI to 14.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@babel/register": "^7.5.5",
     "@elastic/charts": "^12.0.2",
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "8.1.1-kibana2",
     "@elastic/numeral": "2.3.3",

--- a/src/legacy/core_plugins/data/public/search/search_bar/components/saved_query_management/saved_query_management_component.tsx
+++ b/src/legacy/core_plugins/data/public/search/search_bar/components/saved_query_management/saved_query_management_component.tsx
@@ -113,7 +113,6 @@ export const SavedQueryManagementComponent: FunctionComponent<Props> = ({
 
   const savedQueryPopoverButton = (
     <EuiButtonEmpty
-      className="euiFormControlLayout__prepend"
       iconType="arrowDown"
       iconSide="right"
       onClick={() => {
@@ -164,7 +163,6 @@ export const SavedQueryManagementComponent: FunctionComponent<Props> = ({
     <Fragment>
       <EuiPopover
         id="savedQueryPopover"
-        anchorClassName="euiFormControlLayout__prepend"
         button={savedQueryPopoverButton}
         isOpen={isOpen}
         closePopover={() => {

--- a/src/legacy/core_plugins/kibana/public/index.scss
+++ b/src/legacy/core_plugins/kibana/public/index.scss
@@ -1,11 +1,5 @@
 @import 'src/legacy/ui/public/styles/styling_constants';
 
-// Temporary shim to help with EuiFormRow spacing
-// Will move to EUI
-.euiFormRow + .euiButton {
-  margin-top: $euiSize;
-}
-
 // Public UI styles
 @import 'src/legacy/ui/public/index';
 

--- a/src/legacy/core_plugins/kibana/public/management/sections/settings/components/field/__snapshots__/field.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/management/sections/settings/components/field/__snapshots__/field.test.js.snap
@@ -1007,8 +1007,6 @@ exports[`Field for image setting should render as read only with help text if ov
           allowFullScreen={true}
           alt="image:test:setting"
           aria-label="image test setting"
-          fullScreenIconColor="light"
-          size="original"
           url="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
         />
       </EuiFormRow>
@@ -1270,8 +1268,6 @@ exports[`Field for image setting should render user value if there is user value
           allowFullScreen={true}
           alt="image:test:setting"
           aria-label="image test setting"
-          fullScreenIconColor="light"
-          size="original"
           url="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
         />
       </EuiFormRow>

--- a/src/legacy/ui/public/vis/editors/default/components/agg_select.tsx
+++ b/src/legacy/ui/public/vis/editors/default/components/agg_select.tsx
@@ -142,7 +142,7 @@ function DefaultEditorAggSelect({
         isClearable={false}
         isInvalid={showValidation ? !isValid : false}
         fullWidth={true}
-        // compressed
+        compressed
       />
     </EuiFormRow>
   );

--- a/src/legacy/ui/public/vis/editors/default/controls/extended_bounds.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/extended_bounds.tsx
@@ -19,7 +19,7 @@
 
 import React, { useEffect, ChangeEvent } from 'react';
 
-import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiText } from '@elastic/eui';
+import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isUndefined } from 'lodash';
 import { AggParamEditorProps } from '..';
@@ -95,11 +95,7 @@ function ExtendedBoundsParamEditor({
               fullWidth={true}
               isInvalid={showValidation ? !isValid : false}
               aria-label={minLabel}
-              prepend={
-                <EuiText size="xs">
-                  <strong>{minLabel}</strong>
-                </EuiText>
-              }
+              prepend={minLabel}
               compressed
             />
           </EuiFlexItem>
@@ -111,11 +107,7 @@ function ExtendedBoundsParamEditor({
               fullWidth={true}
               isInvalid={showValidation ? !isValid : false}
               aria-label={maxLabel}
-              prepend={
-                <EuiText size="xs">
-                  <strong>{maxLabel}</strong>
-                </EuiText>
-              }
+              prepend={maxLabel}
               compressed
             />
           </EuiFlexItem>

--- a/src/legacy/ui/public/vis/editors/default/controls/field.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/field.tsx
@@ -110,7 +110,7 @@ function FieldParamEditor({
       compressed
     >
       <EuiComboBox
-        // compressed
+        compressed
         placeholder={i18n.translate('common.ui.aggTypes.field.selectFieldPlaceholder', {
           defaultMessage: 'Select a field',
         })}

--- a/src/legacy/ui/public/vis/editors/default/controls/time_interval.tsx
+++ b/src/legacy/ui/public/vis/editors/default/controls/time_interval.tsx
@@ -131,7 +131,7 @@ function TimeIntervalParamEditor({
       })}
     >
       <EuiComboBox
-        // compressed
+        compressed
         fullWidth={true}
         data-test-subj="visEditorInterval"
         isInvalid={showValidation ? !isValid : false}

--- a/src/plugins/es_ui_shared/public/components/cron_editor/cron_daily.js
+++ b/src/plugins/es_ui_shared/public/components/cron_editor/cron_daily.js
@@ -22,29 +22,14 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
 
-export const CronDaily = ({
-  minute,
-  minuteOptions,
-  hour,
-  hourOptions,
-  onChange,
-}) => (
+export const CronDaily = ({ minute, minuteOptions, hour, hourOptions, onChange }) => (
   <Fragment>
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronDaily.fieldTimeLabel"
-          defaultMessage="Time"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronDaily.fieldTimeLabel" defaultMessage="Time" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -54,20 +39,13 @@ export const CronDaily = ({
             options={hourOptions}
             value={hour}
             aria-label={i18n.translate('esUi.cronEditor.cronDaily.hourSelectLabel', {
-              defaultMessage: 'Hour'
+              defaultMessage: 'Hour',
             })}
             onChange={e => onChange({ hour: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  <FormattedMessage
-                    id="esUi.cronEditor.cronDaily.fieldHour.textAtLabel"
-                    defaultMessage="At"
-                  />
-                </strong>
-              </EuiText>
-            )}
+            prepend={i18n.translate('esUi.cronEditor.cronDaily.fieldHour.textAtLabel', {
+              defaultMessage: 'At',
+            })}
             data-test-subj="cronFrequencyDailyHourSelect"
           />
         </EuiFlexItem>
@@ -77,17 +55,11 @@ export const CronDaily = ({
             options={minuteOptions}
             value={minute}
             aria-label={i18n.translate('esUi.cronEditor.cronDaily.minuteSelectLabel', {
-              defaultMessage: 'Minute'
+              defaultMessage: 'Minute',
             })}
             onChange={e => onChange({ minute: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  :
-                </strong>
-              </EuiText>
-            )}
+            prepend=":"
             data-test-subj="cronFrequencyDailyMinuteSelect"
           />
         </EuiFlexItem>

--- a/src/plugins/es_ui_shared/public/components/cron_editor/cron_editor.js
+++ b/src/plugins/es_ui_shared/public/components/cron_editor/cron_editor.js
@@ -21,12 +21,9 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { padLeft } from 'lodash';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
-import {
-  EuiSelect,
-  EuiText,
-  EuiFormRow,
-} from '@elastic/eui';
+import { EuiSelect, EuiFormRow } from '@elastic/eui';
 
 import {
   getOrdinalValue,
@@ -81,25 +78,32 @@ const MONTH_OPTIONS = makeSequence(1, 12).map(value => ({
   text: getMonthName(value - 1),
 }));
 
-const UNITS = [{
-  value: MINUTE,
-  text: 'minute',
-}, {
-  value: HOUR,
-  text: 'hour',
-}, {
-  value: DAY,
-  text: 'day',
-}, {
-  value: WEEK,
-  text: 'week',
-}, {
-  value: MONTH,
-  text: 'month',
-}, {
-  value: YEAR,
-  text: 'year',
-}];
+const UNITS = [
+  {
+    value: MINUTE,
+    text: 'minute',
+  },
+  {
+    value: HOUR,
+    text: 'hour',
+  },
+  {
+    value: DAY,
+    text: 'day',
+  },
+  {
+    value: WEEK,
+    text: 'week',
+  },
+  {
+    value: MONTH,
+    text: 'month',
+  },
+  {
+    value: YEAR,
+    text: 'year',
+  },
+];
 
 const frequencyToFieldsMap = {
   [MINUTE]: {},
@@ -185,7 +189,7 @@ export class CronEditor extends Component {
     frequency: PropTypes.string.isRequired,
     cronExpression: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
-  }
+  };
 
   static getDerivedStateFromProps(props) {
     const { cronExpression } = props;
@@ -209,12 +213,15 @@ export class CronEditor extends Component {
 
     // Update fields which aren't editable with acceptable baseline values.
     const editableFields = Object.keys(frequencyToFieldsMap[frequency]);
-    const inheritedFields = editableFields.reduce((baselineFields, field) => {
-      if (fieldToPreferredValueMap[field] != null) {
-        baselineFields[field] = fieldToPreferredValueMap[field];
-      }
-      return baselineFields;
-    }, { ...frequencyToBaselineFieldsMap[frequency] });
+    const inheritedFields = editableFields.reduce(
+      (baselineFields, field) => {
+        if (fieldToPreferredValueMap[field] != null) {
+          baselineFields[field] = fieldToPreferredValueMap[field];
+        }
+        return baselineFields;
+      },
+      { ...frequencyToBaselineFieldsMap[frequency] }
+    );
 
     const newCronExpression = cronPartsToExpression(inheritedFields);
 
@@ -231,17 +238,20 @@ export class CronEditor extends Component {
     const editableFields = Object.keys(frequencyToFieldsMap[frequency]);
     const newFieldToPreferredValueMap = {};
 
-    const editedFields = editableFields.reduce((accumFields, field) => {
-      if (fields[field] !== undefined) {
-        accumFields[field] = fields[field];
-        // Once the user touches a field, we want to persist its value as the user changes
-        // the cron frequency.
-        newFieldToPreferredValueMap[field] = fields[field];
-      } else {
-        accumFields[field] = this.state[field];
-      }
-      return accumFields;
-    }, { ...frequencyToBaselineFieldsMap[frequency] });
+    const editedFields = editableFields.reduce(
+      (accumFields, field) => {
+        if (fields[field] !== undefined) {
+          accumFields[field] = fields[field];
+          // Once the user touches a field, we want to persist its value as the user changes
+          // the cron frequency.
+          newFieldToPreferredValueMap[field] = fields[field];
+        } else {
+          accumFields[field] = this.state[field];
+        }
+        return accumFields;
+      },
+      { ...frequencyToBaselineFieldsMap[frequency] }
+    );
 
     const newCronExpression = cronPartsToExpression(editedFields);
 
@@ -251,20 +261,14 @@ export class CronEditor extends Component {
       fieldToPreferredValueMap: {
         ...fieldToPreferredValueMap,
         ...newFieldToPreferredValueMap,
-      }
+      },
     });
   };
 
   renderForm() {
     const { frequency } = this.props;
 
-    const {
-      minute,
-      hour,
-      day,
-      date,
-      month,
-    } = this.state;
+    const { minute, hour, day, date, month } = this.state;
 
     switch (frequency) {
       case MINUTE:
@@ -342,12 +346,9 @@ export class CronEditor extends Component {
     return (
       <Fragment>
         <EuiFormRow
-          label={(
-            <FormattedMessage
-              id="esUi.cronEditor.fieldFrequencyLabel"
-              defaultMessage="Frequency"
-            />
-          )}
+          label={
+            <FormattedMessage id="esUi.cronEditor.fieldFrequencyLabel" defaultMessage="Frequency" />
+          }
           fullWidth
         >
           <EuiSelect
@@ -355,16 +356,9 @@ export class CronEditor extends Component {
             value={frequency}
             onChange={e => this.onChangeFrequency(e.target.value)}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  <FormattedMessage
-                    id="esUi.cronEditor.textEveryLabel"
-                    defaultMessage="Every"
-                  />
-                </strong>
-              </EuiText>
-            )}
+            prepend={i18n.translate('esUi.cronEditor.textEveryLabel', {
+              defaultMessage: 'Every',
+            })}
             data-test-subj="cronFrequencySelect"
           />
         </EuiFormRow>

--- a/src/plugins/es_ui_shared/public/components/cron_editor/cron_hourly.js
+++ b/src/plugins/es_ui_shared/public/components/cron_editor/cron_hourly.js
@@ -20,26 +20,16 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
-import {
-  EuiFormRow,
-  EuiSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFormRow, EuiSelect } from '@elastic/eui';
 
-export const CronHourly = ({
-  minute,
-  minuteOptions,
-  onChange,
-}) => (
+export const CronHourly = ({ minute, minuteOptions, onChange }) => (
   <Fragment>
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronHourly.fieldTimeLabel"
-          defaultMessage="Minute"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronHourly.fieldTimeLabel" defaultMessage="Minute" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -48,16 +38,9 @@ export const CronHourly = ({
         value={minute}
         onChange={e => onChange({ minute: e.target.value })}
         fullWidth
-        prepend={(
-          <EuiText size="xs">
-            <strong>
-              <FormattedMessage
-                id="esUi.cronEditor.cronHourly.fieldMinute.textAtLabel"
-                defaultMessage="At"
-              />
-            </strong>
-          </EuiText>
-        )}
+        prepend={i18n.translate('esUi.cronEditor.cronHourly.fieldMinute.textAtLabel', {
+          defaultMessage: 'At',
+        })}
         data-test-subj="cronFrequencyHourlyMinuteSelect"
       />
     </EuiFormRow>

--- a/src/plugins/es_ui_shared/public/components/cron_editor/cron_monthly.js
+++ b/src/plugins/es_ui_shared/public/components/cron_editor/cron_monthly.js
@@ -22,13 +22,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
 
 export const CronMonthly = ({
   minute,
@@ -41,12 +35,9 @@ export const CronMonthly = ({
 }) => (
   <Fragment>
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronMonthly.fieldDateLabel"
-          defaultMessage="Date"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronMonthly.fieldDateLabel" defaultMessage="Date" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -55,27 +46,17 @@ export const CronMonthly = ({
         value={date}
         onChange={e => onChange({ date: e.target.value })}
         fullWidth
-        prepend={(
-          <EuiText size="xs">
-            <strong>
-              <FormattedMessage
-                id="esUi.cronEditor.cronMonthly.textOnTheLabel"
-                defaultMessage="On the"
-              />
-            </strong>
-          </EuiText>
-        )}
+        prepend={i18n.translate('esUi.cronEditor.cronMonthly.textOnTheLabel', {
+          defaultMessage: 'On the',
+        })}
         data-test-subj="cronFrequencyMonthlyDateSelect"
       />
     </EuiFormRow>
 
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronMonthly.fieldTimeLabel"
-          defaultMessage="Time"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronMonthly.fieldTimeLabel" defaultMessage="Time" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -85,20 +66,13 @@ export const CronMonthly = ({
             options={hourOptions}
             value={hour}
             aria-label={i18n.translate('esUi.cronEditor.cronMonthly.hourSelectLabel', {
-              defaultMessage: 'Hour'
+              defaultMessage: 'Hour',
             })}
             onChange={e => onChange({ hour: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  <FormattedMessage
-                    id="esUi.cronEditor.cronMonthly.fieldHour.textAtLabel"
-                    defaultMessage="At"
-                  />
-                </strong>
-              </EuiText>
-            )}
+            prepend={i18n.translate('esUi.cronEditor.cronMonthly.fieldHour.textAtLabel', {
+              defaultMessage: 'At',
+            })}
             data-test-subj="cronFrequencyMonthlyHourSelect"
           />
         </EuiFlexItem>
@@ -108,17 +82,11 @@ export const CronMonthly = ({
             options={minuteOptions}
             value={minute}
             aria-label={i18n.translate('esUi.cronEditor.cronMonthly.minuteSelectLabel', {
-              defaultMessage: 'Minute'
+              defaultMessage: 'Minute',
             })}
             onChange={e => onChange({ minute: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  :
-                </strong>
-              </EuiText>
-            )}
+            prepend=":"
             data-test-subj="cronFrequencyMonthlyMinuteSelect"
           />
         </EuiFlexItem>

--- a/src/plugins/es_ui_shared/public/components/cron_editor/cron_weekly.js
+++ b/src/plugins/es_ui_shared/public/components/cron_editor/cron_weekly.js
@@ -22,13 +22,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
 
 export const CronWeekly = ({
   minute,
@@ -41,12 +35,9 @@ export const CronWeekly = ({
 }) => (
   <Fragment>
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronWeekly.fieldDateLabel"
-          defaultMessage="Day"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronWeekly.fieldDateLabel" defaultMessage="Day" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -55,27 +46,17 @@ export const CronWeekly = ({
         value={day}
         onChange={e => onChange({ day: e.target.value })}
         fullWidth
-        prepend={(
-          <EuiText size="xs">
-            <strong>
-              <FormattedMessage
-                id="esUi.cronEditor.cronWeekly.textOnLabel"
-                defaultMessage="On"
-              />
-            </strong>
-          </EuiText>
-        )}
+        prepend={i18n.translate('esUi.cronEditor.cronWeekly.textOnLabel', {
+          defaultMessage: 'On',
+        })}
         data-test-subj="cronFrequencyWeeklyDaySelect"
       />
     </EuiFormRow>
 
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronWeekly.fieldTimeLabel"
-          defaultMessage="Time"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronWeekly.fieldTimeLabel" defaultMessage="Time" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -85,20 +66,13 @@ export const CronWeekly = ({
             options={hourOptions}
             value={hour}
             aria-label={i18n.translate('esUi.cronEditor.cronWeekly.hourSelectLabel', {
-              defaultMessage: 'Hour'
+              defaultMessage: 'Hour',
             })}
             onChange={e => onChange({ hour: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  <FormattedMessage
-                    id="esUi.cronEditor.cronWeekly.fieldHour.textAtLabel"
-                    defaultMessage="At"
-                  />
-                </strong>
-              </EuiText>
-            )}
+            prepend={i18n.translate('esUi.cronEditor.cronWeekly.fieldHour.textAtLabel', {
+              defaultMessage: 'At',
+            })}
             data-test-subj="cronFrequencyWeeklyHourSelect"
           />
         </EuiFlexItem>
@@ -109,16 +83,10 @@ export const CronWeekly = ({
             value={minute}
             onChange={e => onChange({ minute: e.target.value })}
             aria-label={i18n.translate('esUi.cronEditor.cronWeekly.minuteSelectLabel', {
-              defaultMessage: 'Minute'
+              defaultMessage: 'Minute',
             })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  :
-                </strong>
-              </EuiText>
-            )}
+            prepend=":"
             data-test-subj="cronFrequencyWeeklyMinuteSelect"
           />
         </EuiFlexItem>

--- a/src/plugins/es_ui_shared/public/components/cron_editor/cron_yearly.js
+++ b/src/plugins/es_ui_shared/public/components/cron_editor/cron_yearly.js
@@ -22,13 +22,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFormRow,
-  EuiSelect,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSelect } from '@elastic/eui';
 
 export const CronYearly = ({
   minute,
@@ -43,12 +37,9 @@ export const CronYearly = ({
 }) => (
   <Fragment>
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronYearly.fieldMonthLabel"
-          defaultMessage="Month"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronYearly.fieldMonthLabel" defaultMessage="Month" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -57,27 +48,17 @@ export const CronYearly = ({
         value={month}
         onChange={e => onChange({ month: e.target.value })}
         fullWidth
-        prepend={(
-          <EuiText size="xs">
-            <strong>
-              <FormattedMessage
-                id="esUi.cronEditor.cronYearly.fieldMonth.textInLabel"
-                defaultMessage="In"
-              />
-            </strong>
-          </EuiText>
-        )}
+        prepend={i18n.translate('esUi.cronEditor.cronYearly.fieldMonth.textInLabel', {
+          defaultMessage: 'In',
+        })}
         data-test-subj="cronFrequencyYearlyMonthSelect"
       />
     </EuiFormRow>
 
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronYearly.fieldDateLabel"
-          defaultMessage="Date"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronYearly.fieldDateLabel" defaultMessage="Date" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -86,27 +67,17 @@ export const CronYearly = ({
         value={date}
         onChange={e => onChange({ date: e.target.value })}
         fullWidth
-        prepend={(
-          <EuiText size="xs">
-            <strong>
-              <FormattedMessage
-                id="esUi.cronEditor.cronYearly.fieldDate.textOnTheLabel"
-                defaultMessage="On the"
-              />
-            </strong>
-          </EuiText>
-        )}
+        prepend={i18n.translate('esUi.cronEditor.cronYearly.fieldDate.textOnTheLabel', {
+          defaultMessage: 'On the',
+        })}
         data-test-subj="cronFrequencyYearlyDateSelect"
       />
     </EuiFormRow>
 
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="esUi.cronEditor.cronYearly.fieldTimeLabel"
-          defaultMessage="Time"
-        />
-      )}
+      label={
+        <FormattedMessage id="esUi.cronEditor.cronYearly.fieldTimeLabel" defaultMessage="Time" />
+      }
       fullWidth
       data-test-subj="cronFrequencyConfiguration"
     >
@@ -116,20 +87,13 @@ export const CronYearly = ({
             options={hourOptions}
             value={hour}
             aria-label={i18n.translate('esUi.cronEditor.cronYearly.hourSelectLabel', {
-              defaultMessage: 'Hour'
+              defaultMessage: 'Hour',
             })}
             onChange={e => onChange({ hour: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  <FormattedMessage
-                    id="esUi.cronEditor.cronYearly.fieldHour.textAtLabel"
-                    defaultMessage="At"
-                  />
-                </strong>
-              </EuiText>
-            )}
+            prepend={i18n.translate('esUi.cronEditor.cronYearly.fieldHour.textAtLabel', {
+              defaultMessage: 'At',
+            })}
             data-test-subj="cronFrequencyYearlyHourSelect"
           />
         </EuiFlexItem>
@@ -139,17 +103,11 @@ export const CronYearly = ({
             options={minuteOptions}
             value={minute}
             aria-label={i18n.translate('esUi.cronEditor.cronYearly.minuteSelectLabel', {
-              defaultMessage: 'Minute'
+              defaultMessage: 'Minute',
             })}
             onChange={e => onChange({ minute: e.target.value })}
             fullWidth
-            prepend={(
-              <EuiText size="xs">
-                <strong>
-                  :
-                </strong>
-              </EuiText>
-            )}
+            prepend=":"
             data-test-subj="cronFrequencyYearlyMinuteSelect"
           />
         </EuiFlexItem>

--- a/test/interpreter_functional/plugins/kbn_tp_run_pipeline/package.json
+++ b/test/interpreter_functional/plugins/kbn_tp_run_pipeline/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/test/plugin_functional/plugins/kbn_tp_custom_visualizations/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_custom_visualizations/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "react": "^16.8.0"
   }
 }

--- a/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "react": "^16.8.0"
   },
   "scripts": {

--- a/test/plugin_functional/plugins/kbn_tp_sample_panel_action/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_sample_panel_action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "react": "^16.8.0"
   },
   "scripts": {

--- a/test/plugin_functional/plugins/kbn_tp_visualize_embedding/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_visualize_embedding/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/x-pack/legacy/plugins/canvas/public/components/asset_manager/__examples__/__snapshots__/asset.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/components/asset_manager/__examples__/__snapshots__/asset.examples.storyshot
@@ -17,24 +17,20 @@ exports[`Storyshots components/Assets/Asset airplane 1`] = `
       <div
         className="canvasAsset__thumb canvasCheckered"
       >
-        <button
-          type="button"
-        >
-          <figure
-            className="euiImage canvasAsset__img"
-            style={
-              Object {
-                "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4=)",
-              }
+        <figure
+          className="euiImage canvasAsset__img"
+          style={
+            Object {
+              "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4=)",
             }
-          >
-            <img
-              alt="Asset thumbnail"
-              className="euiImage__img"
-              src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4="
-            />
-          </figure>
-        </button>
+          }
+        >
+          <img
+            alt="Asset thumbnail"
+            className="euiImage__img"
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4="
+          />
+        </figure>
       </div>
       <div
         className="euiSpacer euiSpacer--s"
@@ -215,24 +211,20 @@ exports[`Storyshots components/Assets/Asset marker 1`] = `
       <div
         className="canvasAsset__thumb canvasCheckered"
       >
-        <button
-          type="button"
-        >
-          <figure
-            className="euiImage canvasAsset__img"
-            style={
-              Object {
-                "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4=)",
-              }
+        <figure
+          className="euiImage canvasAsset__img"
+          style={
+            Object {
+              "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4=)",
             }
-          >
-            <img
-              alt="Asset thumbnail"
-              className="euiImage__img"
-              src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4="
-            />
-          </figure>
-        </button>
+          }
+        >
+          <img
+            alt="Asset thumbnail"
+            className="euiImage__img"
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4="
+          />
+        </figure>
       </div>
       <div
         className="euiSpacer euiSpacer--s"

--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart_options.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart_options.tsx
@@ -127,7 +127,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
           })}
         >
           <EuiRadioGroup
-            // compressed
+            compressed
             options={typeRadios}
             idSelected={chartOptions.type}
             onChange={handleTypeChange}
@@ -154,7 +154,7 @@ export const MetricsExplorerChartOptions = ({ chartOptions, onChange }: Props) =
           })}
         >
           <EuiRadioGroup
-            // compressed
+            compressed
             options={yAxisRadios}
             idSelected={chartOptions.yAxisMode}
             onChange={handleYAxisChange}

--- a/x-pack/legacy/plugins/infra/public/components/waffle/custom_field_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/waffle/custom_field_panel.tsx
@@ -48,7 +48,7 @@ export const CustomFieldPanel = injectI18n(
               compressed
             >
               <EuiComboBox
-                // compressed
+                compressed
                 placeholder={intl.formatMessage({
                   id: 'xpack.infra.waffle.customGroupByDropdownPlacehoder',
                   defaultMessage: 'Select one',

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -25,7 +25,7 @@ import {
   EuiText,
   EuiFormControlLayout,
   EuiSwitch,
-  EuiIcon,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -419,8 +419,8 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                       setLocalState(s => ({ ...localState, isTypeFilterOpen: false }))
                     }
                     button={
-                      <EuiButtonEmpty
-                        size="s"
+                      <EuiButtonIcon
+                        iconType="filter"
                         onClick={() => {
                           setLocalState(s => ({
                             ...s,
@@ -429,17 +429,15 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                         }}
                         data-test-subj="lnsIndexPatternFiltersToggle"
                         title={i18n.translate('xpack.lens.indexPatterns.toggleFiltersPopover', {
-                          defaultMessage: 'Toggle filters for index pattern',
+                          defaultMessage: 'Filters for index pattern',
                         })}
                         aria-label={i18n.translate(
                           'xpack.lens.indexPatterns.toggleFiltersPopover',
                           {
-                            defaultMessage: 'Toggle filters for index pattern',
+                            defaultMessage: 'Filters for index pattern',
                           }
                         )}
-                      >
-                        <EuiIcon type="filter" size="m" />
-                      </EuiButtonEmpty>
+                      />
                     }
                   >
                     <EuiPopoverTitle>

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/date_histogram.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/date_histogram.test.tsx
@@ -411,11 +411,14 @@ describe('date_histogram', () => {
         />
       );
 
-      instance.find(EuiRange).prop('onChange')!({
-        target: {
-          value: '2',
-        },
-      } as React.ChangeEvent<HTMLInputElement>);
+      instance.find(EuiRange).prop('onChange')!(
+        {
+          target: {
+            value: '2',
+          },
+        } as React.ChangeEvent<HTMLInputElement>,
+        true
+      );
       expect(setStateSpy).toHaveBeenCalledWith({
         ...state,
         layers: {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.test.tsx
@@ -526,11 +526,14 @@ describe('terms', () => {
         />
       );
 
-      instance.find(EuiRange).prop('onChange')!({
-        target: {
-          value: '7',
-        },
-      } as React.ChangeEvent<HTMLInputElement>);
+      instance.find(EuiRange).prop('onChange')!(
+        {
+          target: {
+            value: '7',
+          },
+        } as React.ChangeEvent<HTMLInputElement>,
+        true
+      );
       expect(setStateSpy).toHaveBeenCalledWith({
         ...state,
         layers: {

--- a/x-pack/legacy/plugins/rollup/public/crud_app/sections/job_create/steps/step_logistics.js
+++ b/x-pack/legacy/plugins/rollup/public/crud_app/sections/job_create/steps/step_logistics.js
@@ -44,7 +44,7 @@ export class StepLogisticsUi extends Component {
     isValidatingIndexPattern: PropTypes.bool.isRequired,
     hasMatchingIndices: PropTypes.bool.isRequired,
     indexPatternAsyncErrors: PropTypes.array,
-  }
+  };
 
   showAdvancedCron = () => {
     const { onFieldsChange } = this.props;
@@ -66,12 +66,9 @@ export class StepLogisticsUi extends Component {
   };
 
   renderIndexPatternHelpText() {
-    const {
-      isValidatingIndexPattern,
-      hasMatchingIndices,
-    } = this.props;
+    const { isValidatingIndexPattern, hasMatchingIndices } = this.props;
 
-    if(!isValidatingIndexPattern && hasMatchingIndices) {
+    if (!isValidatingIndexPattern && hasMatchingIndices) {
       return (
         <EuiTextColor color="secondary" data-test-subj="fieldIndexPatternSuccessMessage">
           <p>
@@ -128,37 +125,25 @@ export class StepLogisticsUi extends Component {
   }
 
   renderCronEditor() {
-    const {
-      fields,
-      onFieldsChange,
-      areStepErrorsVisible,
-      fieldErrors,
-    } = this.props;
+    const { fields, onFieldsChange, areStepErrorsVisible, fieldErrors } = this.props;
 
-    const {
-      rollupCron,
-      cronFrequency,
-      isAdvancedCronVisible,
-      fieldToPreferredValueMap,
-    } = fields;
+    const { rollupCron, cronFrequency, isAdvancedCronVisible, fieldToPreferredValueMap } = fields;
 
-    const {
-      rollupCron: errorRollupCron,
-    } = fieldErrors;
+    const { rollupCron: errorRollupCron } = fieldErrors;
 
     if (isAdvancedCronVisible) {
       return (
         <Fragment>
           <EuiFormRow
-            label={(
+            label={
               <FormattedMessage
                 id="xpack.rollupJobs.create.stepLogistics.fieldCronLabel"
                 defaultMessage="Cron expression"
               />
-            )}
+            }
             error={errorRollupCron}
             isInvalid={Boolean(areStepErrorsVisible && errorRollupCron)}
-            helpText={(
+            helpText={
               <p>
                 <EuiLink href={cronUrl} target="_blank">
                   <FormattedMessage
@@ -167,7 +152,7 @@ export class StepLogisticsUi extends Component {
                   />
                 </EuiLink>
               </p>
-            )}
+            }
             fullWidth
           >
             <EuiFieldText
@@ -199,17 +184,17 @@ export class StepLogisticsUi extends Component {
           fieldToPreferredValueMap={fieldToPreferredValueMap}
           cronExpression={rollupCron}
           frequency={cronFrequency}
-          onChange={({
-            cronExpression,
-            frequency,
-            fieldToPreferredValueMap,
-          }) => onFieldsChange({
-            rollupCron: cronExpression,
-            simpleRollupCron: cronExpression,
-            cronFrequency: frequency,
-            fieldToPreferredValueMap,
-          })}
+          onChange={({ cronExpression, frequency, fieldToPreferredValueMap }) =>
+            onFieldsChange({
+              rollupCron: cronExpression,
+              simpleRollupCron: cronExpression,
+              cronFrequency: frequency,
+              fieldToPreferredValueMap,
+            })
+          }
         />
+
+        <EuiSpacer size="s" />
 
         <EuiText size="s">
           <EuiLink onClick={this.showAdvancedCron} data-test-subj="rollupShowAdvancedCronLink">
@@ -218,7 +203,7 @@ export class StepLogisticsUi extends Component {
               defaultMessage="Create cron expression"
             />
           </EuiLink>
-        </EuiText >
+        </EuiText>
       </Fragment>
     );
   }
@@ -233,13 +218,7 @@ export class StepLogisticsUi extends Component {
       indexPatternAsyncErrors,
     } = this.props;
 
-    const {
-      id,
-      indexPattern,
-      rollupIndex,
-      rollupPageSize,
-      rollupDelay,
-    } = fields;
+    const { id, indexPattern, rollupIndex, rollupPageSize, rollupDelay } = fields;
 
     const {
       id: errorId,
@@ -295,7 +274,7 @@ export class StepLogisticsUi extends Component {
 
         <EuiForm>
           <EuiDescribedFormGroup
-            title={(
+            title={
               <EuiTitle size="s">
                 <h4>
                   <FormattedMessage
@@ -304,22 +283,22 @@ export class StepLogisticsUi extends Component {
                   />
                 </h4>
               </EuiTitle>
-            )}
-            description={(
+            }
+            description={
               <FormattedMessage
                 id="xpack.rollupJobs.create.stepLogistics.sectionIdDescription"
                 defaultMessage="This name will be used as a unique identifier for this rollup job."
               />
-            )}
+            }
             fullWidth
           >
             <EuiFormRow
-              label={(
+              label={
                 <FormattedMessage
                   id="xpack.rollupJobs.create.stepLogistics.fieldIdLabel"
                   defaultMessage="Name"
                 />
-              )}
+              }
               error={errorId}
               isInvalid={Boolean(areStepErrorsVisible && errorId)}
               fullWidth
@@ -335,7 +314,7 @@ export class StepLogisticsUi extends Component {
           </EuiDescribedFormGroup>
 
           <EuiDescribedFormGroup
-            title={(
+            title={
               <EuiTitle size="s">
                 <h4>
                   <FormattedMessage
@@ -344,31 +323,39 @@ export class StepLogisticsUi extends Component {
                   />
                 </h4>
               </EuiTitle>
-            )}
-            description={(
+            }
+            description={
               <FormattedMessage
                 id="xpack.rollupJobs.create.stepLogistics.sectionDataFlowDescription"
                 defaultMessage="Which indices do you want to roll up and where do you want to store the data?"
               />
-            )}
+            }
             fullWidth
           >
             <EuiFormRow
-              label={(
+              label={
                 <FormattedMessage
                   id="xpack.rollupJobs.create.stepLogistics.fieldIndexPatternLabel"
                   defaultMessage="Index pattern"
                 />
-              )}
-              error={isValidatingIndexPattern ? undefined : (errorIndexPattern || indexPatternAsyncErrors)}
-              isInvalid={Boolean((areStepErrorsVisible && errorIndexPattern)) || Boolean(indexPatternAsyncErrors)}
+              }
+              error={
+                isValidatingIndexPattern ? undefined : errorIndexPattern || indexPatternAsyncErrors
+              }
+              isInvalid={
+                Boolean(areStepErrorsVisible && errorIndexPattern) ||
+                Boolean(indexPatternAsyncErrors)
+              }
               helpText={this.renderIndexPatternHelpText()}
               fullWidth
             >
               <EuiFieldText
                 value={indexPattern}
                 onChange={e => onFieldsChange({ indexPattern: e.target.value })}
-                isInvalid={Boolean(areStepErrorsVisible && errorIndexPattern) || Boolean(indexPatternAsyncErrors)}
+                isInvalid={
+                  Boolean(areStepErrorsVisible && errorIndexPattern) ||
+                  Boolean(indexPatternAsyncErrors)
+                }
                 isLoading={isValidatingIndexPattern}
                 fullWidth
                 data-test-subj="rollupIndexPattern"
@@ -376,21 +363,21 @@ export class StepLogisticsUi extends Component {
             </EuiFormRow>
 
             <EuiFormRow
-              label={(
+              label={
                 <FormattedMessage
                   id="xpack.rollupJobs.create.stepLogistics.fieldRollupIndexLabel"
                   defaultMessage="Rollup index name"
                 />
-              )}
+              }
               error={errorRollupIndex}
               isInvalid={Boolean(areStepErrorsVisible && errorRollupIndex)}
-              helpText={(
+              helpText={
                 <FormattedMessage
                   id="xpack.rollupJobs.create.stepLogistics.fieldRollupIndex.helpDisallowLabel"
                   defaultMessage="Spaces, commas, and the characters {characterList} are not allowed."
                   values={{ characterList: <strong>{indexIllegalCharacters}</strong> }}
                 />
-              )}
+              }
               fullWidth
             >
               <EuiFieldText
@@ -404,7 +391,7 @@ export class StepLogisticsUi extends Component {
           </EuiDescribedFormGroup>
 
           <EuiDescribedFormGroup
-            title={(
+            title={
               <EuiTitle size="s">
                 <h4>
                   <FormattedMessage
@@ -413,20 +400,20 @@ export class StepLogisticsUi extends Component {
                   />
                 </h4>
               </EuiTitle>
-            )}
-            description={(
+            }
+            description={
               <FormattedMessage
                 id="xpack.rollupJobs.create.stepLogistics.sectionScheduleDescription"
                 defaultMessage="How often do you want to roll up the data?"
               />
-            )}
+            }
             fullWidth
           >
             {this.renderCronEditor()}
           </EuiDescribedFormGroup>
 
           <EuiDescribedFormGroup
-            title={(
+            title={
               <EuiTitle size="xs">
                 <h5>
                   <FormattedMessage
@@ -435,22 +422,22 @@ export class StepLogisticsUi extends Component {
                   />
                 </h5>
               </EuiTitle>
-            )}
-            description={(
+            }
+            description={
               <FormattedMessage
                 id="xpack.rollupJobs.create.stepLogistics.sectionPageSizeDescription"
                 defaultMessage="A larger page size will roll up data quicker, but requires more memory."
               />
-            )}
+            }
             fullWidth
           >
             <EuiFormRow
-              label={(
+              label={
                 <FormattedMessage
                   id="xpack.rollupJobs.create.stepLogistics.fieldPageSizeLabel"
                   defaultMessage="Page size"
                 />
-              )}
+              }
               error={errorRollupPageSize}
               isInvalid={Boolean(areStepErrorsVisible && errorRollupPageSize)}
               fullWidth
@@ -467,7 +454,7 @@ export class StepLogisticsUi extends Component {
           </EuiDescribedFormGroup>
 
           <EuiDescribedFormGroup
-            title={(
+            title={
               <EuiTitle size="xs">
                 <h5>
                   <FormattedMessage
@@ -476,27 +463,27 @@ export class StepLogisticsUi extends Component {
                   />
                 </h5>
               </EuiTitle>
-            )}
-            description={(
+            }
+            description={
               <FormattedMessage
                 id="xpack.rollupJobs.create.stepLogistics.sectionDelayDescription"
                 defaultMessage="A latency buffer will delay rolling up data. This will yield a
                   higher-fidelity rollup by allowing for variable ingest latency. By default, the
                   rollup job attempts to roll up all data that is available."
               />
-            )}
+            }
             fullWidth
           >
             <EuiFormRow
-              label={(
+              label={
                 <FormattedMessage
                   id="xpack.rollupJobs.create.stepDateHistogram.fieldDelayLabel"
                   defaultMessage="Latency buffer (optional)"
                 />
-              )}
+              }
               error={errorRollupDelay}
               isInvalid={Boolean(areStepErrorsVisible && errorRollupDelay)}
-              helpText={(
+              helpText={
                 <Fragment>
                   <p>
                     <FormattedMessage
@@ -505,7 +492,7 @@ export class StepLogisticsUi extends Component {
                     />
                   </p>
                 </Fragment>
-              )}
+              }
               fullWidth
             >
               <EuiFieldText
@@ -532,7 +519,7 @@ export class StepLogisticsUi extends Component {
     }
 
     return <StepError />;
-  }
+  };
 }
 
 export const StepLogistics = injectI18n(StepLogisticsUi);

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/components/policy_form/steps/step_logistics.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/components/policy_form/steps/step_logistics.tsx
@@ -450,6 +450,8 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
             }}
           />
 
+          <EuiSpacer size="s" />
+
           <EuiText size="s">
             <EuiLink
               onClick={() => {

--- a/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/action_fields/webhook_action_fields.tsx
+++ b/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/action_fields/webhook_action_fields.tsx
@@ -14,7 +14,6 @@ import {
   EuiSelect,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiText,
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -112,11 +111,7 @@ export const WebhookActionFields: React.FunctionComponent<Props> = ({
             )}
           >
             <EuiFieldNumber
-              prepend={
-                <EuiText size="xs">
-                  <strong>:</strong>
-                </EuiText>
-              }
+              prepend=":"
               fullWidth
               name="port"
               value={port || ''}
@@ -144,11 +139,7 @@ export const WebhookActionFields: React.FunctionComponent<Props> = ({
             )}
           >
             <EuiFieldText
-              prepend={
-                <EuiText size="xs">
-                  <strong>/</strong>
-                </EuiText>
-              }
+              prepend="/"
               fullWidth
               name="path"
               value={path || ''}

--- a/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/threshold_watch_edit.tsx
+++ b/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/threshold_watch_edit.tsx
@@ -273,6 +273,7 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
             }}
           />
         </ErrableFormRow>
+        <EuiSpacer />
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem>
             <ErrableFormRow

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -184,7 +184,7 @@
     "@babel/runtime": "^7.5.5",
     "@elastic/ctags-langserver": "^0.1.9",
     "@elastic/datemath": "5.0.2",
-    "@elastic/eui": "14.0.0",
+    "@elastic/eui": "14.2.0",
     "@elastic/javascript-typescript-langserver": "^0.2.2",
     "@elastic/lsp-extension": "^0.1.2",
     "@elastic/maki": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,10 +983,10 @@
     tabbable "^1.1.0"
     uuid "^3.1.0"
 
-"@elastic/eui@14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-14.0.0.tgz#4af6e687aec7b981a87dc4da15699f0d92ad17de"
-  integrity sha512-kU3WNPysOYZkgsrQOO1RmLgQmJWYmjVHw4w4HoliwLka2N9AtEYtNu+rFprkDwO7Pvd1lxb/mRPGdJ6NZtZdvA==
+"@elastic/eui@14.2.0":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-14.2.0.tgz#d6368250e7261c63c06443d3cf3f7cf800916ff2"
+  integrity sha512-6nCV/Q2Ek3zTUj549+cFFx5rpx4ZZ2pjmspPsBhUwsn685qzAPsCv4WB40u4mWBZtMRZagBN2q2M2YxZHSPBLw==
   dependencies:
     "@types/lodash" "^4.14.116"
     "@types/numeral" "^0.0.25"


### PR DESCRIPTION
## [`14.2.0`](https://github.com/elastic/eui/tree/v14.2.0)

- Add `compressed` option to `buttonSize` prop of EuiButtonGroup ([#2343](https://github.com/elastic/eui/pull/2343))
- Added disabled states to `EuiCard`, `EuiKeyPadMenuItem` and `EuiKeyPadMenuItemButton`
 ([#2333](https://github.com/elastic/eui/pull/2340))
- Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))
- Added auto-margin between `EuiFormRow` and `EuiButton` ([#2338](https://github.com/elastic/eui/pull/2338))
- Added border to `[readOnly]` inputs ([#2338](https://github.com/elastic/eui/pull/2338))

**Bug fixes**

- Fixed `onChange` TS defs for EuiRange ([#2349](https://github.com/elastic/eui/pull/2349))
- Fixed default z-index of `EuiPopover` ([#2341](https://github.com/elastic/eui/pull/2341))
- Fixed styling for `prepend` and `append` nodes that may be popovers or tooltips ([#2338](https://github.com/elastic/eui/pull/2338))

## [`14.1.1`](https://github.com/elastic/eui/tree/v14.1.1)

**Bug fixes**

- Fixed accidental removal of Elastic Charts from dependencies ([#2348](https://github.com/elastic/eui/pull/2348))

## [`14.1.0`](https://github.com/elastic/eui/tree/v14.1.0)

- Created `EuiSuggest` component ([#2270](https://github.com/elastic/eui/pull/2270))
- Added missing `compressed` styling to `EuiSwitch` ([#2327](https://github.com/elastic/eui/pull/2327))
- Migrate `EuiBottomBar`, `EuiHealth` and `EuiImage` to TS ([#2328](https://github.com/elastic/eui/pull/2328))
- Added hover and focus states when `allowFullScreen` is true in `EuiImage`([#2287](https://github.com/elastic/eui/pull/2287))
- Converted `EuiColorPicker` to TypeScript ([#2340](https://github.com/elastic/eui/pull/2340))
- Added inline rendering option to `EuiColorPicker` ([#2340](https://github.com/elastic/eui/pull/2340))

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
- ~[ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~

