### PR TITLE
[Graph] Fix wording in field editor

### DIFF
--- a/x-pack/legacy/plugins/graph/public/components/field_manager/field_editor.tsx
+++ b/x-pack/legacy/plugins/graph/public/components/field_manager/field_editor.tsx
@@ -149,11 +149,11 @@ export function FieldEditor({
             id: 'root',
             items: [
               {
-                name: i18n.translate('xpack.graph.fieldManager.displaySettingsLabel', {
-                  defaultMessage: 'Edit display settings',
+                name: i18n.translate('xpack.graph.fieldManager.settingsLabel', {
+                  defaultMessage: 'Edit settings',
                 }),
                 icon: <EuiIcon type="pencil" size="m" />,
-                panel: 'displaySettings',
+                panel: 'settings',
               },
               {
                 name: isDisabled
@@ -195,8 +195,8 @@ export function FieldEditor({
             ],
           },
           {
-            id: 'displaySettings',
-            title: i18n.translate('xpack.graph.fieldManager.displayFormTitle', {
+            id: 'settings',
+            title: i18n.translate('xpack.graph.fieldManager.settingsFormTitle', {
               defaultMessage: 'Edit',
             }),
             width: 380,


### PR DESCRIPTION
This PR changes the wording in the field editor from "display settings" to "settings" because the second menu also contains settings unrelated to just displaying things (field selector and max terms settings are related to discovery).