### PR TITLE
Consistent capitalization for savedObjectsClientMock

### DIFF
--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -29,7 +29,7 @@ export { configServiceMock } from './config/config_service.mock';
 export { elasticsearchServiceMock } from './elasticsearch/elasticsearch_service.mock';
 export { httpServiceMock } from './http/http_service.mock';
 export { loggingServiceMock } from './logging/logging_service.mock';
-export { SavedObjectsClientMock } from './saved_objects/service/saved_objects_client.mock';
+export { savedObjectsClientMock } from './saved_objects/service/saved_objects_client.mock';
 export { uiSettingsServiceMock } from './ui_settings/ui_settings_service.mock';
 
 export function pluginInitializerContextConfigMock<T>(config: T) {

--- a/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
+++ b/src/core/server/saved_objects/export/get_sorted_objects_for_export.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { getSortedObjectsForExport } from './get_sorted_objects_for_export';
-import { SavedObjectsClientMock } from '../service/saved_objects_client.mock';
+import { savedObjectsClientMock } from '../service/saved_objects_client.mock';
 import { Readable } from 'stream';
 import { createPromiseFromStreams, createConcatStream } from '../../../../legacy/utils/streams';
 
@@ -27,7 +27,7 @@ async function readStreamToCompletion(stream: Readable) {
 }
 
 describe('getSortedObjectsForExport()', () => {
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   afterEach(() => {
     savedObjectsClient.find.mockReset();

--- a/src/core/server/saved_objects/export/inject_nested_depdendencies.test.ts
+++ b/src/core/server/saved_objects/export/inject_nested_depdendencies.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { SavedObject } from '../types';
-import { SavedObjectsClientMock } from '../../mocks';
+import { savedObjectsClientMock } from '../../mocks';
 import { getObjectReferencesToFetch, fetchNestedDependencies } from './inject_nested_depdendencies';
 
 describe('getObjectReferencesToFetch()', () => {
@@ -109,7 +109,7 @@ describe('getObjectReferencesToFetch()', () => {
 });
 
 describe('injectNestedDependencies', () => {
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/src/core/server/saved_objects/import/import_saved_objects.test.ts
+++ b/src/core/server/saved_objects/import/import_saved_objects.test.ts
@@ -20,7 +20,7 @@
 import { Readable } from 'stream';
 import { SavedObject } from '../types';
 import { importSavedObjects } from './import_saved_objects';
-import { SavedObjectsClientMock } from '../../mocks';
+import { savedObjectsClientMock } from '../../mocks';
 
 const emptyResponse = {
   saved_objects: [],
@@ -63,7 +63,7 @@ describe('importSavedObjects()', () => {
       references: [],
     },
   ];
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/core/server/saved_objects/import/resolve_import_errors.test.ts
+++ b/src/core/server/saved_objects/import/resolve_import_errors.test.ts
@@ -20,7 +20,7 @@
 import { Readable } from 'stream';
 import { SavedObject } from '../types';
 import { resolveImportErrors } from './resolve_import_errors';
-import { SavedObjectsClientMock } from '../../mocks';
+import { savedObjectsClientMock } from '../../mocks';
 
 describe('resolveImportErrors()', () => {
   const savedObjects: SavedObject[] = [
@@ -63,7 +63,7 @@ describe('resolveImportErrors()', () => {
       ],
     },
   ];
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/core/server/saved_objects/import/validate_references.test.ts
+++ b/src/core/server/saved_objects/import/validate_references.test.ts
@@ -18,10 +18,10 @@
  */
 
 import { getNonExistingReferenceAsKeys, validateReferences } from './validate_references';
-import { SavedObjectsClientMock } from '../../mocks';
+import { savedObjectsClientMock } from '../../mocks';
 
 describe('getNonExistingReferenceAsKeys()', () => {
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -222,7 +222,7 @@ describe('getNonExistingReferenceAsKeys()', () => {
 });
 
 describe('validateReferences()', () => {
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/src/core/server/saved_objects/service/saved_objects_client.mock.ts
+++ b/src/core/server/saved_objects/service/saved_objects_client.mock.ts
@@ -33,4 +33,4 @@ const create = () =>
     update: jest.fn(),
   } as unknown) as jest.Mocked<SavedObjectsClientContract>);
 
-export const SavedObjectsClientMock = { create };
+export const savedObjectsClientMock = { create };

--- a/src/core/server/ui_settings/ui_settings_service.test.ts
+++ b/src/core/server/ui_settings/ui_settings_service.test.ts
@@ -23,7 +23,7 @@ import { MockUiSettingsClientConstructor } from './ui_settings_service.test.mock
 import { UiSettingsService } from './ui_settings_service';
 import { httpServiceMock } from '../http/http_service.mock';
 import { loggingServiceMock } from '../logging/logging_service.mock';
-import { SavedObjectsClientMock } from '../mocks';
+import { savedObjectsClientMock } from '../mocks';
 import { mockCoreContext } from '../core_context.mock';
 
 const overrides = {
@@ -43,7 +43,7 @@ const coreContext = mockCoreContext.create();
 coreContext.configService.atPath.mockReturnValue(new BehaviorSubject({ overrides }));
 const httpSetup = httpServiceMock.createSetupContract();
 const setupDeps = { http: httpSetup };
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 
 afterEach(() => {
   MockUiSettingsClientConstructor.mockClear();

--- a/src/legacy/core_plugins/kibana/server/lib/export/collect_references_deep.test.ts
+++ b/src/legacy/core_plugins/kibana/server/lib/export/collect_references_deep.test.ts
@@ -19,7 +19,7 @@
 
 import { SavedObject, SavedObjectAttributes } from 'src/core/server';
 import { collectReferencesDeep } from './collect_references_deep';
-import { SavedObjectsClientMock } from '../../../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../core/server/mocks';
 
 const data: Array<SavedObject<SavedObjectAttributes>> = [
   {
@@ -102,7 +102,7 @@ const data: Array<SavedObject<SavedObjectAttributes>> = [
 ];
 
 test('collects dashboard and all dependencies', async () => {
-  const savedObjectClient = SavedObjectsClientMock.create();
+  const savedObjectClient = savedObjectsClientMock.create();
   savedObjectClient.bulkGet.mockImplementation(objects => {
     if (!objects) {
       throw new Error('Invalid test data');

--- a/src/legacy/server/saved_objects/routes/bulk_create.test.ts
+++ b/src/legacy/server/saved_objects/routes/bulk_create.test.ts
@@ -22,11 +22,11 @@ import { createMockServer } from './_mock_server';
 import { createBulkCreateRoute } from './bulk_create';
 // Disable lint errors for imports from src/core/* until SavedObjects migration is complete
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { SavedObjectsClientMock } from '../../../../core/server/saved_objects/service/saved_objects_client.mock';
+import { savedObjectsClientMock } from '../../../../core/server/saved_objects/service/saved_objects_client.mock';
 
 describe('POST /api/saved_objects/_bulk_create', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     savedObjectsClient.bulkCreate.mockImplementation(() => Promise.resolve('' as any));

--- a/src/legacy/server/saved_objects/routes/bulk_get.test.ts
+++ b/src/legacy/server/saved_objects/routes/bulk_get.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createBulkGetRoute } from './bulk_get';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('POST /api/saved_objects/_bulk_get', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     savedObjectsClient.bulkGet.mockImplementation(() =>

--- a/src/legacy/server/saved_objects/routes/bulk_update.test.ts
+++ b/src/legacy/server/saved_objects/routes/bulk_update.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createBulkUpdateRoute } from './bulk_update';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('PUT /api/saved_objects/_bulk_update', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     server = createMockServer();

--- a/src/legacy/server/saved_objects/routes/create.test.ts
+++ b/src/legacy/server/saved_objects/routes/create.test.ts
@@ -20,7 +20,7 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createCreateRoute } from './create';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('POST /api/saved_objects/{type}', () => {
   let server: Hapi.Server;
@@ -32,7 +32,7 @@ describe('POST /api/saved_objects/{type}', () => {
     references: [],
     attributes: {},
   };
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     savedObjectsClient.create.mockImplementation(() => Promise.resolve(clientResponse));

--- a/src/legacy/server/saved_objects/routes/delete.test.ts
+++ b/src/legacy/server/saved_objects/routes/delete.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createDeleteRoute } from './delete';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('DELETE /api/saved_objects/{type}/{id}', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     savedObjectsClient.delete.mockImplementation(() => Promise.resolve('{}'));

--- a/src/legacy/server/saved_objects/routes/export.test.ts
+++ b/src/legacy/server/saved_objects/routes/export.test.ts
@@ -28,14 +28,14 @@ import * as exportMock from '../../../../core/server/saved_objects/export';
 import { createMockServer } from './_mock_server';
 import { createExportRoute } from './export';
 import { createListStream } from '../../../utils/streams';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 const getSortedObjectsForExport = exportMock.getSortedObjectsForExport as jest.Mock;
 
 describe('POST /api/saved_objects/_export', () => {
   let server: Hapi.Server;
   const savedObjectsClient = {
-    ...SavedObjectsClientMock.create(),
+    ...savedObjectsClientMock.create(),
     errors: {} as any,
   };
 

--- a/src/legacy/server/saved_objects/routes/find.test.ts
+++ b/src/legacy/server/saved_objects/routes/find.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createFindRoute } from './find';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('GET /api/saved_objects/_find', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   const clientResponse = {
     total: 0,

--- a/src/legacy/server/saved_objects/routes/get.test.ts
+++ b/src/legacy/server/saved_objects/routes/get.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createGetRoute } from './get';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('GET /api/saved_objects/{type}/{id}', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     savedObjectsClient.get.mockImplementation(() =>

--- a/src/legacy/server/saved_objects/routes/import.test.ts
+++ b/src/legacy/server/saved_objects/routes/import.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createImportRoute } from './import';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('POST /api/saved_objects/_import', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
   const emptyResponse = {
     saved_objects: [],
     total: 0,

--- a/src/legacy/server/saved_objects/routes/resolve_import_errors.test.ts
+++ b/src/legacy/server/saved_objects/routes/resolve_import_errors.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createResolveImportErrorsRoute } from './resolve_import_errors';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('POST /api/saved_objects/_resolve_import_errors', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     server = createMockServer();

--- a/src/legacy/server/saved_objects/routes/update.test.ts
+++ b/src/legacy/server/saved_objects/routes/update.test.ts
@@ -20,11 +20,11 @@
 import Hapi from 'hapi';
 import { createMockServer } from './_mock_server';
 import { createUpdateRoute } from './update';
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 
 describe('PUT /api/saved_objects/{type}/{id?}', () => {
   let server: Hapi.Server;
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
 
   beforeEach(() => {
     const clientResponse = {

--- a/src/legacy/ui/ui_settings/integration_tests/ui_settings_mixin.test.ts
+++ b/src/legacy/ui/ui_settings/integration_tests/ui_settings_mixin.test.ts
@@ -20,7 +20,7 @@
 import sinon from 'sinon';
 import expect from '@kbn/expect';
 
-import { SavedObjectsClientMock } from '../../../../core/server/mocks';
+import { savedObjectsClientMock } from '../../../../core/server/mocks';
 import * as uiSettingsServiceFactoryNS from '../ui_settings_service_factory';
 import * as getUiSettingsServiceForRequestNS from '../ui_settings_service_for_request';
 // @ts-ignore
@@ -129,7 +129,7 @@ describe('uiSettingsMixin()', () => {
 
       sinon.assert.notCalled(uiSettingsServiceFactoryStub);
 
-      const savedObjectsClient = SavedObjectsClientMock.create();
+      const savedObjectsClient = savedObjectsClientMock.create();
       decorations.server.uiSettingsServiceFactory({
         savedObjectsClient,
       });

--- a/x-pack/legacy/plugins/actions/server/actions_client.test.ts
+++ b/x-pack/legacy/plugins/actions/server/actions_client.test.ts
@@ -11,9 +11,9 @@ import { ActionsClient } from './actions_client';
 import { ExecutorType } from './types';
 import { ActionExecutor, TaskRunnerFactory } from './lib';
 import { taskManagerMock } from '../../task_manager/task_manager.mock';
-import { SavedObjectsClientMock } from '../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../src/core/server/mocks';
 
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 
 const mockTaskManager = taskManagerMock.create();
 

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/email.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/email.test.ts
@@ -10,7 +10,7 @@ jest.mock('./lib/send_email', () => ({
 
 import { ActionType, ActionTypeExecutorOptions } from '../types';
 import { validateConfig, validateSecrets, validateParams } from '../lib';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { createActionTypeRegistry } from './index.test';
 import { sendEmail } from './lib/send_email';
 import { ActionParamsType, ActionTypeConfigType, ActionTypeSecretsType } from './email';
@@ -23,7 +23,7 @@ const NO_OP_FN = () => {};
 const services = {
   log: NO_OP_FN,
   callCluster: async (path: string, opts: any) => {},
-  savedObjectsClient: SavedObjectsClientMock.create(),
+  savedObjectsClient: savedObjectsClientMock.create(),
 };
 
 let actionType: ActionType;

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/es_index.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/es_index.test.ts
@@ -10,7 +10,7 @@ jest.mock('./lib/send_email', () => ({
 
 import { ActionType, ActionTypeExecutorOptions } from '../types';
 import { validateConfig, validateParams } from '../lib';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { createActionTypeRegistry } from './index.test';
 import { ActionParamsType, ActionTypeConfigType } from './es_index';
 
@@ -20,7 +20,7 @@ const NO_OP_FN = () => {};
 const services = {
   log: NO_OP_FN,
   callCluster: jest.fn(),
-  savedObjectsClient: SavedObjectsClientMock.create(),
+  savedObjectsClient: savedObjectsClientMock.create(),
 };
 
 let actionType: ActionType;

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/pagerduty.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/pagerduty.test.ts
@@ -10,7 +10,7 @@ jest.mock('./lib/post_pagerduty', () => ({
 
 import { ActionType, Services, ActionTypeExecutorOptions } from '../types';
 import { validateConfig, validateSecrets, validateParams } from '../lib';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { postPagerduty } from './lib/post_pagerduty';
 import { createActionTypeRegistry } from './index.test';
 
@@ -20,7 +20,7 @@ const ACTION_TYPE_ID = '.pagerduty';
 
 const services: Services = {
   callCluster: async (path: string, opts: any) => {},
-  savedObjectsClient: SavedObjectsClientMock.create(),
+  savedObjectsClient: savedObjectsClientMock.create(),
 };
 
 let actionType: ActionType;

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/server_log.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/server_log.test.ts
@@ -7,7 +7,7 @@
 import { ActionType } from '../types';
 import { validateParams } from '../lib';
 import { Logger } from '../../../../../../src/core/server';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { createActionTypeRegistry } from './index.test';
 
 const ACTION_TYPE_ID = '.server-log';
@@ -92,7 +92,7 @@ describe('execute()', () => {
       actionId,
       services: {
         callCluster: async (path: string, opts: any) => {},
-        savedObjectsClient: SavedObjectsClientMock.create(),
+        savedObjectsClient: savedObjectsClientMock.create(),
       },
       params: { message: 'message text here', level: 'info' },
       config: {},

--- a/x-pack/legacy/plugins/actions/server/builtin_action_types/slack.test.ts
+++ b/x-pack/legacy/plugins/actions/server/builtin_action_types/slack.test.ts
@@ -6,7 +6,7 @@
 
 import { ActionType, Services, ActionTypeExecutorOptions } from '../types';
 import { ActionTypeRegistry } from '../action_type_registry';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { ActionExecutor, validateParams, validateSecrets, TaskRunnerFactory } from '../lib';
 import { getActionType } from './slack';
 import { taskManagerMock } from '../../../task_manager/task_manager.mock';
@@ -15,7 +15,7 @@ const ACTION_TYPE_ID = '.slack';
 
 const services: Services = {
   callCluster: async (path: string, opts: any) => {},
-  savedObjectsClient: SavedObjectsClientMock.create(),
+  savedObjectsClient: savedObjectsClientMock.create(),
 };
 
 let actionTypeRegistry: ActionTypeRegistry;

--- a/x-pack/legacy/plugins/actions/server/create_execute_function.test.ts
+++ b/x-pack/legacy/plugins/actions/server/create_execute_function.test.ts
@@ -6,10 +6,10 @@
 
 import { taskManagerMock } from '../../task_manager/task_manager.mock';
 import { createExecuteFunction } from './create_execute_function';
-import { SavedObjectsClientMock } from '../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../src/core/server/mocks';
 
 const mockTaskManager = taskManagerMock.create();
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 const getBasePath = jest.fn();
 
 beforeEach(() => jest.resetAllMocks());

--- a/x-pack/legacy/plugins/actions/server/lib/action_executor.test.ts
+++ b/x-pack/legacy/plugins/actions/server/lib/action_executor.test.ts
@@ -10,12 +10,12 @@ import { ActionExecutor } from './action_executor';
 import { actionTypeRegistryMock } from '../action_type_registry.mock';
 import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
 import {
-  SavedObjectsClientMock,
+  savedObjectsClientMock,
   loggingServiceMock,
 } from '../../../../../../src/core/server/mocks';
 
 const actionExecutor = new ActionExecutor();
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 
 function getServices() {
   return {

--- a/x-pack/legacy/plugins/actions/server/lib/task_runner_factory.test.ts
+++ b/x-pack/legacy/plugins/actions/server/lib/task_runner_factory.test.ts
@@ -13,7 +13,7 @@ import { actionTypeRegistryMock } from '../action_type_registry.mock';
 import { actionExecutorMock } from './action_executor.mock';
 import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
 import {
-  SavedObjectsClientMock,
+  savedObjectsClientMock,
   loggingServiceMock,
 } from '../../../../../../src/core/server/mocks';
 
@@ -54,7 +54,7 @@ afterAll(() => fakeTimer.restore());
 const services = {
   log: jest.fn(),
   callCluster: jest.fn(),
-  savedObjectsClient: SavedObjectsClientMock.create(),
+  savedObjectsClient: savedObjectsClientMock.create(),
 };
 const actionExecutorInitializerParams = {
   logger: loggingServiceMock.create().get(),

--- a/x-pack/legacy/plugins/actions/server/routes/_mock_server.ts
+++ b/x-pack/legacy/plugins/actions/server/routes/_mock_server.ts
@@ -5,7 +5,7 @@
  */
 
 import Hapi from 'hapi';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 import { actionsClientMock } from '../actions_client.mock';
 import { actionTypeRegistryMock } from '../action_type_registry.mock';
 import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
@@ -21,7 +21,7 @@ export function createMockServer(config: Record<string, any> = defaultConfig) {
 
   const actionsClient = actionsClientMock.create();
   const actionTypeRegistry = actionTypeRegistryMock.create();
-  const savedObjectsClient = SavedObjectsClientMock.create();
+  const savedObjectsClient = savedObjectsClientMock.create();
   const encryptedSavedObjects = encryptedSavedObjectsMock.create();
 
   server.config = () => {

--- a/x-pack/legacy/plugins/alerting/server/alerts_client.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/alerts_client.test.ts
@@ -6,13 +6,13 @@
 
 import { schema } from '@kbn/config-schema';
 import { AlertsClient } from './alerts_client';
-import { SavedObjectsClientMock, loggingServiceMock } from '../../../../../src/core/server/mocks';
+import { savedObjectsClientMock, loggingServiceMock } from '../../../../../src/core/server/mocks';
 import { taskManagerMock } from '../../task_manager/task_manager.mock';
 import { alertTypeRegistryMock } from './alert_type_registry.mock';
 
 const taskManager = taskManagerMock.create();
 const alertTypeRegistry = alertTypeRegistryMock.create();
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 
 const alertsClientParams = {
   taskManager,

--- a/x-pack/legacy/plugins/alerting/server/lib/task_runner_factory.test.ts
+++ b/x-pack/legacy/plugins/alerting/server/lib/task_runner_factory.test.ts
@@ -11,7 +11,7 @@ import { ConcreteTaskInstance } from '../../../task_manager';
 import { TaskRunnerContext, TaskRunnerFactory } from './task_runner_factory';
 import { encryptedSavedObjectsMock } from '../../../encrypted_saved_objects/server/plugin.mock';
 import {
-  SavedObjectsClientMock,
+  savedObjectsClientMock,
   loggingServiceMock,
 } from '../../../../../../src/core/server/mocks';
 
@@ -51,7 +51,7 @@ beforeAll(() => {
 
 afterAll(() => fakeTimer.restore());
 
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 const encryptedSavedObjectsPlugin = encryptedSavedObjectsMock.create();
 const services = {
   log: jest.fn(),

--- a/x-pack/legacy/plugins/encrypted_saved_objects/server/lib/encrypted_saved_objects_client_wrapper.test.ts
+++ b/x-pack/legacy/plugins/encrypted_saved_objects/server/lib/encrypted_saved_objects_client_wrapper.test.ts
@@ -9,14 +9,14 @@ jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('uuid-v4-id') }));
 import { EncryptedSavedObjectsClientWrapper } from './encrypted_saved_objects_client_wrapper';
 import { EncryptedSavedObjectsService } from './encrypted_saved_objects_service';
 import { createEncryptedSavedObjectsServiceMock } from './encrypted_saved_objects_service.mock';
-import { SavedObjectsClientMock } from 'src/core/server/saved_objects/service/saved_objects_client.mock';
+import { savedObjectsClientMock } from 'src/core/server/saved_objects/service/saved_objects_client.mock';
 import { SavedObjectsClientContract } from 'src/core/server';
 
 let wrapper: EncryptedSavedObjectsClientWrapper;
 let mockBaseClient: jest.Mocked<SavedObjectsClientContract>;
 let encryptedSavedObjectsServiceMock: jest.Mocked<EncryptedSavedObjectsService>;
 beforeEach(() => {
-  mockBaseClient = SavedObjectsClientMock.create();
+  mockBaseClient = savedObjectsClientMock.create();
   encryptedSavedObjectsServiceMock = createEncryptedSavedObjectsServiceMock([
     {
       type: 'known-type',

--- a/x-pack/legacy/plugins/task_manager/task_manager.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.test.ts
@@ -7,11 +7,11 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 import { TaskManager, claimAvailableTasks } from './task_manager';
-import { SavedObjectsClientMock } from 'src/core/server/mocks';
+import { savedObjectsClientMock } from 'src/core/server/mocks';
 import { SavedObjectsSerializer, SavedObjectsSchema } from 'src/core/server';
 import { mockLogger } from './test_utils';
 
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 const serializer = new SavedObjectsSerializer(new SavedObjectsSchema());
 
 describe('TaskManager', () => {

--- a/x-pack/legacy/plugins/task_manager/task_store.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_store.test.ts
@@ -10,7 +10,7 @@ import uuid from 'uuid';
 import { TaskDictionary, TaskDefinition, TaskInstance, TaskStatus } from './task';
 import { FetchOpts, StoreOpts, OwnershipClaimingOpts, TaskStore } from './task_store';
 import { mockLogger } from './test_utils';
-import { SavedObjectsClientMock } from 'src/core/server/mocks';
+import { savedObjectsClientMock } from 'src/core/server/mocks';
 import { SavedObjectsSerializer, SavedObjectsSchema, SavedObjectAttributes } from 'src/core/server';
 
 const taskDefinitions: TaskDictionary<TaskDefinition> = {
@@ -31,7 +31,7 @@ const taskDefinitions: TaskDictionary<TaskDefinition> = {
   },
 };
 
-const savedObjectsClient = SavedObjectsClientMock.create();
+const savedObjectsClient = savedObjectsClientMock.create();
 const serializer = new SavedObjectsSerializer(new SavedObjectsSchema());
 
 beforeEach(() => jest.resetAllMocks());

--- a/x-pack/plugins/spaces/server/lib/saved_objects_client/spaces_saved_objects_client.test.ts
+++ b/x-pack/plugins/spaces/server/lib/saved_objects_client/spaces_saved_objects_client.test.ts
@@ -7,13 +7,13 @@
 import { DEFAULT_SPACE_ID } from '../../../common/constants';
 import { SpacesSavedObjectsClient } from './spaces_saved_objects_client';
 import { spacesServiceMock } from '../../spaces_service/spaces_service.mock';
-import { SavedObjectsClientMock } from '../../../../../../src/core/server/mocks';
+import { savedObjectsClientMock } from '../../../../../../src/core/server/mocks';
 
 const types = ['foo', 'bar', 'space'];
 
 const createMockRequest = () => ({});
 
-const createMockClient = () => SavedObjectsClientMock.create();
+const createMockClient = () => savedObjectsClientMock.create();
 
 const createSpacesService = async (spaceId: string) => {
   return spacesServiceMock.createSetupContract(spaceId);


### PR DESCRIPTION
## Summary

Renames `SavedObjectsClientMock` to `savedObjectsClientMock` to be consistent with the other core mocks.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

