### PR TITLE
[Metrics UI & Logs UI] Deprecate the override fields in settings

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
@@ -66,7 +66,7 @@ export const FieldsConfigurationPanel = ({
         <p>
           <FormattedMessage
             id="xpack.infra.sourceConfiguration.deprecationMessage"
-            defaultMessage="Configuring these fields have been depreciated and will be removed in 8.0.0. This application is designed to work with {ecsLink}, you should adjust your indexing to use the {documentationLink}."
+            defaultMessage="Configuring these fields have been deprecated and will be removed in 8.0.0. This application is designed to work with {ecsLink}, you should adjust your indexing to use the {documentationLink}."
             values={{
               documentationLink: (
                 <EuiLink

--- a/x-pack/legacy/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
@@ -12,6 +12,8 @@ import {
   EuiFormRow,
   EuiSpacer,
   EuiTitle,
+  EuiCallOut,
+  EuiLink,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
@@ -36,251 +38,276 @@ export const FieldsConfigurationPanel = ({
   podFieldProps,
   tiebreakerFieldProps,
   timestampFieldProps,
-}: FieldsConfigurationPanelProps) => (
-  <EuiForm>
-    <EuiTitle size="s">
-      <h3>
-        <FormattedMessage
-          id="xpack.infra.sourceConfiguration.fieldsSectionTitle"
-          defaultMessage="Fields"
-        />
-      </h3>
-    </EuiTitle>
-    <EuiSpacer size="m" />
-    <EuiDescribedFormGroup
-      idAria="timestampField"
-      title={
-        <h4>
+}: FieldsConfigurationPanelProps) => {
+  const isHostValueDefault = hostFieldProps.value === 'host.name';
+  const isContainerValueDefault = containerFieldProps.value === 'container.id';
+  const isPodValueDefault = podFieldProps.value === 'kubernetes.pod.uid';
+  const isTimestampValueDefault = timestampFieldProps.value === '@timestamp';
+  const isTiebreakerValueDefault = tiebreakerFieldProps.value === '_doc';
+  return (
+    <EuiForm>
+      <EuiTitle size="s">
+        <h3>
           <FormattedMessage
-            id="xpack.infra.sourceConfiguration.timestampFieldLabel"
-            defaultMessage="Timestamp"
+            id="xpack.infra.sourceConfiguration.fieldsSectionTitle"
+            defaultMessage="Fields"
           />
-        </h4>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.sourceConfiguration.timestampFieldDescription"
-          defaultMessage="Timestamp used to sort log entries"
-        />
-      }
-    >
-      <EuiFormRow
-        describedByIds={['timestampField']}
-        error={timestampFieldProps.error}
-        fullWidth
-        helpText={
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.timestampFieldRecommendedValue"
-            defaultMessage="The recommended value is {defaultValue}"
-            values={{
-              defaultValue: <EuiCode>@timestamp</EuiCode>,
-            }}
-          />
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiCallOut title="Depreciation Notice" color="warning" iconType="help">
+        <p>
+          Configuring these fields have been depreciated and will be removed in 8.0.0. This
+          application is designed to work with{' '}
+          <EuiLink href="https://www.elastic.co/guide/en/ecs/current/index.html" target="BLANK">
+            ECS
+          </EuiLink>
+          , you should adjust your indexing to use the{' '}
+          <EuiLink
+            href="https://www.elastic.co/guide/en/infrastructure/guide/7.4/infrastructure-metrics.html"
+            target="BLANK"
+          >
+            documented fields
+          </EuiLink>
+          .
+        </p>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+      <EuiDescribedFormGroup
+        idAria="timestampField"
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.timestampFieldLabel"
+              defaultMessage="Timestamp"
+            />
+          </h4>
         }
-        isInvalid={timestampFieldProps.isInvalid}
-        label={
+        description={
           <FormattedMessage
-            id="xpack.infra.sourceConfiguration.timestampFieldLabel"
-            defaultMessage="Timestamp"
-          />
-        }
-      >
-        <EuiFieldText
-          fullWidth
-          disabled={isLoading}
-          readOnly={readOnly}
-          isLoading={isLoading}
-          {...timestampFieldProps}
-        />
-      </EuiFormRow>
-    </EuiDescribedFormGroup>
-    <EuiDescribedFormGroup
-      idAria="tiebreakerField"
-      title={
-        <h4>
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.tiebreakerFieldLabel"
-            defaultMessage="Tiebreaker"
-          />
-        </h4>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.sourceConfiguration.tiebreakerFieldDescription"
-          defaultMessage="Field used to break ties between two entries with the same timestamp"
-        />
-      }
-    >
-      <EuiFormRow
-        describedByIds={['tiebreakerField']}
-        error={tiebreakerFieldProps.error}
-        fullWidth
-        helpText={
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.tiebreakerFieldRecommendedValue"
-            defaultMessage="The recommended value is {defaultValue}"
-            values={{
-              defaultValue: <EuiCode>_doc</EuiCode>,
-            }}
-          />
-        }
-        isInvalid={tiebreakerFieldProps.isInvalid}
-        label={
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.tiebreakerFieldLabel"
-            defaultMessage="Tiebreaker"
+            id="xpack.infra.sourceConfiguration.timestampFieldDescription"
+            defaultMessage="Timestamp used to sort log entries"
           />
         }
       >
-        <EuiFieldText
+        <EuiFormRow
+          describedByIds={['timestampField']}
+          error={timestampFieldProps.error}
           fullWidth
-          disabled={isLoading}
-          readOnly={readOnly}
-          isLoading={isLoading}
-          {...tiebreakerFieldProps}
-        />
-      </EuiFormRow>
-    </EuiDescribedFormGroup>
-    <EuiDescribedFormGroup
-      idAria="containerField"
-      title={
-        <h4>
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.containerFieldLabel"
-            defaultMessage="Container ID"
+          helpText={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.timestampFieldRecommendedValue"
+              defaultMessage="The recommended value is {defaultValue}"
+              values={{
+                defaultValue: <EuiCode>@timestamp</EuiCode>,
+              }}
+            />
+          }
+          isInvalid={timestampFieldProps.isInvalid}
+          label={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.timestampFieldLabel"
+              defaultMessage="Timestamp"
+            />
+          }
+        >
+          <EuiFieldText
+            fullWidth
+            disabled={isLoading || isTimestampValueDefault}
+            readOnly={readOnly}
+            isLoading={isLoading}
+            {...timestampFieldProps}
           />
-        </h4>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.sourceConfiguration.containerFieldDescription"
-          defaultMessage="Field used to identify Docker containers"
-        />
-      }
-    >
-      <EuiFormRow
-        describedByIds={['containerField']}
-        error={containerFieldProps.error}
-        fullWidth
-        helpText={
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.containerFieldRecommendedValue"
-            defaultMessage="The recommended value is {defaultValue}"
-            values={{
-              defaultValue: <EuiCode>container.id</EuiCode>,
-            }}
-          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        idAria="tiebreakerField"
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.tiebreakerFieldLabel"
+              defaultMessage="Tiebreaker"
+            />
+          </h4>
         }
-        isInvalid={containerFieldProps.isInvalid}
-        label={
+        description={
           <FormattedMessage
-            id="xpack.infra.sourceConfiguration.containerFieldLabel"
-            defaultMessage="Container ID"
+            id="xpack.infra.sourceConfiguration.tiebreakerFieldDescription"
+            defaultMessage="Field used to break ties between two entries with the same timestamp"
           />
         }
       >
-        <EuiFieldText
+        <EuiFormRow
+          describedByIds={['tiebreakerField']}
+          error={tiebreakerFieldProps.error}
           fullWidth
-          disabled={isLoading}
-          readOnly={readOnly}
-          isLoading={isLoading}
-          {...containerFieldProps}
-        />
-      </EuiFormRow>
-    </EuiDescribedFormGroup>
-    <EuiDescribedFormGroup
-      idAria="hostNameField"
-      title={
-        <h4>
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.hostNameFieldLabel"
-            defaultMessage="Host name"
+          helpText={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.tiebreakerFieldRecommendedValue"
+              defaultMessage="The recommended value is {defaultValue}"
+              values={{
+                defaultValue: <EuiCode>_doc</EuiCode>,
+              }}
+            />
+          }
+          isInvalid={tiebreakerFieldProps.isInvalid}
+          label={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.tiebreakerFieldLabel"
+              defaultMessage="Tiebreaker"
+            />
+          }
+        >
+          <EuiFieldText
+            fullWidth
+            disabled={isLoading || isTiebreakerValueDefault}
+            readOnly={readOnly}
+            isLoading={isLoading}
+            {...tiebreakerFieldProps}
           />
-        </h4>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.sourceConfiguration.hostNameFieldDescription"
-          defaultMessage="Field used to identify hosts"
-        />
-      }
-    >
-      <EuiFormRow
-        describedByIds={['hostNameField']}
-        error={hostFieldProps.error}
-        fullWidth
-        helpText={
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.hostFieldDescription"
-            defaultMessage="The recommended value is {defaultValue}"
-            values={{
-              defaultValue: <EuiCode>host.name</EuiCode>,
-            }}
-          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        idAria="containerField"
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.containerFieldLabel"
+              defaultMessage="Container ID"
+            />
+          </h4>
         }
-        isInvalid={hostFieldProps.isInvalid}
-        label={
+        description={
           <FormattedMessage
-            id="xpack.infra.sourceConfiguration.hostFieldLabel"
-            defaultMessage="Host name"
+            id="xpack.infra.sourceConfiguration.containerFieldDescription"
+            defaultMessage="Field used to identify Docker containers"
           />
         }
       >
-        <EuiFieldText
+        <EuiFormRow
+          describedByIds={['containerField']}
+          error={containerFieldProps.error}
           fullWidth
-          disabled={isLoading}
-          readOnly={readOnly}
-          isLoading={isLoading}
-          {...hostFieldProps}
-        />
-      </EuiFormRow>
-    </EuiDescribedFormGroup>
-    <EuiDescribedFormGroup
-      idAria="podField"
-      title={
-        <h4>
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.podFieldLabel"
-            defaultMessage="Pod ID"
+          helpText={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.containerFieldRecommendedValue"
+              defaultMessage="The recommended value is {defaultValue}"
+              values={{
+                defaultValue: <EuiCode>container.id</EuiCode>,
+              }}
+            />
+          }
+          isInvalid={containerFieldProps.isInvalid}
+          label={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.containerFieldLabel"
+              defaultMessage="Container ID"
+            />
+          }
+        >
+          <EuiFieldText
+            fullWidth
+            disabled={isLoading || isContainerValueDefault}
+            readOnly={readOnly}
+            isLoading={isLoading}
+            {...containerFieldProps}
           />
-        </h4>
-      }
-      description={
-        <FormattedMessage
-          id="xpack.infra.sourceConfiguration.podFieldDescription"
-          defaultMessage="Field used to identify Kubernetes pods"
-        />
-      }
-    >
-      <EuiFormRow
-        describedByIds={['podField']}
-        error={podFieldProps.error}
-        fullWidth
-        helpText={
-          <FormattedMessage
-            id="xpack.infra.sourceConfiguration.podFieldRecommendedValue"
-            defaultMessage="The recommended value is {defaultValue}"
-            values={{
-              defaultValue: <EuiCode>kubernetes.pod.uid</EuiCode>,
-            }}
-          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        idAria="hostNameField"
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.hostNameFieldLabel"
+              defaultMessage="Host name"
+            />
+          </h4>
         }
-        isInvalid={podFieldProps.isInvalid}
-        label={
+        description={
           <FormattedMessage
-            id="xpack.infra.sourceConfiguration.podFieldLabel"
-            defaultMessage="Pod ID"
+            id="xpack.infra.sourceConfiguration.hostNameFieldDescription"
+            defaultMessage="Field used to identify hosts"
           />
         }
       >
-        <EuiFieldText
+        <EuiFormRow
+          describedByIds={['hostNameField']}
+          error={hostFieldProps.error}
           fullWidth
-          disabled={isLoading}
-          readOnly={readOnly}
-          isLoading={isLoading}
-          {...podFieldProps}
-        />
-      </EuiFormRow>
-    </EuiDescribedFormGroup>
-  </EuiForm>
-);
+          helpText={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.hostFieldDescription"
+              defaultMessage="The recommended value is {defaultValue}"
+              values={{
+                defaultValue: <EuiCode>host.name</EuiCode>,
+              }}
+            />
+          }
+          isInvalid={hostFieldProps.isInvalid}
+          label={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.hostFieldLabel"
+              defaultMessage="Host name"
+            />
+          }
+        >
+          <EuiFieldText
+            fullWidth
+            disabled={isLoading || isHostValueDefault}
+            readOnly={readOnly}
+            isLoading={isLoading}
+            {...hostFieldProps}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+      <EuiDescribedFormGroup
+        idAria="podField"
+        title={
+          <h4>
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.podFieldLabel"
+              defaultMessage="Pod ID"
+            />
+          </h4>
+        }
+        description={
+          <FormattedMessage
+            id="xpack.infra.sourceConfiguration.podFieldDescription"
+            defaultMessage="Field used to identify Kubernetes pods"
+          />
+        }
+      >
+        <EuiFormRow
+          describedByIds={['podField']}
+          error={podFieldProps.error}
+          fullWidth
+          helpText={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.podFieldRecommendedValue"
+              defaultMessage="The recommended value is {defaultValue}"
+              values={{
+                defaultValue: <EuiCode>kubernetes.pod.uid</EuiCode>,
+              }}
+            />
+          }
+          isInvalid={podFieldProps.isInvalid}
+          label={
+            <FormattedMessage
+              id="xpack.infra.sourceConfiguration.podFieldLabel"
+              defaultMessage="Pod ID"
+            />
+          }
+        >
+          <EuiFieldText
+            fullWidth
+            disabled={isLoading || isPodValueDefault}
+            readOnly={readOnly}
+            isLoading={isLoading}
+            {...podFieldProps}
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+    </EuiForm>
+  );
+};

--- a/x-pack/legacy/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/source_configuration/fields_configuration_panel.tsx
@@ -15,6 +15,7 @@ import {
   EuiCallOut,
   EuiLink,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React from 'react';
 
@@ -55,21 +56,39 @@ export const FieldsConfigurationPanel = ({
         </h3>
       </EuiTitle>
       <EuiSpacer size="m" />
-      <EuiCallOut title="Depreciation Notice" color="warning" iconType="help">
+      <EuiCallOut
+        title={i18n.translate('xpack.infra.sourceConfiguration.deprecationNotice', {
+          defaultMessage: 'Deprecation Notice',
+        })}
+        color="warning"
+        iconType="help"
+      >
         <p>
-          Configuring these fields have been depreciated and will be removed in 8.0.0. This
-          application is designed to work with{' '}
-          <EuiLink href="https://www.elastic.co/guide/en/ecs/current/index.html" target="BLANK">
-            ECS
-          </EuiLink>
-          , you should adjust your indexing to use the{' '}
-          <EuiLink
-            href="https://www.elastic.co/guide/en/infrastructure/guide/7.4/infrastructure-metrics.html"
-            target="BLANK"
-          >
-            documented fields
-          </EuiLink>
-          .
+          <FormattedMessage
+            id="xpack.infra.sourceConfiguration.deprecationMessage"
+            defaultMessage="Configuring these fields have been depreciated and will be removed in 8.0.0. This application is designed to work with {ecsLink}, you should adjust your indexing to use the {documentationLink}."
+            values={{
+              documentationLink: (
+                <EuiLink
+                  href="https://www.elastic.co/guide/en/infrastructure/guide/7.4/infrastructure-metrics.html"
+                  target="BLANK"
+                >
+                  <FormattedMessage
+                    id="xpack.infra.sourceConfiguration.documentedFields"
+                    defaultMessage="documented fields"
+                  />
+                </EuiLink>
+              ),
+              ecsLink: (
+                <EuiLink
+                  href="https://www.elastic.co/guide/en/ecs/current/index.html"
+                  target="BLANK"
+                >
+                  ECS
+                </EuiLink>
+              ),
+            }}
+          />
         </p>
       </EuiCallOut>
       <EuiSpacer size="m" />


### PR DESCRIPTION
## Summary

This PR adds a message to the override fields in the settings for both logs and metrics. It also changes the fields to disabled if the current source configuration is set to the defaults.

![image](https://user-images.githubusercontent.com/41702/71935902-38a4be00-3165-11ea-8f04-609cae4bc8a4.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~