### PR TITLE
[Task Manager] Fixes error when we claim new tasks beyond capacity

### DIFF
--- a/x-pack/legacy/plugins/task_manager/task_manager.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.test.ts
@@ -6,7 +6,7 @@
 
 import _ from 'lodash';
 import sinon from 'sinon';
-import { TaskManager } from './task_manager';
+import { TaskManager, claimAvailableTasks } from './task_manager';
 import { SavedObjectsClientMock } from 'src/core/server/mocks';
 import { SavedObjectsSerializer, SavedObjectsSchema } from 'src/core/server';
 import { mockLogger } from './test_utils';
@@ -66,6 +66,7 @@ describe('TaskManager', () => {
     const promise = client.schedule(task);
     client.start();
     await promise;
+
     expect(savedObjectsClient.create).toHaveBeenCalled();
   });
 
@@ -163,5 +164,29 @@ describe('TaskManager', () => {
     expect(() => client.addMiddleware(middleware)).toThrow(
       /Cannot add middleware after the task manager is initialized/i
     );
+  });
+
+  describe('claimAvailableTasks', () => {
+    test('should claim Available Tasks when there are available workers', () => {
+      const logger = mockLogger();
+      const claim = jest.fn(() => Promise.resolve({ docs: [], claimedTasks: 0 }));
+
+      const availableWorkers = 1;
+
+      claimAvailableTasks(claim, availableWorkers, logger);
+
+      expect(claim).toHaveBeenCalledTimes(1);
+    });
+
+    test('shouldnt claim Available Tasks when there are no available workers', () => {
+      const logger = mockLogger();
+      const claim = jest.fn(() => Promise.resolve({ docs: [], claimedTasks: 0 }));
+
+      const availableWorkers = 0;
+
+      claimAvailableTasks(claim, availableWorkers, logger);
+
+      expect(claim).not.toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/legacy/plugins/task_manager/task_manager.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.ts
@@ -114,7 +114,7 @@ export class TaskManager {
           pool.run,
           () =>
             claimAvailableTasks(
-              this.store.claimAvailableTasks,
+              this.store.claimAvailableTasks.bind(this.store),
               this.pool.availableWorkers,
               this.logger
             ),

--- a/x-pack/legacy/plugins/task_manager/task_manager.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.ts
@@ -21,7 +21,13 @@ import {
 import { TaskPoller } from './task_poller';
 import { TaskPool } from './task_pool';
 import { TaskManagerRunner } from './task_runner';
-import { FetchOpts, FetchResult, TaskStore } from './task_store';
+import {
+  FetchOpts,
+  FetchResult,
+  TaskStore,
+  OwnershipClaimingOpts,
+  ClaimOwnershipResult,
+} from './task_store';
 
 export interface TaskManagerOpts {
   logger: Logger;
@@ -103,7 +109,17 @@ export class TaskManager {
     const poller = new TaskPoller({
       logger: this.logger,
       pollInterval: opts.config.get('xpack.task_manager.poll_interval'),
-      work: (): Promise<void> => fillPool(pool.run, () => this.claimAvailableTasks(), createRunner),
+      work: (): Promise<void> =>
+        fillPool(
+          pool.run,
+          () =>
+            claimAvailableTasks(
+              this.store.claimAvailableTasks,
+              this.pool.availableWorkers,
+              this.logger
+            ),
+          createRunner
+        ),
     });
 
     this.pool = pool;
@@ -133,20 +149,6 @@ export class TaskManager {
       }
     };
     startPoller();
-  }
-
-  private async claimAvailableTasks() {
-    const { docs, claimedTasks } = await this.store.claimAvailableTasks({
-      size: this.pool.availableWorkers,
-      claimOwnershipUntil: intervalFromNow('30s')!,
-    });
-
-    if (docs.length !== claimedTasks) {
-      this.logger.warn(
-        `[Task Ownership error]: (${claimedTasks}) tasks were claimed by Kibana, but (${docs.length}) tasks were fetched`
-      );
-    }
-    return docs;
   }
 
   private async waitUntilStarted() {
@@ -246,4 +248,28 @@ export class TaskManager {
       throw new Error(`Cannot ${message} after the task manager is initialized!`);
     }
   }
+}
+
+export async function claimAvailableTasks(
+  claim: (opts: OwnershipClaimingOpts) => Promise<ClaimOwnershipResult>,
+  availableWorkers: number,
+  logger: Logger
+) {
+  if (availableWorkers > 0) {
+    const { docs, claimedTasks } = await claim({
+      size: availableWorkers,
+      claimOwnershipUntil: intervalFromNow('30s')!,
+    });
+
+    if (docs.length !== claimedTasks) {
+      logger.warn(
+        `[Task Ownership error]: (${claimedTasks}) tasks were claimed by Kibana, but (${docs.length}) tasks were fetched`
+      );
+    }
+    return docs;
+  }
+  logger.info(
+    `[Task Ownership]: Task Manager has skipped Claiming Ownership of available tasks at it has ran out Available Workers. If this happens often, consider adjusting the "xpack.task_manager.max_workers" configuration.`
+  );
+  return [];
 }


### PR DESCRIPTION
Fixed issue where we would try and claim new tasks even when there are no available workers

## Summary

An error was introduced recently when Task Manager tries to claim tasks despite having no available workers to do so, resulting in an invalid `updateByQuery` being submitted on every pool refresh interval, flooding the logs.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

