### PR TITLE
Fixes getInjected "any" type return

### DIFF
--- a/src/legacy/core_plugins/ui_metric/public/hacks/ui_metric_init.ts
+++ b/src/legacy/core_plugins/ui_metric/public/hacks/ui_metric_init.ts
@@ -24,7 +24,7 @@ import { createAnalyticsReporter, setTelemetryReporter } from '../services/telem
 
 function telemetryInit($injector: any) {
   const localStorage = $injector.get('localStorage');
-  const debug = chrome.getInjected('debugUiMetric');
+  const debug = chrome.getInjected<boolean>('debugUiMetric');
   const $http = $injector.get('$http');
   const basePath = chrome.getBasePath();
   const uiReporter = createAnalyticsReporter({ localStorage, $http, basePath, debug });

--- a/src/legacy/ui/public/chrome/index.d.ts
+++ b/src/legacy/ui/public/chrome/index.d.ts
@@ -46,7 +46,7 @@ declare interface Chrome extends ChromeNavLinks {
   getSavedObjectsClient(): SavedObjectsClientContract;
   getUiSettingsClient(): any;
   setVisible(visible: boolean): any;
-  getInjected(key: string, defaultValue?: any): any;
+  getInjected<T = unknown>(key: string, defaultValue?: any): T;
   setRootController(name: string, Controller: any): any;
   setBrand(brand: ChromeBrand): this;
   getBrand(key: keyof ChromeBrand): ChromeBrand[keyof ChromeBrand];

--- a/x-pack/legacy/plugins/infra/public/pages/logs/analysis/page_providers.tsx
+++ b/x-pack/legacy/plugins/infra/public/pages/logs/analysis/page_providers.tsx
@@ -9,10 +9,16 @@ import chrome from 'ui/chrome';
 
 import { LogAnalysisJobs } from '../../../containers/logs/log_analysis';
 import { Source } from '../../../containers/source';
+interface ActiveSpace {
+  space: {
+    id: string;
+  };
+}
 
 export const AnalysisPageProviders: React.FunctionComponent = ({ children }) => {
   const { sourceId, source } = useContext(Source.Context);
-  const spaceId = chrome.getInjected('activeSpace').space.id;
+  const activeSpace = chrome.getInjected<ActiveSpace | null>('activeSpace');
+  const spaceId = activeSpace ? activeSpace.space.id : 'default';
 
   return (
     <LogAnalysisJobs.Provider


### PR DESCRIPTION
Right now, `chrome.getInjected()` is typed to return `any`, which means if you do this:
```ts
const spaceId = chrome.getInjected('activeSpace').space.id;
```
while the spaces plugin is disabled, this code blows up. But TS doesn't warn about it because the return value from `getInjected` is `any`. If it were `unknown`, we'd get a type error and have to handle the possible falsy/undefined/null value. 

I know these APIs are going away so this is probably not high priority but it feels better while we are all migrating to TS and the new platform and it's a small change, so I think it might be worth it.

Note: the infra changes for our space ID handling should probably align with changes done in a separate PR --> https://github.com/elastic/kibana/pull/46241