### PR TITLE
[APM] Enhancement to JVM list & metrics view

### DIFF
--- a/x-pack/legacy/plugins/apm/common/i18n.ts
+++ b/x-pack/legacy/plugins/apm/common/i18n.ts
@@ -12,3 +12,10 @@ export const NOT_AVAILABLE_LABEL = i18n.translate(
     defaultMessage: 'N/A'
   }
 );
+
+export const UNIDENTIFIED_SERVICE_NODES_LABEL = i18n.translate(
+  'xpack.apm.serviceNodeNameMissing',
+  {
+    defaultMessage: '(Empty)'
+  }
+);

--- a/x-pack/legacy/plugins/apm/common/service_nodes.ts
+++ b/x-pack/legacy/plugins/apm/common/service_nodes.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const SERVICE_NODE_NAME_MISSING = '_service_node_name_missing_';

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
       },
     ]
   }
-  hidePerPageOptions={false}
   initialPageSize={25}
   initialSortDirection="desc"
   initialSortField="latestOccurrenceAt"
@@ -284,49 +283,7 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
         >
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <div
-              className="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
-              id="customizablePagination"
-              onKeyDown={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchStart={[Function]}
-            >
-              <div
-                className="euiPopover__anchor"
-              >
-                <button
-                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="euiButtonEmpty__content"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
-                      focusable="false"
-                      height={16}
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Rows per page
-                      : 
-                      25
-                    </span>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
+          />
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
           >
@@ -404,7 +361,6 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
       },
     ]
   }
-  hidePerPageOptions={false}
   initialPageSize={25}
   initialSortDirection="desc"
   initialSortField="latestOccurrenceAt"
@@ -1088,49 +1044,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
         >
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <div
-              className="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
-              id="customizablePagination"
-              onKeyDown={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchStart={[Function]}
-            >
-              <div
-                className="euiPopover__anchor"
-              >
-                <button
-                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="euiButtonEmpty__content"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
-                      focusable="false"
-                      height={16}
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Rows per page
-                      : 
-                      25
-                    </span>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
+          />
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
           >

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -159,7 +159,6 @@ const ErrorGroupList: React.FC<Props> = props => {
       initialSortField="latestOccurrenceAt"
       initialSortDirection="desc"
       sortItems={false}
-      hidePerPageOptions={false}
     />
   );
 };

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -136,10 +136,10 @@ export const routes: BreadcrumbRoute[] = [
     path: '/services/:serviceName/nodes/:serviceNodeName/metrics',
     component: () => <ServiceNodeMetrics />,
     breadcrumb: ({ location }) => {
-      let { serviceNodeName } = resolveUrlParams(location, {});
+      const { serviceNodeName } = resolveUrlParams(location, {});
 
       if (serviceNodeName === SERVICE_NODE_NAME_MISSING) {
-        serviceNodeName = UNIDENTIFIED_SERVICE_NODES_LABEL;
+        return UNIDENTIFIED_SERVICE_NODES_LABEL;
       }
 
       return serviceNodeName || '';

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -8,6 +8,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
 import { npStart } from 'ui/new_platform';
+import { SERVICE_NODE_NAME_MISSING } from '../../../../../common/service_nodes';
 import { ErrorGroupDetails } from '../../ErrorGroupDetails';
 import { ServiceDetails } from '../../ServiceDetails';
 import { TransactionDetails } from '../../TransactionDetails';
@@ -18,6 +19,7 @@ import { AgentConfigurations } from '../../Settings/AgentConfigurations';
 import { toQuery } from '../../../shared/Links/url_helpers';
 import { ServiceNodeMetrics } from '../../ServiceNodeMetrics';
 import { resolveUrlParams } from '../../../../context/UrlParamsContext/resolveUrlParams';
+import { UNIDENTIFIED_SERVICE_NODES_LABEL } from '../../../../../common/i18n';
 
 const metricsBreadcrumb = i18n.translate('xpack.apm.breadcrumb.metricsTitle', {
   defaultMessage: 'Metrics'
@@ -134,7 +136,12 @@ export const routes: BreadcrumbRoute[] = [
     path: '/services/:serviceName/nodes/:serviceNodeName/metrics',
     component: () => <ServiceNodeMetrics />,
     breadcrumb: ({ location }) => {
-      const { serviceNodeName } = resolveUrlParams(location, {});
+      let { serviceNodeName } = resolveUrlParams(location, {});
+
+      if (serviceNodeName === SERVICE_NODE_NAME_MISSING) {
+        serviceNodeName = UNIDENTIFIED_SERVICE_NODES_LABEL;
+      }
+
       return serviceNodeName || '';
     },
     name: RouteName.SERVICE_NODE_METRICS

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeMetrics/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeMetrics/index.tsx
@@ -62,7 +62,7 @@ export function ServiceNodeMetrics() {
         });
       }
     },
-    [end, serviceName, serviceNodeName, start, uiFilters]
+    [serviceName, serviceNodeName, start, end, uiFilters]
   );
 
   const isLoading = status === FETCH_STATUS.LOADING;

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeMetrics/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeMetrics/index.tsx
@@ -13,11 +13,14 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiStat,
-  EuiToolTip
+  EuiToolTip,
+  EuiCallOut
 } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { SERVICE_NODE_NAME_MISSING } from '../../../../common/service_nodes';
 import { ApmHeader } from '../../shared/ApmHeader';
 import { useUrlParams } from '../../../hooks/useUrlParams';
 import { useAgentName } from '../../../hooks/useAgentName';
@@ -26,6 +29,7 @@ import { ChartsSyncContextProvider } from '../../../context/ChartsSyncContext';
 import { MetricsChart } from '../../shared/charts/MetricsChart';
 import { useFetcher, FETCH_STATUS } from '../../../hooks/useFetcher';
 import { truncate, px, unit } from '../../../style/variables';
+import { ElasticDocsLink } from '../../shared/Links/ElasticDocsLink';
 
 const INITIAL_DATA = {
   host: '',
@@ -67,6 +71,8 @@ export function ServiceNodeMetrics() {
 
   const isLoading = status === FETCH_STATUS.LOADING;
 
+  const isAggregatedData = serviceNodeName === SERVICE_NODE_NAME_MISSING;
+
   return (
     <div>
       <ApmHeader>
@@ -79,39 +85,71 @@ export function ServiceNodeMetrics() {
         </EuiFlexGroup>
       </ApmHeader>
       <EuiHorizontalRule margin="m" />
-      <EuiFlexGroup gutterSize="xl">
-        <EuiFlexItem grow={false}>
-          <EuiStat
-            titleSize="s"
-            isLoading={isLoading}
-            description={i18n.translate('xpack.apm.serviceNodeMetrics.host', {
-              defaultMessage: 'Host'
-            })}
-            title={
-              <EuiToolTip content={host}>
-                <Truncate>{host}</Truncate>
-              </EuiToolTip>
+      {isAggregatedData ? (
+        <EuiCallOut
+          title={i18n.translate(
+            'xpack.apm.serviceNodeMetrics.unidentifiedServiceNodesWarningTitle',
+            {
+              defaultMessage: 'Could not identify JVMs'
             }
-          ></EuiStat>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiStat
-            titleSize="s"
-            isLoading={isLoading}
-            description={i18n.translate(
-              'xpack.apm.serviceNodeMetrics.containerId',
-              {
-                defaultMessage: 'Container ID'
+          )}
+          iconType="help"
+          color="warning"
+        >
+          <FormattedMessage
+            id="xpack.apm.serviceNodeMetrics.unidentifiedServiceNodesWarningText"
+            defaultMessage="We could not identify which JVMs these metrics belong to. This is likely caused by running a version of APM Server that is older than 7.5. Upgrading to APM Server 7.5 or higher should resolve this issue. For more information on upgrading, see the {link}. As an alternative, you can use the Kibana Query bar to filter by hostname, container ID or other fields."
+            values={{
+              link: (
+                <ElasticDocsLink
+                  target="_blank"
+                  section="/apm/server"
+                  path="/upgrading.html"
+                >
+                  {i18n.translate(
+                    'xpack.apm.serviceNodeMetrics.unidentifiedServiceNodesWarningDocumentationLink',
+                    { defaultMessage: 'documentation of APM Server' }
+                  )}
+                </ElasticDocsLink>
+              )
+            }}
+          ></FormattedMessage>
+        </EuiCallOut>
+      ) : (
+        <EuiFlexGroup gutterSize="xl">
+          <EuiFlexItem grow={false}>
+            <EuiStat
+              titleSize="s"
+              isLoading={isLoading}
+              description={i18n.translate('xpack.apm.serviceNodeMetrics.host', {
+                defaultMessage: 'Host'
+              })}
+              title={
+                <EuiToolTip content={host}>
+                  <Truncate>{host}</Truncate>
+                </EuiToolTip>
               }
-            )}
-            title={
-              <EuiToolTip content={containerId}>
-                <Truncate>{containerId}</Truncate>
-              </EuiToolTip>
-            }
-          ></EuiStat>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+            ></EuiStat>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiStat
+              titleSize="s"
+              isLoading={isLoading}
+              description={i18n.translate(
+                'xpack.apm.serviceNodeMetrics.containerId',
+                {
+                  defaultMessage: 'Container ID'
+                }
+              )}
+              title={
+                <EuiToolTip content={containerId}>
+                  <Truncate>{containerId}</Truncate>
+                </EuiToolTip>
+              }
+            ></EuiStat>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      )}
       <EuiHorizontalRule margin="m" />
       {agentName && serviceNodeName && (
         <ChartsSyncContextProvider>

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeMetrics/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeMetrics/index.tsx
@@ -38,7 +38,7 @@ const Truncate = styled.span`
 `;
 
 export function ServiceNodeMetrics() {
-  const { urlParams } = useUrlParams();
+  const { urlParams, uiFilters } = useUrlParams();
   const { serviceName, serviceNodeName } = urlParams;
 
   const { agentName } = useAgentName();
@@ -47,17 +47,22 @@ export function ServiceNodeMetrics() {
 
   const { data: { host, containerId } = INITIAL_DATA, status } = useFetcher(
     callApmApi => {
-      if (serviceName && serviceNodeName) {
+      if (serviceName && serviceNodeName && start && end) {
         return callApmApi({
           pathname:
             '/api/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
           params: {
-            path: { serviceName, serviceNodeName }
+            path: { serviceName, serviceNodeName },
+            query: {
+              start,
+              end,
+              uiFilters: JSON.stringify(uiFilters)
+            }
           }
         });
       }
     },
-    [serviceName, serviceNodeName]
+    [end, serviceName, serviceNodeName, start, uiFilters]
   );
 
   const isLoading = status === FETCH_STATUS.LOADING;

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
@@ -20,9 +20,9 @@ import {
 import { ServiceNodeMetricOverviewLink } from '../../shared/Links/apm/ServiceNodeMetricOverviewLink';
 import { truncate, px, unit } from '../../../style/variables';
 
-const INITIAL_PAGE_SIZE = 10;
-const INITIAL_SORT_FIELD = 'name';
-const INITIAL_SORT_DIRECTION = 'asc';
+const INITIAL_PAGE_SIZE = 25;
+const INITIAL_SORT_FIELD = 'cpu';
+const INITIAL_SORT_DIRECTION = 'desc';
 
 const ServiceNodeName = styled.div`
   ${truncate(px(8 * unit))}
@@ -73,9 +73,19 @@ const ServiceNodeOverview = () => {
 
   const columns: Array<ITableColumn<typeof items[0]>> = [
     {
-      name: i18n.translate('xpack.apm.jvmsTable.nameColumnLabel', {
-        defaultMessage: 'Name'
-      }),
+      name: (
+        <EuiToolTip
+          content={i18n.translate('xpack.apm.jvmsTable.nameExplanation', {
+            defaultMessage: `By default, the JVM name is the container ID (where applicable) or the hostname, but it can be manually configured through the agent's 'service_node_name' configuration.`
+          })}
+        >
+          <>
+            {i18n.translate('xpack.apm.jvmsTable.nameColumnLabel', {
+              defaultMessage: 'Name'
+            })}
+          </>
+        </EuiToolTip>
+      ),
       field: 'name',
       sortable: true,
       render: (name: string) => {
@@ -93,7 +103,7 @@ const ServiceNodeOverview = () => {
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.cpuColumnLabel', {
-        defaultMessage: 'CPU'
+        defaultMessage: 'CPU avg'
       }),
       field: 'cpu',
       sortable: true,
@@ -101,7 +111,7 @@ const ServiceNodeOverview = () => {
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.heapMemoryColumnLabel', {
-        defaultMessage: 'Heap memory max'
+        defaultMessage: 'Heap memory avg'
       }),
       field: 'heapMemory',
       sortable: true,
@@ -109,7 +119,7 @@ const ServiceNodeOverview = () => {
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.nonHeapMemoryColumnLabel', {
-        defaultMessage: 'Non-heap memory max'
+        defaultMessage: 'Non-heap memory avg'
       }),
       field: 'nonHeapMemory',
       sortable: true,
@@ -117,7 +127,7 @@ const ServiceNodeOverview = () => {
     },
     {
       name: i18n.translate('xpack.apm.jvmsTable.threadCountColumnLabel', {
-        defaultMessage: 'Thread count'
+        defaultMessage: 'Thread count max'
       }),
       field: 'threadCount',
       sortable: true,

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
@@ -99,7 +99,7 @@ const ServiceNodeOverview = () => {
                   'xpack.apm.jvmsTable.explainServiceNodeNameMissing',
                   {
                     defaultMessage:
-                      'These metrics come from agents that do not have the `service.node.name` field set. This field is needed to uniquely identify a JVM. For more information, see the APM Server and Java Agent documentation.'
+                      'We could not identify which JVMs these metrics belong to. This is likely caused by running a version of APM Server that is older than 7.5. Upgrading to APM Server 7.5 or higher should resolve this issue.'
                   }
                 )
               }

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
@@ -151,7 +151,6 @@ const ServiceNodeOverview = () => {
             initialPageSize={INITIAL_PAGE_SIZE}
             initialSortField={INITIAL_SORT_FIELD}
             initialSortDirection={INITIAL_SORT_DIRECTION}
-            hidePerPageOptions={false}
           />
         </EuiPanel>
       </EuiFlexItem>

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
@@ -7,6 +7,8 @@ import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import styled from 'styled-components';
+import { UNIDENTIFIED_SERVICE_NODES_LABEL } from '../../../../common/i18n';
+import { SERVICE_NODE_NAME_MISSING } from '../../../../common/service_nodes';
 import { PROJECTION } from '../../../../common/projections/typings';
 import { LocalUIFilters } from '../../shared/LocalUIFilters';
 import { useUrlParams } from '../../../hooks/useUrlParams';
@@ -89,13 +91,27 @@ const ServiceNodeOverview = () => {
       field: 'name',
       sortable: true,
       render: (name: string) => {
+        const { displayedName, tooltip } =
+          name === SERVICE_NODE_NAME_MISSING
+            ? {
+                displayedName: UNIDENTIFIED_SERVICE_NODES_LABEL,
+                tooltip: i18n.translate(
+                  'xpack.apm.jvmsTable.explainServiceNodeNameMissing',
+                  {
+                    defaultMessage:
+                      'These metrics come from agents that do not have the `service.node.name` field set. This field is needed to uniquely identify a JVM. For more information, see the APM Server and Java Agent documentation.'
+                  }
+                )
+              }
+            : { displayedName: name, tooltip: name };
+
         return (
-          <EuiToolTip content={name}>
+          <EuiToolTip content={tooltip}>
             <ServiceNodeMetricOverviewLink
               serviceName={serviceName}
               serviceNodeName={name}
             >
-              <ServiceNodeName>{name}</ServiceNodeName>
+              <ServiceNodeName>{displayedName}</ServiceNodeName>
             </ServiceNodeMetricOverviewLink>
           </EuiToolTip>
         );

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/ElasticDocsLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/ElasticDocsLink.tsx
@@ -12,7 +12,7 @@ import { metadata } from 'ui/metadata';
 const STACK_VERSION = metadata.branch;
 
 // union type constisting of valid guide sections that we link to
-type DocsSection = '/apm/get-started' | '/x-pack';
+type DocsSection = '/apm/get-started' | '/x-pack' | '/apm/server';
 
 interface Props extends EuiLinkAnchorProps {
   section: DocsSection;

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/index.js
@@ -16,6 +16,7 @@ import VoronoiPlot from './VoronoiPlot';
 import { createSelector } from 'reselect';
 import { getPlotValues } from './plotUtils';
 import { isValidCoordinateValue } from '../../../../utils/isValidCoordinateValue';
+import moment from 'moment';
 
 const VISIBLE_LEGEND_COUNT = 4;
 
@@ -214,7 +215,7 @@ InnerCustomPlot.propTypes = {
 
 InnerCustomPlot.defaultProps = {
   formatTooltipValue: p => p.y,
-  tickFormatX: undefined,
+  tickFormatX: x => moment(x).format('HH:mm'),
   tickFormatY: y => y,
   truncateLegends: false
 };

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/index.js
@@ -16,7 +16,6 @@ import VoronoiPlot from './VoronoiPlot';
 import { createSelector } from 'reselect';
 import { getPlotValues } from './plotUtils';
 import { isValidCoordinateValue } from '../../../../utils/isValidCoordinateValue';
-import moment from 'moment';
 
 const VISIBLE_LEGEND_COUNT = 4;
 
@@ -215,7 +214,7 @@ InnerCustomPlot.propTypes = {
 
 InnerCustomPlot.defaultProps = {
   formatTooltipValue: p => p.y,
-  tickFormatX: x => moment(x).format('HH:mm'),
+  tickFormatX: undefined,
   tickFormatY: y => y,
   truncateLegends: false
 };

--- a/x-pack/legacy/plugins/apm/public/hooks/useServiceMetricCharts.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useServiceMetricCharts.ts
@@ -17,7 +17,7 @@ export function useServiceMetricCharts(
   urlParams: IUrlParams,
   agentName?: string
 ) {
-  const { serviceName, start, end } = urlParams;
+  const { serviceName, start, end, serviceNodeName } = urlParams;
   const uiFilters = useUiFilters(urlParams);
   const { data = INITIAL_DATA, error, status } = useFetcher(
     callApmApi => {
@@ -30,13 +30,14 @@ export function useServiceMetricCharts(
               start,
               end,
               agentName,
+              serviceNodeName,
               uiFilters: JSON.stringify(uiFilters)
             }
           }
         });
       }
     },
-    [serviceName, start, end, agentName, uiFilters]
+    [serviceName, start, end, agentName, serviceNodeName, uiFilters]
   );
 
   return {

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/__snapshots__/queries.test.ts.snap
@@ -1,6 +1,478 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`metrics queries fetches cpu chart data 1`] = `
+exports[`metrics queries with a service node name fetches cpu chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "processCPUAverage": Object {
+        "avg": Object {
+          "field": "system.process.cpu.total.norm.pct",
+        },
+      },
+      "processCPUMax": Object {
+        "max": Object {
+          "field": "system.process.cpu.total.norm.pct",
+        },
+      },
+      "systemCPUAverage": Object {
+        "avg": Object {
+          "field": "system.cpu.total.norm.pct",
+        },
+      },
+      "systemCPUMax": Object {
+        "max": Object {
+          "field": "system.cpu.total.norm.pct",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "processCPUAverage": Object {
+            "avg": Object {
+              "field": "system.process.cpu.total.norm.pct",
+            },
+          },
+          "processCPUMax": Object {
+            "max": Object {
+              "field": "system.process.cpu.total.norm.pct",
+            },
+          },
+          "systemCPUAverage": Object {
+            "avg": Object {
+              "field": "system.cpu.total.norm.pct",
+            },
+          },
+          "systemCPUMax": Object {
+            "max": Object {
+              "field": "system.cpu.total.norm.pct",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with a service node name fetches heap memory chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "heapMemoryCommitted": Object {
+        "avg": Object {
+          "field": "jvm.memory.heap.committed",
+        },
+      },
+      "heapMemoryMax": Object {
+        "avg": Object {
+          "field": "jvm.memory.heap.max",
+        },
+      },
+      "heapMemoryUsed": Object {
+        "avg": Object {
+          "field": "jvm.memory.heap.used",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "heapMemoryCommitted": Object {
+            "avg": Object {
+              "field": "jvm.memory.heap.committed",
+            },
+          },
+          "heapMemoryMax": Object {
+            "avg": Object {
+              "field": "jvm.memory.heap.max",
+            },
+          },
+          "heapMemoryUsed": Object {
+            "avg": Object {
+              "field": "jvm.memory.heap.used",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+          Object {
+            "term": Object {
+              "agent.name": "java",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with a service node name fetches memory chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "memoryUsedAvg": Object {
+        "avg": Object {
+          "script": Object {
+            "lang": "expression",
+            "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+          },
+        },
+      },
+      "memoryUsedMax": Object {
+        "max": Object {
+          "script": Object {
+            "lang": "expression",
+            "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+          },
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "memoryUsedAvg": Object {
+            "avg": Object {
+              "script": Object {
+                "lang": "expression",
+                "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+              },
+            },
+          },
+          "memoryUsedMax": Object {
+            "max": Object {
+              "script": Object {
+                "lang": "expression",
+                "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+              },
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "system.memory.actual.free",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "system.memory.total",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with a service node name fetches non heap memory chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "nonHeapMemoryCommitted": Object {
+        "avg": Object {
+          "field": "jvm.memory.non_heap.committed",
+        },
+      },
+      "nonHeapMemoryMax": Object {
+        "avg": Object {
+          "field": "jvm.memory.non_heap.max",
+        },
+      },
+      "nonHeapMemoryUsed": Object {
+        "avg": Object {
+          "field": "jvm.memory.non_heap.used",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "nonHeapMemoryCommitted": Object {
+            "avg": Object {
+              "field": "jvm.memory.non_heap.committed",
+            },
+          },
+          "nonHeapMemoryMax": Object {
+            "avg": Object {
+              "field": "jvm.memory.non_heap.max",
+            },
+          },
+          "nonHeapMemoryUsed": Object {
+            "avg": Object {
+              "field": "jvm.memory.non_heap.used",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+          Object {
+            "term": Object {
+              "agent.name": "java",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with a service node name fetches thread count chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "threadCount": Object {
+        "avg": Object {
+          "field": "jvm.thread.count",
+        },
+      },
+      "threadCountMax": Object {
+        "max": Object {
+          "field": "jvm.thread.count",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "threadCount": Object {
+            "avg": Object {
+              "field": "jvm.thread.count",
+            },
+          },
+          "threadCountMax": Object {
+            "max": Object {
+              "field": "jvm.thread.count",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+          Object {
+            "term": Object {
+              "agent.name": "java",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries without a service node name fetches cpu chart data 1`] = `
 Object {
   "body": Object {
     "aggs": Object {
@@ -94,7 +566,7 @@ Object {
 }
 `;
 
-exports[`metrics queries fetches heap memory chart data 1`] = `
+exports[`metrics queries without a service node name fetches heap memory chart data 1`] = `
 Object {
   "body": Object {
     "aggs": Object {
@@ -183,7 +655,7 @@ Object {
 }
 `;
 
-exports[`metrics queries fetches memory chart data 1`] = `
+exports[`metrics queries without a service node name fetches memory chart data 1`] = `
 Object {
   "body": Object {
     "aggs": Object {
@@ -279,7 +751,7 @@ Object {
 }
 `;
 
-exports[`metrics queries fetches non heap memory chart data 1`] = `
+exports[`metrics queries without a service node name fetches non heap memory chart data 1`] = `
 Object {
   "body": Object {
     "aggs": Object {
@@ -368,7 +840,7 @@ Object {
 }
 `;
 
-exports[`metrics queries fetches thread count chart data 1`] = `
+exports[`metrics queries without a service node name fetches thread count chart data 1`] = `
 Object {
   "body": Object {
     "aggs": Object {

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/__snapshots__/queries.test.ts.snap
@@ -82,12 +82,12 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "service.node.name": "bar",
             },
           },
           Object {
             "term": Object {
-              "service.node.name": "bar",
+              "service.environment": "prod",
             },
           },
         ],
@@ -171,12 +171,12 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "service.node.name": "bar",
             },
           },
           Object {
             "term": Object {
-              "service.node.name": "bar",
+              "service.environment": "prod",
             },
           },
           Object {
@@ -267,12 +267,12 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "service.node.name": "bar",
             },
           },
           Object {
             "term": Object {
-              "service.node.name": "bar",
+              "service.environment": "prod",
             },
           },
           Object {
@@ -366,12 +366,12 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "service.node.name": "bar",
             },
           },
           Object {
             "term": Object {
-              "service.node.name": "bar",
+              "service.environment": "prod",
             },
           },
           Object {
@@ -450,12 +450,514 @@ Object {
           },
           Object {
             "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+          Object {
+            "term": Object {
               "service.environment": "prod",
             },
           },
           Object {
             "term": Object {
-              "service.node.name": "bar",
+              "agent.name": "java",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with service_node_name_missing fetches cpu chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "processCPUAverage": Object {
+        "avg": Object {
+          "field": "system.process.cpu.total.norm.pct",
+        },
+      },
+      "processCPUMax": Object {
+        "max": Object {
+          "field": "system.process.cpu.total.norm.pct",
+        },
+      },
+      "systemCPUAverage": Object {
+        "avg": Object {
+          "field": "system.cpu.total.norm.pct",
+        },
+      },
+      "systemCPUMax": Object {
+        "max": Object {
+          "field": "system.cpu.total.norm.pct",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "processCPUAverage": Object {
+            "avg": Object {
+              "field": "system.process.cpu.total.norm.pct",
+            },
+          },
+          "processCPUMax": Object {
+            "max": Object {
+              "field": "system.process.cpu.total.norm.pct",
+            },
+          },
+          "systemCPUAverage": Object {
+            "avg": Object {
+              "field": "system.cpu.total.norm.pct",
+            },
+          },
+          "systemCPUMax": Object {
+            "max": Object {
+              "field": "system.cpu.total.norm.pct",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.node.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with service_node_name_missing fetches heap memory chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "heapMemoryCommitted": Object {
+        "avg": Object {
+          "field": "jvm.memory.heap.committed",
+        },
+      },
+      "heapMemoryMax": Object {
+        "avg": Object {
+          "field": "jvm.memory.heap.max",
+        },
+      },
+      "heapMemoryUsed": Object {
+        "avg": Object {
+          "field": "jvm.memory.heap.used",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "heapMemoryCommitted": Object {
+            "avg": Object {
+              "field": "jvm.memory.heap.committed",
+            },
+          },
+          "heapMemoryMax": Object {
+            "avg": Object {
+              "field": "jvm.memory.heap.max",
+            },
+          },
+          "heapMemoryUsed": Object {
+            "avg": Object {
+              "field": "jvm.memory.heap.used",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.node.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "agent.name": "java",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with service_node_name_missing fetches memory chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "memoryUsedAvg": Object {
+        "avg": Object {
+          "script": Object {
+            "lang": "expression",
+            "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+          },
+        },
+      },
+      "memoryUsedMax": Object {
+        "max": Object {
+          "script": Object {
+            "lang": "expression",
+            "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+          },
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "memoryUsedAvg": Object {
+            "avg": Object {
+              "script": Object {
+                "lang": "expression",
+                "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+              },
+            },
+          },
+          "memoryUsedMax": Object {
+            "max": Object {
+              "script": Object {
+                "lang": "expression",
+                "source": "1 - doc['system.memory.actual.free'] / doc['system.memory.total']",
+              },
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.node.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "system.memory.actual.free",
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "system.memory.total",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with service_node_name_missing fetches non heap memory chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "nonHeapMemoryCommitted": Object {
+        "avg": Object {
+          "field": "jvm.memory.non_heap.committed",
+        },
+      },
+      "nonHeapMemoryMax": Object {
+        "avg": Object {
+          "field": "jvm.memory.non_heap.max",
+        },
+      },
+      "nonHeapMemoryUsed": Object {
+        "avg": Object {
+          "field": "jvm.memory.non_heap.used",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "nonHeapMemoryCommitted": Object {
+            "avg": Object {
+              "field": "jvm.memory.non_heap.committed",
+            },
+          },
+          "nonHeapMemoryMax": Object {
+            "avg": Object {
+              "field": "jvm.memory.non_heap.max",
+            },
+          },
+          "nonHeapMemoryUsed": Object {
+            "avg": Object {
+              "field": "jvm.memory.non_heap.used",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.node.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "agent.name": "java",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`metrics queries with service_node_name_missing fetches thread count chart data 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "threadCount": Object {
+        "avg": Object {
+          "field": "jvm.thread.count",
+        },
+      },
+      "threadCountMax": Object {
+        "max": Object {
+          "field": "jvm.thread.count",
+        },
+      },
+      "timeseriesData": Object {
+        "aggs": Object {
+          "threadCount": Object {
+            "avg": Object {
+              "field": "jvm.thread.count",
+            },
+          },
+          "threadCountMax": Object {
+            "max": Object {
+              "field": "jvm.thread.count",
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 1528977600000,
+            "min": 1528113600000,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "10800s",
+          "min_doc_count": 0,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.node.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
             },
           },
           Object {

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/fetchAndTransformGcMetrics.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/fetchAndTransformGcMetrics.ts
@@ -131,11 +131,11 @@ export async function fetchAndTransformGcMetrics({
       // derivative/value will be undefined for the first hit and if the `max` value is null
       const y =
         'value' in bucket && bucket.value.value !== null
-          ? bucket.value.value
+          ? round(bucket.value.value * (60 / bucketSize), 1)
           : null;
 
       return {
-        y: y !== null ? round(y * (60 / bucketSize), 1) : null,
+        y,
         x: bucket.key
       };
     });

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/fetchAndTransformGcMetrics.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/fetchAndTransformGcMetrics.ts
@@ -10,7 +10,7 @@
  */
 
 import { idx } from '@kbn/elastic-idx';
-import { sum } from 'lodash';
+import { sum, round } from 'lodash';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 import { Setup } from '../../../../helpers/setup_request';
 import { getMetricsDateHistogramParams } from '../../../../helpers/metrics';
@@ -23,6 +23,7 @@ import {
   METRIC_JAVA_GC_COUNT,
   METRIC_JAVA_GC_TIME
 } from '../../../../../../common/elasticsearch_fieldnames';
+import { getBucketSize } from '../../../../helpers/get_bucket_size';
 
 const colors = [
   theme.euiColorVis0,
@@ -48,6 +49,8 @@ export async function fetchAndTransformGcMetrics({
   fieldName: typeof METRIC_JAVA_GC_COUNT | typeof METRIC_JAVA_GC_TIME;
 }) {
   const { start, end, client } = setup;
+
+  const { bucketSize } = getBucketSize(start, end, 'auto');
 
   const projection = getMetricsProjection({
     setup,
@@ -132,7 +135,7 @@ export async function fetchAndTransformGcMetrics({
           : null;
 
       return {
-        y,
+        y: y !== null ? round(y * (60 / bucketSize), 1) : null,
         x: bucket.key
       };
     });

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/getGcRateChart.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/getGcRateChart.ts
@@ -14,17 +14,17 @@ import { ChartBase } from '../../../types';
 const series = {
   [METRIC_JAVA_GC_COUNT]: {
     title: i18n.translate('xpack.apm.agentMetrics.java.gcRate', {
-      defaultMessage: 'GC count'
+      defaultMessage: 'GC rate'
     }),
     color: theme.euiColorVis0
   }
 };
 
 const chartBase: ChartBase = {
-  title: i18n.translate('xpack.apm.agentMetrics.java.gcCountChartTitle', {
-    defaultMessage: 'Garbage collection count'
+  title: i18n.translate('xpack.apm.agentMetrics.java.gcRateChartTitle', {
+    defaultMessage: 'Garbage collection rate per minute'
   }),
-  key: 'gc_count_line_chart',
+  key: 'gc_rate_line_chart',
   type: 'linemark',
   yUnit: 'integer',
   series

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/getGcTimeChart.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/getGcTimeChart.ts
@@ -22,7 +22,7 @@ const series = {
 
 const chartBase: ChartBase = {
   title: i18n.translate('xpack.apm.agentMetrics.java.gcTimeChartTitle', {
-    defaultMessage: 'Garbage collection time'
+    defaultMessage: 'Garbage collection time spent per minute'
   }),
   key: 'gc_time_line_chart',
   type: 'linemark',

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/queries.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/queries.test.ts
@@ -13,6 +13,7 @@ import {
   SearchParamsMock,
   inspectSearchParams
 } from '../../../public/utils/testHelpers';
+import { SERVICE_NODE_NAME_MISSING } from '../../../common/service_nodes';
 
 describe('metrics queries', () => {
   let mock: SearchParamsMock;
@@ -65,6 +66,10 @@ describe('metrics queries', () => {
 
   describe('without a service node name', () => {
     createTests();
+  });
+
+  describe('with service_node_name_missing', () => {
+    createTests(SERVICE_NODE_NAME_MISSING);
   });
 
   describe('with a service node name', () => {

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/queries.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/queries.test.ts
@@ -17,41 +17,57 @@ import {
 describe('metrics queries', () => {
   let mock: SearchParamsMock;
 
+  const createTests = (serviceNodeName?: string) => {
+    it('fetches cpu chart data', async () => {
+      mock = await inspectSearchParams(setup =>
+        getCPUChartData(setup, 'foo', serviceNodeName)
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('fetches memory chart data', async () => {
+      mock = await inspectSearchParams(setup =>
+        getMemoryChartData(setup, 'foo', serviceNodeName)
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('fetches heap memory chart data', async () => {
+      mock = await inspectSearchParams(setup =>
+        getHeapMemoryChart(setup, 'foo', serviceNodeName)
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('fetches non heap memory chart data', async () => {
+      mock = await inspectSearchParams(setup =>
+        getNonHeapMemoryChart(setup, 'foo', serviceNodeName)
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('fetches thread count chart data', async () => {
+      mock = await inspectSearchParams(setup =>
+        getThreadCountChart(setup, 'foo', serviceNodeName)
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
+  };
+
   afterEach(() => {
     mock.teardown();
   });
 
-  it('fetches cpu chart data', async () => {
-    mock = await inspectSearchParams(setup => getCPUChartData(setup, 'foo'));
-
-    expect(mock.params).toMatchSnapshot();
+  describe('without a service node name', () => {
+    createTests();
   });
 
-  it('fetches memory chart data', async () => {
-    mock = await inspectSearchParams(setup => getMemoryChartData(setup, 'foo'));
-
-    expect(mock.params).toMatchSnapshot();
-  });
-
-  it('fetches heap memory chart data', async () => {
-    mock = await inspectSearchParams(setup => getHeapMemoryChart(setup, 'foo'));
-
-    expect(mock.params).toMatchSnapshot();
-  });
-
-  it('fetches non heap memory chart data', async () => {
-    mock = await inspectSearchParams(setup =>
-      getNonHeapMemoryChart(setup, 'foo')
-    );
-
-    expect(mock.params).toMatchSnapshot();
-  });
-
-  it('fetches thread count chart data', async () => {
-    mock = await inspectSearchParams(setup =>
-      getThreadCountChart(setup, 'foo')
-    );
-
-    expect(mock.params).toMatchSnapshot();
+  describe('with a service node name', () => {
+    createTests('bar');
   });
 });

--- a/x-pack/legacy/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
@@ -46,12 +46,81 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "service.node.name": "bar",
             },
           },
           Object {
             "term": Object {
-              "service.node.name": "bar",
+              "service.environment": "prod",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`service node queries fetches metadata for unidentified service nodes 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "containerId": Object {
+        "terms": Object {
+          "field": "container.id",
+          "size": 1,
+        },
+      },
+      "host": Object {
+        "terms": Object {
+          "field": "host.hostname",
+          "size": 1,
+        },
+      },
+      "nodes": Object {
+        "terms": Object {
+          "field": "service.node.name",
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.node.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
             },
           },
         ],

--- a/x-pack/legacy/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`service node queries fetches metadata for a service node 1`] = `
+Object {
+  "body": Object {
+    "aggs": Object {
+      "containerId": Object {
+        "terms": Object {
+          "field": "container.id",
+          "size": 1,
+        },
+      },
+      "host": Object {
+        "terms": Object {
+          "field": "host.hostname",
+          "size": 1,
+        },
+      },
+      "nodes": Object {
+        "terms": Object {
+          "field": "service.node.name",
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "processor.event": "metric",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 1528113600000,
+                "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "prod",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.node.name": "bar",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
 exports[`service node queries fetches services nodes 1`] = `
 Object {
   "body": Object {
@@ -29,6 +92,7 @@ Object {
         },
         "terms": Object {
           "field": "service.node.name",
+          "missing": "_service_node_name_missing_",
           "size": 10000,
         },
       },

--- a/x-pack/legacy/plugins/apm/server/lib/service_nodes/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/service_nodes/index.ts
@@ -7,6 +7,7 @@
 import { Setup } from '../helpers/setup_request';
 import { getServiceNodesProjection } from '../../../common/projections/service_nodes';
 import { mergeProjection } from '../../../common/projections/util/merge_projection';
+import { SERVICE_NODE_NAME_MISSING } from '../../../common/service_nodes';
 import {
   METRIC_PROCESS_CPU_PERCENT,
   METRIC_JAVA_THREAD_COUNT,
@@ -30,7 +31,8 @@ const getServiceNodes = async ({
         aggs: {
           nodes: {
             terms: {
-              size: 10000
+              size: 10000,
+              missing: SERVICE_NODE_NAME_MISSING
             },
             aggs: {
               cpu: {

--- a/x-pack/legacy/plugins/apm/server/lib/service_nodes/queries.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/service_nodes/queries.test.ts
@@ -15,6 +15,7 @@ import {
   inspectSearchParams
 } from '../../../public/utils/testHelpers';
 import { getServiceNodeMetadata } from '../services/get_service_node_metadata';
+import { SERVICE_NODE_NAME_MISSING } from '../../../common/service_nodes';
 
 describe('service node queries', () => {
   let mock: SearchParamsMock;
@@ -37,6 +38,18 @@ describe('service node queries', () => {
         setup,
         serviceName: 'foo',
         serviceNodeName: 'bar'
+      })
+    );
+
+    expect(mock.params).toMatchSnapshot();
+  });
+
+  it('fetches metadata for unidentified service nodes', async () => {
+    mock = await inspectSearchParams(setup =>
+      getServiceNodeMetadata({
+        setup,
+        serviceName: 'foo',
+        serviceNodeName: SERVICE_NODE_NAME_MISSING
       })
     );
 

--- a/x-pack/legacy/plugins/apm/server/lib/service_nodes/queries.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/service_nodes/queries.test.ts
@@ -14,6 +14,7 @@ import {
   SearchParamsMock,
   inspectSearchParams
 } from '../../../public/utils/testHelpers';
+import { getServiceNodeMetadata } from '../services/get_service_node_metadata';
 
 describe('service node queries', () => {
   let mock: SearchParamsMock;
@@ -25,6 +26,18 @@ describe('service node queries', () => {
   it('fetches services nodes', async () => {
     mock = await inspectSearchParams(setup =>
       getServiceNodes({ setup, serviceName: 'foo' })
+    );
+
+    expect(mock.params).toMatchSnapshot();
+  });
+
+  it('fetches metadata for a service node', async () => {
+    mock = await inspectSearchParams(setup =>
+      getServiceNodeMetadata({
+        setup,
+        serviceName: 'foo',
+        serviceNodeName: 'bar'
+      })
     );
 
     expect(mock.params).toMatchSnapshot();

--- a/x-pack/legacy/plugins/apm/server/lib/services/get_service_node_metadata.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/get_service_node_metadata.ts
@@ -8,12 +8,11 @@ import { idx } from '@kbn/elastic-idx';
 import { Setup } from '../helpers/setup_request';
 import {
   HOST_NAME,
-  SERVICE_NAME,
-  SERVICE_NODE_NAME,
-  CONTAINER_ID,
-  PROCESSOR_EVENT
+  CONTAINER_ID
 } from '../../../common/elasticsearch_fieldnames';
 import { NOT_AVAILABLE_LABEL } from '../../../common/i18n';
+import { mergeProjection } from '../../../common/projections/util/merge_projection';
+import { getServiceNodesProjection } from '../../../common/projections/service_nodes';
 
 export async function getServiceNodeMetadata({
   serviceName,
@@ -24,37 +23,34 @@ export async function getServiceNodeMetadata({
   serviceNodeName: string;
   setup: Setup;
 }) {
-  const { client, config } = setup;
+  const { client } = setup;
 
-  const query = {
-    index: config.get<string>('apm_oss.metricsIndices'),
-    body: {
-      size: 0,
-      query: {
-        bool: {
-          filter: [
-            { term: { [PROCESSOR_EVENT]: 'metric' } },
-            { term: { [SERVICE_NAME]: serviceName } },
-            { term: { [SERVICE_NODE_NAME]: serviceNodeName } }
-          ]
-        }
-      },
-      aggs: {
-        host: {
-          terms: {
-            field: HOST_NAME,
-            size: 1
-          }
-        },
-        containerId: {
-          terms: {
-            field: CONTAINER_ID,
-            size: 1
+  const query = mergeProjection(
+    getServiceNodesProjection({
+      setup,
+      serviceName,
+      serviceNodeName
+    }),
+    {
+      body: {
+        size: 0,
+        aggs: {
+          host: {
+            terms: {
+              field: HOST_NAME,
+              size: 1
+            }
+          },
+          containerId: {
+            terms: {
+              field: CONTAINER_ID,
+              size: 1
+            }
           }
         }
       }
     }
-  };
+  );
 
   const response = await client.search(query);
 

--- a/x-pack/legacy/plugins/apm/server/routes/service_nodes.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/service_nodes.ts
@@ -17,7 +17,7 @@ export const serviceNodesRoute = createRoute(core => ({
     }),
     query: t.intersection([rangeRt, uiFiltersRt])
   },
-  handler: async (req, { path, query }) => {
+  handler: async (req, { path }) => {
     const setup = await setupRequest(req);
     const { serviceName } = path;
 

--- a/x-pack/legacy/plugins/apm/server/routes/services.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/services.ts
@@ -73,7 +73,8 @@ export const serviceNodeMetadataRoute = createRoute(() => ({
     path: t.type({
       serviceName: t.string,
       serviceNodeName: t.string
-    })
+    }),
+    query: t.intersection([uiFiltersRt, rangeRt])
   },
   handler: async (req, { path }) => {
     const setup = await setupRequest(req);


### PR DESCRIPTION
This addresses some feedback we got from the Java agent team.

- Change column labels to accurately reflect aggregation types
- Add explanatory tooltip for service.node.name column header
- Use fixed unit (per minute) for gc rate/time
- Sort table by default on CPU, desc
- Allow inspection of metrics without `service.node.name` for backwards compatibility

![image](https://user-images.githubusercontent.com/352732/66648908-15817580-ec2d-11e9-8c4a-b2f3f5ecde17.png)

![image](https://user-images.githubusercontent.com/352732/66649761-4367b980-ec2f-11e9-954c-bed5de466f21.png)

![image](https://user-images.githubusercontent.com/352732/66821914-8f727100-ef43-11e9-8cb6-11fb30aa3ae4.png)


![image](https://user-images.githubusercontent.com/352732/66821705-2854bc80-ef43-11e9-9eec-cdaca214bad6.png)



@eyalkoren @felixbarny @nehaduggal LMK if the changes are what you expect. For the tooltip, @eyalkoren suggested to add a link but unfortunately that's not going to work, because the tooltip cannot be hovered over (it disappears).

