### PR TITLE
[Lens] Index pattern selection using EuiSelectable

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/suggestion_panel.tsx
@@ -68,7 +68,7 @@ const PreviewRenderer = ({
   }, [expression]);
 
   return expressionError ? (
-    <div className="lnsSidebar__suggestionIcon">
+    <div className="lnsSuggestionPanel__suggestionIcon">
       <EuiIconTip
         size="xl"
         color="danger"
@@ -83,8 +83,8 @@ const PreviewRenderer = ({
     </div>
   ) : (
     <ExpressionRendererComponent
-      className={classNames('lnsSuggestionChartWrapper', {
-        'lnsSuggestionChartWrapper--withLabel': withLabel,
+      className={classNames('lnsSuggestionPanel__chartWrapper', {
+        'lnsSuggestionPanel__chartWrapper--withLabel': withLabel,
       })}
       expression={expression}
       onRenderFailure={(e: unknown) => {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
@@ -13,7 +13,7 @@
 
   & > .lnsInnerIndexPatternDataPanel__changeLink {
     flex: 0 0 auto;
-    margin: 0 $euiSize;
+    margin: 0 (-$euiSizeS) 0 $euiSizeXS;
   }
 }
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
@@ -102,7 +102,7 @@ export function ChangeIndexPattern({
             }))}
             onChange={choices => {
               // @ts-ignore
-              const newSelectedID = choices.filter(option => option.checked)[0].id;
+              const newSelectedID = choices.find(({ checked }) => checked)!.id;
               onChangeIndexPattern(newSelectedID);
               setSelectedID(newSelectedID);
               setPopoverIsOpen(false);

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
@@ -42,12 +42,10 @@ export function ChangeIndexPattern({
     layer ? layer.indexPatternId : currentIndexPatternId
   );
 
-  const indexPatternList = Object.values(indexPatterns)
-    // .filter(indexPattern => indexPattern.id !== layer.indexPatternId)
-    .map(indexPattern => ({
-      ...indexPattern,
-      isTransferable: layer ? isLayerTransferable(layer, indexPattern) : undefined,
-    }));
+  const indexPatternList = Object.values(indexPatterns).map(indexPattern => ({
+    ...indexPattern,
+    isTransferable: layer ? isLayerTransferable(layer, indexPattern) : undefined,
+  }));
 
   const createTrigger = function() {
     const { label, ...rest } = trigger;

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
@@ -74,7 +74,7 @@ export function ChangeIndexPattern({
         panelPaddingSize="s"
         ownFocus
       >
-        <div style={{ minWidth: 300 }}>
+        <div style={{ width: 320 }}>
           <EuiSelectable
             {...selectableProps}
             searchable

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/change_indexpattern.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import _ from 'lodash';
+import React, { useState } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiIconTip,
+  EuiPopover,
+  EuiSelectable,
+  EuiButtonEmptyProps,
+} from '@elastic/eui';
+import { EuiSelectableProps } from '@elastic/eui/src/components/selectable/selectable';
+import { i18n } from '@kbn/i18n';
+import { IndexPatternPrivateState, IndexPatternLayer } from './indexpattern';
+import { isLayerTransferable } from './state_helpers';
+
+export interface ChangeIndexPatternTriggerProps extends EuiButtonEmptyProps {
+  label: string;
+}
+
+export function ChangeIndexPattern({
+  indexPatterns,
+  currentIndexPatternId,
+  onChangeIndexPattern,
+  trigger,
+  layer,
+  selectableProps,
+}: {
+  trigger: ChangeIndexPatternTriggerProps;
+  indexPatterns: IndexPatternPrivateState['indexPatterns'];
+  onChangeIndexPattern: (newId: string) => void;
+  currentIndexPatternId?: string;
+  layer?: IndexPatternLayer;
+  selectableProps?: EuiSelectableProps;
+}) {
+  const [isPopoverOpen, setPopoverIsOpen] = useState(false);
+  const [selectedID, setSelectedID] = useState(
+    layer ? layer.indexPatternId : currentIndexPatternId
+  );
+
+  const indexPatternList = Object.values(indexPatterns)
+    // .filter(indexPattern => indexPattern.id !== layer.indexPatternId)
+    .map(indexPattern => ({
+      ...indexPattern,
+      isTransferable: layer ? isLayerTransferable(layer, indexPattern) : undefined,
+    }));
+
+  const createTrigger = function() {
+    const { label, ...rest } = trigger;
+    return (
+      <EuiButtonEmpty
+        flush="left"
+        className="eui-textTruncate"
+        size="xs"
+        onClick={() => setPopoverIsOpen(!isPopoverOpen)}
+        {...rest}
+      >
+        {label}
+      </EuiButtonEmpty>
+    );
+  };
+
+  return (
+    <>
+      <EuiPopover
+        button={createTrigger()}
+        isOpen={isPopoverOpen}
+        closePopover={() => setPopoverIsOpen(false)}
+        className="eui-textTruncate"
+        anchorClassName="eui-textTruncate"
+        display="block"
+        panelPaddingSize="s"
+        ownFocus
+      >
+        <div style={{ minWidth: 300 }}>
+          <EuiSelectable
+            {...selectableProps}
+            searchable
+            singleSelection="always"
+            options={indexPatternList.map(indexPattern => ({
+              id: indexPattern.id,
+              label: indexPattern.title,
+              checked: indexPattern.id === selectedID ? 'on' : undefined,
+              append:
+                indexPattern && indexPattern.isTransferable !== false ? (
+                  undefined
+                ) : (
+                  <EuiIconTip
+                    color="warning"
+                    type="minusInCircle"
+                    content={i18n.translate(
+                      'xpack.lens.indexPattern.lossyIndexPatternSwitchDescription',
+                      {
+                        defaultMessage:
+                          'Not all operations are compatible with this index pattern and will be removed on switching.',
+                      }
+                    )}
+                  />
+                ),
+            }))}
+            onChange={choices => {
+              // @ts-ignore
+              const newSelectedID = choices.filter(option => option.checked)[0].id;
+              onChangeIndexPattern(newSelectedID);
+              setSelectedID(newSelectedID);
+              setPopoverIsOpen(false);
+            }}
+            searchProps={{
+              compressed: true,
+              ...(selectableProps ? selectableProps.searchProps : undefined),
+            }}
+          >
+            {(list, search) => (
+              <>
+                {search}
+                {list}
+              </>
+            )}
+          </EuiSelectable>
+        </div>
+      </EuiPopover>
+    </>
+  );
+}

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.test.tsx
@@ -6,13 +6,13 @@
 
 import { shallow, mount } from 'enzyme';
 import React, { ChangeEvent } from 'react';
-import { EuiComboBox } from '@elastic/eui';
 import { IndexPatternPrivateState, IndexPatternColumn } from './indexpattern';
 import { createMockedDragDropContext } from './mocks';
 import { InnerIndexPatternDataPanel, IndexPatternDataPanel, MemoizedDataPanel } from './datapanel';
 import { FieldItem } from './field_item';
 import { act } from 'react-dom/test-utils';
 import { coreMock } from 'src/core/public/mocks';
+import { ChangeIndexPattern } from './change_indexpattern';
 
 jest.mock('ui/new_platform');
 jest.mock('./loader');
@@ -213,8 +213,6 @@ describe('IndexPattern Data Panel', () => {
       dragDropContext: createMockedDragDropContext(),
       currentIndexPatternId: '1',
       indexPatterns: initialState.indexPatterns,
-      showIndexPatternSwitcher: false,
-      setShowIndexPatternSwitcher: jest.fn(),
       onChangeIndexPattern: jest.fn(),
       core,
       dateRange: {
@@ -229,24 +227,22 @@ describe('IndexPattern Data Panel', () => {
 
   it('should update index pattern of layer on switch if it is a single empty one', async () => {
     const setStateSpy = jest.fn();
+    const state = {
+      ...initialState,
+      layers: { first: { indexPatternId: '1', columnOrder: [], columns: {} } },
+    };
     const wrapper = shallow(
       <IndexPatternDataPanel
         {...defaultProps}
-        state={{
-          ...initialState,
-          layers: { first: { indexPatternId: '1', columnOrder: [], columns: {} } },
-        }}
+        state={state}
         setState={setStateSpy}
         dragDropContext={{ dragging: {}, setDragging: () => {} }}
       />
     );
 
-    act(() => {
-      wrapper.find(MemoizedDataPanel).prop('setShowIndexPatternSwitcher')!(true);
-    });
     wrapper.find(MemoizedDataPanel).prop('onChangeIndexPattern')!('2');
 
-    expect(setStateSpy).toHaveBeenCalledWith({
+    expect(setStateSpy.mock.calls[0][0](state)).toEqual({
       ...initialState,
       layers: { first: { indexPatternId: '2', columnOrder: [], columns: {} } },
       currentIndexPatternId: '2',
@@ -271,12 +267,12 @@ describe('IndexPattern Data Panel', () => {
       />
     );
 
-    act(() => {
-      wrapper.find(MemoizedDataPanel).prop('setShowIndexPatternSwitcher')!(true);
-    });
     wrapper.find(MemoizedDataPanel).prop('onChangeIndexPattern')!('2');
 
-    expect(setStateSpy).toHaveBeenCalledWith({ ...state, currentIndexPatternId: '2' });
+    expect(setStateSpy.mock.calls[0][0](state)).toEqual({
+      ...state,
+      currentIndexPatternId: '2',
+    });
   });
 
   it('should not update index pattern of layer on switch if there are columns configured', async () => {
@@ -300,12 +296,12 @@ describe('IndexPattern Data Panel', () => {
       />
     );
 
-    act(() => {
-      wrapper.find(MemoizedDataPanel).prop('setShowIndexPatternSwitcher')!(true);
-    });
     wrapper.find(MemoizedDataPanel).prop('onChangeIndexPattern')!('2');
 
-    expect(setStateSpy).toHaveBeenCalledWith({ ...state, currentIndexPatternId: '2' });
+    expect(setStateSpy.mock.calls[0][0](state)).toEqual({
+      ...state,
+      currentIndexPatternId: '2',
+    });
   });
 
   it('should render a warning if there are no index patterns', () => {
@@ -318,20 +314,7 @@ describe('IndexPattern Data Panel', () => {
   it('should call setState when the index pattern is switched', async () => {
     const wrapper = shallow(<InnerIndexPatternDataPanel {...defaultProps} />);
 
-    wrapper.find('[data-test-subj="indexPattern-switch-link"]').simulate('click');
-
-    expect(defaultProps.setShowIndexPatternSwitcher).toHaveBeenCalledWith(true);
-
-    wrapper.setProps({ showIndexPatternSwitcher: true });
-
-    const comboBox = wrapper.find(EuiComboBox);
-
-    comboBox.prop('onChange')!([
-      {
-        label: initialState.indexPatterns['2'].title,
-        value: '2',
-      },
-    ]);
+    wrapper.find(ChangeIndexPattern).prop('onChangeIndexPattern')('2');
 
     expect(defaultProps.onChangeIndexPattern).toHaveBeenCalledWith('2');
   });

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -67,21 +67,20 @@ export function IndexPatternDataPanel({
   dateRange,
 }: DatasourceDataPanelProps<IndexPatternPrivateState>) {
   const { indexPatterns, currentIndexPatternId } = state;
-  const [showIndexPatternSwitcher, setShowIndexPatternSwitcher] = useState(false);
 
   const onChangeIndexPattern = useCallback(
     (newIndexPattern: string) => {
-      setState({
-        ...state,
-        layers: isSingleEmptyLayer(state.layers)
-          ? mapValues(state.layers, layer =>
+      setState(prevState => ({
+        ...prevState,
+        layers: isSingleEmptyLayer(prevState.layers)
+          ? mapValues(prevState.layers, layer =>
               updateLayerIndexPattern(layer, indexPatterns[newIndexPattern])
             )
-          : state.layers,
+          : prevState.layers,
         currentIndexPatternId: newIndexPattern,
-      });
+      }));
     },
-    [state, setState]
+    [setState]
   );
 
   const updateFieldsWithCounts = useCallback(
@@ -105,12 +104,10 @@ export function IndexPatternDataPanel({
 
   const onToggleEmptyFields = useCallback(() => {
     setState(prevState => ({ ...prevState, showEmptyFields: !prevState.showEmptyFields }));
-  }, [state, setState]);
+  }, [setState]);
 
   return (
     <MemoizedDataPanel
-      showIndexPatternSwitcher={showIndexPatternSwitcher}
-      setShowIndexPatternSwitcher={setShowIndexPatternSwitcher}
       currentIndexPatternId={currentIndexPatternId}
       indexPatterns={indexPatterns}
       query={query}
@@ -119,8 +116,7 @@ export function IndexPatternDataPanel({
       showEmptyFields={state.showEmptyFields}
       onToggleEmptyFields={onToggleEmptyFields}
       core={core}
-      // only pass in the state change callback if it's actually needed to avoid re-renders
-      onChangeIndexPattern={showIndexPatternSwitcher ? onChangeIndexPattern : undefined}
+      onChangeIndexPattern={onChangeIndexPattern}
       updateFieldsWithCounts={
         !indexPatterns[currentIndexPatternId].hasExistence ? updateFieldsWithCounts : undefined
       }
@@ -149,8 +145,6 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   query,
   dateRange,
   dragDropContext,
-  showIndexPatternSwitcher,
-  setShowIndexPatternSwitcher,
   onChangeIndexPattern,
   updateFieldsWithCounts,
   showEmptyFields,
@@ -163,11 +157,9 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   query: Query;
   core: DatasourceDataPanelProps['core'];
   dragDropContext: DragContextState;
-  showIndexPatternSwitcher: boolean;
-  setShowIndexPatternSwitcher: (show: boolean) => void;
   showEmptyFields: boolean;
   onToggleEmptyFields: () => void;
-  onChangeIndexPattern?: (newId: string) => void;
+  onChangeIndexPattern: (newId: string) => void;
   updateFieldsWithCounts?: (indexPatternId: string, fields: IndexPattern['fields']) => void;
 }) {
   if (Object.keys(indexPatterns).length === 0) {
@@ -346,7 +338,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                 currentIndexPatternId={currentIndexPatternId}
                 indexPatterns={indexPatterns}
                 onChangeIndexPattern={(newId: string) => {
-                  if (onChangeIndexPattern) onChangeIndexPattern(newId);
+                  onChangeIndexPattern(newId);
 
                   setLocalState(s => ({
                     ...s,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -43,7 +43,7 @@ function sortFields(fieldA: IndexPatternField, fieldB: IndexPatternField) {
   return fieldA.name.localeCompare(fieldB.name, undefined, { sensitivity: 'base' });
 }
 
-const supportedFieldTypes = ['string', 'number', 'boolean', 'date'];
+const supportedFieldTypes = new Set(['string', 'number', 'boolean', 'date', 'ip']);
 const PAGINATION_SIZE = 50;
 
 const fieldTypeNames: Record<DataType, string> = {
@@ -51,6 +51,7 @@ const fieldTypeNames: Record<DataType, string> = {
   number: i18n.translate('xpack.lens.datatypes.number', { defaultMessage: 'number' }),
   boolean: i18n.translate('xpack.lens.datatypes.boolean', { defaultMessage: 'boolean' }),
   date: i18n.translate('xpack.lens.datatypes.date', { defaultMessage: 'date' }),
+  ip: i18n.translate('xpack.lens.datatypes.ipAddress', { defaultMessage: 'IP' }),
 };
 
 function isSingleEmptyLayer(layerMap: IndexPatternPrivateState['layers']) {
@@ -228,7 +229,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   );
 
   const displayedFields = allFields.filter(field => {
-    if (!supportedFieldTypes.includes(field.type)) {
+    if (!supportedFieldTypes.has(field.type)) {
       return false;
     }
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -167,7 +167,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
     return (
       <EuiFlexGroup
         gutterSize="m"
-        className="lnsIndexPatternDataPanel"
+        className="lnsInnerIndexPatternDataPanel"
         direction="column"
         responsive={false}
       >
@@ -318,7 +318,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
     <ChildDragDropProvider {...dragDropContext}>
       <EuiFlexGroup
         gutterSize="none"
-        className="lnsIndexPatternDataPanel"
+        className="lnsInnerIndexPatternDataPanel"
         direction="column"
         responsive={false}
       >
@@ -354,7 +354,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
         <EuiFlexItem>
           <EuiFlexGroup
             gutterSize="s"
-            className="lnsIndexPatternDataPanel__filter-wrapper"
+            className="lnsInnerIndexPatternDataPanel__filterWrapper"
             responsive={false}
           >
             <EuiFlexItem grow={true}>
@@ -467,7 +467,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
             </EuiFlexItem>
           </EuiFlexGroup>
           <div
-            className="lnsFieldListPanel__list-wrapper"
+            className="lnsInnerIndexPatternDataPanel__listWrapper"
             ref={el => {
               if (el && !el.dataset.dynamicScroll) {
                 el.dataset.dynamicScroll = 'true';
@@ -476,7 +476,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
             }}
             onScroll={lazyScroll}
           >
-            <div className="lnsFieldListPanel__list">
+            <div className="lnsInnerIndexPatternDataPanel__list">
               {localState.isLoading && <EuiLoadingSpinner />}
 
               {paginatedFields.map(field => {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -322,7 +322,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
         responsive={false}
       >
         <EuiFlexItem grow={null}>
-          <div className="lnsIndexPatternDataPanel__header">
+          <div className="lnsInnerIndexPatternDataPanel__header">
             <EuiTitle size="xxs" className="eui-textTruncate">
               <h4 title={currentIndexPattern.title}>{currentIndexPattern.title} </h4>
             </EuiTitle>

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -326,7 +326,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
             <EuiTitle size="xxs" className="eui-textTruncate">
               <h4 title={currentIndexPattern.title}>{currentIndexPattern.title} </h4>
             </EuiTitle>
-            <div>
+            <div className="lnsInnerIndexPatternDataPanel__changeLink">
               <ChangeIndexPattern
                 data-test-subj="indexPattern-switcher"
                 trigger={{

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/layerpanel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/layerpanel.test.tsx
@@ -4,14 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
-import { EuiComboBox } from '@elastic/eui';
+import React, { ReactElement } from 'react';
 import { IndexPatternPrivateState } from './indexpattern';
-import { act } from 'react-dom/test-utils';
 import { IndexPatternLayerPanelProps, LayerPanel } from './layerpanel';
 import { updateLayerIndexPattern } from './state_helpers';
-import { mountWithIntl as mount } from 'test_utils/enzyme_helpers';
-import { ReactWrapper } from 'enzyme';
+import { shallowWithIntl as shallow } from 'test_utils/enzyme_helpers';
+import { ShallowWrapper } from 'enzyme';
+import { EuiSelectable, EuiSelectableList } from '@elastic/eui';
+import { ChangeIndexPattern } from './change_indexpattern';
 
 jest.mock('ui/new_platform');
 jest.mock('./state_helpers');
@@ -177,53 +177,61 @@ describe('Layer Data Panel', () => {
     };
   });
 
-  function clickLabel(instance: ReactWrapper) {
-    act(() => {
-      instance
-        .find('[data-test-subj="lns_layerIndexPatternLabel"]')
-        .first()
-        .simulate('click');
-    });
-
-    instance.update();
+  function getIndexPatternPickerList(instance: ShallowWrapper) {
+    return instance
+      .find(ChangeIndexPattern)
+      .first()
+      .dive()
+      .find(EuiSelectable);
   }
 
-  it('should list all index patterns but the current one', () => {
-    const instance = mount(<LayerPanel {...defaultProps} />);
-    clickLabel(instance);
-
-    expect(
+  function selectIndexPatternPickerOption(instance: ShallowWrapper, selectedLabel: string) {
+    const options: Array<{ label: string; checked?: 'on' | 'off' }> = getIndexPatternPickerOptions(
       instance
-        .find(EuiComboBox)
-        .prop('options')!
-        .map(option => option.label)
-    ).toEqual(['my-fake-restricted-pattern', 'my-compatible-pattern']);
+    ).map(option =>
+      option.label === selectedLabel
+        ? { ...option, checked: 'on' }
+        : { ...option, checked: undefined }
+    );
+    return getIndexPatternPickerList(instance).prop('onChange')!(options);
+  }
+
+  function getIndexPatternPickerOptions(instance: ShallowWrapper) {
+    return getIndexPatternPickerList(instance)
+      .dive()
+      .find(EuiSelectableList)
+      .prop('options');
+  }
+
+  it('should list all index patterns', () => {
+    const instance = shallow(<LayerPanel {...defaultProps} />);
+
+    expect(getIndexPatternPickerOptions(instance)!.map(option => option.label)).toEqual([
+      'my-fake-index-pattern',
+      'my-fake-restricted-pattern',
+      'my-compatible-pattern',
+    ]);
   });
 
-  it('should indicate whether the switch can be made without lossing data', () => {
-    const instance = mount(<LayerPanel {...defaultProps} />);
-    clickLabel(instance);
+  it('should indicate whether the switch can be made without losing data', () => {
+    const instance = shallow(<LayerPanel {...defaultProps} />);
 
     expect(
-      instance
-        .find(EuiComboBox)
-        .prop('options')!
-        .map(option => (option.value as { isTransferable: boolean }).isTransferable)
-    ).toEqual([false, true]);
+      getIndexPatternPickerOptions(instance)!.map(option =>
+        Boolean(
+          option.append &&
+            (option.append as ReactElement).props.content.includes(
+              'Not all operations are compatible with this index pattern'
+            )
+        )
+      )
+    ).toEqual([false, true, false]);
   });
 
   it('should switch data panel to target index pattern', () => {
-    const instance = mount(<LayerPanel {...defaultProps} />);
-    clickLabel(instance);
+    const instance = shallow(<LayerPanel {...defaultProps} />);
 
-    act(() => {
-      instance.find(EuiComboBox).prop('onChange')!([
-        {
-          label: 'my-compatible-pattern',
-          value: defaultProps.state.indexPatterns['3'],
-        },
-      ]);
-    });
+    selectIndexPatternPickerOption(instance, 'my-compatible-pattern');
 
     expect(defaultProps.setState).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -233,17 +241,8 @@ describe('Layer Data Panel', () => {
   });
 
   it('should switch using updateLayerIndexPattern', () => {
-    const instance = mount(<LayerPanel {...defaultProps} />);
-    clickLabel(instance);
-
-    act(() => {
-      instance.find(EuiComboBox).prop('onChange')!([
-        {
-          label: 'my-compatible-pattern',
-          value: defaultProps.state.indexPatterns['3'],
-        },
-      ]);
-    });
+    const instance = shallow(<LayerPanel {...defaultProps} />);
+    selectIndexPatternPickerOption(instance, 'my-compatible-pattern');
 
     expect(updateLayerIndexPattern).toHaveBeenCalledWith(
       defaultProps.state.layers.first,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/layerpanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/layerpanel.tsx
@@ -5,137 +5,28 @@
  */
 
 import _ from 'lodash';
-import React, { useState } from 'react';
-import {
-  // @ts-ignore
-  EuiHighlight,
-  EuiButtonEmpty,
-  EuiIconTip,
-  EuiPopover,
-  EuiSelectable,
-  EuiButtonEmptyProps,
-} from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+import React from 'react';
 import { I18nProvider } from '@kbn/i18n/react';
 import { DatasourceLayerPanelProps, StateSetter } from '../types';
-import { IndexPatternPrivateState, IndexPatternLayer } from './indexpattern';
-import { isLayerTransferable, updateLayerIndexPattern } from './state_helpers';
+import { IndexPatternPrivateState } from './indexpattern';
+import { updateLayerIndexPattern } from './state_helpers';
+import { ChangeIndexPattern } from './change_indexpattern';
 
 export interface IndexPatternLayerPanelProps extends DatasourceLayerPanelProps {
   state: IndexPatternPrivateState;
   setState: StateSetter<IndexPatternPrivateState>;
 }
-
-export interface LayerPanelChooserTriggerProps extends EuiButtonEmptyProps {
-  label: string;
-}
-
-function LayerPanelChooser({
-  indexPatterns,
-  layer,
-  onChangeIndexPattern,
-  trigger,
-}: {
-  indexPatterns: IndexPatternPrivateState['indexPatterns'];
-  layer: IndexPatternLayer;
-  onChangeIndexPattern: (newId: string) => void;
-  trigger: LayerPanelChooserTriggerProps;
-}) {
-  const [isPopoverOpen, setPopoverIsOpen] = useState(false);
-  // const currentIndexPatternId = layer.indexPatternId;
-  const indexPatternList = Object.values(indexPatterns)
-    // .filter(indexPattern => indexPattern.id !== layer.indexPatternId)
-    .map(indexPattern => ({
-      ...indexPattern,
-      isTransferable: isLayerTransferable(layer, indexPattern),
-    }));
-
-  const createTrigger = function() {
-    const { label, ...rest } = trigger;
-    return (
-      <EuiButtonEmpty
-        flush="left"
-        className="eui-textTruncate"
-        size="xs"
-        onClick={() => setPopoverIsOpen(!isPopoverOpen)}
-        {...rest}
-      >
-        {label}
-      </EuiButtonEmpty>
-    );
-  };
-
-  return (
-    <>
-      <EuiPopover
-        button={createTrigger()}
-        isOpen={isPopoverOpen}
-        closePopover={() => setPopoverIsOpen(false)}
-        className="eui-textTruncate"
-        anchorClassName="eui-textTruncate"
-        display="block"
-        panelPaddingSize="s"
-      >
-        <div style={{ minWidth: 300 }}>
-          <EuiSelectable
-            searchable
-            singleSelection="always"
-            options={indexPatternList.map(indexPattern => ({
-              label: indexPattern.title,
-              value: indexPattern,
-              checked: indexPattern.id === layer.indexPatternId ? 'on' : undefined,
-              prepend:
-                indexPattern && indexPattern.isTransferable ? (
-                  undefined
-                ) : (
-                  <EuiIconTip
-                    type="minusInCircle"
-                    content={i18n.translate(
-                      'xpack.lens.indexPattern.lossyIndexPatternSwitchDescription',
-                      {
-                        defaultMessage:
-                          'Not all operations are compatible with this index pattern and will be removed on switching.',
-                      }
-                    )}
-                  />
-                ),
-            }))}
-            onChange={choices => {
-              if (choices.length) {
-                onChangeIndexPattern(
-                  _.find(choices, function(c) {
-                    return c.checked === 'on';
-                  })!.value!.id
-                );
-              }
-            }}
-            searchProps={{
-              compressed: true,
-            }}
-          >
-            {(list, search) => (
-              <>
-                {search}
-                {list}
-              </>
-            )}
-          </EuiSelectable>
-        </div>
-      </EuiPopover>
-    </>
-  );
-}
-
 export function LayerPanel({ state, setState, layerId }: IndexPatternLayerPanelProps) {
   return (
     <I18nProvider>
-      <LayerPanelChooser
+      <ChangeIndexPattern
+        data-test-subj="indexPattern-switcher"
         trigger={{
           label: state.indexPatterns[state.layers[layerId].indexPatternId].title,
           'data-test-subj': 'lns_layerIndexPatternLabel',
         }}
-        indexPatterns={state.indexPatterns}
         layer={state.layers[layerId]}
+        indexPatterns={state.indexPatterns}
         onChangeIndexPattern={newId => {
           setState({
             ...state,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/layerpanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/layerpanel.tsx
@@ -56,7 +56,7 @@ function LayerPanelChooser({
       <EuiButtonEmpty
         flush="left"
         className="eui-textTruncate"
-        size="s"
+        size="xs"
         onClick={() => setPopoverIsOpen(!isPopoverOpen)}
         {...rest}
       >
@@ -73,8 +73,10 @@ function LayerPanelChooser({
         closePopover={() => setPopoverIsOpen(false)}
         className="eui-textTruncate"
         anchorClassName="eui-textTruncate"
+        display="block"
+        panelPaddingSize="s"
       >
-        <div style={{ minWidth: 200 }}>
+        <div style={{ minWidth: 300 }}>
           <EuiSelectable
             searchable
             singleSelection="always"

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_config_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_config_panel.tsx
@@ -169,7 +169,7 @@ export function XYConfigPanel(props: VisualizationProps<State>) {
           data-test-subj={`lnsXY_layer_${layer.layerId}`}
           paddingSize="s"
         >
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
             <EuiFlexItem grow={false}>
               <LayerSettings
                 layer={layer}
@@ -183,7 +183,7 @@ export function XYConfigPanel(props: VisualizationProps<State>) {
               />
             </EuiFlexItem>
 
-            <EuiFlexItem>
+            <EuiFlexItem className="eui-textTruncate">
               <NativeRenderer
                 data-test-subj="lnsXY_layerHeader"
                 render={props.frame.datasourceLayers[layer.layerId].renderLayerPanel}
@@ -192,7 +192,7 @@ export function XYConfigPanel(props: VisualizationProps<State>) {
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          <EuiSpacer size="s" />
+          <EuiSpacer size="xs" />
 
           <EuiFormRow
             className="lnsConfigPanel__axis"


### PR DESCRIPTION
## Created a shared component for changing index pattern

There were two different implementations used in the fields panel and the layer panel. They both used EuiComboBox and swapped out the UI from text to the input. This wasn't ideal as I wanted the selection to occur in a popover with a straight list and search capability.

<img width="334" alt="Screen Shot 2019-09-23 at 12 08 40 PM" src="https://user-images.githubusercontent.com/549577/65442839-ec727f80-ddfa-11e9-921f-299fa7634a60.png">
<img width="393" alt="Screen Shot 2019-09-23 at 12 09 08 PM" src="https://user-images.githubusercontent.com/549577/65442875-f98f6e80-ddfa-11e9-888b-9fba50548990.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~