### PR TITLE
[APM]Add `message` fields to metadata table

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/__test__/SpanMetadata.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/__test__/SpanMetadata.test.tsx
@@ -31,11 +31,15 @@ describe('SpanMetadata', () => {
           name: 'opbeans-java'
         },
         span: {
-          id: '7efbc7056b746fcb'
+          id: '7efbc7056b746fcb',
+          message: {
+            age: { ms: 1577958057123 },
+            queue: { name: 'queue name' }
+          }
         }
       } as unknown) as Span;
       const output = render(<SpanMetadata span={span} />, renderOptions);
-      expectTextsInDocument(output, ['Service', 'Agent']);
+      expectTextsInDocument(output, ['Service', 'Agent', 'Message']);
     });
   });
   describe('when a span is presented', () => {
@@ -55,11 +59,15 @@ describe('SpanMetadata', () => {
             response: { status_code: 200 }
           },
           subtype: 'http',
-          type: 'external'
+          type: 'external',
+          message: {
+            age: { ms: 1577958057123 },
+            queue: { name: 'queue name' }
+          }
         }
       } as unknown) as Span;
       const output = render(<SpanMetadata span={span} />, renderOptions);
-      expectTextsInDocument(output, ['Service', 'Agent', 'Span']);
+      expectTextsInDocument(output, ['Service', 'Agent', 'Span', 'Message']);
     });
   });
   describe('when there is no id inside span', () => {
@@ -83,7 +91,7 @@ describe('SpanMetadata', () => {
       } as unknown) as Span;
       const output = render(<SpanMetadata span={span} />, renderOptions);
       expectTextsInDocument(output, ['Service', 'Agent']);
-      expectTextsNotInDocument(output, ['Span']);
+      expectTextsNotInDocument(output, ['Span', 'Message']);
     });
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/sections.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/SpanMetadata/sections.ts
@@ -11,7 +11,8 @@ import {
   SPAN,
   LABELS,
   TRANSACTION,
-  TRACE
+  TRACE,
+  MESSAGE_SPAN
 } from '../sections';
 
 export const SPAN_METADATA_SECTIONS: Section[] = [
@@ -20,5 +21,6 @@ export const SPAN_METADATA_SECTIONS: Section[] = [
   TRANSACTION,
   TRACE,
   SERVICE,
+  MESSAGE_SPAN,
   AGENT
 ];

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/__test__/TransactionMetadata.test.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/__test__/TransactionMetadata.test.tsx
@@ -35,6 +35,10 @@ function getTransaction() {
       notIncluded: 'transaction not included value',
       custom: {
         someKey: 'custom value'
+      },
+      message: {
+        age: { ms: 1577958057123 },
+        queue: { name: 'queue name' }
       }
     }
   } as unknown) as Transaction;
@@ -59,7 +63,8 @@ describe('TransactionMetadata', () => {
       'Agent',
       'URL',
       'User',
-      'Custom'
+      'Custom',
+      'Message'
     ]);
   });
 
@@ -81,7 +86,9 @@ describe('TransactionMetadata', () => {
       'agent.someKey',
       'url.someKey',
       'user.someKey',
-      'transaction.custom.someKey'
+      'transaction.custom.someKey',
+      'transaction.message.age.ms',
+      'transaction.message.queue.name'
     ]);
 
     // excluded keys
@@ -109,7 +116,9 @@ describe('TransactionMetadata', () => {
       'agent value',
       'url value',
       'user value',
-      'custom value'
+      'custom value',
+      '1577958057123',
+      'queue name'
     ]);
 
     // excluded values
@@ -138,7 +147,8 @@ describe('TransactionMetadata', () => {
       'Process',
       'Agent',
       'URL',
-      'Custom'
+      'Custom',
+      'Message'
     ]);
   });
 });

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/sections.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/TransactionMetadata/sections.ts
@@ -18,7 +18,8 @@ import {
   PAGE,
   USER,
   USER_AGENT,
-  CUSTOM_TRANSACTION
+  CUSTOM_TRANSACTION,
+  MESSAGE_TRANSACTION
 } from '../sections';
 
 export const TRANSACTION_METADATA_SECTIONS: Section[] = [
@@ -29,6 +30,7 @@ export const TRANSACTION_METADATA_SECTIONS: Section[] = [
   CONTAINER,
   SERVICE,
   PROCESS,
+  MESSAGE_TRANSACTION,
   AGENT,
   URL,
   { ...PAGE, key: 'transaction.page' },

--- a/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/sections.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/MetadataTable/sections.ts
@@ -136,3 +136,20 @@ export const CUSTOM_TRANSACTION: Section = {
   key: 'transaction.custom',
   label: customLabel
 };
+
+const messageLabel = i18n.translate(
+  'xpack.apm.metadataTable.section.messageLabel',
+  {
+    defaultMessage: 'Message'
+  }
+);
+
+export const MESSAGE_TRANSACTION: Section = {
+  key: 'transaction.message',
+  label: messageLabel
+};
+
+export const MESSAGE_SPAN: Section = {
+  key: 'span.message',
+  label: messageLabel
+};

--- a/x-pack/legacy/plugins/apm/typings/es_schemas/raw/SpanRaw.ts
+++ b/x-pack/legacy/plugins/apm/typings/es_schemas/raw/SpanRaw.ts
@@ -40,6 +40,12 @@ export interface SpanRaw extends APMBaseDoc {
       statement?: string;
       type?: string;
     };
+    message?: {
+      queue?: { name: string };
+      age?: { ms: number };
+      body?: string;
+      headers?: Record<string, unknown>;
+    };
   };
   transaction?: {
     id: string;

--- a/x-pack/legacy/plugins/apm/typings/es_schemas/raw/TransactionRaw.ts
+++ b/x-pack/legacy/plugins/apm/typings/es_schemas/raw/TransactionRaw.ts
@@ -43,6 +43,12 @@ export interface TransactionRaw extends APMBaseDoc {
     };
     type: string;
     custom?: Record<string, unknown>;
+    message?: {
+      queue?: { name: string };
+      age?: { ms: number };
+      body?: string;
+      headers?: Record<string, unknown>;
+    };
   };
 
   // Shared by errors and transactions


### PR DESCRIPTION
closes #49465 

Transaction metadata:
<img width="1128" alt="Screenshot 2020-01-06 at 15 08 05" src="https://user-images.githubusercontent.com/55978943/71825429-2448be80-309c-11ea-8c32-153b7980d009.png">

Span metadata:
<img width="985" alt="Screenshot 2020-01-06 at 15 10 03" src="https://user-images.githubusercontent.com/55978943/71825442-29a60900-309c-11ea-9e5a-866f0e0709d4.png">
