### PR TITLE
[APM] Improve date formatting across APM

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -714,7 +714,13 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
               >
-                1337 minutes ago (mocking 1515578797)
+                <span
+                  className="euiToolTipAnchor"
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  1337 minutes ago (mocking 1515578797)
+                </span>
               </div>
             </td>
           </tr>
@@ -833,7 +839,13 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
               >
-                1337 minutes ago (mocking 1515578797)
+                <span
+                  className="euiToolTipAnchor"
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  1337 minutes ago (mocking 1515578797)
+                </span>
               </div>
             </td>
           </tr>
@@ -952,7 +964,13 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
               >
-                1337 minutes ago (mocking 1515578796)
+                <span
+                  className="euiToolTipAnchor"
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  1337 minutes ago (mocking 1515578796)
+                </span>
               </div>
             </td>
           </tr>
@@ -1071,7 +1089,13 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
               >
-                1337 minutes ago (mocking 1515578773)
+                <span
+                  className="euiToolTipAnchor"
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  1337 minutes ago (mocking 1515578773)
+                </span>
               </div>
             </td>
           </tr>

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -7,7 +7,6 @@
 import { EuiBadge, EuiToolTip } from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import { i18n } from '@kbn/i18n';
-import moment from 'moment';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
@@ -22,6 +21,7 @@ import {
 import { useUrlParams } from '../../../../hooks/useUrlParams';
 import { ManagedTable } from '../../../shared/ManagedTable';
 import { ErrorDetailLink } from '../../../shared/Links/apm/ErrorDetailLink';
+import { TimestampTooltip } from '../../../shared/TimestampTooltip';
 
 const GroupIdLink = styled(ErrorDetailLink)`
   font-family: ${fontFamilyCode};
@@ -142,7 +142,11 @@ const ErrorGroupList: React.FC<Props> = props => {
         ),
         align: 'right',
         render: (value?: number) =>
-          value ? moment(value).fromNow() : NOT_AVAILABLE_LABEL
+          value ? (
+            <TimestampTooltip time={value} precision="minutes" />
+          ) : (
+            NOT_AVAILABLE_LABEL
+          )
       }
     ],
     [serviceName]

--- a/x-pack/legacy/plugins/apm/public/components/shared/TimestampTooltip/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TimestampTooltip/index.tsx
@@ -12,7 +12,7 @@ interface Props {
    * timestamp in milliseconds
    */
   time: number;
-  precision?: 'days' | 'minutes' | 'milliseconds';
+  precision?: 'days' | 'minutes' | 'seconds' | 'milliseconds';
 }
 
 function getPreciseTime(precision: Props['precision']) {
@@ -21,17 +21,33 @@ function getPreciseTime(precision: Props['precision']) {
       return '';
     case 'minutes':
       return ', HH:mm';
+    case 'seconds':
+      return ', HH:mm:ss';
     default:
       return ', HH:mm:ss.SSS';
   }
 }
 
+function withLeadingPlus(value: number) {
+  return value > 0 ? `+${value}` : value;
+}
+
+export function asAbsoluteTime({ time, precision = 'milliseconds' }: Props) {
+  const momentTime = moment(time);
+  const utcOffsetHours = momentTime.utcOffset() / 60;
+  const utcOffsetFormatted = Number.isInteger(utcOffsetHours)
+    ? withLeadingPlus(utcOffsetHours)
+    : 'Z';
+
+  return momentTime.format(
+    `MMM D, YYYY${getPreciseTime(precision)} (UTC${utcOffsetFormatted})`
+  );
+}
+
 export function TimestampTooltip({ time, precision = 'milliseconds' }: Props) {
   const momentTime = moment(time);
   const relativeTimeLabel = momentTime.fromNow();
-  const absoluteTimeLabel = momentTime.format(
-    `MMM Do YYYY${getPreciseTime(precision)} (ZZ zz)`
-  );
+  const absoluteTimeLabel = asAbsoluteTime({ time, precision });
 
   return (
     <EuiToolTip content={absoluteTimeLabel}>

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Tooltip/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Tooltip/index.js
@@ -7,7 +7,6 @@
 import React from 'react';
 import { isEmpty } from 'lodash';
 import { Hint } from 'react-vis';
-import moment from 'moment';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import {
@@ -20,6 +19,7 @@ import {
 } from '../../../../style/variables';
 import Legend from '../Legend';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { asAbsoluteTime } from '../../TimestampTooltip';
 
 const TooltipElm = styled.div`
   margin: 0 ${px(unit)};
@@ -87,7 +87,9 @@ export default function Tooltip({
   return (
     <Hint {...props} value={{ x, y }}>
       <TooltipElm>
-        <Header>{header || moment(x).format('MMMM Do YYYY, HH:mm:ss')}</Header>
+        <Header>
+          {header || asAbsoluteTime({ time: x, precision: 'seconds' })}
+        </Header>
 
         <Content>
           {showLegends ? (


### PR DESCRIPTION
Fixes #47959
Fixes #18332

This PR solves three timezone-related issues:
 - When the Kibana timezone setting is set to "Browser", moment should "guess" the browsers timezone (and not try to use "Browser" as a timezone, which is invalid)
 - Use `TimestampTooltip` for errors overview ![image](https://user-images.githubusercontent.com/209966/67373529-1943bf00-f580-11e9-8ae3-bad66a247c7a.png)
 - Show timezone information on charts
![image](https://user-images.githubusercontent.com/209966/67373602-3aa4ab00-f580-11e9-8d8f-d7382279649e.png)
![image](https://user-images.githubusercontent.com/209966/67373610-3c6e6e80-f580-11e9-99e1-3b295232d845.png)

