### PR TITLE
Move console logs to actual logger + getRecords to receive the ES client

### DIFF
--- a/src/core/server/pulse/channel.ts
+++ b/src/core/server/pulse/channel.ts
@@ -18,6 +18,7 @@
  */
 
 import { Subject } from 'rxjs';
+import { IClusterClient } from '../elasticsearch';
 
 export interface PulseInstruction {
   owner: string;
@@ -31,7 +32,7 @@ interface ChannelConfig {
 }
 
 export class PulseChannel {
-  public readonly getRecords: () => Promise<Record<string, any>>;
+  public readonly getRecords: (elasticsearch: IClusterClient) => Promise<Record<string, any>>;
 
   constructor(private readonly config: ChannelConfig) {
     this.getRecords = require(`${__dirname}/collectors/${this.id}`).getRecords;

--- a/src/core/server/pulse/collectors/default.ts
+++ b/src/core/server/pulse/collectors/default.ts
@@ -17,6 +17,10 @@
  * under the License.
  */
 
-export async function getRecords() {
-  return [{}];
+import { IClusterClient } from '../../elasticsearch';
+
+export async function getRecords(elasticsearch: IClusterClient) {
+  const pingResult = await elasticsearch.callAsInternalUser('ping');
+
+  return [{ ping_received: pingResult }];
 }

--- a/src/core/server/pulse/index.ts
+++ b/src/core/server/pulse/index.ts
@@ -19,7 +19,7 @@
 
 import { readdirSync } from 'fs';
 import { resolve, parse } from 'path';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 // @ts-ignore
 import fetch from 'node-fetch';
 

--- a/src/core/server/pulse/index.ts
+++ b/src/core/server/pulse/index.ts
@@ -18,14 +18,14 @@
  */
 
 import { readdirSync } from 'fs';
-import { resolve } from 'path';
-import { Subject } from 'rxjs';
+import { resolve, parse } from 'path';
+import { Subject, Subscription } from 'rxjs';
 // @ts-ignore
 import fetch from 'node-fetch';
 
 import { CoreContext } from '../core_context';
 import { Logger } from '../logging';
-import { ElasticsearchServiceSetup } from '../elasticsearch';
+import { ElasticsearchServiceSetup, IClusterClient } from '../elasticsearch';
 import { PulseChannel, PulseInstruction } from './channel';
 
 export interface InternalPulseService {
@@ -48,13 +48,16 @@ interface InstructionsResponse {
 const channelNames = readdirSync(resolve(__dirname, 'collectors'))
   .filter((fileName: string) => !fileName.startsWith('.'))
   .map((fileName: string) => {
-    return fileName.slice(0, -3);
+    // Get the base name without the extension
+    return parse(fileName).name;
   });
 
 export class PulseService {
   private readonly log: Logger;
   private readonly channels: Map<string, PulseChannel>;
   private readonly instructions: Map<string, Subject<any>> = new Map();
+  private readonly subscriptions: Set<Subscription> = new Set();
+  private elasticsearch?: IClusterClient;
 
   constructor(coreContext: CoreContext) {
     this.log = coreContext.logger.get('pulse-service');
@@ -69,22 +72,9 @@ export class PulseService {
   }
 
   public async setup(deps: PulseSetupDeps): Promise<InternalPulseService> {
-    this.log.debug('Setting up pulse service');
+    this.log.info('Setting up service');
 
-    // poll for instructions every second for this deployment
-    setInterval(() => {
-      // eslint-disable-next-line no-console
-      this.loadInstructions().catch(err => console.error(err.stack));
-    }, 1000);
-
-    // eslint-disable-next-line no-console
-    console.log('Will attempt first telemetry collection in 5 seconds...');
-    setTimeout(() => {
-      setInterval(() => {
-        // eslint-disable-next-line no-console
-        this.sendTelemetry().catch(err => console.error(err.stack));
-      }, 5000);
-    }, 5000);
+    this.elasticsearch = deps.elasticsearch.createClient('pulse-service');
 
     return {
       getChannel: (id: string) => {
@@ -95,6 +85,31 @@ export class PulseService {
         return channel;
       },
     };
+  }
+
+  public async start() {
+    this.log.info('Starting service');
+    if (!this.elasticsearch) {
+      throw Error(`The 'PulseService.setup' method needs to be called before the 'start' method`);
+    }
+    const elasticsearch = this.elasticsearch;
+
+    // poll for instructions every second for this deployment
+    setInterval(() => {
+      this.loadInstructions().catch(err => this.log.error(err.stack));
+    }, 1000);
+
+    this.log.debug('Will attempt first telemetry collection in 5 seconds...');
+    setInterval(() => {
+      this.sendTelemetry(elasticsearch).catch(err => this.log.error(err.stack));
+    }, 5000);
+  }
+
+  public async stop() {
+    this.subscriptions.forEach(subscription => {
+      subscription.unsubscribe();
+      this.subscriptions.delete(subscription);
+    });
   }
 
   private retriableErrors = 0;
@@ -137,8 +152,7 @@ export class PulseService {
   private handleRetriableError() {
     this.retriableErrors++;
     if (this.retriableErrors === 1) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      this.log.warn(
         'Kibana is not yet available at http://localhost:5601/api, will continue to check for the next 120 seconds...'
       );
     } else if (this.retriableErrors > 120) {
@@ -146,12 +160,14 @@ export class PulseService {
     }
   }
 
-  private async sendTelemetry() {
+  private async sendTelemetry(elasticsearch: IClusterClient) {
+    this.log.debug('Sending telemetry');
     const url = 'http://localhost:5601/api/pulse_poc/intake/123';
 
     const channels = [];
     for (const channel of this.channels.values()) {
-      const records = await channel.getRecords();
+      const records = await channel.getRecords(elasticsearch);
+      this.log.debug(`Channel "${channel.id}" returns the records ${JSON.stringify(records)}`);
       channels.push({
         records,
         channel_id: channel.id,

--- a/src/core/server/server.ts
+++ b/src/core/server/server.ts
@@ -212,12 +212,16 @@ export class Server {
 
     await this.http.start();
 
+    // Starting it after http because it relies on the the HTTP service
+    await this.pulse.start();
+
     return coreStart;
   }
 
   public async stop() {
     this.log.debug('stopping server');
 
+    await this.pulse.stop();
     await this.legacy.stop();
     await this.plugins.stop();
     await this.savedObjects.stop();


### PR DESCRIPTION
I've been hacking around and found from the conversation between @epixa and @TinaHeiligers `getRecords` needed an ES client sent through in the params (we can revisit about the typings and where they are imported from in the future).

Also found out `console.log` creates more listeners 😱and Kibana crashes after 11+ listeners. That's why I moved the `console.*` to actual `this.log.*`.