### PR TITLE
Fixes #52134: [APM] Update to use 'ProcessorEvent' constants

### DIFF
--- a/x-pack/legacy/plugins/apm/common/processor_event.ts
+++ b/x-pack/legacy/plugins/apm/common/processor_event.ts
@@ -4,11 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
 export enum ProcessorEvent {
   transaction = 'transaction',
   error = 'error',

--- a/x-pack/legacy/plugins/apm/common/processor_event.ts
+++ b/x-pack/legacy/plugins/apm/common/processor_event.ts
@@ -4,8 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
 export enum ProcessorEvent {
   transaction = 'transaction',
   error = 'error',
-  metric = 'metric'
+  metric = 'metric',
+  span = 'span'
 }

--- a/x-pack/legacy/plugins/apm/common/projections/errors.ts
+++ b/x-pack/legacy/plugins/apm/common/projections/errors.ts
@@ -15,6 +15,7 @@ import {
   ERROR_GROUP_ID
 } from '../elasticsearch_fieldnames';
 import { rangeFilter } from '../../server/lib/helpers/range_filter';
+import { ProcessorEvent } from '../../common/processor_event';
 
 export function getErrorGroupsProjection({
   setup,
@@ -32,7 +33,7 @@ export function getErrorGroupsProjection({
         bool: {
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
-            { term: { [PROCESSOR_EVENT]: 'error' } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
             { range: rangeFilter(start, end) },
             ...uiFiltersES
           ]

--- a/x-pack/legacy/plugins/apm/common/projections/metrics.ts
+++ b/x-pack/legacy/plugins/apm/common/projections/metrics.ts
@@ -16,6 +16,7 @@ import {
 } from '../elasticsearch_fieldnames';
 import { rangeFilter } from '../../server/lib/helpers/range_filter';
 import { SERVICE_NODE_NAME_MISSING } from '../service_nodes';
+import { ProcessorEvent } from '../../common/processor_event';
 
 function getServiceNodeNameFilters(serviceNodeName?: string) {
   if (!serviceNodeName) {
@@ -42,7 +43,7 @@ export function getMetricsProjection({
 
   const filter = [
     { term: { [SERVICE_NAME]: serviceName } },
-    { term: { [PROCESSOR_EVENT]: 'metric' } },
+    { term: { [PROCESSOR_EVENT]: ProcessorEvent.metric } },
     { range: rangeFilter(start, end) },
     ...getServiceNodeNameFilters(serviceNodeName),
     ...uiFiltersES

--- a/x-pack/legacy/plugins/apm/common/projections/services.ts
+++ b/x-pack/legacy/plugins/apm/common/projections/services.ts
@@ -11,6 +11,7 @@ import {
 } from '../../server/lib/helpers/setup_request';
 import { SERVICE_NAME, PROCESSOR_EVENT } from '../elasticsearch_fieldnames';
 import { rangeFilter } from '../../server/lib/helpers/range_filter';
+import { ProcessorEvent } from '../../common/processor_event';
 
 export function getServicesProjection({
   setup
@@ -31,7 +32,13 @@ export function getServicesProjection({
         bool: {
           filter: [
             {
-              terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] }
+              terms: {
+                [PROCESSOR_EVENT]: [
+                  ProcessorEvent.transaction,
+                  ProcessorEvent.error,
+                  ProcessorEvent.metric
+                ]
+              }
             },
             { range: rangeFilter(start, end) },
             ...uiFiltersES

--- a/x-pack/legacy/plugins/apm/common/projections/transactions.ts
+++ b/x-pack/legacy/plugins/apm/common/projections/transactions.ts
@@ -16,6 +16,7 @@ import {
   TRANSACTION_NAME
 } from '../elasticsearch_fieldnames';
 import { rangeFilter } from '../../server/lib/helpers/range_filter';
+import { ProcessorEvent } from '../../common/processor_event';
 
 export function getTransactionsProjection({
   setup,
@@ -43,7 +44,7 @@ export function getTransactionsProjection({
   const bool = {
     filter: [
       { range: rangeFilter(start, end) },
-      { term: { [PROCESSOR_EVENT]: 'transaction' } },
+      { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
       ...transactionNameFilter,
       ...transactionTypeFilter,
       ...serviceNameFilter,

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceDetails/ServiceIntegrations/createErrorGroupWatch.ts
@@ -19,6 +19,7 @@ import {
   SERVICE_NAME
 } from '../../../../../common/elasticsearch_fieldnames';
 import { createWatch } from '../../../../services/rest/watcher';
+import { ProcessorEvent } from '../../../../../common/processor_event';
 
 function getSlackPathUrl(slackUrl?: string) {
   if (slackUrl) {
@@ -158,7 +159,7 @@ export async function createErrorGroupWatch({
               bool: {
                 filter: [
                   { term: { [SERVICE_NAME]: '{{ctx.metadata.serviceName}}' } },
-                  { term: { [PROCESSOR_EVENT]: 'error' } },
+                  { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
                   {
                     range: {
                       '@timestamp': {

--- a/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/get_bool_filter.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/get_bool_filter.ts
@@ -13,6 +13,7 @@ import {
   SERVICE_NAME
 } from '../../../../common/elasticsearch_fieldnames';
 import { IUrlParams } from '../../../context/UrlParamsContext/types';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export function getBoolFilter(urlParams: IUrlParams) {
   const { start, end, serviceName, processorEvent } = urlParams;
@@ -42,7 +43,7 @@ export function getBoolFilter(urlParams: IUrlParams) {
   switch (processorEvent) {
     case 'transaction':
       boolFilter.push({
-        term: { [PROCESSOR_EVENT]: 'transaction' }
+        term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction }
       });
 
       if (urlParams.transactionName) {
@@ -60,7 +61,7 @@ export function getBoolFilter(urlParams: IUrlParams) {
 
     case 'error':
       boolFilter.push({
-        term: { [PROCESSOR_EVENT]: 'error' }
+        term: { [PROCESSOR_EVENT]: ProcessorEvent.error }
       });
 
       if (urlParams.errorGroupId) {
@@ -72,7 +73,7 @@ export function getBoolFilter(urlParams: IUrlParams) {
 
     case 'metric':
       boolFilter.push({
-        term: { [PROCESSOR_EVENT]: 'metric' }
+        term: { [PROCESSOR_EVENT]: ProcessorEvent.metric }
       });
       break;
 
@@ -80,9 +81,9 @@ export function getBoolFilter(urlParams: IUrlParams) {
       boolFilter.push({
         bool: {
           should: [
-            { term: { [PROCESSOR_EVENT]: 'error' } },
-            { term: { [PROCESSOR_EVENT]: 'transaction' } },
-            { term: { [PROCESSOR_EVENT]: 'metric' } }
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.metric } }
           ]
         }
       });

--- a/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/ml.ts
@@ -14,6 +14,7 @@ import { getMlJobId, getMlPrefix } from '../../../common/ml_job_constants';
 import { callApi } from './callApi';
 import { ESFilter } from '../../../typings/elasticsearch';
 import { createCallApmApi, APMClient } from './createCallApmApi';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 interface MlResponseItem {
   id: string;
@@ -54,7 +55,7 @@ export async function startMLJob({
   const groups = ['apm', serviceName.toLowerCase()];
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
-    { term: { [PROCESSOR_EVENT]: 'transaction' } },
+    { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
     { term: { [TRANSACTION_TYPE]: transactionType } }
   ];
   groups.push(transactionType.toLowerCase());

--- a/x-pack/legacy/plugins/apm/server/lib/errors/distribution/get_buckets.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/distribution/get_buckets.ts
@@ -16,6 +16,7 @@ import {
   SetupTimeRange,
   SetupUIFilters
 } from '../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export async function getBuckets({
   serviceName,
@@ -30,7 +31,7 @@ export async function getBuckets({
 }) {
   const { start, end, uiFiltersES, client, indices } = setup;
   const filter: ESFilter[] = [
-    { term: { [PROCESSOR_EVENT]: 'error' } },
+    { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
     { term: { [SERVICE_NAME]: serviceName } },
     { range: rangeFilter(start, end) },
     ...uiFiltersES

--- a/x-pack/legacy/plugins/apm/server/lib/errors/get_error_group.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/get_error_group.ts
@@ -19,6 +19,7 @@ import {
   SetupUIFilters
 } from '../helpers/setup_request';
 import { getTransaction } from '../transactions/get_transaction';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 export type ErrorGroupAPIResponse = PromiseReturnType<typeof getErrorGroup>;
 
@@ -42,7 +43,7 @@ export async function getErrorGroup({
         bool: {
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
-            { term: { [PROCESSOR_EVENT]: 'error' } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
             { term: { [ERROR_GROUP_ID]: groupId } },
             { range: rangeFilter(start, end) },
             ...uiFiltersES

--- a/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/get_trace_errors_per_transaction.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 export interface ErrorsPerTransaction {
   [transactionId: string]: number;
@@ -33,7 +34,7 @@ export async function getTraceErrorsPerTransaction(
         bool: {
           filter: [
             { term: { [TRACE_ID]: traceId } },
-            { term: { [PROCESSOR_EVENT]: 'error' } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
             { range: rangeFilter(start, end) }
           ],
           should: [

--- a/x-pack/legacy/plugins/apm/server/lib/index_pattern/get_dynamic_index_pattern.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/index_pattern/get_dynamic_index_pattern.ts
@@ -80,7 +80,11 @@ function getPatternIndices(
 ) {
   const indexNames = processorEvent
     ? [processorEvent]
-    : ['transaction' as const, 'metric' as const, 'error' as const];
+    : [
+        ProcessorEvent.transaction as const,
+        ProcessorEvent.metric as const,
+        ProcessorEvent.error as const
+      ];
 
   const indicesMap = {
     transaction: indices['apm_oss.transactionIndices'],

--- a/x-pack/legacy/plugins/apm/server/lib/index_pattern/get_dynamic_index_pattern.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/index_pattern/get_dynamic_index_pattern.ts
@@ -80,16 +80,13 @@ function getPatternIndices(
 ) {
   const indexNames = processorEvent
     ? [processorEvent]
-    : [
-        ProcessorEvent.transaction as const,
-        ProcessorEvent.metric as const,
-        ProcessorEvent.error as const
-      ];
+    : [ProcessorEvent.transaction, ProcessorEvent.metric, ProcessorEvent.error];
 
   const indicesMap = {
     transaction: indices['apm_oss.transactionIndices'],
     metric: indices['apm_oss.metricsIndices'],
-    error: indices['apm_oss.errorIndices']
+    error: indices['apm_oss.errorIndices'],
+    span: indices['apm_oss.spanIndices']
   };
 
   return indexNames.map(name => indicesMap[name]);

--- a/x-pack/legacy/plugins/apm/server/lib/services/get_service_agent_name.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/get_service_agent_name.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 export async function getServiceAgentName(
   serviceName: string,
@@ -31,7 +32,13 @@ export async function getServiceAgentName(
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
             {
-              terms: { [PROCESSOR_EVENT]: ['error', 'transaction', 'metric'] }
+              terms: {
+                [PROCESSOR_EVENT]: [
+                  ProcessorEvent.error,
+                  ProcessorEvent.transaction,
+                  ProcessorEvent.metric
+                ]
+              }
             },
             { range: rangeFilter(start, end) }
           ]

--- a/x-pack/legacy/plugins/apm/server/lib/services/get_service_transaction_types.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/get_service_transaction_types.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../common/elasticsearch_fieldnames';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 export async function getServiceTransactionTypes(
   serviceName: string,
@@ -25,7 +26,7 @@ export async function getServiceTransactionTypes(
         bool: {
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
-            { terms: { [PROCESSOR_EVENT]: ['transaction'] } },
+            { terms: { [PROCESSOR_EVENT]: [ProcessorEvent.transaction] } },
             { range: rangeFilter(start, end) }
           ]
         }

--- a/x-pack/legacy/plugins/apm/server/lib/services/get_services/get_legacy_data_status.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/get_services/get_legacy_data_status.ts
@@ -9,6 +9,7 @@ import {
   PROCESSOR_EVENT
 } from '../../../../common/elasticsearch_fieldnames';
 import { Setup } from '../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 // returns true if 6.x data is found
 export async function getLegacyDataStatus(setup: Setup) {
@@ -22,7 +23,7 @@ export async function getLegacyDataStatus(setup: Setup) {
       query: {
         bool: {
           filter: [
-            { terms: { [PROCESSOR_EVENT]: ['transaction'] } },
+            { terms: { [PROCESSOR_EVENT]: [ProcessorEvent.transaction] } },
             { range: { [OBSERVER_VERSION_MAJOR]: { lt: 7 } } }
           ]
         }

--- a/x-pack/legacy/plugins/apm/server/lib/services/get_services/has_historical_agent_data.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/services/get_services/has_historical_agent_data.ts
@@ -6,6 +6,7 @@
 
 import { PROCESSOR_EVENT } from '../../../../common/elasticsearch_fieldnames';
 import { Setup } from '../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 // Note: this logic is duplicated in tutorials/apm/envs/on_prem
 export async function hasHistoricalAgentData(setup: Setup) {
@@ -27,10 +28,10 @@ export async function hasHistoricalAgentData(setup: Setup) {
             {
               terms: {
                 [PROCESSOR_EVENT]: [
-                  'error',
-                  'metric',
+                  ProcessorEvent.error,
+                  ProcessorEvent.metric,
                   'sourcemap',
-                  'transaction'
+                  ProcessorEvent.transaction
                 ]
               }
             }

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
@@ -10,6 +10,7 @@ import {
   SERVICE_NAME
 } from '../../../../common/elasticsearch_fieldnames';
 import { SERVICE_AGENT_NAME } from '../../../../common/elasticsearch_fieldnames';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export async function getAgentNameByService({
   serviceName,
@@ -33,7 +34,13 @@ export async function getAgentNameByService({
         bool: {
           filter: [
             {
-              terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] }
+              terms: {
+                [PROCESSOR_EVENT]: [
+                  ProcessorEvent.transaction,
+                  ProcessorEvent.error,
+                  ProcessorEvent.metric
+                ]
+              }
             },
             { term: { [SERVICE_NAME]: serviceName } }
           ]

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_environments/get_all_environments.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_environments/get_all_environments.ts
@@ -11,6 +11,7 @@ import {
   SERVICE_ENVIRONMENT
 } from '../../../../../common/elasticsearch_fieldnames';
 import { ALL_OPTION_VALUE } from '../../../../../common/agent_configuration_constants';
+import { ProcessorEvent } from '../../../../../common/processor_event';
 
 export async function getAllEnvironments({
   serviceName,
@@ -38,7 +39,13 @@ export async function getAllEnvironments({
         bool: {
           filter: [
             {
-              terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] }
+              terms: {
+                [PROCESSOR_EVENT]: [
+                  ProcessorEvent.transaction,
+                  ProcessorEvent.error,
+                  ProcessorEvent.metric
+                ]
+              }
             },
             ...serviceNameFilter
           ]

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
@@ -11,6 +11,7 @@ import {
   SERVICE_NAME
 } from '../../../../common/elasticsearch_fieldnames';
 import { ALL_OPTION_VALUE } from '../../../../common/agent_configuration_constants';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export type AgentConfigurationServicesAPIResponse = PromiseReturnType<
   typeof getServiceNames
@@ -29,7 +30,15 @@ export async function getServiceNames({ setup }: { setup: Setup }) {
       query: {
         bool: {
           filter: [
-            { terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] } }
+            {
+              terms: {
+                [PROCESSOR_EVENT]: [
+                  ProcessorEvent.transaction,
+                  ProcessorEvent.error,
+                  ProcessorEvent.metric
+                ]
+              }
+            }
           ]
         }
       },

--- a/x-pack/legacy/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -40,7 +40,8 @@ export async function getTraceItems(
               terms: {
                 [PROCESSOR_EVENT]: [
                   ProcessorEvent.span,
-                  ProcessorEvent.transaction
+                  ProcessorEvent.transaction,
+                  ProcessorEvent.error
                 ]
               }
             },

--- a/x-pack/legacy/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -16,6 +16,7 @@ import { Transaction } from '../../../typings/es_schemas/ui/Transaction';
 import { APMError } from '../../../typings/es_schemas/ui/APMError';
 import { rangeFilter } from '../helpers/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 export async function getTraceItems(
   traceId: string,
@@ -35,7 +36,9 @@ export async function getTraceItems(
         bool: {
           filter: [
             { term: { [TRACE_ID]: traceId } },
-            { terms: { [PROCESSOR_EVENT]: ['span', 'transaction', 'error'] } },
+            {
+              terms: { [PROCESSOR_EVENT]: ['span', ProcessorEvent.transaction] }
+            },
             { range: rangeFilter(start, end) }
           ],
           should: {

--- a/x-pack/legacy/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -37,7 +37,12 @@ export async function getTraceItems(
           filter: [
             { term: { [TRACE_ID]: traceId } },
             {
-              terms: { [PROCESSOR_EVENT]: ['span', ProcessorEvent.transaction] }
+              terms: {
+                [PROCESSOR_EVENT]: [
+                  ProcessorEvent.span,
+                  ProcessorEvent.transaction
+                ]
+              }
             },
             { range: rangeFilter(start, end) }
           ],

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_country/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/avg_duration_by_country/index.ts
@@ -19,6 +19,7 @@ import {
 } from '../../helpers/setup_request';
 import { rangeFilter } from '../../helpers/range_filter';
 import { TRANSACTION_PAGE_LOAD } from '../../../../common/transaction_types';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export async function getTransactionAvgDurationByCountry({
   setup,
@@ -42,7 +43,7 @@ export async function getTransactionAvgDurationByCountry({
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
             ...transactionNameFilter,
-            { term: { [PROCESSOR_EVENT]: 'transaction' } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
             { term: { [TRANSACTION_TYPE]: TRANSACTION_PAGE_LOAD } },
             { exists: { field: CLIENT_GEO_COUNTRY_ISO_CODE } },
             { range: rangeFilter(start, end) },

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -24,6 +24,7 @@ import { rangeFilter } from '../../helpers/range_filter';
 import { getMetricsDateHistogramParams } from '../../helpers/metrics';
 import { MAX_KPIS } from './constants';
 import { getVizColorForIndex } from '../../../../common/viz_colors';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export async function getTransactionBreakdown({
   setup,
@@ -82,7 +83,7 @@ export async function getTransactionBreakdown({
   const filters = [
     { term: { [SERVICE_NAME]: serviceName } },
     { term: { [TRANSACTION_TYPE]: transactionType } },
-    { term: { [PROCESSOR_EVENT]: 'metric' } },
+    { term: { [PROCESSOR_EVENT]: ProcessorEvent.metric } },
     { range: rangeFilter(start, end) },
     ...uiFiltersES
   ];

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.test.ts
@@ -7,6 +7,7 @@
 import { PROCESSOR_EVENT } from '../../../../../common/elasticsearch_fieldnames';
 import { ESResponse, timeseriesFetcher } from './fetcher';
 import { APMConfig } from '../../../../../../../../plugins/apm/server';
+import { ProcessorEvent } from '../../../../../common/processor_event';
 
 describe('timeseriesFetcher', () => {
   let res: ESResponse;
@@ -58,7 +59,7 @@ describe('timeseriesFetcher', () => {
       expect.arrayContaining([
         {
           term: {
-            [PROCESSOR_EVENT]: 'transaction'
+            [PROCESSOR_EVENT]: ProcessorEvent.transaction
           }
         } as any
       ])

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
@@ -21,6 +21,7 @@ import {
   SetupTimeRange,
   SetupUIFilters
 } from '../../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../../common/processor_event';
 
 export type ESResponse = PromiseReturnType<typeof timeseriesFetcher>;
 export function timeseriesFetcher({
@@ -38,7 +39,7 @@ export function timeseriesFetcher({
   const { intervalString } = getBucketSize(start, end, 'auto');
 
   const filter: ESFilter[] = [
-    { term: { [PROCESSOR_EVENT]: 'transaction' } },
+    { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
     { term: { [SERVICE_NAME]: serviceName } },
     { range: rangeFilter(start, end) },
     ...uiFiltersES

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_buckets/fetcher.ts
@@ -21,6 +21,7 @@ import {
   SetupTimeRange,
   SetupUIFilters
 } from '../../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../../common/processor_event';
 
 export async function bucketFetcher(
   serviceName: string,
@@ -42,7 +43,7 @@ export async function bucketFetcher(
         bool: {
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
-            { term: { [PROCESSOR_EVENT]: 'transaction' } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
             { term: { [TRANSACTION_TYPE]: transactionType } },
             { term: { [TRANSACTION_NAME]: transactionName } },
             { range: rangeFilter(start, end) },

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_distribution_max.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/distribution/get_distribution_max.ts
@@ -16,6 +16,7 @@ import {
   SetupTimeRange,
   SetupUIFilters
 } from '../../helpers/setup_request';
+import { ProcessorEvent } from '../../../../common/processor_event';
 
 export async function getDistributionMax(
   serviceName: string,
@@ -33,7 +34,7 @@ export async function getDistributionMax(
         bool: {
           filter: [
             { term: { [SERVICE_NAME]: serviceName } },
-            { term: { [PROCESSOR_EVENT]: 'transaction' } },
+            { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
             { term: { [TRANSACTION_TYPE]: transactionType } },
             { term: { [TRANSACTION_NAME]: transactionName } },
             {

--- a/x-pack/legacy/plugins/apm/server/lib/ui_filters/get_environments.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/ui_filters/get_environments.ts
@@ -13,6 +13,7 @@ import { rangeFilter } from '../helpers/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
 import { ENVIRONMENT_NOT_DEFINED } from '../../../common/environment_filter_values';
 import { ESFilter } from '../../../typings/elasticsearch';
+import { ProcessorEvent } from '../../../common/processor_event';
 
 export async function getEnvironments(
   setup: Setup & SetupTimeRange,
@@ -21,7 +22,15 @@ export async function getEnvironments(
   const { start, end, client, indices } = setup;
 
   const filter: ESFilter[] = [
-    { terms: { [PROCESSOR_EVENT]: ['transaction', 'error', 'metric'] } },
+    {
+      terms: {
+        [PROCESSOR_EVENT]: [
+          ProcessorEvent.transaction,
+          ProcessorEvent.error,
+          ProcessorEvent.metric
+        ]
+      }
+    },
     { range: rangeFilter(start, end) }
   ];
 

--- a/x-pack/legacy/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/index_pattern.ts
@@ -7,6 +7,7 @@ import * as t from 'io-ts';
 import { createStaticIndexPattern } from '../lib/index_pattern/create_static_index_pattern';
 import { createRoute } from './create_route';
 import { setupRequest } from '../lib/helpers/setup_request';
+import { ProcessorEvent } from '../../common/processor_event';
 
 export const staticIndexPatternRoute = createRoute(() => ({
   method: 'POST',
@@ -25,9 +26,9 @@ export const dynamicIndexPatternRoute = createRoute(() => ({
   params: {
     query: t.partial({
       processorEvent: t.union([
-        t.literal('transaction'),
-        t.literal('metric'),
-        t.literal('error')
+        t.literal(ProcessorEvent.transaction),
+        t.literal(ProcessorEvent.metric),
+        t.literal(ProcessorEvent.error)
       ])
     })
   },


### PR DESCRIPTION
## Summary

Fixes #52134

Updated most, if not all, instances that use literals instead of the 'ProcessorEvent' constants. Please do make me aware in case any instances are missing, or if more changes need to be made. 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

