### PR TITLE
[7.x] [Metrics UI] Customize "node info" section per Inventory Model (#53325)

### DIFF
--- a/x-pack/legacy/plugins/infra/common/inventory_models/aws_ec2/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/aws_ec2/layout.tsx
@@ -8,109 +8,123 @@ import { i18n } from '@kbn/i18n';
 import { LayoutPropsWithTheme } from '../../../public/pages/metrics/types';
 import { Section } from '../../../public/pages/metrics/components/section';
 import { SubSection } from '../../../public/pages/metrics/components/sub_section';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
 import { withTheme } from '../../../../../common/eui_styled_components';
+import { MetadataDetails } from '../../../public/pages/metrics/components/metadata_details';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel="AWS EC2"
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.ec2MetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Aws EC2 Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection
-        id="awsEC2CpuUtilization"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.ec2MetricsLayout.cpuUsageSection.sectionLabel',
+    <MetadataDetails
+      fields={[
+        'cloud.instance.id',
+        'cloud.provider',
+        'cloud.availability_zone',
+        'cloud.machine.type',
+        'cloud.instance.name',
+        'cloud.project.id',
+      ]}
+    />
+    <LayoutContent>
+      <Section
+        navLabel="AWS EC2"
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.ec2MetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'CPU Usage',
+            defaultMessage: 'Aws EC2 Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          stacked={true}
-          type="area"
-          formatter="percent"
-          seriesOverrides={{
-            total: { color: theme.eui.euiColorVis1 },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsEC2NetworkTraffic"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.ec2MetricsLayout.networkTrafficSection.sectionLabel',
-          {
-            defaultMessage: 'Network Traffic',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bits"
-          formatterTemplate="{{value}}/s"
-          type="area"
-          seriesOverrides={{
-            rx: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
-                {
-                  defaultMessage: 'in',
-                }
-              ),
-            },
-            tx: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
-                {
-                  defaultMessage: 'out',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsEC2DiskIOBytes"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.ec2MetricsLayout.diskIOBytesSection.sectionLabel',
-          {
-            defaultMessage: 'Disk IO (Bytes)',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bytes"
-          formatterTemplate="{{value}}/s"
-          type="area"
-          seriesOverrides={{
-            write: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.ec2MetricsLayout.diskIOBytesSection.writeLabel',
-                {
-                  defaultMessage: 'writes',
-                }
-              ),
-            },
-            read: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.ec2MetricsLayout.diskIOBytesSection.readLabel',
-                {
-                  defaultMessage: 'reads',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
+        <SubSection
+          id="awsEC2CpuUtilization"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.ec2MetricsLayout.cpuUsageSection.sectionLabel',
+            {
+              defaultMessage: 'CPU Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            stacked={true}
+            type="area"
+            formatter="percent"
+            seriesOverrides={{
+              total: { color: theme.eui.euiColorVis1 },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsEC2NetworkTraffic"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.ec2MetricsLayout.networkTrafficSection.sectionLabel',
+            {
+              defaultMessage: 'Network Traffic',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bits"
+            formatterTemplate="{{value}}/s"
+            type="area"
+            seriesOverrides={{
+              rx: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
+                  {
+                    defaultMessage: 'in',
+                  }
+                ),
+              },
+              tx: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
+                  {
+                    defaultMessage: 'out',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsEC2DiskIOBytes"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.ec2MetricsLayout.diskIOBytesSection.sectionLabel',
+            {
+              defaultMessage: 'Disk IO (Bytes)',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bytes"
+            formatterTemplate="{{value}}/s"
+            type="area"
+            seriesOverrides={{
+              write: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.ec2MetricsLayout.diskIOBytesSection.writeLabel',
+                  {
+                    defaultMessage: 'writes',
+                  }
+                ),
+              },
+              read: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.ec2MetricsLayout.diskIOBytesSection.readLabel',
+                  {
+                    defaultMessage: 'reads',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/common/inventory_models/aws_rds/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/aws_rds/layout.tsx
@@ -10,171 +10,174 @@ import { Section } from '../../../public/pages/metrics/components/section';
 import { SubSection } from '../../../public/pages/metrics/components/sub_section';
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
 import { withTheme } from '../../../../../common/eui_styled_components';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel="AWS RDS"
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.rdsMetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Aws RDS Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection
-        id="awsRDSCpuTotal"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.rdsMetricsLayout.cpuTotal.sectionLabel',
+    <LayoutContent>
+      <Section
+        navLabel="AWS RDS"
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.rdsMetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'Total CPU Usage',
+            defaultMessage: 'Aws RDS Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          type="area"
-          formatter="percent"
-          seriesOverrides={{
-            cpu: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.cpuTotal.chartLabel',
-                { defaultMessage: 'Total' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsRDSConnections"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.rdsMetricsLayout.connections.sectionLabel',
-          {
-            defaultMessage: 'Connections',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="number"
-          seriesOverrides={{
-            connections: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.connections.chartLabel',
-                { defaultMessage: 'Connections' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsRDSQueriesExecuted"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.rdsMetricsLayout.queriesExecuted.sectionLabel',
-          {
-            defaultMessage: 'Queries Executed',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="number"
-          seriesOverrides={{
-            queries: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.queriesExecuted.chartLabel',
-                { defaultMessage: 'Queries' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsRDSActiveTransactions"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.rdsMetricsLayout.activeTransactions.sectionLabel',
-          {
-            defaultMessage: 'Transactions',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="number"
-          seriesOverrides={{
-            active: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.active.chartLabel',
-                { defaultMessage: 'Active' }
-              ),
-            },
-            blocked: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.blocked.chartLabel',
-                { defaultMessage: 'Blocked' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsRDSLatency"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.sectionLabel',
-          {
-            defaultMessage: 'Latency',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          stacked={true}
-          formatter="highPercision"
-          formatterTemplate={'{{value}} ms'}
-          seriesOverrides={{
-            read: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.read.chartLabel',
-                { defaultMessage: 'Read' }
-              ),
-            },
-            write: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.write.chartLabel',
-                { defaultMessage: 'Write' }
-              ),
-            },
-            insert: {
-              color: theme.eui.euiColorVis0,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.insert.chartLabel',
-                { defaultMessage: 'Insert' }
-              ),
-            },
-            update: {
-              color: theme.eui.euiColorVis7,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.update.chartLabel',
-                { defaultMessage: 'Update' }
-              ),
-            },
-            commit: {
-              color: theme.eui.euiColorVis3,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.commit.chartLabel',
-                { defaultMessage: 'Commit' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
+        <SubSection
+          id="awsRDSCpuTotal"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.rdsMetricsLayout.cpuTotal.sectionLabel',
+            {
+              defaultMessage: 'Total CPU Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="area"
+            formatter="percent"
+            seriesOverrides={{
+              cpu: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.cpuTotal.chartLabel',
+                  { defaultMessage: 'Total' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsRDSConnections"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.rdsMetricsLayout.connections.sectionLabel',
+            {
+              defaultMessage: 'Connections',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="number"
+            seriesOverrides={{
+              connections: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.connections.chartLabel',
+                  { defaultMessage: 'Connections' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsRDSQueriesExecuted"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.rdsMetricsLayout.queriesExecuted.sectionLabel',
+            {
+              defaultMessage: 'Queries Executed',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="number"
+            seriesOverrides={{
+              queries: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.queriesExecuted.chartLabel',
+                  { defaultMessage: 'Queries' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsRDSActiveTransactions"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.rdsMetricsLayout.activeTransactions.sectionLabel',
+            {
+              defaultMessage: 'Transactions',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="number"
+            seriesOverrides={{
+              active: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.active.chartLabel',
+                  { defaultMessage: 'Active' }
+                ),
+              },
+              blocked: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.blocked.chartLabel',
+                  { defaultMessage: 'Blocked' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsRDSLatency"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.sectionLabel',
+            {
+              defaultMessage: 'Latency',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            stacked={true}
+            formatter="highPercision"
+            formatterTemplate={'{{value}} ms'}
+            seriesOverrides={{
+              read: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.read.chartLabel',
+                  { defaultMessage: 'Read' }
+                ),
+              },
+              write: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.write.chartLabel',
+                  { defaultMessage: 'Write' }
+                ),
+              },
+              insert: {
+                color: theme.eui.euiColorVis0,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.insert.chartLabel',
+                  { defaultMessage: 'Insert' }
+                ),
+              },
+              update: {
+                color: theme.eui.euiColorVis7,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.update.chartLabel',
+                  { defaultMessage: 'Update' }
+                ),
+              },
+              commit: {
+                color: theme.eui.euiColorVis3,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.rdsMetricsLayout.latency.commit.chartLabel',
+                  { defaultMessage: 'Commit' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/common/inventory_models/aws_s3/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/aws_s3/layout.tsx
@@ -10,134 +10,137 @@ import { Section } from '../../../public/pages/metrics/components/section';
 import { SubSection } from '../../../public/pages/metrics/components/sub_section';
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
 import { withTheme } from '../../../../../common/eui_styled_components';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel="AWS S3"
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.s3MetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Aws S3 Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection
-        id="awsS3BucketSize"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.s3MetricsLayout.bucketSize.sectionLabel',
+    <LayoutContent>
+      <Section
+        navLabel="AWS S3"
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.s3MetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'Bucket Size',
+            defaultMessage: 'Aws S3 Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          type="bar"
-          formatter="bytes"
-          seriesOverrides={{
-            bytes: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.s3MetricsLayout.bucketSize.chartLabel',
-                { defaultMessage: 'Total Bytes' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsS3NumberOfObjects"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.s3MetricsLayout.numberOfObjects.sectionLabel',
-          {
-            defaultMessage: 'Number of Objects',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            objects: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.s3MetricsLayout.numberOfObjects.chartLabel',
-                { defaultMessage: 'Objects' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsS3TotalRequests"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.s3MetricsLayout.totalRequests.sectionLabel',
-          {
-            defaultMessage: 'Total Requests',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            total: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.s3MetricsLayout.totalRequests.chartLabel',
-                { defaultMessage: 'Requests' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsS3DownloadBytes"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.s3MetricsLayout.downloadBytes.sectionLabel',
-          {
-            defaultMessage: 'Downloaded Bytes',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="bytes"
-          seriesOverrides={{
-            bytes: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.s3MetricsLayout.downloadBytes.chartLabel',
-                { defaultMessage: 'Bytes' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsS3UploadBytes"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.s3MetricsLayout.uploadBytes.sectionLabel',
-          {
-            defaultMessage: 'Uploaded Bytes',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="bytes"
-          seriesOverrides={{
-            bytes: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.s3MetricsLayout.uploadBytes.chartLabel',
-                { defaultMessage: 'Bytes' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
+        <SubSection
+          id="awsS3BucketSize"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.s3MetricsLayout.bucketSize.sectionLabel',
+            {
+              defaultMessage: 'Bucket Size',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="bytes"
+            seriesOverrides={{
+              bytes: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.s3MetricsLayout.bucketSize.chartLabel',
+                  { defaultMessage: 'Total Bytes' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsS3NumberOfObjects"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.s3MetricsLayout.numberOfObjects.sectionLabel',
+            {
+              defaultMessage: 'Number of Objects',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              objects: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.s3MetricsLayout.numberOfObjects.chartLabel',
+                  { defaultMessage: 'Objects' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsS3TotalRequests"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.s3MetricsLayout.totalRequests.sectionLabel',
+            {
+              defaultMessage: 'Total Requests',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              total: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.s3MetricsLayout.totalRequests.chartLabel',
+                  { defaultMessage: 'Requests' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsS3DownloadBytes"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.s3MetricsLayout.downloadBytes.sectionLabel',
+            {
+              defaultMessage: 'Downloaded Bytes',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="bytes"
+            seriesOverrides={{
+              bytes: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.s3MetricsLayout.downloadBytes.chartLabel',
+                  { defaultMessage: 'Bytes' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsS3UploadBytes"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.s3MetricsLayout.uploadBytes.sectionLabel',
+            {
+              defaultMessage: 'Uploaded Bytes',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="bytes"
+            seriesOverrides={{
+              bytes: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.s3MetricsLayout.uploadBytes.chartLabel',
+                  { defaultMessage: 'Bytes' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/common/inventory_models/aws_sqs/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/aws_sqs/layout.tsx
@@ -10,134 +10,137 @@ import { Section } from '../../../public/pages/metrics/components/section';
 import { SubSection } from '../../../public/pages/metrics/components/sub_section';
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
 import { withTheme } from '../../../../../common/eui_styled_components';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel="AWS SQS"
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.sqsMetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Aws SQS Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection
-        id="awsSQSMessagesVisible"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesVisible.sectionLabel',
+    <LayoutContent>
+      <Section
+        navLabel="AWS SQS"
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.sqsMetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'Messages Available',
+            defaultMessage: 'Aws SQS Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            visible: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesVisible.chartLabel',
-                { defaultMessage: 'Available' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsSQSMessagesDelayed"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesDelayed.sectionLabel',
-          {
-            defaultMessage: 'Messages Delayed',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            delayed: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesDelayed.chartLabel',
-                { defaultMessage: 'Delayed' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsSQSMessagesSent"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesSent.sectionLabel',
-          {
-            defaultMessage: 'Messages Added',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            sent: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesSent.chartLabel',
-                { defaultMessage: 'Added' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsSQSMessagesEmpty"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesEmpty.sectionLabel',
-          {
-            defaultMessage: 'Messages Empty',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            sent: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesEmpty.chartLabel',
-                { defaultMessage: 'Empty' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="awsSQSOldestMessage"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.sqsMetricsLayout.oldestMessage.sectionLabel',
-          {
-            defaultMessage: 'Oldest Message',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="bar"
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            oldest: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.sqsMetricsLayout.oldestMessage.chartLabel',
-                { defaultMessage: 'Age' }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
+        <SubSection
+          id="awsSQSMessagesVisible"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesVisible.sectionLabel',
+            {
+              defaultMessage: 'Messages Available',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              visible: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesVisible.chartLabel',
+                  { defaultMessage: 'Available' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsSQSMessagesDelayed"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesDelayed.sectionLabel',
+            {
+              defaultMessage: 'Messages Delayed',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              delayed: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesDelayed.chartLabel',
+                  { defaultMessage: 'Delayed' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsSQSMessagesSent"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesSent.sectionLabel',
+            {
+              defaultMessage: 'Messages Added',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              sent: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesSent.chartLabel',
+                  { defaultMessage: 'Added' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsSQSMessagesEmpty"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesEmpty.sectionLabel',
+            {
+              defaultMessage: 'Messages Empty',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              sent: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.sqsMetricsLayout.messagesEmpty.chartLabel',
+                  { defaultMessage: 'Empty' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="awsSQSOldestMessage"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.sqsMetricsLayout.oldestMessage.sectionLabel',
+            {
+              defaultMessage: 'Oldest Message',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="bar"
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              oldest: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.sqsMetricsLayout.oldestMessage.chartLabel',
+                  { defaultMessage: 'Age' }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/common/inventory_models/container/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/container/layout.tsx
@@ -11,212 +11,220 @@ import { SubSection } from '../../../public/pages/metrics/components/sub_section
 import { GaugesSectionVis } from '../../../public/pages/metrics/components/gauges_section_vis';
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
 import { withTheme } from '../../../../../common/eui_styled_components';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
+import { MetadataDetails } from '../../../public/pages/metrics/components/metadata_details';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel={i18n.translate('xpack.infra.metricDetailPage.containerMetricsLayout.layoutLabel', {
-        defaultMessage: 'Container',
-      })}
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Container Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection id="containerOverview">
-        <GaugesSectionVis
-          seriesOverrides={{
-            cpu: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.cpuUsageSeriesLabel',
-                {
-                  defaultMessage: 'CPU Usage',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            memory: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.memoryUsageSeriesLabel',
-                {
-                  defaultMessage: 'Memory Usage',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            rx: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.inboundRXSeriesLabel',
-                {
-                  defaultMessage: 'Inbound (RX)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'bits',
-              formatterTemplate: '{{value}}/s',
-            },
-            tx: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.outboundTXSeriesLabel',
-                {
-                  defaultMessage: 'Outbound (TX)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'bits',
-              formatterTemplate: '{{value}}/s',
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="containerCpuUsage"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.containerMetricsLayout.cpuUsageSection.sectionLabel',
+    <MetadataDetails />
+    <LayoutContent>
+      <Section
+        navLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.containerMetricsLayout.layoutLabel',
           {
-            defaultMessage: 'CPU Usage',
+            defaultMessage: 'Container',
           }
         )}
-      >
-        <ChartSectionVis
-          stacked={true}
-          type="area"
-          formatter="percent"
-          seriesOverrides={{
-            cpu: { color: theme.eui.euiColorVis1 },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="containerMemory"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.containerMetricsLayout.memoryUsageSection.sectionLabel',
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'Memory Usage',
+            defaultMessage: 'Container Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          stacked={true}
-          type="area"
-          formatter="percent"
-          seriesOverrides={{
-            memory: { color: theme.eui.euiColorVis1 },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="containerNetworkTraffic"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.containerMetricsLayout.networkTrafficSection.sectionLabel',
-          {
-            defaultMessage: 'Network Traffic',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bits"
-          formatterTemplate="{{value}}/s"
-          type="area"
-          seriesOverrides={{
-            rx: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
-                {
-                  defaultMessage: 'in',
-                }
-              ),
-            },
-            tx: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
-                {
-                  defaultMessage: 'out',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="containerDiskIOOps"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoOpsSection.sectionLabel',
-          {
-            defaultMessage: 'Disk IO (Ops)',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="area"
-          formatterTemplate="{{value}}/s"
-          formatter="number"
-          seriesOverrides={{
-            read: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoOpsSection.readRateSeriesLabel',
-                {
-                  defaultMessage: 'reads',
-                }
-              ),
-            },
-            write: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoOpsSection.writeRateSeriesLabel',
-                {
-                  defaultMessage: 'writes',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="containerDiskIOBytes"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoBytesSection.sectionLabel',
-          {
-            defaultMessage: 'Disk IO (Bytes)',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="area"
-          formatter="bytes"
-          formatterTemplate="{{value}}/s"
-          seriesOverrides={{
-            read: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoBytesSection.readRateSeriesLabel',
-                {
-                  defaultMessage: 'reads',
-                }
-              ),
-            },
-            write: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoBytesSection.writeRateSeriesLabel',
-                {
-                  defaultMessage: 'writes',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
+        <SubSection id="containerOverview">
+          <GaugesSectionVis
+            seriesOverrides={{
+              cpu: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.cpuUsageSeriesLabel',
+                  {
+                    defaultMessage: 'CPU Usage',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              memory: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.memoryUsageSeriesLabel',
+                  {
+                    defaultMessage: 'Memory Usage',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              rx: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.inboundRXSeriesLabel',
+                  {
+                    defaultMessage: 'Inbound (RX)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'bits',
+                formatterTemplate: '{{value}}/s',
+              },
+              tx: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.overviewSection.outboundTXSeriesLabel',
+                  {
+                    defaultMessage: 'Outbound (TX)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'bits',
+                formatterTemplate: '{{value}}/s',
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="containerCpuUsage"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.containerMetricsLayout.cpuUsageSection.sectionLabel',
+            {
+              defaultMessage: 'CPU Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            stacked={true}
+            type="area"
+            formatter="percent"
+            seriesOverrides={{
+              cpu: { color: theme.eui.euiColorVis1 },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="containerMemory"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.containerMetricsLayout.memoryUsageSection.sectionLabel',
+            {
+              defaultMessage: 'Memory Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            stacked={true}
+            type="area"
+            formatter="percent"
+            seriesOverrides={{
+              memory: { color: theme.eui.euiColorVis1 },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="containerNetworkTraffic"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.containerMetricsLayout.networkTrafficSection.sectionLabel',
+            {
+              defaultMessage: 'Network Traffic',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bits"
+            formatterTemplate="{{value}}/s"
+            type="area"
+            seriesOverrides={{
+              rx: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
+                  {
+                    defaultMessage: 'in',
+                  }
+                ),
+              },
+              tx: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
+                  {
+                    defaultMessage: 'out',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="containerDiskIOOps"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoOpsSection.sectionLabel',
+            {
+              defaultMessage: 'Disk IO (Ops)',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="area"
+            formatterTemplate="{{value}}/s"
+            formatter="number"
+            seriesOverrides={{
+              read: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoOpsSection.readRateSeriesLabel',
+                  {
+                    defaultMessage: 'reads',
+                  }
+                ),
+              },
+              write: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoOpsSection.writeRateSeriesLabel',
+                  {
+                    defaultMessage: 'writes',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="containerDiskIOBytes"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoBytesSection.sectionLabel',
+            {
+              defaultMessage: 'Disk IO (Bytes)',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="area"
+            formatter="bytes"
+            formatterTemplate="{{value}}/s"
+            seriesOverrides={{
+              read: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoBytesSection.readRateSeriesLabel',
+                  {
+                    defaultMessage: 'reads',
+                  }
+                ),
+              },
+              write: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.containerMetricsLayout.diskIoBytesSection.writeRateSeriesLabel',
+                  {
+                    defaultMessage: 'writes',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/common/inventory_models/host/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/host/layout.tsx
@@ -5,348 +5,366 @@
  */
 import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { withTheme } from '../../../../../common/eui_styled_components/eui_styled_components';
 import { LayoutPropsWithTheme } from '../../../public/pages/metrics/types';
 import { Section } from '../../../public/pages/metrics/components/section';
 import { SubSection } from '../../../public/pages/metrics/components/sub_section';
 import { GaugesSectionVis } from '../../../public/pages/metrics/components/gauges_section_vis';
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
-import { withTheme } from '../../../../../common/eui_styled_components';
 import * as Aws from '../shared/layouts/aws';
 import * as Ngnix from '../shared/layouts/nginx';
+import { MetadataDetails } from '../../../public/pages/metrics/components/metadata_details';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel={i18n.translate('xpack.infra.metricDetailPage.hostMetricsLayout.layoutLabel', {
-        defaultMessage: 'Host',
-      })}
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Host Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection id="hostSystemOverview">
-        <GaugesSectionVis
-          seriesOverrides={{
-            cpu: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.cpuUsageSeriesLabel',
-                {
-                  defaultMessage: 'CPU Usage',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            load: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.loadSeriesLabel',
-                {
-                  defaultMessage: 'Load (5m)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-            },
-            memory: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.memoryCapacitySeriesLabel',
-                {
-                  defaultMessage: 'Memory Usage',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            rx: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.inboundRXSeriesLabel',
-                {
-                  defaultMessage: 'Inbound (RX)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'bits',
-              formatterTemplate: '{{value}}/s',
-            },
-            tx: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.outboundTXSeriesLabel',
-                {
-                  defaultMessage: 'Outbound (TX)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'bits',
-              formatterTemplate: '{{value}}/s',
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostCpuUsage"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.hostMetricsLayout.cpuUsageSection.sectionLabel',
+    <MetadataDetails
+      fields={[
+        'host.hostname',
+        'host.os.name',
+        'host.os.kernel',
+        'host.containerized',
+        'cloud.provider',
+        'cloud.availability_zone',
+        'cloud.machine.type',
+        'cloud.project.id',
+        'cloud.instance.id',
+        'cloud.instance.name',
+      ]}
+    />
+    <LayoutContent>
+      <Section
+        navLabel={i18n.translate('xpack.infra.metricDetailPage.hostMetricsLayout.layoutLabel', {
+          defaultMessage: 'Host',
+        })}
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'CPU Usage',
+            defaultMessage: 'Host Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          stacked={true}
-          type="area"
-          formatter="percent"
-          seriesOverrides={{
-            user: { color: theme.eui.euiColorVis0 },
-            system: { color: theme.eui.euiColorVis2 },
-            steal: { color: theme.eui.euiColorVis9 },
-            irq: { color: theme.eui.euiColorVis4 },
-            softirq: { color: theme.eui.euiColorVis6 },
-            iowait: { color: theme.eui.euiColorVis7 },
-            nice: { color: theme.eui.euiColorVis5 },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostLoad"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.sectionLabel',
+        <SubSection id="hostSystemOverview">
+          <GaugesSectionVis
+            seriesOverrides={{
+              cpu: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.cpuUsageSeriesLabel',
+                  {
+                    defaultMessage: 'CPU Usage',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              load: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.loadSeriesLabel',
+                  {
+                    defaultMessage: 'Load (5m)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+              },
+              memory: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.memoryCapacitySeriesLabel',
+                  {
+                    defaultMessage: 'Memory Usage',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              rx: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.inboundRXSeriesLabel',
+                  {
+                    defaultMessage: 'Inbound (RX)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'bits',
+                formatterTemplate: '{{value}}/s',
+              },
+              tx: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.overviewSection.outboundTXSeriesLabel',
+                  {
+                    defaultMessage: 'Outbound (TX)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'bits',
+                formatterTemplate: '{{value}}/s',
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostCpuUsage"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.hostMetricsLayout.cpuUsageSection.sectionLabel',
+            {
+              defaultMessage: 'CPU Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            stacked={true}
+            type="area"
+            formatter="percent"
+            seriesOverrides={{
+              user: { color: theme.eui.euiColorVis0 },
+              system: { color: theme.eui.euiColorVis2 },
+              steal: { color: theme.eui.euiColorVis9 },
+              irq: { color: theme.eui.euiColorVis4 },
+              softirq: { color: theme.eui.euiColorVis6 },
+              iowait: { color: theme.eui.euiColorVis7 },
+              nice: { color: theme.eui.euiColorVis5 },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostLoad"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.sectionLabel',
+            {
+              defaultMessage: 'Load',
+            }
+          )}
+        >
+          <ChartSectionVis
+            seriesOverrides={{
+              load_1m: {
+                color: theme.eui.euiColorVis0,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.oneMinuteSeriesLabel',
+                  {
+                    defaultMessage: '1m',
+                  }
+                ),
+              },
+              load_5m: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.fiveMinuteSeriesLabel',
+                  {
+                    defaultMessage: '5m',
+                  }
+                ),
+              },
+              load_15m: {
+                color: theme.eui.euiColorVis3,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.fifteenMinuteSeriesLabel',
+                  {
+                    defaultMessage: '15m',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostMemoryUsage"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.hostMetricsLayout.memoryUsageSection.sectionLabel',
+            {
+              defaultMessage: 'Memory Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            stacked={true}
+            formatter="bytes"
+            type="area"
+            seriesOverrides={{
+              used: { color: theme.eui.euiColorVis2 },
+              free: { color: theme.eui.euiColorVis0 },
+              cache: { color: theme.eui.euiColorVis1 },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostNetworkTraffic"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.sectionLabel',
+            {
+              defaultMessage: 'Network Traffic',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bits"
+            formatterTemplate="{{value}}/s"
+            type="area"
+            seriesOverrides={{
+              rx: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
+                  {
+                    defaultMessage: 'in',
+                  }
+                ),
+              },
+              tx: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
+                  {
+                    defaultMessage: 'out',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+      <Section
+        navLabel="Kubernetes"
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'Load',
+            defaultMessage: 'Kubernetes Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          seriesOverrides={{
-            load_1m: {
-              color: theme.eui.euiColorVis0,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.oneMinuteSeriesLabel',
-                {
-                  defaultMessage: '1m',
-                }
-              ),
-            },
-            load_5m: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.fiveMinuteSeriesLabel',
-                {
-                  defaultMessage: '5m',
-                }
-              ),
-            },
-            load_15m: {
-              color: theme.eui.euiColorVis3,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.loadSection.fifteenMinuteSeriesLabel',
-                {
-                  defaultMessage: '15m',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostMemoryUsage"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.hostMetricsLayout.memoryUsageSection.sectionLabel',
-          {
-            defaultMessage: 'Memory Usage',
-          }
-        )}
-      >
-        <ChartSectionVis
-          stacked={true}
-          formatter="bytes"
-          type="area"
-          seriesOverrides={{
-            used: { color: theme.eui.euiColorVis2 },
-            free: { color: theme.eui.euiColorVis0 },
-            cache: { color: theme.eui.euiColorVis1 },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostNetworkTraffic"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.sectionLabel',
-          {
-            defaultMessage: 'Network Traffic',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bits"
-          formatterTemplate="{{value}}/s"
-          type="area"
-          seriesOverrides={{
-            rx: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
-                {
-                  defaultMessage: 'in',
-                }
-              ),
-            },
-            tx: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.hostMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
-                {
-                  defaultMessage: 'out',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
-    <Section
-      navLabel="Kubernetes"
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Kubernetes Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection id="hostK8sOverview">
-        <GaugesSectionVis
-          seriesOverrides={{
-            cpucap: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.cpuUsageSeriesLabel',
-                {
-                  defaultMessage: 'CPU Capacity',
-                }
-              ),
-              color: 'secondary',
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            load: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.loadSeriesLabel',
-                {
-                  defaultMessage: 'Load (5m)',
-                }
-              ),
-              color: 'secondary',
-            },
-            memorycap: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.memoryUsageSeriesLabel',
-                {
-                  defaultMessage: 'Memory Capacity',
-                }
-              ),
-              color: 'secondary',
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            podcap: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.podCapacitySeriesLabel',
-                {
-                  defaultMessage: 'Pod Capacity',
-                }
-              ),
-              color: 'secondary',
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            diskcap: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.diskCapacitySeriesLabel',
-                {
-                  defaultMessage: 'Disk Capacity',
-                }
-              ),
-              color: 'secondary',
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostK8sCpuCap"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodeCpuCapacitySection.sectionLabel',
-          {
-            defaultMessage: 'Node CPU Capacity',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="abbreviatedNumber"
-          seriesOverrides={{
-            capacity: { color: theme.eui.euiColorVis2 },
-            used: { color: theme.eui.euiColorVis1, type: 'area' },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostK8sMemoryCap"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodeMemoryCapacitySection.sectionLabel',
-          {
-            defaultMessage: 'Node Memory Capacity',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bytes"
-          seriesOverrides={{
-            capacity: { color: theme.eui.euiColorVis2 },
-            used: { color: theme.eui.euiColorVis1, type: 'area' },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostK8sDiskCap"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodeDiskCapacitySection.sectionLabel',
-          {
-            defaultMessage: 'Node Disk Capacity',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bytes"
-          seriesOverrides={{
-            capacity: { color: theme.eui.euiColorVis2 },
-            used: { color: theme.eui.euiColorVis1, type: 'area' },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="hostK8sPodCap"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodePodCapacitySection.sectionLabel',
-          {
-            defaultMessage: 'Node Pod Capacity',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="number"
-          seriesOverrides={{
-            capacity: { color: theme.eui.euiColorVis2 },
-            used: { color: theme.eui.euiColorVis1, type: 'area' },
-          }}
-        />
-      </SubSection>
-    </Section>
-    <Aws.Layout metrics={metrics} />
-    <Ngnix.Layout metrics={metrics} />
+        <SubSection id="hostK8sOverview">
+          <GaugesSectionVis
+            seriesOverrides={{
+              cpucap: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.cpuUsageSeriesLabel',
+                  {
+                    defaultMessage: 'CPU Capacity',
+                  }
+                ),
+                color: 'secondary',
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              load: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.loadSeriesLabel',
+                  {
+                    defaultMessage: 'Load (5m)',
+                  }
+                ),
+                color: 'secondary',
+              },
+              memorycap: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.memoryUsageSeriesLabel',
+                  {
+                    defaultMessage: 'Memory Capacity',
+                  }
+                ),
+                color: 'secondary',
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              podcap: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.podCapacitySeriesLabel',
+                  {
+                    defaultMessage: 'Pod Capacity',
+                  }
+                ),
+                color: 'secondary',
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              diskcap: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.kubernetesMetricsLayout.overviewSection.diskCapacitySeriesLabel',
+                  {
+                    defaultMessage: 'Disk Capacity',
+                  }
+                ),
+                color: 'secondary',
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostK8sCpuCap"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodeCpuCapacitySection.sectionLabel',
+            {
+              defaultMessage: 'Node CPU Capacity',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="abbreviatedNumber"
+            seriesOverrides={{
+              capacity: { color: theme.eui.euiColorVis2 },
+              used: { color: theme.eui.euiColorVis1, type: 'area' },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostK8sMemoryCap"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodeMemoryCapacitySection.sectionLabel',
+            {
+              defaultMessage: 'Node Memory Capacity',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bytes"
+            seriesOverrides={{
+              capacity: { color: theme.eui.euiColorVis2 },
+              used: { color: theme.eui.euiColorVis1, type: 'area' },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostK8sDiskCap"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodeDiskCapacitySection.sectionLabel',
+            {
+              defaultMessage: 'Node Disk Capacity',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bytes"
+            seriesOverrides={{
+              capacity: { color: theme.eui.euiColorVis2 },
+              used: { color: theme.eui.euiColorVis1, type: 'area' },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="hostK8sPodCap"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.kubernetesMetricsLayout.nodePodCapacitySection.sectionLabel',
+            {
+              defaultMessage: 'Node Pod Capacity',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="number"
+            seriesOverrides={{
+              capacity: { color: theme.eui.euiColorVis2 },
+              used: { color: theme.eui.euiColorVis1, type: 'area' },
+            }}
+          />
+        </SubSection>
+      </Section>
+      <Aws.Layout metrics={metrics} />
+      <Ngnix.Layout metrics={metrics} />
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/common/inventory_models/pod/layout.tsx
+++ b/x-pack/legacy/plugins/infra/common/inventory_models/pod/layout.tsx
@@ -12,143 +12,148 @@ import { GaugesSectionVis } from '../../../public/pages/metrics/components/gauge
 import { ChartSectionVis } from '../../../public/pages/metrics/components/chart_section_vis';
 import { withTheme } from '../../../../../common/eui_styled_components';
 import * as Nginx from '../shared/layouts/nginx';
+import { MetadataDetails } from '../../../public/pages/metrics/components/metadata_details';
+import { LayoutContent } from '../../../public/pages/metrics/components/layout_content';
 
 export const Layout = withTheme(({ metrics, theme }: LayoutPropsWithTheme) => (
   <React.Fragment>
-    <Section
-      navLabel={i18n.translate('xpack.infra.metricDetailPage.podMetricsLayout.layoutLabel', {
-        defaultMessage: 'Pod',
-      })}
-      sectionLabel={i18n.translate(
-        'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.sectionLabel',
-        {
-          defaultMessage: 'Pod Overview',
-        }
-      )}
-      metrics={metrics}
-    >
-      <SubSection id="podOverview">
-        <GaugesSectionVis
-          seriesOverrides={{
-            cpu: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.cpuUsageSeriesLabel',
-                {
-                  defaultMessage: 'CPU Usage',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            memory: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.memoryUsageSeriesLabel',
-                {
-                  defaultMessage: 'Memory Usage',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'percent',
-              gaugeMax: 1,
-            },
-            rx: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.inboundRXSeriesLabel',
-                {
-                  defaultMessage: 'Inbound (RX)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'bits',
-              formatterTemplate: '{{value}}/s',
-            },
-            tx: {
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.outboundTXSeriesLabel',
-                {
-                  defaultMessage: 'Outbound (TX)',
-                }
-              ),
-              color: theme.eui.euiColorFullShade,
-              formatter: 'bits',
-              formatterTemplate: '{{value}}/s',
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="podCpuUsage"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.podMetricsLayout.cpuUsageSection.sectionLabel',
+    <MetadataDetails />
+    <LayoutContent>
+      <Section
+        navLabel={i18n.translate('xpack.infra.metricDetailPage.podMetricsLayout.layoutLabel', {
+          defaultMessage: 'Pod',
+        })}
+        sectionLabel={i18n.translate(
+          'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.sectionLabel',
           {
-            defaultMessage: 'CPU Usage',
+            defaultMessage: 'Pod Overview',
           }
         )}
+        metrics={metrics}
       >
-        <ChartSectionVis
-          formatter="percent"
-          type="area"
-          seriesOverrides={{
-            cpu: { color: theme.eui.euiColorVis1 },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="podMemoryUsage"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.podMetricsLayout.memoryUsageSection.sectionLabel',
-          {
-            defaultMessage: 'Memory Usage',
-          }
-        )}
-      >
-        <ChartSectionVis
-          type="area"
-          formatter="percent"
-          seriesOverrides={{
-            memory: {
-              color: theme.eui.euiColorVis1,
-            },
-          }}
-        />
-      </SubSection>
-      <SubSection
-        id="podNetworkTraffic"
-        label={i18n.translate(
-          'xpack.infra.metricDetailPage.podMetricsLayout.networkTrafficSection.sectionLabel',
-          {
-            defaultMessage: 'Network Traffic',
-          }
-        )}
-      >
-        <ChartSectionVis
-          formatter="bits"
-          formatterTemplate="{{value}}/s"
-          type="area"
-          seriesOverrides={{
-            rx: {
-              color: theme.eui.euiColorVis1,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.podMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
-                {
-                  defaultMessage: 'in',
-                }
-              ),
-            },
-            tx: {
-              color: theme.eui.euiColorVis2,
-              name: i18n.translate(
-                'xpack.infra.metricDetailPage.podMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
-                {
-                  defaultMessage: 'out',
-                }
-              ),
-            },
-          }}
-        />
-      </SubSection>
-    </Section>
-    <Nginx.Layout metrics={metrics} />
+        <SubSection id="podOverview">
+          <GaugesSectionVis
+            seriesOverrides={{
+              cpu: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.cpuUsageSeriesLabel',
+                  {
+                    defaultMessage: 'CPU Usage',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              memory: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.memoryUsageSeriesLabel',
+                  {
+                    defaultMessage: 'Memory Usage',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'percent',
+                gaugeMax: 1,
+              },
+              rx: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.inboundRXSeriesLabel',
+                  {
+                    defaultMessage: 'Inbound (RX)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'bits',
+                formatterTemplate: '{{value}}/s',
+              },
+              tx: {
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.podMetricsLayout.overviewSection.outboundTXSeriesLabel',
+                  {
+                    defaultMessage: 'Outbound (TX)',
+                  }
+                ),
+                color: theme.eui.euiColorFullShade,
+                formatter: 'bits',
+                formatterTemplate: '{{value}}/s',
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="podCpuUsage"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.podMetricsLayout.cpuUsageSection.sectionLabel',
+            {
+              defaultMessage: 'CPU Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="percent"
+            type="area"
+            seriesOverrides={{
+              cpu: { color: theme.eui.euiColorVis1 },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="podMemoryUsage"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.podMetricsLayout.memoryUsageSection.sectionLabel',
+            {
+              defaultMessage: 'Memory Usage',
+            }
+          )}
+        >
+          <ChartSectionVis
+            type="area"
+            formatter="percent"
+            seriesOverrides={{
+              memory: {
+                color: theme.eui.euiColorVis1,
+              },
+            }}
+          />
+        </SubSection>
+        <SubSection
+          id="podNetworkTraffic"
+          label={i18n.translate(
+            'xpack.infra.metricDetailPage.podMetricsLayout.networkTrafficSection.sectionLabel',
+            {
+              defaultMessage: 'Network Traffic',
+            }
+          )}
+        >
+          <ChartSectionVis
+            formatter="bits"
+            formatterTemplate="{{value}}/s"
+            type="area"
+            seriesOverrides={{
+              rx: {
+                color: theme.eui.euiColorVis1,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.podMetricsLayout.networkTrafficSection.networkRxRateSeriesLabel',
+                  {
+                    defaultMessage: 'in',
+                  }
+                ),
+              },
+              tx: {
+                color: theme.eui.euiColorVis2,
+                name: i18n.translate(
+                  'xpack.infra.metricDetailPage.podMetricsLayout.networkTrafficSection.networkTxRateSeriesLabel',
+                  {
+                    defaultMessage: 'out',
+                  }
+                ),
+              },
+            }}
+          />
+        </SubSection>
+      </Section>
+      <Nginx.Layout metrics={metrics} />
+    </LayoutContent>
   </React.Fragment>
 ));

--- a/x-pack/legacy/plugins/infra/public/pages/metrics/components/layout_content.tsx
+++ b/x-pack/legacy/plugins/infra/public/pages/metrics/components/layout_content.tsx
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { EuiPageContent } from '@elastic/eui';
+import { euiStyled } from '../../../../../../common/eui_styled_components';
+
+export const LayoutContent = euiStyled(EuiPageContent)`
+  position: relative;
+`;

--- a/x-pack/legacy/plugins/infra/public/pages/metrics/components/node_details_page.tsx
+++ b/x-pack/legacy/plugins/infra/public/pages/metrics/components/node_details_page.tsx
@@ -12,7 +12,6 @@ import {
   EuiPageHeaderSection,
   EuiHideFor,
   EuiTitle,
-  EuiPageContent,
 } from '@elastic/eui';
 import { InventoryMetric } from '../../../../common/inventory_models/types';
 import { useNodeDetails } from '../../../containers/node_details/use_node_details';
@@ -20,13 +19,13 @@ import { InfraNodeType, InfraTimerangeInput } from '../../../graphql/types';
 import { MetricsSideNav } from './side_nav';
 import { AutoSizer } from '../../../components/auto_sizer';
 import { MetricsTimeControls } from './time_controls';
-import { NodeDetails } from './node_details';
 import { SideNavContext, NavItem } from '../lib/side_nav_context';
 import { PageBody } from './page_body';
 import euiStyled from '../../../../../../common/eui_styled_components';
 import { MetricsTimeInput } from '../containers/with_metrics_time';
 import { InfraMetadata } from '../../../../common/http_api/metadata_api';
 import { PageError } from './page_error';
+import { MetadataContext } from '../../../pages/metrics/containers/metadata_context';
 
 interface Props {
   name: string;
@@ -100,14 +99,13 @@ export const NodeDetailsPage = (props: Props) => {
                     </MetricsTitleTimeRangeContainer>
                   </EuiPageHeaderSection>
                 </EuiPageHeader>
-                <NodeDetails metadata={props.metadata} />
-                <EuiPageContentWithRelative>
-                  <SideNavContext.Provider
-                    value={{
-                      items: props.sideNav,
-                      addNavItem: props.addNavItem,
-                    }}
-                  >
+                <SideNavContext.Provider
+                  value={{
+                    items: props.sideNav,
+                    addNavItem: props.addNavItem,
+                  }}
+                >
+                  <MetadataContext.Provider value={props.metadata}>
                     <PageBody
                       loading={metrics.length > 0 && props.isAutoReloading ? false : loading}
                       refetch={refetch}
@@ -117,8 +115,8 @@ export const NodeDetailsPage = (props: Props) => {
                       isLiveStreaming={props.isAutoReloading}
                       stopLiveStreaming={() => props.setAutoReload(false)}
                     />
-                  </SideNavContext.Provider>
-                </EuiPageContentWithRelative>
+                  </MetadataContext.Provider>
+                </SideNavContext.Provider>
               </EuiPageBody>
             </MetricsDetailsPageColumn>
           );
@@ -127,10 +125,6 @@ export const NodeDetailsPage = (props: Props) => {
     </EuiPage>
   );
 };
-
-const EuiPageContentWithRelative = euiStyled(EuiPageContent)`
-  position: relative;
-`;
 
 const MetricsDetailsPageColumn = euiStyled.div`
   flex: 1 0 0%;

--- a/x-pack/legacy/plugins/infra/public/pages/metrics/containers/metadata_context.ts
+++ b/x-pack/legacy/plugins/infra/public/pages/metrics/containers/metadata_context.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { InfraMetadata } from '../../../../common/http_api';
+export const MetadataContext = React.createContext<InfraMetadata | null>(null);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Customize "node info" section per Inventory Model (#53325)