### PR TITLE
[APM] Set no of ticks based on available width for chart

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/StaticPlot.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/StaticPlot.js
@@ -158,12 +158,8 @@ class StaticPlot extends PureComponent {
   };
 
   render() {
-    const { width, series, tickFormatY, plotValues, noHits } = this.props;
+    const { series, tickFormatY, plotValues, noHits } = this.props;
     const { xTickValues, yTickValues } = plotValues;
-
-    // approximate number of x-axis ticks based on the width of the plot. There should by approx 1 tick per 100px
-    // d3 will determine the exact number of ticks based on the selected range
-    const xTickTotal = Math.floor(width / 100);
 
     const tickFormatX = this.props.tickFormatX || this.tickFormatXTime;
 
@@ -172,7 +168,6 @@ class StaticPlot extends PureComponent {
         <XAxis
           type="time-utc"
           tickSize={0}
-          tickTotal={xTickTotal}
           tickFormat={tickFormatX}
           tickValues={xTickValues}
         />

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/plotUtils.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/plotUtils.js
@@ -75,11 +75,15 @@ export function getPlotValues(
   const yMaxNice = yScale.domain()[1];
   const yTickValues = [0, yMaxNice / 2, yMaxNice];
 
+  // approximate number of x-axis ticks based on the width of the plot. There should by approx 1 tick per 100px
+  // d3 will determine the exact number of ticks based on the selected range
+  const xTickTotal = Math.floor(width / 100);
+
   const xTickValues = d3.time.scale
     .utc()
     .domain([xMinZone, xMaxZone])
     .range([0, width])
-    .ticks()
+    .ticks(xTickTotal)
     .map(x => {
       const time = x.getTime();
       return new Date(time + getTimezoneOffsetInMs(time));


### PR DESCRIPTION
Closes #50888.

Went for a slightly different approach then suggested, as `width` is already available in `getPlotUtils`, we can just use that to determine what to pass to `ticks()`. Might be missing something though, LMK.