### PR TITLE
[Lens] Replace '' with '(empty)' in Lens visualizations

### DIFF
--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/consts.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/consts.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
-
-// esaggs returns __missing__ for null buckets in some contexts (e.g. split)
-// so, we just force null buckets to have this value, and we special-case it.
-export const MISSING_BUCKET_LABEL = '__missing__';

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/consts.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/consts.ts
@@ -4,5 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export * from './operations';
-export { OperationType, IndexPatternColumn, MISSING_BUCKET_LABEL } from './definitions';
+// esaggs returns __missing__ for null buckets in some contexts (e.g. split)
+// so, we just force null buckets to have this value, and we special-case it.
+export const MISSING_BUCKET_LABEL = '__missing__';

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
@@ -18,7 +18,6 @@ import { countOperation } from './count';
 import { DimensionPriority, StateSetter, OperationMetadata } from '../../../types';
 import { BaseIndexPatternColumn, FieldBasedIndexPatternColumn } from './column_types';
 import { IndexPatternPrivateState, IndexPattern, IndexPatternField } from '../../types';
-export * from './consts';
 
 // List of all operation definitions registered to this data source.
 // If you want to implement a new operation, add it to this array and

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
@@ -18,6 +18,7 @@ import { countOperation } from './count';
 import { DimensionPriority, StateSetter, OperationMetadata } from '../../../types';
 import { BaseIndexPatternColumn, FieldBasedIndexPatternColumn } from './column_types';
 import { IndexPatternPrivateState, IndexPattern, IndexPatternField } from '../../types';
+export * from './consts';
 
 // List of all operation definitions registered to this data source.
 // If you want to implement a new operation, add it to this array and

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.tsx
@@ -12,6 +12,7 @@ import { updateColumnParam } from '../../state_helpers';
 import { DataType } from '../../../types';
 import { OperationDefinition } from '.';
 import { FieldBasedIndexPatternColumn } from './column_types';
+import { MISSING_BUCKET_LABEL } from './consts';
 
 type PropType<C> = C extends React.ComponentType<infer P> ? P : unknown;
 
@@ -107,8 +108,8 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn> = {
       size: column.params.size,
       otherBucket: false,
       otherBucketLabel: 'Other',
-      missingBucket: false,
-      missingBucketLabel: 'Missing',
+      missingBucket: true,
+      missingBucketLabel: MISSING_BUCKET_LABEL,
     },
   }),
   onFieldChange: (oldColumn, indexPattern, field) => {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/terms.tsx
@@ -12,7 +12,6 @@ import { updateColumnParam } from '../../state_helpers';
 import { DataType } from '../../../types';
 import { OperationDefinition } from '.';
 import { FieldBasedIndexPatternColumn } from './column_types';
-import { MISSING_BUCKET_LABEL } from './consts';
 
 type PropType<C> = C extends React.ComponentType<infer P> ? P : unknown;
 
@@ -108,8 +107,8 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn> = {
       size: column.params.size,
       otherBucket: false,
       otherBucketLabel: 'Other',
-      missingBucket: true,
-      missingBucketLabel: MISSING_BUCKET_LABEL,
+      missingBucket: false,
+      missingBucketLabel: 'Missing',
     },
   }),
   onFieldChange: (oldColumn, indexPattern, field) => {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/index.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/index.ts
@@ -5,4 +5,4 @@
  */
 
 export * from './operations';
-export { OperationType, IndexPatternColumn, MISSING_BUCKET_LABEL } from './definitions';
+export { OperationType, IndexPatternColumn } from './definitions';

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
@@ -61,6 +61,25 @@ describe('rename_columns', () => {
     `);
   });
 
+  it('should replace "" with a visible value', () => {
+    const input: KibanaDatatable = {
+      type: 'kibana_datatable',
+      columns: [{ id: 'a', name: 'A' }],
+      rows: [{ a: '' }],
+    };
+
+    const idMap = {
+      a: {
+        id: 'a',
+        label: 'Austrailia',
+      },
+    };
+
+    expect(renameColumns.fn(input, { idMap: JSON.stringify(idMap) }, {}).rows[0].a).toEqual(
+      '(empty)'
+    );
+  });
+
   it('should keep columns which are not mapped', () => {
     const input: KibanaDatatable = {
       type: 'kibana_datatable',

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
@@ -80,6 +80,25 @@ describe('rename_columns', () => {
     );
   });
 
+  it('should replace "__missing__" with (null)', () => {
+    const input: KibanaDatatable = {
+      type: 'kibana_datatable',
+      columns: [{ id: 'a', name: 'A' }],
+      rows: [{ a: '__missing__' }],
+    };
+
+    const idMap = {
+      a: {
+        id: 'a',
+        label: 'Austrailia',
+      },
+    };
+
+    expect(renameColumns.fn(input, { idMap: JSON.stringify(idMap) }, {}).rows[0].a).toEqual(
+      '(null)'
+    );
+  });
+
   it('should keep columns which are not mapped', () => {
     const input: KibanaDatatable = {
       type: 'kibana_datatable',

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
@@ -80,25 +80,6 @@ describe('rename_columns', () => {
     );
   });
 
-  it('should replace "__missing__" with (null)', () => {
-    const input: KibanaDatatable = {
-      type: 'kibana_datatable',
-      columns: [{ id: 'a', name: 'A' }],
-      rows: [{ a: '__missing__' }],
-    };
-
-    const idMap = {
-      a: {
-        id: 'a',
-        label: 'Austrailia',
-      },
-    };
-
-    expect(renameColumns.fn(input, { idMap: JSON.stringify(idMap) }, {}).rows[0].a).toEqual(
-      '(null)'
-    );
-  });
-
   it('should keep columns which are not mapped', () => {
     const input: KibanaDatatable = {
       type: 'kibana_datatable',

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.ts
@@ -54,9 +54,9 @@ export const renameColumns: ExpressionFunction<
 
         Object.entries(row).forEach(([id, value]) => {
           if (id in idMap) {
-            mappedRow[idMap[id].id] = value;
+            mappedRow[idMap[id].id] = sanitizeValue(value);
           } else {
-            mappedRow[id] = value;
+            mappedRow[id] = sanitizeValue(value);
           }
         });
 
@@ -90,4 +90,14 @@ function getColumnName(originalColumn: OriginalColumn, newColumn: KibanaDatatabl
   }
 
   return originalColumn.label;
+}
+
+function sanitizeValue(value: unknown) {
+  if (value === '') {
+    return i18n.translate('xpack.lens.indexpattern.emptyTextColumnValue', {
+      defaultMessage: '(empty)',
+    });
+  }
+
+  return value;
 }

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.ts
@@ -10,7 +10,7 @@ import {
   KibanaDatatable,
   KibanaDatatableColumn,
 } from 'src/legacy/core_plugins/interpreter/public';
-import { IndexPatternColumn, MISSING_BUCKET_LABEL } from './operations';
+import { IndexPatternColumn } from './operations';
 
 interface RemapArgs {
   idMap: string;
@@ -96,12 +96,6 @@ function sanitizeValue(value: unknown) {
   if (value === '') {
     return i18n.translate('xpack.lens.indexpattern.emptyTextColumnValue', {
       defaultMessage: '(empty)',
-    });
-  }
-
-  if (value === MISSING_BUCKET_LABEL) {
-    return i18n.translate('xpack.lens.indexPattern.nullColumnValue', {
-      defaultMessage: '(null)',
     });
   }
 

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.ts
@@ -10,7 +10,7 @@ import {
   KibanaDatatable,
   KibanaDatatableColumn,
 } from 'src/legacy/core_plugins/interpreter/public';
-import { IndexPatternColumn } from './operations';
+import { IndexPatternColumn, MISSING_BUCKET_LABEL } from './operations';
 
 interface RemapArgs {
   idMap: string;
@@ -96,6 +96,12 @@ function sanitizeValue(value: unknown) {
   if (value === '') {
     return i18n.translate('xpack.lens.indexpattern.emptyTextColumnValue', {
       defaultMessage: '(empty)',
+    });
+  }
+
+  if (value === MISSING_BUCKET_LABEL) {
+    return i18n.translate('xpack.lens.indexPattern.nullColumnValue', {
+      defaultMessage: '(null)',
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/47282

![image](https://user-images.githubusercontent.com/833377/67413794-d7bb1000-f58f-11e9-9f5e-bf5edc9731b8.png)

We probably should allow users the ability to customize the text when they configure a string column, but that goes beyond just a bug fix.