### PR TITLE
Fix Unknown Type Of Dashbaord When Using Chinese i18n

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dashboard/saved_dashboard/saved_dashboards.js
+++ b/src/legacy/core_plugins/kibana/public/dashboard/saved_dashboard/saved_dashboards.js
@@ -29,9 +29,10 @@ const module = uiModules.get('app/dashboard');
 // edited by the object editor.
 savedObjectManagementRegistry.register({
   service: 'savedDashboards',
-  title: i18n.translate('kbn.dashboard.savedDashboardsTitle', {
-    defaultMessage: 'dashboards',
-  }),
+  title: 'dashboards',
+//   title: i18n.translate('kbn.dashboard.savedDashboardsTitle', {
+//     defaultMessage: 'dashboards',
+//   }),
 });
 
 // This is the only thing that gets injected into controllers


### PR DESCRIPTION
When displaying the savedobject list in kibana management section, the dashboard's registry title is used for checking the savedobject's type. The checking method simply does a string include check and will fail when the registry title is Chinese '仪表板' but the type in the savedobject list is 'dashboard'.

## Summary

Resolved a problem when using chinese i18n setting, the saved object list will display a unknown type warning.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [ ] ~~This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~