### PR TITLE
[7.x] Functional tests: elastic chart provider (#52085)

### DIFF
--- a/test/functional/page_objects/discover_page.js
+++ b/test/functional/page_objects/discover_page.js
@@ -31,6 +31,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
   const config = getService('config');
   const defaultFindTimeout = config.get('timeouts.find');
   const comboBox = getService('comboBox');
+  const elasticChart = getService('elasticChart');
 
   class DiscoverPage {
     async getQueryField() {
@@ -292,6 +293,9 @@ export function DiscoverPageProvider({ getService, getPageObjects }) {
       await testSubjects.missingOrFail('filterSelectionPanel', { allowHidden: true });
     }
 
+    async waitForChartLoadingComplete(renderCount) {
+      await elasticChart.waitForRenderingCount('discoverChart', renderCount);
+    }
   }
 
   return new DiscoverPage();

--- a/test/functional/services/elastic_chart.ts
+++ b/test/functional/services/elastic_chart.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function ElasticChartProvider({ getService }: FtrProviderContext) {
+  const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+  const log = getService('log');
+
+  class ElasticChart {
+    public async waitForRenderComplete(dataTestSubj: string) {
+      const chart = await testSubjects.find(dataTestSubj);
+      const rendered = await chart.findAllByCssSelector('.echChart[data-ech-render-complete=true]');
+      expect(rendered).to.equal(
+        1,
+        `Rendering for elastic-chart with data-test-subj='${dataTestSubj}' was not finished in time`
+      );
+    }
+
+    public async getVisualizationRenderingCount(dataTestSubj: string) {
+      const chart = await testSubjects.find(dataTestSubj);
+      const visContainer = await chart.findByCssSelector('.echChart');
+      const renderingCount = await visContainer.getAttribute('data-ech-render-count');
+      return Number(renderingCount);
+    }
+
+    public async waitForRenderingCount(dataTestSubj: string, previousCount = 1) {
+      await retry.waitFor(`rendering count to be equal to [${previousCount + 1}]`, async () => {
+        const currentRenderingCount = await this.getVisualizationRenderingCount(dataTestSubj);
+        log.debug(`-- currentRenderingCount=${currentRenderingCount}`);
+        return currentRenderingCount === previousCount + 1;
+      });
+    }
+  }
+
+  return new ElasticChart();
+}

--- a/test/functional/services/index.ts
+++ b/test/functional/services/index.ts
@@ -31,6 +31,7 @@ import {
   // @ts-ignore not TS yet
 } from './dashboard';
 import { DocTableProvider } from './doc_table';
+import { ElasticChartProvider } from './elastic_chart';
 import { EmbeddingProvider } from './embedding';
 import { FailureDebuggingProvider } from './failure_debugging';
 import { FilterBarProvider } from './filter_bar';
@@ -81,4 +82,5 @@ export const services = {
   globalNav: GlobalNavProvider,
   toasts: ToastsProvider,
   savedQueryManagementComponent: SavedQueryManagementComponentProvider,
+  elasticChart: ElasticChartProvider,
 };

--- a/test/visual_regression/tests/discover/chart_visualization.js
+++ b/test/visual_regression/tests/discover/chart_visualization.js
@@ -27,7 +27,6 @@ export default function ({ getService, getPageObjects }) {
   const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['common', 'discover', 'header', 'timePicker']);
   const visualTesting = getService('visualTesting');
-  const find = getService('find');
   const defaultSettings = {
     defaultIndex: 'logstash-*',
     'discover:sampleSize': 1
@@ -54,7 +53,7 @@ export default function ({ getService, getPageObjects }) {
       it('should show bars in the correct time zone', async function () {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -64,7 +63,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await PageObjects.discover.setChartInterval('Hourly');
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -74,7 +73,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await PageObjects.discover.setChartInterval('Daily');
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -84,7 +83,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await PageObjects.discover.setChartInterval('Weekly');
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -98,7 +97,7 @@ export default function ({ getService, getPageObjects }) {
         });
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -108,7 +107,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await PageObjects.discover.setChartInterval('Monthly');
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -118,7 +117,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await PageObjects.discover.setChartInterval('Yearly');
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -128,7 +127,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await PageObjects.discover.setChartInterval('Auto');
-        await find.byCssSelector(`.echChart[data-ech-render-count="${++renderCounter}"]`);
+        await PageObjects.discover.waitForChartLoadingComplete(++renderCounter);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });
@@ -143,6 +142,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         await PageObjects.header.awaitGlobalLoadingIndicatorHidden();
         await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.discover.waitForChartLoadingComplete(1);
         await visualTesting.snapshot({
           show: ['discoverChart'],
         });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Functional tests: elastic chart provider (#52085)