### PR TITLE
Add no-memo-displayname rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -642,6 +642,8 @@ module.exports = {
         jest: true,
       },
       rules: {
+        // This will be turned on after bug fixes are mostly completed
+        // '@kbn/eslint/no-memo-displayname': 'error',
         'accessor-pairs': 'error',
         'array-callback-return': 'error',
         'no-array-constructor': 'error',

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -21,6 +21,7 @@ module.exports = {
   rules: {
     'require-license-header': require('./rules/require_license_header'),
     'disallow-license-headers': require('./rules/disallow_license_headers'),
+    'no-memo-displayname': require('./rules/no_memo_displayname'),
     'no-restricted-paths': require('./rules/no_restricted_paths'),
     module_migration: require('./rules/module_migration'),
   },

--- a/packages/kbn-eslint-plugin-eslint/rules/__tests__/no_memo_displayname.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/__tests__/no_memo_displayname.js
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { RuleTester } = require('eslint');
+const parser = require('@typescript-eslint/parser');
+const rule = require('../no-memo-displayname');
+
+const tester = new RuleTester({
+  parser: parser,
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    jsx: true,
+  },
+});
+
+tester.run('no-memo-displayname', rule, {
+  valid: [
+    {
+      code: `
+        const ReactMemoComponent = () => null;
+        ReactMemoComponent.displayName = 'ReactMemoComponent'
+        const ReactMemo = React.memo(ReactMemoComponent);
+    `,
+    },
+    {
+      code: `
+        const ReactMemoComponent = () => null;
+        ReactMemoComponent.displayName = 'ReactMemoComponent'
+        export const ReactMemo = React.memo(ReactMemoComponent);
+    `,
+    },
+    {
+      code: `
+        const ReactMemoComponent = () => null;
+        ReactMemoComponent.displayName = 'ReactMemoComponent'
+        const ReactMemo = memo(ReactMemoComponent);
+    `,
+    },
+    {
+      code: `
+        const ReactMemoComponent = () => null;
+        ReactMemoComponent.displayName = 'ReactMemoComponent'
+        export const ReactMemo = memo(ReactMemoComponent);
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const ReactMemoComponent = () => null;
+        const ReactMemo = React.memo(ReactMemoComponent);
+        ReactMemo.displayName = 'ReactMemo';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        const ReactMemoComponent = () => null;
+        export const ReactMemo = React.memo(ReactMemoComponent);
+        ReactMemo.displayName = 'ReactMemo';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        const ReactMemoComponent = React.memo(() => null);
+        ReactMemoComponent.displayName = 'ReactMemoComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        export const ReactMemoComponent = React.memo(() => null);
+        ReactMemoComponent.displayName = 'ReactMemoComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        const ReactMemoTSComponent = React.memo<{}>(() => null);
+        ReactMemoTSComponent.displayName = 'ReactMemoTSComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        export const ReactMemoTSComponent = React.memo(() => null);
+        ReactMemoTSComponent.displayName = 'ReactMemoTSComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        const MemoComponent = memo(() => null);
+        MemoComponent.displayName = 'MemoComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        export const MemoComponent = memo(() => null);
+        MemoComponent.displayName = 'MemoComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        const MemoTSComponent = memo<{}>(() => null);
+        MemoTSComponent.displayName = 'MemoTSComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+    {
+      code: `
+        export const MemoTSComponent = memo<{}>(() => null);
+        MemoTSComponent.displayName = 'MemoTSComponent';
+      `,
+      errors: [{ message: "Do not set 'displayName' on memo() component" }],
+    },
+  ],
+});

--- a/packages/kbn-eslint-plugin-eslint/rules/no_memo_displayname.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_memo_displayname.js
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+  create: context => {
+    const sourceCode = context.getSourceCode();
+
+    const variableDeclarators = sourceCode.ast.body.reduce((acc, item) => {
+      if (item.type === 'VariableDeclaration') {
+        acc = [...acc, item.declarations[0]];
+      }
+
+      if (
+        item.type === 'ExportNamedDeclaration' &&
+        item.declaration &&
+        item.declaration.type === 'VariableDeclaration'
+      ) {
+        acc = [...acc, item.declaration.declarations[0]];
+      }
+
+      return acc;
+    }, []);
+
+    const memoComponents = variableDeclarators.reduce((acc, item) => {
+      const init = item.init;
+
+      if (init) {
+        if (init.type === 'BinaryExpression' && init.left.type === 'BinaryExpression') {
+          if (
+            init.left.left.type === 'MemberExpression' &&
+            init.left.left.object.type === 'Identifier' &&
+            init.left.left.object.name === 'React' &&
+            init.left.left.property.type === 'Identifier' &&
+            init.left.left.property.name === 'memo' &&
+            item.id.type === 'Identifier'
+          ) {
+            // console.log("React.memo", item.id.name);
+            acc = [...acc, item.id.name];
+          }
+
+          if (
+            init.left.left.type === 'Identifier' &&
+            init.left.left.name === 'memo' &&
+            item.id.type === 'Identifier'
+          ) {
+            // console.log("memo", item.id.name);
+            acc = [...acc, item.id.name];
+          }
+        }
+
+        if (init.type === 'CallExpression') {
+          if (
+            init.callee.type === 'MemberExpression' &&
+            init.callee.object.type === 'Identifier' &&
+            init.callee.object.name === 'React' &&
+            init.callee.property.type === 'Identifier' &&
+            init.callee.property.name === 'memo' &&
+            item.id.type === 'Identifier'
+          ) {
+            // console.log("React.memo", item.id.name);
+            acc = [...acc, item.id.name];
+          }
+
+          if (
+            init.callee.type === 'Identifier' &&
+            init.callee.name === 'memo' &&
+            item.id.type === 'Identifier'
+          ) {
+            // console.log("memo", item.id.name);
+            acc = [...acc, item.id.name];
+          }
+        }
+      }
+
+      return acc;
+    }, []);
+
+    return {
+      // "ExpressionStatement > MemberExpression > Identifier.property[name='displayName']": (
+      ExpressionStatement: node => {
+        // console.log("node", node.expression);
+        const expression = node.expression; // AssignmentExpression
+
+        if (
+          expression.left &&
+          expression.left.property &&
+          expression.left.property.name === 'displayName' &&
+          memoComponents.includes(expression.left.object.name)
+        ) {
+          context.report({
+            node,
+            message: "Do not set 'displayName' on memo() component",
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
React.memo doesn't handle `displayName` property properly, so we ended up with plenty `Anonymus(memo)` in react devtools what makes debugging extremely hard. 

This rule will help us to recognize places where we added `displayName` to `React.memo` wrapper instead of the wrapped component.

![Screenshot 2020-01-21 at 09 53 30](https://user-images.githubusercontent.com/5188868/72789429-10709100-3c34-11ea-9a21-f3ed11ee424f.png)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

