### PR TITLE
[APM] Delay rendering invalid license notification

### DIFF
--- a/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
@@ -16,12 +16,8 @@ export const LicenseContext = React.createContext<ILicense | undefined>(
 
 export function LicenseProvider({ children }: { children: React.ReactChild }) {
   const { license$ } = useApmPluginContext().plugins.licensing;
-  const license = useObservable(license$);
-  const hasInvalidLicense = !license?.isActive;
-
-  if (!license) {
-    return null;
-  }
+  const license = useObservable(license$, { isActive: true } as ILicense);
+  const hasInvalidLicense = !license.isActive;
 
   // if license is invalid show an error message
   if (hasInvalidLicense) {

--- a/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
@@ -19,6 +19,10 @@ export function LicenseProvider({ children }: { children: React.ReactChild }) {
   const license = useObservable(license$);
   const hasInvalidLicense = !license?.isActive;
 
+  if (!license) {
+    return null;
+  }
+
   // if license is invalid show an error message
   if (hasInvalidLicense) {
     return <InvalidLicenseNotification />;


### PR DESCRIPTION
Don't render an invalid license notification if the license information has not been loaded. (Don't render any UI either).

This only happens for a very, usually unnoticeable, amount of time, but it's still visible from time to time AFAICT.
