### PR TITLE
[Lens] Link to potential docs page

### DIFF
--- a/x-pack/legacy/plugins/lens/public/help_menu_util.tsx
+++ b/x-pack/legacy/plugins/lens/public/help_menu_util.tsx
@@ -12,7 +12,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { Chrome } from 'ui/chrome';
 
-const docsPage = undefined;
+const docsPage = 'lens';
 
 export function addHelpMenuToAppChrome(chrome: Chrome) {
   chrome.helpExtension.set(domElement => {


### PR DESCRIPTION
This uses the docs page from https://github.com/elastic/kibana/pull/47140 and connects it to the help link:

<img width="281" alt="Screenshot 2019-10-29 15 45 35" src="https://user-images.githubusercontent.com/666475/67803305-2884aa00-fa63-11e9-85ed-716671d192d8.png">
