### PR TITLE
[Infra UI] Change charts to use label instead of yAccessors for getSpecId()

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/metrics/sections/series_chart.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics/sections/series_chart.tsx
@@ -60,7 +60,7 @@ export const AreaChart = ({ id, color, series, name, type, stack }: Props) => {
   customColors.set(colors, color || '#999');
   return (
     <AreaSeries
-      id={getSpecId(id)}
+      id={getSpecId(name)}
       name={name}
       xScaleType={ScaleType.Time}
       yScaleType={ScaleType.Linear}
@@ -74,7 +74,7 @@ export const AreaChart = ({ id, color, series, name, type, stack }: Props) => {
   );
 };
 
-export const BarChart = ({ id, color, series, name, type, stack }: Props) => {
+export const BarChart = ({ color, series, name, stack }: Props) => {
   const style: RecursivePartial<BarSeriesStyle> = {
     rectBorder: {
       stroke: color || void 0,
@@ -87,13 +87,13 @@ export const BarChart = ({ id, color, series, name, type, stack }: Props) => {
   };
   const colors: DataSeriesColorsValues = {
     colorValues: [],
-    specId: getSpecId(id),
+    specId: getSpecId(name),
   };
   const customColors: CustomSeriesColorsMap = new Map();
   customColors.set(colors, color || '#999');
   return (
     <BarSeries
-      id={getSpecId(id)}
+      id={getSpecId(name)}
       name={name}
       xScaleType={ScaleType.Time}
       yScaleType={ScaleType.Linear}


### PR DESCRIPTION
## Summary

This PR fixes #47612 by changing the `getSpecId` to use the `label` instead of the `yAccessor`. This also cleans up some duplicate code in the MetricsExplorer charts.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
