### PR TITLE
[APM] Quick fix for ACM to ensure more than 10 items are displayed

### DIFF
--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/__snapshots__/queries.test.ts.snap
@@ -44,6 +44,7 @@ Object {
 exports[`agent configuration queries fetches configurations 1`] = `
 Object {
   "index": "myIndex",
+  "size": 200,
 }
 `;
 

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/list_configurations.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/list_configurations.ts
@@ -15,7 +15,8 @@ export async function listConfigurations({ setup }: { setup: Setup }) {
   const { internalClient, indices } = setup;
 
   const params = {
-    index: indices.apmAgentConfigurationIndex
+    index: indices.apmAgentConfigurationIndex,
+    size: 200
   };
 
   const resp = await internalClient.search<AgentConfiguration>(params);


### PR DESCRIPTION
Turns out there was no `size` parameters set for the ACM list so currently only the first 10 items are displayed. This is a quick fix that increases the list size to 200.

![image](https://user-images.githubusercontent.com/209966/70227473-ed0c8800-1752-11ea-9165-47fa7c4a2815.png)

As a follow-up we should add pagination to improve the experience: https://github.com/elastic/kibana/issues/52261