### PR TITLE
Prevents xpack.task_manager.index being set to .tasks

### DIFF
--- a/x-pack/legacy/plugins/task_manager/index.ts
+++ b/x-pack/legacy/plugins/task_manager/index.ts
@@ -40,7 +40,8 @@ export function taskManager(kibana: any) {
           .default(3000),
         index: Joi.string()
           .description('The name of the index used to store task information.')
-          .default('.kibana_task_manager'),
+          .default('.kibana_task_manager')
+          .invalid(['.tasks']),
         max_workers: Joi.number()
           .description(
             'The maximum number of tasks that this Kibana instance will run simultaneously.'


### PR DESCRIPTION
A quick solution in preventing what was described in https://github.com/elastic/kibana/issues/47716

The `.tasks` index is an internal index used by Elasticsearch and is separate from the Kibana task manager. The prevents `.tasks` from being used which will absolutely cause issues.

cc: @joshdover
