### PR TITLE
[Telemetry/Pulse] Updates advanced settings text for usage data

### DIFF
--- a/src/legacy/core_plugins/telemetry/public/components/__snapshots__/telemetry_form.test.js.snap
+++ b/src/legacy/core_plugins/telemetry/public/components/__snapshots__/telemetry_form.test.js.snap
@@ -38,7 +38,24 @@ exports[`TelemetryForm renders as expected when allows to change optIn status 1`
             "defVal": true,
             "description": <React.Fragment>
               <p>
-                Help us improve the Elastic Stack by providing usage statistics for basic features. We will not share this data outside of Elastic.
+                <FormattedMessage
+                  defaultMessage="Enabling data usage collection helps us manage and improve our products and services. See our {privacyStatementLink} for more details."
+                  id="telemetry.telemetryConfigAndLinkDescription"
+                  values={
+                    Object {
+                      "privacyStatementLink": <ForwardRef
+                        href="https://www.elastic.co/legal/privacy-statement"
+                        target="_blank"
+                      >
+                        <FormattedMessage
+                          defaultMessage="Privacy Statement"
+                          id="telemetry.readOurUsageDataPrivacyStatementLinkText"
+                          values={Object {}}
+                        />
+                      </ForwardRef>,
+                    }
+                  }
+                />
               </p>
               <p>
                 <ForwardRef
@@ -47,18 +64,6 @@ exports[`TelemetryForm renders as expected when allows to change optIn status 1`
                   <FormattedMessage
                     defaultMessage="See an example of what we collect"
                     id="telemetry.seeExampleOfWhatWeCollectLinkText"
-                    values={Object {}}
-                  />
-                </ForwardRef>
-              </p>
-              <p>
-                <ForwardRef
-                  href="https://www.elastic.co/legal/privacy-statement"
-                  target="_blank"
-                >
-                  <FormattedMessage
-                    defaultMessage="Read our usage data privacy statement"
-                    id="telemetry.readOurUsageDataPrivacyStatementLinkText"
                     values={Object {}}
                   />
                 </ForwardRef>

--- a/src/legacy/core_plugins/telemetry/public/components/telemetry_form.js
+++ b/src/legacy/core_plugins/telemetry/public/components/telemetry_form.js
@@ -29,7 +29,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import { getConfigTelemetryDesc, PRIVACY_STATEMENT_URL } from '../../common/constants';
+import { PRIVACY_STATEMENT_URL } from '../../common/constants';
 import { OptInExampleFlyout } from './opt_in_details_component';
 import { Field } from 'ui/management';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -162,20 +162,28 @@ export class TelemetryForm extends Component {
 
   renderDescription = () => (
     <Fragment>
-      <p>{getConfigTelemetryDesc()}</p>
+      <p>
+        <FormattedMessage
+          id="telemetry.telemetryConfigAndLinkDescription"
+          defaultMessage="Enabling data usage collection helps us manage and improve our products and services.
+          See our {privacyStatementLink} for more details."
+          values={{
+            privacyStatementLink: (
+              <EuiLink href={PRIVACY_STATEMENT_URL} target="_blank">
+                <FormattedMessage
+                  id="telemetry.readOurUsageDataPrivacyStatementLinkText"
+                  defaultMessage="Privacy Statement"
+                />
+              </EuiLink>
+            )
+          }}
+        />
+      </p>
       <p>
         <EuiLink onClick={this.toggleExample}>
           <FormattedMessage
             id="telemetry.seeExampleOfWhatWeCollectLinkText"
             defaultMessage="See an example of what we collect"
-          />
-        </EuiLink>
-      </p>
-      <p>
-        <EuiLink href={PRIVACY_STATEMENT_URL} target="_blank">
-          <FormattedMessage
-            id="telemetry.readOurUsageDataPrivacyStatementLinkText"
-            defaultMessage="Read our usage data privacy statement"
           />
         </EuiLink>
       </p>


### PR DESCRIPTION
## Summary
Resolves https://github.com/elastic/kibana/issues/50428
Updates the advanced settings text for usage data that includes the link to the privacy statement.
Removes "Read our usage data privacy statement".

New UI:
![Screen Shot 2019-12-10 at 10 47 13](https://user-images.githubusercontent.com/11909450/70554558-8dd7ba80-1b3a-11ea-8f60-d007d92e3102.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
~~- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~

