### PR TITLE
[Maps] Correctly open layer settings from add layer wizard

### DIFF
--- a/x-pack/legacy/plugins/maps/public/connected_components/widget_overlay/layer_control/index.js
+++ b/x-pack/legacy/plugins/maps/public/connected_components/widget_overlay/layer_control/index.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { LayerControl } from './view';
 import { FLYOUT_STATE } from '../../../reducers/ui';
 import { updateFlyout, setIsLayerTOCOpen } from '../../../actions/ui_actions';
+import { setSelectedLayer } from '../../../actions/map_actions';
 import {
   getIsReadOnly,
   getIsLayerTOCOpen,
@@ -26,7 +27,8 @@ function mapStateToProps(state = {}) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    showAddLayerWizard: () => {
+    showAddLayerWizard: async () => {
+      await dispatch(setSelectedLayer(null));
       dispatch(updateFlyout(FLYOUT_STATE.ADD_LAYER_WIZARD));
     },
     closeLayerTOC: () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/38990

This correctly removes the selection from the store-state, when opening the add-layer wizard.