### PR TITLE
[Lens] Ensure Lens index pattern column names are unique

### DIFF
--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
@@ -122,6 +122,7 @@ describe('IndexPatternDimensionPanel', () => {
       setState,
       columnId: 'col1',
       layerId: 'first',
+      uniqueLabel: 'stuff',
       filterOperations: () => true,
       storage: {} as Storage,
       uiSettings: {} as UiSettingsClientContract,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
@@ -37,6 +37,7 @@ export type IndexPatternDimensionPanelProps = DatasourceDimensionPanelProps & {
   savedObjectsClient: SavedObjectsClientContract;
   layerId: string;
   http: HttpServiceBase;
+  uniqueLabel: string;
 };
 
 export interface OperationFieldSupportMatrix {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
@@ -72,6 +72,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
     setState,
     layerId,
     currentIndexPattern,
+    uniqueLabel,
   } = props;
   const { operationByDocument, operationByField, fieldByOperation } = operationFieldSupportMatrix;
   const [isPopoverOpen, setPopoverOpen] = useState(false);
@@ -221,7 +222,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
               defaultMessage: 'Edit configuration',
             })}
           >
-            {selectedColumn.label}
+            {uniqueLabel}
           </EuiLink>
         ) : (
           <>

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
@@ -14,6 +14,7 @@ import {
   IndexPatternPersistedState,
   IndexPatternPrivateState,
   IndexPatternColumn,
+  uniqueLabels,
 } from './indexpattern';
 import { DatasourcePublicAPI, Operation, Datasource } from '../types';
 import { coreMock } from 'src/core/public/mocks';
@@ -170,6 +171,47 @@ describe('IndexPattern Data Source', () => {
     };
   });
 
+  describe('uniqueLabels', () => {
+    it('appends a suffix to duplicates', () => {
+      const col: IndexPatternColumn = {
+        dataType: 'number',
+        isBucketed: false,
+        label: 'Foo',
+        operationType: 'count',
+      };
+      const map = uniqueLabels({
+        a: {
+          columnOrder: ['a', 'b'],
+          columns: {
+            a: col,
+            b: col,
+          },
+          indexPatternId: 'foo',
+        },
+        b: {
+          columnOrder: ['c', 'd'],
+          columns: {
+            c: col,
+            d: {
+              ...col,
+              label: 'Foo [1]',
+            },
+          },
+          indexPatternId: 'foo',
+        },
+      });
+
+      expect(map).toMatchInlineSnapshot(`
+        Object {
+          "a": "Foo",
+          "b": "Foo [1]",
+          "c": "Foo [2]",
+          "d": "Foo [1] [1]",
+        }
+      `);
+    });
+  });
+
   describe('#initialize', () => {
     it('should load a default state', async () => {
       const state = await indexPatternDatasource.initialize();
@@ -239,13 +281,13 @@ describe('IndexPattern Data Source', () => {
       };
       const state = await indexPatternDatasource.initialize(queryPersistedState);
       expect(indexPatternDatasource.toExpression(state, 'first')).toMatchInlineSnapshot(`
-        "esaggs
-              index=\\"1\\"
-              metricsAtAllLevels=false
-              partialRows=false
-              includeFormatHints=true
-              aggConfigs='[{\\"id\\":\\"col1\\",\\"enabled\\":true,\\"type\\":\\"count\\",\\"schema\\":\\"metric\\",\\"params\\":{}},{\\"id\\":\\"col2\\",\\"enabled\\":true,\\"type\\":\\"date_histogram\\",\\"schema\\":\\"segment\\",\\"params\\":{\\"field\\":\\"timestamp\\",\\"useNormalizedEsInterval\\":true,\\"interval\\":\\"1d\\",\\"drop_partials\\":false,\\"min_doc_count\\":1,\\"extended_bounds\\":{}}}]' | lens_rename_columns idMap='{\\"col-0-col1\\":\\"col1\\",\\"col-1-col2\\":\\"col2\\"}'"
-      `);
+                "esaggs
+                      index=\\"1\\"
+                      metricsAtAllLevels=false
+                      partialRows=false
+                      includeFormatHints=true
+                      aggConfigs='[{\\"id\\":\\"col1\\",\\"enabled\\":true,\\"type\\":\\"count\\",\\"schema\\":\\"metric\\",\\"params\\":{}},{\\"id\\":\\"col2\\",\\"enabled\\":true,\\"type\\":\\"date_histogram\\",\\"schema\\":\\"segment\\",\\"params\\":{\\"field\\":\\"timestamp\\",\\"useNormalizedEsInterval\\":true,\\"interval\\":\\"1d\\",\\"drop_partials\\":false,\\"min_doc_count\\":1,\\"extended_bounds\\":{}}}]' | lens_rename_columns idMap='{\\"col-0-col1\\":\\"col1\\",\\"col-1-col2\\":\\"col2\\"}'"
+            `);
     });
   });
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
@@ -10,6 +10,7 @@ import { render } from 'react-dom';
 import { I18nProvider } from '@kbn/i18n/react';
 import { CoreSetup, SavedObjectsClientContract } from 'src/core/public';
 import { Storage } from 'ui/storage';
+import { i18n } from '@kbn/i18n';
 import {
   DatasourceDimensionPanelProps,
   DatasourceDataPanelProps,
@@ -97,14 +98,45 @@ export type IndexPatternPrivateState = IndexPatternPersistedState & {
   showEmptyFields: boolean;
 };
 
-export function columnToOperation(column: IndexPatternColumn): Operation {
+export function columnToOperation(column: IndexPatternColumn, uniqueLabel?: string): Operation {
   const { dataType, label, isBucketed, scale } = column;
   return {
-    label,
     dataType,
     isBucketed,
     scale,
+    label: uniqueLabel || label,
   };
+}
+
+/**
+ * Return a map of columnId => unique column label. Exported for testing reasons.
+ */
+export function uniqueLabels(layers: Record<string, IndexPatternLayer>) {
+  const columnLabelMap = {} as Record<string, string>;
+  const counts = {} as Record<string, number>;
+
+  const makeUnique = (label: string) => {
+    let uniqueLabel = label;
+
+    while (counts[uniqueLabel] >= 0) {
+      const num = ++counts[uniqueLabel];
+      uniqueLabel = i18n.translate('xpack.lens.indexPattern.uniqueLabel', {
+        defaultMessage: '{label} [{num}]',
+        values: { label, num },
+      });
+    }
+
+    counts[uniqueLabel] = 0;
+    return uniqueLabel;
+  };
+
+  Object.values(layers).forEach(layer => {
+    Object.entries(layer.columns).forEach(([columnId, column]) => {
+      columnLabelMap[columnId] = makeUnique(column.label);
+    });
+  });
+
+  return columnLabelMap;
 }
 
 type UnwrapPromise<T> = T extends Promise<infer P> ? P : T;
@@ -253,6 +285,8 @@ export function getIndexPatternDatasource({
       setState: StateSetter<IndexPatternPrivateState>,
       layerId: string
     ) {
+      const columnLabelMap = uniqueLabels(state.layers);
+
       return {
         getTableSpec: () => {
           return state.layers[layerId].columnOrder.map(colId => ({ columnId: colId }));
@@ -261,7 +295,7 @@ export function getIndexPatternDatasource({
           const layer = state.layers[layerId];
 
           if (layer && layer.columns[columnId]) {
-            return columnToOperation(layer.columns[columnId]);
+            return columnToOperation(layer.columns[columnId], columnLabelMap[columnId]);
           }
           return null;
         },
@@ -276,6 +310,7 @@ export function getIndexPatternDatasource({
                 savedObjectsClient={savedObjectsClient}
                 layerId={props.layerId}
                 http={core.http}
+                uniqueLabel={columnLabelMap[props.columnId]}
                 {...props}
               />
             </I18nProvider>,


### PR DESCRIPTION
This appends a suffix to index pattern columns that have a naming conflict, eliminating a bunch of errors that would show up in the XY chart in that scenario.

![image](https://user-images.githubusercontent.com/833377/65536565-ab996a00-ded1-11e9-9c86-3a48af2a4bd2.png)

My one concern is that it may mislead users into thinking it's an actual value (e.g. "Count of documents [2]" looks a bit like there are 2 documents, rather than that this is the second instance of a similarly named column.

One other question for reviewers: this doesn't take white space into account, so `Count of documents` and `Count of documents ` don't conflict, and therefore aren't disambiguated. Should we take white space into account, simply for UX disambiguation?