### PR TITLE
[Discover] Fix Maximum call stack size exceeded warnings  

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/doc_table/components/table_header.ts
+++ b/src/legacy/core_plugins/kibana/public/discover/doc_table/components/table_header.ts
@@ -17,14 +17,24 @@
  * under the License.
  */
 import { wrapInI18nContext } from 'ui/i18n';
+// @ts-ignore
 import { uiModules } from 'ui/modules';
 import { TableHeader } from './table_header/table_header';
 const module = uiModules.get('app/discover');
 
-module.directive('kbnTableHeader', function (reactDirective, config) {
+module.directive('kbnTableHeader', function(reactDirective: any, config: any) {
   return reactDirective(
     wrapInI18nContext(TableHeader),
-    undefined,
+    [
+      ['columns', { watchDepth: 'collection' }],
+      ['hideTimeColumn', { watchDepth: 'value' }],
+      ['indexPattern', { watchDepth: 'reference' }],
+      ['isShortDots', { watchDepth: 'value' }],
+      ['onChangeSortOrder', { watchDepth: 'reference' }],
+      ['onMoveColumn', { watchDepth: 'reference' }],
+      ['onRemoveColumn', { watchDepth: 'reference' }],
+      ['sortOrder', { watchDepth: 'collection' }],
+    ],
     { restrict: 'A' },
     {
       hideTimeColumn: config.get('doc_table:hideTimeColumn'),


### PR DESCRIPTION
## Summary

PR takes care of a `Maximum call stack size exceeded` error flooding console when accessing `Discover`, seems there were changes to the index pattern provided to the component, so the reactDirective caused this angular related error. Solution was to set `watchDepth` of `indexPattern` to `reference`. 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

~~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [x] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

