### PR TITLE
[Maps] Add UI source for custom vector tile style

### DIFF
--- a/x-pack/legacy/plugins/maps/public/layers/sources/all_sources.js
+++ b/x-pack/legacy/plugins/maps/public/layers/sources/all_sources.js
@@ -8,6 +8,7 @@ import { EMSFileSource } from './ems_file_source';
 import { GeojsonFileSource } from './client_file_source';
 import { KibanaRegionmapSource } from './kibana_regionmap_source';
 import { XYZTMSSource } from './xyz_tms_source';
+import { VectorTileSource } from './vector_tile_source';
 import { EMSTMSSource } from './ems_tms_source';
 import { WMSSource } from './wms_source';
 import { KibanaTilemapSource } from './kibana_tilemap_source';
@@ -22,6 +23,7 @@ export const ALL_SOURCES = [
   ESPewPewSource,
   EMSFileSource,
   EMSTMSSource,
+  VectorTileSource,
   KibanaRegionmapSource,
   KibanaTilemapSource,
   XYZTMSSource,

--- a/x-pack/legacy/plugins/maps/public/layers/vector_tile_layer.js
+++ b/x-pack/legacy/plugins/maps/public/layers/vector_tile_layer.js
@@ -106,8 +106,11 @@ export class VectorTileLayer extends TileLayer {
   }
 
   _makeNamespacedImageId(imageId) {
-    const prefix = this._source.getSpriteNamespacePrefix() + '/';
-    return prefix + imageId;
+    const prefix = this._source.getSpriteNamespacePrefix();
+    if (prefix) {
+      return `${prefix}/${imageId}`;
+    }
+    return imageId;
   }
 
   syncLayerWithMB(mbMap) {
@@ -139,17 +142,16 @@ export class VectorTileLayer extends TileLayer {
 
       //sync spritesheet
       const spriteMeta = this._getSpriteMeta();
-      if (!spriteMeta) {
-        return;
-      }
-      const newJson = {};
-      for (const imageId in spriteMeta.json) {
-        if (spriteMeta.json.hasOwnProperty(imageId)) {
-          const namespacedImageId = this._makeNamespacedImageId(imageId);
-          newJson[namespacedImageId] = spriteMeta.json[imageId];
+      if (spriteMeta) {
+        const newJson = {};
+        for (const imageId in spriteMeta.json) {
+          if (spriteMeta.json.hasOwnProperty(imageId)) {
+            const namespacedImageId = this._makeNamespacedImageId(imageId);
+            newJson[namespacedImageId] = spriteMeta.json[imageId];
+          }
         }
+        addSpritesheetToMap(newJson, spriteMeta.png, mbMap);
       }
-      addSpritesheetToMap(newJson, spriteMeta.png, mbMap);
 
       //sync layers
       vectorStyle.layers.forEach(layer => {


### PR DESCRIPTION
## Summary

WIP. Please do not merge.

Partially fixes #46409.

This adds a new layer source supporting custom vector tiles from a user-specified URL to a style document matching the [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/). 

This naively passes the URL directly to mapbox-gl-js for fetching, validation, and rendering. 

TEST URLS
* https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json
* https://basemaps.cartocdn.com/gl/positron-gl-style/style.json
* https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json
* https://tiles.maps.elastic.co/styles/osm-bright-desaturated/style.json

TODO
- [ ] Retrieve attribution from the style
- [ ] Allow custom style URLs to be defined in `kibana.yml`
- [ ] Tests

QUESTIONS
1. Mapbox styles that use the `mapbox://` URI protocol do not work without an `[accessToken](https://docs.mapbox.com/mapbox-gl-js/api/#accesstoken)` defined on the Map. Should we offer a text field for the user to attach their access token to the map?
2. How smart should this be? Do we need to parse the style.json file and look for `mapbox://` URI protocols before offering this option? Or simply have an optional Mapbox Access Token field.
3. Do other vector tile providers have similar access token requirements that we may need to handle? (e.g. Nextzen, Carto, Esri, Here, ...)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

