### PR TITLE
Add types for Embeddable setup and start contracts

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dashboard/application.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/application.ts
@@ -48,7 +48,7 @@ import {
 // @ts-ignore
 import { initDashboardApp } from './legacy_app';
 import { DataStart } from '../../../data/public';
-import { EmbeddablePublicPlugin } from '../../../../../plugins/embeddable/public';
+import { IEmbeddableStart } from '../../../../../plugins/embeddable/public';
 import { NavigationStart } from '../../../navigation/public';
 import { DataPublicPluginStart as NpDataStart } from '../../../../../plugins/data/public';
 import { SharePluginStart } from '../../../../../plugins/share/public';
@@ -68,7 +68,7 @@ export interface RenderDeps {
   chrome: ChromeStart;
   addBasePath: (path: string) => string;
   savedQueryService: DataStart['search']['services']['savedQueryService'];
-  embeddables: ReturnType<EmbeddablePublicPlugin['start']>;
+  embeddables: IEmbeddableStart;
   localStorage: Storage;
   share: SharePluginStart;
 }

--- a/src/legacy/core_plugins/kibana/public/dashboard/plugin.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/plugin.ts
@@ -29,7 +29,7 @@ import { i18n } from '@kbn/i18n';
 import { RenderDeps } from './application';
 import { DataStart } from '../../../data/public';
 import { DataPublicPluginStart as NpDataStart } from '../../../../../plugins/data/public';
-import { EmbeddablePublicPlugin } from '../../../../../plugins/embeddable/public';
+import { IEmbeddableStart } from '../../../../../plugins/embeddable/public';
 import { Storage } from '../../../../../plugins/kibana_utils/public';
 import { NavigationStart } from '../../../navigation/public';
 import { DashboardConstants } from './dashboard_constants';
@@ -49,7 +49,7 @@ export interface LegacyAngularInjectedDependencies {
 export interface DashboardPluginStartDependencies {
   data: DataStart;
   npData: NpDataStart;
-  embeddables: ReturnType<EmbeddablePublicPlugin['start']>;
+  embeddables: IEmbeddableStart;
   navigation: NavigationStart;
   share: SharePluginStart;
 }
@@ -67,7 +67,7 @@ export class DashboardPlugin implements Plugin {
     dataStart: DataStart;
     npDataStart: NpDataStart;
     savedObjectsClient: SavedObjectsClientContract;
-    embeddables: ReturnType<EmbeddablePublicPlugin['start']>;
+    embeddables: IEmbeddableStart;
     navigation: NavigationStart;
     share: SharePluginStart;
   } | null = null;

--- a/src/legacy/core_plugins/kibana/public/discover/plugin.ts
+++ b/src/legacy/core_plugins/kibana/public/discover/plugin.ts
@@ -21,10 +21,7 @@ import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from 'kibana/p
 import { IUiActionsStart } from 'src/plugins/ui_actions/public';
 import { registerFeature } from './helpers/register_feature';
 import './kibana_services';
-import {
-  Start as EmbeddableStart,
-  Setup as EmbeddableSetup,
-} from '../../../../../plugins/embeddable/public';
+import { IEmbeddableStart, IEmbeddableSetup } from '../../../../../plugins/embeddable/public';
 
 /**
  * These are the interfaces with your public contracts. You should export these
@@ -35,11 +32,11 @@ export type DiscoverSetup = void;
 export type DiscoverStart = void;
 interface DiscoverSetupPlugins {
   uiActions: IUiActionsStart;
-  embeddable: EmbeddableSetup;
+  embeddable: IEmbeddableSetup;
 }
 interface DiscoverStartPlugins {
   uiActions: IUiActionsStart;
-  embeddable: EmbeddableStart;
+  embeddable: IEmbeddableStart;
 }
 
 export class DiscoverPlugin implements Plugin<DiscoverSetup, DiscoverStart> {

--- a/src/legacy/ui/public/new_platform/new_platform.ts
+++ b/src/legacy/ui/public/new_platform/new_platform.ts
@@ -19,7 +19,7 @@
 import { IScope } from 'angular';
 
 import { IUiActionsStart, IUiActionsSetup } from 'src/plugins/ui_actions/public';
-import { Start as EmbeddableStart, Setup as EmbeddableSetup } from 'src/plugins/embeddable/public';
+import { IEmbeddableStart, IEmbeddableSetup } from 'src/plugins/embeddable/public';
 import { LegacyCoreSetup, LegacyCoreStart, App } from '../../../../core/public';
 import { Plugin as DataPlugin } from '../../../../plugins/data/public';
 import { Plugin as ExpressionsPlugin } from '../../../../plugins/expressions/public';
@@ -35,7 +35,7 @@ import { SharePluginSetup, SharePluginStart } from '../../../../plugins/share/pu
 
 export interface PluginsSetup {
   data: ReturnType<DataPlugin['setup']>;
-  embeddable: EmbeddableSetup;
+  embeddable: IEmbeddableSetup;
   expressions: ReturnType<ExpressionsPlugin['setup']>;
   home: HomePublicPluginSetup;
   inspector: InspectorSetup;
@@ -47,7 +47,7 @@ export interface PluginsSetup {
 
 export interface PluginsStart {
   data: ReturnType<DataPlugin['start']>;
-  embeddable: EmbeddableStart;
+  embeddable: IEmbeddableStart;
   eui_utils: EuiUtilsStart;
   expressions: ReturnType<ExpressionsPlugin['start']>;
   home: HomePublicPluginStart;

--- a/src/plugins/dashboard_embeddable_container/public/actions/open_replace_panel_flyout.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/actions/open_replace_panel_flyout.tsx
@@ -24,7 +24,7 @@ import {
   IEmbeddable,
   EmbeddableInput,
   EmbeddableOutput,
-  Start as EmbeddableStart,
+  IEmbeddableStart,
   IContainer,
 } from '../embeddable_plugin';
 
@@ -34,7 +34,7 @@ export async function openReplacePanelFlyout(options: {
   savedObjectFinder: React.ComponentType<any>;
   notifications: CoreStart['notifications'];
   panelToRemove: IEmbeddable<EmbeddableInput, EmbeddableOutput>;
-  getEmbeddableFactories: EmbeddableStart['getEmbeddableFactories'];
+  getEmbeddableFactories: IEmbeddableStart['getEmbeddableFactories'];
 }) {
   const {
     embeddable,

--- a/src/plugins/dashboard_embeddable_container/public/actions/replace_panel_action.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/actions/replace_panel_action.tsx
@@ -19,7 +19,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { CoreStart } from '../../../../core/public';
-import { IEmbeddable, ViewMode, Start as EmbeddableStart } from '../embeddable_plugin';
+import { IEmbeddable, ViewMode, IEmbeddableStart } from '../embeddable_plugin';
 import { DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '../embeddable';
 import { IAction, IncompatibleActionError } from '../ui_actions_plugin';
 import { openReplacePanelFlyout } from './open_replace_panel_flyout';
@@ -43,7 +43,7 @@ export class ReplacePanelAction implements IAction<ActionContext> {
     private core: CoreStart,
     private savedobjectfinder: React.ComponentType<any>,
     private notifications: CoreStart['notifications'],
-    private getEmbeddableFactories: EmbeddableStart['getEmbeddableFactories']
+    private getEmbeddableFactories: IEmbeddableStart['getEmbeddableFactories']
   ) {}
 
   public getDisplayName({ embeddable }: ActionContext) {

--- a/src/plugins/dashboard_embeddable_container/public/actions/replace_panel_flyout.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/actions/replace_panel_flyout.tsx
@@ -20,15 +20,10 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
+import { GetEmbeddableFactories } from 'src/plugins/embeddable/public';
 import { DashboardPanelState } from '../embeddable';
 import { NotificationsStart, Toast } from '../../../../core/public';
-import {
-  IContainer,
-  IEmbeddable,
-  EmbeddableInput,
-  EmbeddableOutput,
-  Start as EmbeddableStart,
-} from '../embeddable_plugin';
+import { IContainer, IEmbeddable, EmbeddableInput, EmbeddableOutput } from '../embeddable_plugin';
 
 interface Props {
   container: IContainer;
@@ -36,7 +31,7 @@ interface Props {
   onClose: () => void;
   notifications: NotificationsStart;
   panelToRemove: IEmbeddable<EmbeddableInput, EmbeddableOutput>;
-  getEmbeddableFactories: EmbeddableStart['getEmbeddableFactories'];
+  getEmbeddableFactories: GetEmbeddableFactories;
 }
 
 export class ReplacePanelFlyout extends React.Component<Props> {

--- a/src/plugins/dashboard_embeddable_container/public/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/embeddable/dashboard_container.tsx
@@ -30,7 +30,7 @@ import {
   ViewMode,
   EmbeddableFactory,
   IEmbeddable,
-  Start as EmbeddableStartContract,
+  IEmbeddableStart,
 } from '../embeddable_plugin';
 import { DASHBOARD_CONTAINER_TYPE } from './dashboard_constants';
 import { createPanelState } from './panel';
@@ -77,7 +77,7 @@ export interface DashboardContainerOptions {
   application: CoreStart['application'];
   overlays: CoreStart['overlays'];
   notifications: CoreStart['notifications'];
-  embeddable: EmbeddableStartContract;
+  embeddable: IEmbeddableStart;
   inspector: InspectorStartContract;
   SavedObjectFinder: React.ComponentType<any>;
   ExitFullScreenButton: React.ComponentType<any>;

--- a/src/plugins/dashboard_embeddable_container/public/plugin.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/plugin.tsx
@@ -22,7 +22,7 @@
 import * as React from 'react';
 import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from 'src/core/public';
 import { IUiActionsSetup, IUiActionsStart } from '../../../plugins/ui_actions/public';
-import { CONTEXT_MENU_TRIGGER, Plugin as EmbeddablePlugin } from './embeddable_plugin';
+import { CONTEXT_MENU_TRIGGER, IEmbeddableSetup, IEmbeddableStart } from './embeddable_plugin';
 import { ExpandPanelAction, ReplacePanelAction } from '.';
 import { DashboardContainerFactory } from './embeddable/dashboard_container_factory';
 import { Start as InspectorStartContract } from '../../../plugins/inspector/public';
@@ -34,12 +34,12 @@ import {
 } from '../../../plugins/kibana_react/public';
 
 interface SetupDependencies {
-  embeddable: ReturnType<EmbeddablePlugin['setup']>;
+  embeddable: IEmbeddableSetup;
   uiActions: IUiActionsSetup;
 }
 
 interface StartDependencies {
-  embeddable: ReturnType<EmbeddablePlugin['start']>;
+  embeddable: IEmbeddableStart;
   inspector: InspectorStartContract;
   uiActions: IUiActionsStart;
 }

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -61,5 +61,4 @@ export function plugin(initializerContext: PluginInitializerContext) {
   return new EmbeddablePublicPlugin(initializerContext);
 }
 
-export { EmbeddablePublicPlugin as Plugin };
-export * from './plugin';
+export { IEmbeddableSetup, IEmbeddableStart } from './plugin';

--- a/src/plugins/embeddable/public/mocks.ts
+++ b/src/plugins/embeddable/public/mocks.ts
@@ -17,14 +17,15 @@
  * under the License.
  */
 
-import { Plugin } from '.';
+import { IEmbeddableStart, IEmbeddableSetup } from '.';
+import { EmbeddablePublicPlugin } from './plugin';
 import { coreMock } from '../../../core/public/mocks';
 
 // eslint-disable-next-line
 import { uiActionsPluginMock } from '../../ui_actions/public/mocks';
 
-export type Setup = jest.Mocked<ReturnType<Plugin['setup']>>;
-export type Start = jest.Mocked<ReturnType<Plugin['start']>>;
+export type Setup = jest.Mocked<IEmbeddableSetup>;
+export type Start = jest.Mocked<IEmbeddableStart>;
 
 const createSetupContract = (): Setup => {
   const setupContract: Setup = {
@@ -43,7 +44,7 @@ const createStartContract = (): Start => {
 };
 
 const createInstance = () => {
-  const plugin = new Plugin({} as any);
+  const plugin = new EmbeddablePublicPlugin({} as any);
   const setup = plugin.setup(coreMock.createSetup(), {
     uiActions: uiActionsPluginMock.createSetupContract(),
   });

--- a/src/plugins/embeddable/public/plugin.ts
+++ b/src/plugins/embeddable/public/plugin.ts
@@ -27,7 +27,13 @@ export interface IEmbeddableSetupDependencies {
   uiActions: IUiActionsSetup;
 }
 
-export class EmbeddablePublicPlugin implements Plugin<any, any> {
+export interface IEmbeddableSetup {
+  registerEmbeddableFactory: EmbeddableApi['registerEmbeddableFactory'];
+}
+
+export type IEmbeddableStart = EmbeddableApi;
+
+export class EmbeddablePublicPlugin implements Plugin<IEmbeddableSetup, IEmbeddableStart> {
   private readonly embeddableFactories: EmbeddableFactoryRegistry = new Map();
   private api!: EmbeddableApi;
 
@@ -52,6 +58,3 @@ export class EmbeddablePublicPlugin implements Plugin<any, any> {
 
   public stop() {}
 }
-
-export type Setup = ReturnType<EmbeddablePublicPlugin['setup']>;
-export type Start = ReturnType<EmbeddablePublicPlugin['start']>;

--- a/src/plugins/embeddable/public/tests/test_plugin.ts
+++ b/src/plugins/embeddable/public/tests/test_plugin.ts
@@ -21,14 +21,14 @@ import { CoreSetup, CoreStart } from 'src/core/public';
 // eslint-disable-next-line
 import { uiActionsTestPlugin } from 'src/plugins/ui_actions/public/tests';
 import { IUiActionsApi } from 'src/plugins/ui_actions/public';
-import { EmbeddablePublicPlugin } from '../plugin';
+import { EmbeddablePublicPlugin, IEmbeddableSetup, IEmbeddableStart } from '../plugin';
 
 export interface TestPluginReturn {
   plugin: EmbeddablePublicPlugin;
   coreSetup: CoreSetup;
   coreStart: CoreStart;
-  setup: ReturnType<EmbeddablePublicPlugin['setup']>;
-  doStart: (anotherCoreStart?: CoreStart) => ReturnType<EmbeddablePublicPlugin['start']>;
+  setup: IEmbeddableSetup;
+  doStart: (anotherCoreStart?: CoreStart) => IEmbeddableStart;
   uiActions: IUiActionsApi;
 }
 

--- a/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/public/np_ready/public/plugin.tsx
+++ b/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/public/np_ready/public/plugin.tsx
@@ -27,7 +27,7 @@ import {
   Setup as InspectorSetupContract,
 } from '../../../../../../../src/plugins/inspector/public';
 
-import { Plugin as EmbeddablePlugin, CONTEXT_MENU_TRIGGER } from './embeddable_api';
+import { CONTEXT_MENU_TRIGGER } from './embeddable_api';
 
 const REACT_ROOT_ID = 'embeddableExplorerRoot';
 
@@ -38,9 +38,13 @@ import {
   ContactCardEmbeddableFactory,
 } from './embeddable_api';
 import { App } from './app';
+import {
+  IEmbeddableStart,
+  IEmbeddableSetup,
+} from '.../../../../../../../src/plugins/embeddable/public';
 
 export interface SetupDependencies {
-  embeddable: ReturnType<EmbeddablePlugin['setup']>;
+  embeddable: IEmbeddableSetup;
   inspector: InspectorSetupContract;
   __LEGACY: {
     SavedObjectFinder: React.ComponentType<any>;
@@ -49,7 +53,7 @@ export interface SetupDependencies {
 }
 
 interface StartDependencies {
-  embeddable: ReturnType<EmbeddablePlugin['start']>;
+  embeddable: IEmbeddableStart;
   uiActions: IUiActionsStart;
   inspector: InspectorStartContract;
   __LEGACY: {

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.tsx
@@ -15,8 +15,8 @@ import {
   ExpressionsStart,
 } from '../../../../../../src/plugins/expressions/public';
 import {
-  Setup as EmbeddableSetup,
-  Start as EmbeddableStart,
+  IEmbeddableSetup,
+  IEmbeddableStart,
 } from '../../../../../../src/plugins/embeddable/public';
 import {
   setup as dataSetup,
@@ -36,13 +36,13 @@ import { getActiveDatasourceIdFromDoc } from './editor_frame/state_management';
 
 export interface EditorFrameSetupPlugins {
   data: typeof dataSetup;
-  embeddable: EmbeddableSetup;
+  embeddable: IEmbeddableSetup;
   expressions: ExpressionsSetup;
 }
 
 export interface EditorFrameStartPlugins {
   data: typeof dataStart;
-  embeddable: EmbeddableStart;
+  embeddable: IEmbeddableStart;
   expressions: ExpressionsStart;
   chrome: Chrome;
 }

--- a/x-pack/plugins/advanced_ui_actions/public/plugin.ts
+++ b/x-pack/plugins/advanced_ui_actions/public/plugin.ts
@@ -15,8 +15,8 @@ import { IUiActionsStart, IUiActionsSetup } from '../../../../src/plugins/ui_act
 import {
   CONTEXT_MENU_TRIGGER,
   PANEL_BADGE_TRIGGER,
-  Setup as EmbeddableSetup,
-  Start as EmbeddableStart,
+  IEmbeddableSetup,
+  IEmbeddableStart,
 } from '../../../../src/plugins/embeddable/public';
 import { CustomTimeRangeAction } from './custom_time_range_action';
 
@@ -24,12 +24,12 @@ import { CustomTimeRangeBadge } from './custom_time_range_badge';
 import { CommonlyUsedRange } from './types';
 
 interface SetupDependencies {
-  embeddable: EmbeddableSetup; // Embeddable are needed because they register basic triggers/actions.
+  embeddable: IEmbeddableSetup; // Embeddable are needed because they register basic triggers/actions.
   uiActions: IUiActionsSetup;
 }
 
 interface StartDependencies {
-  embeddable: EmbeddableStart;
+  embeddable: IEmbeddableStart;
   uiActions: IUiActionsStart;
 }
 


### PR DESCRIPTION
Some small cleanups to Embeddables :

- Remove usage of `any`
- Add setup and start contracts, and export them
- remove the `export * from ./plugin` in the index file.

