### PR TITLE
[APM] Fix service map license check and controls

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Controls.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Controls.tsx
@@ -12,10 +12,11 @@ import { i18n } from '@kbn/i18n';
 import { CytoscapeContext } from './Cytoscape';
 import { FullscreenPanel } from './FullscreenPanel';
 
-const Container = styled('div')`
+const ControlsContainer = styled('div')`
   left: ${theme.gutterTypes.gutterMedium};
   position: absolute;
   top: ${theme.gutterTypes.gutterSmall};
+  z-index: 1; /* The element containing the cytoscape canvas has z-index = 0. */
 `;
 
 const Button = styled(EuiButtonIcon)`
@@ -83,7 +84,7 @@ export function Controls() {
   });
 
   return (
-    <Container>
+    <ControlsContainer>
       <ZoomPanel hasShadow={true} paddingSize="none">
         <ZoomInButton
           aria-label={zoomInLabel}
@@ -103,6 +104,6 @@ export function Controls() {
         />
       </ZoomPanel>
       <FullscreenPanel element={mapDomElement} />
-    </Container>
+    </ControlsContainer>
   );
 }

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -57,7 +57,8 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
   const elements = Array.isArray(data) ? data : [];
   const license = useLicense();
   const isValidPlatinumLicense =
-    license?.isActive && license?.type === 'platinum';
+    license?.isActive &&
+    (license?.type === 'platinum' || license?.type === 'trial');
 
   return isValidPlatinumLicense ? (
     <Cytoscape


### PR DESCRIPTION
* Check for a trial license as well as platinum when loading the map
* Increase the z-index of the controls so clicking on them works
* Rename the styled component to `ControlsContainer` from `Container` to make a less ambiguous class name on the element
