### PR TITLE
changed all 'lucene' to 'kuery'

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverErrorLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverErrorLink.tsx
@@ -24,7 +24,7 @@ function getDiscoverQuery(error: APMError, kuery?: string) {
     _a: {
       interval: 'auto',
       query: {
-        language: 'lucene',
+        language: 'kuery',
         query
       },
       sort: { '@timestamp': 'desc' }

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverSpanLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverSpanLink.tsx
@@ -15,7 +15,7 @@ function getDiscoverQuery(span: Span) {
     _a: {
       interval: 'auto',
       query: {
-        language: 'lucene',
+        language: 'kuery',
         query
       }
     }

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverTransactionLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/DiscoverTransactionLink.tsx
@@ -25,7 +25,7 @@ export function getDiscoverQuery(transaction: Transaction) {
     _a: {
       interval: 'auto',
       query: {
-        language: 'lucene',
+        language: 'kuery',
         query
       }
     }

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/DiscoverLinks.integration.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/DiscoverLinks.integration.test.tsx
@@ -63,7 +63,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toEqual(
-      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'processor.event:"transaction" AND transaction.id:"8b60bd32ecc6e150" AND trace.id:"8b60bd32ecc6e1506735a8b6cfcf175c"'))`
+      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:kuery,query:'processor.event:"transaction" AND transaction.id:"8b60bd32ecc6e150" AND trace.id:"8b60bd32ecc6e1506735a8b6cfcf175c"'))`
     );
   });
 
@@ -79,7 +79,7 @@ describe('DiscoverLinks', () => {
     } as Location);
 
     expect(href).toEqual(
-      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'span.id:"test-span-id"'))`
+      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:kuery,query:'span.id:"test-span-id"'))`
     );
   });
 
@@ -100,7 +100,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toEqual(
-      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'service.name:"service-name" AND error.grouping_key:"grouping-key"'),sort:('@timestamp':desc))`
+      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:kuery,query:'service.name:"service-name" AND error.grouping_key:"grouping-key"'),sort:('@timestamp':desc))`
     );
   });
 
@@ -122,7 +122,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toEqual(
-      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:lucene,query:'service.name:"service-name" AND error.grouping_key:"grouping-key" AND some:kuery-string'),sort:('@timestamp':desc))`
+      `/basepath/app/kibana#/discover?_g=(refreshInterval:(pause:true,value:'0'),time:(from:now%2Fw,to:now))&_a=(index:apm-index-pattern-id,interval:auto,query:(language:kuery,query:'service.name:"service-name" AND error.grouping_key:"grouping-key" AND some:kuery-string'),sort:('@timestamp':desc))`
     );
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverErrorButton.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverErrorButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DiscoverErrorLink with kuery should match snapshot 1`] = `
       "_a": Object {
         "interval": "auto",
         "query": Object {
-          "language": "lucene",
+          "language": "kuery",
           "query": "service.name:\\"myServiceName\\" AND error.grouping_key:\\"myGroupingKey\\" AND transaction.sampled: true",
         },
         "sort": Object {
@@ -26,7 +26,7 @@ exports[`DiscoverErrorLink without kuery should match snapshot 1`] = `
       "_a": Object {
         "interval": "auto",
         "query": Object {
-          "language": "lucene",
+          "language": "kuery",
           "query": "service.name:\\"myServiceName\\" AND error.grouping_key:\\"myGroupingKey\\"",
         },
         "sort": Object {

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverErrorLink.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverErrorLink.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DiscoverErrorLink with kuery should match snapshot 1`] = `
       "_a": Object {
         "interval": "auto",
         "query": Object {
-          "language": "lucene",
+          "language": "kuery",
           "query": "service.name:\\"myServiceName\\" AND error.grouping_key:\\"myGroupingKey\\" AND transaction.sampled: true",
         },
         "sort": Object {
@@ -26,7 +26,7 @@ exports[`DiscoverErrorLink without kuery should match snapshot 1`] = `
       "_a": Object {
         "interval": "auto",
         "query": Object {
-          "language": "lucene",
+          "language": "kuery",
           "query": "service.name:\\"myServiceName\\" AND error.grouping_key:\\"myGroupingKey\\"",
         },
         "sort": Object {

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverTransactionButton.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverTransactionButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DiscoverTransactionLink component should render with data 1`] = `
       "_a": Object {
         "interval": "auto",
         "query": Object {
-          "language": "lucene",
+          "language": "kuery",
           "query": "processor.event:\\"transaction\\" AND transaction.id:\\"8b60bd32ecc6e150\\" AND trace.id:\\"8b60bd32ecc6e1506735a8b6cfcf175c\\"",
         },
       },
@@ -21,7 +21,7 @@ Object {
   "_a": Object {
     "interval": "auto",
     "query": Object {
-      "language": "lucene",
+      "language": "kuery",
       "query": "processor.event:\\"transaction\\" AND transaction.id:\\"8b60bd32ecc6e150\\" AND trace.id:\\"8b60bd32ecc6e1506735a8b6cfcf175c\\"",
     },
   },

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverTransactionLink.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/DiscoverLinks/__test__/__snapshots__/DiscoverTransactionLink.test.tsx.snap
@@ -5,7 +5,7 @@ Object {
   "_a": Object {
     "interval": "auto",
     "query": Object {
-      "language": "lucene",
+      "language": "kuery",
       "query": "processor.event:\\"transaction\\" AND transaction.id:\\"8b60bd32ecc6e150\\" AND trace.id:\\"8b60bd32ecc6e1506735a8b6cfcf175c\\"",
     },
   },


### PR DESCRIPTION
## Summary

Closes: #48740

Links from APM to Discover now use KQL (kuery) instead of Lucene (lucene) query syntax.

![Bildschirmfoto_2019-10-21_12-38-51](https://user-images.githubusercontent.com/23581855/67220331-fd191400-f3ff-11e9-9331-8f1eae1b22bb.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

