### PR TITLE
Upgrade Prettier 1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -433,7 +433,7 @@
     "pngjs": "^3.4.0",
     "postcss": "^7.0.5",
     "postcss-url": "^8.0.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "proxyquire": "1.8.0",
     "regenerate": "^1.4.0",
     "sass-lint": "^1.12.1",

--- a/packages/kbn-dev-utils/src/proc_runner/observe_readable.ts
+++ b/packages/kbn-dev-utils/src/proc_runner/observe_readable.ts
@@ -29,10 +29,7 @@ import { first, ignoreElements, mergeMap } from 'rxjs/operators';
  */
 export function observeReadable(readable: Readable): Rx.Observable<never> {
   return Rx.race(
-    Rx.fromEvent(readable, 'end').pipe(
-      first(),
-      ignoreElements()
-    ),
+    Rx.fromEvent(readable, 'end').pipe(first(), ignoreElements()),
 
     Rx.fromEvent(readable, 'error').pipe(
       first(),

--- a/packages/kbn-dev-utils/src/tooling_log/tooling_log.test.ts
+++ b/packages/kbn-dev-utils/src/tooling_log/tooling_log.test.ts
@@ -112,10 +112,7 @@ describe('#getWritten$()', () => {
     const done$ = new Rx.Subject();
     const promise = log
       .getWritten$()
-      .pipe(
-        takeUntil(done$),
-        toArray()
-      )
+      .pipe(takeUntil(done$), toArray())
       .toPromise();
 
     log.debug('foo');

--- a/packages/kbn-pm/package.json
+++ b/packages/kbn-pm/package.json
@@ -50,7 +50,7 @@
     "log-symbols": "^2.2.0",
     "ncp": "^2.0.0",
     "ora": "^1.4.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "read-pkg": "^5.2.0",
     "rxjs": "^6.5.3",
     "spawn-sync": "^1.0.15",

--- a/packages/kbn-pm/src/commands/bootstrap.test.ts
+++ b/packages/kbn-pm/src/commands/bootstrap.test.ts
@@ -101,7 +101,12 @@ test('handles dependencies of dependencies', async () => {
     'packages/baz'
   );
 
-  const projects = new Map([['kibana', kibana], ['foo', foo], ['bar', bar], ['baz', baz]]);
+  const projects = new Map([
+    ['kibana', kibana],
+    ['foo', foo],
+    ['bar', bar],
+    ['baz', baz],
+  ]);
   const projectGraph = buildProjectGraph(projects);
 
   const logMock = jest.spyOn(console, 'log').mockImplementation(noop);
@@ -133,7 +138,10 @@ test('does not run installer if no deps in package', async () => {
     'packages/bar'
   );
 
-  const projects = new Map([['kibana', kibana], ['bar', bar]]);
+  const projects = new Map([
+    ['kibana', kibana],
+    ['bar', bar],
+  ]);
   const projectGraph = buildProjectGraph(projects);
 
   const logMock = jest.spyOn(console, 'log').mockImplementation(noop);
@@ -193,7 +201,10 @@ test('calls "kbn:bootstrap" scripts and links executables after installing deps'
     'packages/bar'
   );
 
-  const projects = new Map([['kibana', kibana], ['bar', bar]]);
+  const projects = new Map([
+    ['kibana', kibana],
+    ['bar', bar],
+  ]);
   const projectGraph = buildProjectGraph(projects);
 
   jest.spyOn(console, 'log').mockImplementation(noop);

--- a/packages/kbn-spec-to-console/package.json
+++ b/packages/kbn-spec-to-console/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/jbudz/spec-to-console#readme",
   "devDependencies": {
     "jest": "^24.9.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.19.1"
   },
   "dependencies": {
     "commander": "^3.0.0",

--- a/src/core/public/chrome/nav_links/nav_links_service.ts
+++ b/src/core/public/chrome/nav_links/nav_links_service.ts
@@ -130,10 +130,7 @@ export class NavLinksService {
 
     return {
       getNavLinks$: () => {
-        return navLinks$.pipe(
-          map(sortNavLinks),
-          takeUntil(this.stop$)
-        );
+        return navLinks$.pipe(map(sortNavLinks), takeUntil(this.stop$));
       },
 
       get(id: string) {
@@ -192,7 +189,10 @@ export class NavLinksService {
 }
 
 function sortNavLinks(navLinks: ReadonlyMap<string, NavLinkWrapper>) {
-  return sortBy([...navLinks.values()].map(link => link.properties), 'order');
+  return sortBy(
+    [...navLinks.values()].map(link => link.properties),
+    'order'
+  );
 }
 
 function relativeToAbsolute(url: string) {

--- a/src/core/public/chrome/recently_accessed/recently_accessed_service.test.ts
+++ b/src/core/public/chrome/recently_accessed/recently_accessed_service.test.ts
@@ -106,10 +106,7 @@ describe('RecentlyAccessed#start()', () => {
     const stop$ = new Subject();
     const observedValues$ = recentlyAccessed
       .get$()
-      .pipe(
-        bufferCount(3),
-        takeUntil(stop$)
-      )
+      .pipe(bufferCount(3), takeUntil(stop$))
       .toPromise();
     recentlyAccessed.add('/app/item1', 'Item 1', 'item1');
     recentlyAccessed.add('/app/item2', 'Item 2', 'item2');

--- a/src/core/public/core_system.test.ts
+++ b/src/core/public/core_system.test.ts
@@ -174,7 +174,10 @@ describe('#setup()', () => {
   it('injects legacy dependency to context#setup()', async () => {
     const pluginA = Symbol();
     const pluginB = Symbol();
-    const pluginDependencies = new Map<symbol, symbol[]>([[pluginA, []], [pluginB, [pluginA]]]);
+    const pluginDependencies = new Map<symbol, symbol[]>([
+      [pluginA, []],
+      [pluginB, [pluginA]],
+    ]);
     MockPluginsService.getOpaqueIds.mockReturnValue(pluginDependencies);
     await setupCore();
 

--- a/src/core/public/injected_metadata/injected_metadata_service.test.ts
+++ b/src/core/public/injected_metadata/injected_metadata_service.test.ts
@@ -68,18 +68,27 @@ describe('setup.getPlugins()', () => {
   it('returns injectedMetadata.uiPlugins', () => {
     const injectedMetadata = new InjectedMetadataService({
       injectedMetadata: {
-        uiPlugins: [{ id: 'plugin-1', plugin: {} }, { id: 'plugin-2', plugin: {} }],
+        uiPlugins: [
+          { id: 'plugin-1', plugin: {} },
+          { id: 'plugin-2', plugin: {} },
+        ],
       },
     } as any);
 
     const plugins = injectedMetadata.setup().getPlugins();
-    expect(plugins).toEqual([{ id: 'plugin-1', plugin: {} }, { id: 'plugin-2', plugin: {} }]);
+    expect(plugins).toEqual([
+      { id: 'plugin-1', plugin: {} },
+      { id: 'plugin-2', plugin: {} },
+    ]);
   });
 
   it('returns frozen version of uiPlugins', () => {
     const injectedMetadata = new InjectedMetadataService({
       injectedMetadata: {
-        uiPlugins: [{ id: 'plugin-1', plugin: {} }, { id: 'plugin-2', plugin: {} }],
+        uiPlugins: [
+          { id: 'plugin-1', plugin: {} },
+          { id: 'plugin-2', plugin: {} },
+        ],
       },
     } as any);
 

--- a/src/core/public/overlays/banners/priority_map.test.ts
+++ b/src/core/public/overlays/banners/priority_map.test.ts
@@ -42,7 +42,10 @@ describe('PriorityMap', () => {
     map = map.add('b', { priority: 3 });
     map = map.add('c', { priority: 2 });
     map = map.remove('c');
-    expect([...map]).toEqual([['b', { priority: 3 }], ['a', { priority: 1 }]]);
+    expect([...map]).toEqual([
+      ['b', { priority: 3 }],
+      ['a', { priority: 1 }],
+    ]);
   });
 
   it('adds duplicate priorities to end', () => {

--- a/src/core/public/plugins/plugins_service.test.ts
+++ b/src/core/public/plugins/plugins_service.test.ts
@@ -223,10 +223,13 @@ test('`PluginsService.setup` exposes dependent setup contracts to plugins', asyn
 
 test('`PluginsService.setup` does not set missing dependent setup contracts', async () => {
   plugins = [{ id: 'pluginD', plugin: createManifest('pluginD', { optional: ['missing'] }) }];
-  mockPluginInitializers.set('pluginD', jest.fn(() => ({
-    setup: jest.fn(),
-    start: jest.fn(),
-  })) as any);
+  mockPluginInitializers.set(
+    'pluginD',
+    jest.fn(() => ({
+      setup: jest.fn(),
+      start: jest.fn(),
+    })) as any
+  );
 
   const pluginsService = new PluginsService(mockCoreContext, plugins);
   await pluginsService.setup(mockSetupDeps);
@@ -268,10 +271,13 @@ test('`PluginsService.start` exposes dependent start contracts to plugins', asyn
 
 test('`PluginsService.start` does not set missing dependent start contracts', async () => {
   plugins = [{ id: 'pluginD', plugin: createManifest('pluginD', { optional: ['missing'] }) }];
-  mockPluginInitializers.set('pluginD', jest.fn(() => ({
-    setup: jest.fn(),
-    start: jest.fn(),
-  })) as any);
+  mockPluginInitializers.set(
+    'pluginD',
+    jest.fn(() => ({
+      setup: jest.fn(),
+      start: jest.fn(),
+    })) as any
+  );
 
   const pluginsService = new PluginsService(mockCoreContext, plugins);
   await pluginsService.setup(mockSetupDeps);

--- a/src/core/public/ui_settings/ui_settings_api.test.ts
+++ b/src/core/public/ui_settings/ui_settings_api.test.ts
@@ -183,10 +183,7 @@ describe('#getLoadingCount$()', () => {
     const done$ = new Rx.Subject();
     const promise = uiSettingsApi
       .getLoadingCount$()
-      .pipe(
-        takeUntil(done$),
-        toArray()
-      )
+      .pipe(takeUntil(done$), toArray())
       .toPromise();
 
     await uiSettingsApi.batchSet('foo', 'bar');
@@ -214,10 +211,7 @@ describe('#getLoadingCount$()', () => {
     const done$ = new Rx.Subject();
     const promise = uiSettingsApi
       .getLoadingCount$()
-      .pipe(
-        takeUntil(done$),
-        toArray()
-      )
+      .pipe(takeUntil(done$), toArray())
       .toPromise();
 
     await uiSettingsApi.batchSet('foo', 'bar');
@@ -250,7 +244,10 @@ describe('#stop', () => {
     uiSettingsApi.stop();
 
     // both observables should emit the same values, and complete before the request is done loading
-    await expect(promise).resolves.toEqual([[0, 1], [0, 1]]);
+    await expect(promise).resolves.toEqual([
+      [0, 1],
+      [0, 1],
+    ]);
     await batchSetPromise;
   });
 });

--- a/src/core/public/ui_settings/ui_settings_client.test.ts
+++ b/src/core/public/ui_settings/ui_settings_client.test.ts
@@ -83,10 +83,7 @@ describe('#get$', () => {
     const { config } = setup();
     const values = await config
       .get$('dateFormat')
-      .pipe(
-        take(1),
-        toArray()
-      )
+      .pipe(take(1), toArray())
       .toPromise();
 
     expect(values).toEqual(['Browser']);
@@ -122,10 +119,7 @@ You can use \`config.get("unknown key", defaultValue)\`, which will just return
 
     const values = await config
       .get$('dateFormat')
-      .pipe(
-        take(2),
-        toArray()
-      )
+      .pipe(take(2), toArray())
       .toPromise();
 
     expect(values).toEqual(['Browser', 'new format']);
@@ -144,10 +138,7 @@ You can use \`config.get("unknown key", defaultValue)\`, which will just return
 
     const values = await config
       .get$('dateFormat', 'my default')
-      .pipe(
-        take(3),
-        toArray()
-      )
+      .pipe(take(3), toArray())
       .toPromise();
 
     expect(values).toEqual(['my default', 'new format', 'my default']);

--- a/src/core/public/utils/share_weak_replay.test.ts
+++ b/src/core/public/utils/share_weak_replay.test.ts
@@ -153,10 +153,7 @@ Array [
 });
 
 it('resubscribes if parent completes', async () => {
-  const shared = counter().pipe(
-    take(4),
-    shareWeakReplay(4)
-  );
+  const shared = counter().pipe(take(4), shareWeakReplay(4));
 
   await expect(Promise.all([record(shared.pipe(take(1))), record(shared)])).resolves
     .toMatchInlineSnapshot(`
@@ -199,10 +196,7 @@ Array [
 it('supports parents that complete synchronously', async () => {
   const next = jest.fn();
   const complete = jest.fn();
-  const shared = counter({ async: false }).pipe(
-    take(3),
-    shareWeakReplay(1)
-  );
+  const shared = counter({ async: false }).pipe(take(3), shareWeakReplay(1));
 
   shared.subscribe({ next, complete });
   expect(next.mock.calls).toMatchInlineSnapshot(`

--- a/src/core/server/config/ensure_deep_object.ts
+++ b/src/core/server/config/ensure_deep_object.ts
@@ -34,19 +34,16 @@ export function ensureDeepObject(obj: any): any {
     return obj.map(item => ensureDeepObject(item));
   }
 
-  return Object.keys(obj).reduce(
-    (fullObject, propertyKey) => {
-      const propertyValue = obj[propertyKey];
-      if (!propertyKey.includes(separator)) {
-        fullObject[propertyKey] = ensureDeepObject(propertyValue);
-      } else {
-        walk(fullObject, propertyKey.split(separator), propertyValue);
-      }
+  return Object.keys(obj).reduce((fullObject, propertyKey) => {
+    const propertyValue = obj[propertyKey];
+    if (!propertyKey.includes(separator)) {
+      fullObject[propertyKey] = ensureDeepObject(propertyValue);
+    } else {
+      walk(fullObject, propertyKey.split(separator), propertyValue);
+    }
 
-      return fullObject;
-    },
-    {} as any
-  );
+    return fullObject;
+  }, {} as any);
 }
 
 function walk(obj: any, keys: string[], value: any) {

--- a/src/core/server/plugins/plugins_system.ts
+++ b/src/core/server/plugins/plugins_system.ts
@@ -77,18 +77,15 @@ export class PluginsSystem {
 
       this.log.debug(`Setting up plugin "${pluginName}"...`);
       const pluginDeps = new Set([...plugin.requiredPlugins, ...plugin.optionalPlugins]);
-      const pluginDepContracts = Array.from(pluginDeps).reduce(
-        (depContracts, dependencyName) => {
-          // Only set if present. Could be absent if plugin does not have server-side code or is a
-          // missing optional dependency.
-          if (contracts.has(dependencyName)) {
-            depContracts[dependencyName] = contracts.get(dependencyName);
-          }
+      const pluginDepContracts = Array.from(pluginDeps).reduce((depContracts, dependencyName) => {
+        // Only set if present. Could be absent if plugin does not have server-side code or is a
+        // missing optional dependency.
+        if (contracts.has(dependencyName)) {
+          depContracts[dependencyName] = contracts.get(dependencyName);
+        }
 
-          return depContracts;
-        },
-        {} as Record<PluginName, unknown>
-      );
+        return depContracts;
+      }, {} as Record<PluginName, unknown>);
 
       contracts.set(
         pluginName,
@@ -116,18 +113,15 @@ export class PluginsSystem {
       this.log.debug(`Starting plugin "${pluginName}"...`);
       const plugin = this.plugins.get(pluginName)!;
       const pluginDeps = new Set([...plugin.requiredPlugins, ...plugin.optionalPlugins]);
-      const pluginDepContracts = Array.from(pluginDeps).reduce(
-        (depContracts, dependencyName) => {
-          // Only set if present. Could be absent if plugin does not have server-side code or is a
-          // missing optional dependency.
-          if (contracts.has(dependencyName)) {
-            depContracts[dependencyName] = contracts.get(dependencyName);
-          }
+      const pluginDepContracts = Array.from(pluginDeps).reduce((depContracts, dependencyName) => {
+        // Only set if present. Could be absent if plugin does not have server-side code or is a
+        // missing optional dependency.
+        if (contracts.has(dependencyName)) {
+          depContracts[dependencyName] = contracts.get(dependencyName);
+        }
 
-          return depContracts;
-        },
-        {} as Record<PluginName, unknown>
-      );
+        return depContracts;
+      }, {} as Record<PluginName, unknown>);
 
       contracts.set(
         pluginName,

--- a/src/core/server/saved_objects/mappings/lib/get_root_properties_objects.ts
+++ b/src/core/server/saved_objects/mappings/lib/get_root_properties_objects.ts
@@ -39,17 +39,14 @@ const blacklist = ['migrationVersion', 'references'];
 
 export function getRootPropertiesObjects(mappings: IndexMapping) {
   const rootProperties = getRootProperties(mappings);
-  return Object.entries(rootProperties).reduce(
-    (acc, [key, value]) => {
-      // we consider the existence of the properties or type of object to designate that this is an object datatype
-      if (
-        !blacklist.includes(key) &&
-        ((value as ComplexFieldMapping).properties || value.type === 'object')
-      ) {
-        acc[key] = value;
-      }
-      return acc;
-    },
-    {} as MappingProperties
-  );
+  return Object.entries(rootProperties).reduce((acc, [key, value]) => {
+    // we consider the existence of the properties or type of object to designate that this is an object datatype
+    if (
+      !blacklist.includes(key) &&
+      ((value as ComplexFieldMapping).properties || value.type === 'object')
+    ) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {} as MappingProperties);
 }

--- a/src/core/server/saved_objects/service/lib/repository.ts
+++ b/src/core/server/saved_objects/service/lib/repository.ts
@@ -246,15 +246,17 @@ export class SavedObjectsRepository {
       const expectedResult = {
         esRequestIndex: requestIndexCounter++,
         requestedId: object.id,
-        rawMigratedDoc: this._serializer.savedObjectToRaw(this._migrator.migrateDocument({
-          id: object.id,
-          type: object.type,
-          attributes: object.attributes,
-          migrationVersion: object.migrationVersion,
-          namespace,
-          updated_at: time,
-          references: object.references || [],
-        }) as SanitizedSavedObjectDoc),
+        rawMigratedDoc: this._serializer.savedObjectToRaw(
+          this._migrator.migrateDocument({
+            id: object.id,
+            type: object.type,
+            attributes: object.attributes,
+            migrationVersion: object.migrationVersion,
+            namespace,
+            updated_at: time,
+            references: object.references || [],
+          }) as SanitizedSavedObjectDoc
+        ),
       };
 
       bulkCreateParams.push(

--- a/src/core/server/server.test.ts
+++ b/src/core/server/server.test.ts
@@ -70,7 +70,10 @@ test('injects legacy dependency to context#setup()', async () => {
 
   const pluginA = Symbol();
   const pluginB = Symbol();
-  const pluginDependencies = new Map<symbol, symbol[]>([[pluginA, []], [pluginB, [pluginA]]]);
+  const pluginDependencies = new Map<symbol, symbol[]>([
+    [pluginA, []],
+    [pluginB, [pluginA]],
+  ]);
   mockPluginsService.discover.mockResolvedValue(pluginDependencies);
 
   await server.setup();

--- a/src/core/server/ui_settings/ui_settings_client.ts
+++ b/src/core/server/ui_settings/ui_settings_client.ts
@@ -83,14 +83,11 @@ export class UiSettingsClient implements IUiSettingsClient {
   async getAll<T extends SavedObjectAttribute = any>() {
     const raw = await this.getRaw();
 
-    return Object.keys(raw).reduce(
-      (all, key) => {
-        const item = raw[key];
-        all[key] = ('userValue' in item ? item.userValue : item.value) as T;
-        return all;
-      },
-      {} as Record<string, T>
-    );
+    return Object.keys(raw).reduce((all, key) => {
+      const item = raw[key];
+      all[key] = ('userValue' in item ? item.userValue : item.value) as T;
+      return all;
+    }, {} as Record<string, T>);
   }
 
   async getUserProvided<T extends SavedObjectAttribute = any>(): Promise<UserProvided<T>> {

--- a/src/core/utils/context.ts
+++ b/src/core/utils/context.ts
@@ -254,23 +254,20 @@ export class ContextContainer<THandler extends HandlerFunction<any>>
     return [...this.contextProviders]
       .sort(sortByCoreFirst(this.coreId))
       .filter(([contextName]) => contextsToBuild.has(contextName))
-      .reduce(
-        async (contextPromise, [contextName, { provider, source: providerSource }]) => {
-          const resolvedContext = await contextPromise;
+      .reduce(async (contextPromise, [contextName, { provider, source: providerSource }]) => {
+        const resolvedContext = await contextPromise;
 
-          // For the next provider, only expose the context available based on the dependencies of the plugin that
-          // registered that provider.
-          const exposedContext = pick(resolvedContext, [
-            ...this.getContextNamesForSource(providerSource),
-          ]) as Partial<HandlerContextType<THandler>>;
+        // For the next provider, only expose the context available based on the dependencies of the plugin that
+        // registered that provider.
+        const exposedContext = pick(resolvedContext, [
+          ...this.getContextNamesForSource(providerSource),
+        ]) as Partial<HandlerContextType<THandler>>;
 
-          return {
-            ...resolvedContext,
-            [contextName]: await provider(exposedContext, ...contextArgs),
-          };
-        },
-        Promise.resolve({}) as Promise<HandlerContextType<THandler>>
-      );
+        return {
+          ...resolvedContext,
+          [contextName]: await provider(exposedContext, ...contextArgs),
+        };
+      }, Promise.resolve({}) as Promise<HandlerContextType<THandler>>);
   }
 
   private getContextNamesForSource(

--- a/src/core/utils/map_utils.test.ts
+++ b/src/core/utils/map_utils.test.ts
@@ -42,7 +42,11 @@ describe('groupIntoMap', () => {
     const groupBy = (item: { id: number }) => item.id;
 
     expect(groupIntoMap([{ id: 1 }, { id: 2 }, { id: 3 }], groupBy)).toEqual(
-      new Map([[1, [{ id: 1 }]], [2, [{ id: 2 }]], [3, [{ id: 3 }]]])
+      new Map([
+        [1, [{ id: 1 }]],
+        [2, [{ id: 2 }]],
+        [3, [{ id: 3 }]],
+      ])
     );
   });
 
@@ -93,7 +97,12 @@ describe('mapValuesOfMap', () => {
     map.set(even, 2);
     map.set(odd, 1);
 
-    expect(mapValuesOfMap(map, mapper)).toEqual(new Map([[even, 6], [odd, 3]]));
+    expect(mapValuesOfMap(map, mapper)).toEqual(
+      new Map([
+        [even, 6],
+        [odd, 3],
+      ])
+    );
     expect(map.get(odd)).toEqual(1);
     expect(map.get(even)).toEqual(2);
   });

--- a/src/core/utils/merge.ts
+++ b/src/core/utils/merge.ts
@@ -66,20 +66,17 @@ const mergeObjects = <T extends Record<string, any>, U extends Record<string, an
   baseObj: T,
   overrideObj: U
 ): T & U =>
-  [...new Set([...Object.keys(baseObj), ...Object.keys(overrideObj)])].reduce(
-    (merged, key) => {
-      const baseVal = baseObj[key];
-      const overrideVal = overrideObj[key];
+  [...new Set([...Object.keys(baseObj), ...Object.keys(overrideObj)])].reduce((merged, key) => {
+    const baseVal = baseObj[key];
+    const overrideVal = overrideObj[key];
 
-      if (isMergable(baseVal) && isMergable(overrideVal)) {
-        merged[key] = mergeObjects(baseVal, overrideVal);
-      } else if (overrideVal !== undefined) {
-        merged[key] = overrideVal;
-      } else if (baseVal !== undefined) {
-        merged[key] = baseVal;
-      }
+    if (isMergable(baseVal) && isMergable(overrideVal)) {
+      merged[key] = mergeObjects(baseVal, overrideVal);
+    } else if (overrideVal !== undefined) {
+      merged[key] = overrideVal;
+    } else if (baseVal !== undefined) {
+      merged[key] = baseVal;
+    }
 
-      return merged;
-    },
-    {} as any
-  );
+    return merged;
+  }, {} as any);

--- a/src/core/utils/pick.ts
+++ b/src/core/utils/pick.ts
@@ -18,14 +18,11 @@
  */
 
 export function pick<T extends object, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
-  return keys.reduce(
-    (acc, key) => {
-      if (obj.hasOwnProperty(key)) {
-        acc[key] = obj[key];
-      }
+  return keys.reduce((acc, key) => {
+    if (obj.hasOwnProperty(key)) {
+      acc[key] = obj[key];
+    }
 
-      return acc;
-    },
-    {} as Pick<T, K>
-  );
+    return acc;
+  }, {} as Pick<T, K>);
 }

--- a/src/dev/license_checker/valid.ts
+++ b/src/dev/license_checker/valid.ts
@@ -36,24 +36,21 @@ interface Options {
  *  violations or returns undefined.
  */
 export function assertLicensesValid({ packages, validLicenses }: Options) {
-  const invalidMsgs = packages.reduce(
-    (acc, pkg) => {
-      const invalidLicenses = pkg.licenses.filter(license => !validLicenses.includes(license));
+  const invalidMsgs = packages.reduce((acc, pkg) => {
+    const invalidLicenses = pkg.licenses.filter(license => !validLicenses.includes(license));
 
-      if (pkg.licenses.length && !invalidLicenses.length) {
-        return acc;
-      }
+    if (pkg.licenses.length && !invalidLicenses.length) {
+      return acc;
+    }
 
-      return acc.concat(dedent`
+    return acc.concat(dedent`
         ${pkg.name}
           version: ${pkg.version}
           all licenses: ${pkg.licenses}
           invalid licenses: ${invalidLicenses.join(', ')}
           path: ${pkg.relative}
       `);
-    },
-    [] as string[]
-  );
+  }, [] as string[]);
 
   if (invalidMsgs.length) {
     throw createFailError(

--- a/src/legacy/core_plugins/data/public/index_patterns/index_patterns/index_patterns.ts
+++ b/src/legacy/core_plugins/data/public/index_patterns/index_patterns/index_patterns.ts
@@ -52,11 +52,13 @@ export class IndexPatterns {
   }
 
   private async refreshSavedObjectsCache() {
-    this.savedObjectsCache = (await this.savedObjectsClient.find({
-      type: 'index-pattern',
-      fields: [],
-      perPage: 10000,
-    })).savedObjects;
+    this.savedObjectsCache = (
+      await this.savedObjectsClient.find({
+        type: 'index-pattern',
+        fields: [],
+        perPage: 10000,
+      })
+    ).savedObjects;
   }
 
   getIds = async (refresh: boolean = false) => {

--- a/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/options/metrics_axes/index.tsx
+++ b/src/legacy/core_plugins/kbn_vislib_vis_types/public/components/options/metrics_axes/index.tsx
@@ -83,9 +83,11 @@ function MetricsAxisOptions(props: ValidationVisOptionsProps<BasicVislibParams>)
   // stores previous aggs' custom labels
   const [lastCustomLabels, setLastCustomLabels] = useState({} as { [key: string]: string });
   // stores previous aggs' field and type
-  const [lastSeriesAgg, setLastSeriesAgg] = useState({} as {
-    [key: string]: { type: string; field: string };
-  });
+  const [lastSeriesAgg, setLastSeriesAgg] = useState(
+    {} as {
+      [key: string]: { type: string; field: string };
+    }
+  );
 
   const updateAxisTitle = () => {
     const axes = cloneDeep(stateParams.valueAxes);

--- a/src/legacy/core_plugins/kibana/public/management/sections/objects/lib/__jest__/extract_export_details.test.ts
+++ b/src/legacy/core_plugins/kibana/public/management/sections/objects/lib/__jest__/extract_export_details.test.ts
@@ -62,7 +62,10 @@ describe('extractExportDetails', () => {
       [
         [
           objLine('1', 'index-pattern'),
-          detailsLine(1, [{ id: '2', type: 'index-pattern' }, { id: '3', type: 'index-pattern' }]),
+          detailsLine(1, [
+            { id: '2', type: 'index-pattern' },
+            { id: '3', type: 'index-pattern' },
+          ]),
         ].join(''),
       ],
       {
@@ -75,7 +78,10 @@ describe('extractExportDetails', () => {
     expect(result).toEqual({
       exportedCount: 1,
       missingRefCount: 2,
-      missingReferences: [{ id: '2', type: 'index-pattern' }, { id: '3', type: 'index-pattern' }],
+      missingReferences: [
+        { id: '2', type: 'index-pattern' },
+        { id: '3', type: 'index-pattern' },
+      ],
     });
   });
 

--- a/src/legacy/core_plugins/region_map/public/components/region_map_options.tsx
+++ b/src/legacy/core_plugins/region_map/public/components/region_map_options.tsx
@@ -82,7 +82,10 @@ function RegionMapOptions(props: RegionMapOptionsProps) {
   const setField = useCallback(
     (paramName: 'selectedJoinField', value: FileLayerField['name']) => {
       if (stateParams.selectedLayer) {
-        setValue(paramName, stateParams.selectedLayer.fields.find(f => f.name === value));
+        setValue(
+          paramName,
+          stateParams.selectedLayer.fields.find(f => f.name === value)
+        );
       }
     },
     [setValue, stateParams.selectedLayer]

--- a/src/legacy/core_plugins/telemetry/server/collectors/usage/ensure_deep_object.ts
+++ b/src/legacy/core_plugins/telemetry/server/collectors/usage/ensure_deep_object.ts
@@ -42,19 +42,16 @@ export function ensureDeepObject(obj: any): any {
     return obj.map(item => ensureDeepObject(item));
   }
 
-  return Object.keys(obj).reduce(
-    (fullObject, propertyKey) => {
-      const propertyValue = obj[propertyKey];
-      if (!propertyKey.includes(separator)) {
-        fullObject[propertyKey] = ensureDeepObject(propertyValue);
-      } else {
-        walk(fullObject, propertyKey.split(separator), propertyValue);
-      }
+  return Object.keys(obj).reduce((fullObject, propertyKey) => {
+    const propertyValue = obj[propertyKey];
+    if (!propertyKey.includes(separator)) {
+      fullObject[propertyKey] = ensureDeepObject(propertyValue);
+    } else {
+      walk(fullObject, propertyKey.split(separator), propertyValue);
+    }
 
-      return fullObject;
-    },
-    {} as any
-  );
+    return fullObject;
+  }, {} as any);
 }
 
 function walk(obj: any, keys: string[], value: any) {

--- a/src/legacy/ui/public/agg_types/agg_configs.ts
+++ b/src/legacy/ui/public/agg_types/agg_configs.ts
@@ -253,13 +253,10 @@ export class AggConfigs {
     // collect all the aggregations
     const aggregations = this.aggs
       .filter(agg => agg.enabled && agg.type)
-      .reduce(
-        (requestValuesAggs, agg: AggConfig) => {
-          const aggs = agg.getRequestAggs();
-          return aggs ? requestValuesAggs.concat(aggs) : requestValuesAggs;
-        },
-        [] as AggConfig[]
-      );
+      .reduce((requestValuesAggs, agg: AggConfig) => {
+        const aggs = agg.getRequestAggs();
+        return aggs ? requestValuesAggs.concat(aggs) : requestValuesAggs;
+      }, [] as AggConfig[]);
     // move metrics to the end
     return _.sortBy(aggregations, (agg: AggConfig) =>
       agg.type.type === AggGroupNames.Metrics ? 1 : 0
@@ -282,13 +279,10 @@ export class AggConfigs {
    * @return {array[AggConfig]}
    */
   getResponseAggs(): AggConfig[] {
-    return this.getRequestAggs().reduce(
-      function(responseValuesAggs, agg: AggConfig) {
-        const aggs = agg.getResponseAggs();
-        return aggs ? responseValuesAggs.concat(aggs) : responseValuesAggs;
-      },
-      [] as AggConfig[]
-    );
+    return this.getRequestAggs().reduce(function(responseValuesAggs, agg: AggConfig) {
+      const aggs = agg.getResponseAggs();
+      return aggs ? responseValuesAggs.concat(aggs) : responseValuesAggs;
+    }, [] as AggConfig[]);
   }
 
   /**

--- a/src/legacy/ui/public/agg_types/buckets/geo_hash.test.ts
+++ b/src/legacy/ui/public/agg_types/buckets/geo_hash.test.ts
@@ -156,8 +156,9 @@ describe('Geohash Agg', () => {
   describe('aggregation options', () => {
     it('should only create geohash_grid and geo_centroid aggregations when isFilteredByCollar is false', () => {
       const aggConfigs = getAggConfigs({ isFilteredByCollar: false });
-      const requestAggs = geoHashBucketAgg.getRequestAggs(aggConfigs
-        .aggs[0] as IBucketGeoHashGridAggConfig) as IBucketGeoHashGridAggConfig[];
+      const requestAggs = geoHashBucketAgg.getRequestAggs(
+        aggConfigs.aggs[0] as IBucketGeoHashGridAggConfig
+      ) as IBucketGeoHashGridAggConfig[];
 
       expect(requestAggs.length).toEqual(2);
       expect(requestAggs[0].type.name).toEqual('geohash_grid');
@@ -166,8 +167,9 @@ describe('Geohash Agg', () => {
 
     it('should only create filter and geohash_grid aggregations when useGeocentroid is false', () => {
       const aggConfigs = getAggConfigs({ useGeocentroid: false });
-      const requestAggs = geoHashBucketAgg.getRequestAggs(aggConfigs
-        .aggs[0] as IBucketGeoHashGridAggConfig) as IBucketGeoHashGridAggConfig[];
+      const requestAggs = geoHashBucketAgg.getRequestAggs(
+        aggConfigs.aggs[0] as IBucketGeoHashGridAggConfig
+      ) as IBucketGeoHashGridAggConfig[];
 
       expect(requestAggs.length).toEqual(2);
       expect(requestAggs[0].type.name).toEqual('filter');
@@ -179,36 +181,43 @@ describe('Geohash Agg', () => {
     let originalRequestAggs: IBucketGeoHashGridAggConfig[];
 
     beforeEach(() => {
-      originalRequestAggs = geoHashBucketAgg.getRequestAggs(getAggConfigs()
-        .aggs[0] as IBucketGeoHashGridAggConfig) as IBucketGeoHashGridAggConfig[];
+      originalRequestAggs = geoHashBucketAgg.getRequestAggs(
+        getAggConfigs().aggs[0] as IBucketGeoHashGridAggConfig
+      ) as IBucketGeoHashGridAggConfig[];
     });
 
     it('should change geo_bounding_box filter aggregation and vis session state when map movement is outside map collar', () => {
-      const [, geoBoxingBox] = geoHashBucketAgg.getRequestAggs(getAggConfigs({
-        mapBounds: {
-          top_left: { lat: 10.0, lon: -10.0 },
-          bottom_right: { lat: 9.0, lon: -9.0 },
-        },
-      }).aggs[0] as IBucketGeoHashGridAggConfig) as IBucketGeoHashGridAggConfig[];
+      const [, geoBoxingBox] = geoHashBucketAgg.getRequestAggs(
+        getAggConfigs({
+          mapBounds: {
+            top_left: { lat: 10.0, lon: -10.0 },
+            bottom_right: { lat: 9.0, lon: -9.0 },
+          },
+        }).aggs[0] as IBucketGeoHashGridAggConfig
+      ) as IBucketGeoHashGridAggConfig[];
 
       expect(originalRequestAggs[1].params).not.toEqual(geoBoxingBox.params);
     });
 
     it('should not change geo_bounding_box filter aggregation and vis session state when map movement is within map collar', () => {
-      const [, geoBoxingBox] = geoHashBucketAgg.getRequestAggs(getAggConfigs({
-        mapBounds: {
-          top_left: { lat: 1, lon: -1 },
-          bottom_right: { lat: -1, lon: 1 },
-        },
-      }).aggs[0] as IBucketGeoHashGridAggConfig) as IBucketGeoHashGridAggConfig[];
+      const [, geoBoxingBox] = geoHashBucketAgg.getRequestAggs(
+        getAggConfigs({
+          mapBounds: {
+            top_left: { lat: 1, lon: -1 },
+            bottom_right: { lat: -1, lon: 1 },
+          },
+        }).aggs[0] as IBucketGeoHashGridAggConfig
+      ) as IBucketGeoHashGridAggConfig[];
 
       expect(originalRequestAggs[1].params).toEqual(geoBoxingBox.params);
     });
 
     it('should change geo_bounding_box filter aggregation and vis session state when map zoom level changes', () => {
-      const [, geoBoxingBox] = geoHashBucketAgg.getRequestAggs(getAggConfigs({
-        mapZoom: -1,
-      }).aggs[0] as IBucketGeoHashGridAggConfig) as IBucketGeoHashGridAggConfig[];
+      const [, geoBoxingBox] = geoHashBucketAgg.getRequestAggs(
+        getAggConfigs({
+          mapZoom: -1,
+        }).aggs[0] as IBucketGeoHashGridAggConfig
+      ) as IBucketGeoHashGridAggConfig[];
 
       expect(originalRequestAggs[1].lastMapCollar).not.toEqual(geoBoxingBox.lastMapCollar);
     });

--- a/src/legacy/ui/public/agg_types/buckets/range.test.ts
+++ b/src/legacy/ui/public/agg_types/buckets/range.test.ts
@@ -72,7 +72,10 @@ describe('Range Agg', () => {
           schema: 'segment',
           params: {
             field: 'bytes',
-            ranges: [{ from: 0, to: 1000 }, { from: 1000, to: 2000 }],
+            ranges: [
+              { from: 0, to: 1000 },
+              { from: 1000, to: 2000 },
+            ],
           },
         },
       ],

--- a/src/legacy/ui/public/agg_types/buckets/range.ts
+++ b/src/legacy/ui/public/agg_types/buckets/range.ts
@@ -98,7 +98,10 @@ export const rangeBucketAgg = new BucketAggType({
     },
     {
       name: 'ranges',
-      default: [{ from: 0, to: 1000 }, { from: 1000, to: 2000 }],
+      default: [
+        { from: 0, to: 1000 },
+        { from: 1000, to: 2000 },
+      ],
       editorComponent: RangesEditor,
       write(aggConfig: IBucketAggConfig, output: Record<string, any>) {
         output.params.ranges = aggConfig.params.ranges;

--- a/src/legacy/ui/public/agg_types/filter/prop_filter.ts
+++ b/src/legacy/ui/public/agg_types/filter/prop_filter.ts
@@ -59,24 +59,21 @@ function propFilter<P extends string>(prop: P) {
       return list;
     }
 
-    const options = filters.reduce(
-      (acc, filter) => {
-        let type = 'include';
-        let value = filter;
+    const options = filters.reduce((acc, filter) => {
+      let type = 'include';
+      let value = filter;
 
-        if (filter.charAt(0) === '!') {
-          type = 'exclude';
-          value = filter.substr(1);
-        }
+      if (filter.charAt(0) === '!') {
+        type = 'exclude';
+        value = filter.substr(1);
+      }
 
-        if (!acc[type]) {
-          acc[type] = [];
-        }
-        acc[type].push(value);
-        return acc;
-      },
-      {} as { [type: string]: string[] }
-    );
+      if (!acc[type]) {
+        acc[type] = [];
+      }
+      acc[type].push(value);
+      return acc;
+    }, {} as { [type: string]: string[] });
 
     return list.filter(item => {
       const value = item[prop];

--- a/src/legacy/ui/public/agg_types/metrics/metric_agg_type.ts
+++ b/src/legacy/ui/public/agg_types/metrics/metric_agg_type.ts
@@ -58,8 +58,9 @@ export class MetricAggType<
       config.getValue ||
       ((agg, bucket) => {
         // Metric types where an empty set equals `zero`
-        const isSettableToZero = [METRIC_TYPES.CARDINALITY, METRIC_TYPES.SUM].includes(agg.type
-          .name as METRIC_TYPES);
+        const isSettableToZero = [METRIC_TYPES.CARDINALITY, METRIC_TYPES.SUM].includes(
+          agg.type.name as METRIC_TYPES
+        );
 
         // Return proper values when no buckets are present
         // `Count` handles empty sets properly

--- a/src/legacy/ui/public/agg_types/metrics/percentile_ranks.test.ts
+++ b/src/legacy/ui/public/agg_types/metrics/percentile_ranks.test.ts
@@ -63,8 +63,9 @@ describe('AggTypesMetricsPercentileRanksProvider class', function() {
   });
 
   it('uses the custom label if it is set', function() {
-    const responseAggs: any = percentileRanksMetricAgg.getResponseAggs(aggConfigs
-      .aggs[0] as IPercentileRanksAggConfig);
+    const responseAggs: any = percentileRanksMetricAgg.getResponseAggs(
+      aggConfigs.aggs[0] as IPercentileRanksAggConfig
+    );
 
     const percentileRankLabelFor5kBytes = responseAggs[0].makeLabel();
     const percentileRankLabelFor10kBytes = responseAggs[1].makeLabel();

--- a/src/legacy/ui/public/agg_types/metrics/percentiles.test.ts
+++ b/src/legacy/ui/public/agg_types/metrics/percentiles.test.ts
@@ -63,8 +63,9 @@ describe('AggTypesMetricsPercentilesProvider class', () => {
   });
 
   it('uses the custom label if it is set', () => {
-    const responseAggs: any = percentilesMetricAgg.getResponseAggs(aggConfigs
-      .aggs[0] as IPercentileAggConfig);
+    const responseAggs: any = percentilesMetricAgg.getResponseAggs(
+      aggConfigs.aggs[0] as IPercentileAggConfig
+    );
 
     const ninetyFifthPercentileLabel = responseAggs[0].makeLabel();
 

--- a/src/legacy/ui/public/agg_types/metrics/std_deviation.test.ts
+++ b/src/legacy/ui/public/agg_types/metrics/std_deviation.test.ts
@@ -58,8 +58,9 @@ describe('AggTypeMetricStandardDeviationProvider class', () => {
 
   it('uses the custom label if it is set', () => {
     const aggConfigs = getAggConfigs('custom label');
-    const responseAggs: any = stdDeviationMetricAgg.getResponseAggs(aggConfigs
-      .aggs[0] as IStdDevAggConfig);
+    const responseAggs: any = stdDeviationMetricAgg.getResponseAggs(
+      aggConfigs.aggs[0] as IStdDevAggConfig
+    );
 
     const lowerStdDevLabel = responseAggs[0].makeLabel();
     const upperStdDevLabel = responseAggs[1].makeLabel();
@@ -71,8 +72,9 @@ describe('AggTypeMetricStandardDeviationProvider class', () => {
   it('uses the default labels if custom label is not set', () => {
     const aggConfigs = getAggConfigs();
 
-    const responseAggs: any = stdDeviationMetricAgg.getResponseAggs(aggConfigs
-      .aggs[0] as IStdDevAggConfig);
+    const responseAggs: any = stdDeviationMetricAgg.getResponseAggs(
+      aggConfigs.aggs[0] as IStdDevAggConfig
+    );
 
     const lowerStdDevLabel = responseAggs[0].makeLabel();
     const upperStdDevLabel = responseAggs[1].makeLabel();

--- a/src/legacy/ui/public/vis/editors/default/components/agg.test.tsx
+++ b/src/legacy/ui/public/vis/editors/default/components/agg.test.tsx
@@ -248,10 +248,9 @@ describe('DefaultEditorAgg component', () => {
       expect(compHistogram.find(DefaultEditorAggParams).props()).toHaveProperty('disabledParams', [
         'min_doc_count',
       ]);
-      expect(compDateHistogram.find(DefaultEditorAggParams).props()).toHaveProperty(
-        'disabledParams',
-        ['min_doc_count']
-      );
+      expect(
+        compDateHistogram.find(DefaultEditorAggParams).props()
+      ).toHaveProperty('disabledParams', ['min_doc_count']);
     });
 
     it('should set error when agg is not histogram or date_histogram', () => {

--- a/src/legacy/ui/public/vis/editors/default/components/agg_group_state.tsx
+++ b/src/legacy/ui/public/vis/editors/default/components/agg_group_state.tsx
@@ -53,13 +53,10 @@ function aggGroupReducer(state: AggsState, action: AggsAction): AggsState {
 }
 
 function initAggsState(group: AggConfig[]): AggsState {
-  return group.reduce(
-    (state, agg) => {
-      state[agg.id] = { touched: false, valid: true };
-      return state;
-    },
-    {} as AggsState
-  );
+  return group.reduce((state, agg) => {
+    state[agg.id] = { touched: false, valid: true };
+    return state;
+  }, {} as AggsState);
 }
 
 export { aggGroupReducer, initAggsState };

--- a/src/legacy/ui/public/vis/editors/default/components/agg_params_helper.test.ts
+++ b/src/legacy/ui/public/vis/editors/default/components/agg_params_helper.test.ts
@@ -121,7 +121,10 @@ describe('DefaultEditorAggParams helpers', () => {
         },
         schema: {},
         getIndexPattern: jest.fn(() => ({
-          fields: [{ name: '@timestamp', type: 'date' }, { name: 'geo_desc', type: 'string' }],
+          fields: [
+            { name: '@timestamp', type: 'date' },
+            { name: 'geo_desc', type: 'string' },
+          ],
         })),
         params: {
           orderBy: 'orderBy',

--- a/src/legacy/ui/public/vis/editors/default/controls/components/number_list/utils.test.ts
+++ b/src/legacy/ui/public/vis/editors/default/controls/components/number_list/utils.test.ts
@@ -35,7 +35,10 @@ describe('NumberList utils', () => {
   let range: Range;
 
   beforeEach(() => {
-    modelList = [{ value: 1, id: '1', isInvalid: false }, { value: 2, id: '2', isInvalid: false }];
+    modelList = [
+      { value: 1, id: '1', isInvalid: false },
+      { value: 2, id: '2', isInvalid: false },
+    ];
     range = {
       min: 1,
       max: 10,

--- a/src/legacy/ui/public/vis/editors/default/utils.tsx
+++ b/src/legacy/ui/public/vis/editors/default/utils.tsx
@@ -44,24 +44,21 @@ function groupAndSortBy<
   TGroupBy extends string = 'type',
   TLabelName extends string = 'title'
 >(objects: T[], groupBy: TGroupBy, labelName: TLabelName): ComboBoxGroupedOptions<T> {
-  const groupedOptions = objects.reduce(
-    (array, obj) => {
-      const group = array.find(element => element.label === obj[groupBy]);
-      const option = {
-        label: obj[labelName],
-        target: obj,
-      };
+  const groupedOptions = objects.reduce((array, obj) => {
+    const group = array.find(element => element.label === obj[groupBy]);
+    const option = {
+      label: obj[labelName],
+      target: obj,
+    };
 
-      if (group && group.options) {
-        group.options.push(option);
-      } else {
-        array.push({ label: obj[groupBy], options: [option] });
-      }
+    if (group && group.options) {
+      group.options.push(option);
+    } else {
+      array.push({ label: obj[groupBy], options: [option] });
+    }
 
-      return array;
-    },
-    [] as Array<ComboBoxGroupedOption<T>>
-  );
+    return array;
+  }, [] as Array<ComboBoxGroupedOption<T>>);
 
   groupedOptions.sort(sortByLabel);
 

--- a/src/legacy/ui/public/visualize/loader/pipeline_helpers/build_pipeline.test.ts
+++ b/src/legacy/ui/public/visualize/loader/pipeline_helpers/build_pipeline.test.ts
@@ -172,7 +172,10 @@ describe('visualize loader pipeline helpers: build pipeline', () => {
         const visState = { ...visStateDef, params: { foo: 'bar' } };
         const schemas = {
           ...schemasDef,
-          metric: [{ ...schemaConfig, accessor: 0 }, { ...schemaConfig, accessor: 1 }],
+          metric: [
+            { ...schemaConfig, accessor: 0 },
+            { ...schemaConfig, accessor: 1 },
+          ],
         };
         const actual = buildPipelineVisFunction.table(visState, schemas, uiState);
         expect(actual).toMatchSnapshot();
@@ -192,7 +195,10 @@ describe('visualize loader pipeline helpers: build pipeline', () => {
         const visState = { ...visStateDef, params: { foo: 'bar' } };
         const schemas = {
           ...schemasDef,
-          metric: [{ ...schemaConfig, accessor: 0 }, { ...schemaConfig, accessor: 1 }],
+          metric: [
+            { ...schemaConfig, accessor: 0 },
+            { ...schemaConfig, accessor: 1 },
+          ],
           split_row: [2, 4],
           bucket: [3],
         };
@@ -250,7 +256,10 @@ describe('visualize loader pipeline helpers: build pipeline', () => {
         const visState = { ...visStateDef, params: { metric: {} } };
         const schemas = {
           ...schemasDef,
-          metric: [{ ...schemaConfig, accessor: 0 }, { ...schemaConfig, accessor: 1 }],
+          metric: [
+            { ...schemaConfig, accessor: 0 },
+            { ...schemaConfig, accessor: 1 },
+          ],
         };
         const actual = buildPipelineVisFunction.metric(visState, schemas, uiState);
         expect(actual).toMatchSnapshot();
@@ -260,7 +269,10 @@ describe('visualize loader pipeline helpers: build pipeline', () => {
         const visState = { ...visStateDef, params: { metric: {} } };
         const schemas = {
           ...schemasDef,
-          metric: [{ ...schemaConfig, accessor: 0 }, { ...schemaConfig, accessor: 1 }],
+          metric: [
+            { ...schemaConfig, accessor: 0 },
+            { ...schemaConfig, accessor: 1 },
+          ],
           group: [{ accessor: 2 }],
         };
         const actual = buildPipelineVisFunction.metric(visState, schemas, uiState);

--- a/src/plugins/dashboard_embeddable_container/public/plugin.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/plugin.tsx
@@ -61,9 +61,10 @@ export class DashboardEmbeddableContainerPublicPlugin
     const { application, notifications, overlays } = core;
     const { embeddable, inspector, uiActions } = plugins;
 
-    const SavedObjectFinder: React.FC<
-      Exclude<SavedObjectFinderProps, 'savedObjects' | 'uiSettings'>
-    > = props => (
+    const SavedObjectFinder: React.FC<Exclude<
+      SavedObjectFinderProps,
+      'savedObjects' | 'uiSettings'
+    >> = props => (
       <SavedObjectFinderUi
         {...props}
         savedObjects={core.savedObjects}

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_polygon.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_geo_polygon.test.ts
@@ -30,7 +30,10 @@ describe('filter manager utilities', () => {
       },
       geo_polygon: {
         point: {
-          points: [{ lat: 5, lon: 10 }, { lat: 15, lon: 20 }],
+          points: [
+            { lat: 5, lon: 10 },
+            { lat: 15, lon: 20 },
+          ],
         },
       },
     } as esFilters.GeoPolygonFilter;

--- a/src/plugins/data/public/search/create_app_mount_context_search.test.ts
+++ b/src/plugins/data/public/search/create_app_mount_context_search.test.ts
@@ -62,8 +62,10 @@ describe('Create app mount search context', () => {
         });
       },
     });
-    context
-      .search({ greeting: 'hi' } as any, {}, 'mysearch')
-      .subscribe(response => {}, () => {}, done);
+    context.search({ greeting: 'hi' } as any, {}, 'mysearch').subscribe(
+      response => {},
+      () => {},
+      done
+    );
   });
 });

--- a/src/plugins/es_ui_shared/static/forms/helpers/serializers.ts
+++ b/src/plugins/es_ui_shared/static/forms/helpers/serializers.ts
@@ -69,24 +69,21 @@ export const stripEmptyFields = (
 ): { [key: string]: any } => {
   const { types = ['string', 'object'], recursive = false } = options || {};
 
-  return Object.entries(object).reduce(
-    (acc, [key, value]) => {
-      const type = typeof value;
-      const shouldStrip = types.includes(type as 'string');
+  return Object.entries(object).reduce((acc, [key, value]) => {
+    const type = typeof value;
+    const shouldStrip = types.includes(type as 'string');
 
-      if (shouldStrip && type === 'string' && value.trim() === '') {
-        return acc;
-      } else if (type === 'object' && !Array.isArray(value) && value !== null) {
-        if (Object.keys(value).length === 0 && shouldStrip) {
-          return acc;
-        } else if (recursive) {
-          value = stripEmptyFields({ ...value }, options);
-        }
-      }
-
-      acc[key] = value;
+    if (shouldStrip && type === 'string' && value.trim() === '') {
       return acc;
-    },
-    {} as { [key: string]: any }
-  );
+    } else if (type === 'object' && !Array.isArray(value) && value !== null) {
+      if (Object.keys(value).length === 0 && shouldStrip) {
+        return acc;
+      } else if (recursive) {
+        value = stripEmptyFields({ ...value }, options);
+      }
+    }
+
+    acc[key] = value;
+    return acc;
+  }, {} as { [key: string]: any });
 };

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
@@ -65,15 +65,12 @@ export function useForm<T extends object = FormData>(
 
   const stripEmptyFields = (fields: FieldsMap): FieldsMap => {
     if (formOptions.stripEmptyFields) {
-      return Object.entries(fields).reduce(
-        (acc, [key, field]) => {
-          if (typeof field.value !== 'string' || field.value.trim() !== '') {
-            acc[key] = field;
-          }
-          return acc;
-        },
-        {} as FieldsMap
-      );
+      return Object.entries(fields).reduce((acc, [key, field]) => {
+        if (typeof field.value !== 'string' || field.value.trim() !== '') {
+          acc[key] = field;
+        }
+        return acc;
+      }, {} as FieldsMap);
     }
     return fields;
   };

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/lib/utils.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/lib/utils.ts
@@ -50,10 +50,7 @@ export const mapFormFields = (
   formFields: Record<string, FieldHook>,
   fn: (field: FieldHook) => any
 ) =>
-  Object.entries(formFields).reduce(
-    (acc, [key, field]) => {
-      acc[key] = fn(field);
-      return acc;
-    },
-    {} as Record<string, unknown>
-  );
+  Object.entries(formFields).reduce((acc, [key, field]) => {
+    acc[key] = fn(field);
+    return acc;
+  }, {} as Record<string, unknown>);

--- a/src/plugins/expressions/public/interpreter_provider.ts
+++ b/src/plugins/expressions/public/interpreter_provider.ts
@@ -163,9 +163,9 @@ export function interpreterProvider(config: InterpreterConfig): ExpressionInterp
 
     // Check for missing required arguments
     each(argDefs, argDef => {
-      const { aliases, default: argDefault, name: argName, required } = argDef as (ArgumentType<
+      const { aliases, default: argDefault, name: argName, required } = argDef as ArgumentType<
         any
-      > & { name: string });
+      > & { name: string };
       if (
         typeof argDefault === 'undefined' &&
         required &&

--- a/src/plugins/kibana_react/public/context/context.tsx
+++ b/src/plugins/kibana_react/public/context/context.tsx
@@ -32,12 +32,11 @@ const defaultContextValue = {
 
 export const context = createContext<KibanaReactContextValue<KibanaServices>>(defaultContextValue);
 
-export const useKibana = <Extra extends object = {}>(): KibanaReactContextValue<
-  KibanaServices & Extra
-> =>
-  useContext((context as unknown) as React.Context<
-    KibanaReactContextValue<KibanaServices & Extra>
-  >);
+export const useKibana = <Extra extends object = {}>(): KibanaReactContextValue<KibanaServices &
+  Extra> =>
+  useContext(
+    (context as unknown) as React.Context<KibanaReactContextValue<KibanaServices & Extra>>
+  );
 
 export const withKibana = <Props extends { kibana: KibanaReactContextValue<any> }>(
   type: React.ComponentType<Props>

--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -305,9 +305,9 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }: FtrPro
 
     public async getRhythmChartLegendValue(nth = 0) {
       await PageObjects.visualize.waitForVisualizationRenderingStabilized();
-      const metricValue = (await find.allByCssSelector(
-        `.echLegendItem .echLegendItem__displayValue`
-      ))[nth];
+      const metricValue = (
+        await find.allByCssSelector(`.echLegendItem .echLegendItem__displayValue`)
+      )[nth];
       await metricValue.moveMouseTo();
       return await metricValue.getVisibleText();
     }

--- a/test/functional/services/remote/poll_for_log_entry.ts
+++ b/test/functional/services/remote/poll_for_log_entry.ts
@@ -95,10 +95,7 @@ export function pollForLogEntry$(
               [new logging.Entry('SEVERE', `ERROR FETCHING BROWSR LOGS: ${error.message}`)],
 
               // pause 10 seconds then resubscribe
-              Rx.of(1).pipe(
-                delay(10 * 1000),
-                mergeMapTo(resubscribe)
-              )
+              Rx.of(1).pipe(delay(10 * 1000), mergeMapTo(resubscribe))
             );
           })
         )

--- a/test/plugin_functional/plugins/demo_search/public/demo_search_strategy.ts
+++ b/test/plugin_functional/plugins/demo_search/public/demo_search_strategy.ts
@@ -53,9 +53,7 @@ import { DEMO_SEARCH_STRATEGY, IDemoResponse } from '../common';
  * @param context - context supplied by other plugins.
  * @param search - a search function to access other strategies that have already been registered.
  */
-export const demoClientSearchStrategyProvider: TSearchStrategyProvider<
-  typeof DEMO_SEARCH_STRATEGY
-> = (
+export const demoClientSearchStrategyProvider: TSearchStrategyProvider<typeof DEMO_SEARCH_STRATEGY> = (
   context: ISearchContext,
   search: ISearchGeneric
 ): ISearchStrategy<typeof DEMO_SEARCH_STRATEGY> => {

--- a/test/plugin_functional/plugins/demo_search/server/demo_search_strategy.ts
+++ b/test/plugin_functional/plugins/demo_search/server/demo_search_strategy.ts
@@ -20,9 +20,7 @@
 import { TSearchStrategyProvider } from 'src/plugins/data/server';
 import { DEMO_SEARCH_STRATEGY } from '../common';
 
-export const demoSearchStrategyProvider: TSearchStrategyProvider<
-  typeof DEMO_SEARCH_STRATEGY
-> = () => {
+export const demoSearchStrategyProvider: TSearchStrategyProvider<typeof DEMO_SEARCH_STRATEGY> = () => {
   return {
     search: request => {
       return Promise.resolve({

--- a/x-pack/legacy/common/eui_draggable/index.d.ts
+++ b/x-pack/legacy/common/eui_draggable/index.d.ts
@@ -8,7 +8,7 @@ import React from 'react';
 import { EuiDraggable, EuiDragDropContext } from '@elastic/eui';
 
 type PropsOf<T> = T extends React.ComponentType<infer ComponentProps> ? ComponentProps : never;
-type FirstArgumentOf<Func> = Func extends ((arg1: infer FirstArgument, ...rest: any[]) => any)
+type FirstArgumentOf<Func> = Func extends (arg1: infer FirstArgument, ...rest: any[]) => any
   ? FirstArgument
   : never;
 export type DragHandleProps = FirstArgumentOf<

--- a/x-pack/legacy/plugins/actions/server/lib/task_runner_factory.test.ts
+++ b/x-pack/legacy/plugins/actions/server/lib/task_runner_factory.test.ts
@@ -111,11 +111,9 @@ test('executes the task by calling the executor with proper parameters', async (
 
   expect(runnerResult).toBeUndefined();
   expect(spaceIdToNamespace).toHaveBeenCalledWith('test');
-  expect(mockedEncryptedSavedObjectsPlugin.getDecryptedAsInternalUser).toHaveBeenCalledWith(
-    'action_task_params',
-    '3',
-    { namespace: 'namespace-test' }
-  );
+  expect(
+    mockedEncryptedSavedObjectsPlugin.getDecryptedAsInternalUser
+  ).toHaveBeenCalledWith('action_task_params', '3', { namespace: 'namespace-test' });
   expect(mockedActionExecutor.execute).toHaveBeenCalledWith({
     actionId: '2',
     params: { baz: true },

--- a/x-pack/legacy/plugins/apm/common/projections/util/merge_projection/index.ts
+++ b/x-pack/legacy/plugins/apm/common/projections/util/merge_projection/index.ts
@@ -21,14 +21,14 @@ type SourceProjection = Omit<DeepPartial<ESSearchRequest>, 'body'> & {
 };
 
 type DeepMerge<T, U> = U extends PlainObject
-  ? (T extends PlainObject
-      ? (Omit<T, keyof U> &
-          {
-            [key in keyof U]: T extends { [k in key]: any }
-              ? DeepMerge<T[key], U[key]>
-              : U[key];
-          })
-      : U)
+  ? T extends PlainObject
+    ? Omit<T, keyof U> &
+        {
+          [key in keyof U]: T extends { [k in key]: any }
+            ? DeepMerge<T[key], U[key]>
+            : U[key];
+        }
+    : U
   : U;
 
 export function mergeProjection<

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMetrics/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMetrics/index.tsx
@@ -29,9 +29,7 @@ export function ServiceMetrics({ agentName }: ServiceMetricsProps) {
   const { data } = useServiceMetricCharts(urlParams, agentName);
   const { start, end } = urlParams;
 
-  const localFiltersConfig: React.ComponentProps<
-    typeof LocalUIFilters
-  > = useMemo(
+  const localFiltersConfig: React.ComponentProps<typeof LocalUIFilters> = useMemo(
     () => ({
       filterNames: ['host', 'containerId', 'podName'],
       params: {

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceNodeOverview/index.tsx
@@ -34,9 +34,7 @@ const ServiceNodeOverview = () => {
   const { uiFilters, urlParams } = useUrlParams();
   const { serviceName, start, end } = urlParams;
 
-  const localFiltersConfig: React.ComponentProps<
-    typeof LocalUIFilters
-  > = useMemo(
+  const localFiltersConfig: React.ComponentProps<typeof LocalUIFilters> = useMemo(
     () => ({
       filterNames: ['host', 'containerId', 'podName'],
       params: {

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceOverview/index.tsx
@@ -84,9 +84,7 @@ export function ServiceOverview() {
   useTrackPageview({ app: 'apm', path: 'services_overview' });
   useTrackPageview({ app: 'apm', path: 'services_overview', delay: 15000 });
 
-  const localFiltersConfig: React.ComponentProps<
-    typeof LocalUIFilters
-  > = useMemo(
+  const localFiltersConfig: React.ComponentProps<typeof LocalUIFilters> = useMemo(
     () => ({
       filterNames: ['host', 'agentName'],
       projection: PROJECTION.SERVICES

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -195,10 +195,9 @@ export const TransactionDistribution: FunctionComponent<Props> = (
         }
         backgroundHover={(bucket: IChartPoint) => bucket.y > 0 && bucket.sample}
         tooltipHeader={(bucket: IChartPoint) =>
-          `${timeFormatter(bucket.x0, { withUnit: false })} - ${timeFormatter(
-            bucket.x,
-            { withUnit: false }
-          )} ${unit}`
+          `${timeFormatter(bucket.x0, {
+            withUnit: false
+          })} - ${timeFormatter(bucket.x, { withUnit: false })} ${unit}`
         }
         tooltipFooter={(bucket: IChartPoint) =>
           !bucket.sample &&

--- a/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -94,9 +94,7 @@ export function TransactionOverview() {
     }
   }, [http, serviceName, transactionType]);
 
-  const localFiltersConfig: React.ComponentProps<
-    typeof LocalUIFilters
-  > = useMemo(
+  const localFiltersConfig: React.ComponentProps<typeof LocalUIFilters> = useMemo(
     () => ({
       filterNames: ['transactionResult', 'host', 'containerId', 'podName'],
       params: {

--- a/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/index.tsx
@@ -103,12 +103,14 @@ export function KueryBar() {
 
     const boolFilter = getBoolFilter(urlParams);
     try {
-      const suggestions = (await getSuggestions(
-        inputValue,
-        selectionStart,
-        indexPattern,
-        boolFilter
-      ))
+      const suggestions = (
+        await getSuggestions(
+          inputValue,
+          selectionStart,
+          indexPattern,
+          boolFilter
+        )
+      )
         .filter(suggestion => !startsWith(suggestion.text, 'span.'))
         .slice(0, 15);
 

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
@@ -21,7 +21,10 @@ describe('MetadataTable', () => {
         label: 'Bar',
         required: false,
         properties: ['props.A', 'props.B'],
-        rows: [{ key: 'props.A', value: 'A' }, { key: 'props.B', value: 'B' }]
+        rows: [
+          { key: 'props.A', value: 'A' },
+          { key: 'props.B', value: 'B' }
+        ]
       }
     ] as unknown) as SectionsWithRows;
     const output = render(<MetadataTable sections={sectionsWithRows} />);

--- a/x-pack/legacy/plugins/apm/public/components/shared/Stacktrace/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Stacktrace/index.tsx
@@ -78,29 +78,26 @@ interface StackframesGroup {
 }
 
 export function getGroupedStackframes(stackframes: IStackframe[]) {
-  return stackframes.reduce(
-    (acc, stackframe) => {
-      const prevGroup = last(acc);
-      const shouldAppend =
-        prevGroup &&
-        prevGroup.isLibraryFrame === stackframe.library_frame &&
-        !prevGroup.excludeFromGrouping &&
-        !stackframe.exclude_from_grouping;
+  return stackframes.reduce((acc, stackframe) => {
+    const prevGroup = last(acc);
+    const shouldAppend =
+      prevGroup &&
+      prevGroup.isLibraryFrame === stackframe.library_frame &&
+      !prevGroup.excludeFromGrouping &&
+      !stackframe.exclude_from_grouping;
 
-      // append to group
-      if (shouldAppend) {
-        prevGroup.stackframes.push(stackframe);
-        return acc;
-      }
-
-      // create new group
-      acc.push({
-        isLibraryFrame: Boolean(stackframe.library_frame),
-        excludeFromGrouping: Boolean(stackframe.exclude_from_grouping),
-        stackframes: [stackframe]
-      });
+    // append to group
+    if (shouldAppend) {
+      prevGroup.stackframes.push(stackframe);
       return acc;
-    },
-    [] as StackframesGroup[]
-  );
+    }
+
+    // create new group
+    acc.push({
+      isLibraryFrame: Boolean(stackframe.library_frame),
+      excludeFromGrouping: Boolean(stackframe.exclude_from_grouping),
+      stackframes: [stackframe]
+    });
+    return acc;
+  }, [] as StackframesGroup[]);
 }

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/VoronoiPlot.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/VoronoiPlot.js
@@ -32,7 +32,10 @@ class VoronoiPlot extends PureComponent {
         onMouseLeave={this.props.onMouseLeave}
       >
         <Voronoi
-          extent={[[XY_MARGIN.left, XY_MARGIN.top], [XY_WIDTH, XY_HEIGHT]]}
+          extent={[
+            [XY_MARGIN.left, XY_MARGIN.top],
+            [XY_WIDTH, XY_HEIGHT]
+          ]}
           nodes={xValuesCombined}
           onHover={this.props.onHover}
           onMouseDown={this.props.onMouseDown}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/__test__/Histogram.test.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/__test__/Histogram.test.js
@@ -38,10 +38,9 @@ describe('Histogram', () => {
         formatYShort={t => `${asDecimal(t)} occ.`}
         formatYLong={t => `${asDecimal(t)} occurrences`}
         tooltipHeader={bucket =>
-          `${timeFormatter(bucket.x0, { withUnit: false })} - ${timeFormatter(
-            bucket.x,
-            { withUnit: false }
-          )} ${unit}`
+          `${timeFormatter(bucket.x0, {
+            withUnit: false
+          })} - ${timeFormatter(bucket.x, { withUnit: false })} ${unit}`
         }
         width={800}
       />

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
@@ -209,7 +209,10 @@ export class HistogramInner extends PureComponent {
             )}
 
             <Voronoi
-              extent={[[XY_MARGIN.left, XY_MARGIN.top], [XY_WIDTH, XY_HEIGHT]]}
+              extent={[
+                [XY_MARGIN.left, XY_MARGIN.top],
+                [XY_WIDTH, XY_HEIGHT]
+              ]}
               nodes={this.props.buckets.map(bucket => {
                 return {
                   ...bucket,

--- a/x-pack/legacy/plugins/apm/public/selectors/__tests__/chartSelectors.test.ts
+++ b/x-pack/legacy/plugins/apm/public/selectors/__tests__/chartSelectors.test.ts
@@ -35,9 +35,18 @@ describe('chartSelectors', () => {
   describe('getResponseTimeSeries', () => {
     const apmTimeseries = {
       responseTimes: {
-        avg: [{ x: 0, y: 100 }, { x: 1000, y: 200 }],
-        p95: [{ x: 0, y: 200 }, { x: 1000, y: 300 }],
-        p99: [{ x: 0, y: 300 }, { x: 1000, y: 400 }]
+        avg: [
+          { x: 0, y: 100 },
+          { x: 1000, y: 200 }
+        ],
+        p95: [
+          { x: 0, y: 200 },
+          { x: 1000, y: 300 }
+        ],
+        p99: [
+          { x: 0, y: 300 },
+          { x: 1000, y: 400 }
+        ]
       },
       tpmBuckets: [],
       overallAvgDuration: 200
@@ -49,21 +58,30 @@ describe('chartSelectors', () => {
       ).toEqual([
         {
           color: '#3185fc',
-          data: [{ x: 0, y: 100 }, { x: 1000, y: 200 }],
+          data: [
+            { x: 0, y: 100 },
+            { x: 1000, y: 200 }
+          ],
           legendValue: '0 ms',
           title: 'Avg.',
           type: 'linemark'
         },
         {
           color: '#e6c220',
-          data: [{ x: 0, y: 200 }, { x: 1000, y: 300 }],
+          data: [
+            { x: 0, y: 200 },
+            { x: 1000, y: 300 }
+          ],
           title: '95th percentile',
           titleShort: '95th',
           type: 'linemark'
         },
         {
           color: '#f98510',
-          data: [{ x: 0, y: 300 }, { x: 1000, y: 400 }],
+          data: [
+            { x: 0, y: 300 },
+            { x: 1000, y: 400 }
+          ],
           title: '99th percentile',
           titleShort: '99th',
           type: 'linemark'
@@ -87,7 +105,13 @@ describe('chartSelectors', () => {
         p99: []
       },
       tpmBuckets: [
-        { key: 'HTTP 2xx', dataPoints: [{ x: 0, y: 5 }, { x: 0, y: 2 }] },
+        {
+          key: 'HTTP 2xx',
+          dataPoints: [
+            { x: 0, y: 5 },
+            { x: 0, y: 2 }
+          ]
+        },
         { key: 'HTTP 4xx', dataPoints: [{ x: 0, y: 1 }] },
         { key: 'HTTP 5xx', dataPoints: [{ x: 0, y: 0 }] }
       ],
@@ -99,7 +123,10 @@ describe('chartSelectors', () => {
       expect(getTpmSeries(apmTimeseries, transactionType)).toEqual([
         {
           color: successColor,
-          data: [{ x: 0, y: 5 }, { x: 0, y: 2 }],
+          data: [
+            { x: 0, y: 5 },
+            { x: 0, y: 2 }
+          ],
           legendValue: '3.5 tpm',
           title: 'HTTP 2xx',
           type: 'linemark'
@@ -220,9 +247,18 @@ describe('chartSelectors', () => {
     describe('when empty', () => {
       it('produces an empty series', () => {
         const responseTimes = {
-          avg: [{ x: 0, y: 1 }, { x: 100, y: 1 }],
-          p95: [{ x: 0, y: 1 }, { x: 100, y: 1 }],
-          p99: [{ x: 0, y: 1 }, { x: 100, y: 1 }]
+          avg: [
+            { x: 0, y: 1 },
+            { x: 100, y: 1 }
+          ],
+          p95: [
+            { x: 0, y: 1 },
+            { x: 100, y: 1 }
+          ],
+          p99: [
+            { x: 0, y: 1 },
+            { x: 100, y: 1 }
+          ]
         };
         const series = getTpmSeries(
           { ...apmTimeseries, responseTimes, tpmBuckets: [] },

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -151,56 +151,53 @@ export async function getTransactionBreakdown({
 
   const bucketsByDate = idx(resp.aggregations, _ => _.by_date.buckets) || [];
 
-  const timeseriesPerSubtype = bucketsByDate.reduce(
-    (prev, bucket) => {
-      const formattedValues = formatBucket(bucket);
-      const time = bucket.key;
+  const timeseriesPerSubtype = bucketsByDate.reduce((prev, bucket) => {
+    const formattedValues = formatBucket(bucket);
+    const time = bucket.key;
 
-      const updatedSeries = kpiNames.reduce((p, kpiName) => {
-        const { name, percentage } = formattedValues.find(
-          val => val.name === kpiName
-        ) || {
-          name: kpiName,
-          percentage: null
-        };
+    const updatedSeries = kpiNames.reduce((p, kpiName) => {
+      const { name, percentage } = formattedValues.find(
+        val => val.name === kpiName
+      ) || {
+        name: kpiName,
+        percentage: null
+      };
 
-        if (!p[name]) {
-          p[name] = [];
-        }
-        return {
-          ...p,
-          [name]: p[name].concat({
-            x: time,
-            y: percentage
-          })
-        };
-      }, prev);
-
-      const lastValues = Object.values(updatedSeries).map(last);
-
-      // If for a given timestamp, some series have data, but others do not,
-      // we have to set any null values to 0 to make sure the stacked area chart
-      // is drawn correctly.
-      // If we set all values to 0, the chart always displays null values as 0,
-      // and the chart looks weird.
-      const hasAnyValues = lastValues.some(value => value.y !== null);
-      const hasNullValues = lastValues.some(value => value.y === null);
-
-      if (hasAnyValues && hasNullValues) {
-        Object.values(updatedSeries).forEach(series => {
-          const value = series[series.length - 1];
-          const isEmpty = value.y === null;
-          if (isEmpty) {
-            // local mutation to prevent complicated map/reduce calls
-            value.y = 0;
-          }
-        });
+      if (!p[name]) {
+        p[name] = [];
       }
+      return {
+        ...p,
+        [name]: p[name].concat({
+          x: time,
+          y: percentage
+        })
+      };
+    }, prev);
 
-      return updatedSeries;
-    },
-    {} as Record<string, Array<{ x: number; y: number | null }>>
-  );
+    const lastValues = Object.values(updatedSeries).map(last);
+
+    // If for a given timestamp, some series have data, but others do not,
+    // we have to set any null values to 0 to make sure the stacked area chart
+    // is drawn correctly.
+    // If we set all values to 0, the chart always displays null values as 0,
+    // and the chart looks weird.
+    const hasAnyValues = lastValues.some(value => value.y !== null);
+    const hasNullValues = lastValues.some(value => value.y === null);
+
+    if (hasAnyValues && hasNullValues) {
+      Object.values(updatedSeries).forEach(series => {
+        const value = series[series.length - 1];
+        const isEmpty = value.y === null;
+        if (isEmpty) {
+          // local mutation to prevent complicated map/reduce calls
+          value.y = 0;
+        }
+      });
+    }
+
+    return updatedSeries;
+  }, {} as Record<string, Array<{ x: number; y: number | null }>>);
 
   const timeseries = kpis.map(kpi => ({
     title: kpi.name,

--- a/x-pack/legacy/plugins/apm/server/lib/ui_filters/local_ui_filters/config.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/ui_filters/local_ui_filters/config.ts
@@ -61,17 +61,14 @@ export const localUIFilterNames = Object.keys(
   filtersByName
 ) as LocalUIFilterName[];
 
-export const localUIFilters = localUIFilterNames.reduce(
-  (acc, key) => {
-    const field = filtersByName[key];
+export const localUIFilters = localUIFilterNames.reduce((acc, key) => {
+  const field = filtersByName[key];
 
-    return {
-      ...acc,
-      [key]: {
-        ...field,
-        name: key
-      }
-    };
-  },
-  {} as LocalUIFilterMap
-);
+  return {
+    ...acc,
+    [key]: {
+      ...field,
+      name: key
+    }
+  };
+}, {} as LocalUIFilterMap);

--- a/x-pack/legacy/plugins/apm/server/routes/create_api/index.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_api/index.ts
@@ -71,41 +71,38 @@ export function createApi() {
 
                 const parsedParams = (Object.keys(rts) as Array<
                   keyof typeof rts
-                >).reduce(
-                  (acc, key) => {
-                    const codec = rts[key];
-                    const value = paramMap[key];
+                >).reduce((acc, key) => {
+                  const codec = rts[key];
+                  const value = paramMap[key];
 
-                    const result = codec.decode(value);
+                  const result = codec.decode(value);
 
-                    if (isLeft(result)) {
-                      throw Boom.badRequest(PathReporter.report(result)[0]);
-                    }
+                  if (isLeft(result)) {
+                    throw Boom.badRequest(PathReporter.report(result)[0]);
+                  }
 
-                    const strippedKeys = difference(
-                      Object.keys(value || {}),
-                      Object.keys(result.right || {})
+                  const strippedKeys = difference(
+                    Object.keys(value || {}),
+                    Object.keys(result.right || {})
+                  );
+
+                  if (strippedKeys.length) {
+                    throw Boom.badRequest(
+                      `Unknown keys specified: ${strippedKeys}`
                     );
+                  }
 
-                    if (strippedKeys.length) {
-                      throw Boom.badRequest(
-                        `Unknown keys specified: ${strippedKeys}`
-                      );
-                    }
+                  // hide _debug from route handlers
+                  const parsedValue =
+                    key === 'query'
+                      ? omit(result.right, '_debug')
+                      : result.right;
 
-                    // hide _debug from route handlers
-                    const parsedValue =
-                      key === 'query'
-                        ? omit(result.right, '_debug')
-                        : result.right;
-
-                    return {
-                      ...acc,
-                      [key]: parsedValue
-                    };
-                  },
-                  {} as Record<keyof typeof params, any>
-                );
+                  return {
+                    ...acc,
+                    [key]: parsedValue
+                  };
+                }, {} as Record<keyof typeof params, any>);
 
                 return route.handler(
                   request,

--- a/x-pack/legacy/plugins/apm/server/routes/typings.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/typings.ts
@@ -92,7 +92,9 @@ type GetOptionalParamKeys<TParams extends Params> = keyof PickByValue<
   {
     [key in keyof TParams]: TParams[key] extends t.PartialType<any>
       ? false
-      : (TParams[key] extends t.Any ? true : false);
+      : TParams[key] extends t.Any
+      ? true
+      : false;
   },
   false
 >;

--- a/x-pack/legacy/plugins/apm/server/routes/ui_filters.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/ui_filters.ts
@@ -45,9 +45,11 @@ export const uiFiltersEnvironmentsRoute = createRoute(() => ({
 const filterNamesRt = t.type({
   filterNames: jsonRt.pipe(
     t.array(
-      t.keyof(Object.fromEntries(
-        localUIFilterNames.map(filterName => [filterName, null])
-      ) as Record<LocalUIFilterName, null>)
+      t.keyof(
+        Object.fromEntries(
+          localUIFilterNames.map(filterName => [filterName, null])
+        ) as Record<LocalUIFilterName, null>
+      )
     )
   )
 });

--- a/x-pack/legacy/plugins/apm/typings/elasticsearch/aggregations.ts
+++ b/x-pack/legacy/plugins/apm/typings/elasticsearch/aggregations.ts
@@ -202,22 +202,19 @@ interface AggregationResponsePart<
           TDocument
         >
       >
-    : (TAggregationOptionsMap extends {
+    : TAggregationOptionsMap extends {
         filters: {
           filters: Record<string, any>;
         };
       }
-        ? {
-            buckets: {
-              [key in keyof TAggregationOptionsMap['filters']['filters']]: {
-                doc_count: number;
-              } & AggregationResponseMap<
-                TAggregationOptionsMap['aggs'],
-                TDocument
-              >;
-            };
-          }
-        : never);
+    ? {
+        buckets: {
+          [key in keyof TAggregationOptionsMap['filters']['filters']]: {
+            doc_count: number;
+          } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
+        };
+      }
+    : never;
   sampler: {
     doc_count: number;
   } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;

--- a/x-pack/legacy/plugins/apm/typings/elasticsearch/index.ts
+++ b/x-pack/legacy/plugins/apm/typings/elasticsearch/index.ts
@@ -36,8 +36,7 @@ export type ESSearchResponse<
           TDocument
         >;
       }
-    : {}) &
-  ({
+    : {}) & {
     hits: Omit<SearchResponse<TDocument>['hits'], 'total'> &
       (TOptions['restTotalHitsAsInt'] extends true
         ? {
@@ -49,7 +48,7 @@ export type ESSearchResponse<
               relation: 'eq' | 'gte';
             };
           });
-  });
+  };
 
 export interface ESFilter {
   [key: string]: {

--- a/x-pack/legacy/plugins/beats_management/common/config_block_validation.ts
+++ b/x-pack/legacy/plugins/beats_management/common/config_block_validation.ts
@@ -27,20 +27,17 @@ export const validateConfigurationBlocks = (configurationBlocks: ConfigurationBl
       );
     }
 
-    const interfaceConfig = blockSchema.configs.reduce(
-      (props, config) => {
-        if (config.options) {
-          props[config.id] = t.keyof(Object.fromEntries(
-            config.options.map(opt => [opt.value, null])
-          ) as Record<string, null>);
-        } else if (config.validation) {
-          props[config.id] = validationMap[config.validation];
-        }
+    const interfaceConfig = blockSchema.configs.reduce((props, config) => {
+      if (config.options) {
+        props[config.id] = t.keyof(
+          Object.fromEntries(config.options.map(opt => [opt.value, null])) as Record<string, null>
+        );
+      } else if (config.validation) {
+        props[config.id] = validationMap[config.validation];
+      }
 
-        return props;
-      },
-      {} as t.Props
-    );
+      return props;
+    }, {} as t.Props);
 
     const runtimeInterface = createConfigurationBlockInterface(
       t.literal(blockSchema.id),

--- a/x-pack/legacy/plugins/beats_management/common/domain_types.ts
+++ b/x-pack/legacy/plugins/beats_management/common/domain_types.ts
@@ -13,9 +13,9 @@ export const OutputTypesArray = ['elasticsearch', 'logstash', 'kafka', 'redis'];
 // We can also pass in optional params to create spacific runtime checks that
 // can be used to validate blocs on the API and UI
 export const createConfigurationBlockInterface = (
-  configType: t.LiteralType<string> | t.KeyofC<Record<string, null>> = t.keyof(Object.fromEntries(
-    configBlockSchemas.map(s => [s.id, null])
-  ) as Record<string, null>),
+  configType: t.LiteralType<string> | t.KeyofC<Record<string, null>> = t.keyof(
+    Object.fromEntries(configBlockSchemas.map(s => [s.id, null])) as Record<string, null>
+  ),
   beatConfigInterface: t.Mixed = t.Dictionary
 ) =>
   t.interface(

--- a/x-pack/legacy/plugins/beats_management/public/components/autocomplete_field/index.tsx
+++ b/x-pack/legacy/plugins/beats_management/public/components/autocomplete_field/index.tsx
@@ -265,13 +265,11 @@ const withSuggestionsHidden = (state: AutocompleteFieldState) => ({
   selectedIndex: null,
 });
 
-const FixedEuiFieldSearch: React.SFC<
-  React.InputHTMLAttributes<HTMLInputElement> &
-    EuiFieldSearchProps & {
-      inputRef?: (element: HTMLInputElement | null) => void;
-      onSearch: (value: string) => void;
-    }
-> = EuiFieldSearch as any;
+const FixedEuiFieldSearch: React.SFC<React.InputHTMLAttributes<HTMLInputElement> &
+  EuiFieldSearchProps & {
+    inputRef?: (element: HTMLInputElement | null) => void;
+    onSearch: (value: string) => void;
+  }> = EuiFieldSearch as any;
 
 const AutocompleteContainer = styled.div`
   position: relative;

--- a/x-pack/legacy/plugins/beats_management/public/components/navigation/breadcrumb/provider.tsx
+++ b/x-pack/legacy/plugins/beats_management/public/components/navigation/breadcrumb/provider.tsx
@@ -53,16 +53,13 @@ export class BreadcrumbProvider extends Component<ComponentProps, ComponentState
     const { breadcrumbs } = this.state;
 
     const context = {
-      breadcrumbs: breadcrumbs.reduce(
-        (crumbs, crumbStorageItem) => {
-          if (crumbStorageItem.parents) {
-            crumbs = crumbs.concat(crumbStorageItem.parents);
-          }
-          crumbs.push(crumbStorageItem.breadcrumb);
-          return crumbs;
-        },
-        [] as Breadcrumb[]
-      ),
+      breadcrumbs: breadcrumbs.reduce((crumbs, crumbStorageItem) => {
+        if (crumbStorageItem.parents) {
+          crumbs = crumbs.concat(crumbStorageItem.parents);
+        }
+        crumbs.push(crumbStorageItem.breadcrumb);
+        return crumbs;
+      }, [] as Breadcrumb[]),
       addCrumb: this.addCrumb,
       removeCrumb: this.removeCrumb,
     };

--- a/x-pack/legacy/plugins/beats_management/public/components/table/table_type_configs.tsx
+++ b/x-pack/legacy/plugins/beats_management/public/components/table/table_type_configs.tsx
@@ -246,7 +246,10 @@ export const BeatsTableType: TableType = {
         name: i18n.translate('xpack.beatsManagement.beatsTable.typeLabel', {
           defaultMessage: 'Type',
         }),
-        options: uniq(data.map(({ type }: { type: any }) => ({ value: type })), 'value'),
+        options: uniq(
+          data.map(({ type }: { type: any }) => ({ value: type })),
+          'value'
+        ),
       },
     ],
   }),

--- a/x-pack/legacy/plugins/beats_management/public/lib/adapters/beats/rest_beats_adapter.ts
+++ b/x-pack/legacy/plugins/beats_management/public/lib/adapters/beats/rest_beats_adapter.ts
@@ -26,9 +26,9 @@ export class RestBeatsAdapter implements CMBeatsAdapter {
 
   public async getBeatWithToken(enrollmentToken: string): Promise<CMBeat | null> {
     try {
-      return (await this.REST.get<ReturnTypeGet<CMBeat>>(
-        `/api/beats/agent/unknown/${enrollmentToken}`
-      )).item;
+      return (
+        await this.REST.get<ReturnTypeGet<CMBeat>>(`/api/beats/agent/unknown/${enrollmentToken}`)
+      ).item;
     } catch (e) {
       return null;
     }
@@ -59,16 +59,20 @@ export class RestBeatsAdapter implements CMBeatsAdapter {
   public async removeTagsFromBeats(
     removals: BeatsTagAssignment[]
   ): Promise<ReturnTypeBulkAction['results']> {
-    return (await this.REST.post<ReturnTypeBulkAction>(`/api/beats/agents_tags/removals`, {
-      removals,
-    })).results;
+    return (
+      await this.REST.post<ReturnTypeBulkAction>(`/api/beats/agents_tags/removals`, {
+        removals,
+      })
+    ).results;
   }
 
   public async assignTagsToBeats(
     assignments: BeatsTagAssignment[]
   ): Promise<ReturnTypeBulkAction['results']> {
-    return (await this.REST.post<ReturnTypeBulkAction>(`/api/beats/agents_tags/assignments`, {
-      assignments,
-    })).results;
+    return (
+      await this.REST.post<ReturnTypeBulkAction>(`/api/beats/agents_tags/assignments`, {
+        assignments,
+      })
+    ).results;
   }
 }

--- a/x-pack/legacy/plugins/beats_management/public/lib/adapters/tags/rest_tags_adapter.ts
+++ b/x-pack/legacy/plugins/beats_management/public/lib/adapters/tags/rest_tags_adapter.ts
@@ -20,9 +20,9 @@ export class RestTagsAdapter implements CMTagsAdapter {
 
   public async getTagsWithIds(tagIds: string[]): Promise<BeatTag[]> {
     try {
-      return (await this.REST.get<ReturnTypeBulkGet<BeatTag>>(
-        `/api/beats/tags/${uniq(tagIds).join(',')}`
-      )).items;
+      return (
+        await this.REST.get<ReturnTypeBulkGet<BeatTag>>(`/api/beats/tags/${uniq(tagIds).join(',')}`)
+      ).items;
     } catch (e) {
       return [];
     }
@@ -37,9 +37,9 @@ export class RestTagsAdapter implements CMTagsAdapter {
   }
 
   public async delete(tagIds: string[]): Promise<boolean> {
-    return (await this.REST.delete<ReturnTypeBulkDelete>(
-      `/api/beats/tags/${uniq(tagIds).join(',')}`
-    )).success;
+    return (
+      await this.REST.delete<ReturnTypeBulkDelete>(`/api/beats/tags/${uniq(tagIds).join(',')}`)
+    ).success;
   }
 
   public async upsertTag(tag: BeatTag): Promise<BeatTag | null> {
@@ -53,9 +53,11 @@ export class RestTagsAdapter implements CMTagsAdapter {
 
   public async getAssignable(beats: CMBeat[]) {
     try {
-      return (await this.REST.get<ReturnTypeBulkGet<BeatTag>>(
-        `/api/beats/tags/assignable/${beats.map(beat => beat.id).join(',')}`
-      )).items;
+      return (
+        await this.REST.get<ReturnTypeBulkGet<BeatTag>>(
+          `/api/beats/tags/assignable/${beats.map(beat => beat.id).join(',')}`
+        )
+      ).items;
     } catch (e) {
       return [];
     }

--- a/x-pack/legacy/plugins/beats_management/public/lib/adapters/tokens/rest_tokens_adapter.ts
+++ b/x-pack/legacy/plugins/beats_management/public/lib/adapters/tokens/rest_tokens_adapter.ts
@@ -12,12 +12,11 @@ export class RestTokensAdapter implements CMTokensAdapter {
   constructor(private readonly REST: RestAPIAdapter) {}
 
   public async createEnrollmentTokens(numTokens: number = 1): Promise<string[]> {
-    const results = (await this.REST.post<ReturnTypeBulkCreate<string>>(
-      '/api/beats/enrollment_tokens',
-      {
+    const results = (
+      await this.REST.post<ReturnTypeBulkCreate<string>>('/api/beats/enrollment_tokens', {
         num_tokens: numTokens,
-      }
-    )).results;
+      })
+    ).results;
     return results.map(result => result.item);
   }
 }

--- a/x-pack/legacy/plugins/beats_management/public/lib/compose/scripts.ts
+++ b/x-pack/legacy/plugins/beats_management/public/lib/compose/scripts.ts
@@ -22,7 +22,11 @@ import { FrontendLibs } from '../types';
 
 export function compose(basePath: string): FrontendLibs {
   const api = new NodeAxiosAPIAdapter('elastic', 'changeme', basePath);
-  const esAdapter = new MemoryElasticsearchAdapter(() => true, () => '', []);
+  const esAdapter = new MemoryElasticsearchAdapter(
+    () => true,
+    () => '',
+    []
+  );
   const elasticsearchLib = new ElasticsearchLib(esAdapter);
   const configBlocks = new ConfigBlocksLib(
     new RestConfigBlocksAdapter(api),

--- a/x-pack/legacy/plugins/beats_management/server/lib/tags.ts
+++ b/x-pack/legacy/plugins/beats_management/server/lib/tags.ts
@@ -40,15 +40,12 @@ export class CMTagsDomain {
   public async getNonConflictingTags(user: FrameworkUser, existingTagIds: string[]) {
     const tags = await this.adapter.getTagsWithIds(user, existingTagIds);
     const existingUniqueBlockTypes = uniq(
-      tags.reduce(
-        (existingUniqueTypes, tag) => {
-          if (tag.hasConfigurationBlocksTypes) {
-            existingUniqueTypes = existingUniqueTypes.concat(tag.hasConfigurationBlocksTypes);
-          }
-          return existingUniqueTypes;
-        },
-        [] as string[]
-      )
+      tags.reduce((existingUniqueTypes, tag) => {
+        if (tag.hasConfigurationBlocksTypes) {
+          existingUniqueTypes = existingUniqueTypes.concat(tag.hasConfigurationBlocksTypes);
+        }
+        return existingUniqueTypes;
+      }, [] as string[])
     ).filter(type => UNIQUENESS_ENFORCING_TYPES.includes(type));
 
     const safeTags = await this.adapter.getWithoutConfigTypes(user, existingUniqueBlockTypes);

--- a/x-pack/legacy/plugins/beats_management/server/rest_api/__tests__/beats_assignments.test.ts
+++ b/x-pack/legacy/plugins/beats_management/server/rest_api/__tests__/beats_assignments.test.ts
@@ -73,7 +73,10 @@ describe('assign_tags_to_beats', () => {
         authorization: 'loggedin',
       },
       payload: {
-        assignments: [{ beatId: 'foo', tag: 'development' }, { beatId: 'bar', tag: 'development' }],
+        assignments: [
+          { beatId: 'foo', tag: 'development' },
+          { beatId: 'bar', tag: 'development' },
+        ],
       },
     });
 
@@ -115,7 +118,10 @@ describe('assign_tags_to_beats', () => {
         authorization: 'loggedin',
       },
       payload: {
-        assignments: [{ beatId: 'bar', tag: 'development' }, { beatId: 'bar', tag: 'production' }],
+        assignments: [
+          { beatId: 'bar', tag: 'development' },
+          { beatId: 'bar', tag: 'production' },
+        ],
       },
     });
 

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/browser/location.ts
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/browser/location.ts
@@ -32,7 +32,10 @@ export function location(): ExpressionFunction<'location', null, {}, Promise<Ret
           const { latitude, longitude } = geoposition.coords;
           return resolve({
             type: 'datatable',
-            columns: [{ name: 'latitude', type: 'number' }, { name: 'longitude', type: 'number' }],
+            columns: [
+              { name: 'latitude', type: 'number' },
+              { name: 'longitude', type: 'number' },
+            ],
             rows: [{ latitude, longitude }],
           });
         }

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/csv.test.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/csv.test.js
@@ -14,7 +14,10 @@ describe('csv', () => {
   const fn = functionWrapper(csv);
   const expected = {
     type: 'datatable',
-    columns: [{ name: 'name', type: 'string' }, { name: 'number', type: 'string' }],
+    columns: [
+      { name: 'name', type: 'string' },
+      { name: 'number', type: 'string' },
+    ],
     rows: [
       { name: 'one', number: '1' },
       { name: 'two', number: '2' },

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/get_flot_axis_config.test.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/get_flot_axis_config.test.js
@@ -84,10 +84,16 @@ describe('getFlotAxisConfig', () => {
   describe('ticks', () => {
     it('adds a tick mark mapping for string columns', () => {
       let result = getFlotAxisConfig('x', true, { columns, ticks });
-      expect(result.ticks).toEqual([[2, 'product1'], [1, 'product2']]);
+      expect(result.ticks).toEqual([
+        [2, 'product1'],
+        [1, 'product2'],
+      ]);
 
       result = getFlotAxisConfig('x', xAxisConfig, { columns, ticks });
-      expect(result.ticks).toEqual([[2, 'product1'], [1, 'product2']]);
+      expect(result.ticks).toEqual([
+        [2, 'product1'],
+        [1, 'product2'],
+      ]);
     });
   });
 

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/get_tick_hash.test.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/get_tick_hash.test.js
@@ -30,7 +30,12 @@ describe('getTickHash', () => {
       x: { type: 'number', role: 'dimension', expression: 'id' },
       y: { type: 'boolean', role: 'dimension', expression: 'running' },
     };
-    const rows = [{ x: 1, y: true }, { x: 2, y: true }, { x: 1, y: false }, { x: 2, y: false }];
+    const rows = [
+      { x: 1, y: true },
+      { x: 2, y: true },
+      { x: 1, y: false },
+      { x: 2, y: false },
+    ];
 
     expect(getTickHash(columns, rows)).toEqual({
       x: { hash: {}, counter: 0 },

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/math.ts
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/math.ts
@@ -44,7 +44,10 @@ export function math(): ExpressionFunction<'math', Context, Arguments, number> {
       }
 
       const mathContext = isDatatable(context)
-        ? pivotObjectArray(context.rows, context.columns.map(col => col.name))
+        ? pivotObjectArray(
+            context.rows,
+            context.columns.map(col => col.name)
+          )
         : { value: context };
 
       try {

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/server/pointseries/index.ts
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/server/pointseries/index.ts
@@ -187,7 +187,10 @@ export function pointseries(): ExpressionFunction<
       // Then compute that 1 value for each measure
       Object.values<DatatableRow[]>(measureKeys).forEach(valueRows => {
         const subtable = { type: 'datatable', columns: context.columns, rows: valueRows };
-        const subScope = pivotObjectArray(subtable.rows, subtable.columns.map(col => col.name));
+        const subScope = pivotObjectArray(
+          subtable.rows,
+          subtable.columns.map(col => col.name)
+        );
         const measureValues = measureNames.map(measure => {
           try {
             const ev = evaluate(args[measure], subScope);

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/pie/plugins/pie.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/pie/plugins/pie.js
@@ -683,7 +683,14 @@ function init(plot) {
           const p4Y = radius * Math.sin(s.startAngle + s.angle / 1.5);
           const p5X = radius * Math.cos(s.startAngle + s.angle);
           const p5Y = radius * Math.sin(s.startAngle + s.angle);
-          const arrPoly = [[0, 0], [p1X, p1Y], [p2X, p2Y], [p3X, p3Y], [p4X, p4Y], [p5X, p5Y]];
+          const arrPoly = [
+            [0, 0],
+            [p1X, p1Y],
+            [p2X, p2Y],
+            [p3X, p3Y],
+            [p4X, p4Y],
+            [p5X, p5Y],
+          ];
           const arrPoint = [x, y];
 
           // TODO: perhaps do some mathmatical trickery here with the Y-coordinate to compensate for pie tilt?

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/uis/views/pie.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/uis/views/pie.js
@@ -14,7 +14,10 @@ const { Pie: strings } = ViewStrings;
 export const pie = () => ({
   name: 'pie',
   displayName: strings.getDisplayName(),
-  modelArgs: [['color', { label: 'Slice Labels' }], ['size', { label: 'Slice Angles' }]],
+  modelArgs: [
+    ['color', { label: 'Slice Labels' }],
+    ['size', { label: 'Slice Angles' }],
+  ],
   args: [
     {
       name: 'palette',

--- a/x-pack/legacy/plugins/canvas/public/apps/export/export/index.js
+++ b/x-pack/legacy/plugins/canvas/public/apps/export/export/index.js
@@ -25,9 +25,6 @@ const mapDispatchToProps = dispatch => ({
 const branches = [branch(({ workpad }) => workpad == null, renderComponent(LoadWorkpad))];
 
 export const ExportApp = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
   ...branches
 )(Component);

--- a/x-pack/legacy/plugins/canvas/public/apps/home/home_app/index.js
+++ b/x-pack/legacy/plugins/canvas/public/apps/home/home_app/index.js
@@ -14,7 +14,4 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export const HomeApp = connect(
-  null,
-  mapDispatchToProps
-)(Component);
+export const HomeApp = connect(null, mapDispatchToProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/apps/workpad/workpad_app/index.js
+++ b/x-pack/legacy/plugins/canvas/public/apps/workpad/workpad_app/index.js
@@ -35,10 +35,7 @@ const mapDispatchToProps = dispatch => ({
 const branches = [branch(({ workpad }) => workpad == null, renderComponent(LoadWorkpad))];
 
 export const WorkpadApp = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
   ...branches,
   withElementsLoadedTelemetry
 )(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/app/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/app/index.js
@@ -97,11 +97,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 };
 
 export const App = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withProps(() => ({
     onRouteChange: trackRouteChange,
   }))

--- a/x-pack/legacy/plugins/canvas/public/components/asset_manager/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/asset_manager/index.js
@@ -89,10 +89,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 };
 
 export const AssetManager = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withProps({ onAssetCopy: asset => notify.success(`Copied '${asset.id}' to clipboard`) })
 )(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/datasource/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/datasource/index.js
@@ -82,11 +82,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 };
 
 export const Datasource = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withState('stateArgs', 'updateArgs', ({ args }) => args),
   withState('selecting', 'setSelecting', false),
   withState('previewing', 'setPreviewing', false),

--- a/x-pack/legacy/plugins/canvas/public/components/element_content/element_content.js
+++ b/x-pack/legacy/plugins/canvas/public/components/element_content/element_content.js
@@ -21,9 +21,12 @@ import { InvalidElementType } from './invalid_element_type';
 */
 const branches = [
   // no renderable or renderable config value, render loading
-  branch(({ renderable, state }) => {
-    return !state || !renderable;
-  }, renderComponent(({ backgroundColor }) => <Loading backgroundColor={backgroundColor} />)),
+  branch(
+    ({ renderable, state }) => {
+      return !state || !renderable;
+    },
+    renderComponent(({ backgroundColor }) => <Loading backgroundColor={backgroundColor} />)
+  ),
 
   // renderable is available, but no matching element is found, render invalid
   branch(({ renderable, renderFunction }) => {

--- a/x-pack/legacy/plugins/canvas/public/components/element_types/element_types.js
+++ b/x-pack/legacy/plugins/canvas/public/components/element_types/element_types.js
@@ -116,7 +116,10 @@ export class ElementTypes extends Component {
   };
 
   _sortElements = elements =>
-    sortBy(map(elements, (element, name) => ({ name, ...element })), 'displayName');
+    sortBy(
+      map(elements, (element, name) => ({ name, ...element })),
+      'displayName'
+    );
 
   render() {
     const {

--- a/x-pack/legacy/plugins/canvas/public/components/element_types/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/element_types/index.js
@@ -95,11 +95,7 @@ export const ElementTypes = compose(
   withState('customElements', 'setCustomElements', []),
   withState('filterTags', 'setFilterTags', []),
   withProps(() => ({ elements: elementsRegistry.toJS() })),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  )
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)
 )(Component);
 
 ElementTypes.propTypes = {

--- a/x-pack/legacy/plugins/canvas/public/components/embeddable_flyout/index.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/embeddable_flyout/index.tsx
@@ -105,9 +105,5 @@ export class EmbeddableFlyoutPortal extends React.Component<Props> {
 }
 
 export const AddEmbeddablePanel = compose<Props, { onClose: () => void }>(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  )
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)
 )(EmbeddableFlyoutPortal);

--- a/x-pack/legacy/plugins/canvas/public/components/expression/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/expression/index.js
@@ -70,11 +70,7 @@ const expressionLifecycle = lifecycle({
 });
 
 export const Expression = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withState('functionDefinitions', 'setFunctionDefinitions', []),
   withState('formState', 'setFormState', ({ expression }) => ({
     expression,

--- a/x-pack/legacy/plugins/canvas/public/components/function_form/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/function_form/index.js
@@ -105,11 +105,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   };
 };
 
-export const FunctionForm = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
-)(Component);
+export const FunctionForm = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
 
 FunctionForm.propTypes = {
   expressionIndex: PropTypes.number,

--- a/x-pack/legacy/plugins/canvas/public/components/page_config/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/page_config/index.js
@@ -43,8 +43,4 @@ const mergeProps = (stateProps, dispatchProps) => {
   };
 };
 
-export const PageConfig = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
-)(Component);
+export const PageConfig = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/page_manager/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/page_manager/index.js
@@ -32,9 +32,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export const PageManager = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
   withState('deleteId', 'setDeleteId', null)
 )(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/router/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/router/index.js
@@ -20,7 +20,4 @@ const mapDispatchToState = {
   setRefreshInterval,
 };
 
-export const Router = connect(
-  null,
-  mapDispatchToState
-)(Component);
+export const Router = connect(null, mapDispatchToState)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/sidebar/sidebar_content.js
+++ b/x-pack/legacy/plugins/canvas/public/components/sidebar/sidebar_content.js
@@ -93,10 +93,6 @@ const branches = [
 ];
 
 export const SidebarContent = compose(
-  connect(
-    mapStateToProps,
-    null,
-    mergeProps
-  ),
+  connect(mapStateToProps, null, mergeProps),
   ...branches
 )(GlobalConfig);

--- a/x-pack/legacy/plugins/canvas/public/components/sidebar_header/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/sidebar_header/index.js
@@ -56,10 +56,7 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export const SidebarHeader = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
   withHandlers(basicHandlerCreators),
   withHandlers(clipboardHandlerCreators),
   withHandlers(layerHandlerCreators),

--- a/x-pack/legacy/plugins/canvas/public/components/workpad/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad/index.js
@@ -72,11 +72,7 @@ export const Workpad = compose(
     router: PropTypes.object,
   }),
   withState('grid', 'setGrid', false),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withState('transition', 'setTransition', null),
   withState('prevSelectedPageNumber', 'setPrevSelectedPageNumber', 0),
   withProps(({ selectedPageNumber, prevSelectedPageNumber, transition }) => {

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_color_picker/index.ts
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_color_picker/index.ts
@@ -21,7 +21,4 @@ const mapDispatchToProps = {
   onRemoveColor: removeColor,
 };
 
-export const WorkpadColorPicker = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Component);
+export const WorkpadColorPicker = connect(mapStateToProps, mapDispatchToProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_config/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_config/index.js
@@ -31,7 +31,4 @@ const mapDispatchToProps = {
   setWorkpadCSS: css => setWorkpadCSS(css),
 };
 
-export const WorkpadConfig = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Component);
+export const WorkpadConfig = connect(mapStateToProps, mapDispatchToProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/control_settings/index.ts
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/control_settings/index.ts
@@ -32,7 +32,4 @@ const mapDispatchToProps = {
   setAutoplayInterval,
 };
 
-export const ControlSettings = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Component);
+export const ControlSettings = connect(mapStateToProps, mapDispatchToProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/fullscreen_control/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/fullscreen_control/index.js
@@ -68,11 +68,7 @@ export const FullscreenControl = compose(
   getContext({
     router: PropTypes.object,
   }),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withState('transition', 'setTransition', null),
   withState('prevSelectedPageNumber', 'setPrevSelectedPageNumber', 0),
   withProps(({ selectedPageNumber, prevSelectedPageNumber, transition }) => {

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/index.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/index.tsx
@@ -46,8 +46,4 @@ const mergeProps = (
   toggleWriteable: () => dispatchProps.setWriteable(!stateProps.isWriteable),
 });
 
-export const WorkpadHeader = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
-)(Component);
+export const WorkpadHeader = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/refresh_control/index.ts
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/refresh_control/index.ts
@@ -20,7 +20,4 @@ const mapDispatchToProps = {
   doRefresh: fetchAllRenderables,
 };
 
-export const RefreshControl = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Component);
+export const RefreshControl = connect(mapStateToProps, mapDispatchToProps)(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_zoom/index.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_zoom/index.tsx
@@ -33,9 +33,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 });
 
 export const WorkpadZoom = compose<ComponentProps, {}>(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
   withHandlers(zoomHandlerCreators)
 )(Component);

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_page/integration_utils.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_page/integration_utils.js
@@ -135,7 +135,12 @@ export const globalStateUpdater = (dispatch, globalState) => state => {
 
   if (elementsToRemove.length) {
     // remove elements for groups that were ungrouped
-    dispatch(removeElements(elementsToRemove.map(e => e.id), page));
+    dispatch(
+      removeElements(
+        elementsToRemove.map(e => e.id),
+        page
+      )
+    );
   }
 
   // set the selected element on the global store, if one element is selected

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_page/workpad_interactive_page/index.js
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_page/workpad_interactive_page/index.js
@@ -146,11 +146,7 @@ const mergeProps = (
 });
 
 export const InteractivePage = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withState('aeroStore', 'setAeroStore'),
   withProps(componentLayoutState),
   withProps(({ aeroStore, updateGlobalState }) => ({

--- a/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/font.js
+++ b/x-pack/legacy/plugins/canvas/public/expression_types/arg_types/font.js
@@ -24,7 +24,11 @@ export const FontArgInput = props => {
   const spec = mapValues(chainArgs, '[0]');
 
   function handleChange(newSpec) {
-    const newValue = set(argValue, ['chain', 0, 'arguments'], mapValues(newSpec, v => [v]));
+    const newValue = set(
+      argValue,
+      ['chain', 0, 'arguments'],
+      mapValues(newSpec, v => [v])
+    );
     return onValueChange(newValue);
   }
 

--- a/x-pack/legacy/plugins/canvas/public/lib/aeroelastic/layout_functions.js
+++ b/x-pack/legacy/plugins/canvas/public/lib/aeroelastic/layout_functions.js
@@ -62,17 +62,46 @@ const resizeVertexTuples = [
 ];
 
 const connectorVertices = [
-  [[-1, -1], [0, -1]],
-  [[0, -1], [1, -1]],
-  [[1, -1], [1, 0]],
-  [[1, 0], [1, 1]],
-  [[1, 1], [0, 1]],
-  [[0, 1], [-1, 1]],
-  [[-1, 1], [-1, 0]],
-  [[-1, 0], [-1, -1]],
+  [
+    [-1, -1],
+    [0, -1],
+  ],
+  [
+    [0, -1],
+    [1, -1],
+  ],
+  [
+    [1, -1],
+    [1, 0],
+  ],
+  [
+    [1, 0],
+    [1, 1],
+  ],
+  [
+    [1, 1],
+    [0, 1],
+  ],
+  [
+    [0, 1],
+    [-1, 1],
+  ],
+  [
+    [-1, 1],
+    [-1, 0],
+  ],
+  [
+    [-1, 0],
+    [-1, -1],
+  ],
 ];
 
-const cornerVertices = [[-1, -1], [1, -1], [-1, 1], [1, 1]];
+const cornerVertices = [
+  [-1, -1],
+  [1, -1],
+  [-1, 1],
+  [1, 1],
+];
 
 const resizeMultiplierHorizontal = { left: -1, center: 0, right: 1 };
 const resizeMultiplierVertical = { top: -1, center: 0, bottom: 1 };
@@ -91,7 +120,10 @@ const bidirectionalCursors = {
   '315': 'nwse-resize',
 };
 
-const identityAABB = () => [[Infinity, Infinity], [-Infinity, -Infinity]];
+const identityAABB = () => [
+  [Infinity, Infinity],
+  [-Infinity, -Infinity],
+];
 
 const extend = ([[xMin, yMin], [xMax, yMax]], [x0, y0], [x1, y1]) => [
   [Math.min(xMin, x0, x1), Math.min(yMin, y0, y1)],
@@ -547,14 +579,18 @@ export const applyLocalTransforms = (shapes, transformIntents) => {
 // eslint-disable-next-line
 const getUpstreamTransforms = (shapes, shape) =>
   shape.parent
-    ? getUpstreamTransforms(shapes, shapes.find(s => s.id === shape.parent)).concat([
-        shape.localTransformMatrix,
-      ])
+    ? getUpstreamTransforms(
+        shapes,
+        shapes.find(s => s.id === shape.parent)
+      ).concat([shape.localTransformMatrix])
     : [shape.localTransformMatrix];
 
 const getUpstreams = (shapes, shape) =>
   shape.parent
-    ? getUpstreams(shapes, shapes.find(s => s.id === shape.parent)).concat([shape])
+    ? getUpstreams(
+        shapes,
+        shapes.find(s => s.id === shape.parent)
+      ).concat([shape])
     : [shape];
 
 const snappedA = shape => shape.a + (shape.snapResizeVector ? shape.snapResizeVector[0] : 0);
@@ -877,7 +913,12 @@ function resizeAnnotation(config, shapes, selectedShapes, shape) {
   const b = snappedB(properShape);
   const allowResize =
     properShape.type !== 'group' ||
-    (config.groupResize && magic(config, properShape, shapes.filter(s => s.type !== 'annotation')));
+    (config.groupResize &&
+      magic(
+        config,
+        properShape,
+        shapes.filter(s => s.type !== 'annotation')
+      ));
   const resizeVertices = allowResize ? resizeVertexTuples : [];
   const resizePoints = resizeVertices.map(resizePointAnnotations(config, shape, a, b));
   const connectors = connectorVertices.map(resizeEdgeAnnotations(config, shape, a, b));
@@ -1235,7 +1276,10 @@ export const getGrouping = (config, shapes, selectedShapes, groupAction, tuple) 
     return config.groupResize
       ? {
           shapes: [
-            ...resizeGroup(shapes.filter(s => s.type !== 'annotation'), elements[0]),
+            ...resizeGroup(
+              shapes.filter(s => s.type !== 'annotation'),
+              elements[0]
+            ),
             ...shapes.filter(s => s.type === 'annotation'),
           ],
           selectedShapes,

--- a/x-pack/legacy/plugins/canvas/public/state/actions/elements.js
+++ b/x-pack/legacy/plugins/canvas/public/state/actions/elements.js
@@ -227,9 +227,12 @@ export const removeElements = createThunk(
     // todo consider doing the group membership collation in aeroelastic, or the Redux reducer, when adding templates
     const allElements = getNodes(state, pageId);
     const allRoots = rootElementIds.map(id => allElements.find(e => id === e.id)).filter(d => d);
-    const elementIds = subMultitree(e => e.id, e => e.position.parent, allElements, allRoots).map(
-      e => e.id
-    );
+    const elementIds = subMultitree(
+      e => e.id,
+      e => e.position.parent,
+      allElements,
+      allRoots
+    ).map(e => e.id);
 
     const shouldRefresh = elementIds.some(elementId => {
       const element = getNodeById(state, elementId, pageId);

--- a/x-pack/legacy/plugins/graph/public/services/fetch_top_nodes.ts
+++ b/x-pack/legacy/plugins/graph/public/services/fetch_top_nodes.ts
@@ -95,9 +95,11 @@ export async function fetchTopNodes(
     .reduce((allAggs, subAgg) => ({ ...allAggs, ...subAgg }));
   const body = createSamplerSearchBody(aggs);
 
-  const response: TopTermsAggResponse = (await post('../api/graph/searchProxy', {
-    body: JSON.stringify({ index, body }),
-  })).resp;
+  const response: TopTermsAggResponse = (
+    await post('../api/graph/searchProxy', {
+      body: JSON.stringify({ index, body }),
+    })
+  ).resp;
 
   const nodes: ServerResultNode[] = [];
 

--- a/x-pack/legacy/plugins/graph/public/state_management/fields.ts
+++ b/x-pack/legacy/plugins/graph/public/state_management/fields.ts
@@ -51,17 +51,12 @@ export const fieldsReducer = reducerWithInitialState(initialFields)
   .build();
 
 export const fieldMapSelector = (state: GraphState) => state.fields;
-export const fieldsSelector = createSelector(
-  fieldMapSelector,
-  fields => Object.values(fields)
+export const fieldsSelector = createSelector(fieldMapSelector, fields => Object.values(fields));
+export const selectedFieldsSelector = createSelector(fieldsSelector, fields =>
+  fields.filter(field => field.selected)
 );
-export const selectedFieldsSelector = createSelector(
-  fieldsSelector,
-  fields => fields.filter(field => field.selected)
-);
-export const liveResponseFieldsSelector = createSelector(
-  selectedFieldsSelector,
-  fields => fields.filter(field => field.hopSize && field.hopSize > 0)
+export const liveResponseFieldsSelector = createSelector(selectedFieldsSelector, fields =>
+  fields.filter(field => field.hopSize && field.hopSize > 0)
 );
 export const hasFieldsSelector = createSelector(
   selectedFieldsSelector,

--- a/x-pack/legacy/plugins/infra/common/utility_types.ts
+++ b/x-pack/legacy/plugins/infra/common/utility_types.ts
@@ -5,10 +5,10 @@
  */
 
 export type Pick2<T, K1 extends keyof T, K2 extends keyof T[K1]> = {
-  [P1 in K1]: { [P2 in K2]: (T[K1])[P2] };
+  [P1 in K1]: { [P2 in K2]: T[K1][P2] };
 };
 export type Pick3<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]> = {
-  [P1 in K1]: { [P2 in K2]: { [P3 in K3]: ((T[K1])[K2])[P3] } };
+  [P1 in K1]: { [P2 in K2]: { [P3 in K3]: T[K1][K2][P3] } };
 };
 
 export type MandatoryProperty<T, Prop extends keyof T> = T &

--- a/x-pack/legacy/plugins/infra/public/components/autocomplete_field/autocomplete_field.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/autocomplete_field/autocomplete_field.tsx
@@ -302,13 +302,11 @@ const withUnfocused = (state: AutocompleteFieldState) => ({
   isFocused: false,
 });
 
-const FixedEuiFieldSearch: React.SFC<
-  React.InputHTMLAttributes<HTMLInputElement> &
-    EuiFieldSearchProps & {
-      inputRef?: (element: HTMLInputElement | null) => void;
-      onSearch: (value: string) => void;
-    }
-> = EuiFieldSearch as any;
+const FixedEuiFieldSearch: React.SFC<React.InputHTMLAttributes<HTMLInputElement> &
+  EuiFieldSearchProps & {
+    inputRef?: (element: HTMLInputElement | null) => void;
+    onSearch: (value: string) => void;
+  }> = EuiFieldSearch as any;
 
 const AutocompleteContainer = euiStyled.div`
   position: relative;

--- a/x-pack/legacy/plugins/infra/public/components/loading_overlay_wrapper.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/loading_overlay_wrapper.tsx
@@ -10,12 +10,10 @@ import React from 'react';
 
 import { euiStyled } from '../../../../common/eui_styled_components';
 
-export const LoadingOverlayWrapper: React.FC<
-  React.HTMLAttributes<HTMLDivElement> & {
-    isLoading: boolean;
-    loadingChildren?: React.ReactNode;
-  }
-> = ({ children, isLoading, loadingChildren, ...rest }) => {
+export const LoadingOverlayWrapper: React.FC<React.HTMLAttributes<HTMLDivElement> & {
+  isLoading: boolean;
+  loadingChildren?: React.ReactNode;
+}> = ({ children, isLoading, loadingChildren, ...rest }) => {
   return (
     <RelativeDiv {...rest}>
       {children}

--- a/x-pack/legacy/plugins/infra/public/components/logging/log_text_stream/log_entry_icon_column.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/logging/log_text_stream/log_entry_icon_column.tsx
@@ -29,11 +29,9 @@ export const LogEntryIconColumn: React.FunctionComponent<LogEntryIconColumnProps
   );
 };
 
-export const LogEntryDetailsIconColumn: React.FunctionComponent<
-  LogEntryIconColumnProps & {
-    openFlyout: () => void;
-  }
-> = ({ isHighlighted, isHovered, openFlyout }) => {
+export const LogEntryDetailsIconColumn: React.FunctionComponent<LogEntryIconColumnProps & {
+  openFlyout: () => void;
+}> = ({ isHighlighted, isHovered, openFlyout }) => {
   const label = i18n.translate('xpack.infra.logEntryItemView.viewDetailsToolTip', {
     defaultMessage: 'View Details',
   });

--- a/x-pack/legacy/plugins/infra/public/components/logging/log_text_stream/vertical_scroll_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/logging/log_text_stream/vertical_scroll_panel.tsx
@@ -80,18 +80,15 @@ export class VerticalScrollPanel<Child> extends React.PureComponent<
   public updateChildDimensions = () => {
     this.childDimensions = new Map<Child, Rect>(
       sortDimensionsByTop(
-        Array.from(this.childRefs.entries()).reduce(
-          (accumulatedDimensions, [key, child]) => {
-            const currentOffsetRect = child.getOffsetRect();
+        Array.from(this.childRefs.entries()).reduce((accumulatedDimensions, [key, child]) => {
+          const currentOffsetRect = child.getOffsetRect();
 
-            if (currentOffsetRect !== null) {
-              accumulatedDimensions.push([key, currentOffsetRect]);
-            }
+          if (currentOffsetRect !== null) {
+            accumulatedDimensions.push([key, currentOffsetRect]);
+          }
 
-            return accumulatedDimensions;
-          },
-          [] as Array<[any, Rect]>
-        )
+          return accumulatedDimensions;
+        }, [] as Array<[any, Rect]>)
       )
     );
   };

--- a/x-pack/legacy/plugins/infra/public/components/metrics/sections/helpers/index.ts
+++ b/x-pack/legacy/plugins/infra/public/components/metrics/sections/helpers/index.ts
@@ -35,17 +35,11 @@ export const getMaxMinTimestamp = (metric: InfraMetricData): [number, number] =>
   if (metric.series.some(seriesHasLessThen2DataPoints)) {
     return [0, 0];
   }
-  const values = metric.series.reduce(
-    (acc, item) => {
-      const firstRow = first(item.data);
-      const lastRow = last(item.data);
-      return acc.concat([
-        (firstRow && firstRow.timestamp) || 0,
-        (lastRow && lastRow.timestamp) || 0,
-      ]);
-    },
-    [] as number[]
-  );
+  const values = metric.series.reduce((acc, item) => {
+    const firstRow = first(item.data);
+    const lastRow = last(item.data);
+    return acc.concat([(firstRow && firstRow.timestamp) || 0, (lastRow && lastRow.timestamp) || 0]);
+  }, [] as number[]);
   return [min(values), max(values)];
 };
 

--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/helpers/calculate_domain.ts
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/helpers/calculate_domain.ts
@@ -13,21 +13,18 @@ export const calculateDomain = (
   stacked = false
 ): { min: number; max: number } => {
   const values = series.rows
-    .reduce(
-      (acc, row) => {
-        const rowValues = metrics
-          .map((m, index) => {
-            return (row[`metric_${index}`] as number) || null;
-          })
-          .filter(v => v);
-        const minValue = min(rowValues);
-        // For stacked domains we want to add 10% head room so the charts have
-        // enough room to draw the 2 pixel line as well.
-        const maxValue = stacked ? sum(rowValues) * 1.1 : max(rowValues);
-        return acc.concat([minValue || null, maxValue || null]);
-      },
-      [] as Array<number | null>
-    )
+    .reduce((acc, row) => {
+      const rowValues = metrics
+        .map((m, index) => {
+          return (row[`metric_${index}`] as number) || null;
+        })
+        .filter(v => v);
+      const minValue = min(rowValues);
+      // For stacked domains we want to add 10% head room so the charts have
+      // enough room to draw the 2 pixel line as well.
+      const maxValue = stacked ? sum(rowValues) * 1.1 : max(rowValues);
+      return acc.concat([minValue || null, maxValue || null]);
+    }, [] as Array<number | null>)
     .filter(v => v);
   return { min: min(values) || 0, max: max(values) || 0 };
 };

--- a/x-pack/legacy/plugins/infra/public/components/source_configuration/log_columns_configuration_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/source_configuration/log_columns_configuration_panel.tsx
@@ -39,9 +39,13 @@ interface LogColumnsConfigurationPanelProps {
   moveLogColumn: (sourceIndex: number, destinationIndex: number) => void;
 }
 
-export const LogColumnsConfigurationPanel: React.FunctionComponent<
-  LogColumnsConfigurationPanelProps
-> = ({ addLogColumn, moveLogColumn, availableFields, isLoading, logColumnConfiguration }) => {
+export const LogColumnsConfigurationPanel: React.FunctionComponent<LogColumnsConfigurationPanelProps> = ({
+  addLogColumn,
+  moveLogColumn,
+  availableFields,
+  isLoading,
+  logColumnConfiguration,
+}) => {
   const onDragEnd = useCallback(
     ({ source, destination }: DropResult) =>
       destination && moveLogColumn(source.index, destination.index),
@@ -104,9 +108,7 @@ interface LogColumnConfigurationPanelProps {
   dragHandleProps: DragHandleProps;
 }
 
-const LogColumnConfigurationPanel: React.FunctionComponent<
-  LogColumnConfigurationPanelProps
-> = props => (
+const LogColumnConfigurationPanel: React.FunctionComponent<LogColumnConfigurationPanelProps> = props => (
   <>
     <EuiSpacer size="m" />
     {props.logColumnConfigurationProps.type === 'timestamp' ? (
@@ -122,9 +124,10 @@ const LogColumnConfigurationPanel: React.FunctionComponent<
   </>
 );
 
-const TimestampLogColumnConfigurationPanel: React.FunctionComponent<
-  LogColumnConfigurationPanelProps
-> = ({ logColumnConfigurationProps, dragHandleProps }) => (
+const TimestampLogColumnConfigurationPanel: React.FunctionComponent<LogColumnConfigurationPanelProps> = ({
+  logColumnConfigurationProps,
+  dragHandleProps,
+}) => (
   <ExplainedLogColumnConfigurationPanel
     fieldName="Timestamp"
     helpText={
@@ -142,9 +145,10 @@ const TimestampLogColumnConfigurationPanel: React.FunctionComponent<
   />
 );
 
-const MessageLogColumnConfigurationPanel: React.FunctionComponent<
-  LogColumnConfigurationPanelProps
-> = ({ logColumnConfigurationProps, dragHandleProps }) => (
+const MessageLogColumnConfigurationPanel: React.FunctionComponent<LogColumnConfigurationPanelProps> = ({
+  logColumnConfigurationProps,
+  dragHandleProps,
+}) => (
   <ExplainedLogColumnConfigurationPanel
     fieldName="Message"
     helpText={

--- a/x-pack/legacy/plugins/infra/public/containers/logs/log_analysis/log_analysis_results_url_state.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/logs/log_analysis/log_analysis_results_url_state.tsx
@@ -37,10 +37,7 @@ export const useLogAnalysisResultsUrlState = () => {
       endTime: 'now',
     },
     decodeUrlState: (value: unknown) =>
-      pipe(
-        urlTimeRangeRT.decode(value),
-        fold(constant(undefined), identity)
-      ),
+      pipe(urlTimeRangeRT.decode(value), fold(constant(undefined), identity)),
     encodeUrlState: urlTimeRangeRT.encode,
     urlStateKey: TIME_RANGE_URL_STATE_KEY,
   });
@@ -55,10 +52,7 @@ export const useLogAnalysisResultsUrlState = () => {
       interval: 30000,
     },
     decodeUrlState: (value: unknown) =>
-      pipe(
-        autoRefreshRT.decode(value),
-        fold(constant(undefined), identity)
-      ),
+      pipe(autoRefreshRT.decode(value), fold(constant(undefined), identity)),
     encodeUrlState: autoRefreshRT.encode,
     urlStateKey: AUTOREFRESH_URL_STATE_KEY,
   });

--- a/x-pack/legacy/plugins/infra/public/containers/logs/log_analysis/log_analysis_status_state.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/logs/log_analysis/log_analysis_status_state.tsx
@@ -308,9 +308,10 @@ const getSetupStatus = (
     } else if (
       setupStatus === 'skippedButUpdatable' ||
       (jobDefinition &&
-        !isJobRevisionCurrent(jobId, jobDefinition.config.custom_settings.job_revision || 0)(
-          jobSummaries
-        ))
+        !isJobRevisionCurrent(
+          jobId,
+          jobDefinition.config.custom_settings.job_revision || 0
+        )(jobSummaries))
     ) {
       return 'skippedButUpdatable';
     } else if (

--- a/x-pack/legacy/plugins/infra/public/containers/logs/with_log_position.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/logs/with_log_position.tsx
@@ -110,7 +110,7 @@ const mapToUrlState = (value: any): LogPositionUrlState | undefined =>
     : undefined;
 
 const mapToPositionUrlState = (value: any) =>
-  value && (typeof value.time === 'number' && typeof value.tiebreaker === 'number')
+  value && typeof value.time === 'number' && typeof value.tiebreaker === 'number'
     ? pickTimeKey(value)
     : undefined;
 

--- a/x-pack/legacy/plugins/infra/public/containers/metadata/use_metadata.ts
+++ b/x-pack/legacy/plugins/infra/public/containers/metadata/use_metadata.ts
@@ -22,10 +22,7 @@ export function useMetadata(
   sourceId: string
 ) {
   const decodeResponse = (response: any) => {
-    return pipe(
-      InfraMetadataRT.decode(response),
-      fold(throwErrors(createPlainError), identity)
-    );
+    return pipe(InfraMetadataRT.decode(response), fold(throwErrors(createPlainError), identity));
   };
 
   const { error, loading, response, makeRequest } = useHTTPRequest<InfraMetadata>(

--- a/x-pack/legacy/plugins/infra/public/containers/metrics/with_metrics.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/metrics/with_metrics.tsx
@@ -47,12 +47,9 @@ export const WithMetrics = ({
   nodeId,
   cloudId,
 }: WithMetricsProps) => {
-  const metrics = layouts.reduce(
-    (acc, item) => {
-      return acc.concat(item.sections.map(s => s.id));
-    },
-    [] as InventoryMetric[]
-  );
+  const metrics = layouts.reduce((acc, item) => {
+    return acc.concat(item.sections.map(s => s.id));
+  }, [] as InventoryMetric[]);
 
   if (!isInfraMetrics(metrics)) {
     throw new Error(

--- a/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/with_metrics_explorer_options_url_state.tsx
+++ b/x-pack/legacy/plugins/infra/public/containers/metrics_explorer/with_metrics_explorer_options_url_state.tsx
@@ -80,10 +80,9 @@ function isMetricExplorerOptions(subject: any): subject is MetricsExplorerOption
   const MetricOptional = t.partial({
     field: t.string,
     rate: t.boolean,
-    color: t.keyof(Object.fromEntries(values(MetricsExplorerColor).map(c => [c, null])) as Record<
-      string,
-      null
-    >),
+    color: t.keyof(
+      Object.fromEntries(values(MetricsExplorerColor).map(c => [c, null])) as Record<string, null>
+    ),
     label: t.string,
   });
 
@@ -114,12 +113,18 @@ function isMetricExplorerOptions(subject: any): subject is MetricsExplorerOption
 
 function isMetricExplorerChartOptions(subject: any): subject is MetricsExplorerChartOptions {
   const ChartOptions = t.type({
-    yAxisMode: t.keyof(Object.fromEntries(
-      values(MetricsExplorerYAxisMode).map(v => [v, null])
-    ) as Record<string, null>),
-    type: t.keyof(Object.fromEntries(
-      values(MetricsExplorerChartType).map(v => [v, null])
-    ) as Record<string, null>),
+    yAxisMode: t.keyof(
+      Object.fromEntries(values(MetricsExplorerYAxisMode).map(v => [v, null])) as Record<
+        string,
+        null
+      >
+    ),
+    type: t.keyof(
+      Object.fromEntries(values(MetricsExplorerChartType).map(v => [v, null])) as Record<
+        string,
+        null
+      >
+    ),
     stack: t.boolean,
   });
   const result = ChartOptions.decode(subject);

--- a/x-pack/legacy/plugins/infra/public/containers/source_id/source_id.ts
+++ b/x-pack/legacy/plugins/infra/public/containers/source_id/source_id.ts
@@ -28,7 +28,4 @@ export const replaceSourceIdInQueryString = (sourceId: string) =>
 const sourceIdRuntimeType = runtimeTypes.union([runtimeTypes.string, runtimeTypes.undefined]);
 const encodeSourceIdUrlState = sourceIdRuntimeType.encode;
 const decodeSourceIdUrlState = (value: unknown) =>
-  pipe(
-    sourceIdRuntimeType.decode(value),
-    fold(constant(undefined), identity)
-  );
+  pipe(sourceIdRuntimeType.decode(value), fold(constant(undefined), identity));

--- a/x-pack/legacy/plugins/infra/public/lib/adapters/framework/kibana_framework_adapter.ts
+++ b/x-pack/legacy/plugins/infra/public/lib/adapters/framework/kibana_framework_adapter.ts
@@ -122,16 +122,18 @@ export class InfraKibanaFrameworkAdapter implements InfraFrameworkAdapter {
       `,
     }));
 
-    adapterModule.run((
-      config: InfraKibanaUIConfig,
-      kbnVersion: string,
-      Private: <Provider>(provider: Provider) => Provider,
-      // @ts-ignore: inject kibanaAdapter to force eager instatiation
-      kibanaAdapter: any
-    ) => {
-      this.timezone = Private(this.timezoneProvider)();
-      this.kbnVersion = kbnVersion;
-    });
+    adapterModule.run(
+      (
+        config: InfraKibanaUIConfig,
+        kbnVersion: string,
+        Private: <Provider>(provider: Provider) => Provider,
+        // @ts-ignore: inject kibanaAdapter to force eager instatiation
+        kibanaAdapter: any
+      ) => {
+        this.timezone = Private(this.timezoneProvider)();
+        this.kbnVersion = kbnVersion;
+      }
+    );
 
     uiRoutes.enable();
 

--- a/x-pack/legacy/plugins/infra/public/store/local/waffle_time/epic.ts
+++ b/x-pack/legacy/plugins/infra/public/store/local/waffle_time/epic.ts
@@ -21,10 +21,7 @@ export const createWaffleTimeEpic = <State>(): Epic<
   State,
   WaffleTimeEpicDependencies<State>
 > => (action$, state$, { selectWaffleTimeUpdatePolicyInterval }) => {
-  const updateInterval$ = state$.pipe(
-    map(selectWaffleTimeUpdatePolicyInterval),
-    filter(isNotNull)
-  );
+  const updateInterval$ = state$.pipe(map(selectWaffleTimeUpdatePolicyInterval), filter(isNotNull));
 
   return action$.pipe(
     filter(startAutoReload.match),

--- a/x-pack/legacy/plugins/infra/public/store/local/waffle_time/selectors.ts
+++ b/x-pack/legacy/plugins/infra/public/store/local/waffle_time/selectors.ts
@@ -16,11 +16,8 @@ export const selectIsAutoReloading = (state: WaffleTimeState) =>
 export const selectTimeUpdatePolicyInterval = (state: WaffleTimeState) =>
   state.updatePolicy.policy === 'interval' ? state.updatePolicy.interval : null;
 
-export const selectCurrentTimeRange = createSelector(
-  selectCurrentTime,
-  currentTime => ({
-    from: currentTime - 1000 * 60 * 5,
-    interval: '1m',
-    to: currentTime,
-  })
-);
+export const selectCurrentTimeRange = createSelector(selectCurrentTime, currentTime => ({
+  from: currentTime - 1000 * 60 * 5,
+  interval: '1m',
+  to: currentTime,
+}));

--- a/x-pack/legacy/plugins/infra/public/store/remote/log_entries/selectors.ts
+++ b/x-pack/legacy/plugins/infra/public/store/remote/log_entries/selectors.ts
@@ -11,9 +11,8 @@ import { LogEntriesRemoteState } from './state';
 
 const entriesGraphlStateSelectors = createGraphqlStateSelectors<LogEntriesRemoteState>();
 
-export const selectEntries = createSelector(
-  entriesGraphlStateSelectors.selectData,
-  data => (data ? data.entries : [])
+export const selectEntries = createSelector(entriesGraphlStateSelectors.selectData, data =>
+  data ? data.entries : []
 );
 
 export const selectIsLoadingEntries = entriesGraphlStateSelectors.selectIsLoading;
@@ -32,14 +31,12 @@ export const selectIsLoadingMoreEntries = createSelector(
     isLoading && operationInfo ? operationInfo.operationKey === 'load_more' : false
 );
 
-export const selectEntriesStart = createSelector(
-  entriesGraphlStateSelectors.selectData,
-  data => (data && data.start ? data.start : null)
+export const selectEntriesStart = createSelector(entriesGraphlStateSelectors.selectData, data =>
+  data && data.start ? data.start : null
 );
 
-export const selectEntriesEnd = createSelector(
-  entriesGraphlStateSelectors.selectData,
-  data => (data && data.end ? data.end : null)
+export const selectEntriesEnd = createSelector(entriesGraphlStateSelectors.selectData, data =>
+  data && data.end ? data.end : null
 );
 
 export const selectHasMoreBeforeStart = createSelector(
@@ -47,9 +44,8 @@ export const selectHasMoreBeforeStart = createSelector(
   data => (data ? data.hasMoreBefore : true)
 );
 
-export const selectHasMoreAfterEnd = createSelector(
-  entriesGraphlStateSelectors.selectData,
-  data => (data ? data.hasMoreAfter : true)
+export const selectHasMoreAfterEnd = createSelector(entriesGraphlStateSelectors.selectData, data =>
+  data ? data.hasMoreAfter : true
 );
 
 export const selectEntriesLastLoadedTime = entriesGraphlStateSelectors.selectLoadingResultTime;
@@ -58,14 +54,12 @@ export const selectEntriesStartLoadingState = entriesGraphlStateSelectors.select
 
 export const selectEntriesEndLoadingState = entriesGraphlStateSelectors.selectLoadingState;
 
-export const selectFirstEntry = createSelector(
-  selectEntries,
-  entries => (entries.length > 0 ? entries[0] : null)
+export const selectFirstEntry = createSelector(selectEntries, entries =>
+  entries.length > 0 ? entries[0] : null
 );
 
-export const selectLastEntry = createSelector(
-  selectEntries,
-  entries => (entries.length > 0 ? entries[entries.length - 1] : null)
+export const selectLastEntry = createSelector(selectEntries, entries =>
+  entries.length > 0 ? entries[entries.length - 1] : null
 );
 
 export const selectLoadedEntriesTimeInterval = createSelector(

--- a/x-pack/legacy/plugins/infra/public/utils/is_displayable.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/is_displayable.ts
@@ -19,12 +19,9 @@ export const isDisplayable = (field: DisplayableFieldType, additionalPrefixes: s
   // We need to start with at least one prefix, even if it's empty
   const prefixes = additionalPrefixes && additionalPrefixes.length ? additionalPrefixes : [''];
   // Create a set of allowed list based on the prefixes
-  const allowedList = prefixes.reduce(
-    (acc, prefix) => {
-      return uniq([...acc, ...getAllowedListForPrefix(prefix)]);
-    },
-    [] as string[]
-  );
+  const allowedList = prefixes.reduce((acc, prefix) => {
+    return uniq([...acc, ...getAllowedListForPrefix(prefix)]);
+  }, [] as string[]);
   // If the field is displayable and part of the allowed list or covered by the prefix
   return (
     (field.displayable && prefixes.some(fieldStartsWith(field))) ||

--- a/x-pack/legacy/plugins/infra/public/utils/remote_state/remote_graphql_state.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/remote_state/remote_graphql_state.ts
@@ -165,52 +165,25 @@ export const createGraphqlQueryEpic = <Data, Variables, Error = ApolloError>(
 export const createGraphqlStateSelectors = <State>(
   selectState: (parentState: any) => GraphqlState<State> = parentState => parentState
 ) => {
-  const selectData = createSelector(
-    selectState,
-    state => state.data
-  );
+  const selectData = createSelector(selectState, state => state.data);
 
-  const selectLoadingProgress = createSelector(
-    selectState,
-    state => state.current
+  const selectLoadingProgress = createSelector(selectState, state => state.current);
+  const selectLoadingProgressOperationInfo = createSelector(selectLoadingProgress, progress =>
+    isRunningLoadingProgress(progress) ? progress.parameters : null
   );
-  const selectLoadingProgressOperationInfo = createSelector(
-    selectLoadingProgress,
-    progress => (isRunningLoadingProgress(progress) ? progress.parameters : null)
-  );
-  const selectIsLoading = createSelector(
-    selectLoadingProgress,
-    isRunningLoadingProgress
-  );
-  const selectIsIdle = createSelector(
-    selectLoadingProgress,
-    isIdleLoadingProgress
-  );
+  const selectIsLoading = createSelector(selectLoadingProgress, isRunningLoadingProgress);
+  const selectIsIdle = createSelector(selectLoadingProgress, isIdleLoadingProgress);
 
-  const selectLoadingResult = createSelector(
-    selectState,
-    state => state.last
+  const selectLoadingResult = createSelector(selectState, state => state.last);
+  const selectLoadingResultOperationInfo = createSelector(selectLoadingResult, result =>
+    !isUninitializedLoadingResult(result) ? result.parameters : null
   );
-  const selectLoadingResultOperationInfo = createSelector(
-    selectLoadingResult,
-    result => (!isUninitializedLoadingResult(result) ? result.parameters : null)
+  const selectLoadingResultTime = createSelector(selectLoadingResult, result =>
+    !isUninitializedLoadingResult(result) ? result.time : null
   );
-  const selectLoadingResultTime = createSelector(
-    selectLoadingResult,
-    result => (!isUninitializedLoadingResult(result) ? result.time : null)
-  );
-  const selectIsUninitialized = createSelector(
-    selectLoadingResult,
-    isUninitializedLoadingResult
-  );
-  const selectIsSuccess = createSelector(
-    selectLoadingResult,
-    isSuccessLoadingResult
-  );
-  const selectIsFailure = createSelector(
-    selectLoadingResult,
-    isFailureLoadingResult
-  );
+  const selectIsUninitialized = createSelector(selectLoadingResult, isUninitializedLoadingResult);
+  const selectIsSuccess = createSelector(selectLoadingResult, isSuccessLoadingResult);
+  const selectIsFailure = createSelector(selectLoadingResult, isFailureLoadingResult);
 
   const selectLoadingState = createSelector(
     selectLoadingProgress,

--- a/x-pack/legacy/plugins/infra/public/utils/use_kibana_space_id.ts
+++ b/x-pack/legacy/plugins/infra/public/utils/use_kibana_space_id.ts
@@ -15,7 +15,10 @@ export const useKibanaSpaceId = (): string => {
 
   return pipe(
     activeSpaceRT.decode(activeSpace),
-    fold(() => 'default', decodedActiveSpace => decodedActiveSpace.space.id)
+    fold(
+      () => 'default',
+      decodedActiveSpace => decodedActiveSpace.space.id
+    )
   );
 };
 

--- a/x-pack/legacy/plugins/infra/server/lib/adapters/fields/framework_fields_adapter.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/adapters/fields/framework_fields_adapter.ts
@@ -115,13 +115,10 @@ export class FrameworkFieldsAdapter implements FieldsAdapter {
       handleAfterKey
     );
     const dataSets = buckets.map(bucket => bucket.key.dataset);
-    const modules = dataSets.reduce(
-      (acc, dataset) => {
-        const module = first(dataset.split(/\./));
-        return module ? uniq([...acc, module]) : acc;
-      },
-      [] as string[]
-    );
+    const modules = dataSets.reduce((acc, dataset) => {
+      const module = first(dataset.split(/\./));
+      return module ? uniq([...acc, module]) : acc;
+    }, [] as string[]);
     return { modules, dataSets };
   }
 }

--- a/x-pack/legacy/plugins/infra/server/lib/domains/log_entries_domain/convert_document_source_to_log_item_fields.test.ts
+++ b/x-pack/legacy/plugins/infra/server/lib/domains/log_entries_domain/convert_document_source_to_log_item_fields.test.ts
@@ -17,7 +17,10 @@ describe('convertDocumentSourceToLogItemFields', () => {
         version: '7.0.0',
       },
       tags: ['prod', 'web'],
-      metadata: [{ key: 'env', value: 'prod' }, { key: 'stack', value: 'web' }],
+      metadata: [
+        { key: 'env', value: 'prod' },
+        { key: 'stack', value: 'web' },
+      ],
       host: {
         hostname: 'packer-virtualbox-iso-1546820004',
         name: 'demo-stack-client-01',

--- a/x-pack/legacy/plugins/infra/server/routes/metrics_explorer/lib/populate_series_with_tsvb_data.ts
+++ b/x-pack/legacy/plugins/infra/server/routes/metrics_explorer/lib/populate_series_with_tsvb_data.ts
@@ -83,7 +83,10 @@ export const populateSeriesWithTSVBData = (
   // MetricsExplorerRow.
   const timestamps = tsvbResults.custom.series.reduce(
     (currentTimestamps, tsvbSeries) =>
-      union(currentTimestamps, tsvbSeries.data.map(row => row[0])).sort(),
+      union(
+        currentTimestamps,
+        tsvbSeries.data.map(row => row[0])
+      ).sort(),
     [] as number[]
   );
   // Combine the TSVB series for multiple metrics.

--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.test.tsx
@@ -312,9 +312,9 @@ describe('Lens App', () => {
 
         instance.update();
 
-        const handler = instance.findWhere(el => el.prop('onSave')).prop('onSave') as ((
+        const handler = instance.findWhere(el => el.prop('onSave')).prop('onSave') as (
           p: unknown
-        ) => void);
+        ) => void;
         handler(saveProps);
       }
 

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/expression_helpers.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/expression_helpers.ts
@@ -38,9 +38,13 @@ export function prependDatasourceExpression(
   if (datasourceExpressions.length === 0 || visualizationExpression === null) {
     return null;
   }
-  const parsedDatasourceExpressions: Array<[string, Ast]> = datasourceExpressions.map(
-    ([layerId, expr]) => [layerId, typeof expr === 'string' ? fromExpression(expr) : expr]
-  );
+  const parsedDatasourceExpressions: Array<[
+    string,
+    Ast
+  ]> = datasourceExpressions.map(([layerId, expr]) => [
+    layerId,
+    typeof expr === 'string' ? fromExpression(expr) : expr,
+  ]);
 
   const datafetchExpression: ExpressionFunctionAST = {
     type: 'function',

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/embeddable/embeddable_factory.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/embeddable/embeddable_factory.ts
@@ -81,8 +81,10 @@ export class EmbeddableFactory extends AbstractEmbeddableFactory {
         }
       }
     );
-    const indexPatterns = (await Promise.all(promises)).filter(
-      (indexPattern: IndexPattern | null): indexPattern is IndexPattern => Boolean(indexPattern)
+    const indexPatterns = (
+      await Promise.all(promises)
+    ).filter((indexPattern: IndexPattern | null): indexPattern is IndexPattern =>
+      Boolean(indexPattern)
     );
 
     return new Embeddable(

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.test.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.test.ts
@@ -11,14 +11,26 @@ describe('lens_merge_tables', () => {
   it('should produce a row with the nested table as defined', () => {
     const sampleTable1: KibanaDatatable = {
       type: 'kibana_datatable',
-      columns: [{ id: 'bucket', name: 'A' }, { id: 'count', name: 'Count' }],
-      rows: [{ bucket: 'a', count: 5 }, { bucket: 'b', count: 10 }],
+      columns: [
+        { id: 'bucket', name: 'A' },
+        { id: 'count', name: 'Count' },
+      ],
+      rows: [
+        { bucket: 'a', count: 5 },
+        { bucket: 'b', count: 10 },
+      ],
     };
 
     const sampleTable2: KibanaDatatable = {
       type: 'kibana_datatable',
-      columns: [{ id: 'bucket', name: 'C' }, { id: 'avg', name: 'Average' }],
-      rows: [{ bucket: 'a', avg: 2.5 }, { bucket: 'b', avg: 9 }],
+      columns: [
+        { id: 'bucket', name: 'C' },
+        { id: 'avg', name: 'Average' },
+      ],
+      rows: [
+        { bucket: 'a', avg: 2.5 },
+        { bucket: 'b', avg: 9 },
+      ],
     };
 
     expect(

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
@@ -269,7 +269,8 @@ export function PopoverEditor(props: PopoverEditorProps) {
                 if (
                   !incompatibleSelectedOperationType &&
                   selectedColumn &&
-                  ('field' in choice && choice.operationType === selectedColumn.operationType)
+                  'field' in choice &&
+                  choice.operationType === selectedColumn.operationType
                 ) {
                   // If we just changed the field are not in an error state and the operation didn't change,
                   // we use the operations onFieldChange method to calculate the new column.

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/loader.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/loader.ts
@@ -75,9 +75,9 @@ export async function loadIndexPatterns({
 
   return resp.savedObjects.reduce(
     (acc, savedObject) => {
-      const indexPattern = fromSavedObject(savedObject as SimpleSavedObject<
-        SavedIndexPatternAttributes
-      >);
+      const indexPattern = fromSavedObject(
+        savedObject as SimpleSavedObject<SavedIndexPatternAttributes>
+      );
       acc[indexPattern.id] = indexPattern;
       return acc;
     },
@@ -263,13 +263,10 @@ export async function syncExistingFields({
 }
 
 function booleanMap(keys: string[]) {
-  return keys.reduce(
-    (acc, key) => {
-      acc[key] = true;
-      return acc;
-    },
-    {} as Record<string, boolean>
-  );
+  return keys.reduce((acc, key) => {
+    acc[key] = true;
+    return acc;
+  }, {} as Record<string, boolean>);
 }
 
 function isSingleEmptyLayer(layerMap: IndexPatternPrivateState['layers']) {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/operations/definitions/index.ts
@@ -162,14 +162,14 @@ type ColumnFromOperationDefinition<D> = D extends OperationDefinition<infer C> ?
  * typeguards possible that consider all available column types.
  */
 export type IndexPatternColumn = ColumnFromOperationDefinition<
-  (typeof internalOperationDefinitions)[number]
+  typeof internalOperationDefinitions[number]
 >;
 
 /**
  * A union type of all available operation types. The operation type is a unique id of an operation.
  * Each column is assigned to exactly one operation type.
  */
-export type OperationType = (typeof internalOperationDefinitions)[number]['type'];
+export type OperationType = typeof internalOperationDefinitions[number]['type'];
 
 /**
  * This is an operation definition of an unspecified column out of all possible

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/rename_columns.test.ts
@@ -11,8 +11,16 @@ describe('rename_columns', () => {
   it('should rename columns of a given datatable', () => {
     const input: KibanaDatatable = {
       type: 'kibana_datatable',
-      columns: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
-      rows: [{ a: 1, b: 2 }, { a: 3, b: 4 }, { a: 5, b: 6 }, { a: 7, b: 8 }],
+      columns: [
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+      ],
+      rows: [
+        { a: 1, b: 2 },
+        { a: 3, b: 4 },
+        { a: 5, b: 6 },
+        { a: 7, b: 8 },
+      ],
     };
 
     const idMap = {
@@ -83,8 +91,16 @@ describe('rename_columns', () => {
   it('should keep columns which are not mapped', () => {
     const input: KibanaDatatable = {
       type: 'kibana_datatable',
-      columns: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
-      rows: [{ a: 1, b: 2 }, { a: 3, b: 4 }, { a: 5, b: 6 }, { a: 7, b: 8 }],
+      columns: [
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+      ],
+      rows: [
+        { a: 1, b: 2 },
+        { a: 3, b: 4 },
+        { a: 5, b: 6 },
+        { a: 7, b: 8 },
+      ],
     };
 
     const idMap = {
@@ -129,8 +145,16 @@ describe('rename_columns', () => {
   it('should rename date histograms', () => {
     const input: KibanaDatatable = {
       type: 'kibana_datatable',
-      columns: [{ id: 'a', name: 'A' }, { id: 'b', name: 'banana per 30 seconds' }],
-      rows: [{ a: 1, b: 2 }, { a: 3, b: 4 }, { a: 5, b: 6 }, { a: 7, b: 8 }],
+      columns: [
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'banana per 30 seconds' },
+      ],
+      rows: [
+        { a: 1, b: 2 },
+        { a: 3, b: 4 },
+        { a: 5, b: 6 },
+        { a: 7, b: 8 },
+      ],
     };
 
     const idMap = {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/to_expression.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/to_expression.ts
@@ -30,18 +30,15 @@ function getExpressionForLayer(
       return getEsAggsConfig(col, colId);
     });
 
-    const idMap = columnEntries.reduce(
-      (currentIdMap, [colId], index) => {
-        return {
-          ...currentIdMap,
-          [`col-${index}-${colId}`]: {
-            ...columns[colId],
-            id: colId,
-          },
-        };
-      },
-      {} as Record<string, OriginalColumn>
-    );
+    const idMap = columnEntries.reduce((currentIdMap, [colId], index) => {
+      return {
+        ...currentIdMap,
+        [`col-${index}-${colId}`]: {
+          ...columns[colId],
+          id: colId,
+        },
+      };
+    }, {} as Record<string, OriginalColumn>);
 
     return `esaggs
       index="${indexPattern.id}"

--- a/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_expression.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_expression.test.tsx
@@ -17,7 +17,11 @@ function sampleArgs() {
     tables: {
       l1: {
         type: 'kibana_datatable',
-        columns: [{ id: 'a', name: 'a' }, { id: 'b', name: 'b' }, { id: 'c', name: 'c' }],
+        columns: [
+          { id: 'a', name: 'a' },
+          { id: 'b', name: 'b' },
+          { id: 'c', name: 'c' },
+        ],
         rows: [{ a: 10110, b: 2, c: 3 }],
       },
     },

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_expression.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_expression.test.tsx
@@ -28,7 +28,10 @@ function sampleArgs() {
           { id: 'c', name: 'c', formatHint: { id: 'string' } },
           { id: 'd', name: 'ColD', formatHint: { id: 'string' } },
         ],
-        rows: [{ a: 1, b: 2, c: 'I', d: 'Foo' }, { a: 1, b: 5, c: 'J', d: 'Bar' }],
+        rows: [
+          { a: 1, b: 2, c: 'I', d: 'Foo' },
+          { a: 1, b: 5, c: 'J', d: 'Bar' },
+        ],
       },
     },
   };

--- a/x-pack/legacy/plugins/ml/common/util/es_utils.ts
+++ b/x-pack/legacy/plugins/ml/common/util/es_utils.ts
@@ -33,7 +33,8 @@ export function isValidIndexName(indexName: string) {
     // Cannot start with -, _, +
     /^[^-_\+]+$/.test(indexName.charAt(0)) &&
     // Cannot be . or ..
-    (indexName !== '.' && indexName !== '..') &&
+    indexName !== '.' &&
+    indexName !== '..' &&
     // Cannot be longer than 255 bytes (note it is bytes,
     // so multi-byte characters will count towards the 255 limit faster)
     isValidIndexNameLength(indexName)

--- a/x-pack/legacy/plugins/ml/public/components/annotations/annotation_flyout/index.tsx
+++ b/x-pack/legacy/plugins/ml/public/components/annotations/annotation_flyout/index.tsx
@@ -344,6 +344,7 @@ class AnnotationFlyoutIntl extends Component<CommonProps & Props & InjectedIntlP
   }
 }
 
-export const AnnotationFlyout = injectObservablesAsProps({ annotation: annotation$ }, (injectI18n(
-  AnnotationFlyoutIntl
-) as any) as ComponentType);
+export const AnnotationFlyout = injectObservablesAsProps(
+  { annotation: annotation$ },
+  (injectI18n(AnnotationFlyoutIntl) as any) as ComponentType
+);

--- a/x-pack/legacy/plugins/ml/public/data_frame_analytics/pages/analytics_management/components/analytics_list/analytics_list.tsx
+++ b/x-pack/legacy/plugins/ml/public/data_frame_analytics/pages/analytics_management/components/analytics_list/analytics_list.tsx
@@ -48,16 +48,13 @@ function getItemIdToExpandedRowMap(
   itemIds: DataFrameAnalyticsId[],
   dataFrameAnalytics: DataFrameAnalyticsListRow[]
 ): ItemIdToExpandedRowMap {
-  return itemIds.reduce(
-    (m: ItemIdToExpandedRowMap, analyticsId: DataFrameAnalyticsId) => {
-      const item = dataFrameAnalytics.find(analytics => analytics.config.id === analyticsId);
-      if (item !== undefined) {
-        m[analyticsId] = <ExpandedRow item={item} />;
-      }
-      return m;
-    },
-    {} as ItemIdToExpandedRowMap
-  );
+  return itemIds.reduce((m: ItemIdToExpandedRowMap, analyticsId: DataFrameAnalyticsId) => {
+    const item = dataFrameAnalytics.find(analytics => analytics.config.id === analyticsId);
+    if (item !== undefined) {
+      m[analyticsId] = <ExpandedRow item={item} />;
+    }
+    return m;
+  }, {} as ItemIdToExpandedRowMap);
 }
 
 function stringMatch(str: string | undefined, substr: string) {

--- a/x-pack/legacy/plugins/ml/public/datavisualizer/index_based/page.tsx
+++ b/x-pack/legacy/plugins/ml/public/datavisualizer/index_based/page.tsx
@@ -403,7 +403,8 @@ export const Page: FC = () => {
     let allMetricFields = indexPatternFields.filter(f => {
       return (
         f.type === KBN_FIELD_TYPES.NUMBER &&
-        (f.displayName !== undefined && dataLoader.isDisplayField(f.displayName) === true)
+        f.displayName !== undefined &&
+        dataLoader.isDisplayField(f.displayName) === true
       );
     });
     if (metricFieldQuery !== undefined) {
@@ -477,7 +478,8 @@ export const Page: FC = () => {
       allNonMetricFields = indexPatternFields.filter(f => {
         return (
           f.type !== KBN_FIELD_TYPES.NUMBER &&
-          (f.displayName !== undefined && dataLoader.isDisplayField(f.displayName) === true)
+          f.displayName !== undefined &&
+          dataLoader.isDisplayField(f.displayName) === true
         );
       });
     } else {

--- a/x-pack/legacy/plugins/ml/server/models/job_service/new_job/line_chart.ts
+++ b/x-pack/legacy/plugins/ml/server/models/job_service/new_job/line_chart.ts
@@ -49,7 +49,10 @@ export function newJobLineChartProvider(callWithRequest: callWithRequestType) {
     );
 
     const results = await callWithRequest('search', json);
-    return processSearchResults(results, aggFieldNamePairs.map(af => af.field));
+    return processSearchResults(
+      results,
+      aggFieldNamePairs.map(af => af.field)
+    );
   }
 
   return {

--- a/x-pack/legacy/plugins/ml/server/models/job_service/new_job/population_chart.ts
+++ b/x-pack/legacy/plugins/ml/server/models/job_service/new_job/population_chart.ts
@@ -54,7 +54,10 @@ export function newJobPopulationChartProvider(callWithRequest: callWithRequestTy
 
     try {
       const results = await callWithRequest('search', json);
-      return processSearchResults(results, aggFieldNamePairs.map(af => af.field));
+      return processSearchResults(
+        results,
+        aggFieldNamePairs.map(af => af.field)
+      );
     } catch (error) {
       return { error };
     }

--- a/x-pack/legacy/plugins/reporting/export_types/csv/server/create_job.ts
+++ b/x-pack/legacy/plugins/reporting/export_types/csv/server/create_job.ts
@@ -34,6 +34,6 @@ function createJobFn(server: ServerFacade) {
   };
 }
 
-export const createJobFactory: CreateJobFactory = oncePerServer(createJobFn as (
-  server: ServerFacade
-) => ESQueueCreateJobFnDiscoverCsv);
+export const createJobFactory: CreateJobFactory = oncePerServer(
+  createJobFn as (server: ServerFacade) => ESQueueCreateJobFnDiscoverCsv
+);

--- a/x-pack/legacy/plugins/reporting/export_types/png/server/create_job/index.ts
+++ b/x-pack/legacy/plugins/reporting/export_types/png/server/create_job/index.ts
@@ -40,6 +40,6 @@ function createJobFn(server: ServerFacade) {
   };
 }
 
-export const createJobFactory: CreateJobFactory = oncePerServer(createJobFn as (
-  server: ServerFacade
-) => ESQueueCreateJobFnPNG);
+export const createJobFactory: CreateJobFactory = oncePerServer(
+  createJobFn as (server: ServerFacade) => ESQueueCreateJobFnPNG
+);

--- a/x-pack/legacy/plugins/reporting/server/browsers/safe_child_process.ts
+++ b/x-pack/legacy/plugins/reporting/server/browsers/safe_child_process.ts
@@ -22,10 +22,7 @@ export function safeChildProcess(
     Rx.fromEvent(process as NodeJS.EventEmitter, 'SIGTERM').pipe(mapTo('SIGTERM')),
     Rx.fromEvent(process as NodeJS.EventEmitter, 'SIGINT').pipe(mapTo('SIGINT')),
     Rx.fromEvent(process as NodeJS.EventEmitter, 'SIGBREAK').pipe(mapTo('SIGBREAK'))
-  ).pipe(
-    take(1),
-    share()
-  );
+  ).pipe(take(1), share());
 
   const ownTerminateMapToKill$ = ownTerminateSignal$.pipe(
     tap(signal => {

--- a/x-pack/legacy/plugins/searchprofiler/public/np_ready/application/components/profile_tree/init_data.ts
+++ b/x-pack/legacy/plugins/searchprofiler/public/np_ready/application/components/profile_tree/init_data.ts
@@ -105,10 +105,4 @@ export const normalize = (target: Targets) => (data: IndexMap) =>
   });
 
 export const initDataFor = (target: Targets) =>
-  flow(
-    initShards,
-    calculateShardValues(target),
-    initIndices,
-    normalize(target),
-    sortIndices
-  );
+  flow(initShards, calculateShardValues(target), initIndices, normalize(target), sortIndices);

--- a/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/kibana/space_aware_privilege_section/privilege_space_table.test.tsx
+++ b/x-pack/legacy/plugins/security/public/views/management/edit_role/components/privileges/kibana/space_aware_privilege_section/privilege_space_table.test.tsx
@@ -61,26 +61,23 @@ const getTableFromComponent = (
   const table = component.find(EuiInMemoryTable);
   const rows = table.find('tr');
   const dataRows = rows.slice(1);
-  return dataRows.reduce(
-    (acc, row) => {
-      const cells = row.find('td');
-      const spacesCell = cells.at(0);
-      const spacesBadge = spacesCell.find(EuiBadge);
-      const privilegesCell = cells.at(1);
-      const privilegesDisplay = privilegesCell.find(PrivilegeDisplay);
-      return [
-        ...acc,
-        {
-          spaces: spacesBadge.map(badge => badge.text().trim()),
-          privileges: {
-            summary: privilegesDisplay.text().trim(),
-            overridden: privilegesDisplay.find(EuiIconTip).exists('[type="lock"]'),
-          },
+  return dataRows.reduce((acc, row) => {
+    const cells = row.find('td');
+    const spacesCell = cells.at(0);
+    const spacesBadge = spacesCell.find(EuiBadge);
+    const privilegesCell = cells.at(1);
+    const privilegesDisplay = privilegesCell.find(PrivilegeDisplay);
+    return [
+      ...acc,
+      {
+        spaces: spacesBadge.map(badge => badge.text().trim()),
+        privileges: {
+          summary: privilegesDisplay.text().trim(),
+          overridden: privilegesDisplay.find(EuiIconTip).exists('[type="lock"]'),
         },
-      ];
-    },
-    [] as TableRow[]
-  );
+      },
+    ];
+  }, [] as TableRow[]);
 };
 
 describe('only global', () => {

--- a/x-pack/legacy/plugins/siem/common/utility_types.ts
+++ b/x-pack/legacy/plugins/siem/common/utility_types.ts
@@ -7,7 +7,7 @@
 import { ReactNode } from 'react';
 
 export type Pick3<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]> = {
-  [P1 in K1]: { [P2 in K2]: { [P3 in K3]: ((T[K1])[K2])[P3] } };
+  [P1 in K1]: { [P2 in K2]: { [P3 in K3]: T[K1][K2][P3] } };
 };
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/x-pack/legacy/plugins/siem/public/components/autocomplete_field/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/autocomplete_field/index.tsx
@@ -307,14 +307,11 @@ const withUnfocused = (state: AutocompleteFieldState) => ({
   isFocused: false,
 });
 
-export const FixedEuiFieldSearch: React.SFC<
-  React.InputHTMLAttributes<HTMLInputElement> &
-    EuiFieldSearchProps & {
-      inputRef?: (element: HTMLInputElement | null) => void;
-      onSearch: (value: string) => void;
-    }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-> = EuiFieldSearch as any;
+export const FixedEuiFieldSearch: React.SFC<React.InputHTMLAttributes<HTMLInputElement> &
+  EuiFieldSearchProps & {
+    inputRef?: (element: HTMLInputElement | null) => void;
+    onSearch: (value: string) => void;
+  }> = EuiFieldSearch as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 const AutocompleteContainer = euiStyled.div`
   position: relative;

--- a/x-pack/legacy/plugins/siem/public/components/charts/chart_place_holder.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/charts/chart_place_holder.test.tsx
@@ -15,24 +15,36 @@ describe('ChartPlaceHolder', () => {
     {
       key: 'mockKeyA',
       color: 'mockColor',
-      value: [{ x: 'a', y: 0 }, { x: 'b', y: 0 }],
+      value: [
+        { x: 'a', y: 0 },
+        { x: 'b', y: 0 },
+      ],
     },
     {
       key: 'mockKeyB',
       color: 'mockColor',
-      value: [{ x: 'a', y: 0 }, { x: 'b', y: 0 }],
+      value: [
+        { x: 'a', y: 0 },
+        { x: 'b', y: 0 },
+      ],
     },
   ];
   const mockDataUnexpectedValue = [
     {
       key: 'mockKeyA',
       color: 'mockColor',
-      value: [{ x: 'a', y: '' }, { x: 'b', y: 0 }],
+      value: [
+        { x: 'a', y: '' },
+        { x: 'b', y: 0 },
+      ],
     },
     {
       key: 'mockKeyB',
       color: 'mockColor',
-      value: [{ x: 'a', y: {} }, { x: 'b', y: 0 }],
+      value: [
+        { x: 'a', y: {} },
+        { x: 'b', y: 0 },
+      ],
     },
   ];
 

--- a/x-pack/legacy/plugins/siem/public/components/charts/common.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/charts/common.test.tsx
@@ -109,20 +109,70 @@ describe('getChartWidth', () => {
 
 describe('checkIfAllValuesAreZero', () => {
   const mockInvalidDataSets: Array<[ChartSeriesData[]]> = [
-    [[{ key: 'mockKey', color: 'mockColor', value: [{ x: 1, y: 0 }, { x: 1, y: 1 }] }]],
     [
       [
-        { key: 'mockKeyA', color: 'mockColor', value: [{ x: 1, y: 0 }, { x: 1, y: 1 }] },
-        { key: 'mockKeyB', color: 'mockColor', value: [{ x: 1, y: 0 }, { x: 1, y: 0 }] },
+        {
+          key: 'mockKey',
+          color: 'mockColor',
+          value: [
+            { x: 1, y: 0 },
+            { x: 1, y: 1 },
+          ],
+        },
+      ],
+    ],
+    [
+      [
+        {
+          key: 'mockKeyA',
+          color: 'mockColor',
+          value: [
+            { x: 1, y: 0 },
+            { x: 1, y: 1 },
+          ],
+        },
+        {
+          key: 'mockKeyB',
+          color: 'mockColor',
+          value: [
+            { x: 1, y: 0 },
+            { x: 1, y: 0 },
+          ],
+        },
       ],
     ],
   ];
   const mockValidDataSets: Array<[ChartSeriesData[]]> = [
-    [[{ key: 'mockKey', color: 'mockColor', value: [{ x: 0, y: 0 }, { x: 1, y: 0 }] }]],
     [
       [
-        { key: 'mockKeyA', color: 'mockColor', value: [{ x: 1, y: 0 }, { x: 3, y: 0 }] },
-        { key: 'mockKeyB', color: 'mockColor', value: [{ x: 2, y: 0 }, { x: 4, y: 0 }] },
+        {
+          key: 'mockKey',
+          color: 'mockColor',
+          value: [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+          ],
+        },
+      ],
+    ],
+    [
+      [
+        {
+          key: 'mockKeyA',
+          color: 'mockColor',
+          value: [
+            { x: 1, y: 0 },
+            { x: 3, y: 0 },
+          ],
+        },
+        {
+          key: 'mockKeyB',
+          color: 'mockColor',
+          value: [
+            { x: 2, y: 0 },
+            { x: 4, y: 0 },
+          ],
+        },
       ],
     ],
   ];

--- a/x-pack/legacy/plugins/siem/public/components/drag_and_drop/draggable_wrapper.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/drag_and_drop/draggable_wrapper.tsx
@@ -230,13 +230,10 @@ const DraggableWrapperComponent = React.memo<Props>(
 
 DraggableWrapperComponent.displayName = 'DraggableWrapperComponent';
 
-export const DraggableWrapper = connect(
-  null,
-  {
-    registerProvider: dragAndDropActions.registerProvider,
-    unRegisterProvider: dragAndDropActions.unRegisterProvider,
-  }
-)(DraggableWrapperComponent);
+export const DraggableWrapper = connect(null, {
+  registerProvider: dragAndDropActions.registerProvider,
+  unRegisterProvider: dragAndDropActions.unRegisterProvider,
+})(DraggableWrapperComponent);
 
 /**
  * Conditionally wraps children in an EuiPortal to ensure drag offsets are correct when dragging

--- a/x-pack/legacy/plugins/siem/public/components/error_toast_dispatcher/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/error_toast_dispatcher/index.tsx
@@ -58,9 +58,6 @@ const makeMapStateToProps = () => {
   return (state: State) => getErrorSelector(state);
 };
 
-export const ErrorToastDispatcher = connect(
-  makeMapStateToProps,
-  {
-    removeError: appActions.removeError,
-  }
-)(ErrorToastDispatcherComponent);
+export const ErrorToastDispatcher = connect(makeMapStateToProps, {
+  removeError: appActions.removeError,
+})(ErrorToastDispatcherComponent);

--- a/x-pack/legacy/plugins/siem/public/components/events_viewer/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/events_viewer/index.tsx
@@ -205,14 +205,11 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const StatefulEventsViewer = connect(
-  makeMapStateToProps,
-  {
-    createTimeline: timelineActions.createTimeline,
-    deleteEventQuery: inputsActions.deleteOneQuery,
-    updateItemsPerPage: timelineActions.updateItemsPerPage,
-    updateSort: timelineActions.updateSort,
-    removeColumn: timelineActions.removeColumn,
-    upsertColumn: timelineActions.upsertColumn,
-  }
-)(StatefulEventsViewerComponent);
+export const StatefulEventsViewer = connect(makeMapStateToProps, {
+  createTimeline: timelineActions.createTimeline,
+  deleteEventQuery: inputsActions.deleteOneQuery,
+  updateItemsPerPage: timelineActions.updateItemsPerPage,
+  updateSort: timelineActions.updateSort,
+  removeColumn: timelineActions.removeColumn,
+  upsertColumn: timelineActions.upsertColumn,
+})(StatefulEventsViewerComponent);

--- a/x-pack/legacy/plugins/siem/public/components/fields_browser/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/fields_browser/index.tsx
@@ -214,10 +214,7 @@ export const StatefulFieldsBrowserComponent = React.memo<FieldBrowserProps & Dis
 
 StatefulFieldsBrowserComponent.displayName = 'StatefulFieldsBrowserComponent';
 
-export const StatefulFieldsBrowser = connect(
-  null,
-  {
-    removeColumn: timelineActions.removeColumn,
-    upsertColumn: timelineActions.upsertColumn,
-  }
-)(StatefulFieldsBrowserComponent);
+export const StatefulFieldsBrowser = connect(null, {
+  removeColumn: timelineActions.removeColumn,
+  upsertColumn: timelineActions.upsertColumn,
+})(StatefulFieldsBrowserComponent);

--- a/x-pack/legacy/plugins/siem/public/components/flyout/header/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/flyout/header/index.tsx
@@ -215,7 +215,4 @@ const mapDispatchToProps = (dispatch: Dispatch, { timelineId }: OwnProps) => ({
   },
 });
 
-export const FlyoutHeader = connect(
-  makeMapStateToProps,
-  mapDispatchToProps
-)(StatefulFlyoutHeader);
+export const FlyoutHeader = connect(makeMapStateToProps, mapDispatchToProps)(StatefulFlyoutHeader);

--- a/x-pack/legacy/plugins/siem/public/components/flyout/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/flyout/index.tsx
@@ -121,9 +121,6 @@ const mapStateToProps = (state: State, { timelineId }: OwnProps) => {
   return { dataProviders, show, width };
 };
 
-export const Flyout = connect(
-  mapStateToProps,
-  {
-    showTimeline: timelineActions.showTimeline,
-  }
-)(FlyoutComponent);
+export const Flyout = connect(mapStateToProps, {
+  showTimeline: timelineActions.showTimeline,
+})(FlyoutComponent);

--- a/x-pack/legacy/plugins/siem/public/components/flyout/pane/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/flyout/pane/index.tsx
@@ -179,9 +179,6 @@ const FlyoutPaneComponent = React.memo<Props>(
 
 FlyoutPaneComponent.displayName = 'FlyoutPaneComponent';
 
-export const Pane = connect(
-  null,
-  {
-    applyDeltaToWidth: timelineActions.applyDeltaToWidth,
-  }
-)(FlyoutPaneComponent);
+export const Pane = connect(null, {
+  applyDeltaToWidth: timelineActions.applyDeltaToWidth,
+})(FlyoutPaneComponent);

--- a/x-pack/legacy/plugins/siem/public/components/inspect/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/inspect/index.tsx
@@ -152,9 +152,6 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const InspectButton = connect(
-  makeMapStateToProps,
-  {
-    setIsInspected: inputsActions.setInspectionParameter,
-  }
-)(InspectButtonComponent);
+export const InspectButton = connect(makeMapStateToProps, {
+  setIsInspected: inputsActions.setInspectionParameter,
+})(InspectButtonComponent);

--- a/x-pack/legacy/plugins/siem/public/components/ml/conditional_links/replace_kql_parts.ts
+++ b/x-pack/legacy/plugins/siem/public/components/ml/conditional_links/replace_kql_parts.ts
@@ -9,8 +9,5 @@ import { replaceKqlCommasWithOr } from './replace_kql_commas_with_or';
 import { removeKqlVariables } from './remove_kql_variables';
 
 export const replaceKQLParts = (kqlQuery: string): string => {
-  return flow(
-    replaceKqlCommasWithOr,
-    removeKqlVariables
-  )(kqlQuery);
+  return flow(replaceKqlCommasWithOr, removeKqlVariables)(kqlQuery);
 };

--- a/x-pack/legacy/plugins/siem/public/components/ml_popover/hooks/use_siem_jobs_helpers.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/ml_popover/hooks/use_siem_jobs_helpers.tsx
@@ -123,9 +123,10 @@ export const composeModuleAndInstalledJobs = (
 ): SiemJob[] => {
   const installedJobsIds = installedJobs.map(installedJob => installedJob.id);
 
-  return [...installedJobs, ...moduleSiemJobs.filter(mj => !installedJobsIds.includes(mj.id))].sort(
-    (a, b) => a.id.localeCompare(b.id)
-  );
+  return [
+    ...installedJobs,
+    ...moduleSiemJobs.filter(mj => !installedJobsIds.includes(mj.id)),
+  ].sort((a, b) => a.id.localeCompare(b.id));
 };
 /**
  * Creates a list of SiemJobs by composing JobSummary jobs (installed jobs) and Module

--- a/x-pack/legacy/plugins/siem/public/components/navigation/helpers.ts
+++ b/x-pack/legacy/plugins/siem/public/components/navigation/helpers.ts
@@ -51,9 +51,10 @@ export const getSearch = (tab: SearchNavTab, urlState: TabNavigationProps): stri
         }
         return replaceQueryStringInLocation(
           myLocation,
-          replaceStateKeyInQueryString(urlKey, urlStateToReplace)(
-            getQueryStringFromLocation(myLocation)
-          )
+          replaceStateKeyInQueryString(
+            urlKey,
+            urlStateToReplace
+          )(getQueryStringFromLocation(myLocation))
         );
       },
       {

--- a/x-pack/legacy/plugins/siem/public/components/page/hosts/authentications_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/hosts/authentications_table/index.tsx
@@ -143,13 +143,10 @@ const makeMapStateToProps = () => {
   };
 };
 
-export const AuthenticationTable = connect(
-  makeMapStateToProps,
-  {
-    updateTableActivePage: hostsActions.updateTableActivePage,
-    updateTableLimit: hostsActions.updateTableLimit,
-  }
-)(AuthenticationTableComponent);
+export const AuthenticationTable = connect(makeMapStateToProps, {
+  updateTableActivePage: hostsActions.updateTableActivePage,
+  updateTableLimit: hostsActions.updateTableLimit,
+})(AuthenticationTableComponent);
 
 const getAuthenticationColumns = (): AuthTableColumns => [
   {
@@ -339,7 +336,10 @@ export const getAuthenticationColumnsCurated = (
   // Columns to exclude from host details pages
   if (pageType === hostsModel.HostsType.details) {
     return [i18n.LAST_FAILED_DESTINATION, i18n.LAST_SUCCESSFUL_DESTINATION].reduce((acc, name) => {
-      acc.splice(acc.findIndex(column => column.name === name), 1);
+      acc.splice(
+        acc.findIndex(column => column.name === name),
+        1
+      );
       return acc;
     }, columns);
   }

--- a/x-pack/legacy/plugins/siem/public/components/page/hosts/hosts_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/hosts/hosts_table/index.tsx
@@ -209,11 +209,8 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const HostsTable = connect(
-  makeMapStateToProps,
-  {
-    updateHostsSort: hostsActions.updateHostsSort,
-    updateTableActivePage: hostsActions.updateTableActivePage,
-    updateTableLimit: hostsActions.updateTableLimit,
-  }
-)(HostsTableComponent);
+export const HostsTable = connect(makeMapStateToProps, {
+  updateHostsSort: hostsActions.updateHostsSort,
+  updateTableActivePage: hostsActions.updateTableActivePage,
+  updateTableLimit: hostsActions.updateTableLimit,
+})(HostsTableComponent);

--- a/x-pack/legacy/plugins/siem/public/components/page/hosts/uncommon_process_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/hosts/uncommon_process_table/index.tsx
@@ -139,13 +139,10 @@ const makeMapStateToProps = () => {
   return (state: State, { type }: OwnProps) => getUncommonProcessesSelector(state, type);
 };
 
-export const UncommonProcessTable = connect(
-  makeMapStateToProps,
-  {
-    updateTableActivePage: hostsActions.updateTableActivePage,
-    updateTableLimit: hostsActions.updateTableLimit,
-  }
-)(UncommonProcessTableComponent);
+export const UncommonProcessTable = connect(makeMapStateToProps, {
+  updateTableActivePage: hostsActions.updateTableActivePage,
+  updateTableLimit: hostsActions.updateTableLimit,
+})(UncommonProcessTableComponent);
 
 const getUncommonColumns = (): UncommonProcessTableColumns => [
   {
@@ -229,7 +226,10 @@ export const getUncommonColumnsCurated = (pageType: HostsType): UncommonProcessT
   const columns: UncommonProcessTableColumns = getUncommonColumns();
   if (pageType === HostsType.details) {
     return [i18n.HOSTS, i18n.NUMBER_OF_HOSTS].reduce((acc, name) => {
-      acc.splice(acc.findIndex(column => column.name === name), 1);
+      acc.splice(
+        acc.findIndex(column => column.name === name),
+        1
+      );
       return acc;
     }, columns);
   } else {

--- a/x-pack/legacy/plugins/siem/public/components/page/network/flow_target_select_connected/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/flow_target_select_connected/index.tsx
@@ -63,9 +63,6 @@ const makeMapStateToProps = () => {
   };
 };
 
-export const FlowTargetSelectConnected = connect(
-  makeMapStateToProps,
-  {
-    updateIpDetailsFlowTarget: networkActions.updateIpDetailsFlowTarget,
-  }
-)(FlowTargetSelectComponent);
+export const FlowTargetSelectConnected = connect(makeMapStateToProps, {
+  updateIpDetailsFlowTarget: networkActions.updateIpDetailsFlowTarget,
+})(FlowTargetSelectComponent);

--- a/x-pack/legacy/plugins/siem/public/components/page/network/network_dns_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/network_dns_table/index.tsx
@@ -159,9 +159,6 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const NetworkDnsTable = connect(
-  makeMapStateToProps,
-  {
-    updateNetworkTable: networkActions.updateNetworkTable,
-  }
-)(NetworkDnsTableComponent);
+export const NetworkDnsTable = connect(makeMapStateToProps, {
+  updateNetworkTable: networkActions.updateNetworkTable,
+})(NetworkDnsTableComponent);

--- a/x-pack/legacy/plugins/siem/public/components/page/network/network_http_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/network_http_table/index.tsx
@@ -140,10 +140,7 @@ const makeMapStateToProps = () => {
 };
 
 export const NetworkHttpTable = compose<React.ComponentClass<OwnProps>>(
-  connect(
-    makeMapStateToProps,
-    {
-      updateNetworkTable: networkActions.updateNetworkTable,
-    }
-  )
+  connect(makeMapStateToProps, {
+    updateNetworkTable: networkActions.updateNetworkTable,
+  })
 )(NetworkHttpTableComponent);

--- a/x-pack/legacy/plugins/siem/public/components/page/network/network_top_countries_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/network_top_countries_table/index.tsx
@@ -185,10 +185,7 @@ const makeMapStateToProps = () => {
 };
 
 export const NetworkTopCountriesTable = compose<React.ComponentClass<OwnProps>>(
-  connect(
-    makeMapStateToProps,
-    {
-      updateNetworkTable: networkActions.updateNetworkTable,
-    }
-  )
+  connect(makeMapStateToProps, {
+    updateNetworkTable: networkActions.updateNetworkTable,
+  })
 )(NetworkTopCountriesTableComponent);

--- a/x-pack/legacy/plugins/siem/public/components/page/network/network_top_n_flow_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/network_top_n_flow_table/index.tsx
@@ -176,10 +176,7 @@ const makeMapStateToProps = () => {
 };
 
 export const NetworkTopNFlowTable = compose<React.ComponentClass<OwnProps>>(
-  connect(
-    makeMapStateToProps,
-    {
-      updateNetworkTable: networkActions.updateNetworkTable,
-    }
-  )
+  connect(makeMapStateToProps, {
+    updateNetworkTable: networkActions.updateNetworkTable,
+  })
 )(NetworkTopNFlowTableComponent);

--- a/x-pack/legacy/plugins/siem/public/components/page/network/tls_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/tls_table/index.tsx
@@ -144,12 +144,9 @@ const makeMapStateToProps = () => {
 };
 
 export const TlsTable = compose<React.ComponentClass<OwnProps>>(
-  connect(
-    makeMapStateToProps,
-    {
-      updateNetworkTable: networkActions.updateNetworkTable,
-    }
-  )
+  connect(makeMapStateToProps, {
+    updateNetworkTable: networkActions.updateNetworkTable,
+  })
 )(TlsTableComponent);
 
 const getSortField = (sortField: TlsSortField): SortingBasicTable => ({

--- a/x-pack/legacy/plugins/siem/public/components/page/network/users_table/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/page/network/users_table/index.tsx
@@ -145,12 +145,9 @@ const makeMapStateToProps = () => {
   });
 };
 
-export const UsersTable = connect(
-  makeMapStateToProps,
-  {
-    updateNetworkTable: networkActions.updateNetworkTable,
-  }
-)(UsersTableComponent);
+export const UsersTable = connect(makeMapStateToProps, {
+  updateNetworkTable: networkActions.updateNetworkTable,
+})(UsersTableComponent);
 
 const getSortField = (sortField: UsersSortField): SortingBasicTable => {
   switch (sortField.field) {

--- a/x-pack/legacy/plugins/siem/public/components/search_bar/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/search_bar/index.tsx
@@ -401,7 +401,4 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(inputsActions.setSearchBarFilter({ id, filters })),
 });
 
-export const SiemSearchBar = connect(
-  makeMapStateToProps,
-  mapDispatchToProps
-)(SearchBarComponent);
+export const SiemSearchBar = connect(makeMapStateToProps, mapDispatchToProps)(SearchBarComponent);

--- a/x-pack/legacy/plugins/siem/public/components/search_bar/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/components/search_bar/selectors.ts
@@ -24,14 +24,6 @@ export const getFilterQuery = (inputState: InputsRange): Query => inputState.que
 export const getSavedQuery = (inputState: InputsRange): SavedQuery | undefined =>
   inputState.savedQuery;
 
-export const filterQuerySelector = () =>
-  createSelector(
-    getFilterQuery,
-    filterQuery => filterQuery
-  );
+export const filterQuerySelector = () => createSelector(getFilterQuery, filterQuery => filterQuery);
 
-export const savedQuerySelector = () =>
-  createSelector(
-    getSavedQuery,
-    savedQuery => savedQuery
-  );
+export const savedQuerySelector = () => createSelector(getSavedQuery, savedQuery => savedQuery);

--- a/x-pack/legacy/plugins/siem/public/components/super_date_picker/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/components/super_date_picker/selectors.ts
@@ -13,62 +13,25 @@ export const getTimerange = (inputState: InputsRange): TimeRange => inputState.t
 
 export const getQueries = (inputState: InputsRange): GlobalQuery[] => inputState.queries;
 
-export const policySelector = () =>
-  createSelector(
-    getPolicy,
-    policy => policy.kind
-  );
+export const policySelector = () => createSelector(getPolicy, policy => policy.kind);
 
-export const durationSelector = () =>
-  createSelector(
-    getPolicy,
-    policy => policy.duration
-  );
+export const durationSelector = () => createSelector(getPolicy, policy => policy.duration);
 
-export const kindSelector = () =>
-  createSelector(
-    getTimerange,
-    timerange => timerange.kind
-  );
+export const kindSelector = () => createSelector(getTimerange, timerange => timerange.kind);
 
-export const startSelector = () =>
-  createSelector(
-    getTimerange,
-    timerange => timerange.from
-  );
+export const startSelector = () => createSelector(getTimerange, timerange => timerange.from);
 
-export const endSelector = () =>
-  createSelector(
-    getTimerange,
-    timerange => timerange.to
-  );
+export const endSelector = () => createSelector(getTimerange, timerange => timerange.to);
 
-export const fromStrSelector = () =>
-  createSelector(
-    getTimerange,
-    timerange => timerange.fromStr
-  );
+export const fromStrSelector = () => createSelector(getTimerange, timerange => timerange.fromStr);
 
-export const toStrSelector = () =>
-  createSelector(
-    getTimerange,
-    timerange => timerange.toStr
-  );
+export const toStrSelector = () => createSelector(getTimerange, timerange => timerange.toStr);
 
 export const isLoadingSelector = () =>
-  createSelector(
-    getQueries,
-    queries => queries.some(i => i.loading === true)
-  );
+  createSelector(getQueries, queries => queries.some(i => i.loading === true));
 
 export const queriesSelector = () =>
-  createSelector(
-    getQueries,
-    queries => queries.filter(q => q.id !== 'kql')
-  );
+  createSelector(getQueries, queries => queries.filter(q => q.id !== 'kql'));
 
 export const kqlQuerySelector = () =>
-  createSelector(
-    getQueries,
-    queries => queries.find(q => q.id === 'kql')
-  );
+  createSelector(getQueries, queries => queries.find(q => q.id === 'kql'));

--- a/x-pack/legacy/plugins/siem/public/components/timeline/auto_save_warning/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/auto_save_warning/index.tsx
@@ -107,11 +107,8 @@ const mapStateToProps = (state: State) => {
   };
 };
 
-export const AutoSaveWarningMsg = connect(
-  mapStateToProps,
-  {
-    setTimelineRangeDatePicker: dispatchSetTimelineRangeDatePicker,
-    updateAutoSaveMsg: timelineActions.updateAutoSaveMsg,
-    updateTimeline: timelineActions.updateTimeline,
-  }
-)(AutoSaveWarningMsgComponent);
+export const AutoSaveWarningMsg = connect(mapStateToProps, {
+  setTimelineRangeDatePicker: dispatchSetTimelineRangeDatePicker,
+  updateAutoSaveMsg: timelineActions.updateAutoSaveMsg,
+  updateTimeline: timelineActions.updateTimeline,
+})(AutoSaveWarningMsgComponent);

--- a/x-pack/legacy/plugins/siem/public/components/timeline/body/stateful_body.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/body/stateful_body.tsx
@@ -216,17 +216,14 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const StatefulBody = connect(
-  makeMapStateToProps,
-  {
-    addNoteToEvent: timelineActions.addNoteToEvent,
-    applyDeltaToColumnWidth: timelineActions.applyDeltaToColumnWidth,
-    pinEvent: timelineActions.pinEvent,
-    removeColumn: timelineActions.removeColumn,
-    removeProvider: timelineActions.removeProvider,
-    unPinEvent: timelineActions.unPinEvent,
-    updateColumns: timelineActions.updateColumns,
-    updateNote: appActions.updateNote,
-    updateSort: timelineActions.updateSort,
-  }
-)(StatefulBodyComponent);
+export const StatefulBody = connect(makeMapStateToProps, {
+  addNoteToEvent: timelineActions.addNoteToEvent,
+  applyDeltaToColumnWidth: timelineActions.applyDeltaToColumnWidth,
+  pinEvent: timelineActions.pinEvent,
+  removeColumn: timelineActions.removeColumn,
+  removeProvider: timelineActions.removeProvider,
+  unPinEvent: timelineActions.unPinEvent,
+  updateColumns: timelineActions.updateColumns,
+  updateNote: appActions.updateNote,
+  updateSort: timelineActions.updateSort,
+})(StatefulBodyComponent);

--- a/x-pack/legacy/plugins/siem/public/components/timeline/fetch_kql_timeline.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/fetch_kql_timeline.tsx
@@ -71,9 +71,6 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const TimelineKqlFetch = connect(
-  makeMapStateToProps,
-  {
-    setTimelineQuery: inputsActions.setQuery,
-  }
-)(TimelineKqlFetchComponent);
+export const TimelineKqlFetch = connect(makeMapStateToProps, {
+  setTimelineQuery: inputsActions.setQuery,
+})(TimelineKqlFetchComponent);

--- a/x-pack/legacy/plugins/siem/public/components/timeline/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/index.tsx
@@ -341,22 +341,19 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const StatefulTimeline = connect(
-  makeMapStateToProps,
-  {
-    addProvider: timelineActions.addProvider,
-    createTimeline: timelineActions.createTimeline,
-    onDataProviderEdited: timelineActions.dataProviderEdited,
-    removeColumn: timelineActions.removeColumn,
-    removeProvider: timelineActions.removeProvider,
-    updateColumns: timelineActions.updateColumns,
-    updateDataProviderEnabled: timelineActions.updateDataProviderEnabled,
-    updateDataProviderExcluded: timelineActions.updateDataProviderExcluded,
-    updateDataProviderKqlQuery: timelineActions.updateDataProviderKqlQuery,
-    updateHighlightedDropAndProviderId: timelineActions.updateHighlightedDropAndProviderId,
-    updateItemsPerPage: timelineActions.updateItemsPerPage,
-    updateItemsPerPageOptions: timelineActions.updateItemsPerPageOptions,
-    updateSort: timelineActions.updateSort,
-    upsertColumn: timelineActions.upsertColumn,
-  }
-)(StatefulTimelineComponent);
+export const StatefulTimeline = connect(makeMapStateToProps, {
+  addProvider: timelineActions.addProvider,
+  createTimeline: timelineActions.createTimeline,
+  onDataProviderEdited: timelineActions.dataProviderEdited,
+  removeColumn: timelineActions.removeColumn,
+  removeProvider: timelineActions.removeProvider,
+  updateColumns: timelineActions.updateColumns,
+  updateDataProviderEnabled: timelineActions.updateDataProviderEnabled,
+  updateDataProviderExcluded: timelineActions.updateDataProviderExcluded,
+  updateDataProviderKqlQuery: timelineActions.updateDataProviderKqlQuery,
+  updateHighlightedDropAndProviderId: timelineActions.updateHighlightedDropAndProviderId,
+  updateItemsPerPage: timelineActions.updateItemsPerPage,
+  updateItemsPerPageOptions: timelineActions.updateItemsPerPageOptions,
+  updateSort: timelineActions.updateSort,
+  upsertColumn: timelineActions.upsertColumn,
+})(StatefulTimelineComponent);

--- a/x-pack/legacy/plugins/siem/public/components/timeline/refetch_timeline.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/refetch_timeline.tsx
@@ -44,10 +44,7 @@ const TimelineRefetchComponent = memo<OwnProps>(
 );
 
 export const TimelineRefetch = compose<React.ComponentClass<TimelineRefetchProps>>(
-  connect(
-    null,
-    {
-      setTimelineQuery: inputsActions.setQuery,
-    }
-  )
+  connect(null, {
+    setTimelineQuery: inputsActions.setQuery,
+  })
 )(TimelineRefetchComponent);

--- a/x-pack/legacy/plugins/siem/public/components/timeline/search_or_filter/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/search_or_filter/index.tsx
@@ -114,11 +114,8 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const StatefulSearchOrFilter = connect(
-  makeMapStateToProps,
-  {
-    applyKqlFilterQuery: timelineActions.applyKqlFilterQuery,
-    setKqlFilterQueryDraft: timelineActions.setKqlFilterQueryDraft,
-    updateKqlMode: timelineActions.updateKqlMode,
-  }
-)(StatefulSearchOrFilterComponent);
+export const StatefulSearchOrFilter = connect(makeMapStateToProps, {
+  applyKqlFilterQuery: timelineActions.applyKqlFilterQuery,
+  setKqlFilterQueryDraft: timelineActions.setKqlFilterQueryDraft,
+  updateKqlMode: timelineActions.updateKqlMode,
+})(StatefulSearchOrFilterComponent);

--- a/x-pack/legacy/plugins/siem/public/components/url_state/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/url_state/index.tsx
@@ -38,10 +38,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 });
 
 export const UrlStateRedux = compose<React.ComponentClass<UrlStateProps & RouteSpyState>>(
-  connect(
-    makeMapStateToProps,
-    mapDispatchToProps
-  )
+  connect(makeMapStateToProps, mapDispatchToProps)
 )(UrlStateContainer);
 
 export const UseUrlState = React.memo<UrlStateProps>(props => {

--- a/x-pack/legacy/plugins/siem/public/components/url_state/test_dependencies.ts
+++ b/x-pack/legacy/plugins/siem/public/components/url_state/test_dependencies.ts
@@ -265,9 +265,15 @@ export const getMockPropsObj = ({
 
 // silly that this needs to be an array and not an object
 // https://jestjs.io/docs/en/api#testeachtable-name-fn-timeout
-export const testCases: Array<
-  [LocationTypes, string, string, string, string | null, string, undefined | string]
-> = [
+export const testCases: Array<[
+  LocationTypes,
+  string,
+  string,
+  string,
+  string | null,
+  string,
+  undefined | string
+]> = [
   [
     /* page */ CONSTANTS.networkPage,
     /* namespaceLower */ 'network',

--- a/x-pack/legacy/plugins/siem/public/components/url_state/use_url_state.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/url_state/use_url_state.tsx
@@ -75,9 +75,10 @@ export const useUrlStateHooks = ({
         search,
         state: '',
       },
-      replaceStateKeyInQueryString(urlStateKey, urlStateToReplace)(
-        getQueryStringFromLocation(latestLocation)
-      )
+      replaceStateKeyInQueryString(
+        urlStateKey,
+        urlStateToReplace
+      )(getQueryStringFromLocation(latestLocation))
     );
     if (history) {
       history.replace(newLocation);

--- a/x-pack/legacy/plugins/siem/public/containers/global_time/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/containers/global_time/index.tsx
@@ -83,11 +83,8 @@ const mapStateToProps = (state: State) => {
   };
 };
 
-export const GlobalTime = connect(
-  mapStateToProps,
-  {
-    deleteAllQuery: inputsActions.deleteAllQuery,
-    deleteOneQuery: inputsActions.deleteOneQuery,
-    setGlobalQuery: inputsActions.setQuery,
-  }
-)(GlobalTimeComponent);
+export const GlobalTime = connect(mapStateToProps, {
+  deleteAllQuery: inputsActions.deleteAllQuery,
+  deleteOneQuery: inputsActions.deleteOneQuery,
+  setGlobalQuery: inputsActions.setQuery,
+})(GlobalTimeComponent);

--- a/x-pack/legacy/plugins/siem/public/lib/keury/index.ts
+++ b/x-pack/legacy/plugins/siem/public/lib/keury/index.ts
@@ -61,12 +61,7 @@ const escapeAndOr = (val: string) => val.replace(/(\s+)(and|or)(\s+)/gi, '$1\\$2
 
 const escapeNot = (val: string) => val.replace(/not(\s+)/gi, '\\$&');
 
-export const escapeKuery = flow(
-  escapeSpecialCharacters,
-  escapeAndOr,
-  escapeNot,
-  escapeWhitespace
-);
+export const escapeKuery = flow(escapeSpecialCharacters, escapeAndOr, escapeNot, escapeWhitespace);
 
 export interface EsQueryConfig {
   allowLeadingWildcards: boolean;
@@ -88,10 +83,15 @@ export const convertToBuildEsQuery = ({
 }) => {
   try {
     return JSON.stringify(
-      buildEsQuery(indexPattern, queries, filters.filter(f => f.meta.disabled === false), {
-        ...config,
-        dateFormatTZ: null,
-      })
+      buildEsQuery(
+        indexPattern,
+        queries,
+        filters.filter(f => f.meta.disabled === false),
+        {
+          ...config,
+          dateFormatTZ: null,
+        }
+      )
     );
   } catch (exp) {
     return '';

--- a/x-pack/legacy/plugins/siem/public/pages/hosts/details/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/hosts/details/index.tsx
@@ -232,11 +232,8 @@ export const makeMapStateToProps = () => {
 };
 
 export const HostDetails = compose<React.ComponentClass<HostDetailsProps>>(
-  connect(
-    makeMapStateToProps,
-    {
-      setAbsoluteRangeDatePicker: dispatchAbsoluteRangeDatePicker,
-      setHostDetailsTablesActivePageToZero: dispatchHostDetailsTablesActivePageToZero,
-    }
-  )
+  connect(makeMapStateToProps, {
+    setAbsoluteRangeDatePicker: dispatchAbsoluteRangeDatePicker,
+    setHostDetailsTablesActivePageToZero: dispatchHostDetailsTablesActivePageToZero,
+  })
 )(HostDetailsComponent);

--- a/x-pack/legacy/plugins/siem/public/pages/hosts/hosts.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/hosts/hosts.tsx
@@ -154,10 +154,7 @@ interface HostsProps extends GlobalTimeArgs {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Hosts = compose<React.ComponentClass<HostsProps>>(
-  connect(
-    makeMapStateToProps,
-    {
-      setAbsoluteRangeDatePicker: dispatchSetAbsoluteRangeDatePicker,
-    }
-  )
+  connect(makeMapStateToProps, {
+    setAbsoluteRangeDatePicker: dispatchSetAbsoluteRangeDatePicker,
+  })
 )(HostsComponent);

--- a/x-pack/legacy/plugins/siem/public/pages/network/ip_details/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/network/ip_details/index.tsx
@@ -290,10 +290,7 @@ const makeMapStateToProps = () => {
   });
 };
 
-export const IPDetails = connect(
-  makeMapStateToProps,
-  {
-    setAbsoluteRangeDatePicker: dispatchAbsoluteRangeDatePicker,
-    setIpDetailsTablesActivePageToZero: dispatchIpDetailsTablesActivePageToZero,
-  }
-)(IPDetailsComponent);
+export const IPDetails = connect(makeMapStateToProps, {
+  setAbsoluteRangeDatePicker: dispatchAbsoluteRangeDatePicker,
+  setIpDetailsTablesActivePageToZero: dispatchIpDetailsTablesActivePageToZero,
+})(IPDetailsComponent);

--- a/x-pack/legacy/plugins/siem/public/pages/network/network.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/network/network.tsx
@@ -161,9 +161,6 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-export const Network = connect(
-  makeMapStateToProps,
-  {
-    setAbsoluteRangeDatePicker: dispatchSetAbsoluteRangeDatePicker,
-  }
-)(NetworkComponent);
+export const Network = connect(makeMapStateToProps, {
+  setAbsoluteRangeDatePicker: dispatchSetAbsoluteRangeDatePicker,
+})(NetworkComponent);

--- a/x-pack/legacy/plugins/siem/public/store/app/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/store/app/selectors.ts
@@ -33,13 +33,6 @@ export const selectNotesByIdSelector = createSelector(
 );
 
 export const notesByIdsSelector = () =>
-  createSelector(
-    selectNotesById,
-    (notesById: NotesById) => notesById
-  );
+  createSelector(selectNotesById, (notesById: NotesById) => notesById);
 
-export const errorsSelector = () =>
-  createSelector(
-    getErrors,
-    errors => ({ errors })
-  );
+export const errorsSelector = () => createSelector(getErrors, errors => ({ errors }));

--- a/x-pack/legacy/plugins/siem/public/store/hosts/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/store/hosts/selectors.ts
@@ -15,25 +15,12 @@ const selectHosts = (state: State, hostsType: HostsType): GenericHostsModel =>
   get(hostsType, state.hosts);
 
 export const authenticationsSelector = () =>
-  createSelector(
-    selectHosts,
-    hosts => hosts.queries.authentications
-  );
+  createSelector(selectHosts, hosts => hosts.queries.authentications);
 
 export const hostsSelector = () =>
-  createSelector(
-    selectHosts,
-    hosts => hosts.queries[HostsTableType.hosts]
-  );
+  createSelector(selectHosts, hosts => hosts.queries[HostsTableType.hosts]);
 
-export const eventsSelector = () =>
-  createSelector(
-    selectHosts,
-    hosts => hosts.queries.events
-  );
+export const eventsSelector = () => createSelector(selectHosts, hosts => hosts.queries.events);
 
 export const uncommonProcessesSelector = () =>
-  createSelector(
-    selectHosts,
-    hosts => hosts.queries.uncommonProcesses
-  );
+  createSelector(selectHosts, hosts => hosts.queries.uncommonProcesses);

--- a/x-pack/legacy/plugins/siem/public/store/inputs/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/store/inputs/selectors.ts
@@ -37,49 +37,24 @@ const selectTimelineQuery = (state: State, id: string): GlobalQuery =>
     selectedInspectIndex: 0,
   };
 
-export const inputsSelector = () =>
-  createSelector(
-    selectInputs,
-    inputs => inputs
-  );
+export const inputsSelector = () => createSelector(selectInputs, inputs => inputs);
 
 export const timelineTimeRangeSelector = createSelector(
   selectTimeline,
   timeline => timeline.timerange
 );
 
-export const globalTimeRangeSelector = createSelector(
-  selectGlobal,
-  global => global.timerange
-);
+export const globalTimeRangeSelector = createSelector(selectGlobal, global => global.timerange);
 
-export const globalPolicySelector = createSelector(
-  selectGlobal,
-  global => global.policy
-);
+export const globalPolicySelector = createSelector(selectGlobal, global => global.policy);
 
-export const globalQuery = createSelector(
-  selectGlobal,
-  global => global.queries
-);
+export const globalQuery = createSelector(selectGlobal, global => global.queries);
 
-export const globalQueryByIdSelector = () =>
-  createSelector(
-    selectGlobalQuery,
-    query => query
-  );
+export const globalQueryByIdSelector = () => createSelector(selectGlobalQuery, query => query);
 
-export const timelineQueryByIdSelector = () =>
-  createSelector(
-    selectTimelineQuery,
-    query => query
-  );
+export const timelineQueryByIdSelector = () => createSelector(selectTimelineQuery, query => query);
 
-export const globalSelector = () =>
-  createSelector(
-    selectGlobal,
-    global => global
-  );
+export const globalSelector = () => createSelector(selectGlobal, global => global);
 
 export const globalQuerySelector = () =>
   createSelector(
@@ -92,19 +67,9 @@ export const globalQuerySelector = () =>
   );
 
 export const globalSavedQuerySelector = () =>
-  createSelector(
-    selectGlobal,
-    global => global.savedQuery || null
-  );
+  createSelector(selectGlobal, global => global.savedQuery || null);
 
 export const globalFiltersQuerySelector = () =>
-  createSelector(
-    selectGlobal,
-    global => global.filters || []
-  );
+  createSelector(selectGlobal, global => global.filters || []);
 
-export const getTimelineSelector = () =>
-  createSelector(
-    selectTimeline,
-    timeline => timeline
-  );
+export const getTimelineSelector = () => createSelector(selectTimeline, timeline => timeline);

--- a/x-pack/legacy/plugins/siem/public/store/network/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/store/network/selectors.ts
@@ -23,11 +23,7 @@ const selectNetworkPage = (state: State): NetworkPageModel => state.network.page
 const selectNetworkDetails = (state: State): NetworkDetailsModel => state.network.details;
 
 // Network Page Selectors
-export const dnsSelector = () =>
-  createSelector(
-    selectNetworkPage,
-    network => network.queries.dns
-  );
+export const dnsSelector = () => createSelector(selectNetworkPage, network => network.queries.dns);
 
 const selectTopNFlowByType = (
   state: State,
@@ -44,10 +40,7 @@ const selectTopNFlowByType = (
 };
 
 export const topNFlowSelector = () =>
-  createSelector(
-    selectTopNFlowByType,
-    topNFlowQueries => topNFlowQueries
-  );
+  createSelector(selectTopNFlowByType, topNFlowQueries => topNFlowQueries);
 const selectTlsByType = (state: State, networkType: NetworkType) => {
   const tlsType = networkType === NetworkType.page ? NetworkTableType.tls : IpDetailsTableType.tls;
   return (
@@ -56,11 +49,7 @@ const selectTlsByType = (state: State, networkType: NetworkType) => {
   );
 };
 
-export const tlsSelector = () =>
-  createSelector(
-    selectTlsByType,
-    tlsQueries => tlsQueries
-  );
+export const tlsSelector = () => createSelector(selectTlsByType, tlsQueries => tlsQueries);
 
 const selectTopCountriesByType = (
   state: State,
@@ -79,10 +68,7 @@ const selectTopCountriesByType = (
 };
 
 export const topCountriesSelector = () =>
-  createSelector(
-    selectTopCountriesByType,
-    topCountriesQueries => topCountriesQueries
-  );
+  createSelector(selectTopCountriesByType, topCountriesQueries => topCountriesQueries);
 
 const selectHttpByType = (state: State, networkType: NetworkType) => {
   const httpType =
@@ -93,21 +79,11 @@ const selectHttpByType = (state: State, networkType: NetworkType) => {
   );
 };
 
-export const httpSelector = () =>
-  createSelector(
-    selectHttpByType,
-    httpQueries => httpQueries
-  );
+export const httpSelector = () => createSelector(selectHttpByType, httpQueries => httpQueries);
 
 // IP Details Selectors
 export const ipDetailsFlowTargetSelector = () =>
-  createSelector(
-    selectNetworkDetails,
-    network => network.flowTarget
-  );
+  createSelector(selectNetworkDetails, network => network.flowTarget);
 
 export const usersSelector = () =>
-  createSelector(
-    selectNetworkDetails,
-    network => network.queries.users
-  );
+  createSelector(selectNetworkDetails, network => network.queries.users);

--- a/x-pack/legacy/plugins/siem/public/store/timeline/epic.ts
+++ b/x-pack/legacy/plugins/siem/public/store/timeline/epic.ts
@@ -107,20 +107,11 @@ export const createTimelineEpic = <State>(): Epic<
   state$,
   { selectNotesByIdSelector, timelineByIdSelector, timelineTimeRangeSelector, apolloClient$ }
 ) => {
-  const timeline$ = state$.pipe(
-    map(timelineByIdSelector),
-    filter(isNotNull)
-  );
+  const timeline$ = state$.pipe(map(timelineByIdSelector), filter(isNotNull));
 
-  const notes$ = state$.pipe(
-    map(selectNotesByIdSelector),
-    filter(isNotNull)
-  );
+  const notes$ = state$.pipe(map(selectNotesByIdSelector), filter(isNotNull));
 
-  const timelineTimeRange$ = state$.pipe(
-    map(timelineTimeRangeSelector),
-    filter(isNotNull)
-  );
+  const timelineTimeRange$ = state$.pipe(map(timelineTimeRangeSelector), filter(isNotNull));
 
   return merge(
     action$.pipe(

--- a/x-pack/legacy/plugins/siem/public/store/timeline/model.ts
+++ b/x-pack/legacy/plugins/siem/public/store/timeline/model.ts
@@ -71,35 +71,33 @@ export interface TimelineModel {
   version: string | null;
 }
 
-export const timelineDefaults: Readonly<
-  Pick<
-    TimelineModel,
-    | 'columns'
-    | 'dataProviders'
-    | 'description'
-    | 'eventIdToNoteIds'
-    | 'highlightedDropAndProviderId'
-    | 'historyIds'
-    | 'isFavorite'
-    | 'isLive'
-    | 'itemsPerPage'
-    | 'itemsPerPageOptions'
-    | 'kqlMode'
-    | 'kqlQuery'
-    | 'title'
-    | 'noteIds'
-    | 'pinnedEventIds'
-    | 'pinnedEventsSaveObject'
-    | 'dateRange'
-    | 'show'
-    | 'sort'
-    | 'width'
-    | 'isSaving'
-    | 'isLoading'
-    | 'savedObjectId'
-    | 'version'
-  >
-> = {
+export const timelineDefaults: Readonly<Pick<
+  TimelineModel,
+  | 'columns'
+  | 'dataProviders'
+  | 'description'
+  | 'eventIdToNoteIds'
+  | 'highlightedDropAndProviderId'
+  | 'historyIds'
+  | 'isFavorite'
+  | 'isLive'
+  | 'itemsPerPage'
+  | 'itemsPerPageOptions'
+  | 'kqlMode'
+  | 'kqlQuery'
+  | 'title'
+  | 'noteIds'
+  | 'pinnedEventIds'
+  | 'pinnedEventsSaveObject'
+  | 'dateRange'
+  | 'show'
+  | 'sort'
+  | 'width'
+  | 'isSaving'
+  | 'isLoading'
+  | 'savedObjectId'
+  | 'version'
+>> = {
   columns: defaultHeaders,
   dataProviders: [],
   description: '',
@@ -135,32 +133,30 @@ export const timelineDefaults: Readonly<
   version: null,
 };
 
-export const eventsDefaults: Readonly<
-  Pick<
-    TimelineModel,
-    | 'columns'
-    | 'dataProviders'
-    | 'description'
-    | 'eventIdToNoteIds'
-    | 'highlightedDropAndProviderId'
-    | 'historyIds'
-    | 'isFavorite'
-    | 'isLive'
-    | 'itemsPerPage'
-    | 'itemsPerPageOptions'
-    | 'kqlMode'
-    | 'kqlQuery'
-    | 'title'
-    | 'noteIds'
-    | 'pinnedEventIds'
-    | 'pinnedEventsSaveObject'
-    | 'dateRange'
-    | 'show'
-    | 'sort'
-    | 'width'
-    | 'isSaving'
-    | 'isLoading'
-    | 'savedObjectId'
-    | 'version'
-  >
-> = { ...timelineDefaults, columns: eventsDefaultHeaders };
+export const eventsDefaults: Readonly<Pick<
+  TimelineModel,
+  | 'columns'
+  | 'dataProviders'
+  | 'description'
+  | 'eventIdToNoteIds'
+  | 'highlightedDropAndProviderId'
+  | 'historyIds'
+  | 'isFavorite'
+  | 'isLive'
+  | 'itemsPerPage'
+  | 'itemsPerPageOptions'
+  | 'kqlMode'
+  | 'kqlQuery'
+  | 'title'
+  | 'noteIds'
+  | 'pinnedEventIds'
+  | 'pinnedEventsSaveObject'
+  | 'dateRange'
+  | 'show'
+  | 'sort'
+  | 'width'
+  | 'isSaving'
+  | 'isLoading'
+  | 'savedObjectId'
+  | 'version'
+>> = { ...timelineDefaults, columns: eventsDefaultHeaders };

--- a/x-pack/legacy/plugins/siem/public/store/timeline/selectors.ts
+++ b/x-pack/legacy/plugins/siem/public/store/timeline/selectors.ts
@@ -22,10 +22,7 @@ const selectCallOutUnauthorizedMsg = (state: State): boolean =>
 export const selectTimeline = (state: State, timelineId: string): TimelineModel =>
   state.timeline.timelineById[timelineId];
 
-export const autoSaveMsgSelector = createSelector(
-  selectAutoSaveMsg,
-  autoSaveMsg => autoSaveMsg
-);
+export const autoSaveMsgSelector = createSelector(selectAutoSaveMsg, autoSaveMsg => autoSaveMsg);
 
 export const timelineByIdSelector = createSelector(
   selectTimelineById,
@@ -41,45 +38,34 @@ export const getShowCallOutUnauthorizedMsg = () =>
 export const getTimelines = () => timelineByIdSelector;
 
 export const getTimelineByIdSelector = () =>
-  createSelector(
-    selectTimeline,
-    timeline => timeline || timelineDefaults
-  );
+  createSelector(selectTimeline, timeline => timeline || timelineDefaults);
 
 export const getEventsByIdSelector = () =>
-  createSelector(
-    selectTimeline,
-    timeline => timeline || eventsDefaults
-  );
+  createSelector(selectTimeline, timeline => timeline || eventsDefaults);
 
 export const getKqlFilterQuerySelector = () =>
-  createSelector(
-    selectTimeline,
-    timeline =>
-      timeline &&
-      timeline.kqlQuery &&
-      timeline.kqlQuery.filterQuery &&
-      timeline.kqlQuery.filterQuery.kuery
-        ? timeline.kqlQuery.filterQuery.kuery.expression
-        : null
+  createSelector(selectTimeline, timeline =>
+    timeline &&
+    timeline.kqlQuery &&
+    timeline.kqlQuery.filterQuery &&
+    timeline.kqlQuery.filterQuery.kuery
+      ? timeline.kqlQuery.filterQuery.kuery.expression
+      : null
   );
 
 export const getKqlFilterQueryDraftSelector = () =>
-  createSelector(
-    selectTimeline,
-    timeline => (timeline && timeline.kqlQuery ? timeline.kqlQuery.filterQueryDraft : null)
+  createSelector(selectTimeline, timeline =>
+    timeline && timeline.kqlQuery ? timeline.kqlQuery.filterQueryDraft : null
   );
 
 export const getKqlFilterKuerySelector = () =>
-  createSelector(
-    selectTimeline,
-    timeline =>
-      timeline &&
-      timeline.kqlQuery &&
-      timeline.kqlQuery.filterQuery &&
-      timeline.kqlQuery.filterQuery.kuery
-        ? timeline.kqlQuery.filterQuery.kuery
-        : null
+  createSelector(selectTimeline, timeline =>
+    timeline &&
+    timeline.kqlQuery &&
+    timeline.kqlQuery.filterQuery &&
+    timeline.kqlQuery.filterQuery.kuery
+      ? timeline.kqlQuery.filterQuery.kuery
+      : null
   );
 
 export const isFilterQueryDraftValidSelector = () =>

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/alerts/delete_signals.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/alerts/delete_signals.ts
@@ -26,7 +26,7 @@ export const deleteSignals = async ({ alertsClient, actionsClient, id }: DeleteS
 
   // TODO: Remove this as cast as soon as signal.actions TypeScript bug is fixed
   // where it is trying to return AlertAction[] or RawAlertAction[]
-  const actions = (signal.actions as (AlertAction[] | undefined)) || [];
+  const actions = (signal.actions as AlertAction[] | undefined) || [];
 
   const actionsErrors = await deleteAllSignalActions(actionsClient, actions);
   const deletedAlert = await alertsClient.delete({ id: signal.id });

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/schemas.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/schemas.test.ts
@@ -1153,7 +1153,9 @@ describe('update_signals', () => {
     });
 
     test('page validates', () => {
-      expect(findSignalsSchema.validate<Partial<FindParamsRest>>({ page: 5 }).error).toBeFalsy();
+      expect(
+        findSignalsSchema.validate<Partial<FindParamsRest>>({ page: 5 }).error
+      ).toBeFalsy();
     });
 
     test('sort_field validates', () => {

--- a/x-pack/legacy/plugins/siem/server/lib/index_fields/elasticsearch_adapter.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/index_fields/elasticsearch_adapter.ts
@@ -44,9 +44,10 @@ export class ElasticsearchIndexFieldAdapter implements FieldsAdapter {
         })
       )
     );
-    return formatIndexFields(responsesIndexFields, Object.keys(
-      indexesAliasIndices
-    ) as IndexAlias[]);
+    return formatIndexFields(
+      responsesIndexFields,
+      Object.keys(indexesAliasIndices) as IndexAlias[]
+    );
   }
 }
 

--- a/x-pack/legacy/plugins/siem/server/lib/uncommon_processes/elasticsearch_adapter.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/uncommon_processes/elasticsearch_adapter.test.ts
@@ -161,7 +161,10 @@ describe('elasticsearch_adapter', () => {
 
     test('will return two hosts correctly', () => {
       const hosts = getHosts(bucket2.hosts.buckets);
-      expect(hosts).toEqual([{ id: ['123'], name: ['host-1'] }, { id: ['345'], name: ['host-2'] }]);
+      expect(hosts).toEqual([
+        { id: ['123'], name: ['host-1'] },
+        { id: ['345'], name: ['host-2'] },
+      ]);
     });
 
     test('will return a dot notation host', () => {

--- a/x-pack/legacy/plugins/siem/server/utils/build_query/fields.ts
+++ b/x-pack/legacy/plugins/siem/server/utils/build_query/fields.ts
@@ -15,21 +15,18 @@ export const getFields = (
   if (data.kind === 'Field' && data.selectionSet && !isEmpty(data.selectionSet.selections)) {
     return getFields(data.selectionSet, fields);
   } else if (data.kind === 'SelectionSet') {
-    return data.selections.reduce(
-      (res: string[], item: SelectionNode) => {
-        if (item.kind === 'Field') {
-          const field: FieldNode = item as FieldNode;
-          if (field.name.kind === 'Name' && field.name.value.includes('kpi')) {
-            return [...res, field.name.value];
-          } else if (field.selectionSet && !isEmpty(field.selectionSet.selections)) {
-            return getFields(field.selectionSet, res, postFields.concat(field.name.value));
-          }
-          return [...res, [...postFields, field.name.value].join('.')];
+    return data.selections.reduce((res: string[], item: SelectionNode) => {
+      if (item.kind === 'Field') {
+        const field: FieldNode = item as FieldNode;
+        if (field.name.kind === 'Name' && field.name.value.includes('kpi')) {
+          return [...res, field.name.value];
+        } else if (field.selectionSet && !isEmpty(field.selectionSet.selections)) {
+          return getFields(field.selectionSet, res, postFields.concat(field.name.value));
         }
-        return res;
-      },
-      fields as string[]
-    );
+        return [...res, [...postFields, field.name.value].join('.')];
+      }
+      return res;
+    }, fields as string[]);
   }
 
   return fields;

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/lib/authorization/components/with_privileges.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/lib/authorization/components/with_privileges.tsx
@@ -59,22 +59,19 @@ export const WithPrivileges = ({ privileges: requiredPrivileges, children }: Pro
         return !privileges.missingPrivileges[section]!.includes(requiredPrivilege);
       });
 
-  const privilegesMissing = privilegesToArray.reduce(
-    (acc, [section, privilege]) => {
-      if (privilege === '*') {
-        acc[section] = privileges.missingPrivileges[section] || [];
-      } else if (
-        privileges.missingPrivileges[section] &&
-        privileges.missingPrivileges[section]!.includes(privilege)
-      ) {
-        const missing: string[] = acc[section] || [];
-        acc[section] = [...missing, privilege];
-      }
+  const privilegesMissing = privilegesToArray.reduce((acc, [section, privilege]) => {
+    if (privilege === '*') {
+      acc[section] = privileges.missingPrivileges[section] || [];
+    } else if (
+      privileges.missingPrivileges[section] &&
+      privileges.missingPrivileges[section]!.includes(privilege)
+    ) {
+      const missing: string[] = acc[section] || [];
+      acc[section] = [...missing, privilege];
+    }
 
-      return acc;
-    },
-    {} as MissingPrivileges
-  );
+    return acc;
+  }, {} as MissingPrivileges);
 
   return children({ isLoading, hasPrivileges, privilegesMissing });
 };

--- a/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/policy_list/policy_table/policy_table.tsx
+++ b/x-pack/legacy/plugins/snapshot_restore/public/app/sections/home/policy_list/policy_table/policy_table.tsx
@@ -308,7 +308,10 @@ export const PolicyTable: React.FunctionComponent<Props> = ({
           return (
             <EuiButton
               onClick={() =>
-                deletePolicyPrompt(selectedItems.map(({ name }) => name), onPolicyDeleted)
+                deletePolicyPrompt(
+                  selectedItems.map(({ name }) => name),
+                  onPolicyDeleted
+                )
               }
               color="danger"
               data-test-subj="srPolicyListBulkDeleteActionButton"

--- a/x-pack/legacy/plugins/task_manager/lib/fill_pool.test.ts
+++ b/x-pack/legacy/plugins/task_manager/lib/fill_pool.test.ts
@@ -11,7 +11,10 @@ import { TaskPoolRunResult } from '../task_pool';
 
 describe('fillPool', () => {
   test('stops filling when there are no more tasks in the store', async () => {
-    const tasks = [[1, 2, 3], [4, 5]];
+    const tasks = [
+      [1, 2, 3],
+      [4, 5],
+    ];
     let index = 0;
     const fetchAvailableTasks = async () => tasks[index++] || [];
     const run = sinon.spy(async () => TaskPoolRunResult.RunningAllClaimedTasks);
@@ -23,7 +26,10 @@ describe('fillPool', () => {
   });
 
   test('stops filling when the pool has no more capacity', async () => {
-    const tasks = [[1, 2, 3], [4, 5]];
+    const tasks = [
+      [1, 2, 3],
+      [4, 5],
+    ];
     let index = 0;
     const fetchAvailableTasks = async () => tasks[index++] || [];
     const run = sinon.spy(async () => TaskPoolRunResult.RanOutOfCapacity);
@@ -35,7 +41,10 @@ describe('fillPool', () => {
   });
 
   test('calls the converter on the records prior to running', async () => {
-    const tasks = [[1, 2, 3], [4, 5]];
+    const tasks = [
+      [1, 2, 3],
+      [4, 5],
+    ];
     let index = 0;
     const fetchAvailableTasks = async () => tasks[index++] || [];
     const run = sinon.spy(async () => TaskPoolRunResult.RanOutOfCapacity);
@@ -66,7 +75,10 @@ describe('fillPool', () => {
       const converter = (x: number) => x.toString();
 
       try {
-        const tasks = [[1, 2, 3], [4, 5]];
+        const tasks = [
+          [1, 2, 3],
+          [4, 5],
+        ];
         let index = 0;
         const fetchAvailableTasks = async () => tasks[index++] || [];
 
@@ -78,7 +90,10 @@ describe('fillPool', () => {
 
     test('throws exception from converter', async () => {
       try {
-        const tasks = [[1, 2, 3], [4, 5]];
+        const tasks = [
+          [1, 2, 3],
+          [4, 5],
+        ];
         let index = 0;
         const fetchAvailableTasks = async () => tasks[index++] || [];
         const run = sinon.spy(async () => TaskPoolRunResult.RanOutOfCapacity);

--- a/x-pack/legacy/plugins/task_manager/lib/sanitize_task_definitions.ts
+++ b/x-pack/legacy/plugins/task_manager/lib/sanitize_task_definitions.ts
@@ -16,13 +16,10 @@ import { TaskDefinition, TaskDictionary, validateTaskDefinition } from '../task'
 export function sanitizeTaskDefinitions(
   taskDefinitions: TaskDictionary<TaskDefinition> = {}
 ): TaskDictionary<TaskDefinition> {
-  return Object.keys(taskDefinitions).reduce(
-    (acc, type) => {
-      const rawDefinition = taskDefinitions[type];
-      rawDefinition.type = type;
-      acc[type] = Joi.attempt(rawDefinition, validateTaskDefinition) as TaskDefinition;
-      return acc;
-    },
-    {} as TaskDictionary<TaskDefinition>
-  );
+  return Object.keys(taskDefinitions).reduce((acc, type) => {
+    const rawDefinition = taskDefinitions[type];
+    rawDefinition.type = type;
+    acc[type] = Joi.attempt(rawDefinition, validateTaskDefinition) as TaskDefinition;
+    return acc;
+  }, {} as TaskDictionary<TaskDefinition>);
 }

--- a/x-pack/legacy/plugins/transform/common/utils/es_utils.ts
+++ b/x-pack/legacy/plugins/transform/common/utils/es_utils.ts
@@ -33,7 +33,8 @@ export function isValidIndexName(indexName: string) {
     // Cannot start with -, _, +
     /^[^-_\+]+$/.test(indexName.charAt(0)) &&
     // Cannot be . or ..
-    (indexName !== '.' && indexName !== '..') &&
+    indexName !== '.' &&
+    indexName !== '..' &&
     // Cannot be longer than 255 bytes (note it is bytes,
     // so multi-byte characters will count towards the 255 limit faster)
     isValidIndexNameLength(indexName)

--- a/x-pack/legacy/plugins/transform/public/app/hooks/use_get_transforms.ts
+++ b/x-pack/legacy/plugins/transform/public/app/hooks/use_get_transforms.ts
@@ -70,32 +70,27 @@ export const useGetTransforms = (
         const transformConfigs: GetTransformsResponse = await api.getTransforms();
         const transformStats: GetTransformsStatsResponse = await api.getTransformsStats();
 
-        const tableRows = transformConfigs.transforms.reduce(
-          (reducedtableRows, config) => {
-            const stats = isGetTransformsStatsResponseOk(transformStats)
-              ? transformStats.transforms.find(d => config.id === d.id)
-              : undefined;
+        const tableRows = transformConfigs.transforms.reduce((reducedtableRows, config) => {
+          const stats = isGetTransformsStatsResponseOk(transformStats)
+            ? transformStats.transforms.find(d => config.id === d.id)
+            : undefined;
 
-            // A newly created transform might not have corresponding stats yet.
-            // If that's the case we just skip the transform and don't add it to the transform list yet.
-            if (!isTransformStats(stats)) {
-              return reducedtableRows;
-            }
-
-            // Table with expandable rows requires `id` on the outer most level
-            reducedtableRows.push({
-              id: config.id,
-              config,
-              mode:
-                typeof config.sync !== 'undefined'
-                  ? TRANSFORM_MODE.CONTINUOUS
-                  : TRANSFORM_MODE.BATCH,
-              stats,
-            });
+          // A newly created transform might not have corresponding stats yet.
+          // If that's the case we just skip the transform and don't add it to the transform list yet.
+          if (!isTransformStats(stats)) {
             return reducedtableRows;
-          },
-          [] as TransformListRow[]
-        );
+          }
+
+          // Table with expandable rows requires `id` on the outer most level
+          reducedtableRows.push({
+            id: config.id,
+            config,
+            mode:
+              typeof config.sync !== 'undefined' ? TRANSFORM_MODE.CONTINUOUS : TRANSFORM_MODE.BATCH,
+            stats,
+          });
+          return reducedtableRows;
+        }, [] as TransformListRow[]);
 
         setTransforms(tableRows);
         setErrorMessage(undefined);

--- a/x-pack/legacy/plugins/transform/public/app/lib/authorization/components/with_privileges.tsx
+++ b/x-pack/legacy/plugins/transform/public/app/lib/authorization/components/with_privileges.tsx
@@ -45,22 +45,19 @@ export const WithPrivileges = ({ privileges: requiredPrivileges, children }: Pro
   const hasPrivilege = hasPrivilegeFactory(privileges);
   const hasPrivileges = isLoading ? false : privilegesToArray.every(hasPrivilege);
 
-  const privilegesMissing = privilegesToArray.reduce(
-    (acc, [section, privilege]) => {
-      if (privilege === '*') {
-        acc[section] = privileges.missingPrivileges[section] || [];
-      } else if (
-        privileges.missingPrivileges[section] &&
-        privileges.missingPrivileges[section]!.includes(privilege)
-      ) {
-        const missing: string[] = acc[section] || [];
-        acc[section] = [...missing, privilege];
-      }
+  const privilegesMissing = privilegesToArray.reduce((acc, [section, privilege]) => {
+    if (privilege === '*') {
+      acc[section] = privileges.missingPrivileges[section] || [];
+    } else if (
+      privileges.missingPrivileges[section] &&
+      privileges.missingPrivileges[section]!.includes(privilege)
+    ) {
+      const missing: string[] = acc[section] || [];
+      acc[section] = [...missing, privilege];
+    }
 
-      return acc;
-    },
-    {} as MissingPrivileges
-  );
+    return acc;
+  }, {} as MissingPrivileges);
 
   return children({ isLoading, hasPrivileges, privilegesMissing });
 };

--- a/x-pack/legacy/plugins/transform/public/app/sections/create_transform/components/source_index_preview/expanded_row.test.tsx
+++ b/x-pack/legacy/plugins/transform/public/app/sections/create_transform/components/source_index_preview/expanded_row.test.tsx
@@ -24,16 +24,13 @@ describe('Transform: <ExpandedRow />', () => {
       arrayObject: [{ object1: 'the-object-1' }, { object2: 'the-objects-2' }],
     } as Record<string, any>;
 
-    const flattenedSource = getFlattenedFields(source).reduce(
-      (p, c) => {
-        p[c] = getNestedProperty(source, c);
-        if (p[c] === undefined) {
-          p[c] = source[`"${c}"`];
-        }
-        return p;
-      },
-      {} as Record<string, any>
-    );
+    const flattenedSource = getFlattenedFields(source).reduce((p, c) => {
+      p[c] = getNestedProperty(source, c);
+      if (p[c] === undefined) {
+        p[c] = source[`"${c}"`];
+      }
+      return p;
+    }, {} as Record<string, any>);
 
     const props = {
       item: {

--- a/x-pack/legacy/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_list.tsx
+++ b/x-pack/legacy/plugins/transform/public/app/sections/transform_management/components/transform_list/transform_list.tsx
@@ -48,16 +48,13 @@ function getItemIdToExpandedRowMap(
   itemIds: TransformId[],
   transforms: TransformListRow[]
 ): ItemIdToExpandedRowMap {
-  return itemIds.reduce(
-    (m: ItemIdToExpandedRowMap, transformId: TransformId) => {
-      const item = transforms.find(transform => transform.config.id === transformId);
-      if (item !== undefined) {
-        m[transformId] = <ExpandedRow item={item} />;
-      }
-      return m;
-    },
-    {} as ItemIdToExpandedRowMap
-  );
+  return itemIds.reduce((m: ItemIdToExpandedRowMap, transformId: TransformId) => {
+    const item = transforms.find(transform => transform.config.id === transformId);
+    if (item !== undefined) {
+      m[transformId] = <ExpandedRow item={item} />;
+    }
+    return m;
+  }, {} as ItemIdToExpandedRowMap);
 }
 
 function stringMatch(str: string | undefined, substr: string) {

--- a/x-pack/legacy/plugins/upgrade_assistant/public/components/error_banner.tsx
+++ b/x-pack/legacy/plugins/upgrade_assistant/public/components/error_banner.tsx
@@ -12,9 +12,10 @@ import { FormattedMessage } from '@kbn/i18n/react';
 
 import { UpgradeAssistantTabProps } from './types';
 
-export const LoadingErrorBanner: React.StatelessComponent<
-  Pick<UpgradeAssistantTabProps, 'loadingError'>
-> = ({ loadingError }) => {
+export const LoadingErrorBanner: React.StatelessComponent<Pick<
+  UpgradeAssistantTabProps,
+  'loadingError'
+>> = ({ loadingError }) => {
   if (get(loadingError, 'response.status') === 403) {
     return (
       <EuiCallOut

--- a/x-pack/legacy/plugins/upgrade_assistant/public/components/tabs/checkup/deprecations/reindex/flyout/warnings_step.tsx
+++ b/x-pack/legacy/plugins/upgrade_assistant/public/components/tabs/checkup/deprecations/reindex/flyout/warnings_step.tsx
@@ -83,13 +83,10 @@ export class WarningsFlyoutStep extends React.Component<
     super(props);
 
     this.state = {
-      checkedIds: props.warnings.reduce(
-        (checkedIds, warning) => {
-          checkedIds[idForWarning(warning)] = false;
-          return checkedIds;
-        },
-        {} as { [id: string]: boolean }
-      ),
+      checkedIds: props.warnings.reduce((checkedIds, warning) => {
+        checkedIds[idForWarning(warning)] = false;
+        return checkedIds;
+      }, {} as { [id: string]: boolean }),
     };
   }
 

--- a/x-pack/legacy/plugins/upgrade_assistant/public/components/tabs/checkup/filter_bar.tsx
+++ b/x-pack/legacy/plugins/upgrade_assistant/public/components/tabs/checkup/filter_bar.tsx
@@ -37,13 +37,10 @@ export const FilterBar: React.StatelessComponent<FilterBarProps> = ({
   onFilterChange,
 }) => {
   const levelGroups = groupBy(allDeprecations, 'level');
-  const levelCounts = Object.keys(levelGroups).reduce(
-    (counts, level) => {
-      counts[level] = levelGroups[level].length;
-      return counts;
-    },
-    {} as { [level: string]: number }
-  );
+  const levelCounts = Object.keys(levelGroups).reduce((counts, level) => {
+    counts[level] = levelGroups[level].length;
+    return counts;
+  }, {} as { [level: string]: number });
 
   const allCount = allDeprecations.length;
 

--- a/x-pack/legacy/plugins/upgrade_assistant/public/components/tabs/overview/steps.tsx
+++ b/x-pack/legacy/plugins/upgrade_assistant/public/components/tabs/overview/steps.tsx
@@ -92,17 +92,13 @@ const START_UPGRADE_STEP = {
   ),
 };
 
-export const StepsUI: StatelessComponent<
-  UpgradeAssistantTabProps & ReactIntl.InjectedIntlProps
-> = ({ checkupData, setSelectedTabIndex, intl }) => {
+export const StepsUI: StatelessComponent<UpgradeAssistantTabProps &
+  ReactIntl.InjectedIntlProps> = ({ checkupData, setSelectedTabIndex, intl }) => {
   const checkupDataTyped = (checkupData! as unknown) as { [checkupType: string]: any[] };
-  const countByType = Object.keys(checkupDataTyped).reduce(
-    (counts, checkupType) => {
-      counts[checkupType] = checkupDataTyped[checkupType].length;
-      return counts;
-    },
-    {} as { [checkupType: string]: number }
-  );
+  const countByType = Object.keys(checkupDataTyped).reduce((counts, checkupType) => {
+    counts[checkupType] = checkupDataTyped[checkupType].length;
+    return counts;
+  }, {} as { [checkupType: string]: number });
 
   return (
     <EuiSteps

--- a/x-pack/legacy/plugins/upgrade_assistant/server/lib/es_migration_apis.ts
+++ b/x-pack/legacy/plugins/upgrade_assistant/server/lib/es_migration_apis.ts
@@ -49,21 +49,18 @@ export async function getUpgradeAssistantStatus(
 
 // Reformats the index deprecations to an array of deprecation warnings extended with an index field.
 const getCombinedIndexInfos = (deprecations: DeprecationAPIResponse) =>
-  Object.keys(deprecations.index_settings).reduce(
-    (indexDeprecations, indexName) => {
-      return indexDeprecations.concat(
-        deprecations.index_settings[indexName].map(
-          d =>
-            ({
-              ...d,
-              index: indexName,
-              reindex: /Index created before/.test(d.message),
-            } as EnrichedDeprecationInfo)
-        )
-      );
-    },
-    [] as EnrichedDeprecationInfo[]
-  );
+  Object.keys(deprecations.index_settings).reduce((indexDeprecations, indexName) => {
+    return indexDeprecations.concat(
+      deprecations.index_settings[indexName].map(
+        d =>
+          ({
+            ...d,
+            index: indexName,
+            reindex: /Index created before/.test(d.message),
+          } as EnrichedDeprecationInfo)
+      )
+    );
+  }, [] as EnrichedDeprecationInfo[]);
 
 const getClusterDeprecations = (deprecations: DeprecationAPIResponse, isCloudEnabled: boolean) => {
   const combined = deprecations.cluster_settings

--- a/x-pack/legacy/plugins/upgrade_assistant/server/lib/reindexing/reindex_service.ts
+++ b/x-pack/legacy/plugins/upgrade_assistant/server/lib/reindexing/reindex_service.ts
@@ -393,9 +393,11 @@ export const reindexServiceFactory = (
   const switchAlias = async (reindexOp: ReindexSavedObject) => {
     const { indexName, newIndexName } = reindexOp.attributes;
 
-    const existingAliases = (await callCluster('indices.getAlias', {
-      index: indexName,
-    }))[indexName].aliases;
+    const existingAliases = (
+      await callCluster('indices.getAlias', {
+        index: indexName,
+      })
+    )[indexName].aliases;
 
     const extraAlises = Object.keys(existingAliases).map(aliasName => ({
       add: { index: newIndexName, alias: aliasName, ...existingAliases[aliasName] },

--- a/x-pack/legacy/plugins/uptime/public/components/higher_order/uptime_graphql_query.tsx
+++ b/x-pack/legacy/plugins/uptime/public/components/higher_order/uptime_graphql_query.tsx
@@ -51,14 +51,16 @@ export function withUptimeGraphQL<T, P = {}>(WrappedComponent: any, query: any) 
     const { client, implementsCustomErrorState, variables } = props;
     const fetch = () => {
       setLoading(true);
-      client.query<T>({ fetchPolicy: 'network-only', query, variables }).then(
-        (result: any) => {
-          updateState(result.loading, result.data, result.errors);
-        },
-        (result: any) => {
-          updateState(false, undefined, result.graphQLErrors);
-        }
-      );
+      client
+        .query<T>({ fetchPolicy: 'network-only', query, variables })
+        .then(
+          (result: any) => {
+            updateState(result.loading, result.data, result.errors);
+          },
+          (result: any) => {
+            updateState(false, undefined, result.graphQLErrors);
+          }
+        );
     };
     useEffect(() => {
       fetch();

--- a/x-pack/legacy/plugins/uptime/public/lib/helper/__tests__/series_has_down_values.test.ts
+++ b/x-pack/legacy/plugins/uptime/public/lib/helper/__tests__/series_has_down_values.test.ts
@@ -18,7 +18,10 @@ describe('seriesHasDownValues', () => {
 
   it('identifies that a series does not have down values', () => {
     expect(
-      seriesHasDownValues([{ timestamp: 123, down: 0, up: 0 }, { timestamp: 125, down: 0, up: 0 }])
+      seriesHasDownValues([
+        { timestamp: 123, down: 0, up: 0 },
+        { timestamp: 125, down: 0, up: 0 },
+      ])
     ).toBe(false);
   });
 });

--- a/x-pack/legacy/plugins/uptime/server/kibana.index.ts
+++ b/x-pack/legacy/plugins/uptime/server/kibana.index.ts
@@ -31,10 +31,7 @@ export interface KibanaServer extends Server {
 
 export const initServerWithKibana = (server: UptimeCoreSetup, plugins: UptimeCorePlugins) => {
   const { usageCollector, xpack } = plugins;
-  const libs = compose(
-    server,
-    plugins
-  );
+  const libs = compose(server, plugins);
   usageCollector.collectorSet.register(KibanaTelemetryAdapter.initUsageCollector(usageCollector));
   initUptimeServer(libs);
 

--- a/x-pack/legacy/plugins/uptime/server/lib/adapters/pings/elasticsearch_pings_adapter.ts
+++ b/x-pack/legacy/plugins/uptime/server/lib/adapters/pings/elasticsearch_pings_adapter.ts
@@ -166,13 +166,19 @@ export class ElasticsearchPingsAdapter implements UMPingsAdapter {
     const buckets: any[] = get(result, 'aggregations.by_id.buckets', []);
 
     // @ts-ignore TODO fix destructuring implicit any
-    return buckets.map(({ latest: { hits: { hits } } }) => {
-      const timestamp = hits[0]._source[`@timestamp`];
-      return {
-        ...hits[0]._source,
-        timestamp,
-      };
-    });
+    return buckets.map(
+      ({
+        latest: {
+          hits: { hits },
+        },
+      }) => {
+        const timestamp = hits[0]._source[`@timestamp`];
+        return {
+          ...hits[0]._source,
+          timestamp,
+        };
+      }
+    );
   }
 
   /**

--- a/x-pack/legacy/plugins/watcher/__jest__/client_integration/watch_create_threshold.test.tsx
+++ b/x-pack/legacy/plugins/watcher/__jest__/client_integration/watch_create_threshold.test.tsx
@@ -33,7 +33,11 @@ const SETTINGS = {
 };
 
 const WATCH_VISUALIZE_DATA = {
-  count: [[1559404800000, 14], [1559448000000, 196], [1559491200000, 44]],
+  count: [
+    [1559404800000, 14],
+    [1559448000000, 196],
+    [1559491200000, 44],
+  ],
 };
 
 const mockHttpClient = axios.create({ adapter: axiosXhrAdapter });

--- a/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/threshold_watch_edit.tsx
+++ b/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/threshold_watch_edit/threshold_watch_edit.tsx
@@ -320,7 +320,10 @@ export const ThresholdWatchEdit = ({ pageTitle }: { pageTitle: string }) => {
                   };
                 })}
                 onChange={async (selected: EuiComboBoxOptionProps[]) => {
-                  setWatchProperty('index', selected.map(aSelected => aSelected.value));
+                  setWatchProperty(
+                    'index',
+                    selected.map(aSelected => aSelected.value)
+                  );
                   const indices = selected.map(s => s.value as string);
 
                   // reset time field and expression fields if indices are deleted

--- a/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/watch_edit.tsx
+++ b/x-pack/legacy/plugins/watcher/public/sections/watch_edit/components/watch_edit.tsx
@@ -60,7 +60,7 @@ const watchReducer = (state: any, action: any) => {
       } else {
         return {
           ...state,
-          watch: new (Watch.getWatchTypes())[watch.type]({
+          watch: new (Watch.getWatchTypes()[watch.type])({
             ...watch,
             [property]: value,
           }),
@@ -69,7 +69,7 @@ const watchReducer = (state: any, action: any) => {
 
     case 'addAction':
       const { type, defaults } = payload;
-      const newWatch = new (Watch.getWatchTypes())[watch.type](watch);
+      const newWatch = new (Watch.getWatchTypes()[watch.type])(watch);
       newWatch.createAction(type, defaults);
       return {
         ...state,

--- a/x-pack/plugins/encrypted_saved_objects/server/crypto/index.mock.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/crypto/index.mock.ts
@@ -14,7 +14,7 @@ export const encryptedSavedObjectsServiceMock = {
   create(registrations: EncryptedSavedObjectTypeRegistration[] = []) {
     const mock: jest.Mocked<EncryptedSavedObjectsService> = new (jest.requireMock(
       './encrypted_saved_objects_service'
-    )).EncryptedSavedObjectsService();
+    ).EncryptedSavedObjectsService)();
 
     function processAttributes<T extends Record<string, any>>(
       descriptor: Pick<SavedObjectDescriptor, 'type'>,

--- a/x-pack/plugins/encrypted_saved_objects/server/saved_objects/encrypted_saved_objects_client_wrapper.test.ts
+++ b/x-pack/plugins/encrypted_saved_objects/server/saved_objects/encrypted_saved_objects_client_wrapper.test.ts
@@ -370,7 +370,12 @@ describe('#bulkUpdate', () => {
 
     mockBaseClient.bulkUpdate.mockResolvedValue(mockedResponse);
 
-    await expect(wrapper.bulkUpdate(docs.map(doc => ({ ...doc })), {})).resolves.toEqual({
+    await expect(
+      wrapper.bulkUpdate(
+        docs.map(doc => ({ ...doc })),
+        {}
+      )
+    ).resolves.toEqual({
       saved_objects: [
         {
           id: 'some-id',

--- a/x-pack/plugins/features/server/ui_capabilities_for_features.ts
+++ b/x-pack/plugins/features/server/ui_capabilities_for_features.ts
@@ -56,27 +56,21 @@ function getCapabilitiesFromFeature(feature: Feature): FeatureCapabilities {
 }
 
 function buildCapabilities(...allFeatureCapabilities: FeatureCapabilities[]): UICapabilities {
-  return allFeatureCapabilities.reduce<UICapabilities>(
-    (acc, capabilities) => {
-      const mergableCapabilities: UICapabilities = _.omit(
-        capabilities,
-        ...ELIGIBLE_FLAT_MERGE_KEYS
-      );
+  return allFeatureCapabilities.reduce<UICapabilities>((acc, capabilities) => {
+    const mergableCapabilities: UICapabilities = _.omit(capabilities, ...ELIGIBLE_FLAT_MERGE_KEYS);
 
-      const mergedFeatureCapabilities = {
-        ...mergableCapabilities,
-        ...acc,
+    const mergedFeatureCapabilities = {
+      ...mergableCapabilities,
+      ...acc,
+    };
+
+    ELIGIBLE_FLAT_MERGE_KEYS.forEach(key => {
+      mergedFeatureCapabilities[key] = {
+        ...mergedFeatureCapabilities[key],
+        ...capabilities[key],
       };
+    });
 
-      ELIGIBLE_FLAT_MERGE_KEYS.forEach(key => {
-        mergedFeatureCapabilities[key] = {
-          ...mergedFeatureCapabilities[key],
-          ...capabilities[key],
-        };
-      });
-
-      return mergedFeatureCapabilities;
-    },
-    {} as UICapabilities
-  );
+    return mergedFeatureCapabilities;
+  }, {} as UICapabilities);
 }

--- a/x-pack/plugins/licensing/server/__fixtures__/setup.ts
+++ b/x-pack/plugins/licensing/server/__fixtures__/setup.ts
@@ -99,12 +99,7 @@ export async function setup(xpackInfo = {}, pluginInitializerContext: any = {}) 
   clusterClient.callAsInternalUser.mockResolvedValueOnce(licenseMerge(xpackInfo));
 
   const { license$ } = await plugin.setup(coreSetup);
-  const license = await license$
-    .pipe(
-      skip(1),
-      take(1)
-    )
-    .toPromise();
+  const license = await license$.pipe(skip(1), take(1)).toPromise();
 
   return {
     plugin,

--- a/x-pack/plugins/licensing/server/plugin.test.ts
+++ b/x-pack/plugins/licensing/server/plugin.test.ts
@@ -30,12 +30,7 @@ describe('licensing plugin', () => {
     clusterClient.callAsInternalUser.mockRejectedValue(new Error('test'));
 
     const { license$ } = await plugin.setup(coreSetup);
-    const finalLicense = await license$
-      .pipe(
-        skip(1),
-        take(1)
-      )
-      .toPromise();
+    const finalLicense = await license$.pipe(skip(1), take(1)).toPromise();
 
     expect(finalLicense).toBeInstanceOf(License);
   });

--- a/x-pack/plugins/security/public/session/unauthorized_response_http_interceptor.test.ts
+++ b/x-pack/plugins/security/public/session/unauthorized_response_http_interceptor.test.ts
@@ -42,7 +42,10 @@ it(`logs out 401 responses`, async () => {
 
   let fetchResolved = false;
   let fetchRejected = false;
-  http.fetch('/foo-api').then(() => (fetchResolved = true), () => (fetchRejected = true));
+  http.fetch('/foo-api').then(
+    () => (fetchResolved = true),
+    () => (fetchRejected = true)
+  );
 
   await logoutPromise;
   await drainPromiseQueue();

--- a/x-pack/plugins/security/server/authentication/api_keys.test.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys.test.ts
@@ -24,9 +24,9 @@ describe('API Keys', () => {
   beforeEach(() => {
     mockClusterClient = elasticsearchServiceMock.createClusterClient();
     mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    mockClusterClient.asScoped.mockReturnValue((mockScopedClusterClient as unknown) as jest.Mocked<
-      IScopedClusterClient
-    >);
+    mockClusterClient.asScoped.mockReturnValue(
+      (mockScopedClusterClient as unknown) as jest.Mocked<IScopedClusterClient>
+    );
 
     mockLicense = licenseMock.create();
     mockLicense.isEnabled.mockReturnValue(true);

--- a/x-pack/plugins/security/server/authentication/providers/kerberos.ts
+++ b/x-pack/plugins/security/server/authentication/providers/kerberos.ts
@@ -54,7 +54,8 @@ export class KerberosAuthenticationProvider extends BaseAuthenticationProvider {
     const authenticationScheme = getRequestAuthenticationScheme(request);
     if (
       authenticationScheme &&
-      (authenticationScheme !== 'negotiate' && authenticationScheme !== 'bearer')
+      authenticationScheme !== 'negotiate' &&
+      authenticationScheme !== 'bearer'
     ) {
       this.logger.debug(`Unsupported authentication scheme: ${authenticationScheme}`);
       return AuthenticationResult.notHandled();

--- a/x-pack/plugins/security/server/authentication/providers/oidc.ts
+++ b/x-pack/plugins/security/server/authentication/providers/oidc.ts
@@ -250,7 +250,9 @@ export class OIDCAuthenticationProvider extends BaseAuthenticationProvider {
       // user usually doesn't have `cluster:admin/xpack/security/oidc/prepare`.
       const { state, nonce, redirect } = await this.options.client.callAsInternalUser(
         'shield.oidcPrepare',
-        { body: oidcPrepareParams }
+        {
+          body: oidcPrepareParams,
+        }
       );
 
       this.logger.debug('Redirecting to OpenID Connect Provider with authentication request.');

--- a/x-pack/plugins/security/server/authentication/providers/pki.ts
+++ b/x-pack/plugins/security/server/authentication/providers/pki.ts
@@ -214,9 +214,11 @@ export class PKIAuthenticationProvider extends BaseAuthenticationProvider {
     const certificateChain = this.getCertificateChain(peerCertificate);
     let accessToken: string;
     try {
-      accessToken = (await this.options.client.callAsInternalUser('shield.delegatePKI', {
-        body: { x509_certificate_chain: certificateChain },
-      })).access_token;
+      accessToken = (
+        await this.options.client.callAsInternalUser('shield.delegatePKI', {
+          body: { x509_certificate_chain: certificateChain },
+        })
+      ).access_token;
     } catch (err) {
       this.logger.debug(
         `Failed to exchange peer certificate chain to an access token: ${err.message}`

--- a/x-pack/plugins/security/server/authentication/providers/saml.ts
+++ b/x-pack/plugins/security/server/authentication/providers/saml.ts
@@ -502,7 +502,9 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
       // user usually doesn't have `cluster:admin/xpack/security/saml/prepare`.
       const { id: requestId, redirect } = await this.options.client.callAsInternalUser(
         'shield.samlPrepare',
-        { body: { realm: this.realm } }
+        {
+          body: { realm: this.realm },
+        }
       );
 
       this.logger.debug('Redirecting to Identity Provider with SAML request.');

--- a/x-pack/plugins/security/server/authentication/tokens.ts
+++ b/x-pack/plugins/security/server/authentication/tokens.ts
@@ -96,10 +96,11 @@ export class Tokens {
     if (refreshToken) {
       let invalidatedTokensCount;
       try {
-        invalidatedTokensCount = (await this.options.client.callAsInternalUser(
-          'shield.deleteAccessToken',
-          { body: { refresh_token: refreshToken } }
-        )).invalidated_tokens;
+        invalidatedTokensCount = (
+          await this.options.client.callAsInternalUser('shield.deleteAccessToken', {
+            body: { refresh_token: refreshToken },
+          })
+        ).invalidated_tokens;
       } catch (err) {
         this.logger.debug(`Failed to invalidate refresh token: ${err.message}`);
         // We don't re-throw the error here to have a chance to invalidate access token if it's provided.
@@ -120,10 +121,11 @@ export class Tokens {
     if (accessToken) {
       let invalidatedTokensCount;
       try {
-        invalidatedTokensCount = (await this.options.client.callAsInternalUser(
-          'shield.deleteAccessToken',
-          { body: { token: accessToken } }
-        )).invalidated_tokens;
+        invalidatedTokensCount = (
+          await this.options.client.callAsInternalUser('shield.deleteAccessToken', {
+            body: { token: accessToken },
+          })
+        ).invalidated_tokens;
       } catch (err) {
         this.logger.debug(`Failed to invalidate access token: ${err.message}`);
         invalidationError = err;

--- a/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/management.ts
+++ b/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/management.ts
@@ -15,11 +15,8 @@ export class FeaturePrivilegeManagementBuilder extends BaseFeaturePrivilegeBuild
       return [];
     }
 
-    return Object.entries(managementSections).reduce(
-      (acc, [sectionId, items]) => {
-        return [...acc, ...items.map(item => this.actions.ui.get('management', sectionId, item))];
-      },
-      [] as string[]
-    );
+    return Object.entries(managementSections).reduce((acc, [sectionId, items]) => {
+      return [...acc, ...items.map(item => this.actions.ui.get('management', sectionId, item))];
+    }, [] as string[]);
   }
 }

--- a/x-pack/plugins/security/server/authorization/privileges_serializer.ts
+++ b/x-pack/plugins/security/server/authorization/privileges_serializer.ts
@@ -28,64 +28,52 @@ export const serializePrivileges = (
 ): SerializedPrivileges => {
   return {
     [application]: {
-      ...Object.entries(privilegeMap.global).reduce(
-        (acc, [privilegeName, privilegeActions]) => {
-          const name = PrivilegeSerializer.serializeGlobalBasePrivilege(privilegeName);
-          acc[name] = {
-            application,
-            name: privilegeName,
-            actions: privilegeActions,
-            metadata: {},
-          };
-          return acc;
-        },
-        {} as Record<string, any>
-      ),
-      ...Object.entries(privilegeMap.space).reduce(
-        (acc, [privilegeName, privilegeActions]) => {
-          const name = PrivilegeSerializer.serializeSpaceBasePrivilege(privilegeName);
+      ...Object.entries(privilegeMap.global).reduce((acc, [privilegeName, privilegeActions]) => {
+        const name = PrivilegeSerializer.serializeGlobalBasePrivilege(privilegeName);
+        acc[name] = {
+          application,
+          name: privilegeName,
+          actions: privilegeActions,
+          metadata: {},
+        };
+        return acc;
+      }, {} as Record<string, any>),
+      ...Object.entries(privilegeMap.space).reduce((acc, [privilegeName, privilegeActions]) => {
+        const name = PrivilegeSerializer.serializeSpaceBasePrivilege(privilegeName);
+        acc[name] = {
+          application,
+          name,
+          actions: privilegeActions,
+          metadata: {},
+        };
+        return acc;
+      }, {} as Record<string, any>),
+      ...Object.entries(privilegeMap.features).reduce((acc, [featureName, featurePrivileges]) => {
+        Object.entries(featurePrivileges).forEach(([privilegeName, privilegeActions]) => {
+          const name = PrivilegeSerializer.serializeFeaturePrivilege(featureName, privilegeName);
+          if (Object.keys(acc).includes(name)) {
+            throw new Error(`Detected duplicate feature privilege name: ${name}`);
+          }
           acc[name] = {
             application,
             name,
             actions: privilegeActions,
             metadata: {},
           };
-          return acc;
-        },
-        {} as Record<string, any>
-      ),
-      ...Object.entries(privilegeMap.features).reduce(
-        (acc, [featureName, featurePrivileges]) => {
-          Object.entries(featurePrivileges).forEach(([privilegeName, privilegeActions]) => {
-            const name = PrivilegeSerializer.serializeFeaturePrivilege(featureName, privilegeName);
-            if (Object.keys(acc).includes(name)) {
-              throw new Error(`Detected duplicate feature privilege name: ${name}`);
-            }
-            acc[name] = {
-              application,
-              name,
-              actions: privilegeActions,
-              metadata: {},
-            };
-          });
+        });
 
-          return acc;
-        },
-        {} as Record<string, any>
-      ),
-      ...Object.entries(privilegeMap.reserved).reduce(
-        (acc, [privilegeName, privilegeActions]) => {
-          const name = PrivilegeSerializer.serializeReservedPrivilege(privilegeName);
-          acc[name] = {
-            application,
-            name,
-            actions: privilegeActions,
-            metadata: {},
-          };
-          return acc;
-        },
-        {} as Record<string, any>
-      ),
+        return acc;
+      }, {} as Record<string, any>),
+      ...Object.entries(privilegeMap.reserved).reduce((acc, [privilegeName, privilegeActions]) => {
+        const name = PrivilegeSerializer.serializeReservedPrivilege(privilegeName);
+        acc[name] = {
+          application,
+          name,
+          actions: privilegeActions,
+          metadata: {},
+        };
+        return acc;
+      }, {} as Record<string, any>),
     },
   };
 };

--- a/x-pack/plugins/security/server/routes/authorization/roles/model/elasticsearch_role.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/model/elasticsearch_role.ts
@@ -208,19 +208,16 @@ function transformRoleApplicationsToKibanaPrivileges(
           base: basePrivileges.map(privilege =>
             PrivilegeSerializer.serializeGlobalBasePrivilege(privilege)
           ),
-          feature: featurePrivileges.reduce(
-            (acc, privilege) => {
-              const featurePrivilege = PrivilegeSerializer.deserializeFeaturePrivilege(privilege);
-              return {
-                ...acc,
-                [featurePrivilege.featureId]: getUniqueList([
-                  ...(acc[featurePrivilege.featureId] || []),
-                  featurePrivilege.privilege,
-                ]),
-              };
-            },
-            {} as RoleKibanaPrivilege['feature']
-          ),
+          feature: featurePrivileges.reduce((acc, privilege) => {
+            const featurePrivilege = PrivilegeSerializer.deserializeFeaturePrivilege(privilege);
+            return {
+              ...acc,
+              [featurePrivilege.featureId]: getUniqueList([
+                ...(acc[featurePrivilege.featureId] || []),
+                featurePrivilege.privilege,
+              ]),
+            };
+          }, {} as RoleKibanaPrivilege['feature']),
           spaces: ['*'],
         };
       }
@@ -235,19 +232,16 @@ function transformRoleApplicationsToKibanaPrivileges(
         base: basePrivileges.map(privilege =>
           PrivilegeSerializer.deserializeSpaceBasePrivilege(privilege)
         ),
-        feature: featurePrivileges.reduce(
-          (acc, privilege) => {
-            const featurePrivilege = PrivilegeSerializer.deserializeFeaturePrivilege(privilege);
-            return {
-              ...acc,
-              [featurePrivilege.featureId]: getUniqueList([
-                ...(acc[featurePrivilege.featureId] || []),
-                featurePrivilege.privilege,
-              ]),
-            };
-          },
-          {} as RoleKibanaPrivilege['feature']
-        ),
+        feature: featurePrivileges.reduce((acc, privilege) => {
+          const featurePrivilege = PrivilegeSerializer.deserializeFeaturePrivilege(privilege);
+          return {
+            ...acc,
+            [featurePrivilege.featureId]: getUniqueList([
+              ...(acc[featurePrivilege.featureId] || []),
+              featurePrivilege.privilege,
+            ]),
+          };
+        }, {} as RoleKibanaPrivilege['feature']),
         spaces: resources.map(resource => ResourceSerializer.deserializeSpaceResource(resource)),
       };
     }),

--- a/x-pack/plugins/security/server/saved_objects/secure_saved_objects_client_wrapper.test.ts
+++ b/x-pack/plugins/security/server/saved_objects/secure_saved_objects_client_wrapper.test.ts
@@ -171,7 +171,10 @@ describe(`spaces disabled`, () => {
 
       const client = new SecureSavedObjectsClientWrapper(options);
 
-      const objects = [{ type: type1, attributes: {} }, { type: type2, attributes: {} }];
+      const objects = [
+        { type: type1, attributes: {} },
+        { type: type2, attributes: {} },
+      ];
       const apiCallOptions = Object.freeze({ namespace: 'some-ns' });
       await expect(client.bulkCreate(objects, apiCallOptions)).rejects.toThrowError(
         options.forbiddenError
@@ -483,7 +486,10 @@ describe(`spaces disabled`, () => {
 
       const client = new SecureSavedObjectsClientWrapper(options);
 
-      const objects = [{ type: type1, id: `bar-${type1}` }, { type: type2, id: `bar-${type2}` }];
+      const objects = [
+        { type: type1, id: `bar-${type1}` },
+        { type: type2, id: `bar-${type2}` },
+      ];
       const apiCallOptions = Object.freeze({ namespace: 'some-ns' });
       await expect(client.bulkGet(objects, apiCallOptions)).rejects.toThrowError(
         options.forbiddenError
@@ -526,7 +532,10 @@ describe(`spaces disabled`, () => {
 
       const client = new SecureSavedObjectsClientWrapper(options);
 
-      const objects = [{ type: type1, id: `id-${type1}` }, { type: type2, id: `id-${type2}` }];
+      const objects = [
+        { type: type1, id: `id-${type1}` },
+        { type: type2, id: `id-${type2}` },
+      ];
       const apiCallOptions = Object.freeze({ namespace: 'some-ns' });
       await expect(client.bulkGet(objects, apiCallOptions)).resolves.toBe(apiCallReturnValue);
 

--- a/x-pack/plugins/spaces/server/routes/api/external/copy_to_space.test.ts
+++ b/x-pack/plugins/spaces/server/routes/api/external/copy_to_space.test.ts
@@ -172,7 +172,10 @@ describe('copy to space', () => {
     it(`requires objects to be unique`, async () => {
       const payload = {
         spaces: ['a-space'],
-        objects: [{ type: 'foo', id: 'bar' }, { type: 'foo', id: 'bar' }],
+        objects: [
+          { type: 'foo', id: 'bar' },
+          { type: 'foo', id: 'bar' },
+        ],
       };
 
       const { copyToSpace } = await setup();
@@ -185,7 +188,10 @@ describe('copy to space', () => {
     it('does not allow namespace agnostic types to be copied (via "supportedTypes" property)', async () => {
       const payload = {
         spaces: ['a-space'],
-        objects: [{ type: 'globalType', id: 'bar' }, { type: 'visualization', id: 'bar' }],
+        objects: [
+          { type: 'globalType', id: 'bar' },
+          { type: 'visualization', id: 'bar' },
+        ],
       };
 
       const { copyToSpace, legacyAPI } = await setup();
@@ -307,7 +313,10 @@ describe('copy to space', () => {
     it(`requires objects to be unique`, async () => {
       const payload = {
         retries: {},
-        objects: [{ type: 'foo', id: 'bar' }, { type: 'foo', id: 'bar' }],
+        objects: [
+          { type: 'foo', id: 'bar' },
+          { type: 'foo', id: 'bar' },
+        ],
       };
 
       const { resolveConflicts } = await setup();

--- a/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/alerts.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/tests/alerting/alerts.ts
@@ -90,10 +90,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
             case 'superuser at space1':
             case 'space_1_all at space1':
               expect(response.statusCode).to.eql(200);
-              const alertTestRecord = (await esTestIndexTool.waitForDocs(
-                'alert:test.always-firing',
-                reference
-              ))[0];
+              const alertTestRecord = (
+                await esTestIndexTool.waitForDocs('alert:test.always-firing', reference)
+              )[0];
               expect(alertTestRecord._source).to.eql({
                 source: 'alert:test.always-firing',
                 reference,
@@ -103,10 +102,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
                   reference,
                 },
               });
-              const actionTestRecord = (await esTestIndexTool.waitForDocs(
-                'action:test.index-record',
-                reference
-              ))[0];
+              const actionTestRecord = (
+                await esTestIndexTool.waitForDocs('action:test.index-record', reference)
+              )[0];
               expect(actionTestRecord._source).to.eql({
                 config: {
                   unencrypted: `This value shouldn't get encrypted`,
@@ -265,10 +263,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space1':
               expect(response.statusCode).to.eql(200);
               objectRemover.add(space.id, response.body.id, 'alert');
-              alertTestRecord = (await esTestIndexTool.waitForDocs(
-                'alert:test.authorization',
-                reference
-              ))[0];
+              alertTestRecord = (
+                await esTestIndexTool.waitForDocs('alert:test.authorization', reference)
+              )[0];
               expect(alertTestRecord._source.state).to.eql({
                 callClusterSuccess: false,
                 savedObjectsClientSuccess: false,
@@ -288,10 +285,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
             case 'superuser at space1':
               expect(response.statusCode).to.eql(200);
               objectRemover.add(space.id, response.body.id, 'alert');
-              alertTestRecord = (await esTestIndexTool.waitForDocs(
-                'alert:test.authorization',
-                reference
-              ))[0];
+              alertTestRecord = (
+                await esTestIndexTool.waitForDocs('alert:test.authorization', reference)
+              )[0];
               expect(alertTestRecord._source.state).to.eql({
                 callClusterSuccess: true,
                 savedObjectsClientSuccess: false,
@@ -362,10 +358,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
             case 'space_1_all at space1':
               expect(response.statusCode).to.eql(200);
               objectRemover.add(space.id, response.body.id, 'alert');
-              actionTestRecord = (await esTestIndexTool.waitForDocs(
-                'action:test.authorization',
-                reference
-              ))[0];
+              actionTestRecord = (
+                await esTestIndexTool.waitForDocs('action:test.authorization', reference)
+              )[0];
               expect(actionTestRecord._source.state).to.eql({
                 callClusterSuccess: false,
                 savedObjectsClientSuccess: false,
@@ -385,10 +380,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
             case 'superuser at space1':
               expect(response.statusCode).to.eql(200);
               objectRemover.add(space.id, response.body.id, 'alert');
-              actionTestRecord = (await esTestIndexTool.waitForDocs(
-                'action:test.authorization',
-                reference
-              ))[0];
+              actionTestRecord = (
+                await esTestIndexTool.waitForDocs('action:test.authorization', reference)
+              )[0];
               expect(actionTestRecord._source.state).to.eql({
                 callClusterSuccess: true,
                 savedObjectsClientSuccess: false,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/alerts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/alerts.ts
@@ -68,10 +68,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
       const response = await alertUtils.createAlwaysFiringAction({ reference });
 
       expect(response.statusCode).to.eql(200);
-      const alertTestRecord = (await esTestIndexTool.waitForDocs(
-        'alert:test.always-firing',
-        reference
-      ))[0];
+      const alertTestRecord = (
+        await esTestIndexTool.waitForDocs('alert:test.always-firing', reference)
+      )[0];
       expect(alertTestRecord._source).to.eql({
         source: 'alert:test.always-firing',
         reference,
@@ -81,10 +80,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
           reference,
         },
       });
-      const actionTestRecord = (await esTestIndexTool.waitForDocs(
-        'action:test.index-record',
-        reference
-      ))[0];
+      const actionTestRecord = (
+        await esTestIndexTool.waitForDocs('action:test.index-record', reference)
+      )[0];
       expect(actionTestRecord._source).to.eql({
         config: {
           unencrypted: `This value shouldn't get encrypted`,
@@ -207,10 +205,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
 
       expect(response.statusCode).to.eql(200);
       objectRemover.add(Spaces.space1.id, response.body.id, 'alert');
-      const alertTestRecord = (await esTestIndexTool.waitForDocs(
-        'alert:test.authorization',
-        reference
-      ))[0];
+      const alertTestRecord = (
+        await esTestIndexTool.waitForDocs('alert:test.authorization', reference)
+      )[0];
       expect(alertTestRecord._source.state).to.eql({
         callClusterSuccess: true,
         savedObjectsClientSuccess: false,
@@ -263,10 +260,9 @@ export default function alertTests({ getService }: FtrProviderContext) {
 
       expect(response.statusCode).to.eql(200);
       objectRemover.add(Spaces.space1.id, response.body.id, 'alert');
-      const actionTestRecord = (await esTestIndexTool.waitForDocs(
-        'action:test.authorization',
-        reference
-      ))[0];
+      const actionTestRecord = (
+        await esTestIndexTool.waitForDocs('action:test.authorization', reference)
+      )[0];
       expect(actionTestRecord._source.state).to.eql({
         callClusterSuccess: true,
         savedObjectsClientSuccess: false,

--- a/x-pack/test/functional/services/infra_source_configuration_form.ts
+++ b/x-pack/test/functional/services/infra_source_configuration_form.ts
@@ -38,10 +38,12 @@ export function InfraSourceConfigurationFormProvider({ getService }: FtrProvider
     async addTimestampLogColumn() {
       await (await this.getAddLogColumnButton()).click();
       await retry.try(async () => {
-        await (await testSubjects.findDescendant(
-          '~addTimestampLogColumn',
-          await this.getAddLogColumnPopover()
-        )).click();
+        await (
+          await testSubjects.findDescendant(
+            '~addTimestampLogColumn',
+            await this.getAddLogColumnPopover()
+          )
+        ).click();
       });
     },
     async addFieldLogColumn(fieldName: string) {
@@ -49,10 +51,9 @@ export function InfraSourceConfigurationFormProvider({ getService }: FtrProvider
       await retry.try(async () => {
         const popover = await this.getAddLogColumnPopover();
         await (await testSubjects.findDescendant('~fieldSearchInput', popover)).type(fieldName);
-        await (await testSubjects.findDescendant(
-          `~addFieldLogColumn:${fieldName}`,
-          popover
-        )).click();
+        await (
+          await testSubjects.findDescendant(`~addFieldLogColumn:${fieldName}`, popover)
+        ).click();
       });
     },
     async getLogColumnPanels(): Promise<WebElementWrapper[]> {
@@ -98,10 +99,9 @@ export function InfraSourceConfigurationFormProvider({ getService }: FtrProvider
       return await testSubjects.find('~sourceConfigurationContent');
     },
     async saveConfiguration() {
-      await (await testSubjects.findDescendant(
-        '~applySettingsButton',
-        await this.getForm()
-      )).click();
+      await (
+        await testSubjects.findDescendant('~applySettingsButton', await this.getForm())
+      ).click();
 
       await retry.try(async () => {
         const element = await testSubjects.findDescendant(

--- a/x-pack/test/plugin_api_integration/test_suites/encrypted_saved_objects/encrypted_saved_objects_api.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/encrypted_saved_objects/encrypted_saved_objects_api.ts
@@ -252,7 +252,10 @@ export default function({ getService }: FtrProviderContext) {
     });
 
     describe('within a default space', () => {
-      runTests(() => '/api/saved_objects/', id => `${SAVED_OBJECT_WITH_SECRET_TYPE}:${id}`);
+      runTests(
+        () => '/api/saved_objects/',
+        id => `${SAVED_OBJECT_WITH_SECRET_TYPE}:${id}`
+      );
     });
 
     describe('within a custom space', () => {

--- a/x-pack/test/spaces_api_integration/common/suites/copy_to_space.ts
+++ b/x-pack/test/spaces_api_integration/common/suites/copy_to_space.ts
@@ -139,19 +139,16 @@ export function copyToSpaceTestSuiteFactory(
     }
 
     const { countByType } = spaceBucket;
-    const expectedBuckets = Object.entries(expectedCounts).reduce(
-      (acc, entry) => {
-        const [type, count] = entry;
-        return [
-          ...acc,
-          {
-            key: type,
-            doc_count: count,
-          },
-        ];
-      },
-      [] as CountByTypeBucket[]
-    );
+    const expectedBuckets = Object.entries(expectedCounts).reduce((acc, entry) => {
+      const [type, count] = entry;
+      return [
+        ...acc,
+        {
+          key: type,
+          doc_count: count,
+        },
+      ];
+    }, [] as CountByTypeBucket[]);
 
     expectedBuckets.sort(bucketSorter);
     countByType.buckets.sort(bucketSorter);

--- a/x-pack/test_utils/testbed/mount_component.tsx
+++ b/x-pack/test_utils/testbed/mount_component.tsx
@@ -31,9 +31,10 @@ const getCompFromConfig = ({ Component, memoryRouter, store, onRouter }: Config)
     const { componentRoutePath, initialEntries, initialIndex } = memoryRouter!;
 
     // Wrap the componenet with a MemoryRouter and attach it to a react-router <Route />
-    Comp = WithMemoryRouter(initialEntries, initialIndex)(
-      WithRoute(componentRoutePath, onRouter)(Comp)
-    );
+    Comp = WithMemoryRouter(
+      initialEntries,
+      initialIndex
+    )(WithRoute(componentRoutePath, onRouter)(Comp));
   }
 
   return Comp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -21805,10 +21805,10 @@ prettier@1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Summary

This PR updates Prettier to 1.19, which is required for the TypeScript 3.7 upgrade. Due to some [changed heuristics](https://prettier.io/blog/2019/11/09/1.19.0.html) a couple of formatting now needs to look different.

I plainly did a `node scripts/eslint.js --fix` on the repo, so this PR should not change ANY logic at all.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~
- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
- ~[ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~

