### PR TITLE
[APM]: Replace error occurrence watchers with Kibana Alerting

### DIFF
--- a/x-pack/legacy/plugins/apm/common/alerting/constants.ts
+++ b/x-pack/legacy/plugins/apm/common/alerting/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const ERROR_OCCURRENCE_ALERT_TYPE_ID = 'apm.error_occurrence';
+export const NOTIFICATION_EMAIL_ACTION_ID = 'apm.notificationEmail';

--- a/x-pack/legacy/plugins/apm/index.ts
+++ b/x-pack/legacy/plugins/apm/index.ts
@@ -17,7 +17,14 @@ import { plugin } from './server/new-platform/index';
 
 export const apm: LegacyPluginInitializer = kibana => {
   return new kibana.Plugin({
-    require: ['kibana', 'elasticsearch', 'xpack_main', 'apm_oss'],
+    require: [
+      'kibana',
+      'elasticsearch',
+      'xpack_main',
+      'apm_oss',
+      'alerting',
+      'actions'
+    ],
     id: 'apm',
     configPrefix: 'xpack.apm',
     publicDir: resolve(__dirname, 'public'),

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorOccurrenceAlert.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorOccurrenceAlert.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { APMClient } from '../../../../services/rest/createCallApmApi';
+
+export interface Schedule {
+  interval: string;
+}
+
+interface Arguments {
+  callApmApi: APMClient;
+  email: string;
+  serviceName: string;
+  slackUrl: string;
+  threshold: number;
+  timeRange: {
+    value: number;
+    unit: string;
+  };
+}
+
+export async function createErrorOccurrenceAlert({
+  callApmApi,
+  email,
+  serviceName,
+  slackUrl,
+  threshold,
+  timeRange
+}: Arguments) {
+  return callApmApi({
+    pathname: '/api/apm/alerts/error_occurrence',
+    method: 'POST',
+    params: {
+      body: {
+        serviceName,
+        threshold,
+        interval: `${timeRange.value}${timeRange.unit}`,
+        actions: {
+          email,
+          slack: slackUrl
+        }
+      }
+    }
+  });
+}

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/index.tsx
@@ -19,9 +19,11 @@ import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { LicenseContext } from '../../../../context/LicenseContext';
 import { MachineLearningFlyout } from './MachineLearningFlyout';
 import { WatcherFlyout } from './WatcherFlyout';
+import { APMClient } from '../../../../services/rest/createCallApmApi';
 
 interface Props {
   urlParams: IUrlParams;
+  callApmApi: APMClient;
 }
 interface State {
   isPopoverOpen: boolean;
@@ -162,6 +164,7 @@ export class ServiceIntegrations extends React.Component<Props, State> {
               urlParams={this.props.urlParams}
             />
             <WatcherFlyout
+              callApmApi={this.props.callApmApi}
               isOpen={this.state.activeFlyout === 'Watcher'}
               onClose={this.closeFlyouts}
               urlParams={this.props.urlParams}

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/index.tsx
@@ -10,6 +10,7 @@ import { ApmHeader } from '../../shared/ApmHeader';
 import { ServiceDetailTabs } from './ServiceDetailTabs';
 import { ServiceIntegrations } from './ServiceIntegrations';
 import { useUrlParams } from '../../../hooks/useUrlParams';
+import { useCallApmApi } from '../../../hooks/useCallApmApi';
 
 interface Props {
   tab: React.ComponentProps<typeof ServiceDetailTabs>['tab'];
@@ -18,6 +19,7 @@ interface Props {
 export function ServiceDetails({ tab }: Props) {
   const { urlParams } = useUrlParams();
   const { serviceName } = urlParams;
+  const callApmApi = useCallApmApi();
 
   return (
     <div>
@@ -29,7 +31,10 @@ export function ServiceDetails({ tab }: Props) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <ServiceIntegrations urlParams={urlParams} />
+            <ServiceIntegrations
+              urlParams={urlParams}
+              callApmApi={callApmApi}
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       </ApmHeader>

--- a/x-pack/legacy/plugins/apm/server/lib/alerting/error_occurrence/create_alert.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/alerting/error_occurrence/create_alert.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { ERROR_OCCURRENCE_ALERT_TYPE_ID } from '../../../../common/alerting/constants';
+import { ActionsClient } from '../../../../../actions';
+import { AlertsClient } from '../../../../../alerting';
+
+interface Properties {
+  serviceName: string;
+  threshold: number;
+  interval: string;
+  actions: {
+    email: string;
+    slack: string;
+  };
+}
+
+interface Clients {
+  alertsClient: AlertsClient;
+  actionsClient: ActionsClient;
+}
+
+interface Action {
+  actionTypeId: string;
+  description: string;
+  config: Record<string, any>;
+  secrets: Record<string, any>;
+}
+const createAlert = async (
+  { alertsClient, actionsClient }: Clients,
+  { actions: { slack, email }, serviceName, threshold, interval }: Properties
+) => {
+  const actions: Array<{ params: Record<string, any>; action: Action }> = [];
+
+  const values = {
+    errorLogMessage: '{{{context.errorLogMessage}}}',
+    errorCulprit: '{{{context.errorCulprit}}}',
+    docCount: '{{context.docCount}}',
+    serviceName,
+    threshold,
+    interval
+  };
+
+  if (email) {
+    actions.push({
+      action: {
+        actionTypeId: '.email',
+        description: 'Email notifications for error occurrences',
+        config: {
+          from: ''
+        },
+        secrets: {
+          user: '',
+          password: ''
+        }
+      },
+      params: {
+        to: email,
+        subject: i18n.translate(
+          'xpack.apm.serviceDetails.enableErrorReportsPanel.emailSubjectText',
+          {
+            defaultMessage:
+              '{serviceName} has error groups which exceeds the threshold',
+            values: { serviceName }
+          }
+        ),
+        body: i18n.translate(
+          'xpack.apm.serviceDetails.enableErrorReportsPanel.emailTemplateText',
+          {
+            defaultMessage:
+              `Your service {serviceName} has error groups which exceeds {threshold} occurrences within {interval}<br/>` +
+              '<br/>' +
+              '{errorLogMessage}<br/>' +
+              '{errorCulprit}<br/>' +
+              '{docCount} occurrences<br/>',
+            values
+          }
+        )
+      }
+    });
+  }
+
+  if (slack) {
+    actions.push({
+      action: {
+        actionTypeId: '.slack',
+        description: 'Slack notifications for error occurrences',
+        config: {},
+        secrets: {
+          webhookUrl: slack
+        }
+      },
+      params: {
+        message: i18n.translate(
+          'xpack.apm.serviceDetails.enableErrorReportsPanel.slackTemplateText',
+          {
+            defaultMessage: `Your service *{serviceName}* has error groups which exceeds {threshold} occurrences within {interval}
+>*{errorLogMessage}*
+>\`{errorCulprit}\`
+>{docCount} occurrences`,
+            values
+          }
+        )
+      }
+    });
+  }
+
+  if (!actions.length) {
+    throw new Error(
+      'No actions were defined. Need at least one of email, slack'
+    );
+  }
+
+  const actionResults = await Promise.all(
+    actions.map(({ action, params }) => {
+      return actionsClient
+        .create({
+          action: {
+            actionTypeId: action.actionTypeId,
+            description: action.description,
+            config: action.config,
+            secrets: action.secrets
+          }
+        })
+        .then(result => ({
+          result,
+          params
+        }));
+    })
+  );
+
+  return alertsClient.create({
+    data: {
+      name: `Error threshold for ${serviceName} exceeded`,
+      alertTypeId: ERROR_OCCURRENCE_ALERT_TYPE_ID,
+      alertTypeParams: {
+        serviceName,
+        threshold,
+        interval
+      },
+      interval,
+      enabled: true,
+      actions: actionResults.map(({ result, params }) => {
+        return {
+          group: 'default',
+          id: result.id,
+          params
+        };
+      }),
+      throttle: null
+    }
+  });
+};
+
+export { createAlert };

--- a/x-pack/legacy/plugins/apm/server/lib/alerting/error_occurrence/register_error_occurrence_alert_type.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/alerting/error_occurrence/register_error_occurrence_alert_type.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { schema, TypeOf } from '@kbn/config-schema';
+import { InternalCoreSetup } from 'src/core/server';
+import { idx } from '@kbn/elastic-idx';
+import { ESSearchResponse } from '../../../../typings/elasticsearch';
+import { NOT_AVAILABLE_LABEL } from '../../../../common/i18n';
+import { APMError } from '../../../../typings/es_schemas/ui/APMError';
+import { ERROR_OCCURRENCE_ALERT_TYPE_ID } from '../../../../common/alerting/constants';
+import {
+  SERVICE_NAME,
+  PROCESSOR_EVENT,
+  ERROR_LOG_MESSAGE,
+  ERROR_EXC_MESSAGE,
+  ERROR_EXC_HANDLED,
+  ERROR_CULPRIT,
+  ERROR_GROUP_ID
+} from '../../../../common/elasticsearch_fieldnames';
+
+const paramsSchema = schema.object({
+  threshold: schema.number({ min: 1 }),
+  interval: schema.string(),
+  serviceName: schema.string()
+});
+
+const registerErrorOccurrenceAlertType = async (core: InternalCoreSetup) => {
+  const { alerting, elasticsearch } = core.http.server.plugins;
+
+  if (!alerting) {
+    throw new Error(
+      'Cannot register error occurrence alert type. Both the actions and alerting plugins need to be enabled'
+    );
+  }
+
+  alerting.setup.registerType({
+    id: ERROR_OCCURRENCE_ALERT_TYPE_ID,
+    name: 'Error occurrences',
+    actionGroups: ['default'],
+    validate: {
+      params: paramsSchema
+    },
+    async executor({ params, services }) {
+      const { threshold, interval, serviceName } = params as TypeOf<
+        typeof paramsSchema
+      >;
+
+      const request = {
+        body: {
+          query: {
+            bool: {
+              filter: [
+                { term: { [SERVICE_NAME]: serviceName } },
+                { term: { [PROCESSOR_EVENT]: 'error' } },
+                {
+                  range: {
+                    '@timestamp': {
+                      gte: `now-${interval}`
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          aggs: {
+            error_groups: {
+              terms: {
+                min_doc_count: threshold,
+                field: ERROR_GROUP_ID,
+                size: 10,
+                order: {
+                  _count: 'desc' as const
+                }
+              },
+              aggs: {
+                sample: {
+                  top_hits: {
+                    _source: [
+                      ERROR_LOG_MESSAGE,
+                      ERROR_EXC_MESSAGE,
+                      ERROR_EXC_HANDLED,
+                      ERROR_CULPRIT,
+                      ERROR_GROUP_ID,
+                      '@timestamp'
+                    ],
+                    sort: [
+                      {
+                        '@timestamp': 'desc' as const
+                      }
+                    ],
+                    size: 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const { callWithInternalUser } = elasticsearch.getCluster('admin');
+
+      const response: ESSearchResponse<
+        unknown,
+        typeof request
+      > = await callWithInternalUser('search', request);
+      const { aggregations } = response;
+
+      if (!aggregations) {
+        throw new Error(
+          'No aggregations were returned for search. This happens when no matching indices are found.'
+        );
+      }
+
+      const infringingErrorGroups = aggregations.error_groups.buckets;
+
+      const shouldAlert = infringingErrorGroups.length > 0;
+
+      if (shouldAlert) {
+        const alertInstance = services.alertInstanceFactory('');
+
+        const sampleError = infringingErrorGroups[0].sample.hits.hits[0]
+          ._source as APMError;
+
+        alertInstance.scheduleActions('default', {
+          errorGroupsBuckets: infringingErrorGroups,
+          errorLogMessage:
+            idx(sampleError, _ => _.error.log.message) ||
+            idx(sampleError, _ => _.error.exception[0].message),
+          errorCulprit:
+            idx(sampleError, _ => _.error.culprit) || NOT_AVAILABLE_LABEL,
+          docCount: infringingErrorGroups[0].doc_count
+        });
+      }
+    }
+  });
+};
+
+export { registerErrorOccurrenceAlertType };

--- a/x-pack/legacy/plugins/apm/server/lib/alerting/register_alert_types.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/alerting/register_alert_types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { InternalCoreSetup } from 'src/core/server';
+import { registerErrorOccurrenceAlertType } from './error_occurrence/register_error_occurrence_alert_type';
+
+const registerAlertTypes = (core: InternalCoreSetup) => {
+  const { server } = core.http;
+
+  const { alerting } = server.plugins;
+
+  if (alerting) {
+    const registerFns = [registerErrorOccurrenceAlertType];
+
+    registerFns.forEach(fn => {
+      fn(core);
+    });
+  }
+};
+
+export { registerAlertTypes };

--- a/x-pack/legacy/plugins/apm/server/new-platform/plugin.ts
+++ b/x-pack/legacy/plugins/apm/server/new-platform/plugin.ts
@@ -9,11 +9,13 @@ import { makeApmUsageCollector } from '../lib/apm_telemetry';
 import { CoreSetupWithUsageCollector } from '../lib/apm_telemetry/make_apm_usage_collector';
 import { createApmAgentConfigurationIndex } from '../lib/settings/agent_configuration/create_agent_config_index';
 import { createApmApi } from '../routes/create_apm_api';
+import { registerAlertTypes } from '../lib/alerting/register_alert_types';
 
 export class Plugin {
   public setup(core: InternalCoreSetup) {
     createApmApi().init(core);
     createApmAgentConfigurationIndex(core);
     makeApmUsageCollector(core as CoreSetupWithUsageCollector);
+    registerAlertTypes(core);
   }
 }

--- a/x-pack/legacy/plugins/apm/server/routes/create_apm_api.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_apm_api.ts
@@ -51,6 +51,7 @@ import {
   serviceNodesLocalFiltersRoute,
   uiFiltersEnvironmentsRoute
 } from './ui_filters';
+import { errorOccurrenceAlertRoute } from './error_occurrence_alert';
 import { createApi } from './create_api';
 import { serviceMapRoute } from './services';
 
@@ -110,7 +111,10 @@ const createApmApi = () => {
     .add(transactionsLocalFiltersRoute)
     .add(serviceNodesLocalFiltersRoute)
     .add(uiFiltersEnvironmentsRoute)
-    .add(serviceMapRoute);
+    .add(serviceMapRoute)
+
+    // alerts
+    .add(errorOccurrenceAlertRoute);
 
   return api;
 };

--- a/x-pack/legacy/plugins/apm/server/routes/error_occurrence_alert.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/error_occurrence_alert.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as t from 'io-ts';
+import { createRoute } from './create_route';
+import { createAlert } from '../lib/alerting/error_occurrence/create_alert';
+
+export const errorOccurrenceAlertRoute = createRoute(core => ({
+  path: '/api/apm/alerts/error_occurrence',
+  method: 'POST',
+  params: {
+    body: t.type({
+      serviceName: t.string,
+      threshold: t.number,
+      actions: t.type({
+        email: t.string,
+        slack: t.string
+      }),
+      interval: t.string
+    })
+  },
+  handler: async (req, { body }, h) => {
+    const alertsClient =
+      typeof req.getAlertsClient === 'function' ? req.getAlertsClient() : null;
+
+    const actionsClient =
+      typeof req.getActionsClient === 'function'
+        ? req.getActionsClient()
+        : null;
+
+    if (!alertsClient || !actionsClient) {
+      return h.response().code(404);
+    }
+
+    return createAlert({ alertsClient, actionsClient }, body);
+  }
+}));


### PR DESCRIPTION
This is a proof of concept that replaces the APM error occurrence Watcher (an Elasticsearch feature) with the new Kibana alerting and actions plugin. The Slack action succesfully fires, but I haven't bothered with the Email action because the approach is pretty similar, and we decided to timebox this to two days. 

Here's the gist:
- Define an `Alert Type` for error occurrences. An `Alert Type` is essentially a function (called an executor) that, given a set of parameters, decides whether (and which) actions need to be triggered. Actions are triggered via an `Alert Instance`, which captures state of previous executions (for the purpose of this POC, I don't think we need that state). 
- When the user configures a new alert, we create an `Alert` object on the server. An `Alert` is a configuration object for an `Alert Type`, that tells it at what interval it and with what parameters it should execute.
- An `Alert` also configures the action groups that can be triggered from the `Alert Type` executor. For this POC, we create Slack and Email actions based on the user's input when configuring an alert, and add them to the default group.
- In the executor of the `Alert Type`, that now runs at the configured interval for the `Alert` that was created, we run a query for the number of error occurrences and determine whether the threshold was exceeded. If so, we fire the default actions for the `Alert`, which can be either the Slack or Email action, or both.
- To make formatting easier, we pre-process some of the output from the query and pass this as context to the actions that are triggered.

**To test this, make sure to explicitly enable both required plugins in your kibana config file**:
```yml
xpack.actions.enabled: true
xpack.alerting.enabled: true
```

Notes:
- Currently an `Alert` only supports `interval` as a scheduling option. That means that we cannot run the executor at a given time each day, which is something that our current implementation does support. I've been told expanding the scheduling options is on the roadmap.
- To determine the timeframe for the query we run in the executor, we need the `interval` parameter. However, it doesn't seem like that's automatically available in the executor, so we pass it as a parameter instead. Maybe there's a nicer way to solve this.
- We have to create actions in addition to each Alert that we create (AFAICT), because we allow our users to configure the Slack webhook URL and email addresses in the form. This could present some maintenance issues. It might make more sense to expect the user to create specific Slack/Email actions first, and then provide them with a UI to select those predefined actions. This would limit the amount of maintenance/cleanup of orphaned actions that would be needed in our current implementation.
- The Alerting plugin still uses template rendering, but it's a lot easier now that we can pre-process the output from the query with JavaScript, and then pass it to a Mustache renderer. One thing that could me off guard was that Mustache escapes by default, which broke the formatting of the Slack message initially.

Some questions/suggestions for the Alerting/Actions team:
- Some of the configuration options for the email and slack actions are now seemingly moved to the `secrets` param, but this is not reflected in the documentation (https://github.com/elastic/kibana/blob/master/x-pack/legacy/plugins/actions/README.md)
- As explained above, would be nice to have the `interval` available in the executor as well (if it's not already there and I missed it). Seems like it's a common use case.
- I could not figure out what `actionGroups` is for in the `Alert Type`. It's seemingly not documented, but it is required.
- The typings of `registerType` could be improved by having typed `params` (instead of `Record<string, any>`). Similar to what we did for APM in https://github.com/elastic/kibana/pull/42961 (happy to open a PR if welcome).
- The `kbn-action` CLI tool has been super useful, thanks for taking the time to build that.