### PR TITLE
[APM] Add `_debug=true` to APM docs

### DIFF
--- a/x-pack/legacy/plugins/apm/dev_docs/github_commands.md
+++ b/x-pack/legacy/plugins/apm/dev_docs/github_commands.md
@@ -1,0 +1,6 @@
+### Useful Github Pull Request commands
+
+The following commands can be executed by writing them as comments on a pull request:
+
+- `@elasticmachine merge upstream`: Will merge the upstream (eg. master or 7.x) into the branch. This is useful if a bug has been fixed upstream and the fix is necessary to pass CI checks
+- `retest` Re-run the tests. This is useful if a flaky test caused the build to fail

--- a/x-pack/legacy/plugins/apm/dev_docs/vscode_setup.md
+++ b/x-pack/legacy/plugins/apm/dev_docs/vscode_setup.md
@@ -1,0 +1,53 @@
+### Visual Studio Code
+
+When using [Visual Studio Code](https://code.visualstudio.com/) with APM it's best to set up a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces) and add the `x-pack/legacy/plugins/apm` directory, the `x-pack` directory, and the root of the Kibana repository to the workspace. This makes it so you can navigate and search within APM and use the wider workspace roots when you need to widen your search.
+
+#### Using the Jest extension
+
+The [vscode-jest extension](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) is a good way to run your Jest tests inside the editor.
+
+Some of the benefits of using the extension over just running it in a terminal are:
+
+• It shows the pass/fail of a test inline in the test file
+• It shows the error message in the test file if it fails
+• You don’t have to have the terminal process running
+• It can automatically update your snapshots when they change
+• Coverage mapping
+
+The extension doesn't really work well if you're trying to use it on all of Kibana or all of X-Pack, but it works well if you configure it to run only on the files in APM.
+
+If you have a workspace configured as described above you should have:
+
+```json
+"jest.disabledWorkspaceFolders": ["kibana", "x-pack"]
+```
+
+in your Workspace settings, and:
+
+```json
+"jest.pathToJest": "node scripts/jest.js --testPathPattern=legacy/plugins/apm",
+"jest.rootPath": "../../.."
+```
+
+in the settings for the APM folder.
+
+#### Jest debugging
+
+To make the [VSCode debugger](https://vscode.readthedocs.io/en/latest/editor/debugging/) work with Jest (you can set breakpoints in the code and tests and use the VSCode debugger) you'll need the [Node Debug extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.node-debug2) installed and can set up a launch configuration like:
+
+```json
+{
+  "type": "node",
+  "name": "APM Jest",
+  "request": "launch",
+  "args": ["--runInBand", "--testPathPattern=legacy/plugins/apm"],
+  "cwd": "${workspaceFolder}/../../..",
+  "console": "internalConsole",
+  "internalConsoleOptions": "openOnSessionStart",
+  "disableOptimisticBPs": true,
+  "program": "${workspaceFolder}/../../../scripts/jest.js",
+  "runtimeVersion": "10.15.2"
+}
+```
+
+(you'll want `runtimeVersion` to match what's in the Kibana root .nvmrc. Depending on your setup, you might be able to remove this line.)

--- a/x-pack/legacy/plugins/apm/readme.md
+++ b/x-pack/legacy/plugins/apm/readme.md
@@ -29,6 +29,13 @@ cd apm-integration-testing/
 
 _Docker Compose is required_
 
+### Debugging Elasticsearch queries
+
+All APM api endpoints accept `_debug=true` as a query param that will result in the underlying ES query being outputted in the Kibana backend process.
+
+Example:
+`/api/apm/services/my_service?_debug=true`
+
 ### Unit testing
 
 Note: Run the following commands from `kibana/x-pack`.
@@ -44,10 +51,6 @@ node scripts/jest.js plugins/apm --watch
 ```
 node scripts/jest.js plugins/apm --updateSnapshot
 ```
-
-### Cypress E2E tests
-
-See the Cypress-specific [readme.md](cypress/README.md)
 
 ### Linting
 
@@ -65,63 +68,8 @@ yarn prettier  "./x-pack/legacy/plugins/apm/**/*.{tsx,ts,js}" --write
 yarn eslint ./x-pack/legacy/plugins/apm --fix
 ```
 
-### Useful Github Pull Request commands
+#### Further resouces
 
-The following commands can be executed by writing them as comments on a pull request:
-
- - `@elasticmachine merge upstream`: Will merge the upstream (eg. master or 7.x) into the branch. This is useful if a bug has been fixed upstream and the fix is necessary to pass CI checks
- - `retest` Re-run the tests. This is useful if a flaky test caused the build to fail
-
-### Visual Studio Code
-
-When using [Visual Studio Code](https://code.visualstudio.com/) with APM it's best to set up a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces) and add the `x-pack/legacy/plugins/apm` directory, the `x-pack` directory, and the root of the Kibana repository to the workspace. This makes it so you can navigate and search within APM and use the wider workspace roots when you need to widen your search.
-
-#### Using the Jest extension
-
-The [vscode-jest extension](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) is a good way to run your Jest tests inside the editor.
-
-Some of the benefits of using the extension over just running it in a terminal are:
-
-• It shows the pass/fail of a test inline in the test file
-• It shows the error message in the test file if it fails
-• You don’t have to have the terminal process running
-• It can automatically update your snapshots when they change
-• Coverage mapping
-
-The extension doesn't really work well if you're trying to use it on all of Kibana or all of X-Pack, but it works well if you configure it to run only on the files in APM.
-
-If you have a workspace configured as described above you should have:
-
-```json
-"jest.disabledWorkspaceFolders": ["kibana", "x-pack"]
-```
-
-in your Workspace settings, and:
-
-```json
-"jest.pathToJest": "node scripts/jest.js --testPathPattern=legacy/plugins/apm",
-"jest.rootPath": "../../.."
-```
-
-in the settings for the APM folder.
-
-#### Jest debugging
-
-To make the [VSCode debugger](https://vscode.readthedocs.io/en/latest/editor/debugging/) work with Jest (you can set breakpoints in the code and tests and use the VSCode debugger) you'll need the [Node Debug extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.node-debug2) installed and can set up a launch configuration like:
-
-```json
-{
-  "type": "node",
-  "name": "APM Jest",
-  "request": "launch",
-  "args": ["--runInBand", "--testPathPattern=legacy/plugins/apm"],
-  "cwd": "${workspaceFolder}/../../..",
-  "console": "internalConsole",
-  "internalConsoleOptions": "openOnSessionStart",
-  "disableOptimisticBPs": true,
-  "program": "${workspaceFolder}/../../../scripts/jest.js",
-  "runtimeVersion": "10.15.2"
-}
-```
-
-(you'll want `runtimeVersion` to match what's in the Kibana root .nvmrc. Depending on your setup, you might be able to remove this line.)
+- [Cypress integration tests](cypress/README.md)
+- [VSCode setup instructions](./dev_docs/vscode_setup.md)
+- [Github PR commands](./dev_docs/github_commands.md)

--- a/x-pack/legacy/plugins/apm/readme.md
+++ b/x-pack/legacy/plugins/apm/readme.md
@@ -68,7 +68,7 @@ yarn prettier  "./x-pack/legacy/plugins/apm/**/*.{tsx,ts,js}" --write
 yarn eslint ./x-pack/legacy/plugins/apm --fix
 ```
 
-#### Further resouces
+#### Further resources
 
 - [Cypress integration tests](cypress/README.md)
 - [VSCode setup instructions](./dev_docs/vscode_setup.md)


### PR DESCRIPTION
 - Add docs for `_debug=true`
 - Move "useful pr commands" and "vscode setup instructions" to separate files