### PR TITLE
[APM]Changing status code colors on trace summary

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/Summary/HttpInfoSummaryItem/__test__/HttpInfoSummaryItem.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Summary/HttpInfoSummaryItem/__test__/HttpInfoSummaryItem.test.tsx
@@ -6,16 +6,16 @@
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { palettes } from '@elastic/eui';
-import { HttpInfoSummaryItem } from './';
-import * as exampleTransactions from '../__fixtures__/transactions';
+import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { HttpInfoSummaryItem } from '../';
+import * as exampleTransactions from '../../__fixtures__/transactions';
 
 describe('HttpInfoSummaryItem', () => {
   describe('render', () => {
     const transaction = exampleTransactions.httpOk;
     const url = 'https://example.com';
     const method = 'get';
-    const props = { transaction, url, method, status: 200 };
+    const props = { transaction, url, method, status: 100 };
 
     it('renders', () => {
       expect(() =>
@@ -23,12 +23,23 @@ describe('HttpInfoSummaryItem', () => {
       ).not.toThrowError();
     });
 
-    describe('with status code 200', () => {
+    describe('with status code 100', () => {
       it('shows a success color', () => {
         const wrapper = mount(<HttpInfoSummaryItem {...props} />);
 
         expect(wrapper.find('HttpStatusBadge EuiBadge').prop('color')).toEqual(
-          palettes.euiPaletteForStatus.colors[0]
+          theme.euiColorDarkShade
+        );
+      });
+    });
+
+    describe('with status code 200', () => {
+      it('shows a success color', () => {
+        const p = { ...props, status: 200 };
+        const wrapper = mount(<HttpInfoSummaryItem {...p} />);
+
+        expect(wrapper.find('HttpStatusBadge EuiBadge').prop('color')).toEqual(
+          theme.euiColorSecondary
         );
       });
     });
@@ -40,7 +51,7 @@ describe('HttpInfoSummaryItem', () => {
         const wrapper = mount(<HttpInfoSummaryItem {...p} />);
 
         expect(wrapper.find('HttpStatusBadge EuiBadge').prop('color')).toEqual(
-          palettes.euiPaletteForStatus.colors[4]
+          theme.euiColorDarkShade
         );
       });
     });
@@ -52,7 +63,7 @@ describe('HttpInfoSummaryItem', () => {
         const wrapper = mount(<HttpInfoSummaryItem {...p} />);
 
         expect(wrapper.find('HttpStatusBadge EuiBadge').prop('color')).toEqual(
-          palettes.euiPaletteForStatus.colors[9]
+          theme.euiColorWarning
         );
       });
     });
@@ -64,7 +75,7 @@ describe('HttpInfoSummaryItem', () => {
         const wrapper = mount(<HttpInfoSummaryItem {...p} />);
 
         expect(wrapper.find('HttpStatusBadge EuiBadge').prop('color')).toEqual(
-          palettes.euiPaletteForStatus.colors[9]
+          theme.euiColorDanger
         );
       });
     });

--- a/x-pack/legacy/plugins/apm/public/components/shared/Summary/HttpInfoSummaryItem/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Summary/HttpInfoSummaryItem/index.tsx
@@ -6,24 +6,26 @@
 
 import React from 'react';
 import { EuiToolTip, EuiBadge } from '@elastic/eui';
+import theme from '@elastic/eui/dist/eui_theme_light.json';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
-import { palettes } from '@elastic/eui';
 import { units, px, truncate, unit } from '../../../../style/variables';
 import { statusCodes } from './statusCodes';
 
-const statusColors = {
-  success: palettes.euiPaletteForStatus.colors[0],
-  warning: palettes.euiPaletteForStatus.colors[4],
-  error: palettes.euiPaletteForStatus.colors[9]
-};
+const {
+  euiColorDarkShade,
+  euiColorSecondary,
+  euiColorWarning,
+  euiColorDanger
+} = theme;
 
 function getStatusColor(status: number) {
   const colors: { [key: string]: string } = {
-    2: statusColors.success,
-    3: statusColors.warning,
-    4: statusColors.error,
-    5: statusColors.error
+    1: euiColorDarkShade,
+    2: euiColorSecondary,
+    3: euiColorDarkShade,
+    4: euiColorWarning,
+    5: euiColorDanger
   };
 
   return colors[status.toString().substr(0, 1)] || 'default';


### PR DESCRIPTION
closes #45406 

Using light theme colors.

Before Dark/Light themes:
<img width="642" alt="before-dark" src="https://user-images.githubusercontent.com/55978943/66046442-06604080-e526-11e9-980f-17556d241356.png">
<img width="643" alt="before-light" src="https://user-images.githubusercontent.com/55978943/66046447-09f3c780-e526-11e9-9872-67df749d588f.png">

After Dark/Light themes:
<img width="651" alt="after-dark" src="https://user-images.githubusercontent.com/55978943/66046463-12e49900-e526-11e9-80bd-874a5a7817a7.png">
<img width="643" alt="after-light" src="https://user-images.githubusercontent.com/55978943/66046471-1546f300-e526-11e9-843a-5e486b65ab6a.png">


