### PR TITLE
[APM] Remove redundant, custom typescript helpers

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Main/ProvideBreadcrumbs.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/ProvideBreadcrumbs.tsx
@@ -12,11 +12,10 @@ import {
   RouteProps,
   withRouter
 } from 'react-router-dom';
-import { StringMap } from '../../../../typings/common';
 import { RouteName } from './route_config/route_names';
 
 type LocationMatch = Pick<
-  RouteComponentProps<StringMap<string>>,
+  RouteComponentProps<Record<string, string>>,
   'location' | 'match'
 >;
 
@@ -75,7 +74,7 @@ export function getBreadcrumb({
       return null;
     }
 
-    const match = matchPath<StringMap<string>>(currentPath, route);
+    const match = matchPath<Record<string, string>>(currentPath, route);
 
     if (match) {
       return parse({

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/__test__/createErrorGroupWatch.test.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/__test__/createErrorGroupWatch.test.ts
@@ -7,7 +7,6 @@
 import { isArray, isObject, isString } from 'lodash';
 import mustache from 'mustache';
 import uuid from 'uuid';
-import { StringMap } from '../../../../../../typings/common';
 // @ts-ignore
 import * as rest from '../../../../../services/rest/watcher';
 import { createErrorGroupWatch } from '../createErrorGroupWatch';
@@ -85,8 +84,11 @@ describe('createErrorGroupWatch', () => {
 });
 
 // Recursively iterate a nested structure and render strings as mustache templates
-type InputOutput = string | string[] | StringMap<any>;
-function renderMustache(input: InputOutput, ctx: StringMap): InputOutput {
+type InputOutput = string | string[] | Record<string, any>;
+function renderMustache(
+  input: InputOutput,
+  ctx: Record<string, unknown>
+): InputOutput {
   if (isString(input)) {
     return mustache.render(input, {
       ctx,

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
@@ -17,7 +17,6 @@ import {
   PROCESSOR_EVENT,
   SERVICE_NAME
 } from '../../../../../common/elasticsearch_fieldnames';
-import { StringMap } from '../../../../../typings/common';
 // @ts-ignore
 import { createWatch } from '../../../../services/rest/watcher';
 
@@ -50,8 +49,8 @@ interface Arguments {
 
 interface Actions {
   log_error: { logging: { text: string } };
-  slack_webhook?: StringMap;
-  email?: StringMap;
+  slack_webhook?: Record<string, unknown>;
+  email?: Record<string, unknown>;
 }
 
 export async function createErrorGroupWatch({

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
@@ -22,7 +22,6 @@ import {
 import { useFetcher } from '../../../../hooks/useFetcher';
 import { useCallApmApi } from '../../../../hooks/useCallApmApi';
 import { APMClient } from '../../../../services/rest/createCallApmApi';
-import { StringMap } from '../../../../../typings/common';
 import { useKibanaCore } from '../../../../../../observability/public';
 
 const APM_INDEX_LABELS = [
@@ -79,7 +78,7 @@ async function saveApmIndices({
   apmIndices
 }: {
   callApmApi: APMClient;
-  apmIndices: StringMap<string>;
+  apmIndices: Record<string, string>;
 }) {
   await callApmApi({
     method: 'POST',
@@ -95,7 +94,7 @@ export function ApmIndices() {
     notifications: { toasts }
   } = useKibanaCore();
 
-  const [apmIndices, setApmIndices] = useState<StringMap<string>>({});
+  const [apmIndices, setApmIndices] = useState<Record<string, string>>({});
   const [isSaving, setIsSaving] = useState(false);
 
   const callApmApiFromHook = useCallApmApi();

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -17,7 +17,6 @@ import {
 } from 'lodash';
 import { idx } from '@kbn/elastic-idx';
 import { TraceAPIResponse } from '../../../../../../../../server/lib/traces/get_trace';
-import { StringMap } from '../../../../../../../../typings/common';
 import { Span } from '../../../../../../../../typings/es_schemas/ui/Span';
 import { Transaction } from '../../../../../../../../typings/es_schemas/ui/Transaction';
 
@@ -191,7 +190,7 @@ function getServices(items: IWaterfallItem[]) {
   return uniq(serviceNames);
 }
 
-export type IServiceColors = StringMap<string>;
+export type IServiceColors = Record<string, string>;
 
 function getServiceColors(services: string[]) {
   const assignedColors = [

--- a/x-pack/legacy/plugins/apm/public/components/shared/ImpactBar/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/ImpactBar/index.tsx
@@ -6,10 +6,9 @@
 
 import { EuiProgress } from '@elastic/eui';
 import React from 'react';
-import { StringMap } from '../../../../typings/common';
 
 // TODO: extend from EUI's EuiProgress prop interface
-export interface ImpactBarProps extends StringMap {
+export interface ImpactBarProps extends Record<string, unknown> {
   value: number;
   max?: number;
 }

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/url_helpers.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/url_helpers.ts
@@ -6,13 +6,12 @@
 
 import qs from 'querystring';
 import { LocalUIFilterName } from '../../../../server/lib/ui_filters/local_ui_filters/config';
-import { StringMap } from '../../../../typings/common';
 
 export function toQuery(search?: string): APMQueryParamsRaw {
   return search ? qs.parse(search.slice(1)) : {};
 }
 
-export function fromQuery(query: StringMap<any>) {
+export function fromQuery(query: Record<string, any>) {
   return qs.stringify(query, undefined, undefined, {
     encodeURIComponent: (value: string) => {
       return encodeURIComponent(value).replace(/%3A/g, ':');

--- a/x-pack/legacy/plugins/apm/public/components/shared/ManagedTable/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/ManagedTable/index.tsx
@@ -8,7 +8,6 @@ import { EuiBasicTable } from '@elastic/eui';
 import { sortByOrder } from 'lodash';
 import React, { useMemo, useCallback, ReactNode } from 'react';
 import { idx } from '@kbn/elastic-idx';
-import { StringMap } from '../../../../typings/common';
 import { useUrlParams } from '../../../hooks/useUrlParams';
 import { history } from '../../../utils/history';
 import { fromQuery, toQuery } from '../Links/url_helpers';
@@ -16,7 +15,7 @@ import { fromQuery, toQuery } from '../Links/url_helpers';
 // TODO: this should really be imported from EUI
 export interface ITableColumn<T> {
   name: ReactNode;
-  actions?: StringMap[];
+  actions?: Array<Record<string, unknown>>;
   field?: string;
   dataType?: string;
   align?: string;

--- a/x-pack/legacy/plugins/apm/public/selectors/chartSelectors.ts
+++ b/x-pack/legacy/plugins/apm/public/selectors/chartSelectors.ts
@@ -11,7 +11,6 @@ import mean from 'lodash.mean';
 import { rgba } from 'polished';
 import { TimeSeriesAPIResponse } from '../../server/lib/transactions/charts';
 import { ApmTimeSeriesResponse } from '../../server/lib/transactions/charts/get_timeseries_data/transform';
-import { StringMap } from '../../typings/common';
 import {
   Coordinate,
   RectCoordinate,
@@ -192,7 +191,7 @@ function getColorByKey(keys: string[]) {
   const assignedColors = ['HTTP 2xx', 'HTTP 3xx', 'HTTP 4xx', 'HTTP 5xx'];
 
   const unknownKeys = difference(keys, assignedColors);
-  const unassignedColors: StringMap<string> = zipObject(unknownKeys, [
+  const unassignedColors: Record<string, string> = zipObject(unknownKeys, [
     theme.euiColorVis1,
     theme.euiColorVis3,
     theme.euiColorVis4,

--- a/x-pack/legacy/plugins/apm/public/services/__test__/SessionStorageMock.ts
+++ b/x-pack/legacy/plugins/apm/public/services/__test__/SessionStorageMock.ts
@@ -4,10 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { StringMap } from '../../../typings/common';
-
 export class SessionStorageMock {
-  private store: StringMap = {};
+  private store: Record<string, unknown> = {};
 
   public clear() {
     this.store = {};

--- a/x-pack/legacy/plugins/apm/public/services/rest/xpack.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/xpack.ts
@@ -5,7 +5,6 @@
  */
 
 import { HttpServiceBase } from 'kibana/public';
-import { StringMap } from '../../../typings/common';
 import { callApi } from './callApi';
 
 export interface LicenseApiResponse {
@@ -13,11 +12,11 @@ export interface LicenseApiResponse {
     is_active: boolean;
   };
   features: {
-    beats_management?: StringMap;
-    graph?: StringMap;
-    grokdebugger?: StringMap;
-    index_management?: StringMap;
-    logstash?: StringMap;
+    beats_management?: Record<string, unknown>;
+    graph?: Record<string, unknown>;
+    grokdebugger?: Record<string, unknown>;
+    index_management?: Record<string, unknown>;
+    logstash?: Record<string, unknown>;
     ml?: {
       is_available: boolean;
       license_type: number;
@@ -25,12 +24,12 @@ export interface LicenseApiResponse {
       enable_links: boolean;
       show_links: boolean;
     };
-    reporting?: StringMap;
-    rollup?: StringMap;
-    searchprofiler?: StringMap;
-    security?: StringMap;
-    spaces?: StringMap;
-    tilemap?: StringMap;
+    reporting?: Record<string, unknown>;
+    rollup?: Record<string, unknown>;
+    searchprofiler?: Record<string, unknown>;
+    security?: Record<string, unknown>;
+    spaces?: Record<string, unknown>;
+    tilemap?: Record<string, unknown>;
     watcher?: {
       is_available: boolean;
       enable_links: boolean;

--- a/x-pack/legacy/plugins/apm/public/utils/httpStatusCodeToColor.ts
+++ b/x-pack/legacy/plugins/apm/public/utils/httpStatusCodeToColor.ts
@@ -5,8 +5,6 @@
  */
 
 import theme from '@elastic/eui/dist/eui_theme_light.json';
-import { StringMap } from '../../typings/common';
-
 const { euiColorDarkShade, euiColorWarning } = theme;
 
 export const errorColor = '#c23c2b';
@@ -14,7 +12,7 @@ export const neutralColor = euiColorDarkShade;
 export const successColor = '#327a42';
 export const warningColor = euiColorWarning;
 
-const httpStatusCodeColors: StringMap<string> = {
+const httpStatusCodeColors: Record<string, string> = {
   1: neutralColor,
   2: successColor,
   3: neutralColor,

--- a/x-pack/legacy/plugins/apm/server/lib/helpers/es_client.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/helpers/es_client.ts
@@ -14,7 +14,6 @@ import {
 import { Legacy } from 'kibana';
 import { cloneDeep, has, isString, set, pick } from 'lodash';
 import { OBSERVER_VERSION_MAJOR } from '../../../common/elasticsearch_fieldnames';
-import { StringMap, Omit } from '../../../typings/common';
 import { getApmIndices } from '../settings/apm_indices/get_apm_indices';
 import {
   ESSearchResponse,
@@ -95,7 +94,7 @@ interface APMOptions {
 
 export function getESClient(req: Legacy.Request) {
   const cluster = req.server.plugins.elasticsearch.getCluster('data');
-  const query = req.query as StringMap;
+  const query = req.query as Record<string, unknown>;
 
   return {
     search: async <

--- a/x-pack/legacy/plugins/apm/typings/common.ts
+++ b/x-pack/legacy/plugins/apm/typings/common.ts
@@ -4,10 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export interface StringMap<T = unknown> {
-  [key: string]: T;
-}
-
 // Allow unknown properties in an object
 export type AllowUnknownProperties<T> = T extends Array<infer X>
   ? Array<AllowUnknownObjectProperties<X>>
@@ -24,9 +20,3 @@ export type PromiseReturnType<Func> = Func extends (
 ) => Promise<infer Value>
   ? Value
   : Func;
-
-export type IndexAsString<Map> = {
-  [k: string]: Map[keyof Map];
-} & Map;
-
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/x-pack/legacy/plugins/apm/typings/elasticsearch/index.ts
+++ b/x-pack/legacy/plugins/apm/typings/elasticsearch/index.ts
@@ -4,10 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Omit } from 'utility-types';
 import { SearchParams, SearchResponse } from 'elasticsearch';
 import { AggregationResponseMap, AggregationInputMap } from './aggregations';
-import { StringMap } from '../common';
 
 export interface ESSearchBody {
   query?: any;
@@ -55,6 +53,11 @@ export type ESSearchResponse<
 
 export interface ESFilter {
   [key: string]: {
-    [key: string]: string | string[] | number | StringMap | ESFilter[];
+    [key: string]:
+      | string
+      | string[]
+      | number
+      | Record<string, unknown>
+      | ESFilter[];
   };
 }


### PR DESCRIPTION
Small cleanup PR to remove unused/custom Typescript helpers

- Replace `StringMap` with `Record<P, Q>`
- Remove unused `IndexAsString`
- Remove custom `Omit`
