### PR TITLE
Allow drag / drop of Lens dimension panels

### DIFF
--- a/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.test.tsx
@@ -12,7 +12,7 @@ import {
   DataTableLayer,
 } from './visualization';
 import { mount } from 'enzyme';
-import { Operation, DataType, FramePublicAPI } from '../types';
+import { Operation, DataType, FramePublicAPI, ColumnRemover } from '../types';
 import { generateId } from '../id_generator';
 
 jest.mock('../id_generator');
@@ -128,9 +128,9 @@ describe('Datatable Visualization', () => {
       const onRemove = component
         .find('[data-test-subj="datatable_multicolumnEditor"]')
         .first()
-        .prop('onRemove') as (k: string) => {};
+        .prop('onRemove') as ColumnRemover;
 
-      onRemove('b');
+      onRemove({ layerId: 'a', columnId: 'b' });
 
       expect(setState).toHaveBeenCalledWith({
         layers: [

--- a/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.tsx
+++ b/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.tsx
@@ -76,9 +76,19 @@ export function DataTableLayer({
           filterOperations={allOperations}
           layerId={layer.layerId}
           onAdd={() => setState(updateColumns(state, layer, columns => [...columns, generateId()]))}
-          onRemove={column =>
-            setState(updateColumns(state, layer, columns => columns.filter(c => c !== column)))
-          }
+          onRemove={column => {
+            const targetLayer = state.layers.find(l => l.layerId === column.layerId);
+
+            if (!targetLayer) {
+              return;
+            }
+
+            setState(
+              updateColumns(state, targetLayer, columns =>
+                columns.filter(c => c !== column.columnId)
+              )
+            );
+          }}
           testSubj="datatable_columns"
           data-test-subj="datatable_multicolumnEditor"
         />

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
@@ -880,7 +880,9 @@ describe('IndexPatternDimensionPanel', () => {
       clearButton.simulate('click');
     });
 
-    expect(setState).toHaveBeenCalledWith({
+    const setterFn = setState.mock.calls[0][0] as SetState;
+
+    expect(setterFn(defaultProps.state)).toMatchObject({
       ...state,
       layers: {
         first: {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
@@ -79,6 +79,7 @@ export interface IndexPatternField {
 export interface DraggedField {
   field: IndexPatternField;
   indexPatternId: string;
+  movedColumn?: { layerId: string; columnId: string };
 }
 
 export interface IndexPatternLayer {

--- a/x-pack/legacy/plugins/lens/public/multi_column_editor/multi_column_editor.tsx
+++ b/x-pack/legacy/plugins/lens/public/multi_column_editor/multi_column_editor.tsx
@@ -6,14 +6,14 @@
 
 import React, { useEffect } from 'react';
 import { NativeRenderer } from '../native_renderer';
-import { DatasourcePublicAPI, OperationMetadata } from '../types';
+import { DatasourcePublicAPI, OperationMetadata, ColumnRemover } from '../types';
 import { DragContextState } from '../drag_drop';
 
 interface Props {
   accessors: string[];
   datasource: DatasourcePublicAPI;
   dragDropContext: DragContextState;
-  onRemove: (accessor: string) => void;
+  onRemove: ColumnRemover;
   onAdd: () => void;
   filterOperations: (op: OperationMetadata) => boolean;
   suggestedPriority?: 0 | 1 | 2 | undefined;

--- a/x-pack/legacy/plugins/lens/public/types.ts
+++ b/x-pack/legacy/plugins/lens/public/types.ts
@@ -167,6 +167,8 @@ export interface DatasourceDataPanelProps<T = unknown> {
   dateRange: FramePublicAPI['dateRange'];
 }
 
+export type ColumnRemover = (column: { layerId: string; columnId: string }) => void;
+
 // The only way a visualization has to restrict the query building
 export interface DatasourceDimensionPanelProps {
   layerId: string;
@@ -180,7 +182,7 @@ export interface DatasourceDimensionPanelProps {
   // Visualizations can hint at the role this dimension would play, which
   // affects the default ordering of the query
   suggestedPriority?: DimensionPriority;
-  onRemove?: (accessor: string) => void;
+  onRemove?: ColumnRemover;
 }
 
 export interface DatasourceLayerPanelProps {

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_config_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_config_panel.test.tsx
@@ -9,7 +9,7 @@ import { ReactWrapper } from 'enzyme';
 import { mountWithIntl as mount } from 'test_utils/enzyme_helpers';
 import { EuiButtonGroupProps } from '@elastic/eui';
 import { XYConfigPanel } from './xy_config_panel';
-import { DatasourceDimensionPanelProps, Operation, FramePublicAPI } from '../types';
+import { DatasourceDimensionPanelProps, Operation, FramePublicAPI, ColumnRemover } from '../types';
 import { State, XYState } from './types';
 import { Position } from '@elastic/charts';
 import { NativeRendererProps } from '../native_renderer';
@@ -213,9 +213,9 @@ describe('XYConfigPanel', () => {
     const onRemove = component
       .find('[data-test-subj="lensXY_yDimensionPanel"]')
       .first()
-      .prop('onRemove') as (accessor: string) => {};
+      .prop('onRemove') as ColumnRemover;
 
-    onRemove('b');
+    onRemove({ layerId: 'first', columnId: 'b' });
 
     expect(setState).toHaveBeenCalledTimes(1);
     expect(setState.mock.calls[0][0]).toMatchObject({


### PR DESCRIPTION
This is a move operation. If you drag a dimension panel and drop it onto a different dimension panel, the dragged item should be removed from its origin and should replace its destination.