### PR TITLE
[APM] Always show transaction breakdown

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/TransactionBreakdownHeader.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/TransactionBreakdownHeader.tsx
@@ -17,9 +17,8 @@ import { i18n } from '@kbn/i18n';
 
 const TransactionBreakdownHeader: React.FC<{
   showChart: boolean;
-  hideShowChartButton: boolean;
   onToggleClick: () => void;
-}> = ({ showChart, onToggleClick, hideShowChartButton }) => {
+}> = ({ showChart, onToggleClick }) => {
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
@@ -50,23 +49,21 @@ const TransactionBreakdownHeader: React.FC<{
           </h3>
         </EuiTitle>
       </EuiFlexItem>
-      {!hideShowChartButton ? (
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            size="xs"
-            iconType={showChart ? 'arrowDown' : 'arrowRight'}
-            onClick={() => onToggleClick()}
-          >
-            {showChart
-              ? i18n.translate('xpack.apm.transactionBreakdown.hideChart', {
-                  defaultMessage: 'Hide chart'
-                })
-              : i18n.translate('xpack.apm.transactionBreakdown.showChart', {
-                  defaultMessage: 'Show chart'
-                })}
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-      ) : null}
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          size="xs"
+          iconType={showChart ? 'arrowDown' : 'arrowRight'}
+          onClick={() => onToggleClick()}
+        >
+          {showChart
+            ? i18n.translate('xpack.apm.transactionBreakdown.hideChart', {
+                defaultMessage: 'Hide chart'
+              })
+            : i18n.translate('xpack.apm.transactionBreakdown.showChart', {
+                defaultMessage: 'Show chart'
+              })}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
     </EuiFlexGroup>
   );
 };

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/index.tsx
@@ -4,43 +4,21 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import React, { useState } from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiSpacer,
-  EuiPanel
-} from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
-import styled from 'styled-components';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import { useTransactionBreakdown } from '../../../hooks/useTransactionBreakdown';
 import { TransactionBreakdownHeader } from './TransactionBreakdownHeader';
 import { TransactionBreakdownKpiList } from './TransactionBreakdownKpiList';
 import { TransactionBreakdownGraph } from './TransactionBreakdownGraph';
 import { trackEvent } from '../../../../../infra/public/hooks/use_track_metric';
 
-const NoTransactionsTitle = styled.span`
-  font-weight: bold;
-`;
-
 const TransactionBreakdown: React.FC<{
   initialIsOpen?: boolean;
 }> = ({ initialIsOpen }) => {
   const [showChart, setShowChart] = useState(!!initialIsOpen);
 
-  const {
-    data,
-    status,
-    receivedDataDuringLifetime
-  } = useTransactionBreakdown();
+  const { data } = useTransactionBreakdown();
 
   const { kpis, timeseries } = data;
-
-  const hasHits = kpis.length > 0;
-
-  if (!receivedDataDuringLifetime) {
-    return null;
-  }
 
   return (
     <EuiPanel>
@@ -48,7 +26,6 @@ const TransactionBreakdown: React.FC<{
         <EuiFlexItem grow={false}>
           <TransactionBreakdownHeader
             showChart={showChart}
-            hideShowChartButton={!hasHits}
             onToggleClick={() => {
               setShowChart(!showChart);
               if (showChart) {
@@ -59,42 +36,10 @@ const TransactionBreakdown: React.FC<{
             }}
           />
         </EuiFlexItem>
-        {hasHits ? (
-          <EuiFlexItem grow={false}>
-            <TransactionBreakdownKpiList kpis={kpis} />
-          </EuiFlexItem>
-        ) : (
-          status === 'success' && (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup justifyContent="center">
-                  <EuiFlexItem grow={false}>
-                    <EuiText>
-                      <NoTransactionsTitle>
-                        {i18n.translate(
-                          'xpack.apm.transactionBreakdown.noTransactionsTitle',
-                          {
-                            defaultMessage: 'No transactions were found.'
-                          }
-                        )}
-                      </NoTransactionsTitle>
-                      {' ' +
-                        i18n.translate(
-                          'xpack.apm.transactionBreakdown.noTransactionsTip',
-                          {
-                            defaultMessage:
-                              'Try another time range or reset the filter.'
-                          }
-                        )}
-                    </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
-              <EuiSpacer size="m" />
-            </>
-          )
-        )}
-        {showChart && hasHits ? (
+        <EuiFlexItem grow={false}>
+          <TransactionBreakdownKpiList kpis={kpis} />
+        </EuiFlexItem>
+        {showChart ? (
           <EuiFlexItem grow={false}>
             <TransactionBreakdownGraph timeseries={timeseries} />
           </EuiFlexItem>

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionBreakdown/index.tsx
@@ -4,21 +4,30 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import React, { useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useTransactionBreakdown } from '../../../hooks/useTransactionBreakdown';
 import { TransactionBreakdownHeader } from './TransactionBreakdownHeader';
 import { TransactionBreakdownKpiList } from './TransactionBreakdownKpiList';
 import { TransactionBreakdownGraph } from './TransactionBreakdownGraph';
 import { trackEvent } from '../../../../../infra/public/hooks/use_track_metric';
+import { FETCH_STATUS } from '../../../hooks/useFetcher';
+
+const emptyMessage = i18n.translate('xpack.apm.transactionBreakdown.noData', {
+  defaultMessage: 'No data within this time range.'
+});
 
 const TransactionBreakdown: React.FC<{
   initialIsOpen?: boolean;
 }> = ({ initialIsOpen }) => {
   const [showChart, setShowChart] = useState(!!initialIsOpen);
 
-  const { data } = useTransactionBreakdown();
+  const { data, status } = useTransactionBreakdown();
 
   const { kpis, timeseries } = data;
+
+  const noHits = data.kpis.length === 0 && status === FETCH_STATUS.SUCCESS;
+  const showEmptyMessage = noHits && !showChart;
 
   return (
     <EuiPanel>
@@ -37,7 +46,11 @@ const TransactionBreakdown: React.FC<{
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <TransactionBreakdownKpiList kpis={kpis} />
+          {showEmptyMessage ? (
+            <EuiText>{emptyMessage}</EuiText>
+          ) : (
+            <TransactionBreakdownKpiList kpis={kpis} />
+          )}
         </EuiFlexItem>
         {showChart ? (
           <EuiFlexItem grow={false}>

--- a/x-pack/legacy/plugins/apm/public/hooks/useTransactionBreakdown.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useTransactionBreakdown.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { useRef } from 'react';
 import { useFetcher } from './useFetcher';
 import { useUrlParams } from './useUrlParams';
 import { callApmApi } from '../services/rest/callApmApi';
@@ -38,16 +37,9 @@ export function useTransactionBreakdown() {
     }
   }, [serviceName, start, end, transactionType, transactionName, uiFilters]);
 
-  const receivedDataDuringLifetime = useRef(false);
-
-  if (data && data.kpis.length) {
-    receivedDataDuringLifetime.current = true;
-  }
-
   return {
     data,
     status,
-    error,
-    receivedDataDuringLifetime: receivedDataDuringLifetime.current
+    error
   };
 }


### PR DESCRIPTION
Closes #43527.

We might want to look at the empty state for when the component is collapsed. Any suggestions @formgeist?

Badge:
![image](https://user-images.githubusercontent.com/352732/65676444-37390500-e050-11e9-8f89-071adb33c636.png)

=>
![image](https://user-images.githubusercontent.com/352732/65676420-2daf9d00-e050-11e9-9d15-0ded584bd3c9.png)

Empty state:
![image](https://user-images.githubusercontent.com/352732/65676492-4cae2f00-e050-11e9-8c77-92f3b5d5f277.png)
=>
expanded:
![image](https://user-images.githubusercontent.com/352732/65676503-520b7980-e050-11e9-9c91-d356a72e5be4.png)
collapsed:
![image](https://user-images.githubusercontent.com/352732/65777712-dc350a00-e144-11e9-9397-b64abb3b324c.png)

