### PR TITLE
[Graph] Check license on controller load

### DIFF
--- a/x-pack/legacy/plugins/graph/public/app.js
+++ b/x-pack/legacy/plugins/graph/public/app.js
@@ -66,26 +66,16 @@ import './angular/directives/graph_inspect';
 
 const app = uiModules.get('app/graph');
 
-function checkLicense(Promise, kbnBaseUrl) {
+function checkLicense(kbnBaseUrl) {
   const licenseAllowsToShowThisPage = xpackInfo.get('features.graph.showAppLink') &&
     xpackInfo.get('features.graph.enableAppLink');
   if (!licenseAllowsToShowThisPage) {
     const message = xpackInfo.get('features.graph.message');
     const newUrl = addAppRedirectMessageToUrl(chrome.addBasePath(kbnBaseUrl), message);
     window.location.href = newUrl;
-    return Promise.halt();
+    throw new Error('Graph license error');
   }
-
-  return Promise.resolve();
 }
-
-app.directive('focusOn', function () {
-  return function (scope, elem, attr) {
-    scope.$on(attr.focusOn, function () {
-      elem[0].focus();
-    });
-  };
-});
 
 app.directive('vennDiagram', function (reactDirective) {
   return reactDirective(VennDiagram);
@@ -126,8 +116,8 @@ uiRoutes
   .when('/home', {
     template: listingTemplate,
     badge: getReadonlyBadge,
-    controller($injector, $location, $scope, Private, config, Promise, kbnBaseUrl) {
-      checkLicense(Promise, kbnBaseUrl);
+    controller($injector, $location, $scope, Private, config, kbnBaseUrl) {
+      checkLicense(kbnBaseUrl);
       const services = Private(SavedObjectRegistryProvider).byLoaderPropertiesName;
       const graphService = services['Graph workspace'];
       const kbnUrl = $injector.get('kbnUrl');
@@ -167,7 +157,6 @@ uiRoutes
             }
           ) : savedGraphWorkspaces.get();
       },
-      //Copied from example found in wizard.js ( Kibana TODO - can't
       indexPatterns: function (Private) {
         const savedObjectsClient = Private(SavedObjectsClientProvider);
 
@@ -196,17 +185,13 @@ app.controller('graphuiPlugin', function (
   $route,
   $http,
   kbnUrl,
-  Promise,
   confirmModal,
   kbnBaseUrl
 ) {
-  function handleSuccess(data) {
-    return checkLicense(Promise, kbnBaseUrl)
-      .then(() => data);
-  }
+  checkLicense(kbnBaseUrl);
 
   function handleError(err) {
-    return checkLicense(Promise, kbnBaseUrl)
+    return checkLicense(kbnBaseUrl)
       .then(() => {
         const toastTitle = i18n.translate('xpack.graph.errorToastTitle', {
           defaultMessage: 'Graph Error',
@@ -226,7 +211,7 @@ app.controller('graphuiPlugin', function (
   }
 
   function handleHttpError(error) {
-    return checkLicense(Promise, kbnBaseUrl)
+    return checkLicense(kbnBaseUrl)
       .then(() => {
         toastNotifications.addDanger(formatAngularHttpError(error));
       });
@@ -427,13 +412,6 @@ app.controller('graphuiPlugin', function (
     }
     $scope.workspace.simpleSearch(searchTerm, $scope.liveResponseFields, numHops);
   };
-
-  $scope.clearWorkspace = function () {
-    $scope.workspace = null;
-    $scope.detail = null;
-    if ($scope.closeMenus) $scope.closeMenus();
-  };
-
 
   $scope.selectSelected = function (node) {
     $scope.detail = {


### PR DESCRIPTION
This PR adds a license check on loading a graph workspace, simplifies the implementation and removes some unused code.