### PR TITLE
[7.3] Update geckodriver to the latest 0.25.0 release (#46309)

### DIFF
--- a/package.json
+++ b/package.json
@@ -375,7 +375,7 @@
     "exit-hook": "^2.2.0",
     "faker": "1.1.0",
     "fetch-mock": "7.3.3",
-    "geckodriver": "1.16.2",
+    "geckodriver": "^1.18.0",
     "getopts": "^2.2.4",
     "grunt": "1.0.4",
     "grunt-cli": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13128,10 +13128,10 @@ gaze@^1.0.0, gaze@^1.1.0:
   dependencies:
     globule "^1.0.0"
 
-geckodriver@1.16.2:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.16.2.tgz#4766e6eb6835e9ec8797f1dce1966df2b3fb5985"
-  integrity sha512-kXZP4QferAv57Ru4Fx2WYuu//ErKJP4hPEkJm4mSETo42jsdYFwdNxwQ4vCGhf14gsCdxU9YrwNupJ8gr1GxPg==
+geckodriver@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.18.0.tgz#a4d9b0504be26ed933d7be208b06b15833e32415"
+  integrity sha512-PFBq5UsngfLrxmNqnynix4rQgOkOWCKl3I3PlXCROiTQKSE2znIK9MnEUNQznzxNOPMRt1RGGy2cinIARSRvKQ==
   dependencies:
     adm-zip "0.4.11"
     bluebird "3.4.6"


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Update geckodriver to the latest 0.25.0 release (#46309)