### PR TITLE
[7.x] [discover] fix histogram brushing test (#49024)

### DIFF
--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -105,9 +105,9 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.discover.brushHistogram();
 
         const newDurationHours = await PageObjects.timePicker.getTimeDurationInHours();
-        expect(Math.round(newDurationHours)).to.be(108);
+        expect(Math.round(newDurationHours)).to.be(25);
         const rowData = await PageObjects.discover.getDocTableField(1);
-        expect(rowData).to.have.string('Sep 22, 2015 @ 23:50:13.253');
+        expect(Date.parse(rowData)).to.be.within(Date.parse('Sep 20, 2015 @ 22:00:00.000'), Date.parse('Sep 20, 2015 @ 23:30:00.000'));
       });
 
       it('should show correct initial chart interval of Auto', async function () {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [discover] fix histogram brushing test (#49024)