### PR TITLE
Empty message "No data available" for Labels and User metadata sections missing

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/Section.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/Section.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export function Section({ keyValuePairs }: Props) {
-  if (keyValuePairs) {
+  if (keyValuePairs && keyValuePairs.length > 0) {
     return <KeyValueTable keyValuePairs={keyValuePairs} />;
   }
   return (

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/Section.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/Section.tsx
@@ -5,17 +5,18 @@
  */
 
 import React from 'react';
+import { isEmpty } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { EuiText } from '@elastic/eui';
 import { KeyValueTable } from '../KeyValueTable';
 import { KeyValuePair } from '../../../utils/flattenObject';
 
 interface Props {
-  keyValuePairs?: KeyValuePair[];
+  keyValuePairs: KeyValuePair[];
 }
 
 export function Section({ keyValuePairs }: Props) {
-  if (keyValuePairs && keyValuePairs.length > 0) {
+  if (!isEmpty(keyValuePairs)) {
     return <KeyValueTable keyValuePairs={keyValuePairs} />;
   }
   return (

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/Section.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/Section.test.tsx
@@ -11,9 +11,9 @@ import { expectTextsInDocument } from '../../../../utils/testHelpers';
 
 describe('Section', () => {
   it('shows "empty state message" if no data is available', () => {
-    let output = render(<Section />);
-    expectTextsInDocument(output, ['No data available']);
-    output = render(<Section keyValuePairs={[]} />);
-    expectTextsInDocument(output, ['No data available']);
+    const undefinedPropertyComponent = render(<Section />);
+    expectTextsInDocument(undefinedPropertyComponent, ['No data available']);
+    const emptyPropertyComponent = render(<Section keyValuePairs={[]} />);
+    expectTextsInDocument(emptyPropertyComponent, ['No data available']);
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/Section.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/Section.test.tsx
@@ -11,9 +11,7 @@ import { expectTextsInDocument } from '../../../../utils/testHelpers';
 
 describe('Section', () => {
   it('shows "empty state message" if no data is available', () => {
-    const undefinedPropertyComponent = render(<Section />);
-    expectTextsInDocument(undefinedPropertyComponent, ['No data available']);
-    const emptyPropertyComponent = render(<Section keyValuePairs={[]} />);
-    expectTextsInDocument(emptyPropertyComponent, ['No data available']);
+    const component = render(<Section keyValuePairs={[]} />);
+    expectTextsInDocument(component, ['No data available']);
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/Section.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/Section.test.tsx
@@ -11,7 +11,9 @@ import { expectTextsInDocument } from '../../../../utils/testHelpers';
 
 describe('Section', () => {
   it('shows "empty state message" if no data is available', () => {
-    const output = render(<Section />);
+    let output = render(<Section />);
+    expectTextsInDocument(output, ['No data available']);
+    output = render(<Section keyValuePairs={[]} />);
     expectTextsInDocument(output, ['No data available']);
   });
 });


### PR DESCRIPTION
closes #49841 

<img width="1262" alt="Screenshot 2019-10-31 at 10 27 47" src="https://user-images.githubusercontent.com/55978943/67935170-93e88c00-fbc9-11e9-8c02-1e53521f5a82.png">
