### PR TITLE
[Dashboard] Redesign empty screen in readonly mode

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dashboard/__tests__/__snapshots__/dashboard_empty_screen.test.tsx.snap
+++ b/src/legacy/core_plugins/kibana/public/dashboard/__tests__/__snapshots__/dashboard_empty_screen.test.tsx.snap
@@ -1,5 +1,348 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DashboardEmptyScreen renders correctly with readonly mode 1`] = `
+<DashboardEmptyScreen
+  http={
+    Object {
+      "addLoadingCountSource": [MockFunction],
+      "anonymousPaths": Object {
+        "isAnonymous": [MockFunction],
+        "register": [MockFunction],
+      },
+      "basePath": BasePath {
+        "basePath": "",
+        "get": [Function],
+        "prepend": [Function],
+        "remove": [Function],
+      },
+      "delete": [MockFunction],
+      "fetch": [MockFunction],
+      "get": [MockFunction],
+      "getLoadingCount$": [MockFunction],
+      "head": [MockFunction],
+      "intercept": [MockFunction],
+      "options": [MockFunction],
+      "patch": [MockFunction],
+      "post": [MockFunction],
+      "put": [MockFunction],
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "units": "day",
+          },
+          "hours": Object {
+            "units": "hour",
+          },
+          "minutes": Object {
+            "units": "minute",
+          },
+          "months": Object {
+            "units": "month",
+          },
+          "seconds": Object {
+            "units": "second",
+          },
+          "years": Object {
+            "units": "year",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": Symbol(react.fragment),
+      "timeZone": null,
+    }
+  }
+  isReadonlyMode={true}
+  onLinkClick={[MockFunction]}
+  showLinkToVisualize={true}
+  uiSettings={
+    Object {
+      "get": [MockFunction] {
+        "calls": Array [
+          Array [
+            "theme:darkMode",
+          ],
+          Array [
+            "theme:darkMode",
+          ],
+          Array [
+            "theme:darkMode",
+          ],
+          Array [
+            "theme:darkMode",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+      "get$": [MockFunction],
+      "getAll": [MockFunction],
+      "getSaved$": [MockFunction],
+      "getUpdate$": [MockFunction],
+      "getUpdateErrors$": [MockFunction],
+      "isCustom": [MockFunction],
+      "isDeclared": [MockFunction],
+      "isDefault": [MockFunction],
+      "isOverridden": [MockFunction],
+      "overrideLocalDefault": [MockFunction],
+      "remove": [MockFunction],
+      "set": [MockFunction],
+    }
+  }
+>
+  <I18nProvider>
+    <IntlProvider
+      defaultLocale="en"
+      formats={
+        Object {
+          "date": Object {
+            "full": Object {
+              "day": "numeric",
+              "month": "long",
+              "weekday": "long",
+              "year": "numeric",
+            },
+            "long": Object {
+              "day": "numeric",
+              "month": "long",
+              "year": "numeric",
+            },
+            "medium": Object {
+              "day": "numeric",
+              "month": "short",
+              "year": "numeric",
+            },
+            "short": Object {
+              "day": "numeric",
+              "month": "numeric",
+              "year": "2-digit",
+            },
+          },
+          "number": Object {
+            "currency": Object {
+              "style": "currency",
+            },
+            "percent": Object {
+              "style": "percent",
+            },
+          },
+          "relative": Object {
+            "days": Object {
+              "units": "day",
+            },
+            "hours": Object {
+              "units": "hour",
+            },
+            "minutes": Object {
+              "units": "minute",
+            },
+            "months": Object {
+              "units": "month",
+            },
+            "seconds": Object {
+              "units": "second",
+            },
+            "years": Object {
+              "units": "year",
+            },
+          },
+          "time": Object {
+            "full": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "long": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+              "timeZoneName": "short",
+            },
+            "medium": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+              "second": "numeric",
+            },
+            "short": Object {
+              "hour": "numeric",
+              "minute": "numeric",
+            },
+          },
+        }
+      }
+      locale="en"
+      messages={Object {}}
+      textComponent={Symbol(react.fragment)}
+    >
+      <PseudoLocaleWrapper>
+        <EuiPage
+          className="dshStartScreen"
+          restrictWidth="500px"
+        >
+          <div
+            className="euiPage euiPage--restrictWidth-custom dshStartScreen"
+            style={
+              Object {
+                "maxWidth": "500px",
+              }
+            }
+          >
+            <EuiPageBody>
+              <main
+                className="euiPageBody"
+              >
+                <EuiPageContent
+                  className="dshStartScreen__pageContent"
+                  horizontalPosition="center"
+                  paddingSize="none"
+                  verticalPosition="center"
+                >
+                  <EuiPanel
+                    className="euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter dshStartScreen__pageContent"
+                    paddingSize="none"
+                  >
+                    <div
+                      className="euiPanel euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter dshStartScreen__pageContent"
+                    >
+                      <EuiImage
+                        alt=""
+                        url="/plugins/kibana/home/assets/welcome_graphic_light_2x.png"
+                      >
+                        <figure
+                          className="euiImage"
+                          role="figure"
+                        >
+                          <img
+                            alt=""
+                            className="euiImage__img"
+                            src="/plugins/kibana/home/assets/welcome_graphic_light_2x.png"
+                          />
+                        </figure>
+                      </EuiImage>
+                      <EuiText
+                        size="m"
+                      >
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <p
+                            style={
+                              Object {
+                                "fontWeight": "bold",
+                              }
+                            }
+                          >
+                            This dashboard is empty.
+                          </p>
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiPanel>
+                </EuiPageContent>
+              </main>
+            </EuiPageBody>
+          </div>
+        </EuiPage>
+      </PseudoLocaleWrapper>
+    </IntlProvider>
+  </I18nProvider>
+</DashboardEmptyScreen>
+`;
+
 exports[`DashboardEmptyScreen renders correctly with visualize paragraph 1`] = `
 <DashboardEmptyScreen
   http={

--- a/src/legacy/core_plugins/kibana/public/dashboard/__tests__/__snapshots__/dashboard_empty_screen.test.tsx.snap
+++ b/src/legacy/core_plugins/kibana/public/dashboard/__tests__/__snapshots__/dashboard_empty_screen.test.tsx.snap
@@ -326,8 +326,27 @@ exports[`DashboardEmptyScreen renders correctly with readonly mode 1`] = `
                               }
                             }
                           >
-                            This dashboard is empty.
+                            This dashboard is empty or you do not have permission to view.
                           </p>
+                        </div>
+                      </EuiText>
+                      <EuiText
+                        color="subdued"
+                        size="m"
+                      >
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <EuiTextColor
+                            color="subdued"
+                            component="div"
+                          >
+                            <div
+                              className="euiTextColor euiTextColor--subdued"
+                            >
+                              Please contact the owner of the dashboard if you think this is an error.
+                            </div>
+                          </EuiTextColor>
                         </div>
                       </EuiText>
                     </div>

--- a/src/legacy/core_plugins/kibana/public/dashboard/__tests__/__snapshots__/dashboard_empty_screen.test.tsx.snap
+++ b/src/legacy/core_plugins/kibana/public/dashboard/__tests__/__snapshots__/dashboard_empty_screen.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`DashboardEmptyScreen renders correctly with readonly mode 1`] = `
                               }
                             }
                           >
-                            This dashboard is empty or you do not have permission to view.
+                            This dashboard is empty.
                           </p>
                         </div>
                       </EuiText>
@@ -344,7 +344,7 @@ exports[`DashboardEmptyScreen renders correctly with readonly mode 1`] = `
                             <div
                               className="euiTextColor euiTextColor--subdued"
                             >
-                              Please contact the owner of the dashboard if you think this is an error.
+                              You need additional privileges to edit this dashboard.
                             </div>
                           </EuiTextColor>
                         </div>

--- a/src/legacy/core_plugins/kibana/public/dashboard/__tests__/dashboard_empty_screen.test.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/__tests__/dashboard_empty_screen.test.tsx
@@ -38,8 +38,7 @@ describe('DashboardEmptyScreen', () => {
 
   function mountComponent(props?: DashboardEmptyScreenProps) {
     const compProps = props || defaultProps;
-    const comp = mountWithIntl(<DashboardEmptyScreen {...compProps} />);
-    return comp;
+    return mountWithIntl(<DashboardEmptyScreen {...compProps} />);
   }
 
   test('renders correctly with visualize paragraph', () => {
@@ -52,8 +51,10 @@ describe('DashboardEmptyScreen', () => {
   test('renders correctly without visualize paragraph', () => {
     const component = mountComponent({ ...defaultProps, ...{ showLinkToVisualize: false } });
     expect(component).toMatchSnapshot();
-    const paragraph = findTestSubject(component, 'linkToVisualizeParagraph');
-    expect(paragraph.length).toBe(0);
+    const linkToVisualizeParagraph = findTestSubject(component, 'linkToVisualizeParagraph');
+    expect(linkToVisualizeParagraph.length).toBe(0);
+    const enterEditModeParagraph = component.find('.dshStartScreen__panelDesc');
+    expect(enterEditModeParagraph.length).toBe(1);
   });
 
   test('when specified, prop onVisualizeClick is called correctly', () => {
@@ -65,5 +66,12 @@ describe('DashboardEmptyScreen', () => {
     const button = findTestSubject(component, 'addVisualizationButton');
     button.simulate('click');
     expect(onVisualizeClick).toHaveBeenCalled();
+  });
+
+  test('renders correctly with readonly mode', () => {
+    const component = mountComponent({ ...defaultProps, ...{ isReadonlyMode: true } });
+    expect(component).toMatchSnapshot();
+    const paragraph = component.find('.dshStartScreen__panelDesc');
+    expect(paragraph.length).toBe(0);
   });
 });

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
@@ -161,6 +161,12 @@ export class DashboardAppController {
       dashboardStateManager.getIsViewMode() &&
       !dashboardConfig.getHideWriteControls();
 
+    const getIsEmptyInReadonlyMode = () =>
+      !dashboardStateManager.getPanels().length &&
+      !getShouldShowEditHelp() &&
+      !getShouldShowViewHelp() &&
+      dashboardConfig.getHideWriteControls();
+
     const addVisualization = () => {
       navActions[TopNavIds.VISUALIZE]();
     };
@@ -193,7 +199,10 @@ export class DashboardAppController {
       }
     };
 
-    const getEmptyScreenProps = (shouldShowEditHelp: boolean): DashboardEmptyScreenProps => {
+    const getEmptyScreenProps = (
+      shouldShowEditHelp: boolean,
+      isEmptyInReadOnlyMode: boolean
+    ): DashboardEmptyScreenProps => {
       const emptyScreenProps: DashboardEmptyScreenProps = {
         onLinkClick: shouldShowEditHelp ? $scope.showAddPanel : $scope.enterEditMode,
         showLinkToVisualize: shouldShowEditHelp,
@@ -202,6 +211,9 @@ export class DashboardAppController {
       };
       if (shouldShowEditHelp) {
         emptyScreenProps.onVisualizeClick = addVisualization;
+      }
+      if (isEmptyInReadOnlyMode) {
+        emptyScreenProps.isReadonlyMode = true;
       }
       return emptyScreenProps;
     };
@@ -219,6 +231,7 @@ export class DashboardAppController {
       }
       const shouldShowEditHelp = getShouldShowEditHelp();
       const shouldShowViewHelp = getShouldShowViewHelp();
+      const isEmptyInReadonlyMode = getIsEmptyInReadonlyMode();
       return {
         id: dashboardStateManager.savedDashboard.id || '',
         filters: queryFilter.getFilters(),
@@ -231,7 +244,7 @@ export class DashboardAppController {
         viewMode: dashboardStateManager.getViewMode(),
         panels: embeddablesMap,
         isFullScreenMode: dashboardStateManager.getFullScreenMode(),
-        isEmptyState: shouldShowEditHelp || shouldShowViewHelp,
+        isEmptyState: shouldShowEditHelp || shouldShowViewHelp || isEmptyInReadonlyMode,
         useMargins: dashboardStateManager.getUseMargins(),
         lastReloadRequestTime,
         title: dashboardStateManager.getTitle(),
@@ -275,9 +288,12 @@ export class DashboardAppController {
           dashboardContainer.renderEmpty = () => {
             const shouldShowEditHelp = getShouldShowEditHelp();
             const shouldShowViewHelp = getShouldShowViewHelp();
-            const isEmptyState = shouldShowEditHelp || shouldShowViewHelp;
+            const isEmptyInReadOnlyMode = getIsEmptyInReadonlyMode();
+            const isEmptyState = shouldShowEditHelp || shouldShowViewHelp || isEmptyInReadOnlyMode;
             return isEmptyState ? (
-              <DashboardEmptyScreen {...getEmptyScreenProps(shouldShowEditHelp)} />
+              <DashboardEmptyScreen
+                {...getEmptyScreenProps(shouldShowEditHelp, isEmptyInReadOnlyMode)}
+              />
             ) : null;
           };
 

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen.tsx
@@ -100,7 +100,7 @@ export function DashboardEmptyScreen({
     constants.addExistingVisualizationLinkText,
     constants.addExistingVisualizationLinkAriaLabel
   );
-  const page = (text: string, showAdditionalParagraph: boolean) => {
+  const page = (mainText: string, showAdditionalParagraph?: boolean, additionalText?: string) => {
     return (
       <EuiPage className="dshStartScreen" restrictWidth="500px">
         <EuiPageBody>
@@ -112,8 +112,13 @@ export function DashboardEmptyScreen({
           >
             <EuiImage url={http.basePath.prepend(emptyStateGraphicURL)} alt="" />
             <EuiText size="m">
-              <p style={{ fontWeight: 'bold' }}>{text}</p>
+              <p style={{ fontWeight: 'bold' }}>{mainText}</p>
             </EuiText>
+            {additionalText ? (
+              <EuiText size="m" color="subdued">
+                {additionalText}
+              </EuiText>
+            ) : null}
             {showAdditionalParagraph ? (
               <React.Fragment>
                 <EuiSpacer size="m" />
@@ -125,7 +130,11 @@ export function DashboardEmptyScreen({
       </EuiPage>
     );
   };
-  const readonlyMode = page(constants.emptyDashboardTitle, false);
+  const readonlyMode = page(
+    constants.emptyDashboardTitle,
+    false,
+    constants.emptyDashboardContactOwner
+  );
   const viewMode = page(constants.fillDashboardTitle, true);
   const editMode = (
     <div data-test-subj="emptyDashboardWidget" className="dshEmptyWidget">

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen.tsx
@@ -37,6 +37,7 @@ export interface DashboardEmptyScreenProps {
   onVisualizeClick?: () => void;
   uiSettings: IUiSettingsClient;
   http: HttpStart;
+  isReadonlyMode?: boolean;
 }
 
 export function DashboardEmptyScreen({
@@ -45,6 +46,7 @@ export function DashboardEmptyScreen({
   onVisualizeClick,
   uiSettings,
   http,
+  isReadonlyMode,
 }: DashboardEmptyScreenProps) {
   const IS_DARK_THEME = uiSettings.get('theme:darkMode');
   const emptyStateGraphicURL = IS_DARK_THEME
@@ -98,25 +100,33 @@ export function DashboardEmptyScreen({
     constants.addExistingVisualizationLinkText,
     constants.addExistingVisualizationLinkAriaLabel
   );
-  const viewMode = (
-    <EuiPage className="dshStartScreen" restrictWidth="500px">
-      <EuiPageBody>
-        <EuiPageContent
-          verticalPosition="center"
-          horizontalPosition="center"
-          paddingSize="none"
-          className="dshStartScreen__pageContent"
-        >
-          <EuiImage url={http.basePath.prepend(emptyStateGraphicURL)} alt="" />
-          <EuiText size="m">
-            <p style={{ fontWeight: 'bold' }}>{constants.fillDashboardTitle}</p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          <div className="dshStartScreen__panelDesc">{enterEditModeParagraph}</div>
-        </EuiPageContent>
-      </EuiPageBody>
-    </EuiPage>
-  );
+  const page = (text: string, showAdditionalParagraph: boolean) => {
+    return (
+      <EuiPage className="dshStartScreen" restrictWidth="500px">
+        <EuiPageBody>
+          <EuiPageContent
+            verticalPosition="center"
+            horizontalPosition="center"
+            paddingSize="none"
+            className="dshStartScreen__pageContent"
+          >
+            <EuiImage url={http.basePath.prepend(emptyStateGraphicURL)} alt="" />
+            <EuiText size="m">
+              <p style={{ fontWeight: 'bold' }}>{text}</p>
+            </EuiText>
+            {showAdditionalParagraph ? (
+              <React.Fragment>
+                <EuiSpacer size="m" />
+                <div className="dshStartScreen__panelDesc">{enterEditModeParagraph}</div>
+              </React.Fragment>
+            ) : null}
+          </EuiPageContent>
+        </EuiPageBody>
+      </EuiPage>
+    );
+  };
+  const readonlyMode = page(constants.emptyDashboardTitle, false);
+  const viewMode = page(constants.fillDashboardTitle, true);
   const editMode = (
     <div data-test-subj="emptyDashboardWidget" className="dshEmptyWidget">
       {enterViewModeParagraph}
@@ -124,5 +134,6 @@ export function DashboardEmptyScreen({
       {linkToVisualizeParagraph}
     </div>
   );
-  return <I18nProvider>{showLinkToVisualize ? editMode : viewMode}</I18nProvider>;
+  const actionableMode = showLinkToVisualize ? editMode : viewMode;
+  return <I18nProvider>{isReadonlyMode ? readonlyMode : actionableMode}</I18nProvider>;
 }

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen.tsx
@@ -133,7 +133,7 @@ export function DashboardEmptyScreen({
   const readonlyMode = page(
     constants.emptyDashboardTitle,
     false,
-    constants.emptyDashboardContactOwner
+    constants.emptyDashboardAdditionalPrivilege
   );
   const viewMode = page(constants.fillDashboardTitle, true);
   const editMode = (

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen_constants.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen_constants.tsx
@@ -21,11 +21,14 @@ import { i18n } from '@kbn/i18n';
 
 /** READONLY VIEW CONSTANTS **/
 export const emptyDashboardTitle: string = i18n.translate('kbn.dashboard.emptyDashboardTitle', {
-  defaultMessage: 'This dashboard is empty or you do not have permission to view.',
+  defaultMessage: 'This dashboard is empty.',
 });
-export const emptyDashboardContactOwner = i18n.translate('kbn.dashboard.emptyDashboardTitle', {
-  defaultMessage: 'Please contact the owner of the dashboard if you think this is an error.',
-});
+export const emptyDashboardAdditionalPrivilege = i18n.translate(
+  'kbn.dashboard.emptyDashboardAdditionalPrivilege',
+  {
+    defaultMessage: 'You need additional privileges to edit this dashboard.',
+  }
+);
 /** VIEW MODE CONSTANTS **/
 export const fillDashboardTitle: string = i18n.translate('kbn.dashboard.fillDashboardTitle', {
   defaultMessage: 'This dashboard is empty. Let\u2019s fill it up!',

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen_constants.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen_constants.tsx
@@ -19,6 +19,10 @@
 
 import { i18n } from '@kbn/i18n';
 
+/** READONLY VIEW CONSTANTS **/
+export const emptyDashboardTitle: string = i18n.translate('kbn.dashboard.emptyDashboardTitle', {
+  defaultMessage: 'This dashboard is empty.',
+});
 /** VIEW MODE CONSTANTS **/
 export const fillDashboardTitle: string = i18n.translate('kbn.dashboard.fillDashboardTitle', {
   defaultMessage: 'This dashboard is empty. Let\u2019s fill it up!',

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen_constants.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_empty_screen_constants.tsx
@@ -21,7 +21,10 @@ import { i18n } from '@kbn/i18n';
 
 /** READONLY VIEW CONSTANTS **/
 export const emptyDashboardTitle: string = i18n.translate('kbn.dashboard.emptyDashboardTitle', {
-  defaultMessage: 'This dashboard is empty.',
+  defaultMessage: 'This dashboard is empty or you do not have permission to view.',
+});
+export const emptyDashboardContactOwner = i18n.translate('kbn.dashboard.emptyDashboardTitle', {
+  defaultMessage: 'Please contact the owner of the dashboard if you think this is an error.',
 });
 /** VIEW MODE CONSTANTS **/
 export const fillDashboardTitle: string = i18n.translate('kbn.dashboard.fillDashboardTitle', {


### PR DESCRIPTION
## Summary
When in readonly mode, we were not showing a meaningful empty screen, which was a bit confusing. Related: https://github.com/elastic/kibana/issues/54002

This PR utilizes the new empty screen graphic to show it on readonly screen.
<img width="529" alt="Screenshot 2020-01-06 at 21 40 25" src="https://user-images.githubusercontent.com/1937956/71852624-11041600-30d1-11ea-9164-24c493c457a7.png">


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [X] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

