### PR TITLE
[Lens] Fix telemetry factory and tests

### DIFF
--- a/x-pack/legacy/plugins/lens/public/app_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/plugin.tsx
@@ -72,7 +72,6 @@ export class AppPlugin {
     setReportManager(
       new LensReportManager({
         storage: new Storage(localStorage),
-        basePath: core.http.basePath.get(),
         http: core.http,
       })
     );

--- a/x-pack/legacy/plugins/lens/public/lens_ui_telemetry/factory.test.ts
+++ b/x-pack/legacy/plugins/lens/public/lens_ui_telemetry/factory.test.ts
@@ -45,7 +45,6 @@ describe('Lens UI telemetry', () => {
     const fakeManager = new LensReportManager({
       http,
       storage,
-      basePath: '/basepath',
     });
     setReportManager(fakeManager);
   });
@@ -84,7 +83,7 @@ describe('Lens UI telemetry', () => {
 
     jest.runOnlyPendingTimers();
 
-    expect(http.post).toHaveBeenCalledWith(`/basepath/api/lens/telemetry`, {
+    expect(http.post).toHaveBeenCalledWith(`/api/lens/telemetry`, {
       body: JSON.stringify({
         events: {
           '2019-10-23': {

--- a/x-pack/legacy/plugins/lens/public/lens_ui_telemetry/factory.ts
+++ b/x-pack/legacy/plugins/lens/public/lens_ui_telemetry/factory.ts
@@ -45,21 +45,11 @@ export class LensReportManager {
 
   private storage: Storage;
   private http: HttpServiceBase;
-  private basePath: string;
   private timer: ReturnType<typeof setInterval>;
 
-  constructor({
-    storage,
-    http,
-    basePath,
-  }: {
-    storage: Storage;
-    http: HttpServiceBase;
-    basePath: string;
-  }) {
+  constructor({ storage, http }: { storage: Storage; http: HttpServiceBase }) {
     this.storage = storage;
     this.http = http;
-    this.basePath = basePath;
 
     this.readFromStorage();
 
@@ -96,7 +86,7 @@ export class LensReportManager {
     this.readFromStorage();
     if (Object.keys(this.events).length || Object.keys(this.suggestionEvents).length) {
       try {
-        await this.http.post(`${this.basePath}${BASE_API_URL}/telemetry`, {
+        await this.http.post(`${BASE_API_URL}/telemetry`, {
           body: JSON.stringify({
             events: this.events,
             suggestionEvents: this.suggestionEvents,


### PR DESCRIPTION
Telemetry wasn't working properly with Kibana's base path system. This PR fixes that.

Run Kibana with a simple `yarn start`, and you'll see the bug in master after performing any interaction in Lens, then waiting 10 seconds for the telemetry attempt.

![image](https://user-images.githubusercontent.com/833377/67509230-875fb300-f660-11e9-8599-fb3def3cd1dd.png)

Do the same in this branch, and the error no longer occurs.