### PR TITLE
[APM] Fix agent config flyout state

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyout.tsx
@@ -18,7 +18,7 @@ import {
   EuiButtonEmpty,
   EuiCallOut
 } from '@elastic/eui';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { toastNotifications } from 'ui/notify';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -57,6 +57,7 @@ export function AddSettingsFlyout({
       ? selectedConfig.settings.transaction_sample_rate.toString()
       : ''
   );
+
   const { data: serviceNames = [], status: serviceNamesStatus } = useFetcher(
     () =>
       callApmApi({
@@ -87,6 +88,18 @@ export function AddSettingsFlyout({
     env =>
       env.name === environment && (Boolean(selectedConfig) || env.available)
   );
+
+  useEffect(() => {
+    if (selectedConfig) {
+      setEnvironment(selectedConfig.service.environment);
+      setServiceName(selectedConfig.service.name);
+      setSampleRate(selectedConfig.settings.transaction_sample_rate.toString());
+    } else {
+      setEnvironment(ENVIRONMENT_NOT_DEFINED);
+      setServiceName(undefined);
+      setSampleRate('');
+    }
+  }, [selectedConfig]);
 
   if (!isOpen) {
     return null;

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AddSettings/AddSettingFlyoutBody.tsx
@@ -157,7 +157,11 @@ export function AddSettingFlyoutBody({
             placeholder={selectPlaceholderLabel}
             isLoading={environmentStatus === 'loading'}
             options={environmentOptions}
-            value={environment}
+            value={
+              selectedConfig
+                ? environment || ENVIRONMENT_NOT_DEFINED
+                : environment
+            }
             disabled={!serviceName || Boolean(selectedConfig)}
             onChange={e => {
               e.preventDefault();

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/index.tsx
@@ -52,10 +52,10 @@ export function Settings() {
   );
 
   const hasConfigurations = !isEmpty(data);
-
   return (
     <>
       <AddSettingsFlyout
+        // key={selectedConfig ? selectedConfig.id : 0}
         isOpen={isFlyoutOpen}
         selectedConfig={selectedConfig}
         onClose={() => {

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/index.tsx
@@ -55,7 +55,6 @@ export function Settings() {
   return (
     <>
       <AddSettingsFlyout
-        // key={selectedConfig ? selectedConfig.id : 0}
         isOpen={isFlyoutOpen}
         selectedConfig={selectedConfig}
         onClose={() => {


### PR DESCRIPTION
Fixes #46947
The flyout state was not reflecting the current configuration, so it was not allowing the user to edit the config.