### PR TITLE
[WIP] Expressions caching

### DIFF
--- a/src/plugins/data/public/search/expressions/esaggs.ts
+++ b/src/plugins/data/public/search/expressions/esaggs.ts
@@ -213,6 +213,7 @@ const handleCourierRequest = async ({
 
 export const esaggs = (): EsaggsExpressionFunctionDefinition => ({
   name,
+  noCache: true,
   type: 'kibana_datatable',
   inputTypes: ['kibana_context', 'null'],
   help: i18n.translate('data.functions.esaggs.help', {

--- a/src/plugins/expressions/common/execution/execution.test.ts
+++ b/src/plugins/expressions/common/execution/execution.test.ts
@@ -40,6 +40,7 @@ const createExecution = (
     ast: parseExpression(expression),
     context,
     debug,
+    functionCache: new Map(),
   });
   return execution;
 };
@@ -143,6 +144,7 @@ describe('Execution', () => {
       const execution = new Execution({
         executor,
         expression,
+        functionCache: new Map(),
       });
       expect(execution.expression).toBe(expression);
     });
@@ -153,6 +155,7 @@ describe('Execution', () => {
       const execution = new Execution({
         ast: parseExpression(expression),
         executor,
+        functionCache: new Map(),
       });
       expect(execution.expression).toBe(expression);
     });
@@ -620,6 +623,7 @@ describe('Execution', () => {
           executor,
           ast: parseExpression('add val=1 | throws | add val=3'),
           debug: true,
+          functionCache: new Map(),
         });
         execution.start(0);
         await execution.result;
@@ -638,6 +642,7 @@ describe('Execution', () => {
           executor,
           ast: parseExpression('add val=1 | throws | add val=3'),
           debug: true,
+          functionCache: new Map(),
         });
         execution.start(0);
         await execution.result;
@@ -659,6 +664,7 @@ describe('Execution', () => {
           executor,
           ast: parseExpression('add val=1 | throws | add val=3'),
           debug: true,
+          functionCache: new Map(),
         });
         execution.start(0);
         await execution.result;

--- a/src/plugins/expressions/common/execution/execution_contract.test.ts
+++ b/src/plugins/expressions/common/execution/execution_contract.test.ts
@@ -31,6 +31,7 @@ const createExecution = (
     executor,
     ast: parseExpression(expression),
     context,
+    functionCache: new Map(),
   });
   return execution;
 };

--- a/src/plugins/expressions/common/execution/types.ts
+++ b/src/plugins/expressions/common/execution/types.ts
@@ -43,6 +43,11 @@ export interface ExecutionContext<Input = unknown, InspectorAdapters extends Ada
   types: Record<string, ExpressionType>;
 
   /**
+   * Prevents caching in the current execution.
+   */
+  disableCache?: boolean;
+
+  /**
    * Adds ability to abort current execution.
    */
   abortSignal: AbortSignal;

--- a/src/plugins/expressions/common/executor/executor.test.ts
+++ b/src/plugins/expressions/common/executor/executor.test.ts
@@ -152,4 +152,71 @@ describe('Executor', () => {
       });
     });
   });
+
+  describe('caching', () => {
+    const functionCache: Map<string, any> = new Map();
+    const fakeCacheEntry = { type: 'kibana_context', value: 'test' };
+    let executor: Executor;
+
+    beforeAll(() => {
+      executor = new Executor(undefined, functionCache);
+      executor.registerFunction(expressionFunctions.variable);
+      executor.registerFunction(expressionFunctions.kibana);
+    });
+
+    afterEach(() => {
+      functionCache.clear();
+    });
+
+    it('caches the result of function', async () => {
+      await executor.run('kibana', null);
+      expect(functionCache.size).toEqual(1);
+      const entry = functionCache.keys().next().value;
+      functionCache.set(entry, fakeCacheEntry);
+      const result = await executor.run('kibana', null);
+      expect(functionCache.size).toEqual(1);
+      expect(result).toEqual(fakeCacheEntry);
+    });
+
+    it('doesnt cache if disableCache flag is enabled', async () => {
+      await executor.run('kibana', null);
+      expect(functionCache.size).toEqual(1);
+      const entry = functionCache.keys().next().value;
+      functionCache.set(entry, fakeCacheEntry);
+      const result = await executor.run('kibana', null, { disableCache: true });
+      expect(functionCache.size).toEqual(1);
+      expect(result).not.toEqual(fakeCacheEntry);
+    });
+
+    it('doesnt cache results of functions that have disableCache property set', async () => {
+      await executor.run('var name="test"', null);
+      expect(functionCache.size).toEqual(0);
+    });
+
+    describe('doesnt use cached version', () => {
+      const cachedVersion = { test: 'value' };
+
+      beforeAll(async () => {
+        await executor.run('kibana', null);
+        expect(functionCache.size).toEqual(1);
+        const entry: string = Object.keys(functionCache)[0];
+        functionCache.set(entry, cachedVersion);
+      });
+
+      it('input changed', async () => {
+        const result = await executor.run('kibana', { type: 'kibana_context', value: 'test' });
+        expect(result).not.toEqual(cachedVersion);
+      });
+
+      it('arguments changed', async () => {
+        const result = await executor.run('kibana', null);
+        expect(result).not.toEqual(cachedVersion);
+      });
+
+      it('search context changed', async () => {
+        const result = await executor.run('kibana', null, { search: { filters: [] } });
+        expect(result).not.toEqual(cachedVersion);
+      });
+    });
+  });
 });

--- a/src/plugins/expressions/common/executor/executor.ts
+++ b/src/plugins/expressions/common/executor/executor.ts
@@ -105,10 +105,13 @@ export class Executor<Context extends Record<string, unknown> = Record<string, u
    */
   public readonly types: TypesRegistry;
 
-  constructor(state?: ExecutorState<Context>) {
+  private functionCache: Map<string, any>;
+
+  constructor(state?: ExecutorState<Context>, functionCache: Map<string, any> = new Map()) {
     this.state = createExecutorContainer<Context>(state);
     this.functions = new FunctionsRegistry(this);
     this.types = new TypesRegistry(this);
+    this.functionCache = functionCache || new Map();
   }
 
   public registerFunction(
@@ -186,6 +189,7 @@ export class Executor<Context extends Record<string, unknown> = Record<string, u
         ...this.context,
         ...context,
       } as Context & ExtraContext,
+      functionCache: this.functionCache,
       debug,
     };
 

--- a/src/plugins/expressions/common/expression_functions/expression_function.ts
+++ b/src/plugins/expressions/common/expression_functions/expression_function.ts
@@ -41,6 +41,11 @@ export class ExpressionFunction {
   type: string;
 
   /**
+   * Opt-out of caching this function. By default function outputs are cached and given the same inputs cached result is returned.
+   */
+  disableCache: boolean;
+
+  /**
    * Function to run function (context, args)
    */
   fn: (input: ExpressionValue, params: Record<string, any>, handlers: object) => ExpressionValue;
@@ -61,7 +66,17 @@ export class ExpressionFunction {
   inputTypes: string[] | undefined;
 
   constructor(functionDefinition: AnyExpressionFunctionDefinition) {
-    const { name, type, aliases, fn, help, args, inputTypes, context } = functionDefinition;
+    const {
+      name,
+      type,
+      aliases,
+      fn,
+      help,
+      args,
+      inputTypes,
+      context,
+      disableCache,
+    } = functionDefinition;
 
     this.name = name;
     this.type = type;
@@ -70,6 +85,7 @@ export class ExpressionFunction {
       Promise.resolve(fn(input, params, handlers as ExecutionContext));
     this.help = help || '';
     this.inputTypes = inputTypes || context?.types;
+    this.disableCache = !!disableCache;
 
     for (const [key, arg] of Object.entries(args || {})) {
       this.args[key] = new ExpressionFunctionParameter(key, arg);

--- a/src/plugins/expressions/common/expression_functions/specs/var.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var.ts
@@ -36,6 +36,7 @@ export const variable: ExpressionFunctionVar = {
   help: i18n.translate('expressions.functions.var.help', {
     defaultMessage: 'Updates the Kibana global context.',
   }),
+  disableCache: true,
   args: {
     name: {
       types: ['string'],

--- a/src/plugins/expressions/common/expression_functions/specs/var_set.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var_set.ts
@@ -37,6 +37,7 @@ export const variableSet: ExpressionFunctionVarSet = {
   help: i18n.translate('expressions.functions.varset.help', {
     defaultMessage: 'Updates the Kibana global context.',
   }),
+  disableCache: true,
   args: {
     name: {
       types: ['string'],

--- a/src/plugins/expressions/common/expression_functions/types.ts
+++ b/src/plugins/expressions/common/expression_functions/types.ts
@@ -53,6 +53,11 @@ export interface ExpressionFunctionDefinition<
   type?: TypeToString<UnwrapPromiseOrReturn<Output>>;
 
   /**
+   * Opt-out of caching this function. By default function outputs are cached and given the same inputs cached result is returned.
+   */
+  disableCache?: boolean;
+
+  /**
    * List of allowed type names for input value of this function. If this
    * property is set the input of function will be cast to the first possible
    * type in this list. If this property is missing the input will be provided

--- a/src/plugins/expressions/common/mocks.ts
+++ b/src/plugins/expressions/common/mocks.ts
@@ -38,6 +38,7 @@ export const createMockExecutionContext = <ExtraContext extends object = object>
       data: {} as any,
     },
     search: {},
+    disableCache: false,
   };
 
   return {

--- a/src/plugins/expressions/public/loader.ts
+++ b/src/plugins/expressions/public/loader.ts
@@ -181,6 +181,9 @@ export class ExpressionLoader {
     if (params.variables && this.params) {
       this.params.variables = params.variables;
     }
+    if (params.disableCache !== undefined) {
+      this.params.disableCache = params.disableCache;
+    }
 
     this.params.inspectorAdapters = (params.inspectorAdapters ||
       this.execution?.inspect()) as Adapters;

--- a/src/plugins/expressions/public/types/index.ts
+++ b/src/plugins/expressions/public/types/index.ts
@@ -51,6 +51,7 @@ export interface IExpressionLoaderParams {
   uiState?: unknown;
   inspectorAdapters?: Adapters;
   onRenderError?: RenderErrorHandlerFnType;
+  disableCache?: boolean;
 }
 
 export interface ExpressionRenderError extends Error {

--- a/src/plugins/vis_type_timeseries/public/metrics_fn.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_fn.ts
@@ -49,6 +49,7 @@ export const createMetricsFn = (): ExpressionFunctionDefinition<
   Output
 > => ({
   name: 'tsvb',
+  noCache: true,
   type: 'render',
   inputTypes: ['kibana_context', 'null'],
   help: i18n.translate('visTypeTimeseries.function.help', {

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -152,7 +152,7 @@ export class VisualizeEmbeddable
 
     this.autoRefreshFetchSubscription = timefilter
       .getAutoRefreshFetch$()
-      .subscribe(this.updateHandler.bind(this));
+      .subscribe(this.updateHandler.bind(this, true));
 
     this.subscriptions.push(
       Rx.merge(this.getOutput$(), this.getInput$()).subscribe(() => {
@@ -364,10 +364,10 @@ export class VisualizeEmbeddable
   }
 
   public reload = () => {
-    this.handleVisUpdate();
+    this.handleVisUpdate(true);
   };
 
-  private async updateHandler() {
+  private async updateHandler(disableCache: boolean = false) {
     const expressionParams: IExpressionLoaderParams = {
       searchContext: {
         timeRange: this.timeRange,
@@ -376,6 +376,7 @@ export class VisualizeEmbeddable
       },
       uiState: this.vis.uiState,
       inspectorAdapters: this.inspectorAdapters,
+      disableCache,
     };
     if (this.abortController) {
       this.abortController.abort();
@@ -393,8 +394,8 @@ export class VisualizeEmbeddable
     }
   }
 
-  private handleVisUpdate = async () => {
-    this.updateHandler();
+  private handleVisUpdate = async (disableCache: boolean = false) => {
+    this.updateHandler(disableCache);
   };
 
   private uiStateChangeHandler = () => {


### PR DESCRIPTION
## Summary

Adds caching for interpreter:

- caching can be disabled for every call at `interpretAst`
- at the time function should be executed we calculate a hash of: `input`, `args`, `executionContext` and `fnDef` and check the cache for existing result. If we find one we can skip executing this function.
- function can have `disableCache` flag set to true, which will prevent caching of that function

arguments are resolved before this, so using subexpressions, default values etc should work as expected (if subexpression evaluates to the same result it did last time executing the current function can be skipped)

todo:
as timerange which we use in `esaggs` is in estime format `now-90d` caching kicks in when we rerun same expression at later time and we don't get new result. For now `esaggs` function has the `disableCache` flag set to true. When we refactore esaggs in the future this flag should move to the function that will be generating actual timerange from the `estime` format


open questions:
- how to handle cache expiration and limits

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [x] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

