### PR TITLE
Improve kql error message handling and avoid fetcihng twice

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
@@ -671,7 +671,9 @@ function discoverController(
       $scope.$watch('state.query', (newQuery, oldQuery) => {
         if (!_.isEqual(newQuery, oldQuery)) {
           const query = migrateLegacyQuery(newQuery);
-          $scope.updateQueryAndFetch({ query });
+          if (!_.isEqual(query, newQuery)) {
+            $scope.updateQueryAndFetch({ query });
+          }
         }
       });
 
@@ -817,6 +819,7 @@ function discoverController(
             title: i18n.translate('kbn.discover.errorLoadingData', {
               defaultMessage: 'Error loading data',
             }),
+            toastMessage: error.shortMessage,
           });
         }
       });

--- a/src/plugins/data/common/es_query/kuery/kuery_syntax_error.ts
+++ b/src/plugins/data/common/es_query/kuery/kuery_syntax_error.ts
@@ -41,7 +41,7 @@ const grammarRuleTranslations: Record<string, string> = {
 
 interface KQLSyntaxErrorData extends Error {
   found: string;
-  expected: KQLSyntaxErrorExpected[];
+  expected: KQLSyntaxErrorExpected[] | null;
   location: any;
 }
 
@@ -53,19 +53,22 @@ export class KQLSyntaxError extends Error {
   shortMessage: string;
 
   constructor(error: KQLSyntaxErrorData, expression: any) {
-    const translatedExpectations = error.expected.map(expected => {
-      return grammarRuleTranslations[expected.description] || expected.description;
-    });
+    let message = error.message;
+    if (error.expected) {
+      const translatedExpectations = error.expected.map(expected => {
+        return grammarRuleTranslations[expected.description] || expected.description;
+      });
 
-    const translatedExpectationText = translatedExpectations.join(', ');
+      const translatedExpectationText = translatedExpectations.join(', ');
 
-    const message = i18n.translate('data.common.esQuery.kql.errors.syntaxError', {
-      defaultMessage: 'Expected {expectedList} but {foundInput} found.',
-      values: {
-        expectedList: translatedExpectationText,
-        foundInput: error.found ? `"${error.found}"` : endOfInputText,
-      },
-    });
+      message = i18n.translate('data.common.esQuery.kql.errors.syntaxError', {
+        defaultMessage: 'Expected {expectedList} but {foundInput} found.',
+        values: {
+          expectedList: translatedExpectationText,
+          foundInput: error.found ? `"${error.found}"` : endOfInputText,
+        },
+      });
+    }
 
     const fullMessage = [message, expression, repeat('-', error.location.start.offset) + '^'].join(
       '\n'


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/48392

The code building the errors message for a KQL parsing exception assumes the `expected` property is an array - in some cases (e.g. when using a leading wildcard) this is not the case.

This PR makes sure in these cases a meaningful error message is built.

While working on this problem I noticed that Discover sends two requests when updating the query because there is a watcher on the `query` state that triggers an additional fetch. In this PR it is made sure that the fetch is only triggered when necessary.