### PR TITLE
autocompleteTerminateAfter should be a number

### DIFF
--- a/src/core/server/kibana_config.ts
+++ b/src/core/server/kibana_config.ts
@@ -28,7 +28,10 @@ export const config = {
     defaultAppId: schema.string({ defaultValue: 'home' }),
     index: schema.string({ defaultValue: '.kibana' }),
     disableWelcomeScreen: schema.boolean({ defaultValue: false }),
-    autocompleteTerminateAfter: schema.duration({ defaultValue: 100000 }),
+    autocompleteTerminateAfter: schema.number({
+      defaultValue: 100000,
+      min: 1,
+    }),
     autocompleteTimeout: schema.duration({ defaultValue: 1000 }),
   }),
 };


### PR DESCRIPTION
## Summary

The config option for `autocompleteTerminateAfter` is currently set to a `duration` type, even though it is used for `terminate_after` in Elasticsearch queries, which expects a raw number.

It is already documented to expect a positive number.

I expect that this is a problematic side effect of `duration` not _requiring_ units.

This change makes it match the legacy implementation as closely as possible:

https://github.com/elastic/kibana/blob/12ec08e8abbab313a4024d7b608349a18824f773/src/legacy/core_plugins/kibana/index.js#L50-L53

There were no existing tests for this _and_ it's already used as a number by callers.

It's _possible_ that the original implementation used `duration` to force the number to be an integer (which it should be!) and possibly this needs an enhancement to `kbn-config` to force integer values.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

