### PR TITLE
[APM] Metadata sections should show message when no data is available

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/__test__/SpanMetadata.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/__test__/SpanMetadata.test.tsx
@@ -9,7 +9,10 @@ import 'jest-dom/extend-expect';
 import { render, cleanup } from 'react-testing-library';
 import { SpanMetadata } from '..';
 import { Span } from '../../../../../../typings/es_schemas/ui/Span';
-import { expectTextsInDocument } from '../../../../../utils/testHelpers';
+import {
+  expectTextsInDocument,
+  expectTextsNotInDocument
+} from '../../../../../utils/testHelpers';
 
 describe('SpanMetadata', () => {
   afterEach(cleanup);
@@ -54,6 +57,30 @@ describe('SpanMetadata', () => {
       } as unknown) as Span;
       const output = render(<SpanMetadata span={span} />);
       expectTextsInDocument(output, ['Service', 'Agent', 'Span']);
+    });
+  });
+  describe('when there is no id inside span', () => {
+    it('does not show the section', () => {
+      const span = ({
+        agent: {
+          ephemeral_id: 'ed8e3a4f-21d2-4a1f-bbc7-fa2064d94225',
+          name: 'java',
+          version: '1.9.1-SNAPSHOT'
+        },
+        service: {
+          name: 'opbeans-java'
+        },
+        span: {
+          http: {
+            response: { status_code: 200 }
+          },
+          subtype: 'http',
+          type: 'external'
+        }
+      } as unknown) as Span;
+      const output = render(<SpanMetadata span={span} />);
+      expectTextsInDocument(output, ['Service', 'Agent']);
+      expectTextsNotInDocument(output, ['Span']);
     });
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import 'jest-dom/extend-expect';
+import { render, cleanup } from 'react-testing-library';
+import { MetadataTable } from '..';
+import {
+  expectTextsInDocument,
+  expectTextsNotInDocument
+} from '../../../../utils/testHelpers';
+
+describe('MetadataTable', () => {
+  afterEach(cleanup);
+  describe('required sections', () => {
+    it('shows message if no data is available', () => {
+      const sections = [
+        {
+          key: 'foo',
+          label: 'Foo',
+          required: true
+        }
+      ];
+      // @ts-ignore
+      const output = render(<MetadataTable item={{}} sections={sections} />);
+      expectTextsInDocument(output, ['Foo', 'No data available']);
+    });
+    it('shows message if property is not available', () => {
+      const sections = [
+        {
+          key: 'foo',
+          label: 'Foo',
+          required: true,
+          properties: ['bar']
+        }
+      ];
+      const item = {
+        foo: {
+          foobar: 'bar'
+        }
+      };
+      // @ts-ignore
+      const output = render(<MetadataTable item={item} sections={sections} />);
+      expectTextsInDocument(output, ['Foo', 'No data available']);
+    });
+  });
+  describe('not required sections', () => {
+    it('does not show section when any item is provided', () => {
+      const sections = [
+        {
+          key: 'foo',
+          label: 'Foo',
+          required: false
+        }
+      ];
+      // @ts-ignore
+      const output = render(<MetadataTable item={{}} sections={sections} />);
+      expectTextsNotInDocument(output, ['Foo']);
+    });
+    it('does not show section if property is not available', () => {
+      const sections = [
+        {
+          key: 'foo',
+          label: 'Foo',
+          required: false,
+          properties: ['bar']
+        }
+      ];
+      const item = {
+        foo: {
+          foobar: 'bar'
+        }
+      };
+      // @ts-ignore
+      const output = render(<MetadataTable item={item} sections={sections} />);
+      expectTextsNotInDocument(output, ['Foo']);
+    });
+  });
+});

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
@@ -17,7 +17,7 @@ import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 describe('MetadataTable', () => {
   afterEach(cleanup);
   describe('required sections', () => {
-    it('shows message if no data is available', () => {
+    it('shows "empty state message" if no data is available', () => {
       const sections = [
         {
           key: 'foo',
@@ -30,7 +30,7 @@ describe('MetadataTable', () => {
       );
       expectTextsInDocument(output, ['Foo', 'No data available']);
     });
-    it('shows message if property is not available', () => {
+    it('shows "empty state message" if property is not available', () => {
       const sections = [
         {
           key: 'foo',
@@ -50,7 +50,7 @@ describe('MetadataTable', () => {
     });
   });
   describe('not required sections', () => {
-    it('does not show section when any item is provided', () => {
+    it('does not show section when no items are provided', () => {
       const sections = [
         {
           key: 'foo',

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
@@ -12,6 +12,7 @@ import {
   expectTextsInDocument,
   expectTextsNotInDocument
 } from '../../../../utils/testHelpers';
+import { Transaction } from '../../../../../typings/es_schemas/ui/Transaction';
 
 describe('MetadataTable', () => {
   afterEach(cleanup);
@@ -24,8 +25,9 @@ describe('MetadataTable', () => {
           required: true
         }
       ];
-      // @ts-ignore
-      const output = render(<MetadataTable item={{}} sections={sections} />);
+      const output = render(
+        <MetadataTable item={{} as Transaction} sections={sections} />
+      );
       expectTextsInDocument(output, ['Foo', 'No data available']);
     });
     it('shows message if property is not available', () => {
@@ -37,12 +39,12 @@ describe('MetadataTable', () => {
           properties: ['bar']
         }
       ];
-      const item = {
+      const item = ({
         foo: {
           foobar: 'bar'
         }
-      };
-      // @ts-ignore
+      } as unknown) as Transaction;
+
       const output = render(<MetadataTable item={item} sections={sections} />);
       expectTextsInDocument(output, ['Foo', 'No data available']);
     });
@@ -56,8 +58,9 @@ describe('MetadataTable', () => {
           required: false
         }
       ];
-      // @ts-ignore
-      const output = render(<MetadataTable item={{}} sections={sections} />);
+      const output = render(
+        <MetadataTable item={{} as Transaction} sections={sections} />
+      );
       expectTextsNotInDocument(output, ['Foo']);
     });
     it('does not show section if property is not available', () => {
@@ -69,12 +72,11 @@ describe('MetadataTable', () => {
           properties: ['bar']
         }
       ];
-      const item = {
+      const item = ({
         foo: {
           foobar: 'bar'
         }
-      };
-      // @ts-ignore
+      } as unknown) as Transaction;
       const output = render(<MetadataTable item={item} sections={sections} />);
       expectTextsNotInDocument(output, ['Foo']);
     });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/index.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle
 } from '@elastic/eui';
 import React from 'react';
-import { get, has, pick, isEmpty } from 'lodash';
+import { get, pick, isEmpty } from 'lodash';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DottedKeyValueTable } from '../DottedKeyValueTable';

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/index.tsx
@@ -30,24 +30,15 @@ interface Props {
 }
 
 const filterSections = (sections: SectionType[], item: Item) =>
-  sections.filter(({ key, required, properties }) => {
-    if (required) {
-      return true;
-    }
-    const hasKey = has(item, key);
-    if (!hasKey) {
-      return false;
-    }
-
-    if (properties) {
-      let sectionData: Record<string, unknown> = get(item, key);
-      sectionData = pick(sectionData, properties);
-      if (isEmpty(sectionData)) {
-        return false;
-      }
-    }
-    return true;
-  });
+  sections
+    .map(section => {
+      const data: Record<string, unknown> = get(item, section.key);
+      return {
+        ...section,
+        data: section.properties ? pick(data, section.properties) : data
+      };
+    })
+    .filter(({ required, data }) => required || !isEmpty(data));
 
 export function MetadataTable({ item, sections }: Props) {
   const filteredSections = filterSections(sections, item);
@@ -62,22 +53,16 @@ export function MetadataTable({ item, sections }: Props) {
           </ElasticDocsLink>
         </EuiFlexItem>
       </EuiFlexGroup>
-      {filteredSections.map(section => {
-        let sectionData: Record<string, unknown> = get(item, section.key);
-        if (section.properties) {
-          sectionData = pick(sectionData, section.properties);
-        }
-        return (
-          <div key={section.key}>
-            <EuiTitle size="xs">
-              <h6>{section.label}</h6>
-            </EuiTitle>
-            <EuiSpacer size="s" />
-            <Section propData={sectionData} propKey={section.key} />
-            <EuiSpacer size="xl" />
-          </div>
-        );
-      })}
+      {filteredSections.map(section => (
+        <div key={section.key}>
+          <EuiTitle size="xs">
+            <h6>{section.label}</h6>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <Section propData={section.data} propKey={section.key} />
+          <EuiSpacer size="xl" />
+        </div>
+      ))}
     </React.Fragment>
   );
 }

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/index.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle
 } from '@elastic/eui';
 import React from 'react';
-import { get, has, pick } from 'lodash';
+import { get, has, pick, isEmpty } from 'lodash';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DottedKeyValueTable } from '../DottedKeyValueTable';
@@ -45,7 +45,10 @@ export function MetadataTable({ item, sections }: Props) {
       {filteredSections.map(section => {
         let sectionData: Record<string, unknown> = get(item, section.key);
         if (section.properties) {
-          sectionData = pick(item, section.properties);
+          sectionData = pick(sectionData, section.properties);
+          if (isEmpty(sectionData) && !section.required) {
+            return;
+          }
         }
         return (
           <div key={section.key}>
@@ -63,24 +66,24 @@ export function MetadataTable({ item, sections }: Props) {
 }
 
 function Section({
-  propData,
+  propData = {},
   propKey
 }: {
   propData?: Record<string, unknown>;
   propKey?: string;
 }) {
+  if (isEmpty(propData)) {
+    return (
+      <EuiText size="s">
+        {i18n.translate(
+          'xpack.apm.propertiesTable.agentFeature.noDataAvailableLabel',
+          { defaultMessage: 'No data available' }
+        )}
+      </EuiText>
+    );
+  }
+
   return (
-    <React.Fragment>
-      {propData ? (
-        <DottedKeyValueTable data={propData} parentKey={propKey} maxDepth={5} />
-      ) : (
-        <EuiText size="s">
-          {i18n.translate(
-            'xpack.apm.propertiesTable.agentFeature.noDataAvailableLabel',
-            { defaultMessage: 'No data available' }
-          )}
-        </EuiText>
-      )}
-    </React.Fragment>
+    <DottedKeyValueTable data={propData} parentKey={propKey} maxDepth={5} />
   );
 }


### PR DESCRIPTION
closes #47816

Show message if section is required or if property does not have value and is required