### PR TITLE
[7.4] update geckodriver (#48201)

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,7 +378,7 @@
     "exit-hook": "^2.2.0",
     "faker": "1.1.0",
     "fetch-mock": "^7.3.9",
-    "geckodriver": "^1.18.0",
+    "geckodriver": "^1.19.0",
     "getopts": "^2.2.4",
     "grunt": "1.0.4",
     "grunt-available-tasks": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13012,10 +13012,10 @@ gaze@^1.0.0, gaze@^1.1.0:
   dependencies:
     globule "^1.0.0"
 
-geckodriver@^1.18.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.18.0.tgz#a4d9b0504be26ed933d7be208b06b15833e32415"
-  integrity sha512-PFBq5UsngfLrxmNqnynix4rQgOkOWCKl3I3PlXCROiTQKSE2znIK9MnEUNQznzxNOPMRt1RGGy2cinIARSRvKQ==
+geckodriver@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.19.0.tgz#b2b07e343c2e409ce645e65fe88132bd34fa400a"
+  integrity sha512-Zq98rXKjvB+NCfzKlJGkQkFAO8zvmUSNqYEIxUwlF1qxmv4taRwwBbEfDa6Dj7Auf7C0p+ZZZmIA8KmlL1cfsw==
   dependencies:
     adm-zip "0.4.11"
     bluebird "3.4.6"


### PR DESCRIPTION
Backports the following commits to 7.4:
 - update geckodriver (#48201)