### PR TITLE
[APM] Ensure correct encoding of body in callApi

### DIFF
--- a/x-pack/legacy/plugins/apm/public/services/__test__/callApi.test.ts
+++ b/x-pack/legacy/plugins/apm/public/services/__test__/callApi.test.ts
@@ -35,6 +35,54 @@ describe('callApi', () => {
     clearCache();
   });
 
+  describe('encoding', () => {
+    describe('when getting', () => {
+      it('it should correctly encode the request parameters', async () => {
+        await callApi(http, {
+          pathname: `/api/kibana`,
+          query: { start: '2010', end: '2011' }
+        });
+
+        expect(http.get).toHaveBeenCalledTimes(1);
+
+        expect(http.get).toHaveBeenCalledWith('/api/kibana', {
+          query: {
+            start: '2010',
+            end: '2011'
+          }
+        });
+      });
+    });
+    describe('when posting', () => {
+      it('it should correctly encode the request parameters', async () => {
+        await callApi(http, {
+          method: 'POST',
+          pathname: `/api/kibana`,
+          query: { start: '2010', end: '2011' },
+          body: {
+            foo: {
+              bar: 1
+            }
+          }
+        });
+
+        expect(http.post).toHaveBeenCalledTimes(1);
+
+        expect(http.post).toHaveBeenCalledWith('/api/kibana', {
+          query: {
+            start: '2010',
+            end: '2011'
+          },
+          body: JSON.stringify({
+            foo: {
+              bar: 1
+            }
+          })
+        });
+      });
+    });
+  });
+
   describe('apm_debug', () => {
     beforeEach(() => {
       sessionStorage.setItem('apm_debug', 'true');
@@ -159,35 +207,6 @@ describe('callApi', () => {
         });
 
         expect(http.get).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('when posting', () => {
-      it('it should correctly encode the request parameters', async () => {
-        await callApi(http, {
-          method: 'POST',
-          pathname: `/api/kibana`,
-          query: { start: '2010', end: '2011' },
-          body: {
-            foo: {
-              bar: 1
-            }
-          }
-        });
-
-        expect(http.post).toHaveBeenCalledTimes(1);
-
-        expect(http.post).toHaveBeenCalledWith('/api/kibana', {
-          query: {
-            start: '2010',
-            end: '2011'
-          },
-          body: JSON.stringify({
-            foo: {
-              bar: 1
-            }
-          })
-        });
       });
     });
   });

--- a/x-pack/legacy/plugins/apm/public/services/__test__/callApi.test.ts
+++ b/x-pack/legacy/plugins/apm/public/services/__test__/callApi.test.ts
@@ -20,6 +20,9 @@ describe('callApi', () => {
     http = ({
       get: jest.fn().mockReturnValue({
         my_key: 'hello_world'
+      }),
+      post: jest.fn().mockReturnValue({
+        my_key: 'hello_world'
       })
     } as unknown) as HttpMock;
 
@@ -156,6 +159,35 @@ describe('callApi', () => {
         });
 
         expect(http.get).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when posting', () => {
+      it('it should correctly encode the request parameters', async () => {
+        await callApi(http, {
+          method: 'POST',
+          pathname: `/api/kibana`,
+          query: { start: '2010', end: '2011' },
+          body: {
+            foo: {
+              bar: 1
+            }
+          }
+        });
+
+        expect(http.post).toHaveBeenCalledTimes(1);
+
+        expect(http.post).toHaveBeenCalledWith('/api/kibana', {
+          query: {
+            start: '2010',
+            end: '2011'
+          },
+          body: JSON.stringify({
+            foo: {
+              bar: 1
+            }
+          })
+        });
       });
     });
   });

--- a/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
@@ -9,10 +9,11 @@ import LRU from 'lru-cache';
 import hash from 'object-hash';
 import { HttpServiceBase, HttpFetchOptions } from 'kibana/public';
 
-export type FetchOptions = HttpFetchOptions & {
+export type FetchOptions = Omit<HttpFetchOptions, 'body'> & {
   pathname: string;
   forceCache?: boolean;
   method?: string;
+  body?: object;
 };
 
 function fetchOptionsWithDebug(fetchOptions: FetchOptions) {
@@ -22,8 +23,10 @@ function fetchOptionsWithDebug(fetchOptions: FetchOptions) {
 
   const isGet = !fetchOptions.method || fetchOptions.method === 'GET';
 
+  const { body, ...rest } = fetchOptions;
+
   // Need an empty body to pass route validation
-  const body = isGet
+  const bodyObject = isGet
     ? {}
     : {
         body: JSON.stringify(
@@ -32,8 +35,8 @@ function fetchOptionsWithDebug(fetchOptions: FetchOptions) {
       };
 
   return {
-    ...fetchOptions,
-    ...body,
+    ...rest,
+    ...bodyObject,
     query: {
       ...fetchOptions.query,
       ...(debugEnabled ? { _debug: true } : {})

--- a/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
@@ -21,7 +21,7 @@ function fetchOptionsWithDebug(fetchOptions: FetchOptions) {
     sessionStorage.getItem('apm_debug') === 'true' &&
     startsWith(fetchOptions.pathname, '/api/apm');
 
-  const isGet = !fetchOptions.method || fetchOptions.method === 'GET';
+  const isGetRequest = !fetchOptions.method || fetchOptions.method === 'GET';
 
   const { body, ...rest } = fetchOptions;
 

--- a/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
@@ -26,7 +26,7 @@ function fetchOptionsWithDebug(fetchOptions: FetchOptions) {
   const { body, ...rest } = fetchOptions;
 
   // Need an empty body to pass route validation
-  const bodyObject = isGet
+  const bodyObject = isGetRequest
     ? {}
     : {
         body: JSON.stringify(

--- a/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
@@ -61,7 +61,7 @@ export async function startMLJob({
   return callApi<StartedMLJobApiResponse>(http, {
     method: 'POST',
     pathname: `/api/ml/modules/setup/apm_transaction`,
-    body: JSON.stringify({
+    body: {
       prefix: getMlPrefix(serviceName, transactionType),
       groups,
       indexPatternName: transactionIndices,
@@ -71,7 +71,7 @@ export async function startMLJob({
           filter
         }
       }
-    })
+    }
   });
 }
 

--- a/x-pack/legacy/plugins/apm/public/services/rest/watcher.js
+++ b/x-pack/legacy/plugins/apm/public/services/rest/watcher.js
@@ -10,6 +10,6 @@ export async function createWatch(id, watch) {
   return callApi({
     method: 'PUT',
     pathname: `/api/watcher/watch/${id}`,
-    body: JSON.stringify({ type: 'json', id, watch })
+    body: { type: 'json', id, watch }
   });
 }


### PR DESCRIPTION
Fixes issue with the ML and Watcher integrations where the body ended up being encoded to JSON twice. Introduced in 06bee6051258009cca6c0c92fa1362c56823e734.
