### PR TITLE
[7.5] FTR: clear browser storage between test suites (#48683)

### DIFF
--- a/test/functional/services/remote/remote.ts
+++ b/test/functional/services/remote/remote.ts
@@ -75,6 +75,8 @@ export async function RemoteProvider({ getService }: FtrProviderContext) {
       .manage()
       .window()
       .setRect({ width, height });
+    await driver.executeScript('window.sessionStorage.clear();');
+    await driver.executeScript('window.localStorage.clear();');
   });
 
   lifecycle.on('cleanup', async () => await driver.quit());

--- a/x-pack/test/functional/apps/logstash/pipeline_list.js
+++ b/x-pack/test/functional/apps/logstash/pipeline_list.js
@@ -22,6 +22,9 @@ export default function ({ getService, getPageObjects }) {
       originalWindowSize = await browser.getWindowSize();
       await browser.setWindowSize(1600, 1000);
       await esArchiver.load('logstash/example_pipelines');
+    });
+
+    beforeEach(async () => {
       await PageObjects.logstash.gotoPipelineList();
     });
 
@@ -86,10 +89,6 @@ export default function ({ getService, getPageObjects }) {
         await pipelineEditor.assertExists();
         await pipelineEditor.assertDefaultInputs();
       });
-
-      after(async () => {
-        await PageObjects.logstash.gotoPipelineList();
-      });
     });
 
     describe('delete button', () => {
@@ -122,14 +121,11 @@ export default function ({ getService, getPageObjects }) {
 
     describe('row links', () => {
       it('opens the selected row in the editor', async () => {
+        await PageObjects.logstash.gotoPipelineList();
         await pipelineList.setFilter('tweets_and_beats');
         await pipelineList.clickFirstRowId();
         await pipelineEditor.assertExists();
         await pipelineEditor.assertEditorId('tweets_and_beats');
-      });
-
-      after(async () => {
-        await PageObjects.logstash.gotoPipelineList();
       });
     });
 
@@ -224,10 +220,6 @@ export default function ({ getService, getPageObjects }) {
           queueMaxBytesUnits,
           queueCheckpointWrites,
         });
-      });
-
-      after(async () => {
-        await PageObjects.logstash.gotoPipelineList();
       });
     });
   });

--- a/x-pack/test/functional/apps/machine_learning/anomaly_detection/multi_metric_job.ts
+++ b/x-pack/test/functional/apps/machine_learning/anomaly_detection/multi_metric_job.ts
@@ -74,7 +74,7 @@ export default function({ getService }: FtrProviderContext) {
   describe('multi metric', function() {
     this.tags(['smoke', 'mlqa']);
     before(async () => {
-      await esArchiver.loadIfNeeded('ml/farequote');
+      await esArchiver.load('ml/farequote');
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/machine_learning/anomaly_detection/population_job.ts
+++ b/x-pack/test/functional/apps/machine_learning/anomaly_detection/population_job.ts
@@ -88,7 +88,7 @@ export default function({ getService }: FtrProviderContext) {
   describe('population', function() {
     this.tags(['smoke', 'mlqa']);
     before(async () => {
-      await esArchiver.loadIfNeeded('ml/ecommerce');
+      await esArchiver.load('ml/ecommerce');
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/machine_learning/anomaly_detection/saved_search_job.ts
+++ b/x-pack/test/functional/apps/machine_learning/anomaly_detection/saved_search_job.ts
@@ -274,7 +274,7 @@ export default function({ getService }: FtrProviderContext) {
   describe('saved search', function() {
     this.tags(['smoke', 'mlqa']);
     before(async () => {
-      await esArchiver.loadIfNeeded('ml/farequote');
+      await esArchiver.load('ml/farequote');
     });
 
     after(async () => {

--- a/x-pack/test/functional/apps/machine_learning/anomaly_detection/single_metric_job.ts
+++ b/x-pack/test/functional/apps/machine_learning/anomaly_detection/single_metric_job.ts
@@ -73,7 +73,7 @@ export default function({ getService }: FtrProviderContext) {
   describe('single metric', function() {
     this.tags(['smoke', 'mlqa']);
     before(async () => {
-      await esArchiver.loadIfNeeded('ml/farequote');
+      await esArchiver.load('ml/farequote');
     });
 
     after(async () => {


### PR DESCRIPTION
Backports the following commits to 7.5:
 - FTR: clear browser storage between test suites (#48683)