### PR TITLE
[APM] Address fallout from NP server migration

### DIFF
--- a/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
@@ -21,18 +21,11 @@ function fetchOptionsWithDebug(fetchOptions: FetchOptions) {
     sessionStorage.getItem('apm_debug') === 'true' &&
     startsWith(fetchOptions.pathname, '/api/apm');
 
-  const isGet = !fetchOptions.method || fetchOptions.method === 'GET';
-
-  // Need an empty body to pass route validation
-  const body = isGet
-    ? {}
-    : {
-        body: JSON.stringify(fetchOptions.body || {})
-      };
+  const { body, ...rest } = fetchOptions;
 
   return {
-    ...fetchOptions,
-    ...body,
+    ...rest,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     query: {
       ...fetchOptions.query,
       ...(debugEnabled ? { _debug: true } : {})

--- a/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
@@ -61,7 +61,7 @@ export async function startMLJob({
   return callApi<StartedMLJobApiResponse>(http, {
     method: 'POST',
     pathname: `/api/ml/modules/setup/apm_transaction`,
-    body: JSON.stringify({
+    body: {
       prefix: getMlPrefix(serviceName, transactionType),
       groups,
       indexPatternName: transactionIndices,
@@ -71,7 +71,7 @@ export async function startMLJob({
           filter
         }
       }
-    })
+    }
   });
 }
 

--- a/x-pack/legacy/plugins/apm/server/routes/create_api/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_api/index.test.ts
@@ -131,7 +131,7 @@ describe('createApi', () => {
             // stub default values
             params: {},
             query: {},
-            body: {},
+            body: null,
             ...requestMock
           },
           responseMock
@@ -144,7 +144,7 @@ describe('createApi', () => {
     it('adds a _debug query parameter by default', async () => {
       const { simulate, handlerMock, responseMock } = initApi({});
 
-      await simulate({ query: { _debug: true } });
+      await simulate({ query: { _debug: 'true' } });
 
       expect(handlerMock).toHaveBeenCalledTimes(1);
 
@@ -288,7 +288,7 @@ describe('createApi', () => {
       await simulate({
         query: {
           bar: '',
-          _debug: true
+          _debug: 'true'
         }
       });
 

--- a/x-pack/legacy/plugins/apm/server/routes/create_api/index.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_api/index.ts
@@ -18,8 +18,9 @@ import {
   Route,
   Params
 } from '../typings';
+import { jsonRt } from '../../../common/runtime_types/json_rt';
 
-const debugRt = t.partial({ _debug: t.boolean });
+const debugRt = t.partial({ _debug: jsonRt.pipe(t.boolean) });
 
 export function createApi() {
   const factoryFns: Array<RouteFactoryFn<any, any, any, any>> = [];
@@ -53,28 +54,37 @@ export function createApi() {
           | 'get'
           | 'delete';
 
-        const bodyRt = params.body;
-        const fallbackBodyRt = bodyRt || t.strict({});
+        // For all runtime types with props, we create an exact
+        // version that will strip all keys that are unvalidated.
+
+        const bodyRt =
+          params.body && 'props' in params.body
+            ? t.exact(params.body)
+            : params.body;
 
         const rts = {
-          // add _debug query parameter to all routes
+          // Add _debug query parameter to all routes
           query: params.query
             ? t.exact(t.intersection([params.query, debugRt]))
             : t.exact(debugRt),
           path: params.path ? t.exact(params.path) : t.strict({}),
-          body: bodyRt && 'props' in bodyRt ? t.exact(bodyRt) : fallbackBodyRt
+          body: bodyRt || t.null
         };
+
+        const anyObject = schema.object({}, { allowUnknowns: true });
 
         (router[routerMethod] as RouteRegistrar<typeof routerMethod>)(
           {
             path,
             options,
             validate: {
-              ...(routerMethod === 'get'
-                ? {}
-                : { body: schema.object({}, { allowUnknowns: true }) }),
-              params: schema.object({}, { allowUnknowns: true }),
-              query: schema.object({}, { allowUnknowns: true })
+              // `body` can be null, but `validate` expects non-nullable types
+              // if any validation is defined. Not having validation currently
+              // means we don't get the payload. See
+              // https://github.com/elastic/kibana/issues/50179
+              body: schema.nullable(anyObject) as typeof anyObject,
+              params: anyObject,
+              query: anyObject
             }
           },
           async (context, request, response) => {
@@ -83,7 +93,7 @@ export function createApi() {
                 path: request.params,
                 body: request.body,
                 query: {
-                  _debug: false,
+                  _debug: 'false',
                   ...request.query
                 }
               };
@@ -100,6 +110,9 @@ export function createApi() {
                   throw Boom.badRequest(PathReporter.report(result)[0]);
                 }
 
+                // `io-ts` has stripped unvalidated keys, so we can compare
+                // the output with the input to see if all object keys are
+                // known and validated.
                 const strippedKeys = difference(
                   Object.keys(value || {}),
                   Object.keys(result.right || {})
@@ -124,7 +137,9 @@ export function createApi() {
                 context: {
                   ...context,
                   __LEGACY,
-                  // only return values for parameters that have runtime types
+                  // Only return values for parameters that have runtime types,
+                  // but always include query as _debug is always set even if
+                  // it's not defined in the route.
                   params: pick(parsedParams, ...Object.keys(params), 'query'),
                   config,
                   logger

--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -29,7 +29,7 @@ export class APMPlugin implements Plugin<APMPluginContract> {
     this.legacySetup$ = new AsyncSubject();
   }
 
-  public setup(
+  public async setup(
     core: CoreSetup,
     plugins: {
       apm_oss: APMOSSPlugin extends Plugin<infer TSetup> ? TSetup : never;
@@ -46,14 +46,17 @@ export class APMPlugin implements Plugin<APMPluginContract> {
       createApmApi().init(core, { config$: mergedConfig$, logger, __LEGACY });
     });
 
-    combineLatest(mergedConfig$, core.elasticsearch.dataClient$).subscribe(
-      ([config, dataClient]) => {
-        createApmAgentConfigurationIndex({
-          esClient: dataClient,
-          config,
-        });
-      }
-    );
+    await new Promise(resolve => {
+      combineLatest(mergedConfig$, core.elasticsearch.dataClient$).subscribe(
+        async ([config, dataClient]) => {
+          await createApmAgentConfigurationIndex({
+            esClient: dataClient,
+            config,
+          });
+          resolve();
+        }
+      );
+    });
 
     return {
       config$: mergedConfig$,

--- a/x-pack/test/api_integration/apis/apm/agent_configuration.ts
+++ b/x-pack/test/api_integration/apis/apm/agent_configuration.ts
@@ -39,7 +39,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
     return supertest
       .delete(`/api/apm/settings/agent-configuration/${configurationId}`)
       .set('kbn-xsrf', 'foo')
-      .then(response => {
+      .then((response: any) => {
         createdConfigIds = createdConfigIds.filter(id => id === configurationId);
         return response;
       });
@@ -47,7 +47,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
 
   describe('agent configuration', () => {
     describe('when creating one configuration', () => {
-      let createdConfigId;
+      let createdConfigId: string;
 
       const parameters = {
         service: { name: 'myservice', environment: 'development' },

--- a/x-pack/test/api_integration/apis/apm/agent_configuration.ts
+++ b/x-pack/test/api_integration/apis/apm/agent_configuration.ts
@@ -32,17 +32,56 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
 
   function deleteCreatedConfigurations() {
     const promises = Promise.all(createdConfigIds.map(deleteConfiguration));
-    createdConfigIds = [];
     return promises;
   }
 
   function deleteConfiguration(configurationId: string) {
     return supertest
       .delete(`/api/apm/settings/agent-configuration/${configurationId}`)
-      .set('kbn-xsrf', 'foo');
+      .set('kbn-xsrf', 'foo')
+      .then(response => {
+        createdConfigIds = createdConfigIds.filter(id => id === configurationId);
+        return response;
+      });
   }
 
   describe('agent configuration', () => {
+    describe('when creating one configuration', () => {
+      let createdConfigId;
+
+      const parameters = {
+        service: { name: 'myservice', environment: 'development' },
+        etag: '7312bdcc34999629a3d39df24ed9b2a7553c0c39',
+      };
+
+      before(async () => {
+        log.debug('creating agent configuration');
+
+        // all / all
+        const { body } = await createConfiguration({
+          service: {},
+          settings: { transaction_sample_rate: 0.1 },
+        });
+
+        createdConfigId = body._id;
+      });
+
+      it('returns the created configuration', async () => {
+        const { statusCode, body } = await searchConfigurations(parameters);
+
+        expect(statusCode).to.equal(200);
+        expect(body._id).to.equal(createdConfigId);
+      });
+
+      it('succesfully deletes the configuration', async () => {
+        await deleteConfiguration(createdConfigId);
+
+        const { statusCode } = await searchConfigurations(parameters);
+
+        expect(statusCode).to.equal(404);
+      });
+    });
+
     describe('when creating four configurations', () => {
       before(async () => {
         log.debug('creating agent configuration');

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -39,7 +39,10 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
   }
   const endpoints: Endpoint[] = [
     {
-      req: { url: `/api/apm/services/foo/errors?start=${start}&end=${end}&uiFilters=%7B%7D` },
+      // this doubles as a smoke test for the _debug query parameter
+      req: {
+        url: `/api/apm/services/foo/errors?start=${start}&end=${end}&uiFilters=%7B%7D_debug=true`,
+      },
       expectForbidden: expect404,
       expectResponse: expect200,
     },


### PR DESCRIPTION
After [the NP server migration](https://github.com/elastic/kibana/pull/49455/files), several issues have surfaced with our endpoints:

1. All non-GET endpoints now require at least an empty object for `body` (e.g., it cannot be undefined). The reason behind this is to work around NP's current requirement ([soon to be removed](https://github.com/elastic/kibana/issues/50179)) to have validation in place for request parameters to access its values. This is a breaking change and could lead or has led to issues in testing. In the UI this is not an issue because we call our endpoints with `callApi` which will stub the `body` value. In hindsight, this was the wrong approach, as we cannot expect everybody who consumes the APM API (APM Server, other plugins) to add this stub.

Fix:
- create a nullable empty object schema for `body`, and a type assertion to satisfy the `validate` type.
- removing the stub in `callApi`
- add an integration test for deleting agent configurations (which would have failed after the NP migration). 

2. Integrations (ML, Watcher) were broken due to double encoding. As part of #49455 , I moved the responsibility of encoding the body from `callApmApi` to `callApi`. Unfortunately, I did not change the calls for the integrations, which were doing their own encoding, so the payload was doubly encoded JSON, and thus unreadable by the respective endpoints.

Fix:
- Removed the encoding at the call site. For the watcher integration, another bug surfaced, which will be addressed in #51721 separately.

3. Adding a `_debug` parameter to any request results in a 400. Previously, the debug runtime type was first parsing the query input as JSON before validating the type (boolean). In NP, it seemed like this was no longer necessary, and the parsing was removed. Either this observation was wrong or this was changed after the initial implementation. The values from the query are passed unparsed (as strings), breaking the request validation. Additionally, a smoke test for `_debug` in the API integration tests was inadvertently removed.

Fix:
- Parse `_debug` as JSON before validating whether it's a boolean
- Re-add the API integration smoke test with an explicit comment about why it's there
