### PR TITLE
[APM] Make sure toasts work for failed useFetcher calls

### DIFF
--- a/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
@@ -51,9 +51,7 @@ export function useFetcher(
     initialState?: unknown;
   } = {}
 ) {
-  const {
-    notifications: { toasts }
-  } = useKibanaCore();
+  const { notifications } = useKibanaCore();
   const { preservePreviousData = true } = options;
   const id = useComponentId();
   const { dispatchStatus } = useContext(LoadingIndicatorContext);
@@ -96,7 +94,7 @@ export function useFetcher(
       } catch (e) {
         const err = e as KFetchError;
         if (!didCancel) {
-          toasts.addWarning({
+          notifications.toasts.addWarning({
             title: i18n.translate('xpack.apm.fetcher.error.title', {
               defaultMessage: `Error while fetching resource`
             }),

--- a/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
@@ -52,9 +52,7 @@ export function useFetcher(
   } = {}
 ) {
   const {
-    notifications: {
-      toasts: { addWarning }
-    }
+    notifications: { toasts }
   } = useKibanaCore();
   const { preservePreviousData = true } = options;
   const id = useComponentId();
@@ -98,7 +96,7 @@ export function useFetcher(
       } catch (e) {
         const err = e as KFetchError;
         if (!didCancel) {
-          addWarning({
+          toasts.addWarning({
             title: i18n.translate('xpack.apm.fetcher.error.title', {
               defaultMessage: `Error while fetching resource`
             }),


### PR DESCRIPTION
`toasts.addWarning` is a class method, and fails when called without bound context, which was what happened in `useFetcher` notifications.

