### PR TITLE
[Dashboard] Fixing addVisualization func test

### DIFF
--- a/test/functional/apps/dashboard/empty_dashboard.js
+++ b/test/functional/apps/dashboard/empty_dashboard.js
@@ -28,7 +28,6 @@ export default function({ getService, getPageObjects }) {
   const dashboardExpect = getService('dashboardExpect');
   const PageObjects = getPageObjects(['common', 'dashboard']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/48236
   describe('empty dashboard', () => {
     before(async () => {
       await esArchiver.load('dashboard/current/kibana');
@@ -59,10 +58,10 @@ export default function({ getService, getPageObjects }) {
     it('should add new visualization from dashboard', async () => {
       await testSubjects.exists('addVisualizationButton');
       await testSubjects.click('addVisualizationButton');
-      await dashboardVisualizations.createAndAddMarkdown(
-        { name: 'Dashboard Test Markdown', markdown: 'Markdown text' },
-        false
-      );
+      await dashboardVisualizations.createAndAddMarkdown({
+        name: 'Dashboard Test Markdown',
+        markdown: 'Markdown text',
+      });
       await PageObjects.dashboard.waitForRenderComplete();
       await dashboardExpect.markdownWithValuesExists(['Markdown text']);
     });

--- a/test/functional/apps/dashboard/empty_dashboard.js
+++ b/test/functional/apps/dashboard/empty_dashboard.js
@@ -29,7 +29,7 @@ export default function({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['common', 'dashboard']);
 
   // FLAKY: https://github.com/elastic/kibana/issues/48236
-  describe.skip('empty dashboard', () => {
+  describe('empty dashboard', () => {
     before(async () => {
       await esArchiver.load('dashboard/current/kibana');
       await kibanaServer.uiSettings.replace({
@@ -57,6 +57,7 @@ export default function({ getService, getPageObjects }) {
     });
 
     it('should add new visualization from dashboard', async () => {
+      await testSubjects.exists('addVisualizationButton');
       await testSubjects.click('addVisualizationButton');
       await dashboardVisualizations.createAndAddMarkdown(
         { name: 'Dashboard Test Markdown', markdown: 'Markdown text' },

--- a/test/functional/services/dashboard/visualizations.js
+++ b/test/functional/services/dashboard/visualizations.js
@@ -99,18 +99,13 @@ export function DashboardVisualizationProvider({ getService, getPageObjects }) {
       }
     }
 
-    async createAndAddMarkdown({ name, markdown }, checkForAddPanel = true) {
+    async createAndAddMarkdown({ name, markdown }) {
       log.debug(`createAndAddMarkdown(${markdown})`);
       const inViewMode = await PageObjects.dashboard.getIsInViewMode();
       if (inViewMode) {
         await PageObjects.dashboard.switchToEditMode();
       }
-      if (checkForAddPanel) {
-        await dashboardAddPanel.ensureAddPanelIsShowing();
-        await dashboardAddPanel.clickAddNewEmbeddableLink('visualization');
-      } else {
-        await this.ensureNewVisualizationDialogIsShowing();
-      }
+      await this.ensureNewVisualizationDialogIsShowing();
       await PageObjects.visualize.clickMarkdownWidget();
       await PageObjects.visualize.setMarkdownTxt(markdown);
       await PageObjects.visualize.clickGo();


### PR DESCRIPTION
## Summary

Fixes: #48236
(I hope).

The test is adding a new visualization from the dashboard empty screen. 
From the log output, the `New Visualization` dialog was not visible when `addVisualizationButton` was clicked. Attempting to fix this by ensuring that the new vis dialog is showing before proceeding to add the widget. I ran it 6 times locally and it succeeded every time.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

