### PR TITLE
[APM] Update metadata order for Transactions, Spans and Errors

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/sections.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/sections.ts
@@ -20,8 +20,8 @@ import {
 } from '../sections';
 
 export const ERROR_METADATA_SECTIONS: Section[] = [
-  ERROR,
   { ...LABELS, required: true },
+  ERROR,
   HTTP,
   HOST,
   CONTAINER,

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/sections.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/sections.ts
@@ -15,10 +15,10 @@ import {
 } from '../sections';
 
 export const SPAN_METADATA_SECTIONS: Section[] = [
-  SPAN,
-  AGENT,
-  SERVICE,
-  TRANSACTION,
   LABELS,
-  TRACE
+  SPAN,
+  TRANSACTION,
+  TRACE,
+  SERVICE,
+  AGENT
 ];

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/sections.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/sections.ts
@@ -22,8 +22,8 @@ import {
 } from '../sections';
 
 export const TRANSACTION_METADATA_SECTIONS: Section[] = [
-  TRANSACTION,
   { ...LABELS, required: true },
+  TRANSACTION,
   HTTP,
   HOST,
   CONTAINER,


### PR DESCRIPTION
## Summary

Reordering the metadata sections for transactions, errors and spans.

### Transactions

![screencapture-localhost-5601-fyl-app-apm-2019-10-25-14_04_07](https://user-images.githubusercontent.com/4104278/67569942-8433f800-f730-11e9-93ea-aa9668b89797.png)

### Spans

![screencapture-localhost-5601-fyl-app-apm-2019-10-25-14_04_53](https://user-images.githubusercontent.com/4104278/67569947-872ee880-f730-11e9-9261-175562a4080f.png)

### Errors

![screencapture-localhost-5601-fyl-app-apm-2019-10-25-14_05_21](https://user-images.githubusercontent.com/4104278/67569953-89914280-f730-11e9-8389-31b888f9990b.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

