### PR TITLE
[Lens] Fix crash when switching from subtype to subtype

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/chart_switch.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/chart_switch.test.tsx
@@ -369,7 +369,7 @@ describe('chart_switch', () => {
     );
   });
 
-  it('should not remove layers if the visualization is not changing', () => {
+  it('should not remove layers when switching between subtypes', () => {
     const dispatch = jest.fn();
     const frame = mockFrame(['a', 'b', 'c']);
     const visualizations = mockVisualizations();
@@ -397,6 +397,7 @@ describe('chart_switch', () => {
         initialState: 'therebedragons',
       })
     );
+    expect(frame.removeLayers).not.toHaveBeenCalled();
   });
 
   it('should switch to the updated datasource state', () => {

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/chart_switch.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/chart_switch.tsx
@@ -28,6 +28,7 @@ interface VisualizationSelection {
   dataLoss: 'nothing' | 'layers' | 'everything' | 'columns';
   datasourceId?: string;
   datasourceState?: unknown;
+  sameDatasources?: boolean;
 }
 
 interface Props {
@@ -89,7 +90,10 @@ export function ChartSwitch(props: Props) {
       'SWITCH_VISUALIZATION'
     );
 
-    if (!selection.datasourceId || selection.dataLoss === 'everything') {
+    if (
+      (!selection.datasourceId && !selection.sameDatasources) ||
+      selection.dataLoss === 'everything'
+    ) {
       props.framePublicAPI.removeLayers(Object.keys(props.framePublicAPI.datasourceLayers));
     }
   };
@@ -109,6 +113,7 @@ export function ChartSwitch(props: Props) {
         dataLoss: 'nothing',
         keptLayerIds: Object.keys(props.framePublicAPI.datasourceLayers),
         getVisualizationState: () => switchVisType(subVisualizationId, props.visualizationState),
+        sameDatasources: true,
       };
     }
 


### PR DESCRIPTION
Fixes a crash that happens every time in the chart switcher when switching from a type like Bar to Line. This bug happened because the suggestion being build did not include `datasourceId`, which was also used in the logic to remove layers. This still lets us clear layers when switching between two separate datasources without breaking the same-datasource case.