### PR TITLE
[APM] Remove `type` from agent configuration

### DIFF
--- a/x-pack/legacy/plugins/apm/server/lib/helpers/es_client.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/helpers/es_client.ts
@@ -17,6 +17,9 @@ import { cloneDeep, has, isString, set } from 'lodash';
 import { OBSERVER_VERSION_MAJOR } from '../../../common/elasticsearch_fieldnames';
 import { StringMap } from '../../../typings/common';
 
+// `type` was deprecated in 7.0
+export type APMIndexDocumentParams<T> = Omit<IndexDocumentParams<T>, 'type'>;
+
 function getApmIndices(config: Legacy.KibanaConfig) {
   return [
     config.get<string>('apm_oss.errorIndices'),
@@ -118,7 +121,7 @@ export function getESClient(req: Legacy.Request) {
         AggregationSearchResponseWithTotalHitsAsObject<Hits, U>
       >;
     },
-    index: <Body>(params: IndexDocumentParams<Body>) => {
+    index: <Body>(params: APMIndexDocumentParams<Body>) => {
       return cluster.callWithRequest(req, 'index', params);
     },
     delete: (params: IndicesDeleteParams) => {

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
@@ -5,9 +5,9 @@
  */
 
 import hash from 'object-hash';
-import { IndexDocumentParams } from 'elasticsearch';
 import { Setup } from '../../helpers/setup_request';
 import { AgentConfiguration } from './configuration_types';
+import { APMIndexDocumentParams } from '../../helpers/es_client';
 
 export async function createOrUpdateConfiguration({
   configurationId,
@@ -23,8 +23,7 @@ export async function createOrUpdateConfiguration({
 }) {
   const { client, config } = setup;
 
-  const params: IndexDocumentParams<AgentConfiguration> = {
-    type: '_doc',
+  const params: APMIndexDocumentParams<AgentConfiguration> = {
     refresh: true,
     index: config.get<string>('apm_oss.apmAgentConfigurationIndex'),
     body: {

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/mark_applied_by_agent.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/mark_applied_by_agent.ts
@@ -19,7 +19,6 @@ export async function markAppliedByAgent({
   const { client, config } = setup;
 
   const params = {
-    type: '_doc',
     index: config.get<string>('apm_oss.apmAgentConfigurationIndex'),
     id, // by specifying the `id` elasticsearch will do an "upsert"
     body: {


### PR DESCRIPTION
`type` was deprecated in 7.0 and will be removed in 8.0. This has starting failing on master (8.0.0) but is not a problem on 7.x so won't be backported to 7.5.

@jalvz 