### PR TITLE
[discover] fix shared links tests for cloud testing

### DIFF
--- a/test/functional/page_objects/share_page.js
+++ b/test/functional/page_objects/share_page.js
@@ -49,7 +49,20 @@ export function SharePageProvider({ getService, getPageObjects }) {
       await testSubjects.waitForDeleted(menuPanel);
     }
 
+    /**
+     * if there are more entries in the share menu, the permalinks entry has to be clicked first
+     * else the selection isn't displayed. this happens if you're testing against an instance
+     * with xpack features enabled, where there's also a csv sharing option
+     * in a pure OSS environment, the permalinks sharing panel is displayed initially
+     */
+    async openPermaLinks() {
+      if(await testSubjects.exists('sharePanel-Permalinks')) {
+        await testSubjects.click(`sharePanel-Permalinks`);
+      }
+    }
+
     async getSharedUrl() {
+      await this.openPermaLinks();
       return await testSubjects.getAttribute('copyShareUrlButton', 'data-share-url');
     }
 
@@ -68,6 +81,7 @@ export function SharePageProvider({ getService, getPageObjects }) {
     }
 
     async exportAsSavedObject() {
+      await this.openPermaLinks();
       return await testSubjects.click('exportAsSavedObject');
     }
 

--- a/test/functional/page_objects/share_page.ts
+++ b/test/functional/page_objects/share_page.ts
@@ -17,7 +17,9 @@
  * under the License.
  */
 
-export function SharePageProvider({ getService, getPageObjects }) {
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function SharePageProvider({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const PageObjects = getPageObjects(['visualize', 'common']);
@@ -32,7 +34,7 @@ export function SharePageProvider({ getService, getPageObjects }) {
       return testSubjects.click('shareTopNavButton');
     }
 
-    async openShareMenuItem(itemTitle) {
+    async openShareMenuItem(itemTitle: string) {
       log.debug(`openShareMenuItem title:${itemTitle}`);
       const isShareMenuOpen = await this.isShareMenuOpen();
       if (!isShareMenuOpen) {
@@ -45,7 +47,7 @@ export function SharePageProvider({ getService, getPageObjects }) {
         await this.clickShareTopNavButton();
       }
       const menuPanel = await find.byCssSelector('div.euiContextMenuPanel');
-      testSubjects.click(`sharePanel-${itemTitle.replace(' ', '')}`);
+      await testSubjects.click(`sharePanel-${itemTitle.replace(' ', '')}`);
       await testSubjects.waitForDeleted(menuPanel);
     }
 
@@ -56,7 +58,7 @@ export function SharePageProvider({ getService, getPageObjects }) {
      * in a pure OSS environment, the permalinks sharing panel is displayed initially
      */
     async openPermaLinks() {
-      if(await testSubjects.exists('sharePanel-Permalinks')) {
+      if (await testSubjects.exists('sharePanel-Permalinks')) {
         await testSubjects.click(`sharePanel-Permalinks`);
       }
     }
@@ -84,7 +86,6 @@ export function SharePageProvider({ getService, getPageObjects }) {
       await this.openPermaLinks();
       return await testSubjects.click('exportAsSavedObject');
     }
-
   }
 
   return new SharePage();


### PR DESCRIPTION
## Summary

In cloud tests sharing discover links failed. the tests expected the sharing menu with no choice between csv & permalink sharing. 

<img width="539" alt="Bildschirmfoto 2019-10-08 um 13 03 05" src="https://user-images.githubusercontent.com/463851/66410862-1af37b80-e9f3-11e9-8fa4-886d498e408a.png">

This was fixed so this works now also when there are multiple ways of sharing offered.


![](https://user-images.githubusercontent.com/23424008/58592243-43898e80-8225-11e9-8ce8-8f02f3cf4a32.png)



 In this case the permalink menu entry is clicked before the test continues.



Additionally, since it was a low hanging fruit in this case, the file was converted to TypeScript

Fixes #37408

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

~~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [x] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

