### PR TITLE
[Discover] Place tooltip of cell at bottom of button to prevent hover conflict

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/angular/doc_table/components/table_row/cell.html
+++ b/src/legacy/core_plugins/kibana/public/discover/angular/doc_table/components/table_row/cell.html
@@ -19,9 +19,9 @@ if (timefield) {
         tooltip-append-to-body="1"
         data-test-subj="docTableCellFilter"
         tooltip="{{ ::'kbn.docTable.tableRow.filterForValueButtonTooltip' | i18n: {defaultMessage: 'Filter for value'} }}"
+        tooltip-placement="bottom"
         aria-label="{{ ::'kbn.docTable.tableRow.filterForValueButtonAriaLabel' | i18n: {defaultMessage: 'Filter for value'} }}"
       ></button>
-
       <button
         ng-click="inlineFilter($event, '-')"
         class="fa fa-search-minus kbnDocTableRowFilterButton"
@@ -30,6 +30,7 @@ if (timefield) {
         tooltip="{{ ::'kbn.docTable.tableRow.filterOutValueButtonTooltip' | i18n: {defaultMessage: 'Filter out value'} }}"
         aria-label="{{ ::'kbn.docTable.tableRow.filterOutValueButtonAriaLabel' | i18n: {defaultMessage: 'Filter out value'} }}"
         tooltip-append-to-body="1"
+        tooltip-placement="bottom"
       ></button>
     <% } %>
   </span>


### PR DESCRIPTION
## Summary

This is a simple fix for an annoying behavior in our soon to be replaced legacy data table in Discover. When you try to filter out the last field in a row, the legacy tooltip overlaps the filter out button, which causes an unhover event. Button and tooltip disappear. This behavior is changed by displaying the tooltip below the button.

Old:
![65331960-63054800-db83-11e9-811d-bda38800f45c](https://user-images.githubusercontent.com/463851/70606598-19b21b00-1bfd-11ea-902a-692033f92487.gif)

New:
![Bildschirmfoto 2019-12-11 um 10 04 49](https://user-images.githubusercontent.com/463851/70606912-c68c9800-1bfd-11ea-980c-f99981c594d4.png)



Fixes #47801
Fixes #46232





### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

~~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
- [x] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

