### PR TITLE
Changing background color to align with EUI color

### DIFF
--- a/src/core/server/rendering/views/styles.tsx
+++ b/src/core/server/rendering/views/styles.tsx
@@ -28,8 +28,6 @@ interface Props {
 }
 
 export const Styles: FunctionComponent<Props> = ({ darkMode }) => {
-  const themeBackground = darkMode ? '#25262e' : '#f5f7fa';
-
   return (
     <style
       dangerouslySetInnerHTML={{
@@ -42,11 +40,9 @@ export const Styles: FunctionComponent<Props> = ({ darkMode }) => {
             width: 100%;
             height: 100%;
             margin: 0;
-            background-color: ${themeBackground};
           }
 
           .kibanaWelcomeView {
-            background-color: ${themeBackground};
             height: 100%;
             display: -webkit-box;
             display: -webkit-flex;

--- a/src/legacy/ui/public/styles/_legacy/_base.scss
+++ b/src/legacy/ui/public/styles/_legacy/_base.scss
@@ -78,6 +78,7 @@ input[type='checkbox'],
   flex-shrink: 0;
   flex-basis: auto;
   flex-direction: column;
+  background-color: $euiPageBackgroundColor;
 
   > * {
     flex-shrink: 0;

--- a/src/legacy/ui/public/styles/_legacy/_base.scss
+++ b/src/legacy/ui/public/styles/_legacy/_base.scss
@@ -78,7 +78,6 @@ input[type='checkbox'],
   flex-shrink: 0;
   flex-basis: auto;
   flex-direction: column;
-  background-color: $euiPageBackgroundColor;
 
   > * {
     flex-shrink: 0;


### PR DESCRIPTION
## Summary
Applying `euiPageBackgroundColor` to application class to remove discrepancy between the EUI background and Kibana apps background.
Fixes: https://github.com/elastic/kibana/issues/53867
Some apps where I tested this:
Visualizations
<img width="407" alt="Screenshot 2020-01-06 at 20 59 00" src="https://user-images.githubusercontent.com/1937956/71848765-507a3480-30c8-11ea-914c-bb87e9f35e28.png">
Dashboard:
<img width="238" alt="Screenshot 2020-01-06 at 20 59 47" src="https://user-images.githubusercontent.com/1937956/71848779-5bcd6000-30c8-11ea-8317-30de7d033d2d.png">
Maps:
<img width="204" alt="Screenshot 2020-01-06 at 21 00 03" src="https://user-images.githubusercontent.com/1937956/71848787-5f60e700-30c8-11ea-8dbb-792912c2c74f.png">
Home:
<img width="376" alt="Screenshot 2020-01-06 at 20 59 30" src="https://user-images.githubusercontent.com/1937956/71848815-6d166c80-30c8-11ea-81f6-4ae492e4c6da.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [X] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

