### PR TITLE
[7.4] Re-enable tsvb math aggs test (#46188)

### DIFF
--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -51,8 +51,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
         expect(value).to.eql('156');
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/45315
-      it.skip('should show correct data with Math Aggregation', async () => {
+      it('should show correct data with Math Aggregation', async () => {
         await PageObjects.visualBuilder.createNewAgg();
         await PageObjects.visualBuilder.selectAggType('math', 1);
         await PageObjects.visualBuilder.fillInVariable();


### PR DESCRIPTION
Backports the following commits to 7.4:
 - Re-enable tsvb math aggs test (#46188)