### PR TITLE
[Lens] Making field filters more obvious

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/_frame_layout.scss
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/_frame_layout.scss
@@ -20,8 +20,9 @@
   min-width: $lnsPanelMinWidth + $euiSizeXL;
   overflow: hidden;
   // Leave out bottom padding so the suggestions scrollbar stays flush to window edge
+  // Leave out left padding so the left sidebar's focus states are visible outside of content bounds
   // This also means needing to add same amount of margin to page content and suggestion items
-  padding: $euiSize $euiSize 0;
+  padding: $euiSize $euiSize 0 0;
 
   &:first-child {
     padding-left: $euiSize;

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
@@ -24,7 +24,6 @@
 .lnsInnerIndexPatternDataPanel__listWrapper {
   @include euiOverflowShadow;
   @include euiScrollBar;
-  margin-top: 2px; // form control shadow
   position: relative;
   flex-grow: 1;
   overflow: auto;
@@ -37,3 +36,9 @@
   left: 0;
   right: 0;
 }
+
+.lnsInnerIndexPatternDataPanel__filterButton {
+  width: 100%;
+  color: $euiColorPrimary;
+}
+

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
@@ -3,7 +3,7 @@
 .lnsInnerIndexPatternDataPanel {
   width: 100%;
   height: 100%;
-  padding: $euiSize 0 0 $euiSize;
+  padding: $euiSize $euiSize 0;
 }
 
 .lnsInnerIndexPatternDataPanel__header {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
@@ -1,3 +1,5 @@
+@import '@elastic/eui/src/components/form/form_control_layout/mixins';
+
 .lnsInnerIndexPatternDataPanel {
   width: 100%;
   height: 100%;
@@ -40,5 +42,10 @@
 .lnsInnerIndexPatternDataPanel__filterButton {
   width: 100%;
   color: $euiColorPrimary;
+}
+
+.lnsInnerIndexPatternDataPanel__textField {
+  @include euiFormControlLayoutPadding(1, 'right');
+  @include euiFormControlLayoutPadding(1, 'left');
 }
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/_datapanel.scss
@@ -42,6 +42,8 @@
 .lnsInnerIndexPatternDataPanel__filterButton {
   width: 100%;
   color: $euiColorPrimary;
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
 }
 
 .lnsInnerIndexPatternDataPanel__textField {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -451,6 +451,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
               closePopover={() => setLocalState(s => ({ ...localState, isTypeFilterOpen: false }))}
               button={
                 <EuiFacetButton
+                  data-test-subj="lnsIndexPatternFiltersToggle"
                   className="lnsInnerIndexPatternDataPanel__filterButton"
                   quantity={localState.typeFilter.length}
                   icon={<EuiIcon type="filter" />}

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -464,8 +464,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                 >
                   <FormattedMessage
                     id="xpack.lens.indexPatterns.toggleFiltersPopover"
-                    defaultMessage="Fields list filters {isApplied}"
-                    values={{ isApplied: localState.typeFilter.length ? 'applied' : undefined }}
+                    defaultMessage="Fields filtered"
                   />
                 </EuiFacetButton>
               }

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -21,7 +21,8 @@ import {
   EuiText,
   EuiFormControlLayout,
   EuiSwitch,
-  EuiButtonIcon,
+  EuiFacetButton,
+  EuiIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -355,6 +356,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
           <div className="lnsInnerIndexPatternDataPanel__filterWrapper">
             <EuiFormControlLayout
               icon="search"
+              fullWidth
               clear={{
                 title: i18n.translate('xpack.lens.indexPatterns.clearFiltersLabel', {
                   defaultMessage: 'Clear name and type filters',
@@ -372,7 +374,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
               }}
             >
               <input
-                className="euiFieldText lnsInnerIndexPatternDataPanel__textField"
+                className="euiFieldText euiFieldText--fullWidth lnsInnerIndexPatternDataPanel__textField"
                 data-test-subj="lnsIndexPatternFieldSearch"
                 placeholder={i18n.translate('xpack.lens.indexPatterns.filterByNameLabel', {
                   defaultMessage: 'Search for fields',

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -7,14 +7,10 @@
 import { mapValues, uniq, indexBy } from 'lodash';
 import React, { useState, useEffect, memo, useCallback } from 'react';
 import {
-  EuiComboBox,
   EuiLoadingSpinner,
-  // @ts-ignore
-  EuiHighlight,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
-  EuiButtonEmpty,
   EuiContextMenuPanel,
   EuiContextMenuItem,
   EuiContextMenuPanelProps,
@@ -25,8 +21,7 @@ import {
   EuiText,
   EuiFormControlLayout,
   EuiSwitch,
-  EuiFacetButton,
-  EuiIcon,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -37,6 +32,7 @@ import { ChildDragDropProvider, DragContextState } from '../drag_drop';
 import { FieldItem } from './field_item';
 import { FieldIcon } from './field_icon';
 import { updateLayerIndexPattern } from './state_helpers';
+import { ChangeIndexPattern } from './change_indexpattern';
 
 // TODO the typings for EuiContextMenuPanel are incorrect - watchedItemProps is missing. This can be removed when the types are adjusted
 const FixedEuiContextMenuPanel = (EuiContextMenuPanel as unknown) as React.FunctionComponent<
@@ -72,21 +68,20 @@ export function IndexPatternDataPanel({
   dateRange,
 }: DatasourceDataPanelProps<IndexPatternPrivateState>) {
   const { indexPatterns, currentIndexPatternId } = state;
-  const [showIndexPatternSwitcher, setShowIndexPatternSwitcher] = useState(false);
 
   const onChangeIndexPattern = useCallback(
     (newIndexPattern: string) => {
-      setState({
-        ...state,
-        layers: isSingleEmptyLayer(state.layers)
-          ? mapValues(state.layers, layer =>
+      setState(prevState => ({
+        ...prevState,
+        layers: isSingleEmptyLayer(prevState.layers)
+          ? mapValues(prevState.layers, layer =>
               updateLayerIndexPattern(layer, indexPatterns[newIndexPattern])
             )
-          : state.layers,
+          : prevState.layers,
         currentIndexPatternId: newIndexPattern,
-      });
+      }));
     },
-    [state, setState]
+    [setState]
   );
 
   const updateFieldsWithCounts = useCallback(
@@ -110,12 +105,10 @@ export function IndexPatternDataPanel({
 
   const onToggleEmptyFields = useCallback(() => {
     setState(prevState => ({ ...prevState, showEmptyFields: !prevState.showEmptyFields }));
-  }, [state, setState]);
+  }, [setState]);
 
   return (
     <MemoizedDataPanel
-      showIndexPatternSwitcher={showIndexPatternSwitcher}
-      setShowIndexPatternSwitcher={setShowIndexPatternSwitcher}
       currentIndexPatternId={currentIndexPatternId}
       indexPatterns={indexPatterns}
       query={query}
@@ -124,8 +117,7 @@ export function IndexPatternDataPanel({
       showEmptyFields={state.showEmptyFields}
       onToggleEmptyFields={onToggleEmptyFields}
       core={core}
-      // only pass in the state change callback if it's actually needed to avoid re-renders
-      onChangeIndexPattern={showIndexPatternSwitcher ? onChangeIndexPattern : undefined}
+      onChangeIndexPattern={onChangeIndexPattern}
       updateFieldsWithCounts={
         !indexPatterns[currentIndexPatternId].hasExistence ? updateFieldsWithCounts : undefined
       }
@@ -154,8 +146,6 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   query,
   dateRange,
   dragDropContext,
-  showIndexPatternSwitcher,
-  setShowIndexPatternSwitcher,
   onChangeIndexPattern,
   updateFieldsWithCounts,
   showEmptyFields,
@@ -168,11 +158,9 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
   query: Query;
   core: DatasourceDataPanelProps['core'];
   dragDropContext: DragContextState;
-  showIndexPatternSwitcher: boolean;
-  setShowIndexPatternSwitcher: (show: boolean) => void;
   showEmptyFields: boolean;
   onToggleEmptyFields: () => void;
-  onChangeIndexPattern?: (newId: string) => void;
+  onChangeIndexPattern: (newId: string) => void;
   updateFieldsWithCounts?: (indexPatternId: string, fields: IndexPattern['fields']) => void;
 }) {
   if (Object.keys(indexPatterns).length === 0) {
@@ -336,70 +324,31 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
       >
         <EuiFlexItem grow={null}>
           <div className="lnsInnerIndexPatternDataPanel__header">
-            {!showIndexPatternSwitcher ? (
-              <>
-                <EuiTitle size="xxs">
-                  <h4
-                    className="lnsInnerIndexPatternDataPanel__header"
-                    title={currentIndexPattern.title}
-                  >
-                    {currentIndexPattern.title}{' '}
-                  </h4>
-                </EuiTitle>
-                <EuiButtonEmpty
-                  data-test-subj="indexPattern-switch-link"
-                  className="lnsInnerIndexPatternDataPanel__changeLink"
-                  onClick={() => setShowIndexPatternSwitcher(true)}
-                  size="xs"
-                >
-                  (
-                  <FormattedMessage
-                    id="xpack.lens.indexPatterns.changePatternLabel"
-                    defaultMessage="change"
-                  />
-                  )
-                </EuiButtonEmpty>
-              </>
-            ) : (
-              <EuiComboBox
+            <EuiTitle size="xxs" className="eui-textTruncate">
+              <h4 title={currentIndexPattern.title}>{currentIndexPattern.title} </h4>
+            </EuiTitle>
+            <div className="lnsInnerIndexPatternDataPanel__changeLink">
+              <ChangeIndexPattern
                 data-test-subj="indexPattern-switcher"
-                options={Object.values(indexPatterns).map(({ title, id }) => ({
-                  label: title,
-                  value: id,
-                }))}
-                inputRef={el => {
-                  if (el) {
-                    el.focus();
-                  }
+                trigger={{
+                  label: i18n.translate('xpack.lens.indexPatterns.changePatternLabel', {
+                    defaultMessage: '(change)',
+                  }),
+                  'data-test-subj': 'indexPattern-switch-link',
                 }}
-                selectedOptions={
-                  currentIndexPatternId
-                    ? [
-                        {
-                          label: currentIndexPattern.title,
-                          value: currentIndexPattern.id,
-                        },
-                      ]
-                    : undefined
-                }
-                singleSelection={{ asPlainText: true }}
-                isClearable={false}
-                onBlur={() => {
-                  setShowIndexPatternSwitcher(false);
-                }}
-                onChange={choices => {
-                  onChangeIndexPattern!(choices[0].value as string);
+                currentIndexPatternId={currentIndexPatternId}
+                indexPatterns={indexPatterns}
+                onChangeIndexPattern={(newId: string) => {
+                  onChangeIndexPattern(newId);
 
                   setLocalState(s => ({
                     ...s,
                     nameFilter: '',
                     typeFilter: [],
                   }));
-
-                  setShowIndexPatternSwitcher(false);
                 }}
               />
-            )}
+            </div>
           </div>
         </EuiFlexItem>
         <EuiFlexItem>

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/datapanel.tsx
@@ -405,6 +405,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
         <EuiFlexItem>
           <div className="lnsInnerIndexPatternDataPanel__filterWrapper">
             <EuiFormControlLayout
+              icon="search"
               clear={{
                 title: i18n.translate('xpack.lens.indexPatterns.clearFiltersLabel', {
                   defaultMessage: 'Clear name and type filters',
@@ -422,10 +423,10 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
               }}
             >
               <input
-                className="euiFieldText"
+                className="euiFieldText lnsInnerIndexPatternDataPanel__textField"
                 data-test-subj="lnsIndexPatternFieldSearch"
                 placeholder={i18n.translate('xpack.lens.indexPatterns.filterByNameLabel', {
-                  defaultMessage: 'Search fields',
+                  defaultMessage: 'Search for fields',
                   description:
                     'Search the list of fields in the index pattern for the provided text',
                 })}


### PR DESCRIPTION
Moved the popover trigger from the search field's prepend to a button below with an indicator of the number of filters applied.

<img src="https://d.pr/free/i/c4UvwS+" />

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~

