### PR TITLE
[APM] Template for APM optimized tsconfig.json

### DIFF
--- a/x-pack/legacy/plugins/apm/.gitignore
+++ b/x-pack/legacy/plugins/apm/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.json

--- a/x-pack/legacy/plugins/apm/tsconfig-template.json
+++ b/x-pack/legacy/plugins/apm/tsconfig-template.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./", "./typings/**/*", "../../../typings/**/*"],
+  "exclude": ["./cypress"]
+}

--- a/x-pack/legacy/plugins/apm/typings/common.ts
+++ b/x-pack/legacy/plugins/apm/typings/common.ts
@@ -4,6 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import '../../infra/types/rison_node';
+import {} from '../../reporting/public/components/report_listing';
+import '../../canvas/types/webpack';
+
 export interface StringMap<T = unknown> {
   [key: string]: T;
 }


### PR DESCRIPTION
Adds a template for a tsconfig.json file that only type checks APM files. This should hugely speed up local typescript checks (3x as fast) & editor responsiveness. Some of us have a variation of this already but I think it might be useful for others to have something checked in/documented as well.

For CLI support, run:
`$ yarn tsc --noEmit --pretty --project x-pack/legacy/plugins/apm/tsconfig-template.json`

For VS Code support, copy `tsconfig-template.json` to `tsconfig.json`. 

In order for this to be non-disruptive, I've named this file `tsconfig-template.json` instead of `tsconfig.json`, because it otherwise would be used by the x-pack compilation that is used on CI as well. I've also added explicit imports for types that we (sort of accidentally) depend on in `typings/common.ts`. Maybe we should have a policy around declarations only existing in `x-pack/typings` 😅