### PR TITLE
[Lens] Pass date range to the query bar

### DIFF
--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.test.tsx
@@ -496,6 +496,8 @@ describe('Lens App', () => {
       expect(TopNavMenu).toHaveBeenCalledWith(
         expect.objectContaining({
           query: { query: '', language: 'kuery' },
+          dateRangeFrom: 'now-7d',
+          dateRangeTo: 'now',
         }),
         {}
       );
@@ -570,6 +572,8 @@ describe('Lens App', () => {
       expect(TopNavMenu).toHaveBeenCalledWith(
         expect.objectContaining({
           query: { query: 'new', language: 'lucene' },
+          dateRangeFrom: 'now-14d',
+          dateRangeTo: 'now-7d',
         }),
         {}
       );

--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
@@ -256,6 +256,8 @@ export function App({
                 }));
               }}
               query={state.query}
+              dateRangeFrom={state.dateRange.fromDate}
+              dateRangeTo={state.dateRange.toDate}
             />
           </div>
 


### PR DESCRIPTION
Fixes a bug in Lens where the query bar would always show "Update" instead of "Refresh" even when changes had been applied.
