### PR TITLE
[discover] fix histogram brushing test

### DIFF
--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -106,9 +106,9 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.discover.brushHistogram();
 
         const newDurationHours = await PageObjects.timePicker.getTimeDurationInHours();
-        expect(Math.round(newDurationHours)).to.be(108);
+        expect(Math.round(newDurationHours)).to.be(25);
         const rowData = await PageObjects.discover.getDocTableField(1);
-        expect(rowData).to.have.string('Sep 22, 2015 @ 23:50:13.253');
+        expect(rowData).to.have.string('Sep 20, 2015 @ 22:17:57.757');
       });
 
       it('should show correct initial chart interval of Auto', async function () {

--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -108,7 +108,7 @@ export default function ({ getService, getPageObjects }) {
         const newDurationHours = await PageObjects.timePicker.getTimeDurationInHours();
         expect(Math.round(newDurationHours)).to.be(25);
         const rowData = await PageObjects.discover.getDocTableField(1);
-        expect(rowData).to.have.string('Sep 20, 2015 @ 22:17:57.757');
+        expect(Date.parse(rowData)).to.be.within(Date.parse('Sep 20, 2015 @ 22:00:00.000'), Date.parse('Sep 20, 2015 @ 23:30:00.000'));
       });
 
       it('should show correct initial chart interval of Auto', async function () {


### PR DESCRIPTION
## Summary

Crome was update to v78 on CI workers and `should modify the time range when the histogram is brushed` test started to fail. It is not a bug, but a fix for dragAndDrop that now brushes the chart correctly.

I'm using the range to verify 1st doc timestamp since we got a different result for head/headless and linux/mac

<img width="650" alt="Object details - Google Cloud Platform 2019-10-23 12-35-37" src="https://user-images.githubusercontent.com/10977896/67384617-c8d55d00-f591-11e9-841d-f137a0ba67d2.png">
