### PR TITLE
[APM] Exclude logs from error counts

### DIFF
--- a/x-pack/legacy/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
@@ -12,6 +12,8 @@ exports[`Error ERROR_EXC_MESSAGE 1`] = `undefined`;
 
 exports[`Error ERROR_GROUP_ID 1`] = `"grouping key"`;
 
+exports[`Error ERROR_LOG_LEVEL 1`] = `undefined`;
+
 exports[`Error ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Error ERROR_PAGE_URL 1`] = `undefined`;
@@ -114,6 +116,8 @@ exports[`Span ERROR_EXC_MESSAGE 1`] = `undefined`;
 
 exports[`Span ERROR_GROUP_ID 1`] = `undefined`;
 
+exports[`Span ERROR_LOG_LEVEL 1`] = `undefined`;
+
 exports[`Span ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Span ERROR_PAGE_URL 1`] = `undefined`;
@@ -215,6 +219,8 @@ exports[`Transaction ERROR_EXC_HANDLED 1`] = `undefined`;
 exports[`Transaction ERROR_EXC_MESSAGE 1`] = `undefined`;
 
 exports[`Transaction ERROR_GROUP_ID 1`] = `undefined`;
+
+exports[`Transaction ERROR_LOG_LEVEL 1`] = `undefined`;
 
 exports[`Transaction ERROR_LOG_MESSAGE 1`] = `undefined`;
 

--- a/x-pack/legacy/plugins/apm/common/elasticsearch_fieldnames.ts
+++ b/x-pack/legacy/plugins/apm/common/elasticsearch_fieldnames.ts
@@ -39,6 +39,7 @@ export const PARENT_ID = 'parent.id';
 
 export const ERROR_GROUP_ID = 'error.grouping_key';
 export const ERROR_CULPRIT = 'error.culprit';
+export const ERROR_LOG_LEVEL = 'error.log.level';
 export const ERROR_LOG_MESSAGE = 'error.log.message';
 export const ERROR_EXC_MESSAGE = 'error.exception.message'; // only to be used in es queries, since error.exception is now an array
 export const ERROR_EXC_HANDLED = 'error.exception.handled'; // only to be used in es queries, since error.exception is now an array

--- a/x-pack/legacy/plugins/apm/server/lib/errors/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/__snapshots__/queries.test.ts.snap
@@ -239,6 +239,17 @@ Object {
             },
           },
         ],
+        "must_not": Array [
+          Object {
+            "terms": Object {
+              "error.log.level": Array [
+                "debug",
+                "info",
+                "warning",
+              ],
+            },
+          },
+        ],
       },
     },
     "size": 0,

--- a/x-pack/legacy/plugins/apm/server/lib/errors/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/__snapshots__/queries.test.ts.snap
@@ -239,13 +239,24 @@ Object {
             },
           },
         ],
-        "must_not": Array [
+        "should": Array [
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "error.log.level",
+                  },
+                },
+              ],
+            },
+          },
           Object {
             "terms": Object {
               "error.log.level": Array [
-                "debug",
-                "info",
-                "warning",
+                "critical",
+                "error",
+                "fatal",
               ],
             },
           },

--- a/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
@@ -6,6 +6,7 @@
 
 import { idx } from '@kbn/elastic-idx';
 import {
+  ERROR_LOG_LEVEL,
   PROCESSOR_EVENT,
   TRACE_ID,
   TRANSACTION_ID
@@ -16,6 +17,8 @@ import { Setup } from '../helpers/setup_request';
 export interface ErrorsPerTransaction {
   [transactionId: string]: number;
 }
+
+const excludedLogLevels = ['debug', 'info', 'warning'];
 
 export async function getTraceErrorsPerTransaction(
   traceId: string,
@@ -33,7 +36,8 @@ export async function getTraceErrorsPerTransaction(
             { term: { [TRACE_ID]: traceId } },
             { term: { [PROCESSOR_EVENT]: 'error' } },
             { range: rangeFilter(start, end) }
-          ]
+          ],
+          must_not: [{ terms: { [ERROR_LOG_LEVEL]: excludedLogLevels } }]
         }
       },
       aggs: {

--- a/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
@@ -18,7 +18,7 @@ export interface ErrorsPerTransaction {
   [transactionId: string]: number;
 }
 
-const excludedLogLevels = ['debug', 'info', 'warning'];
+const includedLogLevels = ['critical', 'error', 'fatal'];
 
 export async function getTraceErrorsPerTransaction(
   traceId: string,
@@ -37,7 +37,10 @@ export async function getTraceErrorsPerTransaction(
             { term: { [PROCESSOR_EVENT]: 'error' } },
             { range: rangeFilter(start, end) }
           ],
-          must_not: [{ terms: { [ERROR_LOG_LEVEL]: excludedLogLevels } }]
+          should: [
+            { bool: { must_not: [{ exists: { field: ERROR_LOG_LEVEL } }] } },
+            { terms: { [ERROR_LOG_LEVEL]: includedLogLevels } }
+          ]
         }
       },
       aggs: {


### PR DESCRIPTION
Some agents send messages as errors that are actually logs and should not be included in error counts.

Exclude items with a log level of warning, info, or debug from the error counts.

Fixes #48100.
