### PR TITLE
[APM] Expose and reorganize platform config

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Home/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Home/index.tsx
@@ -28,9 +28,9 @@ import { ServiceMap } from '../ServiceMap';
 import { usePlugins } from '../../../new-platform/plugin';
 
 function getHomeTabs({
-  apmServiceMapEnabled = false
+  serviceMapEnabled = false
 }: {
-  apmServiceMapEnabled: boolean;
+  serviceMapEnabled: boolean;
 }) {
   const homeTabs = [
     {
@@ -57,7 +57,7 @@ function getHomeTabs({
     }
   ];
 
-  if (apmServiceMapEnabled) {
+  if (serviceMapEnabled) {
     homeTabs.push({
       link: (
         <ServiceMapLink>
@@ -83,8 +83,8 @@ interface Props {
 
 export function Home({ tab }: Props) {
   const { apm } = usePlugins();
-  const { apmServiceMapEnabled } = apm.config;
-  const homeTabs = getHomeTabs({ apmServiceMapEnabled });
+  const { serviceMapEnabled } = apm.config;
+  const homeTabs = getHomeTabs({ serviceMapEnabled });
   const selectedTab = homeTabs.find(
     homeTab => homeTab.name === tab
   ) as $ElementType<typeof homeTabs, number>;

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/__test__/UpdateBreadcrumbs.test.js
@@ -19,7 +19,7 @@ const coreMock = {
 
 jest.spyOn(kibanaCore, 'useKibanaCore').mockReturnValue(coreMock);
 
-const routes = getRoutes({ apmServiceMapEnabled: true });
+const routes = getRoutes({ serviceMapEnabled: true });
 
 function expectBreadcrumbToMatchSnapshot(route, params = '') {
   mount(

--- a/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -43,9 +43,9 @@ const renderAsRedirectTo = (to: string) => {
 };
 
 export function getRoutes({
-  apmServiceMapEnabled
+  serviceMapEnabled
 }: {
-  apmServiceMapEnabled: boolean;
+  serviceMapEnabled: boolean;
 }): BreadcrumbRoute[] {
   const routes: BreadcrumbRoute[] = [
     {
@@ -201,7 +201,7 @@ export function getRoutes({
     }
   ];
 
-  if (apmServiceMapEnabled) {
+  if (serviceMapEnabled) {
     routes.push(
       {
         exact: true,

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceDetailTabs.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceDetailTabs.tsx
@@ -32,7 +32,7 @@ export function ServiceDetailTabs({ tab }: Props) {
   const { serviceName } = urlParams;
   const { agentName } = useAgentName();
   const { apm } = usePlugins();
-  const { apmServiceMapEnabled } = apm.config;
+  const { serviceMapEnabled } = apm.config;
 
   if (!serviceName) {
     // this never happens, urlParams type is not accurate enough
@@ -107,7 +107,7 @@ export function ServiceDetailTabs({ tab }: Props) {
     name: 'service-map'
   };
 
-  if (apmServiceMapEnabled) {
+  if (serviceMapEnabled) {
     tabs.push(serviceMapTab);
   }
 

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/WatcherFlyout.tsx
@@ -151,9 +151,9 @@ export class WatcherFlyout extends Component<
   };
 
   public createWatch = ({
-    apmIndexPatternTitle
+    indexPatternTitle
   }: {
-    apmIndexPatternTitle: string;
+    indexPatternTitle: string;
   }) => () => {
     const { serviceName } = this.props.urlParams;
     const core = this.context;
@@ -199,7 +199,7 @@ export class WatcherFlyout extends Component<
       slackUrl,
       threshold: this.state.threshold,
       timeRange,
-      apmIndexPatternTitle
+      apmIndexPatternTitle: indexPatternTitle
     })
       .then((id: string) => {
         this.props.onClose();

--- a/x-pack/legacy/plugins/apm/public/new-platform/getConfigFromInjectedMetadata.ts
+++ b/x-pack/legacy/plugins/apm/public/new-platform/getConfigFromInjectedMetadata.ts
@@ -17,8 +17,8 @@ export function getConfigFromInjectedMetadata(): ConfigSchema {
   } = core.injectedMetadata.getInjectedVars();
 
   return {
-    apmIndexPatternTitle,
-    apmServiceMapEnabled,
-    apmUiEnabled
-  } as ConfigSchema;
+    indexPatternTitle: `${apmIndexPatternTitle}`,
+    serviceMapEnabled: !!apmServiceMapEnabled,
+    ui: { enabled: !!apmUiEnabled }
+  };
 }

--- a/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
+++ b/x-pack/legacy/plugins/apm/public/new-platform/plugin.tsx
@@ -71,9 +71,11 @@ export interface ApmPluginStartDeps {
 }
 
 export interface ConfigSchema {
-  apmIndexPatternTitle: string;
-  apmServiceMapEnabled: boolean;
-  apmUiEnabled: boolean;
+  indexPatternTitle: string;
+  serviceMapEnabled: boolean;
+  ui: {
+    enabled: boolean;
+  };
 }
 
 // These are to be used until we switch over all our context handling to

--- a/x-pack/legacy/plugins/apm/public/new-platform/toggleAppLinkInNav.ts
+++ b/x-pack/legacy/plugins/apm/public/new-platform/toggleAppLinkInNav.ts
@@ -5,9 +5,10 @@
  */
 
 import { CoreStart } from 'kibana/public';
+import { ConfigSchema } from './plugin';
 
-export function toggleAppLinkInNav(core: CoreStart, { apmUiEnabled = false }) {
-  if (apmUiEnabled === false) {
+export function toggleAppLinkInNav(core: CoreStart, { ui }: ConfigSchema) {
+  if (ui.enabled === false) {
     core.chrome.navLinks.update('apm', { hidden: true });
   }
 }

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -10,6 +10,10 @@ import { APMOSSConfig } from 'src/plugins/apm_oss/server';
 import { APMPlugin } from './plugin';
 
 export const config = {
+  exposeToBrowser: {
+    serviceMapEnabled: true,
+    ui: true,
+  },
   schema: schema.object({
     serviceMapEnabled: schema.boolean({ defaultValue: false }),
     autocreateApmIndexPattern: schema.boolean({ defaultValue: true }),


### PR DESCRIPTION
Add `exposeToBrowser` to the config object's we're using in the server config.

Update our shim and usage of these config variables to match.
