### PR TITLE
[APM]Removing 0 suffix if array contains only one element

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/DottedKeyValueTable/__test__/DottedKeyValueTable.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/DottedKeyValueTable/__test__/DottedKeyValueTable.test.tsx
@@ -104,4 +104,31 @@ describe('DottedKeyValueTable', () => {
       'top.name.last'
     ]);
   });
+
+  it('should not add 0 sufix if value is an array with one element', () => {
+    const data = {
+      a: {
+        b: {
+          c1: ['foo', 'bar'],
+          c2: ['foo']
+        }
+      },
+      b: {
+        c: ['foo']
+      },
+      c: {
+        d: ['foo', 'bar']
+      }
+    };
+    const output = render(<DottedKeyValueTable data={data} maxDepth={5} />);
+
+    expect(getKeys(output)).toEqual([
+      'a.b.c1.0',
+      'a.b.c1.1',
+      'a.b.c2',
+      'b.c',
+      'c.d.0',
+      'c.d.1'
+    ]);
+  });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/DottedKeyValueTable/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/DottedKeyValueTable/index.tsx
@@ -34,10 +34,12 @@ export function pathify(
   item: StringMap<any>,
   { maxDepth, parentKey = '', depth = 0 }: PathifyOptions
 ): PathifyResult {
+  const isArrayWithSingleValue = Array.isArray(item) && item.length === 1;
   return Object.keys(item)
     .sort()
     .reduce((pathified, key) => {
-      const currentKey = compact([parentKey, key]).join('.');
+      const childKey = isArrayWithSingleValue ? '' : key;
+      const currentKey = compact([parentKey, childKey]).join('.');
       if ((!maxDepth || depth + 1 <= maxDepth) && isObject(item[key])) {
         return {
           ...pathified,


### PR DESCRIPTION
Fixes: #37013

## Summary

Remove "0" from MetadataTable suffix if there is only a single item in the array

Before:
![before](https://user-images.githubusercontent.com/55978943/65966323-3b09c480-e460-11e9-9b57-648b8b73cb03.png)

After:
<img width="829" alt="Screenshot 2019-10-01 at 15 30 04" src="https://user-images.githubusercontent.com/55978943/65966444-668caf00-e460-11e9-9074-cfcc0dceb6e4.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
