### PR TITLE
[APM] Add version annotations to timeseries charts

### DIFF
--- a/x-pack/legacy/plugins/apm/common/annotations.ts
+++ b/x-pack/legacy/plugins/apm/common/annotations.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export enum AnnotationType {
+  VERSION = 'version'
+}
+
+export interface Annotation {
+  type: AnnotationType;
+  id: string;
+  time: number;
+  text: string;
+}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/AnnotationsPlot.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/AnnotationsPlot.tsx
@@ -55,7 +55,7 @@ export function AnnotationsPlot(props: Props) {
             content={
               <EuiFlexGroup>
                 <EuiFlexItem grow={true}>
-                  <EuiText color="subdued">
+                  <EuiText>
                     {i18n.translate('xpack.apm.version', {
                       defaultMessage: 'Version'
                     })}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/AnnotationsPlot.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/AnnotationsPlot.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React from 'react';
+import { VerticalGridLines } from 'react-vis';
+import theme from '@elastic/eui/dist/eui_theme_light.json';
+import {
+  EuiIcon,
+  EuiToolTip,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { Maybe } from '../../../../../typings/common';
+import { Annotation } from '../../../../../common/annotations';
+import { PlotValues, SharedPlot } from './plotUtils';
+import { asAbsoluteDateTime } from '../../../../utils/formatters';
+
+interface Props {
+  annotations: Annotation[];
+  plotValues: PlotValues;
+  width: number;
+  overlay: Maybe<HTMLElement>;
+}
+
+const style = {
+  stroke: theme.euiColorSecondary,
+  strokeDasharray: 'none'
+};
+
+export function AnnotationsPlot(props: Props) {
+  const { plotValues, annotations } = props;
+
+  const tickValues = annotations.map(annotation => annotation.time);
+
+  return (
+    <>
+      <SharedPlot plotValues={plotValues}>
+        <VerticalGridLines tickValues={tickValues} style={style} />
+      </SharedPlot>
+      {annotations.map(annotation => (
+        <div
+          key={annotation.id}
+          style={{
+            position: 'absolute',
+            left: plotValues.x(annotation.time) - 8,
+            top: -2
+          }}
+        >
+          <EuiToolTip
+            title={asAbsoluteDateTime(annotation.time, 'seconds')}
+            content={
+              <EuiFlexGroup>
+                <EuiFlexItem grow={true}>
+                  <EuiText color="subdued">
+                    {i18n.translate('xpack.apm.version', {
+                      defaultMessage: 'Version'
+                    })}
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>{annotation.text}</EuiFlexItem>
+              </EuiFlexGroup>
+            }
+          >
+            <EuiIcon type="tag" color={theme.euiColorSecondary} />
+          </EuiToolTip>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/Legends.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/Legends.js
@@ -16,6 +16,8 @@ import {
   truncate
 } from '../../../../style/variables';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
+import { i18n } from '@kbn/i18n';
+import { EuiIcon } from '@elastic/eui';
 
 const Container = styled.div`
   display: flex;
@@ -73,9 +75,12 @@ export default function Legends({
   noHits,
   series,
   seriesEnabledState,
-  truncateLegends
+  truncateLegends,
+  hasAnnotations,
+  showAnnotations,
+  onAnnotationsToggle
 }) {
-  if (noHits) {
+  if (noHits && !hasAnnotations) {
     return null;
   }
 
@@ -107,6 +112,30 @@ export default function Legends({
           />
         );
       })}
+      {hasAnnotations && (
+        <Legend
+          key="annotations"
+          onClick={() => {
+            if (onAnnotationsToggle) {
+              onAnnotationsToggle();
+            }
+          }}
+          text={
+            <LegendContent>
+              {i18n.translate('xpack.apm.serviceVersion', {
+                defaultMessage: 'Service version'
+              })}
+            </LegendContent>
+          }
+          indicator={() => (
+            <div style={{ marginRight: px(units.quarter) }}>
+              <EuiIcon type="tag" color={theme.euiColorSecondary} />
+            </div>
+          )}
+          disabled={!showAnnotations}
+          color={theme.euiColorSecondary}
+        />
+      )}
       <MoreSeries hiddenSeriesCount={hiddenSeriesCount} />
     </Container>
   );
@@ -118,5 +147,8 @@ Legends.propTypes = {
   noHits: PropTypes.bool.isRequired,
   series: PropTypes.array.isRequired,
   seriesEnabledState: PropTypes.array.isRequired,
-  truncateLegends: PropTypes.bool.isRequired
+  truncateLegends: PropTypes.bool.isRequired,
+  hasAnnotations: PropTypes.bool,
+  showAnnotations: PropTypes.bool,
+  onAnnotationsToggle: PropTypes.func
 };

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/index.js
@@ -13,6 +13,7 @@ import Legends from './Legends';
 import StaticPlot from './StaticPlot';
 import InteractivePlot from './InteractivePlot';
 import VoronoiPlot from './VoronoiPlot';
+import { AnnotationsPlot } from './AnnotationsPlot';
 import { createSelector } from 'reselect';
 import { getPlotValues } from './plotUtils';
 import { isValidCoordinateValue } from '../../../../utils/isValidCoordinateValue';
@@ -28,7 +29,8 @@ export class InnerCustomPlot extends PureComponent {
     seriesEnabledState: [],
     isDrawing: false,
     selectionStart: null,
-    selectionEnd: null
+    selectionEnd: null,
+    showAnnotations: true
   };
 
   getEnabledSeries = createSelector(
@@ -122,7 +124,7 @@ export class InnerCustomPlot extends PureComponent {
   }
 
   render() {
-    const { series, truncateLegends, width } = this.props;
+    const { series, truncateLegends, width, annotations } = this.props;
 
     if (!width) {
       return null;
@@ -166,6 +168,14 @@ export class InnerCustomPlot extends PureComponent {
             tickFormatX={this.props.tickFormatX}
           />
 
+          {this.state.showAnnotations && !isEmpty(annotations) && (
+            <AnnotationsPlot
+              plotValues={plotValues}
+              width={width}
+              annotations={annotations || []}
+            />
+          )}
+
           <InteractivePlot
             plotValues={plotValues}
             hoverX={this.props.hoverX}
@@ -192,6 +202,13 @@ export class InnerCustomPlot extends PureComponent {
           hiddenSeriesCount={hiddenSeriesCount}
           clickLegend={this.clickLegend}
           seriesEnabledState={this.state.seriesEnabledState}
+          hasAnnotations={!isEmpty(annotations)}
+          showAnnotations={this.state.showAnnotations}
+          onAnnotationsToggle={() => {
+            this.setState(({ showAnnotations }) => ({
+              showAnnotations: !showAnnotations
+            }));
+          }}
         />
       </Fragment>
     );
@@ -209,7 +226,14 @@ InnerCustomPlot.propTypes = {
   truncateLegends: PropTypes.bool,
   width: PropTypes.number.isRequired,
   height: PropTypes.number,
-  stackBy: PropTypes.string
+  stackBy: PropTypes.string,
+  annotations: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string,
+      id: PropTypes.string,
+      firstSeen: PropTypes.number
+    })
+  )
 };
 
 InnerCustomPlot.defaultProps = {

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/plotUtils.test.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/plotUtils.test.ts
@@ -6,6 +6,7 @@
 
 // @ts-ignore
 import * as plotUtils from './plotUtils';
+import { TimeSeries, Coordinate } from '../../../../../typings/timeseries';
 
 describe('plotUtils', () => {
   describe('getPlotValues', () => {
@@ -34,7 +35,10 @@ describe('plotUtils', () => {
           expect(
             plotUtils
               .getPlotValues(
-                [{ data: { x: 0, y: 200 } }, { data: { x: 0, y: 300 } }],
+                [
+                  { data: [{ x: 0, y: 200 }] },
+                  { data: [{ x: 0, y: 300 }] }
+                ] as Array<TimeSeries<Coordinate>>,
                 [],
                 {
                   height: 1,

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/test/__snapshots__/CustomPlot.test.js.snap
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/CustomPlot/test/__snapshots__/CustomPlot.test.js.snap
@@ -46,6 +46,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -2094,6 +2095,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -2126,6 +2128,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -2818,6 +2821,7 @@ Object {
   "selectionEnd": null,
   "selectionStart": null,
   "seriesEnabledState": Array [],
+  "showAnnotations": true,
 }
 `;
 
@@ -2969,6 +2973,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -5017,6 +5022,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -5283,6 +5289,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -5975,6 +5982,7 @@ Object {
   "selectionEnd": null,
   "selectionStart": null,
   "seriesEnabledState": Array [],
+  "showAnnotations": true,
 }
 `;
 
@@ -5992,6 +6000,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -6355,6 +6364,7 @@ Array [
       style={
         Object {
           "left": 0,
+          "pointerEvents": "none",
           "position": "absolute",
           "top": 0,
         }
@@ -6394,5 +6404,6 @@ Object {
   "selectionEnd": null,
   "selectionStart": null,
   "seriesEnabledState": Array [],
+  "showAnnotations": true,
 }
 `;

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Legend/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Legend/index.js
@@ -48,11 +48,7 @@ export default class Legend extends PureComponent {
         fontSize={fontSize}
         {...rest}
       >
-        {indicator ? (
-          indicator({ color, radius })
-        ) : (
-          <Indicator color={color} radius={radius} />
-        )}
+        {indicator ? indicator() : <Indicator color={color} radius={radius} />}
         {text}
       </Container>
     );

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Legend/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Legend/index.js
@@ -37,6 +37,7 @@ export default class Legend extends PureComponent {
       radius = units.minus - 1,
       disabled = false,
       clickable = false,
+      indicator,
       ...rest
     } = this.props;
     return (
@@ -47,7 +48,11 @@ export default class Legend extends PureComponent {
         fontSize={fontSize}
         {...rest}
       >
-        <Indicator color={color} radius={radius} />
+        {indicator ? (
+          indicator({ color, radius })
+        ) : (
+          <Indicator color={color} radius={radius} />
+        )}
         {text}
       </Container>
     );

--- a/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/multiple-versions.json
+++ b/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/multiple-versions.json
@@ -1,0 +1,34 @@
+{
+  "took": 444,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "versions": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "8.0.0",
+          "doc_count": 615285
+        },
+        {
+          "key": "7.5.0",
+          "doc_count": 615285
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/no-versions.json
+++ b/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/no-versions.json
@@ -1,0 +1,25 @@
+{
+  "took": 398,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "versions": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": []
+    }
+  }
+}

--- a/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/one-version.json
+++ b/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/one-version.json
@@ -1,0 +1,30 @@
+{
+  "took": 444,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "versions": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "8.0.0",
+          "doc_count": 615285
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/versions-first-seen.json
+++ b/x-pack/legacy/plugins/apm/server/lib/services/annotations/__fixtures__/versions-first-seen.json
@@ -1,0 +1,24 @@
+{
+  "took": 4750,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "first_seen": {
+      "value": 1.5281138E12,
+      "value_as_string": "2018-06-04T12:00:00.000Z"
+    }
+  }
+}

--- a/x-pack/legacy/plugins/apm/server/lib/services/annotations/index.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/annotations/index.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { getServiceAnnotations } from '.';
+import {
+  SearchParamsMock,
+  inspectSearchParams
+} from '../../../../public/utils/testHelpers';
+import noVersions from './__fixtures__/no-versions.json';
+import oneVersion from './__fixtures__/one-version.json';
+import multipleVersions from './__fixtures__/multiple-versions.json';
+import versionsFirstSeen from './__fixtures__/versions-first-seen.json';
+
+describe('getServiceAnnotations', () => {
+  let mock: SearchParamsMock;
+
+  afterEach(() => {
+    mock.teardown();
+  });
+
+  describe('with 0 versions', () => {
+    it('returns no annotations', async () => {
+      mock = await inspectSearchParams(
+        setup =>
+          getServiceAnnotations({
+            setup,
+            serviceName: 'foo',
+            environment: 'bar'
+          }),
+        {
+          mockResponse: () => noVersions
+        }
+      );
+
+      expect(mock.response).toEqual({ annotations: [] });
+    });
+  });
+
+  describe('with 1 version', () => {
+    it('returns no annotations', async () => {
+      mock = await inspectSearchParams(
+        setup =>
+          getServiceAnnotations({
+            setup,
+            serviceName: 'foo',
+            environment: 'bar'
+          }),
+        {
+          mockResponse: () => oneVersion
+        }
+      );
+
+      expect(mock.response).toEqual({ annotations: [] });
+    });
+  });
+
+  describe('with more than 1 version', () => {
+    it('returns two annotations', async () => {
+      const responses = [
+        multipleVersions,
+        versionsFirstSeen,
+        versionsFirstSeen
+      ];
+      mock = await inspectSearchParams(
+        setup =>
+          getServiceAnnotations({
+            setup,
+            serviceName: 'foo',
+            environment: 'bar'
+          }),
+        {
+          mockResponse: () => responses.shift()
+        }
+      );
+
+      expect(mock.spy.mock.calls.length).toBe(3);
+
+      expect(mock.response).toEqual({
+        annotations: [
+          {
+            id: '8.0.0',
+            text: '8.0.0',
+            time: 1.5281138e12,
+            type: 'version'
+          },
+          {
+            id: '7.5.0',
+            text: '7.5.0',
+            time: 1.5281138e12,
+            type: 'version'
+          }
+        ]
+      });
+    });
+  });
+});

--- a/x-pack/legacy/plugins/apm/server/lib/services/annotations/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/annotations/index.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { isNumber } from 'lodash';
+import { Annotation, AnnotationType } from '../../../../common/annotations';
+import { ESFilter } from '../../../../typings/elasticsearch';
+import {
+  SERVICE_NAME,
+  SERVICE_ENVIRONMENT
+} from '../../../../common/elasticsearch_fieldnames';
+import { Setup, SetupTimeRange } from '../../helpers/setup_request';
+import { rangeFilter } from '../../helpers/range_filter';
+import { SERVICE_VERSION } from '../../../../common/elasticsearch_fieldnames';
+
+export async function getServiceAnnotations({
+  setup,
+  serviceName,
+  environment
+}: {
+  serviceName: string;
+  environment?: string;
+  setup: Setup & SetupTimeRange;
+}) {
+  const { start, end, client, indices } = setup;
+
+  const filter: ESFilter[] = [
+    { range: rangeFilter(start, end) },
+    { term: { [SERVICE_NAME]: serviceName } }
+  ];
+
+  if (environment) {
+    filter.push({ term: { [SERVICE_ENVIRONMENT]: environment } });
+  }
+
+  const versions =
+    (
+      await client.search({
+        index: indices['apm_oss.transactionIndices'],
+        body: {
+          size: 0,
+          query: {
+            bool: {
+              filter
+            }
+          },
+          aggs: {
+            versions: {
+              terms: {
+                field: SERVICE_VERSION
+              }
+            }
+          }
+        }
+      })
+    ).aggregations?.versions.buckets.map(bucket => bucket.key) ?? [];
+
+  if (versions.length > 1) {
+    const annotations = await Promise.all(
+      versions.map(async version => {
+        const response = await client.search({
+          index: indices['apm_oss.transactionIndices'],
+          body: {
+            size: 0,
+            query: {
+              bool: {
+                filter: [
+                  {
+                    term: {
+                      [SERVICE_VERSION]: version
+                    }
+                  }
+                ]
+              }
+            },
+            aggs: {
+              first_seen: {
+                min: {
+                  field: '@timestamp'
+                }
+              }
+            }
+          }
+        });
+
+        const firstSeen = response.aggregations?.first_seen.value;
+
+        if (!isNumber(firstSeen)) {
+          throw new Error(
+            'First seen for version was unexpectedly undefined or null.'
+          );
+        }
+
+        if (firstSeen < start || firstSeen > end) {
+          return null;
+        }
+
+        return {
+          type: AnnotationType.VERSION,
+          id: version,
+          time: firstSeen,
+          text: version
+        };
+      })
+    );
+    return { annotations: annotations.filter(Boolean) as Annotation[] };
+  }
+  return { annotations: [] };
+}

--- a/x-pack/legacy/plugins/apm/server/routes/create_apm_api.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/create_apm_api.ts
@@ -17,7 +17,8 @@ import {
   serviceAgentNameRoute,
   serviceTransactionTypesRoute,
   servicesRoute,
-  serviceNodeMetadataRoute
+  serviceNodeMetadataRoute,
+  serviceAnnotationsRoute
 } from './services';
 import {
   agentConfigurationRoute,
@@ -75,6 +76,7 @@ const createApmApi = () => {
     .add(serviceTransactionTypesRoute)
     .add(servicesRoute)
     .add(serviceNodeMetadataRoute)
+    .add(serviceAnnotationsRoute)
 
     // Agent configuration
     .add(agentConfigurationAgentNameRoute)

--- a/x-pack/legacy/plugins/apm/server/routes/services.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/services.ts
@@ -19,6 +19,7 @@ import { getServiceNodeMetadata } from '../lib/services/get_service_node_metadat
 import { createRoute } from './create_route';
 import { uiFiltersRt, rangeRt } from './default_api_types';
 import { getServiceMap } from '../lib/services/map';
+import { getServiceAnnotations } from '../lib/services/annotations';
 
 export const servicesRoute = createRoute(() => ({
   path: '/api/apm/services',
@@ -96,5 +97,31 @@ export const serviceMapRoute = createRoute(() => ({
       return getServiceMap();
     }
     return new Boom('Not found', { statusCode: 404 });
+  }
+}));
+
+export const serviceAnnotationsRoute = createRoute(() => ({
+  path: '/api/apm/services/{serviceName}/annotations',
+  params: {
+    path: t.type({
+      serviceName: t.string
+    }),
+    query: t.intersection([
+      rangeRt,
+      t.partial({
+        environment: t.string
+      })
+    ])
+  },
+  handler: async ({ context, request }) => {
+    const setup = await setupRequest(context, request);
+    const { serviceName } = context.params.path;
+    const { environment } = context.params.query;
+
+    return getServiceAnnotations({
+      setup,
+      serviceName,
+      environment
+    });
   }
 }));

--- a/x-pack/legacy/plugins/apm/typings/react-vis.d.ts
+++ b/x-pack/legacy/plugins/apm/typings/react-vis.d.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+declare module 'react-vis';

--- a/x-pack/legacy/plugins/apm/typings/timeseries.ts
+++ b/x-pack/legacy/plugins/apm/typings/timeseries.ts
@@ -15,12 +15,14 @@ export interface RectCoordinate {
   x0: number;
 }
 
-export interface TimeSeries {
+export interface TimeSeries<
+  TCoordinate extends { x: number } = Coordinate | RectCoordinate
+> {
   title: string;
   titleShort?: string;
   hideLegend?: boolean;
   hideTooltipValue?: boolean;
-  data: Array<Coordinate | RectCoordinate>;
+  data: TCoordinate[];
   legendValue?: string;
   type: string;
   color: string;


### PR DESCRIPTION
Closes #51426.

Gist of it:
- Add a `/services/{serviceName}/annotations` endpoint that returns all annotations for the given service, environment and time range (right now only versions)
- Converts some of the charts code to TypeScript. Not all, because I expect us to replace that with elastic charts at some point anyway.
- Extend `inspectSearchParams` to be able to inspect multiple calls and responses (probably needs a better name/design at this point, we can cover that in #50521)
- Set chart plot backdrop to `pointer-events: none` to allow mouse events to pass through

To test, you'll need data that has multiple versions for a service. ~apm.elstc.co doesn't have it right now~. You can:

- Connect a local Kibana instance to apm.elstc.co and navigate to http://localhost:5601/app/apm#/services/apm-server/transactions?rangeFrom=now-1h&rangeTo=now&refreshPaused=true&refreshInterval=0&transactionType=Publisher
- Spin up APM Server with 7.x against an ES instance that already has 8.0.0 data
- Upload an event with a manually adjusted version to ES/Intake API
- Connect to my local ES instance, happy to assist

![image](https://user-images.githubusercontent.com/352732/70541738-e3768c00-1b67-11ea-8f96-1518b156d502.png)
