### PR TITLE
Fix: invalid translation referenced

### DIFF
--- a/src/legacy/core_plugins/kibana/server/tutorials/activemq_metrics/index.js
+++ b/src/legacy/core_plugins/kibana/server/tutorials/activemq_metrics/index.js
@@ -48,7 +48,7 @@ export function activemqMetricsSpecProvider(context) {
     isBeta: true,
     artifacts: {
       application: {
-        label: i18n.translate('kbn.server.tutorials.corednsMetrics.artifacts.application.label', {
+        label: i18n.translate('kbn.server.tutorials.activemqMetrics.artifacts.application.label', {
           defaultMessage: 'Discover',
         }),
         path: '/app/kibana#/discover',


### PR DESCRIPTION
## Summary

This PR fixes invalid translation label for ActiveMQ.
