### PR TITLE
[Lens] Fix sorting crash when removing a Y axis that is being used for sorting

### DIFF
--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/state_helpers.test.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/state_helpers.test.ts
@@ -32,8 +32,8 @@ describe('state_helpers', () => {
         operationType: 'terms',
         sourceField: 'source',
         params: {
-          orderBy: { type: 'alphabetical' },
-          orderDirection: 'asc',
+          orderBy: { type: 'column', columnId: 'col2' },
+          orderDirection: 'desc',
           size: 5,
         },
       };
@@ -65,11 +65,18 @@ describe('state_helpers', () => {
       expect(
         deleteColumn({ state, columnId: 'col2', layerId: 'first' }).layers.first.columns
       ).toEqual({
-        col1: termsColumn,
+        col1: {
+          ...termsColumn,
+          params: {
+            ...termsColumn.params,
+            orderBy: { type: 'alphabetical' },
+            orderDirection: 'asc',
+          },
+        },
       });
     });
 
-    it('should execute adjustments for other columns', () => {
+    it('should adjust when deleting other columns', () => {
       const termsColumn: TermsIndexPatternColumn = {
         label: 'Top values of source',
         dataType: 'string',

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/state_helpers.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/state_helpers.ts
@@ -124,11 +124,10 @@ export function deleteColumn({
   layerId: string;
   columnId: string;
 }): IndexPatternPrivateState {
-  const newColumns = adjustColumnReferencesForChangedColumn(
-    state.layers[layerId].columns,
-    columnId
-  );
-  delete newColumns[columnId];
+  const hypotheticalColumns = { ...state.layers[layerId].columns };
+  delete hypotheticalColumns[columnId];
+
+  const newColumns = adjustColumnReferencesForChangedColumn(hypotheticalColumns, columnId);
 
   return {
     ...state,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/51128

Steps to reproduce the issue:

1. Select a Top Values aggregation for the X axis in Lens
2. Add 2 different metrics on the Y axis. Note which one was added first.
3. Delete the first metric
4. The Top Values aggregation will start sorting alphabetically now

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

