### PR TITLE
[7.x] skip flaky test (#46977) (#47437)

### DIFF
--- a/x-pack/test/functional/apps/code/with_security.ts
+++ b/x-pack/test/functional/apps/code/with_security.ts
@@ -23,7 +23,8 @@ export default function testWithSecurity({ getService, getPageObjects }: FtrProv
   const security = getService('security');
   const config = getService('config');
 
-  describe('Security', () => {
+  // FLAKY: https://github.com/elastic/kibana/issues/46977
+  describe.skip('Security', () => {
     describe('with security enabled:', () => {
       before(async () => {
         await esArchiver.load('empty_kibana');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - skip flaky test (#46977) (#47437)