### PR TITLE
[APM]: Fix render error when license has not been loaded

### DIFF
--- a/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/context/LicenseContext/index.tsx
@@ -16,8 +16,9 @@ export const LicenseContext = React.createContext<ILicense | undefined>(
 
 export function LicenseProvider({ children }: { children: React.ReactChild }) {
   const { license$ } = useApmPluginContext().plugins.licensing;
-  const license = useObservable(license$, { isActive: true } as ILicense);
-  const hasInvalidLicense = !license.isActive;
+  const license = useObservable(license$);
+  // if license is not loaded yet, consider it valid
+  const hasInvalidLicense = license?.isActive === false;
 
   // if license is invalid show an error message
   if (hasInvalidLicense) {


### PR DESCRIPTION
In #53924, we chose to render the UI if the license has not been loaded to prevent a license prompt flash. However, that introduced a bug where certain components in certain situations errored out due to the license not being available. This PR addresses that issue by not stubbing parts of the license but just having a more explicit check on `license?.isActive`.