### PR TITLE
[Graph] Fix default discover url template building

### DIFF
--- a/x-pack/legacy/plugins/graph/public/state_management/legacy.test.ts
+++ b/x-pack/legacy/plugins/graph/public/state_management/legacy.test.ts
@@ -14,6 +14,7 @@ import {
   updateFieldProperties,
 } from './fields';
 import { AdvancedSettings, WorkspaceField, WorkspaceNode } from '../types';
+import { loadTemplates, syncTemplatesSaga } from './url_templates';
 
 /**
  * This suite tests all the sagas that only exist to sync the legacy world
@@ -25,7 +26,13 @@ describe('legacy sync sagas', () => {
 
   beforeEach(() => {
     env = createMockGraphStore({
-      sagas: [syncSettingsSaga, updateSaveButtonSaga, syncFieldsSaga, syncNodeStyleSaga],
+      sagas: [
+        syncSettingsSaga,
+        updateSaveButtonSaga,
+        syncFieldsSaga,
+        syncNodeStyleSaga,
+        syncTemplatesSaga,
+      ],
       initialStateOverwrites: {
         fields: {
           field1: {
@@ -65,6 +72,12 @@ describe('legacy sync sagas', () => {
     const newSettings = {} as AdvancedSettings;
     env.store.dispatch(updateSettings(newSettings));
     expect(env.mockedDeps.getWorkspace()!.options.exploreControls).toBe(newSettings);
+  });
+
+  it('syncs templates with workspace', () => {
+    env.store.dispatch(loadTemplates([]));
+    expect(env.mockedDeps.setUrlTemplates).toHaveBeenCalledWith([]);
+    expect(env.mockedDeps.notifyAngular).toHaveBeenCalled();
   });
 
   it('notifies angular when fields are selected', () => {

--- a/x-pack/legacy/plugins/graph/public/state_management/url_templates.test.ts
+++ b/x-pack/legacy/plugins/graph/public/state_management/url_templates.test.ts
@@ -22,7 +22,8 @@ describe('url_templates', () => {
       );
       expect(templates.length).toBe(1);
       expect(templates[0].encoder).toBe(outlinkEncoders[0]);
-      expect(templates[0].url).toContain('test-pattern');
+      expect(templates[0].url).not.toContain('test-pattern');
+      expect(templates[0].url).toContain('123456');
       expect(templates[0].isDefault).toBe(true);
     });
 

--- a/x-pack/legacy/plugins/graph/public/state_management/url_templates.ts
+++ b/x-pack/legacy/plugins/graph/public/state_management/url_templates.ts
@@ -9,7 +9,7 @@ import { reducerWithInitialState } from 'typescript-fsa-reducers/dist';
 import { KibanaParsedUrl } from 'ui/url/kibana_parsed_url';
 import { i18n } from '@kbn/i18n';
 import rison from 'rison-node';
-import { takeEvery, select, call } from 'redux-saga/effects';
+import { takeEvery, select } from 'redux-saga/effects';
 import { GraphState, GraphStoreDependencies } from './store';
 import { UrlTemplate } from '../types';
 import { reset } from './global';

--- a/x-pack/legacy/plugins/graph/public/state_management/url_templates.ts
+++ b/x-pack/legacy/plugins/graph/public/state_management/url_templates.ts
@@ -9,7 +9,7 @@ import { reducerWithInitialState } from 'typescript-fsa-reducers/dist';
 import { KibanaParsedUrl } from 'ui/url/kibana_parsed_url';
 import { i18n } from '@kbn/i18n';
 import rison from 'rison-node';
-import { takeEvery, select } from 'redux-saga/effects';
+import { takeEvery, select, call } from 'redux-saga/effects';
 import { GraphState, GraphStoreDependencies } from './store';
 import { UrlTemplate } from '../types';
 import { reset } from './global';
@@ -44,7 +44,7 @@ function generateDefaultTemplate(
     '_a',
     rison.encode({
       columns: ['_source'],
-      index: datasource.title,
+      index: datasource.id,
       interval: 'auto',
       query: { language: 'kuery', query: urlTemplatePlaceholder },
       sort: ['_score', 'desc'],
@@ -106,6 +106,9 @@ export const syncTemplatesSaga = ({ setUrlTemplates, notifyAngular }: GraphStore
   }
 
   return function*() {
-    yield takeEvery(matchesOne(loadTemplates, saveTemplate, removeTemplate), syncTemplates);
+    yield takeEvery(
+      matchesOne(loadTemplates, saveTemplate, removeTemplate, requestDatasource, setDatasource),
+      syncTemplates
+    );
   };
 };


### PR DESCRIPTION
This PR fixes the URL for the default discover drilldown link. It mistakenly used the index name instead of the id. This also adds a test whether templates get synced correctly with the scope.