### PR TITLE
[Lens] Modify merge tables to use the same logic as auto date

### DIFF
--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.test.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.test.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import moment from 'moment';
 import { mergeTables } from './merge_tables';
 import { KibanaDatatable } from 'src/plugins/expressions/public';
 
@@ -68,5 +69,39 @@ describe('lens_merge_tables', () => {
         "type": "lens_multitable",
       }
     `);
+  });
+
+  it('should handle this week now/w', () => {
+    const { dateRange } = mergeTables.fn(
+      {
+        type: 'kibana_context',
+        timeRange: {
+          from: 'now/w',
+          to: 'now/w',
+        },
+      },
+      { layerIds: ['first', 'second'], tables: [] },
+      {}
+    );
+
+    expect(
+      moment
+        .duration(
+          moment()
+            .startOf('week')
+            .diff(dateRange!.fromDate)
+        )
+        .asDays()
+    ).toEqual(0);
+
+    expect(
+      moment
+        .duration(
+          moment()
+            .endOf('week')
+            .diff(dateRange!.toDate)
+        )
+        .asDays()
+    ).toEqual(0);
   });
 });

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.ts
@@ -8,6 +8,7 @@ import { i18n } from '@kbn/i18n';
 import dateMath from '@elastic/datemath';
 import { ExpressionFunction, KibanaContext, KibanaDatatable } from 'src/plugins/expressions/public';
 import { LensMultiTable } from '../types';
+import { toConcreteDates } from '../indexpattern_plugin/auto_date';
 
 interface MergeTables {
   layerIds: string[];
@@ -58,15 +59,11 @@ function getDateRange(ctx?: KibanaContext | null) {
     return;
   }
 
-  const fromDate = dateMath.parse(ctx.timeRange.from);
-  const toDate = dateMath.parse(ctx.timeRange.to);
+  const dateRange = toConcreteDates({ fromDate: ctx.timeRange.from, toDate: ctx.timeRange.to });
 
-  if (!fromDate || !toDate) {
+  if (!dateRange) {
     return;
   }
 
-  return {
-    fromDate: fromDate.toDate(),
-    toDate: toDate.toDate(),
-  };
+  return dateRange;
 }

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/merge_tables.ts
@@ -5,10 +5,9 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import dateMath from '@elastic/datemath';
 import { ExpressionFunction, KibanaContext, KibanaDatatable } from 'src/plugins/expressions/public';
 import { LensMultiTable } from '../types';
-import { toConcreteDates } from '../indexpattern_plugin/auto_date';
+import { toAbsoluteDates } from '../indexpattern_plugin/auto_date';
 
 interface MergeTables {
   layerIds: string[];
@@ -59,7 +58,7 @@ function getDateRange(ctx?: KibanaContext | null) {
     return;
   }
 
-  const dateRange = toConcreteDates({ fromDate: ctx.timeRange.from, toDate: ctx.timeRange.to });
+  const dateRange = toAbsoluteDates({ fromDate: ctx.timeRange.from, toDate: ctx.timeRange.to });
 
   if (!dateRange) {
     return;

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
@@ -35,7 +35,7 @@ export function toAbsoluteDates(dateRange?: DateRange) {
 }
 
 export function autoIntervalFromDateRange(dateRange?: DateRange, defaultValue: string = '1h') {
-  const dates = toConcreteDates(dateRange);
+  const dates = toAbsoluteDates(dateRange);
   if (!dates) {
     return defaultValue;
   }

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
@@ -16,16 +16,36 @@ interface LensAutoDateProps {
   aggConfigs: string;
 }
 
-export function autoIntervalFromDateRange(dateRange?: DateRange, defaultValue: string = '1h') {
+export function toConcreteDates(dateRange?: DateRange) {
   if (!dateRange) {
+    return;
+  }
+
+  const fromDate = dateMath.parse(dateRange.fromDate);
+  const toDate = dateMath.parse(dateRange.toDate, { roundUp: true });
+
+  if (!fromDate || !toDate) {
+    return;
+  }
+
+  return {
+    fromDate: fromDate.toDate(),
+    toDate: toDate.toDate(),
+  };
+}
+
+export function autoIntervalFromDateRange(dateRange?: DateRange, defaultValue: string = '1h') {
+  const dates = toConcreteDates(dateRange);
+  if (!dates) {
     return defaultValue;
   }
 
   const buckets = new TimeBuckets();
+
   buckets.setInterval('auto');
   buckets.setBounds({
-    min: dateMath.parse(dateRange.fromDate),
-    max: dateMath.parse(dateRange.toDate, { roundUp: true }),
+    min: dates.fromDate,
+    max: dates.toDate,
   });
 
   return buckets.getInterval().expression;

--- a/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
+++ b/x-pack/legacy/plugins/lens/public/indexpattern_plugin/auto_date.ts
@@ -16,7 +16,7 @@ interface LensAutoDateProps {
   aggConfigs: string;
 }
 
-export function toConcreteDates(dateRange?: DateRange) {
+export function toAbsoluteDates(dateRange?: DateRange) {
   if (!dateRange) {
     return;
   }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/51139

Taken over from PR: https://github.com/elastic/kibana/pull/52673

The issue here is caused by relative dates using datemath, as reported in the issue. "This week" and "today" are internally represented as `now/w` and `now/d` for both the start and end dates, which has special handling in our datemath library. The datemath library needs to be told to round datemath up to the end of the interval, which was not happening.

Previously, 0 or 1 bars would show up for the interval "this week". Now it shows all possible bars, even ones in the future:

<img width="1030" alt="Screenshot 2019-12-10 14 45 19" src="https://user-images.githubusercontent.com/666475/70563317-0438e480-1b5c-11ea-8ab1-a19b7457bd44.png">
