### PR TITLE
[APM] Support error.{log,exception}.stacktrace.classname

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/Stacktrace/FrameHeading.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Stacktrace/FrameHeading.tsx
@@ -35,9 +35,13 @@ const FrameHeading: React.FC<Props> = ({ stackframe, isLibraryFrame }) => {
     ? LibraryFrameFileDetail
     : AppFrameFileDetail;
   const lineNumber = stackframe.line.number;
+
+  const name =
+    'filename' in stackframe ? stackframe.filename : stackframe.classname;
+
   return (
     <FileDetails>
-      <FileDetail>{stackframe.filename}</FileDetail> in{' '}
+      <FileDetail>{name}</FileDetail> in{' '}
       <FileDetail>{stackframe.function}</FileDetail>
       {lineNumber > 0 && (
         <Fragment>

--- a/x-pack/legacy/plugins/apm/typings/es_schemas/raw/fields/Stackframe.ts
+++ b/x-pack/legacy/plugins/apm/typings/es_schemas/raw/fields/Stackframe.ts
@@ -4,8 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-interface IStackframeBase {
-  filename: string;
+type IStackframeBase = {
   function?: string;
   library_frame?: boolean;
   exclude_from_grouping?: boolean;
@@ -19,13 +18,13 @@ interface IStackframeBase {
   line: {
     number: number;
   };
-}
+} & ({ classname: string } | { filename: string });
 
-export interface IStackframeWithLineContext extends IStackframeBase {
+export type IStackframeWithLineContext = IStackframeBase & {
   line: {
     number: number;
     context: string;
   };
-}
+};
 
 export type IStackframe = IStackframeBase | IStackframeWithLineContext;


### PR DESCRIPTION
In elastic/apm-server/pull/3096, an alternative to stacktrace.filename was introduced: stacktrace.classname. This change makes sure classname is properly represented in the UI and in our types.

