### PR TITLE
[7.x] [Metrics UI] Add AWS Cloudwatch dimensions to groups filter in Metrics Explorer  (#53624)

### DIFF
--- a/x-pack/legacy/plugins/infra/common/ecs_allowed_list.ts
+++ b/x-pack/legacy/plugins/infra/common/ecs_allowed_list.ts
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { first } from 'lodash';
+import { first, memoize } from 'lodash';
 
 export const ECS_ALLOWED_LIST = [
   'host',
@@ -46,8 +46,9 @@ export const DOCKER_ALLOWED_LIST = [
 ];
 
 export const AWS_S3_ALLOWED_LIST = ['aws.s3'];
+export const AWS_METRICS_ALLOWED_LIST = ['aws.cloudwatch'];
 
-export const getAllowedListForPrefix = (prefix: string) => {
+export const getAllowedListForPrefix = memoize((prefix: string) => {
   const firstPart = first(prefix.split(/\./));
   const defaultAllowedList = prefix ? [...ECS_ALLOWED_LIST, prefix] : ECS_ALLOWED_LIST;
   switch (firstPart) {
@@ -61,7 +62,10 @@ export const getAllowedListForPrefix = (prefix: string) => {
       if (prefix === 'aws.s3_daily_storage') {
         return [...defaultAllowedList, ...AWS_S3_ALLOWED_LIST];
       }
+      if (prefix === 'aws.metrics') {
+        return [...defaultAllowedList, ...AWS_METRICS_ALLOWED_LIST];
+      }
     default:
       return defaultAllowedList;
   }
-};
+});

--- a/x-pack/legacy/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
+++ b/x-pack/legacy/plugins/infra/server/routes/metrics_explorer/lib/get_dataset_for_field.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { RequestHandlerContext } from 'kibana/server';
+import { KibanaFramework } from '../../../lib/adapters/framework/kibana_framework_adapter';
+
+interface EventDatasetHit {
+  _source: {
+    event?: {
+      dataset?: string;
+    };
+  };
+}
+
+export const getDatasetForField = async (
+  framework: KibanaFramework,
+  requestContext: RequestHandlerContext,
+  field: string,
+  indexPattern: string
+) => {
+  const params = {
+    allowNoIndices: true,
+    ignoreUnavailable: true,
+    terminateAfter: 1,
+    index: indexPattern,
+    body: {
+      query: { exists: { field } },
+      size: 1,
+      _source: ['event.dataset'],
+    },
+  };
+
+  const response = await framework.callWithRequest<EventDatasetHit>(
+    requestContext,
+    'search',
+    params
+  );
+  if (response.hits.total.value === 0) {
+    return null;
+  }
+
+  return response.hits.hits?.[0]._source.event?.dataset;
+};


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Add AWS Cloudwatch dimensions to groups filter in Metrics Explorer  (#53624)