### PR TITLE
POC Typescript incremental build

### DIFF
--- a/packages/kbn-analytics/tsconfig.json
+++ b/packages/kbn-analytics/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "./target/types",
+    "outDir": "../../build/.cache/packages/kbn-analytics",
     "stripInternal": true,
     "declarationMap": true,
     "types": [

--- a/packages/kbn-es/tsconfig.json
+++ b/packages/kbn-es/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": [
     "src/**/*.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-es"
+  }
 }

--- a/packages/kbn-expect/tsconfig.json
+++ b/packages/kbn-expect/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": [
     "expect.js.d.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-expect"
+  }
 }

--- a/packages/kbn-i18n/tsconfig.json
+++ b/packages/kbn-i18n/tsconfig.json
@@ -10,6 +10,7 @@
     "target"
   ],
   "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-i18n",
     "declaration": true,
     "declarationDir": "./target/types",
     "types": [

--- a/packages/kbn-interpreter/tsconfig.json
+++ b/packages/kbn-interpreter/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["index.d.ts", "src/**/*.d.ts"]
+  "include": ["index.d.ts", "src/**/*.d.ts"],
+  "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-interpreter"
+  }
 }

--- a/packages/kbn-pm/tsconfig.json
+++ b/packages/kbn-pm/tsconfig.json
@@ -7,6 +7,7 @@
     "./src/**/*.ts",
   ],
   "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-pm",
     "types": [
       "jest",
       "node"

--- a/packages/kbn-test-subj-selector/tsconfig.json
+++ b/packages/kbn-test-subj-selector/tsconfig.json
@@ -3,4 +3,7 @@
   "include": [
     "index.d.ts"
   ],
+  "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-test-subj-selector"
+  }
 }

--- a/packages/kbn-test/tsconfig.json
+++ b/packages/kbn-test/tsconfig.json
@@ -4,5 +4,8 @@
     "types/**/*",
     "src/functional_test_runner/**/*",
     "src/mocha/xml.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "outDir": "../../build/.cache/packages/kbn-test"
+  }
 }

--- a/src/dev/typescript/run_type_check_cli.ts
+++ b/src/dev/typescript/run_type_check_cli.ts
@@ -79,7 +79,7 @@ export function runTypeCheckCli() {
     process.exit();
   }
 
-  const tscArgs = ['--noEmit', '--pretty', ...(opts['skip-lib-check'] ? ['--skipLibCheck'] : [])];
+  const tscArgs = ['--pretty', ...(opts['skip-lib-check'] ? ['--skipLibCheck'] : [])];
   const projects = filterProjectsByFlag(opts.project);
 
   if (!projects.length) {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "outDir": "../build/.cache/test",
     "types": [
       "node",
       "mocha"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "outDir": "build/.cache/kibana",
     "baseUrl": ".",
     "paths": {
       // Allows for importing from `kibana` package for the exported types.
@@ -67,5 +69,5 @@
     // file, but if we did it during development IDEs would not be able to find
     // the tsconfig.json file for public files correctly.
     // "src/**/public/**/*"
-  ]
+  ],
 }

--- a/x-pack/legacy/plugins/apm/cypress/tsconfig.json
+++ b/x-pack/legacy/plugins/apm/cypress/tsconfig.json
@@ -3,6 +3,7 @@
   "exclude": [],
   "include": ["./**/*"],
   "compilerOptions": {
+    "outDir": "../../../../../build/.cache/apm/cypress",
     "types": ["cypress", "node"]
   }
 }

--- a/x-pack/legacy/plugins/siem/cypress/tsconfig.json
+++ b/x-pack/legacy/plugins/siem/cypress/tsconfig.json
@@ -5,6 +5,7 @@
     "./**/*"
   ],
   "compilerOptions": {
+    "outDir": "../../../../../build/.cache/siem/cypress",
     "types": [
       "cypress",
       "node"

--- a/x-pack/test/tsconfig.json
+++ b/x-pack/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "outDir": "../build/.cache/x-pack/test",
     "types": [
       "mocha",
       "node"

--- a/x-pack/tsconfig.json
+++ b/x-pack/tsconfig.json
@@ -15,7 +15,7 @@
     "**/typespec_tests.ts"
   ],
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "../build/.cache/x-pack",
     "paths": {
       "kibana/public": ["src/core/public"],
       "kibana/server": ["src/core/server"],


### PR DESCRIPTION
Until microsoft/TypeScript#30661 is fixed we can't do incremental builds
with --noEmit so this sets an outDir for all typescript projects that
don't already have one.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

