### PR TITLE
[Lens] Fix rendering of dates with datemath such as "This week"

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.test.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.test.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import moment from 'moment';
 import { mergeTables } from './merge_tables';
 import { KibanaDatatable } from 'src/plugins/expressions/public';
 
@@ -63,6 +64,35 @@ describe('lens_merge_tables', () => {
         "dateRange": Object {
           "fromDate": 2019-01-01T05:00:00.000Z,
           "toDate": 2020-01-01T05:00:00.000Z,
+        },
+        "tables": Object {},
+        "type": "lens_multitable",
+      }
+    `);
+  });
+
+  it('should handle date ranges with now and datemath', () => {
+    expect(
+      mergeTables.fn(
+        {
+          type: 'kibana_context',
+          timeRange: {
+            from: 'now/w',
+            to: 'now/w',
+          },
+        },
+        {
+          layerIds: ['first', 'second'],
+          tables: [],
+          _forceNowForTesting: moment('2019-01-01T05:00:00.000Z').toDate(),
+        },
+        {}
+      )
+    ).toMatchInlineSnapshot(`
+      Object {
+        "dateRange": Object {
+          "fromDate": 2018-12-30T05:00:00.000Z,
+          "toDate": 2019-01-06T04:59:59.999Z,
         },
         "tables": Object {},
         "type": "lens_multitable",

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
@@ -23,6 +23,7 @@ export function autoIntervalFromDateRange(dateRange?: DateRange, defaultValue: s
 
   const buckets = new TimeBuckets();
   buckets.setInterval('auto');
+  // For datemath expressions such as now/d, this gets the upper and lower bound
   buckets.setBounds({
     min: dateMath.parse(dateRange.fromDate),
     max: dateMath.parse(dateRange.toDate, { roundUp: true }),


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/51139

The issue here is caused by relative dates using datemath, as reported in the issue. "This week" and "today" are internally represented as `now/w` and `now/d` for both the start and end dates, which has special handling in our datemath library. The datemath library needs to be told to round datemath up to the end of the interval, which was not happening.

Previously, 0 or 1 bars would show up for the interval "this week". Now it shows all possible bars, even ones in the future:

<img width="1030" alt="Screenshot 2019-12-10 14 45 19" src="https://user-images.githubusercontent.com/666475/70563317-0438e480-1b5c-11ea-8ab1-a19b7457bd44.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

