### PR TITLE
[DOC] Code: YourCodeNoteAddress -> YourCodeNodeAddress

### DIFF
--- a/docs/code/code-multiple-kibana-instances-config.asciidoc
+++ b/docs/code/code-multiple-kibana-instances-config.asciidoc
@@ -7,4 +7,4 @@ If you are using multiple instances of {kib}, you must manually assign at least 
 xpack.code.codeNodeUrl: 'http://$YourCodeNodeAddress'
 ----
 
-`$YourCodeNoteAddress` is the URL of your assigned *Code* node accessible by other {kib} instances.
+`$YourCodeNodeAddress` is the URL of your assigned *Code* node accessible by other {kib} instances.


### PR DESCRIPTION
`$YourCodeNoteAddress` to `$YourCodeNodeAddress`

>`$YourCodeNoteAddress` is the URL of your assigned *Code* node accessible by other {kib} instances.	