### PR TITLE
[Visualizations] Add default filename when exporting CSV

### DIFF
--- a/src/plugins/inspector/public/views/data/components/download_options.tsx
+++ b/src/plugins/inspector/public/views/data/components/download_options.tsx
@@ -20,6 +20,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
 import { EuiButton, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
 import { DataViewColumn, DataViewRow } from '../types';
@@ -66,8 +67,14 @@ class DataDownloadOptions extends Component<DataDownloadOptionsProps, DataDownlo
   };
 
   exportCsv = (customParams: any = {}) => {
+    let filename = this.props.title;
+    if (!filename || filename.length === 0) {
+      filename = i18n.translate('inspector.data.downloadOptionsUnsavedFilename', {
+        defaultMessage: 'unsaved',
+      });
+    }
     exportAsCsv({
-      filename: `${this.props.title}.csv`,
+      filename: `${filename}.csv`,
       columns: this.props.columns,
       rows: this.props.rows,
       csvSeparator: this.props.csvSeparator,


### PR DESCRIPTION
….if visualization hasn't been saved

## Summary

Fixes: https://github.com/elastic/kibana/issues/53960

When exporting a visualization, filename defaults to a visualization name. If visualization hasn't been saved previously, a file with an empty filename was exported, which led to confusing and erroneous behavior.

This PR introduces default (`unsaved`) filename, if visualization hasn't been saved previously.

Before:
<img width="440" alt="Screenshot 2020-01-06 at 10 11 11" src="https://user-images.githubusercontent.com/1937956/71812607-87702c00-306f-11ea-9753-eafdc58dccb5.png">

After:
<img width="439" alt="Screenshot 2020-01-06 at 10 20 26" src="https://user-images.githubusercontent.com/1937956/71812619-90f99400-306f-11ea-81b5-e5e1e5125d6e.png">


Tested in Firefox and Chrome.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

