### PR TITLE
Fix eslint rule for vis_type_metric `jsx-a11y/click-events-have-key-events`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,12 +102,6 @@ module.exports = {
       },
     },
     {
-      files: ['src/legacy/core_plugins/vis_type_metric/**/*.{js,ts,tsx}'],
-      rules: {
-        'jsx-a11y/click-events-have-key-events': 'off',
-      },
-    },
-    {
       files: ['src/legacy/core_plugins/vis_type_table/**/*.{js,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',

--- a/src/legacy/core_plugins/vis_type_metric/public/components/metric_vis_value.js
+++ b/src/legacy/core_plugins/vis_type_metric/public/components/metric_vis_value.js
@@ -42,11 +42,14 @@ class MetricVisValue extends Component {
       'mtrVis__container-isfilterable': hasFilter,
     });
 
+    const handleClick = hasFilter ? this.onClick : null;
+
     const metricComponent = (
       <div
         className={containerClassName}
         style={{ backgroundColor: metric.bgColor }}
-        onClick={hasFilter ? this.onClick : null}
+        onClick={handleClick}
+        onKeyPress={handleClick}
         tabIndex={hasFilter ? 0 : null}
         role={hasFilter ? 'button' : null}
       >

--- a/src/legacy/core_plugins/vis_type_metric/public/components/metric_vis_value.js
+++ b/src/legacy/core_plugins/vis_type_metric/public/components/metric_vis_value.js
@@ -21,11 +21,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EuiKeyboardAccessible } from '@elastic/eui';
+import { EuiKeyboardAccessible, keyCodes } from '@elastic/eui';
 
 class MetricVisValue extends Component {
   onClick = () => {
     this.props.onFilter(this.props.metric);
+  };
+
+  onKeyPress = e => {
+    if (e.keyCode === keyCodes.ENTER) {
+      this.onClick();
+    }
   };
 
   render() {
@@ -42,14 +48,12 @@ class MetricVisValue extends Component {
       'mtrVis__container-isfilterable': hasFilter,
     });
 
-    const handleClick = hasFilter ? this.onClick : null;
-
     const metricComponent = (
       <div
         className={containerClassName}
         style={{ backgroundColor: metric.bgColor }}
-        onClick={handleClick}
-        onKeyPress={handleClick}
+        onClick={hasFilter ? this.onClick : null}
+        onKeyPress={hasFilter ? this.onKeyPress : null}
         tabIndex={hasFilter ? 0 : null}
         role={hasFilter ? 'button' : null}
       >


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/49550
Adds `onKeyPress` event to `metricComponent` (same as for `onClick`) to improve accessibility. 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

