### PR TITLE
Allow ['*'] for actions whitelistedHosts

### DIFF
--- a/x-pack/legacy/plugins/actions/index.ts
+++ b/x-pack/legacy/plugins/actions/index.ts
@@ -28,7 +28,11 @@ export function actions(kibana: any) {
         .keys({
           enabled: Joi.boolean().default(false),
           whitelistedHosts: Joi.array()
-            .items(Joi.string().hostname())
+            .items(
+              Joi.string()
+                .hostname()
+                .allow('*')
+            )
             .sparse(false)
             .default([]),
         })


### PR DESCRIPTION
In this PR, I'm changing the Joi validation for actions plugin config to allow `xpack.actions.whitelistedHosts: ['*']`. The underlying code & tests support it but the validation wasn't aligned.