### PR TITLE
[task-manager] Improve messaging on error due to inline scripts being disabled

### DIFF
--- a/x-pack/legacy/plugins/task_manager/lib/identify_es_error.test.ts
+++ b/x-pack/legacy/plugins/task_manager/lib/identify_es_error.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { identifyEsError, ESErrorCausedBy } from './identify_es_error';
+
+describe('identifyEsError', () => {
+  test('extracts messages from root cause', () => {
+    expect(
+      identifyEsError(
+        generateESErrorWithResponse(
+          [
+            {
+              type: 'illegal_argument_exception',
+              reason: 'root cause',
+            },
+          ],
+          {}
+        )
+      )
+    ).toContain('root cause');
+  });
+
+  test('extracts messages from deep root cause', () => {
+    expect(
+      identifyEsError(
+        generateESErrorWithResponse(
+          [
+            {
+              type: 'illegal_argument_exception',
+              reason: 'root cause',
+            },
+            {
+              type: 'illegal_argument_exception',
+              reason: 'deep root cause',
+            },
+          ],
+          {}
+        )
+      )
+    ).toContain('deep root cause');
+  });
+
+  test('extracts messages from first caused by', () => {
+    expect(
+      identifyEsError(
+        generateESErrorWithResponse(
+          [
+            {
+              type: 'illegal_argument_exception',
+              reason: 'root cause',
+            },
+            {
+              type: 'illegal_argument_exception',
+              reason: 'deep root cause',
+            },
+          ],
+          {
+            type: 'illegal_argument_exception',
+            reason: 'first caused by',
+            caused_by: {
+              type: 'illegal_argument_exception',
+              reason: 'second caused by',
+            },
+          }
+        )
+      )
+    ).toContain('first caused by');
+  });
+
+  test('extracts messages from deep caused by', () => {
+    expect(
+      identifyEsError(
+        generateESErrorWithResponse(
+          [
+            {
+              type: 'illegal_argument_exception',
+              reason: 'root cause',
+            },
+            {
+              type: 'illegal_argument_exception',
+              reason: 'deep root cause',
+            },
+          ],
+          {
+            type: 'illegal_argument_exception',
+            reason: 'first caused by',
+            caused_by: {
+              type: 'illegal_argument_exception',
+              reason: 'second caused by',
+            },
+          }
+        )
+      )
+    ).toContain('second caused by');
+  });
+
+  test('extracts all messages in error', () => {
+    expect(
+      identifyEsError(
+        generateESErrorWithResponse(
+          [
+            {
+              type: 'illegal_argument_exception',
+              reason: 'root cause',
+            },
+            {
+              type: 'illegal_argument_exception',
+              reason: 'deep root cause',
+            },
+          ],
+          {
+            type: 'illegal_argument_exception',
+            reason: 'first caused by',
+            caused_by: {
+              type: 'illegal_argument_exception',
+              reason: 'second caused by',
+            },
+          }
+        )
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        "first caused by",
+        "second caused by",
+        "root cause",
+        "deep root cause",
+      ]
+    `);
+  });
+});
+
+function generateESErrorWithResponse(
+  rootCause: ESErrorCausedBy[] = [],
+  causeBy: ESErrorCausedBy = {}
+) {
+  return Object.assign(new Error(), {
+    msg: '[illegal_argument_exception] cannot execute [inline] scripts',
+    path: '/.kibana_task_manager/_update_by_query',
+    query: {},
+    body: '{"query":{}}',
+    statusCode: 400,
+    response: JSON.stringify({
+      error: {
+        root_cause: rootCause,
+        type: 'search_phase_execution_exception',
+        reason: 'all shards failed',
+        phase: 'query',
+        grouped: true,
+        failed_shards: [
+          {
+            shard: 0,
+            index: '.kibana_task_manager_1',
+            node: '24A4QbjHSK6prvtopAKLKw',
+            reason: {
+              type: 'illegal_argument_exception',
+              reason: 'cannot execute [inline] scripts',
+            },
+          },
+        ],
+        caused_by: causeBy,
+      },
+      status: 400,
+    }),
+  });
+}

--- a/x-pack/legacy/plugins/task_manager/lib/identify_es_error.ts
+++ b/x-pack/legacy/plugins/task_manager/lib/identify_es_error.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+interface ESErrorCausedBy {
+  reason?: string;
+  caused_by?: ESErrorCausedBy;
+}
+
+interface ESError {
+  root_cause?: ESErrorCausedBy[];
+  caused_by?: ESErrorCausedBy;
+}
+
+function extractCausedByChain(
+  causedBy: ESErrorCausedBy = {},
+  accumulator: string[] = []
+): string[] {
+  const { reason, caused_by: innerCausedBy } = causedBy;
+
+  if (reason) {
+    accumulator.push(reason);
+  }
+
+  if (innerCausedBy) {
+    return extractCausedByChain(innerCausedBy, accumulator);
+  }
+
+  return accumulator;
+}
+
+/**
+ * Identified causes for ES Error
+ *
+ * @param err Object Error thrown by ES JS client
+ * @return ES error cause
+ */
+export function identifyEsError(err: { response: string }) {
+  const { response } = err;
+
+  if (response) {
+    const { error } = JSON.parse(response) as { error?: ESError };
+    if (error) {
+      const { root_cause: rootCause = [], caused_by: causedBy } = error;
+
+      // The caused_by chain has the most information so use that if it's available. If not then
+      // settle for the root_cause.
+      const causedByChain = extractCausedByChain(causedBy);
+      if (causedByChain.length) {
+        return causedByChain;
+      }
+      return rootCause.length ? extractCausedByChain(rootCause[0]) : [];
+    }
+  }
+  return [];
+}

--- a/x-pack/legacy/plugins/task_manager/task_manager.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.test.ts
@@ -215,6 +215,10 @@ describe('TaskManager', () => {
       expect(claim).not.toHaveBeenCalled();
     });
 
+    /**
+     * This handles the case in which Elasticsearch has had inline script disabled.
+     * This is achieved by setting the `script.allowed_types` flag on Elasticsearch to `none`
+     */
     test('handles failure due to inline scripts being disabled', () => {
       const logger = mockLogger();
       const claim = jest.fn(() => {

--- a/x-pack/legacy/plugins/task_manager/task_manager.test.ts
+++ b/x-pack/legacy/plugins/task_manager/task_manager.test.ts
@@ -214,5 +214,30 @@ describe('TaskManager', () => {
 
       expect(claim).not.toHaveBeenCalled();
     });
+
+    test('handles failure due to inline scripts being disabled', () => {
+      const logger = mockLogger();
+      const claim = jest.fn(() => {
+        throw Object.assign(new Error(), {
+          msg: '[illegal_argument_exception] cannot execute [inline] scripts',
+          path: '/.kibana_task_manager/_update_by_query',
+          query: {
+            ignore_unavailable: true,
+            refresh: true,
+            max_docs: 200,
+            conflicts: 'proceed',
+          },
+          body:
+            '{"query":{"bool":{"must":[{"term":{"type":"task"}},{"bool":{"must":[{"bool":{"should":[{"bool":{"must":[{"term":{"task.status":"idle"}},{"range":{"task.runAt":{"lte":"now"}}}]}},{"bool":{"must":[{"bool":{"should":[{"term":{"task.status":"running"}},{"term":{"task.status":"claiming"}}]}},{"range":{"task.retryAt":{"lte":"now"}}}]}}]}},{"bool":{"should":[{"exists":{"field":"task.interval"}},{"bool":{"must":[{"term":{"task.taskType":"vis_telemetry"}},{"range":{"task.attempts":{"lt":3}}}]}},{"bool":{"must":[{"term":{"task.taskType":"lens_telemetry"}},{"range":{"task.attempts":{"lt":3}}}]}},{"bool":{"must":[{"term":{"task.taskType":"actions:.server-log"}},{"range":{"task.attempts":{"lt":1}}}]}},{"bool":{"must":[{"term":{"task.taskType":"actions:.slack"}},{"range":{"task.attempts":{"lt":1}}}]}},{"bool":{"must":[{"term":{"task.taskType":"actions:.email"}},{"range":{"task.attempts":{"lt":1}}}]}},{"bool":{"must":[{"term":{"task.taskType":"actions:.index"}},{"range":{"task.attempts":{"lt":1}}}]}},{"bool":{"must":[{"term":{"task.taskType":"actions:.pagerduty"}},{"range":{"task.attempts":{"lt":1}}}]}},{"bool":{"must":[{"term":{"task.taskType":"actions:.webhook"}},{"range":{"task.attempts":{"lt":1}}}]}}]}}]}}]}},"sort":{"_script":{"type":"number","order":"asc","script":{"lang":"expression","source":"doc[\'task.retryAt\'].value || doc[\'task.runAt\'].value"}}},"seq_no_primary_term":true,"script":{"source":"ctx._source.task.ownerId=params.ownerId; ctx._source.task.status=params.status; ctx._source.task.retryAt=params.retryAt;","lang":"painless","params":{"ownerId":"kibana:5b2de169-2785-441b-ae8c-186a1936b17d","retryAt":"2019-10-31T13:35:43.579Z","status":"claiming"}}}',
+          statusCode: 400,
+          response:
+            '{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"cannot execute [inline] scripts"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":".kibana_task_manager_1","node":"24A4QbjHSK6prvtopAKLKw","reason":{"type":"illegal_argument_exception","reason":"cannot execute [inline] scripts"}}],"caused_by":{"type":"illegal_argument_exception","reason":"cannot execute [inline] scripts","caused_by":{"type":"illegal_argument_exception","reason":"cannot execute [inline] scripts"}}},"status":400}',
+        });
+      });
+
+      claimAvailableTasks(claim, 10, logger);
+
+      sinon.assert.calledWithMatch(logger.warn, /inline scripts/);
+    });
   });
 });


### PR DESCRIPTION
addresses #49853, but doesn't resolve it completely as further mitigation may very likely be required.

## Summary

This PR detects when claiming tasks fails due to inline scripts being disabled in Elasticsearch and improves the message reported in the Kibana log.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

