### PR TITLE
[Telemetry] Improve isTaskManagerReady checks for telemetry

### DIFF
--- a/x-pack/legacy/plugins/lens/server/usage/collectors.ts
+++ b/x-pack/legacy/plugins/lens/server/usage/collectors.ts
@@ -74,7 +74,9 @@ function addEvents(prevEvents: Record<string, number>, newEvents: Record<string,
 }
 
 async function isTaskManagerReady(server: Server) {
-  return (await getLatestTaskState(server)) !== null;
+  const result = await getLatestTaskState(server);
+  const runs = get(result, '[0].state.runs', 0);
+  return runs > 0;
 }
 
 async function getLatestTaskState(server: Server) {

--- a/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js
+++ b/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js
@@ -15,7 +15,8 @@ export function initTelemetryCollection(usageCollection, server) {
 
 async function isTaskManagerReady(server) {
   const result = await fetch(server);
-  return result !== null;
+  const runs = _.get(result, '[0].state.runs', 0);
+  return runs > 0;
 }
 
 async function fetch(server) {

--- a/x-pack/legacy/plugins/oss_telemetry/server/lib/collectors/visualizations/get_usage_collector.ts
+++ b/x-pack/legacy/plugins/oss_telemetry/server/lib/collectors/visualizations/get_usage_collector.ts
@@ -10,7 +10,8 @@ import { PLUGIN_ID, VIS_TELEMETRY_TASK, VIS_USAGE_TYPE } from '../../../../const
 
 async function isTaskManagerReady(server: HapiServer) {
   const result = await fetch(server);
-  return result !== null;
+  const runs = get(result, '[0].state.runs', 0);
+  return runs > 0;
 }
 
 async function fetch(server: HapiServer) {


### PR DESCRIPTION
Related to https://github.com/elastic/elastic-stack-testing/pull/451

In a few plugins, we are using the task manager as a way to asynchronously fetch telemetry data. In order for telemetry collection to know to wait for this asynchronous action, there is an `isReady` check on each usage collector that returns true/false. All of these plugins use a [naive check](https://github.com/elastic/kibana/blob/master/x-pack/legacy/plugins/maps/server/maps_telemetry/maps_usage_collector.js#L18) to see if the task manager is running, but this is apparently not enough.

It's a race condition, but there are time where `isReady()` is returning `true`, but the task manager hasn't actually ran the task to fetch the telemetry data. 

I think we can avoid this by not returning `true` from `isReady()` until the task has actually been ran. 

As a quick side note, I discovered https://github.com/elastic/kibana/pull/52439 while working on this which affects maps telemetry