### PR TITLE
Update http route registration in migration guide and examples

### DIFF
--- a/src/core/MIGRATION.md
+++ b/src/core/MIGRATION.md
@@ -498,8 +498,7 @@ export interface DemoSetupDeps {}
 export interface DemoStartDeps {}
 
 export class DemoPlugin implements Plugin<DemoSetup, DemoStart, DemoSetupDeps, DemoStartDeps> {
-export class Plugin {
-  public setup(core: CoreSetup, plugins: PluginsSetup, __LEGACY: LegacySetup) {
+  public setup(core: CoreSetup, plugins: PluginsSetup, __LEGACY: LegacySetup): DemoSetup {
     // We're still using the legacy Elasticsearch and http router here, but we're now accessing
     // these services in the same way a NP plugin would: injected into the setup function. It's
     // also obvious that these dependencies needs to be removed by migrating over to the New 
@@ -666,7 +665,7 @@ With the previous steps resolved, this final step should be easy, but the exact 
 
 Other plugins may want to move subsystems over individually. For instance, you can move routes over to the New Platform in groups rather than all at once. Other examples that could be broken up:
 - Configuration schema ([see example](./MIGRATION_EXAMPLES.md#declaring-config-schema))
-- HTTP route registration ([see example](./MIGRATION_EXAMPLES.md#route-registration))
+- HTTP route registration ([see example](./MIGRATION_EXAMPLES.md#http-routes))
 - Polling mechanisms (eg. job worker)
 
 In general, we recommend moving all at once by ensuring you're not depending on any legacy code before you move over.

--- a/src/core/MIGRATION.md
+++ b/src/core/MIGRATION.md
@@ -476,8 +476,8 @@ interface FooSetup {
   getBar(): string
 }
 
-// We inject all legacy dependencies into our plugin including dependencies on other legacy plugins.
-// Take care to only expose the legacy functionality you need e.g. don't inject the whole 
+// We inject the miminal legacy dependencies into our plugin including dependencies on other legacy
+// plugins. Take care to only expose the legacy functionality you need e.g. don't inject the whole 
 // `Legacy.Server` if you only depend on `Legacy.Server['route']`.
 interface LegacySetup {
   route: Legacy.Server['route']


### PR DESCRIPTION
## Summary

Update http route registration in migration guide and migration examples. Make it clearer that a shim exposing `server.route` isn't NP compatible, but can be a helpful way to break down the migration into steps.

[skip-ci]
### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

