### PR TITLE
[APM] Add log statements for flaky test

### DIFF
--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
@@ -4,8 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-/* eslint-disable no-console */
-
 import hash from 'object-hash';
 import { Setup } from '../../helpers/setup_request';
 import { AgentConfiguration } from './configuration_types';
@@ -46,10 +44,5 @@ export async function createOrUpdateConfiguration({
     params.id = configurationId;
   }
 
-  // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
-  console.log(`Creating agent configuration`);
-  const res = await internalClient.index(params);
-  // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
-  console.log(`Success creating agent configuration`);
-  return res;
+  return internalClient.index(params);
 }

--- a/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+/* eslint-disable no-console */
+
 import hash from 'object-hash';
 import { Setup } from '../../helpers/setup_request';
 import { AgentConfiguration } from './configuration_types';
@@ -44,5 +46,10 @@ export async function createOrUpdateConfiguration({
     params.id = configurationId;
   }
 
-  return internalClient.index(params);
+  // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
+  console.log(`Creating agent configuration`);
+  const res = await internalClient.index(params);
+  // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
+  console.log(`Success creating agent configuration`);
+  return res;
 }

--- a/x-pack/legacy/plugins/apm/server/routes/settings/agent_configuration.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings/agent_configuration.ts
@@ -121,7 +121,7 @@ export const createAgentConfigurationRoute = createRoute(() => ({
 
     // TODO: Remove logger. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
     context.logger.info(
-      `Hitting: /api/apm/settings/agent-configuration/new with ${configuration}`
+      `Hitting: /api/apm/settings/agent-configuration/new with ${configuration.service.name}/${configuration.service.environment}`
     );
     const res = await createOrUpdateConfiguration({
       configuration,

--- a/x-pack/legacy/plugins/apm/server/routes/settings/agent_configuration.ts
+++ b/x-pack/legacy/plugins/apm/server/routes/settings/agent_configuration.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+/* eslint-disable no-console */
+
 import * as t from 'io-ts';
 import Boom from 'boom';
 import { setupRequest } from '../../lib/helpers/setup_request';
@@ -161,6 +163,9 @@ export const agentConfigurationSearchRoute = createRoute(core => ({
     })
   },
   handler: async ({ context, request }) => {
+    // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
+    // TODO: Remove console.log before 8.0 to avoid releasing to end users
+    console.log('Hitting: /api/apm/settings/agent-configuration/search');
     const setup = await setupRequest(context, request);
     const { body } = context.params;
     const config = await searchConfigurations({
@@ -170,6 +175,10 @@ export const agentConfigurationSearchRoute = createRoute(core => ({
     });
 
     if (!config) {
+      // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
+      console.log(
+        `Config was not found for ${body.service.name}/${body.service.environment}`
+      );
       context.logger.info(
         `Config was not found for ${body.service.name}/${body.service.environment}`
       );

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -207,7 +207,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     spaceId?: string;
   }) {
     for (const endpoint of endpoints) {
-      console.log(`Requesting: ${endpoint.req.url} ${endpoint.req.body}`);
+      console.log(`Requesting: ${endpoint.req.url}. Expecting: ${expectation}`);
       const result = await executeAsUser(endpoint.req, username, password, spaceId);
       console.log(`Responded: ${endpoint.req.url}`);
 

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -207,12 +207,9 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     spaceId?: string;
   }) {
     for (const endpoint of endpoints) {
-      // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
-      console.log(`Requesting: ${endpoint.req.url}`);
-      log.info(`Requesting: ${endpoint.req.url}`);
+      console.log(`Requesting: ${endpoint.req.url} ${endpoint.req.body}`);
       const result = await executeAsUser(endpoint.req, username, password, spaceId);
       console.log(`Responded: ${endpoint.req.url}`);
-      log.info(`Responded: ${endpoint.req.url}`);
 
       try {
         if (expectation === 'forbidden') {
@@ -221,9 +218,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
           endpoint.expectResponse(result);
         }
       } catch (e) {
-        // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
-        console.log(`${endpoint.req.url} failed`);
-        log.warning(`${endpoint.req.url} failed`);
+        console.warn(`Expectation for endpoint: "${endpoint.req.url}" failed`);
 
         const { statusCode, body, req } = result.response;
         throw new Error(
@@ -240,9 +235,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
   describe('apm feature controls', () => {
     let res: any;
     before(async () => {
-      // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
       console.log(`Creating agent configuration`);
-      log.info('Creating agent configuration');
       res = await executeAsAdmin({
         method: 'post',
         url: '/api/apm/settings/agent-configuration/new',
@@ -251,13 +244,11 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
           settings: { transaction_sample_rate: 0.5 },
         },
       });
-      // TODO: Remove console.log. Only added temporarily to debug flaky test (https://github.com/elastic/kibana/issues/51764)
       console.log(`Agent configuration created`);
-      log.info('Agent configuration created');
     });
 
     after(async () => {
-      log.info('deleting agent configuration');
+      console.log('deleting agent configuration');
       const configurationId = res.body._id;
       await executeAsAdmin({
         method: 'delete',


### PR DESCRIPTION
I've been unable to reproduce a test failure that occasionally happens on CI. For details about the failure see https://github.com/elastic/kibana/issues/51764.

I have a hunch that a race condition is causing the test to fail. The test that is failing tries to verify that an existing agent config can be found when given the correct arguments. However, sometimes it is not found.
My hypothesis is the agent configuration is either not created correctly, or is created in parallel with the search request, causing the search request to be made before the config is created.

I was having problems seeing `log.debug`/`log.info` so resorted to `console.log`. Would prefer not using `console.log` though.

**Important log lines indicating that the agent configuration was created:**
```
[2019-12-23T22:54:27.872Z] Creating agent configuration
[2019-12-23T22:54:27.872Z]                │ proc [kibana] Could not get dynamic index pattern because indices "apm-*,apm-*,apm-*" don't exist
[2019-12-23T22:54:27.872Z]                │ proc [kibana]   log   [22:54:27.850] [info][apm][apm][plugins] Hitting: /api/apm/settings/agent-configuration/new with test-service/undefined
[2019-12-23T22:54:27.872Z]                │ proc [kibana]   log   [22:54:27.865] [info][apm][apm][plugins] Created agent configuration
[2019-12-23T22:54:27.872Z] Agent configuration created
```
**Important log lines indicating that the agent configuration was found:**
```
[2019-12-23T22:54:30.435Z] Requesting: /api/apm/settings/agent-configuration/search. Expecting: response
[2019-12-23T22:54:30.435Z]                │ proc [kibana]   log   [22:54:30.292] [info][apm][apm][plugins] Hitting: /api/apm/settings/agent-configuration/search for test-service/undefined
[2019-12-23T22:54:30.435Z]                │ proc [kibana]   log   [22:54:30.317] [info][apm][apm][plugins] Config was found for test-service/undefined
[2019-12-23T22:54:30.436Z] Responded: /api/apm/settings/agent-configuration/search
[2019-12-23T22:54:30.436Z]                └- ✓ pass  (1.3s) "apis APM apm feature controls APIs can be accessed by global_all user"
```