### PR TITLE
Upgrade EUI to 14.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@elastic/charts": "^13.5.4",
     "@elastic/datemath": "5.0.2",
     "@elastic/ems-client": "1.0.5",
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/good": "8.1.1-kibana2",
     "@elastic/numeral": "2.3.3",

--- a/test/interpreter_functional/plugins/kbn_tp_run_pipeline/package.json
+++ b/test/interpreter_functional/plugins/kbn_tp_run_pipeline/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/test/plugin_functional/plugins/kbn_tp_custom_visualizations/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_custom_visualizations/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "react": "^16.8.0"
   }
 }

--- a/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "react": "^16.8.0"
   },
   "scripts": {

--- a/test/plugin_functional/plugins/kbn_tp_sample_panel_action/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_sample_panel_action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "react": "^16.8.0"
   },
   "scripts": {

--- a/test/plugin_functional/plugins/kbn_tp_visualize_embedding/package.json
+++ b/test/plugin_functional/plugins/kbn_tp_visualize_embedding/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   }

--- a/x-pack/dev-tools/jest/create_jest_config.js
+++ b/x-pack/dev-tools/jest/create_jest_config.js
@@ -13,7 +13,6 @@ export function createJestConfig({ kibanaDirectory, xPackKibanaDirectory }) {
       '<rootDir>/legacy/plugins',
       '<rootDir>/legacy/server',
       '<rootDir>/test_utils/jest/contract_tests',
-      '<rootDir>/legacy/plugins/canvas/.storybook',
     ],
     moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
     moduleNameMapper: {

--- a/x-pack/dev-tools/jest/create_jest_config.js
+++ b/x-pack/dev-tools/jest/create_jest_config.js
@@ -13,6 +13,7 @@ export function createJestConfig({ kibanaDirectory, xPackKibanaDirectory }) {
       '<rootDir>/legacy/plugins',
       '<rootDir>/legacy/server',
       '<rootDir>/test_utils/jest/contract_tests',
+      '<rootDir>/legacy/plugins/canvas/.storybook',
     ],
     moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
     moduleNameMapper: {

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -132,7 +132,11 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
               data-test-subj="tableHeaderCell_groupId_0"
               role="columnheader"
               scope="col"
-              width="96px"
+              style={
+                Object {
+                  "width": "96px",
+                }
+              }
             >
               <div
                 className="euiTableCellContent"
@@ -149,7 +153,11 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
               data-test-subj="tableHeaderCell_message_1"
               role="columnheader"
               scope="col"
-              width="50%"
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
             >
               <div
                 className="euiTableCellContent"
@@ -166,6 +174,11 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
               data-test-subj="tableHeaderCell_handled_2"
               role="columnheader"
               scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight"
@@ -182,6 +195,11 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
               data-test-subj="tableHeaderCell_occurrenceCount_3"
               role="columnheader"
               scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <button
                 className="euiTableHeaderButton"
@@ -212,6 +230,11 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
               data-test-subj="tableHeaderCell_latestOccurrenceAt_4"
               role="columnheader"
               scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <button
                 className="euiTableHeaderButton euiTableHeaderButton-isSorted"
@@ -254,6 +277,11 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
             <td
               className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
               colSpan={5}
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignCenter"
@@ -483,7 +511,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               data-test-subj="tableHeaderCell_groupId_0"
               role="columnheader"
               scope="col"
-              width="96px"
+              style={
+                Object {
+                  "width": "96px",
+                }
+              }
             >
               <div
                 className="euiTableCellContent"
@@ -500,7 +532,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               data-test-subj="tableHeaderCell_message_1"
               role="columnheader"
               scope="col"
-              width="50%"
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
             >
               <div
                 className="euiTableCellContent"
@@ -517,6 +553,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               data-test-subj="tableHeaderCell_handled_2"
               role="columnheader"
               scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight"
@@ -533,6 +574,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               data-test-subj="tableHeaderCell_occurrenceCount_3"
               role="columnheader"
               scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <button
                 className="euiTableHeaderButton"
@@ -563,6 +609,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
               data-test-subj="tableHeaderCell_latestOccurrenceAt_4"
               role="columnheader"
               scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <button
                 className="euiTableHeaderButton euiTableHeaderButton-isSorted"
@@ -604,7 +655,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
           >
             <td
               className="euiTableRowCell"
-              width="96px"
+              style={
+                Object {
+                  "width": "96px",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -630,7 +685,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
-              width="50%"
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -684,6 +743,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
@@ -691,6 +755,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -705,6 +774,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -723,7 +797,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
           >
             <td
               className="euiTableRowCell"
-              width="96px"
+              style={
+                Object {
+                  "width": "96px",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -749,7 +827,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
-              width="50%"
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -803,6 +885,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
@@ -810,6 +897,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -824,6 +916,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -842,7 +939,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
           >
             <td
               className="euiTableRowCell"
-              width="96px"
+              style={
+                Object {
+                  "width": "96px",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -868,7 +969,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
-              width="50%"
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -922,6 +1027,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
@@ -929,6 +1039,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -943,6 +1058,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -961,7 +1081,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
           >
             <td
               className="euiTableRowCell"
-              width="96px"
+              style={
+                Object {
+                  "width": "96px",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -987,7 +1111,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
-              width="50%"
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1041,6 +1169,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
@@ -1048,6 +1181,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1062,6 +1200,11 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
             </td>
             <td
               className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
             >
               <div
                 className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
@@ -143,7 +143,7 @@ NodeList [
   >
     <td
       class="euiTableRowCell"
-      width="40%"
+      style="width: 40%;"
     >
       <div
         class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -168,7 +168,7 @@ NodeList [
     </td>
     <td
       class="euiTableRowCell"
-      width="20%"
+      style="width: 20%;"
     >
       <div
         class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -241,7 +241,7 @@ NodeList [
   >
     <td
       class="euiTableRowCell"
-      width="40%"
+      style="width: 40%;"
     >
       <div
         class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -266,7 +266,7 @@ NodeList [
     </td>
     <td
       class="euiTableRowCell"
-      width="20%"
+      style="width: 20%;"
     >
       <div
         class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -81,7 +81,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
 
   const infraConfigItems: InfraConfigItem[] = [
     {
-      icon: 'loggingApp',
+      icon: 'logsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showPodLogsLinkLabel',
         { defaultMessage: 'Show pod logs' }
@@ -91,7 +91,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       query: { time }
     },
     {
-      icon: 'loggingApp',
+      icon: 'logsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showContainerLogsLinkLabel',
         { defaultMessage: 'Show container logs' }
@@ -101,7 +101,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       query: { time }
     },
     {
-      icon: 'loggingApp',
+      icon: 'logsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showHostLogsLinkLabel',
         { defaultMessage: 'Show host logs' }
@@ -111,7 +111,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       query: { time }
     },
     {
-      icon: 'loggingApp',
+      icon: 'logsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showTraceLogsLinkLabel',
         { defaultMessage: 'Show trace logs' }
@@ -124,7 +124,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       }
     },
     {
-      icon: 'infraApp',
+      icon: 'metricsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showPodMetricsLinkLabel',
         { defaultMessage: 'Show pod metrics' }
@@ -134,7 +134,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       query: infraMetricsQuery
     },
     {
-      icon: 'infraApp',
+      icon: 'metricsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showContainerMetricsLinkLabel',
         { defaultMessage: 'Show container metrics' }
@@ -144,7 +144,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = (
       query: infraMetricsQuery
     },
     {
-      icon: 'infraApp',
+      icon: 'metricsApp',
       label: i18n.translate(
         'xpack.apm.transactionActionMenu.showHostMetricsLinkLabel',
         { defaultMessage: 'Show host metrics' }

--- a/x-pack/legacy/plugins/canvas/public/components/asset_manager/__examples__/__snapshots__/asset.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/public/components/asset_manager/__examples__/__snapshots__/asset.examples.storyshot
@@ -19,16 +19,17 @@ exports[`Storyshots components/Assets/Asset airplane 1`] = `
       >
         <figure
           className="euiImage canvasAsset__img"
-          style={
-            Object {
-              "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4=)",
-            }
-          }
+          role="figure"
         >
           <img
             alt="Asset thumbnail"
             className="euiImage__img"
             src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4="
+            style={
+              Object {
+                "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4=)",
+              }
+            }
           />
         </figure>
       </div>
@@ -213,16 +214,17 @@ exports[`Storyshots components/Assets/Asset marker 1`] = `
       >
         <figure
           className="euiImage canvasAsset__img"
-          style={
-            Object {
-              "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4=)",
-            }
-          }
+          role="figure"
         >
           <img
             alt="Asset thumbnail"
             className="euiImage__img"
             src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4="
+            style={
+              Object {
+                "backgroundImage": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzOC4zOSA1Ny41NyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMTliOGY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkxvY2F0aW9uIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTkuMTksMUExOC4xOSwxOC4xOSwwLDAsMCwyLjk0LDI3LjM2aDBhMTkuNTEsMTkuNTEsMCwwLDAsMSwxLjc4TDE5LjE5LDU1LjU3LDM0LjM4LDI5LjIxQTE4LjE5LDE4LjE5LDAsMCwwLDE5LjE5LDFabTAsMjMuMjlhNS41Myw1LjUzLDAsMSwxLDUuNTMtNS41M0E1LjUzLDUuNTMsMCwwLDEsMTkuMTksMjQuMjlaIi8+PC9nPjwvZz48L3N2Zz4=)",
+              }
+            }
           />
         </figure>
       </div>

--- a/x-pack/legacy/plugins/code/public/components/file_tree/__snapshots__/file_tree.test.tsx.snap
+++ b/x-pack/legacy/plugins/code/public/components/file_tree/__snapshots__/file_tree.test.tsx.snap
@@ -28,23 +28,11 @@ exports[`render correctly 1`] = `
   </button>
   <div
     className="euiSideNav__content"
-    role="menubar"
   >
     <div
       className="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
-        aria-label={
-          <span
-            className="euiSideNavItemButton__content"
-          >
-            <span
-              className="euiSideNavItemButton__label"
-            >
-              
-            </span>
-          </span>
-        }
         className="euiSideNavItemButton"
       >
         <span

--- a/x-pack/legacy/plugins/code/public/components/symbol_tree/__test__/__snapshots__/symbol_tree.test.tsx.snap
+++ b/x-pack/legacy/plugins/code/public/components/symbol_tree/__test__/__snapshots__/symbol_tree.test.tsx.snap
@@ -31,23 +31,11 @@ exports[`render symbol tree correctly 1`] = `
     </button>
     <div
       className="euiSideNav__content"
-      role="menubar"
     >
       <div
         className="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
       >
         <div
-          aria-label={
-            <span
-              className="euiSideNavItemButton__content"
-            >
-              <span
-                className="euiSideNavItemButton__label"
-              >
-                
-              </span>
-            </span>
-          }
           className="euiSideNavItemButton"
         >
           <span

--- a/x-pack/legacy/plugins/infra/index.ts
+++ b/x-pack/legacy/plugins/infra/index.ts
@@ -43,7 +43,7 @@ export function infra(kibana: any) {
             defaultMessage: 'Explore your metrics',
           }),
           icon: 'plugins/infra/images/infra_mono_white.svg',
-          euiIconType: 'infraApp',
+          euiIconType: 'metricsApp',
           id: 'infra:home',
           order: 8000,
           title: i18n.translate('xpack.infra.linkInfrastructureTitle', {
@@ -56,7 +56,7 @@ export function infra(kibana: any) {
             defaultMessage: 'Explore your logs',
           }),
           icon: 'plugins/infra/images/logging_mono_white.svg',
-          euiIconType: 'loggingApp',
+          euiIconType: 'logsApp',
           id: 'infra:logs',
           order: 8001,
           title: i18n.translate('xpack.infra.linkLogsTitle', {
@@ -76,7 +76,7 @@ export function infra(kibana: any) {
         {
           path: `/app/${APP_ID}#/logs`,
           label: logsSampleDataLinkLabel,
-          icon: 'loggingApp',
+          icon: 'logsApp',
         },
       ]);
     },

--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart_context_menu.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart_context_menu.tsx
@@ -96,7 +96,7 @@ export const MetricsExplorerChartContextMenu = ({
           name: i18n.translate('xpack.infra.metricsExplorer.filterByLabel', {
             defaultMessage: 'Add filter',
           }),
-          icon: 'infraApp',
+          icon: 'metricsApp',
           onClick: handleFilter,
           'data-test-subj': 'metricsExplorerAction-AddFilter',
         },
@@ -111,7 +111,7 @@ export const MetricsExplorerChartContextMenu = ({
             defaultMessage: 'View metrics for {name}',
             values: { name: nodeType },
           }),
-          icon: 'infraApp',
+          icon: 'metricsApp',
           href: createNodeDetailLink(nodeType, series.id, timeRange.from, timeRange.to),
           'data-test-subj': 'metricsExplorerAction-ViewNodeMetrics',
         },

--- a/x-pack/legacy/plugins/infra/public/register_feature.ts
+++ b/x-pack/legacy/plugins/infra/public/register_feature.ts
@@ -21,7 +21,7 @@ FeatureCatalogueRegistryProvider.register((i18n: I18nServiceType) => ({
     defaultMessage:
       'Explore infrastructure metrics and logs for common servers, containers, and services.',
   }),
-  icon: 'infraApp',
+  icon: 'metricsApp',
   path: `/app/${APP_ID}#infrastructure`,
   showOnHomePage: true,
   category: FeatureCatalogueCategory.DATA,
@@ -36,7 +36,7 @@ FeatureCatalogueRegistryProvider.register((i18n: I18nServiceType) => ({
     defaultMessage:
       'Stream logs in real time or scroll through historical views in a console-like experience.',
   }),
-  icon: 'loggingApp',
+  icon: 'logsApp',
   path: `/app/${APP_ID}#logs`,
   showOnHomePage: true,
   category: FeatureCatalogueCategory.DATA,

--- a/x-pack/legacy/plugins/infra/server/kibana.index.ts
+++ b/x-pack/legacy/plugins/infra/server/kibana.index.ts
@@ -35,7 +35,7 @@ export const initServerWithKibana = (kbnServer: KbnServer) => {
     name: i18n.translate('xpack.infra.featureRegistry.linkInfrastructureTitle', {
       defaultMessage: 'Metrics',
     }),
-    icon: 'infraApp',
+    icon: 'metricsApp',
     navLinkId: 'infra:home',
     app: ['infra', 'kibana'],
     catalogue: ['infraops'],
@@ -73,7 +73,7 @@ export const initServerWithKibana = (kbnServer: KbnServer) => {
     name: i18n.translate('xpack.infra.featureRegistry.linkLogsTitle', {
       defaultMessage: 'Logs',
     }),
-    icon: 'loggingApp',
+    icon: 'logsApp',
     navLinkId: 'infra:logs',
     app: ['infra', 'kibana'],
     catalogue: ['infralogging'],

--- a/x-pack/legacy/plugins/ml/server/models/data_recognizer/modules/logs_ui_analysis/logo.json
+++ b/x-pack/legacy/plugins/ml/server/models/data_recognizer/modules/logs_ui_analysis/logo.json
@@ -1,3 +1,3 @@
 {
-  "icon": "loggingApp"
+  "icon": "logsApp"
 }

--- a/x-pack/legacy/plugins/monitoring/public/components/logs/__snapshots__/logs.test.js.snap
+++ b/x-pack/legacy/plugins/monitoring/public/components/logs/__snapshots__/logs.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Logs should render a link to filter by cluster uuid 1`] = `
 <EuiCallOut
-  iconType="loggingApp"
+  iconType="logsApp"
   size="m"
   title="Want to see more log entries?"
 >
@@ -26,7 +26,7 @@ exports[`Logs should render a link to filter by cluster uuid 1`] = `
 
 exports[`Logs should render a link to filter by cluster uuid and index uuid 1`] = `
 <EuiCallOut
-  iconType="loggingApp"
+  iconType="logsApp"
   size="m"
   title="Want to see more log entries?"
 >
@@ -50,7 +50,7 @@ exports[`Logs should render a link to filter by cluster uuid and index uuid 1`] 
 
 exports[`Logs should render a link to filter by cluster uuid and node uuid 1`] = `
 <EuiCallOut
-  iconType="loggingApp"
+  iconType="logsApp"
   size="m"
   title="Want to see more log entries?"
 >
@@ -275,7 +275,7 @@ exports[`Logs should render normally 1`] = `
     size="m"
   />
   <EuiCallOut
-    iconType="loggingApp"
+    iconType="logsApp"
     size="m"
     title="Want to see more log entries?"
   >

--- a/x-pack/legacy/plugins/monitoring/public/components/logs/logs.js
+++ b/x-pack/legacy/plugins/monitoring/public/components/logs/logs.js
@@ -169,7 +169,7 @@ export class Logs extends PureComponent {
         title={i18n.translate('xpack.monitoring.logs.listing.calloutTitle', {
           defaultMessage: 'Want to see more log entries?'
         })}
-        iconType="loggingApp"
+        iconType="logsApp"
       >
         <p>
           <FormattedMessage

--- a/x-pack/legacy/plugins/reporting/public/components/__snapshots__/report_listing.test.tsx.snap
+++ b/x-pack/legacy/plugins/reporting/public/components/__snapshots__/report_listing.test.tsx.snap
@@ -112,6 +112,11 @@ Array [
                       data-test-subj="tableHeaderCell_object_title_0"
                       role="columnheader"
                       scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
                     >
                       <div
                         className="euiTableCellContent"
@@ -134,6 +139,11 @@ Array [
                       data-test-subj="tableHeaderCell_created_at_1"
                       role="columnheader"
                       scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
                     >
                       <div
                         className="euiTableCellContent"
@@ -156,6 +166,11 @@ Array [
                       data-test-subj="tableHeaderCell_status_2"
                       role="columnheader"
                       scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
                     >
                       <div
                         className="euiTableCellContent"
@@ -176,6 +191,11 @@ Array [
                       className="euiTableHeaderCell"
                       role="columnheader"
                       scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
                     >
                       <div
                         className="euiTableCellContent euiTableCellContent--alignRight"
@@ -205,6 +225,11 @@ Array [
                       <td
                         className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
                         colSpan={4}
+                        style={
+                          Object {
+                            "width": undefined,
+                          }
+                        }
                       >
                         <div
                           className="euiTableCellContent euiTableCellContent--alignCenter"
@@ -362,6 +387,11 @@ Array [
                     data-test-subj="tableHeaderCell_object_title_0"
                     role="columnheader"
                     scope="col"
+                    style={
+                      Object {
+                        "width": undefined,
+                      }
+                    }
                   >
                     <div
                       className="euiTableCellContent"
@@ -384,6 +414,11 @@ Array [
                     data-test-subj="tableHeaderCell_created_at_1"
                     role="columnheader"
                     scope="col"
+                    style={
+                      Object {
+                        "width": undefined,
+                      }
+                    }
                   >
                     <div
                       className="euiTableCellContent"
@@ -406,6 +441,11 @@ Array [
                     data-test-subj="tableHeaderCell_status_2"
                     role="columnheader"
                     scope="col"
+                    style={
+                      Object {
+                        "width": undefined,
+                      }
+                    }
                   >
                     <div
                       className="euiTableCellContent"
@@ -426,6 +466,11 @@ Array [
                     className="euiTableHeaderCell"
                     role="columnheader"
                     scope="col"
+                    style={
+                      Object {
+                        "width": undefined,
+                      }
+                    }
                   >
                     <div
                       className="euiTableCellContent euiTableCellContent--alignRight"
@@ -455,6 +500,11 @@ Array [
                     <td
                       className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
                       colSpan={4}
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
                     >
                       <div
                         className="euiTableCellContent euiTableCellContent--alignCenter"

--- a/x-pack/legacy/plugins/uptime/public/components/functional/__tests__/__snapshots__/integration_group.test.tsx.snap
+++ b/x-pack/legacy/plugins/uptime/public/components/functional/__tests__/__snapshots__/integration_group.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`IntegrationGroup will not display APM links when APM is unavailable 1`]
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Infrastructure UI for this montor's ip address"
-      iconType="infraApp"
+      iconType="metricsApp"
       message="Show host metrics"
       tooltipContent="Check Infrastructure UI for the IP \\"\\""
     />
@@ -15,7 +15,7 @@ exports[`IntegrationGroup will not display APM links when APM is unavailable 1`]
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Infrastructure UI for this monitor's pod UID"
-      iconType="infraApp"
+      iconType="metricsApp"
       message="Show pod metrics"
       tooltipContent="Check Infrastructure UI for pod UID \\"\\"."
     />
@@ -23,7 +23,7 @@ exports[`IntegrationGroup will not display APM links when APM is unavailable 1`]
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Infrastructure UI for this monitor's container ID"
-      iconType="infraApp"
+      iconType="metricsApp"
       message="Show container metrics"
       tooltipContent="Check Infrastructure UI for container ID \\"\\""
     />
@@ -31,7 +31,7 @@ exports[`IntegrationGroup will not display APM links when APM is unavailable 1`]
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Logging UI for this monitor's ip address"
-      iconType="loggingApp"
+      iconType="logsApp"
       message="Show host logs"
       tooltipContent="Check Logging UI for the IP \\"\\""
     />
@@ -39,7 +39,7 @@ exports[`IntegrationGroup will not display APM links when APM is unavailable 1`]
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Show pod logs"
-      iconType="loggingApp"
+      iconType="logsApp"
       message="Show pod logs"
       tooltipContent="Check for logs for pod UID \\"\\""
     />
@@ -47,7 +47,7 @@ exports[`IntegrationGroup will not display APM links when APM is unavailable 1`]
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Show container logs"
-      iconType="loggingApp"
+      iconType="logsApp"
       message="Show container logs"
       tooltipContent="Check Logging UI for container ID \\"\\""
     />
@@ -71,7 +71,7 @@ exports[`IntegrationGroup will not display infra links when infra is unavailable
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Logging UI for this monitor's ip address"
-      iconType="loggingApp"
+      iconType="logsApp"
       message="Show host logs"
       tooltipContent="Check Logging UI for the IP \\"\\""
     />
@@ -79,7 +79,7 @@ exports[`IntegrationGroup will not display infra links when infra is unavailable
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Show pod logs"
-      iconType="loggingApp"
+      iconType="logsApp"
       message="Show pod logs"
       tooltipContent="Check for logs for pod UID \\"\\""
     />
@@ -87,7 +87,7 @@ exports[`IntegrationGroup will not display infra links when infra is unavailable
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Show container logs"
-      iconType="loggingApp"
+      iconType="logsApp"
       message="Show container logs"
       tooltipContent="Check Logging UI for container ID \\"\\""
     />
@@ -111,7 +111,7 @@ exports[`IntegrationGroup will not display logging links when logging is unavail
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Infrastructure UI for this montor's ip address"
-      iconType="infraApp"
+      iconType="metricsApp"
       message="Show host metrics"
       tooltipContent="Check Infrastructure UI for the IP \\"\\""
     />
@@ -119,7 +119,7 @@ exports[`IntegrationGroup will not display logging links when logging is unavail
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Infrastructure UI for this monitor's pod UID"
-      iconType="infraApp"
+      iconType="metricsApp"
       message="Show pod metrics"
       tooltipContent="Check Infrastructure UI for pod UID \\"\\"."
     />
@@ -127,7 +127,7 @@ exports[`IntegrationGroup will not display logging links when logging is unavail
   <EuiFlexItem>
     <IntegrationLink
       ariaLabel="Check Infrastructure UI for this monitor's container ID"
-      iconType="infraApp"
+      iconType="metricsApp"
       message="Show container metrics"
       tooltipContent="Check Infrastructure UI for container ID \\"\\""
     />

--- a/x-pack/legacy/plugins/uptime/public/components/functional/integration_group.tsx
+++ b/x-pack/legacy/plugins/uptime/public/components/functional/integration_group.tsx
@@ -87,7 +87,7 @@ export const IntegrationGroup = ({
                 }
               )}
               href={getInfraIpHref(summary, basePath)}
-              iconType="infraApp"
+              iconType="metricsApp"
               message={i18n.translate(
                 'xpack.uptime.monitorList.infraIntegrationAction.ip.message',
                 {
@@ -116,7 +116,7 @@ export const IntegrationGroup = ({
                 }
               )}
               href={getInfraKubernetesHref(summary, basePath)}
-              iconType="infraApp"
+              iconType="metricsApp"
               message={i18n.translate(
                 'xpack.uptime.monitorList.infraIntegrationAction.kubernetes.message',
                 {
@@ -145,7 +145,7 @@ export const IntegrationGroup = ({
                 }
               )}
               href={getInfraContainerHref(summary, basePath)}
-              iconType="infraApp"
+              iconType="metricsApp"
               message={i18n.translate(
                 'xpack.uptime.monitorList.infraIntegrationAction.container.message',
                 {
@@ -177,7 +177,7 @@ export const IntegrationGroup = ({
                 }
               )}
               href={getLoggingIpHref(summary, basePath)}
-              iconType="loggingApp"
+              iconType="logsApp"
               message={i18n.translate(
                 'xpack.uptime.monitorList.loggingIntegrationAction.ip.message',
                 {
@@ -200,7 +200,7 @@ export const IntegrationGroup = ({
                 }
               )}
               href={getLoggingKubernetesHref(summary, basePath)}
-              iconType="loggingApp"
+              iconType="logsApp"
               message={i18n.translate(
                 'xpack.uptime.monitorList.loggingIntegrationAction.kubernetes.message',
                 {
@@ -227,7 +227,7 @@ export const IntegrationGroup = ({
                 }
               )}
               href={getLoggingContainerHref(summary, basePath)}
-              iconType="loggingApp"
+              iconType="logsApp"
               message={i18n.translate(
                 'xpack.uptime.monitorList.loggingIntegrationAction.container.message',
                 {

--- a/x-pack/legacy/plugins/uptime/public/components/functional/integration_link.tsx
+++ b/x-pack/legacy/plugins/uptime/public/components/functional/integration_link.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 interface IntegrationLinkProps {
   ariaLabel: string;
   href: string | undefined;
-  iconType: 'apmApp' | 'infraApp' | 'loggingApp';
+  iconType: 'apmApp' | 'metricsApp' | 'logsApp';
   message: string;
   tooltipContent: string;
 }

--- a/x-pack/legacy/plugins/watcher/common/types/action_types.ts
+++ b/x-pack/legacy/plugins/watcher/common/types/action_types.ts
@@ -34,7 +34,7 @@ export interface EmailAction extends BaseAction {
 
 export interface LoggingAction extends BaseAction {
   type: LoggingActionType;
-  iconClass: 'loggingApp';
+  iconClass: 'logsApp';
   text: string;
 }
 

--- a/x-pack/legacy/plugins/watcher/public/models/action/logging_action.js
+++ b/x-pack/legacy/plugins/watcher/public/models/action/logging_action.js
@@ -68,7 +68,7 @@ export class LoggingAction extends BaseAction {
   static typeName = i18n.translate('xpack.watcher.models.loggingAction.typeName', {
     defaultMessage: 'Logging',
   });
-  static iconClass = 'loggingApp';
+  static iconClass = 'logsApp';
   static selectMessage = i18n.translate('xpack.watcher.models.loggingAction.selectMessageText', {
     defaultMessage: 'Add an item to the logs.',
   });

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -194,7 +194,7 @@
     "@elastic/ctags-langserver": "^0.1.11",
     "@elastic/datemath": "5.0.2",
     "@elastic/ems-client": "1.0.5",
-    "@elastic/eui": "14.5.0",
+    "@elastic/eui": "14.7.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/javascript-typescript-langserver": "^0.3.3",
     "@elastic/lsp-extension": "^0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,10 +1153,10 @@
     tabbable "^1.1.0"
     uuid "^3.1.0"
 
-"@elastic/eui@14.5.0":
-  version "14.5.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-14.5.0.tgz#1b27559cd644403e2692cab1549082cbd3421dab"
-  integrity sha512-QpmfO6Unt4evb4P18CyWzassLFrw/4CUPFYZXQK12IChDOs6GrwQ6xZM8f0wjN/NXwjRjlWzMhtCWHYmrI6NGg==
+"@elastic/eui@14.7.0":
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-14.7.0.tgz#dcbd3e9a9307e52a2fdca5833a116de5940de06d"
+  integrity sha512-IjYjUqhfqjqG6cbaTANiuHyWq3U62ODzcOnIKACxHOGCK2JVwiDvtDByAuj3PvD0wG/cDN49oNbUZ/o0QCapVw==
   dependencies:
     "@types/lodash" "^4.14.116"
     "@types/numeral" "^0.0.25"


### PR DESCRIPTION
Most of the changes are from updated icons: `ifraApp` became `metricsApp`, and `loggingApp` became `logsApp`.

___

## [`14.7.0`](https://github.com/elastic/eui/tree/v14.7.0)

- Converted `EuiRadio` and `EuiRadioGroup` to TypeScript ([#2438](https://github.com/elastic/eui/pull/2438))
- Improved a11y in `EuiImage` ([#2447](https://github.com/elastic/eui/pull/2447))
- Made EuiIcon a PureComponent, to speed up React re-render performance ([#2448](https://github.com/elastic/eui/pull/2448))
- Added ability for `EuiColorStops` to accept user-defined range bounds ([#2396](https://github.com/elastic/eui/pull/2396))
- Added `external` prop to `EuiLink` ([#2442](https://github.com/elastic/eui/pull/2442))
- Added disabled state to `EuiBadge` ([#2440](https://github.com/elastic/eui/pull/2440))
- Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
- Added `minimize` glyph to `EuiIcon` ([#2457](https://github.com/elastic/eui/pull/2457))

**Bug fixes**

- Reenabled `width` property for `EuiTable` cell components ([#2452](https://github.com/elastic/eui/pull/2452))
- Fixed `EuiNavDrawer` collapse/expand button height issue
 ([#2463](https://github.com/elastic/eui/pull/2463))

## [`14.6.0`](https://github.com/elastic/eui/tree/v14.6.0)

- Added new updated `infraApp` and `logsApp` icons. ([#2430](https://github.com/elastic/eui/pull/2430))

**Bug fixes**

- Fixed missing misc. button and link type definition exports ([#2434](https://github.com/elastic/eui/pull/2434))
- Strip custom semantics from `EuiSideNav` ([#2429](https://github.com/elastic/eui/pull/2429))
