### PR TITLE
[Reporting/Screenshots] Add step to skip telemetry

### DIFF
--- a/x-pack/legacy/plugins/reporting/export_types/common/lib/screenshots/index.ts
+++ b/x-pack/legacy/plugins/reporting/export_types/common/lib/screenshots/index.ts
@@ -25,6 +25,7 @@ import { waitForElementsToBeInDOM } from './wait_for_dom_elements';
 import { getTimeRange } from './get_time_range';
 import { getElementPositionAndAttributes } from './get_element_position_data';
 import { getScreenshots } from './get_screenshots';
+import { skipTelemetry } from './skip_telemetry';
 
 // NOTE: Typescript does not throw an error if this interface has errors!
 interface ScreenshotResults {
@@ -54,6 +55,10 @@ export function screenshotsObservableFactory(server: KbnServer) {
         const screenshot$ = driver$.pipe(
           mergeMap(
             (browser: HeadlessBrowser) => openUrl(browser, url, conditionalHeaders, logger),
+            browser => browser
+          ),
+          mergeMap(
+            (browser: HeadlessBrowser) => skipTelemetry(browser, logger),
             browser => browser
           ),
           mergeMap(

--- a/x-pack/legacy/plugins/reporting/export_types/common/lib/screenshots/skip_telemetry.ts
+++ b/x-pack/legacy/plugins/reporting/export_types/common/lib/screenshots/skip_telemetry.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { HeadlessChromiumDriver as HeadlessBrowser } from '../../../../server/browsers/chromium/driver';
+import { LevelLogger } from '../../../../server/lib';
+
+const LAST_REPORT_STORAGE_KEY = 'xpack.data';
+
+export async function skipTelemetry(browser: HeadlessBrowser, logger: LevelLogger) {
+  const storageData = await browser.evaluate({
+    fn: storageKey => {
+      // set something
+      const optOutJSON = JSON.stringify({ lastReport: Date.now() });
+      localStorage.setItem(storageKey, optOutJSON);
+
+      // get it
+      const session = localStorage.getItem(storageKey);
+
+      // return it
+      return session;
+    },
+    args: [LAST_REPORT_STORAGE_KEY],
+  });
+
+  logger.debug(`added data to localStorage to skip telmetry: ${storageData}`);
+}


### PR DESCRIPTION
## Summary

This PR adds a step to Reporting screenshot capturing to skip collection and sending of telemetry in the headless browser.

It is important to start adding tests for each one of these steps. I'm not sure how to do so.

Release note: Added a step when capturing screenshots from Kibana Reporting to skip the chance to send telemetry from the headless browser.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [x] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- ~~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
