### PR TITLE
[APM] Assigns a default object value for event.target in Typeahead component

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/Typeahead/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/Typeahead/index.js
@@ -122,7 +122,7 @@ export class Typeahead extends Component {
   };
 
   onChangeInputValue = event => {
-    const { value, selectionStart } = event.target;
+    const { value = '', selectionStart = 0 } = event.target ?? {};
     const hasValue = Boolean(value.trim());
     this.setState({
       value,


### PR DESCRIPTION
Closes #55146