### PR TITLE
[APM] Script optimization of APM-specific tsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ package-lock.json
 *.sublime-*
 npm-debug.log*
 .tern-project
+x-pack/legacy/plugins/apm/tsconfig.json
+apm.tsconfig.json

--- a/x-pack/legacy/plugins/apm/dev_docs/typescript.md
+++ b/x-pack/legacy/plugins/apm/dev_docs/typescript.md
@@ -1,0 +1,11 @@
+#### Optimizing TypeScript 
+
+Kibana and X-Pack are very large TypeScript projects, and it comes at a cost. Editor responsiveness is not great, and the CLI type check for X-Pack takes about a minute. To get faster feedback, we create a smaller APM TypeScript project that only type checks the APM project and the files it uses. This optimization consists of creating a `tsconfig.json` in APM that includes the Kibana/X-Pack typings, and editing the Kibana/X-Pack configurations to not include any files, or removing the configurations altogether. The script configures git to ignore any changes in these files, and has an undo script as well.
+
+To run the optimization:
+
+`$ node x-pack/legacy/plugins/apm/scripts/optimize-tsconfig`
+
+To undo the optimization:
+
+`$ node x-pack/legacy/plugins/apm/scripts/unoptimize-tsconfig`

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig.js
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+const { optimizeTsConfig } = require('./optimize-tsconfig/optimize');
+
+optimizeTsConfig();

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/optimize.js
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/optimize.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+/* eslint-disable import/no-extraneous-dependencies */
+
+const fs = require('fs');
+const promisify = require('util').promisify;
+const path = require('path');
+const json5 = require('json5');
+const execa = require('execa');
+
+const copyFile = promisify(fs.copyFile);
+const rename = promisify(fs.rename);
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+const { xpackRoot, kibanaRoot, apmRoot, tsconfigTpl } = require('./paths');
+const { unoptimizeTsConfig } = require('./unoptimize');
+
+function updateParentTsConfigs() {
+  return Promise.all(
+    [xpackRoot, kibanaRoot].map(async dir => {
+      const filename = path.resolve(dir, 'apm.tsconfig.json');
+      const config = json5.parse(await readFile(filename, 'utf-8'));
+
+      const include = [];
+      const extendsOption =
+        'extends' in config ? { extends: '../apm.tsconfig.json' } : {};
+
+      await writeFile(
+        filename,
+        JSON.stringify({
+          ...config,
+          include,
+          ...extendsOption
+        }),
+        { encoding: 'utf-8' }
+      );
+    })
+  );
+}
+
+async function setIgnoreChanges() {
+  await execa('git', [
+    'update-index',
+    '--skip-worktree',
+    path.resolve(xpackRoot, 'tsconfig.json')
+  ]);
+
+  await execa('git', [
+    'update-index',
+    '--skip-worktree',
+    path.resolve(kibanaRoot, 'tsconfig.json')
+  ]);
+}
+
+const optimizeTsConfig = () => {
+  return unoptimizeTsConfig()
+    .then(() =>
+      Promise.all([
+        copyFile(tsconfigTpl, path.resolve(apmRoot, './tsconfig.json')),
+        rename(
+          path.resolve(xpackRoot, 'tsconfig.json'),
+          path.resolve(xpackRoot, 'apm.tsconfig.json')
+        ),
+        rename(
+          path.resolve(kibanaRoot, 'tsconfig.json'),
+          path.resolve(kibanaRoot, 'apm.tsconfig.json')
+        )
+      ])
+    )
+    .then(() => updateParentTsConfigs())
+    .then(() => setIgnoreChanges())
+    .then(() => {
+      // eslint-disable-next-line no-console
+      console.log(
+        'Created an optimized tsconfig.json for APM. To undo these changes, run `./scripts/unoptimize-tsconfig.js`'
+      );
+    });
+};
+
+module.exports = {
+  optimizeTsConfig
+};

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/paths.js
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/paths.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+const path = require('path');
+
+const apmRoot = path.resolve(__dirname, '../..');
+const xpackRoot = path.resolve(apmRoot, '../../..');
+const kibanaRoot = path.resolve(xpackRoot, '..');
+
+const tsconfigTpl = path.resolve(__dirname, './tsconfig.json');
+
+module.exports = {
+  apmRoot,
+  xpackRoot,
+  kibanaRoot,
+  tsconfigTpl
+};

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/paths.js
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/paths.js
@@ -11,9 +11,15 @@ const kibanaRoot = path.resolve(xpackRoot, '..');
 
 const tsconfigTpl = path.resolve(__dirname, './tsconfig.json');
 
+const filesToIgnore = [
+  path.resolve(xpackRoot, 'tsconfig.json'),
+  path.resolve(kibanaRoot, 'tsconfig.json')
+];
+
 module.exports = {
   apmRoot,
   xpackRoot,
   kibanaRoot,
-  tsconfigTpl
+  tsconfigTpl,
+  filesToIgnore
 };

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../apm.tsconfig.json",
+  "include": [
+    "./**/*",
+    "../../../typings/**/*"
+  ],
+  "exclude": [
+    "**/__fixtures__/**/*",
+    "./cypress/**/*"
+  ]
+}

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/unoptimize.js
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/unoptimize.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+
+const path = require('path');
+const execa = require('execa');
+const fs = require('fs');
+const promisify = require('util').promisify;
+const removeFile = promisify(fs.unlink);
+const exists = promisify(fs.exists);
+
+const { xpackRoot, kibanaRoot, apmRoot } = require('./paths');
+
+async function unoptimizeTsConfig() {
+  await execa('git', [
+    'update-index',
+    '--no-skip-worktree',
+    path.resolve(xpackRoot, 'tsconfig.json')
+  ]);
+
+  await execa('git', [
+    'update-index',
+    '--no-skip-worktree',
+    path.resolve(kibanaRoot, 'tsconfig.json')
+  ]);
+
+  await execa('git', ['checkout', path.resolve(xpackRoot, 'tsconfig.json')]);
+  await execa('git', ['checkout', path.resolve(kibanaRoot, 'tsconfig.json')]);
+
+  const apmTsConfig = path.join(apmRoot, 'tsconfig.json');
+  if (await exists(apmTsConfig)) {
+    await removeFile(apmTsConfig);
+  }
+}
+
+module.exports = {
+  unoptimizeTsConfig: () => {
+    return unoptimizeTsConfig().then(() => {
+      // eslint-disable-next-line no-console
+      console.log('Removed APM TypeScript optimizations');
+    });
+  }
+};

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/unoptimize.js
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/unoptimize.js
@@ -12,23 +12,13 @@ const promisify = require('util').promisify;
 const removeFile = promisify(fs.unlink);
 const exists = promisify(fs.exists);
 
-const { xpackRoot, kibanaRoot, apmRoot } = require('./paths');
+const { apmRoot, filesToIgnore } = require('./paths');
 
 async function unoptimizeTsConfig() {
-  await execa('git', [
-    'update-index',
-    '--no-skip-worktree',
-    path.resolve(xpackRoot, 'tsconfig.json')
-  ]);
-
-  await execa('git', [
-    'update-index',
-    '--no-skip-worktree',
-    path.resolve(kibanaRoot, 'tsconfig.json')
-  ]);
-
-  await execa('git', ['checkout', path.resolve(xpackRoot, 'tsconfig.json')]);
-  await execa('git', ['checkout', path.resolve(kibanaRoot, 'tsconfig.json')]);
+  for (const filename of filesToIgnore) {
+    await execa('git', ['update-index', '--no-skip-worktree', filename]);
+    await execa('git', ['checkout', filename]);
+  }
 
   const apmTsConfig = path.join(apmRoot, 'tsconfig.json');
   if (await exists(apmTsConfig)) {

--- a/x-pack/legacy/plugins/apm/scripts/unoptimize-tsconfig.js
+++ b/x-pack/legacy/plugins/apm/scripts/unoptimize-tsconfig.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+const { unoptimizeTsConfig } = require('./optimize-tsconfig/unoptimize');
+
+unoptimizeTsConfig();

--- a/x-pack/legacy/plugins/apm/typings/common.d.ts
+++ b/x-pack/legacy/plugins/apm/typings/common.d.ts
@@ -4,6 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import '../../infra/types/rison_node';
+import '../../infra/types/eui';
+// EUIBasicTable
+import {} from '../../reporting/public/components/report_listing';
+// .svg
+import '../../canvas/types/webpack';
+
 // Allow unknown properties in an object
 export type AllowUnknownProperties<T> = T extends Array<infer X>
   ? Array<AllowUnknownObjectProperties<X>>


### PR DESCRIPTION
Third time's the charm. Previous attempts:

- [commit APM-specific tsconfig.json](https://github.com/elastic/kibana/pull/48751). Not ideal, because there's still a lot of overhead when using types that belong to either the kibana or the x-pack project. 
- [split up TS projects into smaller ones](https://github.com/elastic/kibana/pull/48965). I don't expect this to land soon, because it's a pretty big change to work around something that is more likely [a VS Code or TypeScript performance issue](https://github.com/microsoft/TypeScript/issues/34843).

This attempt adds two scripts in `apm/scripts`, that either create a tsconfig.json optimized for APM, or undo the changes in the optimization. Here's what the optimization process is like:

- Create a `tsconfig.json` file in `x-pack/legacy/plugins/apm`
- Rename Kibana and X-Pack `tsconfig.json`s to `apm.tsconfig.json` so these projecst are not bootstrapped by VS Code when a file from those projects is encountered.
- Set `--skip-worktree` for those `tsconfig.json`s to prevent any changes to these files (including deleting them) to show up in the git staging area.