### PR TITLE
Reconstruct setup\start data shim APIs (due to savedObject N/A in setup)

### DIFF
--- a/src/legacy/core_plugins/data/public/filter/filter_service.mock.ts
+++ b/src/legacy/core_plugins/data/public/filter/filter_service.mock.ts
@@ -17,16 +17,18 @@
  * under the License.
  */
 
-import { FilterService, FilterSetup } from '.';
+import { FilterService, FilterStart } from '.';
 
 type FilterServiceClientContract = PublicMethodsOf<FilterService>;
 
-const createSetupContractMock = () => {
-  const setupContract: jest.Mocked<FilterSetup> = {
+const createSetupContract = () => {};
+
+const createStartContractMock = () => {
+  const startContract: jest.Mocked<FilterStart> = {
     filterManager: jest.fn() as any,
   };
 
-  return setupContract;
+  return startContract;
 };
 
 const createMock = () => {
@@ -36,12 +38,13 @@ const createMock = () => {
     stop: jest.fn(),
   };
 
-  mocked.setup.mockReturnValue(createSetupContractMock());
+  mocked.setup.mockReturnValue(createSetupContract());
+  mocked.start.mockReturnValue(createStartContractMock());
   return mocked;
 };
 
 export const filterServiceMock = {
   create: createMock,
-  createSetupContract: createSetupContractMock,
-  createStartContract: createSetupContractMock,
+  createSetupContract,
+  createStartContract: createStartContractMock,
 };

--- a/src/legacy/core_plugins/data/public/filter/filter_service.ts
+++ b/src/legacy/core_plugins/data/public/filter/filter_service.ts
@@ -32,14 +32,14 @@ export interface FilterServiceDependencies {
 }
 
 export class FilterService {
-  public setup({ indexPatterns, uiSettings }: FilterServiceDependencies) {
+  public setup() {
+    // Filter service requires index patterns, which are only available in `start`
+  }
+
+  public start({ indexPatterns, uiSettings }: FilterServiceDependencies) {
     return {
       filterManager: new FilterManager(indexPatterns, uiSettings),
     };
-  }
-
-  public start() {
-    // nothing to do here yet
   }
 
   public stop() {
@@ -48,4 +48,4 @@ export class FilterService {
 }
 
 /** @public */
-export type FilterSetup = ReturnType<FilterService['setup']>;
+export type FilterStart = ReturnType<FilterService['start']>;

--- a/src/legacy/core_plugins/data/public/filter/index.tsx
+++ b/src/legacy/core_plugins/data/public/filter/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export { FilterService, FilterSetup } from './filter_service';
+export { FilterService, FilterStart } from './filter_service';
 
 export { FilterBar } from './filter_bar';
 

--- a/src/legacy/core_plugins/data/public/index_patterns/index_patterns_service.ts
+++ b/src/legacy/core_plugins/data/public/index_patterns/index_patterns_service.ts
@@ -46,23 +46,28 @@ export interface IndexPatternDependencies {
  * @internal
  */
 export class IndexPatternsService {
-  public setup({ uiSettings, savedObjectsClient, http, notifications }: IndexPatternDependencies) {
-    return {
+  setupApi: any;
+
+  public setup() {
+    this.setupApi = {
       FieldList,
       flattenHitWrapper: createFlattenHitWrapper(),
       formatHitProvider,
-      indexPatterns: new IndexPatterns(uiSettings, savedObjectsClient, http, notifications),
-      IndexPatternSelect: createIndexPatternSelect(savedObjectsClient),
       __LEGACY: {
         // For BWC we must temporarily export the class implementation of Field,
         // which is only used externally by the Index Pattern UI.
         FieldImpl: Field,
       },
     };
+    return this.setupApi;
   }
 
-  public start() {
-    // nothing to do here yet
+  public start({ uiSettings, savedObjectsClient, http, notifications }: IndexPatternDependencies) {
+    return {
+      ...this.setupApi,
+      indexPatterns: new IndexPatterns(uiSettings, savedObjectsClient, http, notifications),
+      IndexPatternSelect: createIndexPatternSelect(savedObjectsClient),
+    };
   }
 
   public stop() {
@@ -99,6 +104,7 @@ export {
 
 /** @internal */
 export type IndexPatternsSetup = ReturnType<IndexPatternsService['setup']>;
+export type IndexPatternsStart = ReturnType<IndexPatternsService['start']>;
 
 /** @public */
 export { IndexPattern, IndexPatterns, StaticIndexPattern, Field, FieldType };

--- a/src/legacy/core_plugins/data/public/index_patterns/index_patterns_service.ts
+++ b/src/legacy/core_plugins/data/public/index_patterns/index_patterns_service.ts
@@ -46,7 +46,7 @@ export interface IndexPatternDependencies {
  * @internal
  */
 export class IndexPatternsService {
-  setupApi: any;
+  private setupApi: any;
 
   public setup() {
     this.setupApi = {

--- a/src/legacy/core_plugins/data/public/plugin.ts
+++ b/src/legacy/core_plugins/data/public/plugin.ts
@@ -18,11 +18,11 @@
  */
 
 import { CoreSetup, CoreStart, Plugin } from 'kibana/public';
-import { SearchService, SearchSetup, createSearchBar, StatetfulSearchBarProps } from './search';
+import { SearchService, SearchStart, createSearchBar, StatetfulSearchBarProps } from './search';
 import { QueryService, QuerySetup } from './query';
-import { FilterService, FilterSetup } from './filter';
+import { FilterService, FilterStart } from './filter';
 import { TimefilterService, TimefilterSetup } from './timefilter';
-import { IndexPatternsService, IndexPatternsSetup } from './index_patterns';
+import { IndexPatternsService, IndexPatternsSetup, IndexPatternsStart } from './index_patterns';
 import {
   LegacyDependenciesPluginSetup,
   LegacyDependenciesPluginStart,
@@ -49,11 +49,9 @@ export interface DataPluginStartDependencies {
  * @public
  */
 export interface DataSetup {
-  indexPatterns: IndexPatternsSetup;
-  filter: FilterSetup;
   query: QuerySetup;
-  search: SearchSetup;
   timefilter: TimefilterSetup;
+  indexPatterns: IndexPatternsSetup;
 }
 
 /**
@@ -62,11 +60,11 @@ export interface DataSetup {
  * @public
  */
 export interface DataStart {
-  indexPatterns: IndexPatternsSetup;
-  filter: FilterSetup;
   query: QuerySetup;
-  search: SearchSetup;
   timefilter: TimefilterSetup;
+  indexPatterns: IndexPatternsStart;
+  filter: FilterStart;
+  search: SearchStart;
   ui: {
     SearchBar: React.ComponentType<StatetfulSearchBarProps>;
   };
@@ -96,45 +94,49 @@ export class DataPlugin
   private setupApi!: DataSetup;
 
   public setup(core: CoreSetup, { __LEGACY }: DataPluginSetupDependencies): DataSetup {
-    const { uiSettings, http, notifications } = core;
-    const savedObjectsClient = __LEGACY.savedObjectsClient;
-
-    const indexPatternsService = this.indexPatterns.setup({
-      uiSettings,
-      savedObjectsClient,
-      http,
-      notifications,
-    });
+    const { uiSettings } = core;
 
     const timefilterService = this.timefilter.setup({
       uiSettings,
       store: __LEGACY.storage,
     });
     this.setupApi = {
-      indexPatterns: indexPatternsService,
-      filter: this.filter.setup({
-        uiSettings,
-        indexPatterns: indexPatternsService.indexPatterns,
-      }),
+      indexPatterns: this.indexPatterns.setup(),
       query: this.query.setup(),
-      search: this.search.setup(savedObjectsClient),
       timefilter: timefilterService,
     };
 
     return this.setupApi;
   }
 
-  public start(core: CoreStart, { __LEGACY, data }: DataPluginStartDependencies) {
+  public start(core: CoreStart, { __LEGACY, data }: DataPluginStartDependencies): DataStart {
+    const { uiSettings, http, notifications, savedObjects } = core;
+
+    const indexPatternsService = this.indexPatterns.start({
+      uiSettings,
+      savedObjectsClient: savedObjects.client,
+      http,
+      notifications,
+    });
+
+    const filterService = this.filter.start({
+      uiSettings,
+      indexPatterns: indexPatternsService.indexPatterns,
+    });
+
     const SearchBar = createSearchBar({
       core,
       data,
       store: __LEGACY.storage,
       timefilter: this.setupApi.timefilter,
-      filterManager: this.setupApi.filter.filterManager,
+      filterManager: filterService.filterManager,
     });
 
     return {
       ...this.setupApi!,
+      indexPatterns: indexPatternsService,
+      filter: filterService,
+      search: this.search.start(savedObjects.client),
       ui: {
         SearchBar,
       },

--- a/src/legacy/core_plugins/data/public/search/index.ts
+++ b/src/legacy/core_plugins/data/public/search/index.ts
@@ -17,6 +17,5 @@
  * under the License.
  */
 
-export { SearchService, SearchSetup } from './search_service';
-
+export * from './search_service';
 export * from './search_bar';

--- a/src/legacy/core_plugins/data/public/search/search_service.ts
+++ b/src/legacy/core_plugins/data/public/search/search_service.ts
@@ -26,7 +26,11 @@ import { createSavedQueryService } from './search_bar/lib/saved_query_service';
  */
 
 export class SearchService {
-  public setup(savedObjectsClient: SavedObjectsClientContract) {
+  public setup() {
+    // Service requires index patterns, which are only available in `start`
+  }
+
+  public start(savedObjectsClient: SavedObjectsClientContract) {
     return {
       services: {
         savedQueryService: createSavedQueryService(savedObjectsClient),
@@ -39,4 +43,4 @@ export class SearchService {
 
 /** @public */
 
-export type SearchSetup = ReturnType<SearchService['setup']>;
+export type SearchStart = ReturnType<SearchService['start']>;

--- a/src/legacy/core_plugins/data/public/shim/legacy_dependencies_plugin.ts
+++ b/src/legacy/core_plugins/data/public/shim/legacy_dependencies_plugin.ts
@@ -17,14 +17,12 @@
  * under the License.
  */
 
-import chrome from 'ui/chrome';
 import { Storage } from 'ui/storage';
 import { Plugin } from '../../../../../../src/core/public';
 import { initLegacyModule } from './legacy_module';
 
 /** @internal */
 export interface LegacyDependenciesPluginSetup {
-  savedObjectsClient: any;
   storage: Storage;
 }
 
@@ -37,7 +35,6 @@ export class LegacyDependenciesPlugin implements Plugin<any, any> {
     initLegacyModule();
 
     return {
-      savedObjectsClient: chrome.getSavedObjectsClient(),
       storage: new Storage(window.localStorage),
     } as LegacyDependenciesPluginSetup;
   }

--- a/src/legacy/core_plugins/input_control_vis/public/components/editor/controls_tab.js
+++ b/src/legacy/core_plugins/input_control_vis/public/components/editor/controls_tab.js
@@ -23,7 +23,7 @@ import { ControlEditor } from './control_editor';
 import { addControl, moveControl, newControl, removeControl, setControl } from '../../editor_utils';
 import { getLineageMap, getParentCandidates } from '../../lineage';
 import { injectI18n, FormattedMessage } from '@kbn/i18n/react';
-import { setup as data } from '../../../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../../../core_plugins/data/public/legacy';
 
 import {
   EuiButton,

--- a/src/legacy/core_plugins/input_control_vis/public/control/list_control_factory.js
+++ b/src/legacy/core_plugins/input_control_vis/public/control/list_control_factory.js
@@ -27,7 +27,7 @@ import { PhraseFilterManager } from './filter_manager/phrase_filter_manager';
 import { createSearchSource } from './create_search_source';
 import { i18n } from '@kbn/i18n';
 import chrome from 'ui/chrome';
-import { setup as data } from '../../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../../core_plugins/data/public/legacy';
 
 function getEscapedQuery(query = '') {
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html#_standard_operators

--- a/src/legacy/core_plugins/input_control_vis/public/control/list_control_factory.test.js
+++ b/src/legacy/core_plugins/input_control_vis/public/control/list_control_factory.test.js
@@ -25,7 +25,7 @@ jest.mock('ui/timefilter', () => ({
 }));
 
 jest.mock('../../../../core_plugins/data/public/legacy', () => ({
-  setup: {
+  start: {
     indexPatterns: {
       indexPatterns: {
         get: () => ({

--- a/src/legacy/core_plugins/input_control_vis/public/control/range_control_factory.js
+++ b/src/legacy/core_plugins/input_control_vis/public/control/range_control_factory.js
@@ -26,7 +26,7 @@ import {
 import { RangeFilterManager } from './filter_manager/range_filter_manager';
 import { createSearchSource } from './create_search_source';
 import { i18n } from '@kbn/i18n';
-import { setup as data } from '../../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../../core_plugins/data/public/legacy';
 
 const minMaxAgg = (field) => {
   const aggBody = {};

--- a/src/legacy/core_plugins/input_control_vis/public/control/range_control_factory.test.js
+++ b/src/legacy/core_plugins/input_control_vis/public/control/range_control_factory.test.js
@@ -33,7 +33,7 @@ jest.mock('ui/timefilter', () => ({
 }));
 
 jest.mock('../../../../core_plugins/data/public/legacy', () => ({
-  setup: {
+  start: {
     indexPatterns: {
       indexPatterns: {
         get: () => ({

--- a/src/legacy/core_plugins/input_control_vis/public/vis_controller.js
+++ b/src/legacy/core_plugins/input_control_vis/public/vis_controller.js
@@ -23,7 +23,7 @@ import { I18nContext } from 'ui/i18n';
 import { InputControlVis } from './components/vis/input_control_vis';
 import { controlFactory } from './control/control_factory';
 import { getLineageMap } from './lineage';
-import { setup as data } from '../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../core_plugins/data/public/legacy';
 
 class VisController {
   constructor(el, vis) {

--- a/src/legacy/core_plugins/interpreter/public/functions/esaggs.ts
+++ b/src/legacy/core_plugins/interpreter/public/functions/esaggs.ts
@@ -44,7 +44,7 @@ import { RequestHandlerParams } from '../../../../ui/public/visualize/loader/emb
 import { tabifyAggResponse } from '../../../../ui/public/agg_response/tabify/tabify';
 import { KibanaContext, KibanaDatatable } from '../../common';
 import { ExpressionFunction, KibanaDatatableColumn } from '../../types';
-import { setup as data } from '../../../data/public/legacy';
+import { start as data } from '../../../data/public/legacy';
 
 const name = 'esaggs';
 

--- a/src/legacy/core_plugins/interpreter/public/functions/visualization.ts
+++ b/src/legacy/core_plugins/interpreter/public/functions/visualization.ts
@@ -23,7 +23,7 @@ import chrome from 'ui/chrome';
 import { FilterBarQueryFilterProvider } from 'ui/filter_manager/query_filter';
 import { PersistedState } from 'ui/persisted_state';
 import { VisResponseValue } from 'src/plugins/visualizations/public';
-import { setup as data } from '../../../data/public/legacy';
+import { start as data } from '../../../data/public/legacy';
 import { start as visualizations } from '../../../visualizations/public/np_ready/public/legacy';
 import { ExpressionFunction, Render } from '../../types';
 

--- a/src/legacy/core_plugins/kibana/public/dashboard/dashboard_app_controller.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/dashboard_app_controller.tsx
@@ -58,7 +58,7 @@ import { Subscription } from 'rxjs';
 import { npStart } from 'ui/new_platform';
 import { SavedObjectFinder } from 'ui/saved_objects/components/saved_object_finder';
 import { extractTimeFilter, changeTimeFilter } from '../../../data/public';
-import { data } from '../../../data/public/setup';
+import { start as data } from '../../../data/public/legacy';
 
 import {
   DashboardContainer,

--- a/src/legacy/core_plugins/kibana/public/discover/controllers/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/controllers/discover.js
@@ -73,7 +73,7 @@ import 'ui/capabilities/route_setup';
 import { addHelpMenuToAppChrome } from '../components/help_menu/help_menu_util';
 
 import { extractTimeFilter, changeTimeFilter } from '../../../../data/public';
-import { setup as data } from '../../../../data/public/legacy';
+import { start as data } from '../../../../data/public/legacy';
 import { npStart } from 'ui/new_platform';
 
 const { savedQueryService } = data.search.services;

--- a/src/legacy/core_plugins/tile_map/public/tile_map_visualization.js
+++ b/src/legacy/core_plugins/tile_map/public/tile_map_visualization.js
@@ -21,7 +21,7 @@ import { get } from 'lodash';
 import { GeohashLayer } from './geohash_layer';
 import { BaseMapsVisualizationProvider } from './base_maps_visualization';
 import { TileMapTooltipFormatterProvider } from './editors/_tooltip_formatter';
-import { setup as data } from '../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../core_plugins/data/public/legacy';
 const filterManager = data.filter.filterManager;
 
 export const createTileMapVisualization = ({ serviceSettings, $injector }) => {

--- a/src/legacy/core_plugins/vis_type_vega/public/vega_visualization.js
+++ b/src/legacy/core_plugins/vis_type_vega/public/vega_visualization.js
@@ -23,7 +23,7 @@ import { VegaView } from './vega_view/vega_view';
 import { VegaMapView } from './vega_view/vega_map_view';
 import { findObjectByTitle } from 'ui/saved_objects';
 import { timefilter } from 'ui/timefilter';
-import { setup as data } from '../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../core_plugins/data/public/legacy';
 
 export const createVegaVisualization = ({ serviceSettings }) => class VegaVisualization {
   constructor(el, vis) {

--- a/src/legacy/ui/public/filter_manager/query_filter.js
+++ b/src/legacy/ui/public/filter_manager/query_filter.js
@@ -22,8 +22,8 @@ import { FilterStateManager } from 'plugins/data';
 export function FilterBarQueryFilterProvider(getAppState, globalState) {
   // TODO: this is imported here to avoid circular imports.
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { setup } = require('../../../core_plugins/data/public/legacy');
-  const filterManager = setup.filter.filterManager;
+  const { start } = require('../../../core_plugins/data/public/legacy');
+  const filterManager = start.filter.filterManager;
   const filterStateManager = new FilterStateManager(globalState, getAppState, filterManager);
 
   const queryFilter = {};

--- a/src/legacy/ui/public/index_patterns/index.ts
+++ b/src/legacy/ui/public/index_patterns/index.ts
@@ -24,7 +24,7 @@
  * from ui/index_patterns for backwards compatibility.
  */
 
-import { setup as data } from '../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../core_plugins/data/public/legacy';
 
 export const {
   FieldList, // only used in Discover and StubIndexPattern

--- a/src/legacy/ui/public/timefilter/index.ts
+++ b/src/legacy/ui/public/timefilter/index.ts
@@ -20,7 +20,7 @@
 import uiRoutes from 'ui/routes';
 import { TimefilterContract, TimeHistoryContract } from '../../../core_plugins/data/public';
 import { registerTimefilterWithGlobalState } from './setup_router';
-import { setup as data } from '../../../core_plugins/data/public/legacy';
+import { start as data } from '../../../core_plugins/data/public/legacy';
 
 export {
   getTime,

--- a/x-pack/legacy/plugins/graph/public/app.js
+++ b/x-pack/legacy/plugins/graph/public/app.js
@@ -26,7 +26,7 @@ import { uiModules } from 'ui/modules';
 import uiRoutes from 'ui/routes';
 import { addAppRedirectMessageToUrl, toastNotifications } from 'ui/notify';
 import { formatAngularHttpError } from 'ui/notify/lib';
-import { setup as data } from '../../../../../src/legacy/core_plugins/data/public/legacy';
+import { start as data } from '../../../../../src/legacy/core_plugins/data/public/legacy';
 import { SavedObjectsClientProvider } from 'ui/saved_objects';
 import { npStart } from 'ui/new_platform';
 import { SavedObjectRegistryProvider } from 'ui/saved_objects/saved_object_registry';

--- a/x-pack/legacy/plugins/maps/public/angular/map_controller.js
+++ b/x-pack/legacy/plugins/maps/public/angular/map_controller.js
@@ -53,7 +53,7 @@ import {
   MAP_APP_PATH
 } from '../../common/constants';
 import { FilterStateStore } from '@kbn/es-query';
-import { setup as data } from '../../../../../../src/legacy/core_plugins/data/public/legacy';
+import { start as data } from '../../../../../../src/legacy/core_plugins/data/public/legacy';
 
 const { savedQueryService } = data.search.services;
 

--- a/x-pack/legacy/plugins/maps/public/kibana_services.js
+++ b/x-pack/legacy/plugins/maps/public/kibana_services.js
@@ -8,7 +8,7 @@ import { uiModules } from 'ui/modules';
 import { SearchSourceProvider } from 'ui/courier';
 import { getRequestInspectorStats, getResponseInspectorStats } from 'ui/courier/utils/courier_inspector_utils';
 export { xpackInfo } from 'plugins/xpack_main/services/xpack_info';
-import { setup as data } from '../../../../../src/legacy/core_plugins/data/public/legacy';
+import { start as data } from '../../../../../src/legacy/core_plugins/data/public/legacy';
 
 export const indexPatternService = data.indexPatterns.indexPatterns;
 

--- a/x-pack/legacy/plugins/ml/public/util/index_utils.ts
+++ b/x-pack/legacy/plugins/ml/public/util/index_utils.ts
@@ -10,7 +10,7 @@ import { IndexPattern, IndexPatterns } from 'ui/index_patterns';
 import { SavedObjectAttributes, SimpleSavedObject } from 'kibana/public';
 import chrome from 'ui/chrome';
 import { SavedSearchLoader } from '../../../../../../src/legacy/core_plugins/kibana/public/discover/types';
-import { setup as data } from '../../../../../../src/legacy/core_plugins/data/public/legacy';
+import { start as data } from '../../../../../../src/legacy/core_plugins/data/public/legacy';
 
 type IndexPatternSavedObject = SimpleSavedObject<SavedObjectAttributes>;
 

--- a/x-pack/legacy/plugins/security/public/views/management/edit_role/index.js
+++ b/x-pack/legacy/plugins/security/public/views/management/edit_role/index.js
@@ -13,7 +13,7 @@ import template from 'plugins/security/views/management/edit_role/edit_role.html
 import 'plugins/security/services/shield_user';
 import 'plugins/security/services/shield_role';
 import 'plugins/security/services/shield_indices';
-import { setup as data } from '../../../../../../../../src/legacy/core_plugins/data/public/legacy';
+import { start as data } from '../../../../../../../../src/legacy/core_plugins/data/public/legacy';
 import { xpackInfo } from 'plugins/xpack_main/services/xpack_info';
 import { SpacesManager } from '../../../../../spaces/public/lib';
 import { ROLES_PATH, CLONE_ROLES_PATH, EDIT_ROLES_PATH } from '../management_urls';

--- a/x-pack/legacy/plugins/transform/public/app/lib/kibana/kibana_provider.tsx
+++ b/x-pack/legacy/plugins/transform/public/app/lib/kibana/kibana_provider.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useState, FC } from 'react';
 
 import { npStart } from 'ui/new_platform';
 
-import { setup as data } from '../../../../../../../../src/legacy/core_plugins/data/public/legacy';
+import { start as data } from '../../../../../../../../src/legacy/core_plugins/data/public/legacy';
 
 import { useAppDependencies } from '../../app_dependencies';
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/47726

Saved object client is not available in `setup` in NP.
Update the APIs accordingly as well as consumers.

## Dev Docs

savedObjects.client is not available in `setup` in NP.
The following APIs were updated accordingly as well as their consumers.

 - `filter` service is available only on `start`.
 - `indexPatterns.indexPatterns` service  is available only on `start`.
 - `search.savedQueries` service  is available only on `start`.


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

