### PR TITLE
[Lens] Refactor: remove id generation from visualizations

### DIFF
--- a/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.test.tsx
@@ -13,9 +13,6 @@ import {
 } from './visualization';
 import { mount } from 'enzyme';
 import { Operation, DataType, FramePublicAPI, TableSuggestionColumn } from '../types';
-import { generateId } from '../id_generator';
-
-jest.mock('../id_generator');
 
 function mockFrame(): FramePublicAPI {
   return {
@@ -34,12 +31,11 @@ function mockFrame(): FramePublicAPI {
 describe('Datatable Visualization', () => {
   describe('#initialize', () => {
     it('should initialize from the empty state', () => {
-      (generateId as jest.Mock).mockReturnValueOnce('id');
       expect(datatableVisualization.initialize(mockFrame(), undefined)).toEqual({
         layers: [
           {
             layerId: 'aaa',
-            columns: ['id'],
+            columns: [],
           },
         ],
       });
@@ -250,7 +246,6 @@ describe('Datatable Visualization', () => {
     });
 
     it('allows columns to be added', () => {
-      (generateId as jest.Mock).mockReturnValueOnce('d');
       const setState = jest.fn();
       const datasource = createMockDatasource();
       const layer = { layerId: 'a', columns: ['b', 'c'] };
@@ -269,9 +264,9 @@ describe('Datatable Visualization', () => {
       const onAdd = component
         .find('[data-test-subj="datatable_multicolumnEditor"]')
         .first()
-        .prop('onAdd') as () => {};
+        .prop('onAdd') as (s: string) => {};
 
-      onAdd();
+      onAdd('d');
 
       expect(setState).toHaveBeenCalledWith({
         layers: [

--- a/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.tsx
+++ b/x-pack/legacy/plugins/lens/public/datatable_visualization_plugin/visualization.tsx
@@ -17,7 +17,6 @@ import {
   VisualizationSuggestion,
   Operation,
 } from '../types';
-import { generateId } from '../id_generator';
 import { NativeRenderer } from '../native_renderer';
 import chartTableSVG from '../assets/chart_datatable.svg';
 
@@ -33,7 +32,7 @@ export interface DatatableVisualizationState {
 function newLayerState(layerId: string): LayerState {
   return {
     layerId,
-    columns: [generateId()],
+    columns: [],
   };
 }
 
@@ -81,7 +80,7 @@ export function DataTableLayer({
           dragDropContext={dragDropContext}
           filterOperations={allOperations}
           layerId={layer.layerId}
-          onAdd={() => setState(updateColumns(state, layer, columns => [...columns, generateId()]))}
+          onAdd={column => setState(updateColumns(state, layer, columns => [...columns, column]))}
           onRemove={column =>
             setState(updateColumns(state, layer, columns => columns.filter(c => c !== column)))
           }

--- a/x-pack/legacy/plugins/lens/public/dimension_panel/dimension_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/dimension_panel/dimension_panel.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { DatasourcePublicAPI, DatasourceDimensionPanelProps } from '../types';
+import { NativeRenderer } from '../native_renderer';
+
+interface Props extends DatasourceDimensionPanelProps {
+  datasource: DatasourcePublicAPI;
+  'data-test-subj'?: string;
+}
+
+export function DimensionPanel({ datasource, ...props }: Props) {
+  return (
+    <NativeRenderer
+      data-test-subj={props['data-test-subj']}
+      render={datasource.renderDimensionPanel}
+      nativeProps={props}
+    />
+  );
+}

--- a/x-pack/legacy/plugins/lens/public/dimension_panel/index.ts
+++ b/x-pack/legacy/plugins/lens/public/dimension_panel/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export * from './dimension_panel';

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.test.tsx
@@ -139,6 +139,8 @@ describe('IndexPatternDimensionPanel', () => {
       uiSettings: {} as UiSettingsClientContract,
       savedObjectsClient: {} as SavedObjectsClientContract,
       http: {} as HttpServiceBase,
+      onRemove: jest.fn(),
+      onCreate: jest.fn(),
     };
 
     jest.clearAllMocks();
@@ -956,15 +958,17 @@ describe('IndexPatternDimensionPanel', () => {
         .prop('onClick')!({} as React.MouseEvent<{}, MouseEvent>);
     });
 
-    expect(changeColumn).toHaveBeenCalledWith({
-      state: initialState,
-      columnId: 'col1',
-      layerId: 'first',
-      newColumn: expect.objectContaining({
-        sourceField: 'bytes',
-        operationType: 'min',
-      }),
-    });
+    expect(changeColumn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: initialState,
+        columnId: 'col1',
+        layerId: 'first',
+        newColumn: expect.objectContaining({
+          sourceField: 'bytes',
+          operationType: 'min',
+        }),
+      })
+    );
   });
 
   it('should clear the dimension with the clear button', () => {

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/dimension_panel.tsx
@@ -44,9 +44,9 @@ export interface OperationFieldSupportMatrix {
 }
 
 export const IndexPatternDimensionPanel = memo(function IndexPatternDimensionPanel(
-  props: IndexPatternDimensionPanelProps
+  props: IndexPatternDimensionPanelProps & { columnId: string }
 ) {
-  const layerId = props.layerId;
+  const { layerId, onCreate } = props;
   const currentIndexPattern = props.state.indexPatterns[props.state.layers[layerId].indexPatternId];
 
   const operationFieldSupportMatrix = useMemo(() => {
@@ -142,8 +142,9 @@ export const IndexPatternDimensionPanel = memo(function IndexPatternDimensionPan
             changeColumn({
               state: props.state,
               layerId,
-              columnId: props.columnId,
+              onCreate,
               newColumn,
+              columnId: props.columnId,
               // If the field has changed, the onFieldChange method needs to take care of everything including moving
               // over params. If we create a new column above we want changeColumn to move over params.
               keepParams: !hasFieldChanged,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/dimension_panel/popover_editor.tsx
@@ -57,7 +57,7 @@ function asOperationOptions(operationTypes: OperationType[], compatibleWithCurre
     }));
 }
 
-export function PopoverEditor(props: PopoverEditorProps) {
+export function PopoverEditor(props: PopoverEditorProps & { columnId: string }) {
   const {
     selectedColumn,
     operationFieldSupportMatrix,
@@ -68,6 +68,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
     currentIndexPattern,
     uniqueLabel,
     hideGrouping,
+    onCreate,
   } = props;
   const { operationByField, fieldByOperation } = operationFieldSupportMatrix;
   const [isPopoverOpen, setPopoverOpen] = useState(false);
@@ -136,6 +137,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
                     state,
                     layerId,
                     columnId,
+                    onCreate,
                     newColumn: buildColumn({
                       columns: props.state.layers[props.layerId].columns,
                       suggestedPriority: props.suggestedPriority,
@@ -180,6 +182,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
                 layerId,
                 columnId,
                 newColumn,
+                onCreate,
               })
             );
           },
@@ -308,6 +311,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
                     columnId,
                     newColumn: column,
                     keepParams: false,
+                    onCreate,
                   })
                 );
                 setInvalidOperationType(null);
@@ -376,6 +380,7 @@ export function PopoverEditor(props: PopoverEditorProps) {
                             state,
                             layerId,
                             columnId,
+                            onCreate,
                             newColumn: {
                               ...selectedColumn,
                               label: e.target.value,

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/indexpattern.tsx
@@ -240,6 +240,7 @@ export function getIndexPatternDatasource({
                   http={core.http}
                   uniqueLabel={columnLabelMap[props.columnId]}
                   dateRange={dateRange}
+                  columnId={props.columnId}
                   {...props}
                 />
               </KibanaContextProvider>

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/state_helpers.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/state_helpers.test.ts
@@ -220,6 +220,7 @@ describe('state_helpers', () => {
             },
             sourceField: 'timestamp',
           },
+          onCreate: jest.fn(),
         })
       ).toEqual({
         ...state,
@@ -276,6 +277,7 @@ describe('state_helpers', () => {
               interval: 'w',
             },
           },
+          onCreate: jest.fn(),
         }).layers.first.columns.col1
       ).toEqual(
         expect.objectContaining({
@@ -339,6 +341,7 @@ describe('state_helpers', () => {
         layerId: 'first',
         columnId: 'col2',
         newColumn,
+        onCreate: jest.fn(),
       });
 
       expect(operationDefinitionMap.terms.onOtherColumnChanged).toHaveBeenCalledWith(termsColumn, {

--- a/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_config_panel.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_config_panel.test.tsx
@@ -49,7 +49,7 @@ describe('MetricConfigPanel', () => {
     );
 
     const panel = testSubj(component, 'lns_metric_valueDimensionPanel');
-    const nativeProps = (panel as NativeRendererProps<DatasourceDimensionPanelProps>).nativeProps;
+    const nativeProps = panel as DatasourceDimensionPanelProps;
     const { columnId, filterOperations } = nativeProps;
     const exampleOperation: Operation = {
       dataType: 'number',

--- a/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_config_panel.tsx
+++ b/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_config_panel.tsx
@@ -8,8 +8,9 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { State } from './types';
-import { VisualizationProps, OperationMetadata } from '../types';
+import { VisualizationProps, OperationMetadata, EMPTY_ACCESSOR } from '../types';
 import { NativeRenderer } from '../native_renderer';
+import { DimensionPanel } from '../dimension_panel';
 
 const isMetric = (op: OperationMetadata) => !op.isBucketed && op.dataType === 'number';
 
@@ -30,15 +31,15 @@ export function MetricConfigPanel(props: VisualizationProps<State>) {
           defaultMessage: 'Value',
         })}
       >
-        <NativeRenderer
-          data-test-subj={'lns_metric_valueDimensionPanel'}
-          render={datasource.renderDimensionPanel}
-          nativeProps={{
-            layerId,
-            columnId: state.accessor,
-            dragDropContext: props.dragDropContext,
-            filterOperations: isMetric,
-          }}
+        <DimensionPanel
+          data-test-subj="lns_metric_valueDimensionPanel"
+          datasource={datasource}
+          layerId={layerId}
+          columnId={state.accessor}
+          dragDropContext={props.dragDropContext}
+          filterOperations={isMetric}
+          onCreate={accessor => props.setState({ ...state, accessor })}
+          onRemove={() => props.setState({ ...state, accessor: EMPTY_ACCESSOR })}
         />
       </EuiFormRow>
     </EuiPanel>

--- a/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_visualization.test.ts
+++ b/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_visualization.test.ts
@@ -7,10 +7,7 @@
 import { metricVisualization } from './metric_visualization';
 import { State } from './types';
 import { createMockDatasource, createMockFramePublicAPI } from '../editor_frame_plugin/mocks';
-import { generateId } from '../id_generator';
 import { DatasourcePublicAPI, FramePublicAPI } from '../types';
-
-jest.mock('../id_generator');
 
 function exampleState(): State {
   return {
@@ -33,13 +30,12 @@ function mockFrame(): FramePublicAPI {
 describe('metric_visualization', () => {
   describe('#initialize', () => {
     it('loads default state', () => {
-      (generateId as jest.Mock).mockReturnValueOnce('test-id1');
       const initialState = metricVisualization.initialize(mockFrame());
 
       expect(initialState.accessor).toBeDefined();
       expect(initialState).toMatchInlineSnapshot(`
                 Object {
-                  "accessor": "test-id1",
+                  "accessor": "",
                   "layerId": "l42",
                 }
             `);

--- a/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_visualization.tsx
+++ b/x-pack/legacy/plugins/lens/public/metric_visualization_plugin/metric_visualization.tsx
@@ -11,9 +11,8 @@ import { i18n } from '@kbn/i18n';
 import { Ast } from '@kbn/interpreter/target/common';
 import { getSuggestions } from './metric_suggestions';
 import { MetricConfigPanel } from './metric_config_panel';
-import { Visualization, FramePublicAPI } from '../types';
+import { Visualization, FramePublicAPI, EMPTY_ACCESSOR } from '../types';
 import { State, PersistableState } from './types';
-import { generateId } from '../id_generator';
 import chartMetricSVG from '../assets/chart_metric.svg';
 
 const toExpression = (
@@ -69,7 +68,7 @@ export const metricVisualization: Visualization<State, PersistableState> = {
     return (
       state || {
         layerId: frame.addNewLayer(),
-        accessor: generateId(),
+        accessor: EMPTY_ACCESSOR,
       }
     );
   },

--- a/x-pack/legacy/plugins/lens/public/multi_column_editor/multi_column_editor.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/multi_column_editor/multi_column_editor.test.tsx
@@ -9,14 +9,12 @@ import { createMockDatasource } from '../editor_frame_plugin/mocks';
 import { MultiColumnEditor } from './multi_column_editor';
 import { mount } from 'enzyme';
 
-jest.useFakeTimers();
-
 describe('MultiColumnEditor', () => {
-  it('should add a trailing accessor if the accessor list is empty', () => {
+  it('should not call onAdd if an existing dimension is edited', () => {
     const onAdd = jest.fn();
-    mount(
+    const component = mount(
       <MultiColumnEditor
-        accessors={[]}
+        accessors={['foo']}
         datasource={createMockDatasource().publicAPIMock}
         dragDropContext={{ dragging: undefined, setDragging: jest.fn() }}
         filterOperations={() => true}
@@ -29,14 +27,18 @@ describe('MultiColumnEditor', () => {
 
     expect(onAdd).toHaveBeenCalledTimes(0);
 
-    jest.runAllTimers();
+    const onCreate = component
+      .find('[data-test-subj="lns_multi_column_bar_foo"]')
+      .first()
+      .prop('onCreate');
+    (onCreate as () => {})();
 
-    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd).toHaveBeenCalledTimes(0);
   });
 
   it('should add a trailing accessor if the last accessor is configured', () => {
     const onAdd = jest.fn();
-    mount(
+    const component = mount(
       <MultiColumnEditor
         accessors={['baz']}
         datasource={{
@@ -64,8 +66,12 @@ describe('MultiColumnEditor', () => {
 
     expect(onAdd).toHaveBeenCalledTimes(0);
 
-    jest.runAllTimers();
+    const onCreate = component
+      .find('[data-test-subj="lns_multi_column_add_bar"]')
+      .first()
+      .prop('onCreate');
+    (onCreate as (s: string) => {})('hi');
 
-    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd).toHaveBeenCalledWith('hi');
   });
 });

--- a/x-pack/legacy/plugins/lens/public/multi_column_editor/multi_column_editor.tsx
+++ b/x-pack/legacy/plugins/lens/public/multi_column_editor/multi_column_editor.tsx
@@ -4,22 +4,24 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { useEffect } from 'react';
-import { NativeRenderer } from '../native_renderer';
+import React from 'react';
 import { DatasourcePublicAPI, OperationMetadata } from '../types';
 import { DragContextState } from '../drag_drop';
+import { DimensionPanel } from '../dimension_panel';
 
 interface Props {
   accessors: string[];
   datasource: DatasourcePublicAPI;
   dragDropContext: DragContextState;
   onRemove: (accessor: string) => void;
-  onAdd: () => void;
+  onAdd: (accessor: string) => void;
   filterOperations: (op: OperationMetadata) => boolean;
   suggestedPriority?: 0 | 1 | 2 | undefined;
   testSubj: string;
   layerId: string;
 }
+
+const noop = () => {};
 
 export function MultiColumnEditor({
   accessors,
@@ -32,32 +34,33 @@ export function MultiColumnEditor({
   testSubj,
   layerId,
 }: Props) {
-  const lastOperation = datasource.getOperationForColumnId(accessors[accessors.length - 1]);
-
-  useEffect(() => {
-    if (accessors.length === 0 || lastOperation !== null) {
-      setTimeout(onAdd);
-    }
-  }, [lastOperation]);
-
   return (
     <>
       {accessors.map(accessor => (
         <div key={accessor}>
-          <NativeRenderer
-            data-test-subj={`lnsXY_${testSubj}_${accessor}`}
-            render={datasource.renderDimensionPanel}
-            nativeProps={{
-              columnId: accessor,
-              dragDropContext,
-              filterOperations,
-              suggestedPriority,
-              layerId,
-              onRemove,
-            }}
+          <DimensionPanel
+            data-test-subj={`lns_multi_column_${testSubj}_${accessor}`}
+            datasource={datasource}
+            layerId={layerId}
+            columnId={accessor}
+            dragDropContext={dragDropContext}
+            filterOperations={filterOperations}
+            onRemove={onRemove}
+            onCreate={noop}
+            suggestedPriority={suggestedPriority}
           />
         </div>
       ))}
+      <DimensionPanel
+        data-test-subj={`lns_multi_column_add_${testSubj}`}
+        columnId={''}
+        datasource={datasource}
+        layerId={layerId}
+        dragDropContext={dragDropContext}
+        filterOperations={filterOperations}
+        onCreate={onAdd}
+        onRemove={noop}
+      />
     </>
   );
 }

--- a/x-pack/legacy/plugins/lens/public/types.ts
+++ b/x-pack/legacy/plugins/lens/public/types.ts
@@ -15,6 +15,8 @@ import { Document } from './persistence';
 import { DateRange } from '../common';
 import { esFilters } from '../../../../../src/plugins/data/public';
 
+export const EMPTY_ACCESSOR = '';
+
 // eslint-disable-next-line
 export interface EditorFrameOptions {}
 
@@ -195,7 +197,8 @@ export interface DatasourceDimensionPanelProps {
   // Visualizations can hint at the role this dimension would play, which
   // affects the default ordering of the query
   suggestedPriority?: DimensionPriority;
-  onRemove?: (accessor: string) => void;
+  onRemove: (columnId: string) => void;
+  onCreate: (columnId: string) => void;
 
   // Some dimension editors will allow users to change the operation grouping
   // from the panel, and this lets the visualization hint that it doesn't want

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_suggestions.test.ts
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_suggestions.test.ts
@@ -10,11 +10,9 @@ import {
   VisualizationSuggestion,
   DataType,
   TableSuggestion,
+  EMPTY_ACCESSOR,
 } from '../types';
 import { State, XYState } from './types';
-import { generateId } from '../id_generator';
-
-jest.mock('../id_generator');
 
 describe('xy_suggestions', () => {
   function numCol(columnId: string): TableSuggestionColumn {
@@ -107,7 +105,6 @@ describe('xy_suggestions', () => {
   });
 
   test('suggests a basic x y chart with date on x', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('aaa');
     const [suggestion, ...rest] = getSuggestions({
       table: {
         isMultiRow: true,
@@ -123,7 +120,7 @@ describe('xy_suggestions', () => {
       Array [
         Object {
           "seriesType": "bar_stacked",
-          "splitAccessor": "aaa",
+          "splitAccessor": "",
           "x": "date",
           "y": Array [
             "bytes",
@@ -240,7 +237,6 @@ describe('xy_suggestions', () => {
   });
 
   test('only makes a seriesType suggestion for unchanged table without split', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('dummyCol');
     const currentState: XYState = {
       legend: { isVisible: true, position: 'bottom' },
       preferredSeriesType: 'bar',
@@ -249,7 +245,7 @@ describe('xy_suggestions', () => {
           accessors: ['price'],
           layerId: 'first',
           seriesType: 'bar',
-          splitAccessor: 'dummyCol',
+          splitAccessor: EMPTY_ACCESSOR,
           xAccessor: 'date',
         },
       ],
@@ -316,7 +312,6 @@ describe('xy_suggestions', () => {
   });
 
   test('suggests a flipped chart for unchanged table and existing bar chart on ordinal x axis', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('dummyCol');
     const currentState: XYState = {
       legend: { isVisible: true, position: 'bottom' },
       preferredSeriesType: 'bar',
@@ -421,7 +416,6 @@ describe('xy_suggestions', () => {
   });
 
   test('overwrites column to dimension mappings if a date dimension is added', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('dummyCol');
     const currentState: XYState = {
       legend: { isVisible: true, position: 'bottom' },
       preferredSeriesType: 'bar',
@@ -460,7 +454,6 @@ describe('xy_suggestions', () => {
   });
 
   test('handles two numeric values', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('ddd');
     const [suggestion] = getSuggestions({
       table: {
         isMultiRow: true,
@@ -472,21 +465,20 @@ describe('xy_suggestions', () => {
     });
 
     expect(suggestionSubset(suggestion)).toMatchInlineSnapshot(`
-                        Array [
-                          Object {
-                            "seriesType": "bar_stacked",
-                            "splitAccessor": "ddd",
-                            "x": "quantity",
-                            "y": Array [
-                              "price",
-                            ],
-                          },
-                        ]
-                `);
+      Array [
+        Object {
+          "seriesType": "bar_stacked",
+          "splitAccessor": "",
+          "x": "quantity",
+          "y": Array [
+            "price",
+          ],
+        },
+      ]
+    `);
   });
 
   test('handles ip', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('ddd');
     const [suggestion] = getSuggestions({
       table: {
         isMultiRow: true,
@@ -509,21 +501,20 @@ describe('xy_suggestions', () => {
     });
 
     expect(suggestionSubset(suggestion)).toMatchInlineSnapshot(`
-            Array [
-              Object {
-                "seriesType": "bar_stacked",
-                "splitAccessor": "ddd",
-                "x": "myip",
-                "y": Array [
-                  "quantity",
-                ],
-              },
-            ]
-        `);
+      Array [
+        Object {
+          "seriesType": "bar_stacked",
+          "splitAccessor": "",
+          "x": "myip",
+          "y": Array [
+            "quantity",
+          ],
+        },
+      ]
+    `);
   });
 
   test('handles unbucketed suggestions', () => {
-    (generateId as jest.Mock).mockReturnValueOnce('eee');
     const [suggestion] = getSuggestions({
       table: {
         isMultiRow: true,
@@ -545,16 +536,16 @@ describe('xy_suggestions', () => {
     });
 
     expect(suggestionSubset(suggestion)).toMatchInlineSnapshot(`
-                  Array [
-                    Object {
-                      "seriesType": "bar_stacked",
-                      "splitAccessor": "eee",
-                      "x": "mybool",
-                      "y": Array [
-                        "num votes",
-                      ],
-                    },
-                  ]
-            `);
+      Array [
+        Object {
+          "seriesType": "bar_stacked",
+          "splitAccessor": "",
+          "x": "mybool",
+          "y": Array [
+            "num votes",
+          ],
+        },
+      ]
+    `);
   });
 });

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_suggestions.ts
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_suggestions.ts
@@ -13,9 +13,9 @@ import {
   TableSuggestionColumn,
   TableSuggestion,
   TableChangeType,
+  EMPTY_ACCESSOR,
 } from '../types';
 import { State, SeriesType, XYState } from './types';
-import { generateId } from '../id_generator';
 import { getIconForSeries } from './state_helpers';
 
 const columnSortOrder = {
@@ -356,7 +356,7 @@ function buildSuggestion({
     layerId,
     seriesType,
     xAccessor: xValue.columnId,
-    splitAccessor: splitBy ? splitBy.columnId : generateId(),
+    splitAccessor: splitBy ? splitBy.columnId : EMPTY_ACCESSOR,
     accessors: yValues.map(col => col.columnId),
   };
 

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_visualization.test.ts
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_visualization.test.ts
@@ -6,13 +6,10 @@
 
 import { xyVisualization } from './xy_visualization';
 import { Position } from '@elastic/charts';
-import { Operation } from '../types';
+import { Operation, EMPTY_ACCESSOR } from '../types';
 import { State, SeriesType } from './types';
 import { createMockDatasource, createMockFramePublicAPI } from '../editor_frame_plugin/mocks';
-import { generateId } from '../id_generator';
 import { Ast } from '@kbn/interpreter/target/common';
-
-jest.mock('../id_generator');
 
 function exampleState(): State {
   return {
@@ -87,31 +84,24 @@ describe('xy_visualization', () => {
 
   describe('#initialize', () => {
     it('loads default state', () => {
-      (generateId as jest.Mock)
-        .mockReturnValueOnce('test-id1')
-        .mockReturnValueOnce('test-id2')
-        .mockReturnValue('test-id3');
       const mockFrame = createMockFramePublicAPI();
       const initialState = xyVisualization.initialize(mockFrame);
 
       expect(initialState.layers).toHaveLength(1);
-      expect(initialState.layers[0].xAccessor).toBeDefined();
-      expect(initialState.layers[0].accessors[0]).toBeDefined();
-      expect(initialState.layers[0].xAccessor).not.toEqual(initialState.layers[0].accessors[0]);
+      expect(initialState.layers[0].xAccessor).toEqual(EMPTY_ACCESSOR);
+      expect(initialState.layers[0].accessors).toHaveLength(0);
 
       expect(initialState).toMatchInlineSnapshot(`
         Object {
           "layers": Array [
             Object {
-              "accessors": Array [
-                "test-id1",
-              ],
+              "accessors": Array [],
               "layerId": "",
               "position": "top",
               "seriesType": "bar_stacked",
               "showGridlines": false,
-              "splitAccessor": "test-id2",
-              "xAccessor": "test-id3",
+              "splitAccessor": "",
+              "xAccessor": "",
             },
           ],
           "legend": Object {

--- a/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_visualization.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization_plugin/xy_visualization.tsx
@@ -12,10 +12,9 @@ import { I18nProvider } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 import { getSuggestions } from './xy_suggestions';
 import { XYConfigPanel } from './xy_config_panel';
-import { Visualization } from '../types';
+import { Visualization, EMPTY_ACCESSOR } from '../types';
 import { State, PersistableState, SeriesType, visualizationTypes } from './types';
 import { toExpression, toPreviewExpression } from './to_expression';
-import { generateId } from '../id_generator';
 import chartBarStackedSVG from '../assets/chart_bar_stacked.svg';
 import chartMixedSVG from '../assets/chart_mixed_xy.svg';
 import { isHorizontalChart } from './state_helpers';
@@ -99,12 +98,12 @@ export const xyVisualization: Visualization<State, PersistableState> = {
         layers: [
           {
             layerId: frame.addNewLayer(),
-            accessors: [generateId()],
+            accessors: [],
             position: Position.Top,
             seriesType: defaultSeriesType,
             showGridlines: false,
-            splitAccessor: generateId(),
-            xAccessor: generateId(),
+            splitAccessor: EMPTY_ACCESSOR,
+            xAccessor: EMPTY_ACCESSOR,
           },
         ],
       }


### PR DESCRIPTION
This removes the need for visualizations to generate IDs for accessors. That responsibility now belongs to the datasource, and simplifies some edge cases such as the "add new Y dimension" scenario.