### PR TITLE
[APM] Documentation and alignment for impact column

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -85,11 +85,25 @@ const traceListColumns: Array<ITableColumn<ITransactionGroup>> = [
   },
   {
     field: 'impact',
-    name: i18n.translate('xpack.apm.tracesTable.impactColumnLabel', {
-      defaultMessage: 'Impact'
-    }),
+    name: (
+      <EuiToolTip
+        content={i18n.translate(
+          'xpack.apm.tracesTable.impactColumnDescription',
+          {
+            defaultMessage:
+              "Impact shows the most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute."
+          }
+        )}
+      >
+        <>
+          {i18n.translate('xpack.apm.tracesTable.impactColumnLabel', {
+            defaultMessage: 'Impact'
+          })}
+        </>
+      </EuiToolTip>
+    ),
     width: '20%',
-    align: 'right',
+    align: 'left',
     sortable: true,
     render: (value: number) => <ImpactBar value={value} />
   }

--- a/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -91,7 +91,7 @@ const traceListColumns: Array<ITableColumn<ITransactionGroup>> = [
           'xpack.apm.tracesTable.impactColumnDescription',
           {
             defaultMessage:
-              "Impact shows the most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute."
+              "The most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute."
           }
         )}
       >

--- a/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiToolTip } from '@elastic/eui';
+import { EuiIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import styled from 'styled-components';
@@ -98,7 +98,13 @@ const traceListColumns: Array<ITableColumn<ITransactionGroup>> = [
         <>
           {i18n.translate('xpack.apm.tracesTable.impactColumnLabel', {
             defaultMessage: 'Impact'
-          })}
+          })}{' '}
+          <EuiIcon
+            size="s"
+            color="subdued"
+            type="questionInCircle"
+            className="eui-alignTop"
+          />
         </>
       </EuiToolTip>
     ),

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -107,7 +107,7 @@ export function TransactionList({ items, isLoading }: Props) {
               'xpack.apm.transactionsTable.impactColumnDescription',
               {
                 defaultMessage:
-                  "Impact shows the most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute."
+                  "The most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute."
               }
             )}
           >

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -101,9 +101,23 @@ export function TransactionList({ items, isLoading }: Props) {
       },
       {
         field: 'impact',
-        name: i18n.translate('xpack.apm.transactionsTable.impactColumnLabel', {
-          defaultMessage: 'Impact'
-        }),
+        name: (
+          <EuiToolTip
+            content={i18n.translate(
+              'xpack.apm.transactionsTable.impactColumnDescription',
+              {
+                defaultMessage:
+                  "Impact shows the most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute."
+              }
+            )}
+          >
+            <>
+              {i18n.translate('xpack.apm.transactionsTable.impactColumnLabel', {
+                defaultMessage: 'Impact'
+              })}
+            </>
+          </EuiToolTip>
+        ),
         sortable: true,
         dataType: 'number',
         render: (value: number) => <ImpactBar value={value} />

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/List/index.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiToolTip } from '@elastic/eui';
+import { EuiIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
@@ -114,7 +114,13 @@ export function TransactionList({ items, isLoading }: Props) {
             <>
               {i18n.translate('xpack.apm.transactionsTable.impactColumnLabel', {
                 defaultMessage: 'Impact'
-              })}
+              })}{' '}
+              <EuiIcon
+                size="s"
+                color="subdued"
+                type="questionInCircle"
+                className="eui-alignTop"
+              />
             </>
           </EuiToolTip>
         ),

--- a/x-pack/legacy/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -6,7 +6,7 @@
 
 import { EuiBasicTable } from '@elastic/eui';
 import { sortByOrder } from 'lodash';
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, ReactNode } from 'react';
 import { idx } from '@kbn/elastic-idx';
 import { StringMap } from '../../../../typings/common';
 import { useUrlParams } from '../../../hooks/useUrlParams';
@@ -15,7 +15,7 @@ import { fromQuery, toQuery } from '../Links/url_helpers';
 
 // TODO: this should really be imported from EUI
 export interface ITableColumn<T> {
-  name: string;
+  name: ReactNode;
   actions?: StringMap[];
   field?: string;
   dataType?: string;


### PR DESCRIPTION
In the traces and transactions tables, left align the impact column heading and add a tooltip explaining what it means.

Fixes #44313
Fixes #28559

![image](https://user-images.githubusercontent.com/9912/66422944-4153ef80-e9d0-11e9-80e5-680059cbb1fa.png)
