### PR TITLE
[APM] Fix tooltip for service name in span flyout

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/SpanFlyout/StickySpanProperties.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/SpanFlyout/StickySpanProperties.tsx
@@ -6,11 +6,11 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { SERVICE_NAME } from '../../../../../../../../../../../plugins/licensing/server/constants';
 import { Transaction } from '../../../../../../../../typings/es_schemas/ui/Transaction';
 import {
   SPAN_NAME,
-  TRANSACTION_NAME
+  TRANSACTION_NAME,
+  SERVICE_NAME
 } from '../../../../../../../../common/elasticsearch_fieldnames';
 import { NOT_AVAILABLE_LABEL } from '../../../../../../../../common/i18n';
 import { Span } from '../../../../../../../../typings/es_schemas/ui/Span';


### PR DESCRIPTION
In #46312, we moved the service name property to the StickySpanProperties component. However, the import of SERVICE_NAME was incorrect, resulting in the tooltip showing the string 'licensing' instead of 'service.name'. The import now correctly points at our elasticsearch field names file.

I noticed this when I was backporting - the imported file does not exist in 7.x. I already fixed in the backport PR.