### PR TITLE
FTR: Do not collect browser console logs on Windows

### DIFF
--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -136,6 +136,20 @@ async function attemptToCreateCommand(
           // See: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode
           firefoxOptions.headless();
         }
+
+        // Windows issue with stout socket https://github.com/elastic/kibana/issues/52053
+        if (process.platform === 'win32') {
+          const session = await new Builder()
+            .forBrowser(browserType)
+            .setFirefoxOptions(firefoxOptions)
+            .setFirefoxService(new firefox.ServiceBuilder(geckoDriver.path))
+            .build();
+          return {
+            session,
+            consoleLog$: Rx.EMPTY,
+          };
+        }
+
         const { input, chunk$, cleanup } = await createStdoutSocket();
         lifecycle.on('cleanup', cleanup);
 


### PR DESCRIPTION
## Summary

This PR is a temporary fix for #52053 in order to unblock people trying to run functional tests in Firefox on Windows

The issue is reproduced only on Windows machines and related to the way we process console logs with socket connection. It works fine on Windows if we just set stdio to "inherit" mode, but it is not very useful.
