### PR TITLE
Small touch ups to lens empty state and field previews

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/workspace_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/workspace_panel.tsx
@@ -14,7 +14,6 @@ import {
   EuiImage,
   EuiText,
   EuiBetaBadge,
-  EuiButton,
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { toExpression } from '@kbn/interpreter/common';

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/workspace_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/workspace_panel.tsx
@@ -6,7 +6,17 @@
 
 import React, { useState, useEffect, useMemo, useContext } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiImage, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiImage,
+  EuiText,
+  EuiBetaBadge,
+  EuiButton,
+  EuiButtonEmpty,
+} from '@elastic/eui';
 import { toExpression } from '@kbn/interpreter/common';
 import { CoreStart, CoreSetup } from 'src/core/public';
 import { ExpressionRenderer } from '../../../../../../../src/legacy/core_plugins/expressions/public';
@@ -94,26 +104,45 @@ export function InnerWorkspacePanel({
   }
 
   function renderEmptyWorkspace() {
+    const tooltipContent = i18n.translate('xpack.lens.editorFrame.tooltipContent', {
+      defaultMessage:
+        'Lens is in beta and is subject to change.  The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features',
+    });
     return (
-      <EuiText textAlign="center" grow={false} color="subdued" data-test-subj="empty-workspace">
-        <h3>
-          <FormattedMessage
-            id="xpack.lens.editorFrame.emptyWorkspaceHeading"
-            defaultMessage="Create a visualization"
+      <div className="eui-textCenter">
+        <EuiText textAlign="center" grow={false} color="subdued" data-test-subj="empty-workspace">
+          <h3>
+            <FormattedMessage
+              id="xpack.lens.editorFrame.emptyWorkspace"
+              defaultMessage="Drop some fields here to start"
+            />
+          </h3>
+          <EuiImage
+            style={{ width: 360 }}
+            url={core.http.basePath.prepend(emptyStateGraphicURL)}
+            alt=""
           />
-        </h3>
-        <EuiImage
-          style={{ width: 360 }}
-          url={core.http.basePath.prepend(emptyStateGraphicURL)}
-          alt=""
-        />
-        <p>
-          <FormattedMessage
-            id="xpack.lens.editorFrame.emptyWorkspace"
-            defaultMessage="Drop some fields here."
-          />
-        </p>
-      </EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.lens.editorFrame.emptyWorkspaceHeading"
+              defaultMessage="Lens is a new tool for creating visualizations"
+            />{' '}
+            <EuiBetaBadge label="Beta" tooltipContent={tooltipContent} />
+          </p>
+          <EuiButtonEmpty
+            href="https://discuss.elastic.co/c/kibana"
+            iconType="popout"
+            iconSide="right"
+            size="xs"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="xpack.lens.editorFrame.goToForums"
+              defaultMessage="Make requests and give feedback"
+            />
+          </EuiButtonEmpty>
+        </EuiText>
+      </div>
     );
   }
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/field_item.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/field_item.tsx
@@ -456,7 +456,7 @@ function FieldItemPopoverContents(props: State & FieldItemProps) {
                     </EuiText>
                   ) : (
                     <EuiToolTip content={formatted} delay="long">
-                      <EuiText size="s" className="eui-textTruncate">
+                      <EuiText size="xs" color="subdued" className="eui-textTruncate">
                         {formatted}
                       </EuiText>
                     </EuiToolTip>

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/field_item.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/field_item.tsx
@@ -447,7 +447,7 @@ function FieldItemPopoverContents(props: State & FieldItemProps) {
               <EuiFlexGroup alignItems="stretch" key={topValue.key} gutterSize="xs">
                 <EuiFlexItem grow={true} className="eui-textTruncate">
                   {formatted === '' ? (
-                    <EuiText size="s" color="subdued">
+                    <EuiText size="xs" color="subdued">
                       <em>
                         {i18n.translate('xpack.lens.indexPattern.fieldPanelEmptyStringValue', {
                           defaultMessage: 'Empty string',
@@ -483,7 +483,7 @@ function FieldItemPopoverContents(props: State & FieldItemProps) {
           <>
             <EuiFlexGroup alignItems="stretch" gutterSize="xs">
               <EuiFlexItem grow={true} className="eui-textTruncate">
-                <EuiText size="s" className="eui-textTruncate" color="subdued">
+                <EuiText size="xs" className="eui-textTruncate" color="subdued">
                   {i18n.translate('xpack.lens.indexPattern.otherDocsLabel', {
                     defaultMessage: 'Other',
                   })}


### PR DESCRIPTION
## Summary

### Links / messaging

@AlonaNadler requested and approved this

Summarize your PR. If it involves visual changes include a screenshot or gif.
![image](https://user-images.githubusercontent.com/324519/66690063-9139ed00-ec42-11e9-804e-1ae7c0f6c956.png)

### Tightened up preview graphs

The graph titles were a little too large. Likely there will be longer form strings in here, and this evens it out a bit.

![image](https://user-images.githubusercontent.com/324519/66690103-c3e3e580-ec42-11e9-81e9-475ec7246dbb.png)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] ~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~
- [ ] ~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~

### For maintainers

- [ ] ~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
- [ ] ~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~

