### PR TITLE
Adding KibanaContextProvider to DimensionPanel component

### DIFF
--- a/src/legacy/core_plugins/data/public/query/query_bar/components/query_bar_input.tsx
+++ b/src/legacy/core_plugins/data/public/query/query_bar/components/query_bar_input.tsx
@@ -119,9 +119,11 @@ export class QueryBarInputUI extends Component<Props, State> {
       this.services.uiSettings!
     )) as IndexPattern[];
 
-    this.setState({
-      indexPatterns: [...objectPatterns, ...objectPatternsFromStrings],
-    });
+    if (!this.componentIsUnmounting) {
+      this.setState({
+        indexPatterns: [...objectPatterns, ...objectPatternsFromStrings],
+      });
+    }
   };
 
   private getSuggestions = async () => {
@@ -386,34 +388,34 @@ export class QueryBarInputUI extends Component<Props, State> {
     this.inputRef.focus();
   };
 
+  private initPersistedLog = () => {
+    const { uiSettings, store, appName } = this.services;
+    this.persistedLog = this.props.persistedLog
+      ? this.props.persistedLog
+      : getQueryLog(uiSettings, store, appName, this.props.query.language);
+  };
+
   public onMouseEnterSuggestion = (index: number) => {
     this.setState({ index });
   };
 
   public componentDidMount() {
-    const { uiSettings, store, appName } = this.services;
     const parsedQuery = fromUser(toUser(this.props.query.query));
     if (!isEqual(this.props.query.query, parsedQuery)) {
       this.onChange({ ...this.props.query, query: parsedQuery });
     }
 
-    this.persistedLog = this.props.persistedLog
-      ? this.props.persistedLog
-      : getQueryLog(uiSettings, store, appName, this.props.query.language);
-
+    this.initPersistedLog();
     this.fetchIndexPatterns().then(this.updateSuggestions);
   }
 
   public componentDidUpdate(prevProps: Props) {
-    const { uiSettings, store, appName } = this.services;
     const parsedQuery = fromUser(toUser(this.props.query.query));
     if (!isEqual(this.props.query.query, parsedQuery)) {
       this.onChange({ ...this.props.query, query: parsedQuery });
     }
 
-    this.persistedLog = this.props.persistedLog
-      ? this.props.persistedLog
-      : getQueryLog(uiSettings, store, appName, this.props.query.language);
+    this.initPersistedLog();
 
     if (!isEqual(prevProps.indexPatterns, this.props.indexPatterns)) {
       this.fetchIndexPatterns().then(this.updateSuggestions);

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
@@ -14,6 +14,8 @@ import {
   SavedObjectsClientContract,
   HttpServiceBase,
 } from 'src/core/public';
+import { npStart } from 'ui/new_platform';
+import { KibanaContextProvider } from '../../../../../../../src/plugins/kibana_react/public';
 import { DatasourceDimensionPanelProps, StateSetter } from '../../types';
 import {
   IndexPatternColumn,
@@ -155,12 +157,22 @@ export const IndexPatternDimensionPanel = memo(function IndexPatternDimensionPan
           );
         }}
       >
-        <PopoverEditor
-          {...props}
-          currentIndexPattern={currentIndexPattern}
-          selectedColumn={selectedColumn}
-          operationFieldSupportMatrix={operationFieldSupportMatrix}
-        />
+        <KibanaContextProvider
+          services={{
+            appName: 'lens',
+            store: props.storage,
+            uiSettings: props.uiSettings,
+            data: npStart.plugins.data,
+            savedObjects: npStart.core.savedObjects,
+          }}
+        >
+          <PopoverEditor
+            {...props}
+            currentIndexPattern={currentIndexPattern}
+            selectedColumn={selectedColumn}
+            operationFieldSupportMatrix={operationFieldSupportMatrix}
+          />
+        </KibanaContextProvider>
         {selectedColumn && (
           <EuiButtonIcon
             data-test-subj="indexPattern-dimensionPopover-remove"

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
@@ -14,8 +14,6 @@ import {
   SavedObjectsClientContract,
   HttpServiceBase,
 } from 'src/core/public';
-import { npStart } from 'ui/new_platform';
-import { KibanaContextProvider } from '../../../../../../../src/plugins/kibana_react/public';
 import { DatasourceDimensionPanelProps, StateSetter } from '../../types';
 import {
   IndexPatternColumn,
@@ -157,22 +155,12 @@ export const IndexPatternDimensionPanel = memo(function IndexPatternDimensionPan
           );
         }}
       >
-        <KibanaContextProvider
-          services={{
-            appName: 'lens',
-            store: props.storage,
-            uiSettings: props.uiSettings,
-            data: npStart.plugins.data,
-            savedObjects: npStart.core.savedObjects,
-          }}
-        >
-          <PopoverEditor
-            {...props}
-            currentIndexPattern={currentIndexPattern}
-            selectedColumn={selectedColumn}
-            operationFieldSupportMatrix={operationFieldSupportMatrix}
-          />
-        </KibanaContextProvider>
+        <PopoverEditor
+          {...props}
+          currentIndexPattern={currentIndexPattern}
+          selectedColumn={selectedColumn}
+          operationFieldSupportMatrix={operationFieldSupportMatrix}
+        />
         {selectedColumn && (
           <EuiButtonIcon
             data-test-subj="indexPattern-dimensionPopover-remove"

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
@@ -5,6 +5,7 @@
  */
 
 import chromeMock from 'ui/chrome';
+
 import { Storage } from 'ui/storage';
 import {
   getIndexPatternDatasource,
@@ -15,6 +16,7 @@ import {
 } from './indexpattern';
 import { DatasourcePublicAPI, Operation, Datasource } from '../types';
 import { coreMock } from 'src/core/public/mocks';
+import { Plugin as DataPlugin } from '../../../../../../src/plugins/data/public';
 
 jest.mock('./loader');
 jest.mock('../id_generator');
@@ -135,6 +137,7 @@ describe('IndexPattern Data Source', () => {
       chrome: chromeMock,
       storage: {} as Storage,
       core: coreMock.createStart(),
+      data: {} as ReturnType<DataPlugin['start']>,
     });
 
     persistedState = {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
@@ -15,7 +15,7 @@ import {
 } from './indexpattern';
 import { DatasourcePublicAPI, Operation, Datasource } from '../types';
 import { coreMock } from 'src/core/public/mocks';
-import { Plugin as DataPlugin } from '../../../../../../src/plugins/data/public';
+import { pluginsMock } from 'ui/new_platform/__mocks__/helpers';
 
 jest.mock('./loader');
 jest.mock('../id_generator');
@@ -136,7 +136,7 @@ describe('IndexPattern Data Source', () => {
       chrome: chromeMock,
       storage: {} as Storage,
       core: coreMock.createStart(),
-      data: {} as ReturnType<DataPlugin['start']>,
+      data: pluginsMock.createStart().data,
     });
 
     persistedState = {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.test.ts
@@ -5,7 +5,6 @@
  */
 
 import chromeMock from 'ui/chrome';
-
 import { Storage } from 'ui/storage';
 import {
   getIndexPatternDatasource,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern_suggestions.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern_suggestions.test.tsx
@@ -14,6 +14,7 @@ import { Datasource, DatasourceSuggestion } from '../types';
 import { generateId } from '../id_generator';
 import { Storage } from 'ui/storage';
 import { coreMock } from 'src/core/public/mocks';
+import { pluginsMock } from 'ui/new_platform/__mocks__/helpers';
 
 jest.mock('./loader');
 jest.mock('../id_generator');
@@ -135,6 +136,7 @@ describe('IndexPattern Data Source suggestions', () => {
       core: coreMock.createStart(),
       chrome: chromeMock,
       storage: {} as Storage,
+      data: pluginsMock.createStart().data,
     });
 
     persistedState = {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/plugin.tsx
@@ -57,6 +57,7 @@ export const indexPatternDatasourceSetup = () => {
     core: npStart.core,
     chrome,
     storage: new Storage(localStorage),
+    data: npStart.plugins.data,
   });
 };
 export const indexPatternDatasourceStop = () => plugin.stop();


### PR DESCRIPTION
## Summary

Fix for #47330.
The problem here was that when [rendered](https://github.com/elastic/kibana/blob/2f80cc5fb3e0ec69bb12d78eac32893964dad10a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/filter_ratio.tsx#L95) from `FilterRatio` component, there was no context provided to the component to read the `services` from, so it couldn't correctly initialize. 
This PR adds an explicit `KibanaContextProvider` in `DimensionPanel`.
It's not an ideal solution; as discussed with @wylieconlon, it would be nice to have a Lens-specific HOC with the relevant context. 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

