### PR TITLE
[APM] Performance comparison charts by user agent (browser)

### DIFF
--- a/x-pack/legacy/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
@@ -102,6 +102,8 @@ exports[`Error TRANSACTION_TYPE 1`] = `"request"`;
 
 exports[`Error URL_FULL 1`] = `undefined`;
 
+exports[`Error USER_AGENT_NAME 1`] = `undefined`;
+
 exports[`Error USER_ID 1`] = `undefined`;
 
 exports[`Span CLIENT_GEO_COUNTRY_ISO_CODE 1`] = `undefined`;
@@ -206,6 +208,8 @@ exports[`Span TRANSACTION_TYPE 1`] = `undefined`;
 
 exports[`Span URL_FULL 1`] = `undefined`;
 
+exports[`Span USER_AGENT_NAME 1`] = `undefined`;
+
 exports[`Span USER_ID 1`] = `undefined`;
 
 exports[`Transaction CLIENT_GEO_COUNTRY_ISO_CODE 1`] = `undefined`;
@@ -309,5 +313,7 @@ exports[`Transaction TRANSACTION_SAMPLED 1`] = `true`;
 exports[`Transaction TRANSACTION_TYPE 1`] = `"transaction type"`;
 
 exports[`Transaction URL_FULL 1`] = `"http://www.elastic.co"`;
+
+exports[`Transaction USER_AGENT_NAME 1`] = `undefined`;
 
 exports[`Transaction USER_ID 1`] = `"1337"`;

--- a/x-pack/legacy/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/common/__snapshots__/elasticsearch_fieldnames.test.ts.snap
@@ -314,6 +314,6 @@ exports[`Transaction TRANSACTION_TYPE 1`] = `"transaction type"`;
 
 exports[`Transaction URL_FULL 1`] = `"http://www.elastic.co"`;
 
-exports[`Transaction USER_AGENT_NAME 1`] = `undefined`;
+exports[`Transaction USER_AGENT_NAME 1`] = `"Other"`;
 
 exports[`Transaction USER_ID 1`] = `"1337"`;

--- a/x-pack/legacy/plugins/apm/common/elasticsearch_fieldnames.test.ts
+++ b/x-pack/legacy/plugins/apm/common/elasticsearch_fieldnames.test.ts
@@ -34,6 +34,7 @@ describe('Transaction', () => {
     timestamp: { us: 1337 },
     trace: { id: 'trace id' },
     user: { id: '1337' },
+    user_agent: { name: 'Other', original: 'test original' },
     parent: {
       id: 'parentId'
     },

--- a/x-pack/legacy/plugins/apm/common/elasticsearch_fieldnames.ts
+++ b/x-pack/legacy/plugins/apm/common/elasticsearch_fieldnames.ts
@@ -10,6 +10,7 @@ export const SERVICE_NODE_NAME = 'service.node.name';
 export const URL_FULL = 'url.full';
 export const HTTP_REQUEST_METHOD = 'http.request.method';
 export const USER_ID = 'user.id';
+export const USER_AGENT_NAME = 'user_agent.name';
 
 export const OBSERVER_VERSION_MAJOR = 'observer.version_major';
 export const OBSERVER_LISTENING = 'observer.listening';

--- a/x-pack/legacy/plugins/apm/common/processor_event.ts
+++ b/x-pack/legacy/plugins/apm/common/processor_event.ts
@@ -4,4 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export type ProcessorEvent = 'transaction' | 'error' | 'metric';
+export enum ProcessorEvent {
+  transaction = 'transaction',
+  error = 'error',
+  metric = 'metric'
+}

--- a/x-pack/legacy/plugins/apm/common/transaction_types.ts
+++ b/x-pack/legacy/plugins/apm/common/transaction_types.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+export const TRANSACTION = 'transaction';
 export const TRANSACTION_PAGE_LOAD = 'page-load';
-export const TRANSACTION_ROUTE_CHANGE = 'route-change';
 export const TRANSACTION_REQUEST = 'request';
+export const TRANSACTION_ROUTE_CHANGE = 'route-change';

--- a/x-pack/legacy/plugins/apm/common/transaction_types.ts
+++ b/x-pack/legacy/plugins/apm/common/transaction_types.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export const TRANSACTION = 'transaction';
 export const TRANSACTION_PAGE_LOAD = 'page-load';
 export const TRANSACTION_REQUEST = 'request';
 export const TRANSACTION_ROUTE_CHANGE = 'route-change';

--- a/x-pack/legacy/plugins/apm/common/viz_colors.ts
+++ b/x-pack/legacy/plugins/apm/common/viz_colors.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import lightTheme from '@elastic/eui/dist/eui_theme_light.json';
+
+function getVizColorsForTheme(theme = lightTheme) {
+  return [
+    theme.euiColorVis0,
+    theme.euiColorVis1,
+    theme.euiColorVis2,
+    theme.euiColorVis3,
+    theme.euiColorVis4,
+    theme.euiColorVis5,
+    theme.euiColorVis6,
+    theme.euiColorVis7,
+    theme.euiColorVis8,
+    theme.euiColorVis9
+  ];
+}
+
+export function getVizColorForIndex(index = 0, theme = lightTheme) {
+  const colors = getVizColorsForTheme(theme);
+  return colors[index % colors.length];
+}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/BrowserLineChart.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/BrowserLineChart.test.tsx
@@ -11,9 +11,7 @@ import { BrowserLineChart } from './BrowserLineChart';
 describe('BrowserLineChart', () => {
   describe('render', () => {
     it('renders', () => {
-      const props = { series: [] };
-
-      expect(() => shallow(<BrowserLineChart {...props} />)).not.toThrowError();
+      expect(() => shallow(<BrowserLineChart />)).not.toThrowError();
     });
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/BrowserLineChart.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/BrowserLineChart.test.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { BrowserLineChart } from './BrowserLineChart';
+
+describe('BrowserLineChart', () => {
+  describe('render', () => {
+    it('renders', () => {
+      const props = { series: [] };
+
+      expect(() => shallow(<BrowserLineChart {...props} />)).not.toThrowError();
+    });
+  });
+});

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/BrowserLineChart.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/BrowserLineChart.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiTitle } from '@elastic/eui';
+import { TransactionLineChart } from './TransactionLineChart';
+import {
+  getMaxY,
+  getResponseTimeTickFormatter,
+  getResponseTimeTooltipFormatter
+} from '.';
+import { getDurationFormatter } from '../../../../utils/formatters';
+import { useAvgDurationByBrowser } from '../../../../hooks/useAvgDurationByBrowser';
+
+export function BrowserLineChart() {
+  const { data } = useAvgDurationByBrowser();
+  const maxY = getMaxY(data);
+  const formatter = getDurationFormatter(maxY);
+  const formatTooltipValue = getResponseTimeTooltipFormatter(formatter);
+  const tickFormatY = getResponseTimeTickFormatter(formatter);
+
+  return (
+    <>
+      <EuiTitle size="xs">
+        <span>
+          {i18n.translate(
+            'xpack.apm.metrics.pageLoadCharts.avgPageLoadByBrowser',
+            {
+              defaultMessage: 'Avg. page load duration distribution by browser'
+            }
+          )}
+        </span>
+      </EuiTitle>
+      <TransactionLineChart
+        formatTooltipValue={formatTooltipValue}
+        series={data}
+        tickFormatY={tickFormatY}
+      />
+    </>
+  );
+}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/DurationByCountryMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/DurationByCountryMap/index.tsx
@@ -4,33 +4,30 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiFlexGrid, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
+import { EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useAvgDurationByCountry } from '../../../../../hooks/useAvgDurationByCountry';
+
 import { ChoroplethMap } from '../ChoroplethMap';
 
 export const DurationByCountryMap: React.SFC = () => {
   const { data } = useAvgDurationByCountry();
 
   return (
-    <EuiFlexGrid columns={1} gutterSize="s">
-      <EuiFlexItem>
-        <EuiPanel>
-          <EuiTitle size="xs">
-            <span>
-              {i18n.translate(
-                'xpack.apm.metrics.durationByCountryMap.avgPageLoadByCountryLabel',
-                {
-                  defaultMessage:
-                    'Avg. page load duration distribution by country'
-                }
-              )}
-            </span>
-          </EuiTitle>
-          <ChoroplethMap items={data} />
-        </EuiPanel>
-      </EuiFlexItem>
-    </EuiFlexGrid>
+    <>
+      {' '}
+      <EuiTitle size="xs">
+        <span>
+          {i18n.translate(
+            'xpack.apm.metrics.durationByCountryMap.avgPageLoadByCountryLabel',
+            {
+              defaultMessage: 'Avg. page load duration distribution by country'
+            }
+          )}
+        </span>
+      </EuiTitle>
+      <ChoroplethMap items={data} />
+    </>
   );
 };

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/TransactionCharts/index.tsx
@@ -33,6 +33,7 @@ import { MLJobLink } from '../../Links/MachineLearningLinks/MLJobLink';
 import { LicenseContext } from '../../../../context/LicenseContext';
 import { TransactionLineChart } from './TransactionLineChart';
 import { isValidCoordinateValue } from '../../../../utils/isValidCoordinateValue';
+import { BrowserLineChart } from './BrowserLineChart';
 import { DurationByCountryMap } from './DurationByCountryMap';
 import {
   TRANSACTION_PAGE_LOAD,
@@ -59,31 +60,29 @@ const ShiftedEuiText = styled(EuiText)`
   top: 5px;
 `;
 
+export function getResponseTimeTickFormatter(formatter: TimeFormatter) {
+  return (t: number) => formatter(t).formatted;
+}
+
+export function getResponseTimeTooltipFormatter(formatter: TimeFormatter) {
+  return (p: Coordinate) => {
+    return isValidCoordinateValue(p.y)
+      ? formatter(p.y).formatted
+      : NOT_AVAILABLE_LABEL;
+  };
+}
+
+export function getMaxY(responseTimeSeries: TimeSeries[]) {
+  const coordinates = flatten(
+    responseTimeSeries.map((serie: TimeSeries) => serie.data as Coordinate[])
+  );
+
+  const numbers: number[] = coordinates.map((c: Coordinate) => (c.y ? c.y : 0));
+
+  return Math.max(...numbers, 0);
+}
+
 export class TransactionCharts extends Component<TransactionChartProps> {
-  public getMaxY = (responseTimeSeries: TimeSeries[]) => {
-    const coordinates = flatten(
-      responseTimeSeries.map((serie: TimeSeries) => serie.data as Coordinate[])
-    );
-
-    const numbers: number[] = coordinates.map((c: Coordinate) =>
-      c.y ? c.y : 0
-    );
-
-    return Math.max(...numbers, 0);
-  };
-
-  public getResponseTimeTickFormatter = (formatter: TimeFormatter) => {
-    return (t: number) => formatter(t).formatted;
-  };
-
-  public getResponseTimeTooltipFormatter = (formatter: TimeFormatter) => {
-    return (p: Coordinate) => {
-      return isValidCoordinateValue(p.y)
-        ? formatter(p.y).formatted
-        : NOT_AVAILABLE_LABEL;
-    };
-  };
-
   public getTPMFormatter = (t: number) => {
     const { urlParams } = this.props;
     const unit = tpmUnit(urlParams.transactionType);
@@ -154,7 +153,7 @@ export class TransactionCharts extends Component<TransactionChartProps> {
     const { charts, urlParams } = this.props;
     const { responseTimeSeries, tpmSeries } = charts;
     const { transactionType } = urlParams;
-    const maxY = this.getMaxY(responseTimeSeries);
+    const maxY = getMaxY(responseTimeSeries);
     const formatter = getDurationFormatter(maxY);
 
     return (
@@ -177,8 +176,8 @@ export class TransactionCharts extends Component<TransactionChartProps> {
                 </EuiFlexGroup>
                 <TransactionLineChart
                   series={responseTimeSeries}
-                  tickFormatY={this.getResponseTimeTickFormatter(formatter)}
-                  formatTooltipValue={this.getResponseTimeTooltipFormatter(
+                  tickFormatY={getResponseTimeTickFormatter(formatter)}
+                  formatTooltipValue={getResponseTimeTooltipFormatter(
                     formatter
                   )}
                 />
@@ -205,7 +204,18 @@ export class TransactionCharts extends Component<TransactionChartProps> {
         {transactionType === TRANSACTION_PAGE_LOAD && (
           <>
             <EuiSpacer size="s" />
-            <DurationByCountryMap />
+            <EuiFlexGrid columns={2} gutterSize="s">
+              <EuiFlexItem>
+                <EuiPanel>
+                  <DurationByCountryMap />
+                </EuiPanel>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiPanel>
+                  <BrowserLineChart />
+                </EuiPanel>
+              </EuiFlexItem>
+            </EuiFlexGrid>
           </>
         )}
       </>

--- a/x-pack/legacy/plugins/apm/public/context/UrlParamsContext/helpers.ts
+++ b/x-pack/legacy/plugins/apm/public/context/UrlParamsContext/helpers.ts
@@ -83,24 +83,24 @@ export function getPathParams(pathname: string = ''): PathParams {
       switch (servicePageName) {
         case 'transactions':
           return {
-            processorEvent: 'transaction',
+            processorEvent: ProcessorEvent.transaction,
             serviceName
           };
         case 'errors':
           return {
-            processorEvent: 'error',
+            processorEvent: ProcessorEvent.error,
             serviceName,
             errorGroupId: paths[3]
           };
         case 'metrics':
           return {
-            processorEvent: 'metric',
+            processorEvent: ProcessorEvent.metric,
             serviceName,
             serviceNodeName
           };
         case 'nodes':
           return {
-            processorEvent: 'metric',
+            processorEvent: ProcessorEvent.metric,
             serviceName
           };
         case 'service-map':
@@ -113,7 +113,7 @@ export function getPathParams(pathname: string = ''): PathParams {
 
     case 'traces':
       return {
-        processorEvent: 'transaction'
+        processorEvent: ProcessorEvent.transaction
       };
     default:
       return {};

--- a/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.test.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { renderHook } from 'react-hooks-testing-library';
+import theme from '@elastic/eui/dist/eui_theme_light.json';
+import * as useFetcherModule from './useFetcher';
+import { useAvgDurationByBrowser } from './useAvgDurationByBrowser';
+
+describe('useAvgDurationByBrowser', () => {
+  it('returns data', () => {
+    const data = [
+      { title: 'Other', data: [{ x: 1572530100000, y: 130010.8947368421 }] }
+    ];
+    jest.spyOn(useFetcherModule, 'useFetcher').mockReturnValueOnce({
+      data,
+      refetch: () => {},
+      status: 'success' as useFetcherModule.FETCH_STATUS
+    });
+    const { result } = renderHook(() => useAvgDurationByBrowser());
+
+    expect(result.current.data).toEqual([
+      {
+        color: theme.euiColorVis0,
+        data: [{ x: 1572530100000, y: 130010.8947368421 }],
+        title: 'Other',
+        type: 'linemark'
+      }
+    ]);
+  });
+});

--- a/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.ts
@@ -23,7 +23,7 @@ const colors = [
   theme.euiColorVis9
 ];
 
-function toTimeSeries(data: AvgDurationByBrowserAPIResponse): TimeSeries[] {
+function toTimeSeries(data?: AvgDurationByBrowserAPIResponse): TimeSeries[] {
   if (!data) {
     return [];
   }

--- a/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { useFetcher } from './useFetcher';
+import { useUrlParams } from './useUrlParams';
+import { AvgDurationByBrowserAPIResponse } from '../../server/lib/transactions/avg_duration_by_browser';
+import { TimeSeries } from '../../typings/timeseries';
+
+const colors = [
+  theme.euiColorVis0,
+  theme.euiColorVis1,
+  theme.euiColorVis2,
+  theme.euiColorVis3,
+  theme.euiColorVis4,
+  theme.euiColorVis5,
+  theme.euiColorVis6,
+  theme.euiColorVis7,
+  theme.euiColorVis8,
+  theme.euiColorVis9
+];
+
+function toTimeSeries(data: AvgDurationByBrowserAPIResponse): TimeSeries[] {
+  if (!data) {
+    return [];
+  }
+
+  return data.map((item, index) => {
+    return {
+      ...item,
+      color: colors[index % colors.length],
+      type: 'linemark'
+    };
+  });
+}
+
+export function useAvgDurationByBrowser() {
+  const {
+    urlParams: { serviceName, start, end, transactionName },
+    uiFilters
+  } = useUrlParams();
+
+  const { data, error, status } = useFetcher(
+    callApmApi => {
+      if (serviceName && start && end) {
+        return callApmApi({
+          pathname:
+            '/api/apm/services/{serviceName}/transaction_groups/avg_duration_by_browser',
+          params: {
+            path: { serviceName },
+            query: {
+              start,
+              end,
+              transactionName,
+              uiFilters: JSON.stringify(uiFilters)
+            }
+          }
+        });
+      }
+    },
+    [serviceName, start, end, transactionName, uiFilters]
+  );
+
+  return {
+    data: toTimeSeries(data),
+    status,
+    error
+  };
+}

--- a/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useAvgDurationByBrowser.ts
@@ -9,19 +9,7 @@ import { useFetcher } from './useFetcher';
 import { useUrlParams } from './useUrlParams';
 import { AvgDurationByBrowserAPIResponse } from '../../server/lib/transactions/avg_duration_by_browser';
 import { TimeSeries } from '../../typings/timeseries';
-
-const colors = [
-  theme.euiColorVis0,
-  theme.euiColorVis1,
-  theme.euiColorVis2,
-  theme.euiColorVis3,
-  theme.euiColorVis4,
-  theme.euiColorVis5,
-  theme.euiColorVis6,
-  theme.euiColorVis7,
-  theme.euiColorVis8,
-  theme.euiColorVis9
-];
+import { getVizColorForIndex } from '../../common/viz_colors';
 
 function toTimeSeries(data?: AvgDurationByBrowserAPIResponse): TimeSeries[] {
   if (!data) {
@@ -31,7 +19,7 @@ function toTimeSeries(data?: AvgDurationByBrowserAPIResponse): TimeSeries[] {
   return data.map((item, index) => {
     return {
       ...item,
-      color: colors[index % colors.length],
+      color: getVizColorForIndex(index, theme),
       type: 'linemark'
     };
   });

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/fetchAndTransformGcMetrics.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/by_agent/java/gc/fetchAndTransformGcMetrics.ts
@@ -23,16 +23,7 @@ import {
   METRIC_JAVA_GC_TIME
 } from '../../../../../../common/elasticsearch_fieldnames';
 import { getBucketSize } from '../../../../helpers/get_bucket_size';
-
-const colors = [
-  theme.euiColorVis0,
-  theme.euiColorVis1,
-  theme.euiColorVis2,
-  theme.euiColorVis3,
-  theme.euiColorVis4,
-  theme.euiColorVis5,
-  theme.euiColorVis6
-];
+import { getVizColorForIndex } from '../../../../../../common/viz_colors';
 
 export async function fetchAndTransformGcMetrics({
   setup,
@@ -148,7 +139,7 @@ export async function fetchAndTransformGcMetrics({
       title: label,
       key: label,
       type: chartBase.type,
-      color: colors[i],
+      color: getVizColorForIndex(i, theme),
       overallValue,
       data
     };

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/transform_metrics_chart.ts
@@ -11,16 +11,7 @@ import {
   ESSearchRequest
 } from '../../../typings/elasticsearch';
 import { AggregationOptionsByType } from '../../../typings/elasticsearch/aggregations';
-
-const colors = [
-  theme.euiColorVis0,
-  theme.euiColorVis1,
-  theme.euiColorVis2,
-  theme.euiColorVis3,
-  theme.euiColorVis4,
-  theme.euiColorVis5,
-  theme.euiColorVis6
-];
+import { getVizColorForIndex } from '../../../common/viz_colors';
 
 export type GenericMetricsChart = ReturnType<
   typeof transformDataToMetricsChart
@@ -66,7 +57,8 @@ export function transformDataToMetricsChart(
         title: chartBase.series[seriesKey].title,
         key: seriesKey,
         type: chartBase.type,
-        color: chartBase.series[seriesKey].color || colors[i],
+        color:
+          chartBase.series[seriesKey].color || getVizColorForIndex(i, theme),
         overallValue,
         data:
           timeseriesData?.buckets.map(bucket => {

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/__fixtures__/responses.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/__fixtures__/responses.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  ESSearchResponse,
+  ESSearchRequest
+} from '../../../../../typings/elasticsearch';
+
+export const response = ({
+  hits: {
+    total: 599,
+    max_score: 0,
+    hits: []
+  },
+  took: 4,
+  timed_out: false,
+  _shards: {
+    total: 1,
+    successful: 1,
+    skipped: 0,
+    failed: 0
+  },
+  aggregations: {
+    user_agent_keys: {
+      buckets: [{ key: 'Firefox' }, { key: 'Other' }]
+    },
+    browsers: {
+      buckets: [
+        {
+          key_as_string: '2019-10-21T04:38:20.000-05:00',
+          key: 1571650700000,
+          doc_count: 0,
+          user_agent: {
+            doc_count_error_upper_bound: 0,
+            sum_other_doc_count: 0,
+            buckets: []
+          }
+        },
+        {
+          key_as_string: '2019-10-21T04:40:00.000-05:00',
+          key: 1571650800000,
+          doc_count: 1,
+          user_agent: {
+            doc_count_error_upper_bound: 0,
+            sum_other_doc_count: 0,
+            buckets: [
+              {
+                key: 'Other',
+                doc_count: 1,
+                avg_duration: {
+                  value: 860425.0
+                }
+              },
+              {
+                key: 'Firefox',
+                doc_count: 10,
+                avg_duration: {
+                  value: 86425.1
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+} as unknown) as ESSearchResponse<
+  unknown,
+  ESSearchRequest,
+  { restTotalHitsAsInt: false }
+>;

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { Setup } from '../../helpers/setup_request';
+import { fetcher } from './fetcher';
+
+describe('fetcher', () => {
+  it('performs a search', async () => {
+    const search = jest.fn();
+    const setup = ({
+      client: { search },
+      indices: {},
+      uiFiltersES: []
+    } as unknown) as Setup;
+
+    await fetcher({ serviceName: 'testServiceName', setup });
+
+    expect(search).toHaveBeenCalled();
+  });
+});

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
@@ -16,6 +16,10 @@ import {
 import { rangeFilter } from '../../helpers/range_filter';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { Options } from '.';
+import {
+  TRANSACTION,
+  TRANSACTION_PAGE_LOAD
+} from '../../../../common/transaction_types';
 
 export type ESResponse = PromiseReturnType<typeof fetcher>;
 
@@ -25,9 +29,9 @@ export function fetcher(options: Options) {
   const { intervalString } = getBucketSize(start, end, 'auto');
 
   const filter: ESFilter[] = [
-    { term: { [PROCESSOR_EVENT]: 'transaction' } },
+    { term: { [PROCESSOR_EVENT]: TRANSACTION } },
     { term: { [SERVICE_NAME]: serviceName } },
-    { term: { [TRANSACTION_TYPE]: 'page-load' } },
+    { term: { [TRANSACTION_TYPE]: TRANSACTION_PAGE_LOAD } },
     { range: rangeFilter(start, end) },
     ...uiFiltersES
   ];

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
@@ -16,10 +16,8 @@ import {
 import { rangeFilter } from '../../helpers/range_filter';
 import { getBucketSize } from '../../helpers/get_bucket_size';
 import { Options } from '.';
-import {
-  TRANSACTION,
-  TRANSACTION_PAGE_LOAD
-} from '../../../../common/transaction_types';
+import { TRANSACTION_PAGE_LOAD } from '../../../../common/transaction_types';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export type ESResponse = PromiseReturnType<typeof fetcher>;
 
@@ -29,7 +27,7 @@ export function fetcher(options: Options) {
   const { intervalString } = getBucketSize(start, end, 'auto');
 
   const filter: ESFilter[] = [
-    { term: { [PROCESSOR_EVENT]: TRANSACTION } },
+    { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
     { term: { [SERVICE_NAME]: serviceName } },
     { term: { [TRANSACTION_TYPE]: TRANSACTION_PAGE_LOAD } },
     { range: rangeFilter(start, end) },

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { SearchParams } from 'elasticsearch';
+import { ESFilter, ESSearchRequest } from '../../../../typings/elasticsearch';
+import { PromiseReturnType } from '../../../../typings/common';
+import {
+  PROCESSOR_EVENT,
+  SERVICE_NAME,
+  TRANSACTION_TYPE,
+  USER_AGENT_NAME,
+  TRANSACTION_DURATION
+} from '../../../../common/elasticsearch_fieldnames';
+import { rangeFilter } from '../../helpers/range_filter';
+import { getBucketSize } from '../../helpers/get_bucket_size';
+import { Options } from '.';
+
+export type ESResponse = PromiseReturnType<typeof fetcher>;
+type Document = unknown;
+
+export function fetcher(options: Options) {
+  const { end, client, indices, start, uiFiltersES } = options.setup;
+  const { serviceName } = options;
+  const { intervalString } = getBucketSize(start, end, 'auto');
+
+  const filter: ESFilter[] = [
+    { term: { [PROCESSOR_EVENT]: 'transaction' } },
+    { term: { [SERVICE_NAME]: serviceName } },
+    { term: { [TRANSACTION_TYPE]: 'page-load' } },
+    { range: rangeFilter(start, end) },
+    ...uiFiltersES
+  ];
+
+  const params = {
+    index: indices['apm_oss.transactionIndices'],
+    body: {
+      size: 0,
+      query: { bool: { filter } },
+      aggs: {
+        user_agent_keys: {
+          terms: {
+            field: USER_AGENT_NAME
+          }
+        },
+        browsers: {
+          date_histogram: {
+            extended_bounds: {
+              max: end,
+              min: start
+            },
+            field: '@timestamp',
+            fixed_interval: intervalString,
+            min_doc_count: 0
+          },
+          aggs: {
+            user_agent: {
+              terms: {
+                field: USER_AGENT_NAME
+              },
+              aggs: {
+                avg_duration: {
+                  avg: {
+                    field: TRANSACTION_DURATION
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return client.search(params);
+}

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/fetcher.ts
@@ -4,8 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { SearchParams } from 'elasticsearch';
-import { ESFilter, ESSearchRequest } from '../../../../typings/elasticsearch';
+import { ESFilter } from '../../../../typings/elasticsearch';
 import { PromiseReturnType } from '../../../../typings/common';
 import {
   PROCESSOR_EVENT,
@@ -19,7 +18,6 @@ import { getBucketSize } from '../../helpers/get_bucket_size';
 import { Options } from '.';
 
 export type ESResponse = PromiseReturnType<typeof fetcher>;
-type Document = unknown;
 
 export function fetcher(options: Options) {
   const { end, client, indices, start, uiFiltersES } = options.setup;

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/index.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  getTransactionAvgDurationByBrowser,
+  Options,
+  AvgDurationByBrowserAPIResponse
+} from '.';
+import * as transformerModule from './transformer';
+import * as fetcherModule from './fetcher';
+import { response } from './__fixtures__/responses';
+
+describe('getAvgDurationByBrowser', () => {
+  it('returns a transformed response', async () => {
+    const transformer = jest
+      .spyOn(transformerModule, 'transformer')
+      .mockReturnValueOnce(({} as unknown) as AvgDurationByBrowserAPIResponse);
+    const search = () => {};
+    const options = ({
+      setup: { client: { search }, indices: {}, uiFiltersES: [] }
+    } as unknown) as Options;
+    jest.spyOn(fetcherModule, 'fetcher').mockResolvedValueOnce(response);
+
+    await getTransactionAvgDurationByBrowser(options);
+
+    expect(transformer).toHaveBeenCalledWith({ response });
+  });
+});

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/index.test.ts
@@ -22,7 +22,9 @@ describe('getAvgDurationByBrowser', () => {
     const options = ({
       setup: { client: { search }, indices: {}, uiFiltersES: [] }
     } as unknown) as Options;
-    jest.spyOn(fetcherModule, 'fetcher').mockResolvedValueOnce(response);
+    jest
+      .spyOn<{ fetcher: any }, 'fetcher'>(fetcherModule, 'fetcher')
+      .mockResolvedValueOnce(response);
 
     await getTransactionAvgDurationByBrowser(options);
 

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { Coordinate } from '../../../../typings/timeseries';
+import { Setup } from '../../helpers/setup_request';
+import { fetcher } from './fetcher';
+import { transformer } from './transformer';
+
+export interface Options {
+  serviceName: string;
+  setup: Setup;
+}
+
+export type AvgDurationByBrowserAPIResponse = Array<{
+  data: Coordinate[];
+  title: string;
+}>;
+
+export async function getTransactionAvgDurationByBrowser(options: Options) {
+  return transformer({ response: await fetcher(options) });
+}

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/transformer.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/transformer.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { transformer } from './transformer';
+import { response } from './__fixtures__/responses';
+
+describe('transformer', () => {
+  it('transforms', () => {
+    expect(transformer({ response })).toEqual([
+      {
+        data: [
+          { x: 1571650700000, y: undefined },
+          { x: 1571650800000, y: 86425.1 }
+        ],
+        title: 'Firefox'
+      },
+      {
+        data: [
+          { x: 1571650700000, y: undefined },
+          { x: 1571650800000, y: 860425.0 }
+        ],
+        title: 'Other'
+      }
+    ]);
+  });
+});

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/transformer.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/transformer.ts
@@ -15,9 +15,9 @@ export function transformer({
   response: ESResponse;
 }): AvgDurationByBrowserAPIResponse {
   const allUserAgentKeys = new Set<string>(
-    (idx(response, _ => _.aggregations.user_agent_keys.buckets) || []).map(
-      ({ key }) => key.toString()
-    )
+    (
+      idx(response, _ => _.aggregations.user_agent_keys.buckets) || []
+    ).map(({ key }) => key.toString())
   );
   const buckets = idx(response, _ => _.aggregations.browsers.buckets) || [];
 

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/transformer.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_browser/transformer.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { idx } from '@kbn/elastic-idx/target';
+import { ESResponse } from './fetcher';
+import { AvgDurationByBrowserAPIResponse } from '.';
+import { Coordinate } from '../../../../typings/timeseries';
+
+export function transformer({
+  response
+}: {
+  response: ESResponse;
+}): AvgDurationByBrowserAPIResponse {
+  const allUserAgentKeys = new Set<string>(
+    (idx(response, _ => _.aggregations.user_agent_keys.buckets) || []).map(
+      ({ key }) => key.toString()
+    )
+  );
+  const buckets = idx(response, _ => _.aggregations.browsers.buckets) || [];
+
+  const series = buckets.reduce<{ [key: string]: Coordinate[] }>(
+    (acc, next) => {
+      const userAgentBuckets = idx(next, _ => _.user_agent.buckets) || [];
+      const x = next.key;
+      const seenUserAgentKeys = new Set<string>();
+
+      userAgentBuckets.map(userAgentBucket => {
+        const key = userAgentBucket.key;
+        const y = idx(userAgentBucket, _ => _.avg_duration.value);
+
+        seenUserAgentKeys.add(key.toString());
+        acc[key] = (acc[key] || []).concat({ x, y });
+      });
+
+      const emptyUserAgents = new Set<string>(
+        [...allUserAgentKeys].filter(key => !seenUserAgentKeys.has(key))
+      );
+
+      // If no user agent requests exist for this bucked, fill in the data with
+      // undefined
+      [...emptyUserAgents].map(key => {
+        acc[key] = (acc[key] || []).concat({ x, y: undefined });
+      });
+
+      return acc;
+    },
+    {}
+  );
+
+  return Object.entries(series).map(([title, data]) => ({ title, data }));
+}

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/constants.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/constants.ts
@@ -3,6 +3,5 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import theme from '@elastic/eui/dist/eui_theme_light.json';
 
 export const MAX_KPIS = 20;

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/constants.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/constants.ts
@@ -6,16 +6,3 @@
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 
 export const MAX_KPIS = 20;
-
-export const COLORS = [
-  theme.euiColorVis0,
-  theme.euiColorVis1,
-  theme.euiColorVis2,
-  theme.euiColorVis3,
-  theme.euiColorVis4,
-  theme.euiColorVis5,
-  theme.euiColorVis6,
-  theme.euiColorVis7,
-  theme.euiColorVis8,
-  theme.euiColorVis9
-];

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -18,7 +18,8 @@ import {
 import { Setup } from '../../helpers/setup_request';
 import { rangeFilter } from '../../helpers/range_filter';
 import { getMetricsDateHistogramParams } from '../../helpers/metrics';
-import { MAX_KPIS, COLORS } from './constants';
+import { MAX_KPIS } from './constants';
+import { getVizColorForIndex } from '../../../../common/viz_colors';
 
 export async function getTransactionBreakdown({
   setup,
@@ -142,7 +143,7 @@ export async function getTransactionBreakdown({
   const kpis = sortByOrder(visibleKpis, 'name').map((kpi, index) => {
     return {
       ...kpi,
-      color: COLORS[index % COLORS.length]
+      color: getVizColorForIndex(index)
     };
   });
 

--- a/x-pack/legacy/plugins/apm/server/routes/create_apm_api.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_apm_api.ts
@@ -42,7 +42,8 @@ import {
   transactionGroupsChartsRoute,
   transactionGroupsDistributionRoute,
   transactionGroupsRoute,
-  transactionGroupsAvgDurationByCountry
+  transactionGroupsAvgDurationByCountry,
+  transactionGroupsAvgDurationByBrowser
 } from './transaction_groups';
 import {
   errorGroupsLocalFiltersRoute,
@@ -102,6 +103,7 @@ const createApmApi = () => {
     .add(transactionGroupsChartsRoute)
     .add(transactionGroupsDistributionRoute)
     .add(transactionGroupsRoute)
+    .add(transactionGroupsAvgDurationByBrowser)
     .add(transactionGroupsAvgDurationByCountry)
 
     // UI filters

--- a/x-pack/legacy/plugins/apm/server/routes/transaction_groups.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/transaction_groups.ts
@@ -12,6 +12,7 @@ import { getTransactionBreakdown } from '../lib/transactions/breakdown';
 import { getTransactionGroupList } from '../lib/transaction_groups';
 import { createRoute } from './create_route';
 import { uiFiltersRt, rangeRt } from './default_api_types';
+import { getTransactionAvgDurationByBrowser } from '../lib/transactions/avg_duration_by_browser';
 import { getTransactionAvgDurationByCountry } from '../lib/transactions/avg_duration_by_country';
 
 export const transactionGroupsRoute = createRoute(() => ({
@@ -139,6 +140,32 @@ export const transactionGroupsBreakdownRoute = createRoute(() => ({
       serviceName,
       transactionName,
       transactionType,
+      setup
+    });
+  }
+}));
+
+export const transactionGroupsAvgDurationByBrowser = createRoute(() => ({
+  path: `/api/apm/services/{serviceName}/transaction_groups/avg_duration_by_browser`,
+  params: {
+    path: t.type({
+      serviceName: t.string
+    }),
+    query: t.intersection([
+      t.partial({
+        transactionType: t.string,
+        transactionName: t.string
+      }),
+      uiFiltersRt,
+      rangeRt
+    ])
+  },
+  handler: async (req, { path }) => {
+    const setup = await setupRequest(req);
+    const { serviceName } = path;
+
+    return getTransactionAvgDurationByBrowser({
+      serviceName,
       setup
     });
   }


### PR DESCRIPTION
Show a chart with average page load broken down by user agent name on the RUM overview.

I tested this by setting up a RUM agent on a sample app on my test cloud cluster.

On the internal APM dev cluster you'll need to set the time range to about 90 days then look at the "client" app and find the time range where there are requests. Unfortunately with this sample data the only series you see is "Other" because there aren't a lot of requests.

Also factor out the color selection into a common helper.

Fixes #43342