### PR TITLE
[APM] metadata.branch shim

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Home/Home.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Home/Home.test.tsx
@@ -10,9 +10,9 @@ import { Home } from '../Home';
 import * as plugin from '../../../new-platform/plugin';
 
 jest.spyOn(plugin, 'usePlugins').mockReturnValue(({
-  apm: { config: {} as plugin.ConfigSchema }
+  apm: { config: {} as plugin.ConfigSchema, stackVersion: '0' }
 } as unknown) as plugin.ApmPluginStartDeps & {
-  apm: { config: plugin.ConfigSchema };
+  apm: { config: plugin.ConfigSchema; stackVersion: string };
 });
 
 describe('Home component', () => {

--- a/x-pack/legacy/plugins/apm/public/components/app/Home/Home.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Home/Home.test.tsx
@@ -7,20 +7,26 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import { Home } from '../Home';
-import * as plugin from '../../../new-platform/plugin';
-
-jest.spyOn(plugin, 'usePlugins').mockReturnValue(({
-  apm: { config: {} as plugin.ConfigSchema, stackVersion: '0' }
-} as unknown) as plugin.ApmPluginStartDeps & {
-  apm: { config: plugin.ConfigSchema; stackVersion: string };
-});
+import { MockPluginContextWrapper } from '../../../utils/testHelpers';
 
 describe('Home component', () => {
   it('should render services', () => {
-    expect(shallow(<Home tab="services" />)).toMatchSnapshot();
+    expect(
+      shallow(
+        <MockPluginContextWrapper>
+          <Home tab="services" />
+        </MockPluginContextWrapper>
+      )
+    ).toMatchSnapshot();
   });
 
   it('should render traces', () => {
-    expect(shallow(<Home tab="traces" />)).toMatchSnapshot();
+    expect(
+      shallow(
+        <MockPluginContextWrapper>
+          <Home tab="traces" />
+        </MockPluginContextWrapper>
+      )
+    ).toMatchSnapshot();
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/app/Home/__snapshots__/Home.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/Home/__snapshots__/Home.test.tsx.snap
@@ -1,129 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Home component should render services 1`] = `
-<div>
-  <ApmHeader>
-    <EuiFlexGroup
-      alignItems="center"
-    >
-      <EuiFlexItem
-        grow={false}
-      >
-        <EuiTitle
-          size="l"
-        >
-          <h1>
-            APM
-          </h1>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <SettingsLink>
-          <EuiButtonEmpty
-            color="primary"
-            iconType="gear"
-            size="s"
-          >
-            Settings
-          </EuiButtonEmpty>
-        </SettingsLink>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <SetupInstructionsLink />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </ApmHeader>
-  <EuiTabs
-    display="default"
-    expand={false}
-    size="m"
-  >
-    <EuiTabLink
-      isSelected={true}
-      key="services"
-    >
-      <ServiceOverviewLink>
-        Services
-      </ServiceOverviewLink>
-    </EuiTabLink>
-    <EuiTabLink
-      isSelected={false}
-      key="traces"
-    >
-      <TraceOverviewLink>
-        Traces
-      </TraceOverviewLink>
-    </EuiTabLink>
-  </EuiTabs>
-  <EuiSpacer />
-  <ServiceOverview />
-</div>
+<ContextProvider
+  value={
+    Object {
+      "apm": Object {
+        "config": Object {},
+        "stackVersion": "0",
+      },
+    }
+  }
+>
+  <Home
+    tab="services"
+  />
+</ContextProvider>
 `;
 
 exports[`Home component should render traces 1`] = `
-<div>
-  <ApmHeader>
-    <EuiFlexGroup
-      alignItems="center"
-    >
-      <EuiFlexItem
-        grow={false}
-      >
-        <EuiTitle
-          size="l"
-        >
-          <h1>
-            APM
-          </h1>
-        </EuiTitle>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <SettingsLink>
-          <EuiButtonEmpty
-            color="primary"
-            iconType="gear"
-            size="s"
-          >
-            Settings
-          </EuiButtonEmpty>
-        </SettingsLink>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <SetupInstructionsLink />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </ApmHeader>
-  <EuiTabs
-    display="default"
-    expand={false}
-    size="m"
-  >
-    <EuiTabLink
-      isSelected={false}
-      key="services"
-    >
-      <ServiceOverviewLink>
-        Services
-      </ServiceOverviewLink>
-    </EuiTabLink>
-    <EuiTabLink
-      isSelected={true}
-      key="traces"
-    >
-      <TraceOverviewLink>
-        Traces
-      </TraceOverviewLink>
-    </EuiTabLink>
-  </EuiTabs>
-  <EuiSpacer />
-  <TraceOverview />
-</div>
+<ContextProvider
+  value={
+    Object {
+      "apm": Object {
+        "config": Object {},
+        "stackVersion": "0",
+      },
+    }
+  }
+>
+  <Home
+    tab="traces"
+  />
+</ContextProvider>
 `;

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
@@ -11,8 +11,6 @@ import { UpdateBreadcrumbs } from '../UpdateBreadcrumbs';
 import * as kibanaCore from '../../../../../../observability/public/context/kibana_core';
 import { getRoutes } from '../route_config';
 
-jest.mock('ui/index_patterns');
-
 const coreMock = {
   chrome: {
     setBreadcrumbs: jest.fn()

--- a/x-pack/legacy/plugins/apm/public/components/shared/Links/ElasticDocsLink.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Links/ElasticDocsLink.tsx
@@ -6,10 +6,7 @@
 
 import React from 'react';
 import { EuiLink, EuiLinkAnchorProps } from '@elastic/eui';
-import { metadata } from 'ui/metadata';
-
-// TODO: metadata should be read from a useContext hook in new platform
-const STACK_VERSION = metadata.branch;
+import { usePlugins } from '../../../new-platform/plugin';
 
 // union type constisting of valid guide sections that we link to
 type DocsSection = '/apm/get-started' | '/x-pack' | '/apm/server';
@@ -20,6 +17,8 @@ interface Props extends EuiLinkAnchorProps {
 }
 
 export function ElasticDocsLink({ section, path, ...rest }: Props) {
-  const href = `https://www.elastic.co/guide/en${section}/${STACK_VERSION}${path}`;
+  const { apm } = usePlugins();
+  const { stackVersion } = apm;
+  const href = `https://www.elastic.co/guide/en${section}/${stackVersion}${path}`;
   return <EuiLink href={href} {...rest} />;
 }

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/__test__/ErrorMetadata.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/ErrorMetadata/__test__/ErrorMetadata.test.tsx
@@ -10,8 +10,13 @@ import { render } from '@testing-library/react';
 import { APMError } from '../../../../../../typings/es_schemas/ui/APMError';
 import {
   expectTextsInDocument,
-  expectTextsNotInDocument
+  expectTextsNotInDocument,
+  MockPluginContextWrapper
 } from '../../../../../utils/testHelpers';
+
+const renderOptions = {
+  wrapper: MockPluginContextWrapper
+};
 
 function getError() {
   return ({
@@ -38,7 +43,7 @@ function getError() {
 describe('ErrorMetadata', () => {
   it('should render a error with all sections', () => {
     const error = getError();
-    const output = render(<ErrorMetadata error={error} />);
+    const output = render(<ErrorMetadata error={error} />, renderOptions);
 
     // sections
     expectTextsInDocument(output, [
@@ -57,7 +62,7 @@ describe('ErrorMetadata', () => {
 
   it('should render a error with all included dot notation keys', () => {
     const error = getError();
-    const output = render(<ErrorMetadata error={error} />);
+    const output = render(<ErrorMetadata error={error} />, renderOptions);
 
     // included keys
     expectTextsInDocument(output, [
@@ -79,7 +84,7 @@ describe('ErrorMetadata', () => {
 
   it('should render a error with all included values', () => {
     const error = getError();
-    const output = render(<ErrorMetadata error={error} />);
+    const output = render(<ErrorMetadata error={error} />, renderOptions);
 
     // included values
     expectTextsInDocument(output, [
@@ -104,7 +109,7 @@ describe('ErrorMetadata', () => {
 
   it('should render a error with only the required sections', () => {
     const error = {} as APMError;
-    const output = render(<ErrorMetadata error={error} />);
+    const output = render(<ErrorMetadata error={error} />, renderOptions);
 
     // required sections should be found
     expectTextsInDocument(output, ['Labels', 'User']);

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/__test__/SpanMetadata.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/__test__/SpanMetadata.test.tsx
@@ -10,8 +10,13 @@ import { SpanMetadata } from '..';
 import { Span } from '../../../../../../typings/es_schemas/ui/Span';
 import {
   expectTextsInDocument,
-  expectTextsNotInDocument
+  expectTextsNotInDocument,
+  MockPluginContextWrapper
 } from '../../../../../utils/testHelpers';
+
+const renderOptions = {
+  wrapper: MockPluginContextWrapper
+};
 
 describe('SpanMetadata', () => {
   describe('render', () => {
@@ -29,7 +34,7 @@ describe('SpanMetadata', () => {
           id: '7efbc7056b746fcb'
         }
       } as unknown) as Span;
-      const output = render(<SpanMetadata span={span} />);
+      const output = render(<SpanMetadata span={span} />, renderOptions);
       expectTextsInDocument(output, ['Service', 'Agent']);
     });
   });
@@ -53,7 +58,7 @@ describe('SpanMetadata', () => {
           type: 'external'
         }
       } as unknown) as Span;
-      const output = render(<SpanMetadata span={span} />);
+      const output = render(<SpanMetadata span={span} />, renderOptions);
       expectTextsInDocument(output, ['Service', 'Agent', 'Span']);
     });
   });
@@ -76,7 +81,7 @@ describe('SpanMetadata', () => {
           type: 'external'
         }
       } as unknown) as Span;
-      const output = render(<SpanMetadata span={span} />);
+      const output = render(<SpanMetadata span={span} />, renderOptions);
       expectTextsInDocument(output, ['Service', 'Agent']);
       expectTextsNotInDocument(output, ['Span']);
     });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/__test__/TransactionMetadata.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/__test__/TransactionMetadata.test.tsx
@@ -10,8 +10,13 @@ import { render } from '@testing-library/react';
 import { Transaction } from '../../../../../../typings/es_schemas/ui/Transaction';
 import {
   expectTextsInDocument,
-  expectTextsNotInDocument
+  expectTextsNotInDocument,
+  MockPluginContextWrapper
 } from '../../../../../utils/testHelpers';
+
+const renderOptions = {
+  wrapper: MockPluginContextWrapper
+};
 
 function getTransaction() {
   return ({
@@ -38,7 +43,10 @@ function getTransaction() {
 describe('TransactionMetadata', () => {
   it('should render a transaction with all sections', () => {
     const transaction = getTransaction();
-    const output = render(<TransactionMetadata transaction={transaction} />);
+    const output = render(
+      <TransactionMetadata transaction={transaction} />,
+      renderOptions
+    );
 
     // sections
     expectTextsInDocument(output, [
@@ -57,7 +65,10 @@ describe('TransactionMetadata', () => {
 
   it('should render a transaction with all included dot notation keys', () => {
     const transaction = getTransaction();
-    const output = render(<TransactionMetadata transaction={transaction} />);
+    const output = render(
+      <TransactionMetadata transaction={transaction} />,
+      renderOptions
+    );
 
     // included keys
     expectTextsInDocument(output, [
@@ -82,7 +93,10 @@ describe('TransactionMetadata', () => {
 
   it('should render a transaction with all included values', () => {
     const transaction = getTransaction();
-    const output = render(<TransactionMetadata transaction={transaction} />);
+    const output = render(
+      <TransactionMetadata transaction={transaction} />,
+      renderOptions
+    );
 
     // included values
     expectTextsInDocument(output, [
@@ -107,7 +121,10 @@ describe('TransactionMetadata', () => {
 
   it('should render a transaction with only the required sections', () => {
     const transaction = {} as Transaction;
-    const output = render(<TransactionMetadata transaction={transaction} />);
+    const output = render(
+      <TransactionMetadata transaction={transaction} />,
+      renderOptions
+    );
 
     // required sections should be found
     expectTextsInDocument(output, ['Labels', 'User']);

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/__test__/MetadataTable.test.tsx
@@ -7,8 +7,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { MetadataTable } from '..';
-import { expectTextsInDocument } from '../../../../utils/testHelpers';
+import {
+  expectTextsInDocument,
+  MockPluginContextWrapper
+} from '../../../../utils/testHelpers';
 import { SectionsWithRows } from '../helper';
+
+const renderOptions = {
+  wrapper: MockPluginContextWrapper
+};
 
 describe('MetadataTable', () => {
   it('shows sections', () => {
@@ -25,7 +32,10 @@ describe('MetadataTable', () => {
         ]
       }
     ] as unknown) as SectionsWithRows;
-    const output = render(<MetadataTable sections={sectionsWithRows} />);
+    const output = render(
+      <MetadataTable sections={sectionsWithRows} />,
+      renderOptions
+    );
     expectTextsInDocument(output, [
       'Foo',
       'No data available',
@@ -45,7 +55,10 @@ describe('MetadataTable', () => {
           required: true
         }
       ] as unknown) as SectionsWithRows;
-      const output = render(<MetadataTable sections={sectionsWithRows} />);
+      const output = render(
+        <MetadataTable sections={sectionsWithRows} />,
+        renderOptions
+      );
       expectTextsInDocument(output, ['Foo', 'No data available']);
     });
   });

--- a/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
+++ b/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
@@ -78,12 +78,15 @@ export interface ConfigSchema {
 // These are to be used until we switch over all our context handling to
 // kibana_react
 export const PluginsContext = createContext<
-  ApmPluginStartDeps & { apm: { config: ConfigSchema } }
+  ApmPluginStartDeps & { apm: { config: ConfigSchema; stackVersion: string } }
 >(
   {} as ApmPluginStartDeps & {
     apm: { config: ConfigSchema; stackVersion: string };
   }
 );
+export function usePlugins() {
+  return useContext(PluginsContext);
+}
 
 export class ApmPlugin
   implements

--- a/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
+++ b/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
@@ -35,6 +35,7 @@ import { featureCatalogueEntry } from './featureCatalogueEntry';
 import { getConfigFromInjectedMetadata } from './getConfigFromInjectedMetadata';
 import { toggleAppLinkInNav } from './toggleAppLinkInNav';
 import { BreadcrumbRoute } from '../components/app/Main/ProvideBreadcrumbs';
+import { stackVersionFromLegacyMetadata } from './stackVersionFromLegacyMetadata';
 
 export const REACT_APP_ROOT_ID = 'react-apm-root';
 
@@ -78,10 +79,11 @@ export interface ConfigSchema {
 // kibana_react
 export const PluginsContext = createContext<
   ApmPluginStartDeps & { apm: { config: ConfigSchema } }
->({} as ApmPluginStartDeps & { apm: { config: ConfigSchema } });
-export function usePlugins() {
-  return useContext(PluginsContext);
-}
+>(
+  {} as ApmPluginStartDeps & {
+    apm: { config: ConfigSchema; stackVersion: string };
+  }
+);
 
 export class ApmPlugin
   implements
@@ -112,7 +114,17 @@ export class ApmPlugin
     //
     // Until then we use a shim to get it from legacy injectedMetadata:
     const config = getConfigFromInjectedMetadata();
-    const pluginsForContext = { ...plugins, apm: { config } };
+
+    // Once we're actually an NP plugin we'll get the package info from the
+    // initializerContext like:
+    //
+    //     const stackVersion = this.initializerContext.env.packageInfo.branch
+    //
+    // Until then we use a shim to get it from legacy metadata:
+    const stackVersion = stackVersionFromLegacyMetadata;
+
+    const pluginsForContext = { ...plugins, apm: { config, stackVersion } };
+
     const routes = getRoutes(config);
 
     // render APM feedback link in global help menu

--- a/x-pack/legacy/plugins/apm/public/new-platform/stackVersionFromLegacyMetadata.ts
+++ b/x-pack/legacy/plugins/apm/public/new-platform/stackVersionFromLegacyMetadata.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { metadata } from 'ui/metadata';
+
+export const stackVersionFromLegacyMetadata = metadata.branch;

--- a/x-pack/legacy/plugins/apm/public/utils/testHelpers.tsx
+++ b/x-pack/legacy/plugins/apm/public/utils/testHelpers.tsx
@@ -11,7 +11,7 @@ import enzymeToJson from 'enzyme-to-json';
 import { Location } from 'history';
 import moment from 'moment';
 import { Moment } from 'moment-timezone';
-import React from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import { render, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { MemoryRouter } from 'react-router-dom';
@@ -19,6 +19,11 @@ import { APMConfig } from '../../../../../plugins/apm/server';
 import { LocationProvider } from '../context/LocationContext';
 import { PromiseReturnType } from '../../typings/common';
 import { ESFilter } from '../../typings/elasticsearch';
+import {
+  PluginsContext,
+  ConfigSchema,
+  ApmPluginStartDeps
+} from '../new-platform/plugin';
 
 export function toJson(wrapper: ReactWrapper) {
   return enzymeToJson(wrapper, {
@@ -179,3 +184,23 @@ export async function inspectSearchParams(
 }
 
 export type SearchParamsMock = PromiseReturnType<typeof inspectSearchParams>;
+
+export const MockPluginContextWrapper: FunctionComponent<{}> = ({
+  children
+}: {
+  children?: ReactNode;
+}) => {
+  return (
+    <PluginsContext.Provider
+      value={
+        {
+          apm: { config: {} as ConfigSchema, stackVersion: '0' }
+        } as ApmPluginStartDeps & {
+          apm: { config: ConfigSchema; stackVersion: string };
+        }
+      }
+    >
+      {children}
+    </PluginsContext.Provider>
+  );
+};


### PR DESCRIPTION
Set up the APM public NP plugin to expose the stack version

Since we're not yet running as an NP plugin, we don't get passed a pluginInitializerContext,
so we use a shim in the plugin setup that gets the branch values from ui/metadata for the time being.

This has some changes about the same as #51635, so they'll have to be reconciled when merged.

Fixes #49327.
