### PR TITLE
[APM] x-axis labels on Error occurrences chart are incorrect based on Kibana timezone

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
@@ -74,6 +74,12 @@ export function ErrorDistribution({ distribution, title }: Props) {
     );
   }
 
+  const xMin = d3.min(buckets, d => d.x0);
+  const xMax = d3.max(buckets, d => d.x);
+  const tickFormat = scaleUtc()
+    .domain([xMin, xMax])
+    .tickFormat();
+
   return (
     <div>
       <EuiTitle size="xs">
@@ -85,11 +91,7 @@ export function ErrorDistribution({ distribution, title }: Props) {
         xType="time-utc"
         formatX={(value: Date) => {
           const time = value.getTime();
-          const xMin = d3.min(buckets, d => d.x0);
-          const xMax = d3.max(buckets, d => d.x);
-          return scaleUtc()
-            .domain([xMin, xMax])
-            .tickFormat()(new Date(time - getTimezoneOffsetInMs(time)));
+          return tickFormat(new Date(time - getTimezoneOffsetInMs(time)));
         }}
         buckets={buckets}
         bucketSize={distribution.bucketSize}

--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
@@ -7,6 +7,7 @@
 import { EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { scaleUtc } from 'd3-scale';
+import d3 from 'd3';
 import React from 'react';
 import { asRelativeDateTimeRange } from '../../../../utils/formatters';
 import { getTimezoneOffsetInMs } from '../../../shared/charts/CustomPlot/getTimezoneOffsetInMs';
@@ -82,14 +83,13 @@ export function ErrorDistribution({ distribution, title }: Props) {
         tooltipHeader={tooltipHeader}
         verticalLineHover={(bucket: FormattedBucket) => bucket.x}
         xType="time-utc"
-        formatX={(value: any) => {
-          if (value && 'getTime' in value) {
-            const time = value.getTime();
-            return scaleUtc().tickFormat()(
-              new Date(time - getTimezoneOffsetInMs(time))
-            );
-          }
-          return value;
+        formatX={(value: Date) => {
+          const time = value.getTime();
+          const xMin = d3.min(buckets, d => d.x0);
+          const xMax = d3.max(buckets, d => d.x);
+          return scaleUtc()
+            .domain([xMin, xMax])
+            .tickFormat()(new Date(time - getTimezoneOffsetInMs(time)));
         }}
         buckets={buckets}
         bucketSize={distribution.bucketSize}

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
@@ -25,6 +25,7 @@ import { unit } from '../../../../style/variables';
 import Tooltip from '../Tooltip';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 import { tint } from 'polished';
+import { getTimezoneOffsetInMs } from '../CustomPlot/getTimezoneOffsetInMs';
 
 const XY_HEIGHT = unit * 10;
 const XY_MARGIN = {
@@ -104,6 +105,9 @@ export class HistogramInner extends PureComponent {
       return null;
     }
 
+    const isTimeSeries =
+      this.props.xType === 'time' || this.props.xType === 'time-utc';
+
     const xMin = d3.min(buckets, d => d.x0);
     const xMax = d3.max(buckets, d => d.x);
     const yMin = 0;
@@ -120,11 +124,25 @@ export class HistogramInner extends PureComponent {
       .range([XY_HEIGHT, 0])
       .nice();
 
+    const [xMinZone, xMaxZone] = [xMin, xMax].map(x => {
+      return x - getTimezoneOffsetInMs(x);
+    });
+
+    const xTickValues = isTimeSeries
+      ? d3.time.scale
+          .utc()
+          .domain([xMinZone, xMaxZone])
+          .range([0, XY_WIDTH])
+          .ticks(X_TICK_TOTAL)
+          .map(x => {
+            const time = x.getTime();
+            return new Date(time + getTimezoneOffsetInMs(time));
+          })
+      : undefined;
+
     const xDomain = x.domain();
     const yDomain = y.domain();
     const yTickValues = [0, yDomain[1] / 2, yDomain[1]];
-    const isTimeSeries =
-      this.props.xType === 'time' || this.props.xType === 'time-utc';
     const shouldShowTooltip =
       hoveredBucket.x > 0 && (hoveredBucket.y > 0 || isTimeSeries);
 
@@ -150,6 +168,7 @@ export class HistogramInner extends PureComponent {
               tickSizeInner={0}
               tickTotal={X_TICK_TOTAL}
               tickFormat={formatX}
+              tickValues={xTickValues}
             />
             <YAxis
               tickSize={0}
@@ -213,7 +232,7 @@ export class HistogramInner extends PureComponent {
                 [XY_MARGIN.left, XY_MARGIN.top],
                 [XY_WIDTH, XY_HEIGHT]
               ]}
-              nodes={this.props.buckets.map(bucket => {
+              nodes={buckets.map(bucket => {
                 return {
                   ...bucket,
                   xCenter: (bucket.x0 + bucket.x) / 2

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/Histogram/index.js
@@ -25,7 +25,7 @@ import { unit } from '../../../../style/variables';
 import Tooltip from '../Tooltip';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 import { tint } from 'polished';
-import { getTimezoneOffsetInMs } from '../CustomPlot/getTimezoneOffsetInMs';
+import { getTimeTicksTZ, getDomainTZ } from '../helper/timezone';
 
 const XY_HEIGHT = unit * 10;
 const XY_MARGIN = {
@@ -124,20 +124,13 @@ export class HistogramInner extends PureComponent {
       .range([XY_HEIGHT, 0])
       .nice();
 
-    const [xMinZone, xMaxZone] = [xMin, xMax].map(x => {
-      return x - getTimezoneOffsetInMs(x);
-    });
-
+    const [xMinZone, xMaxZone] = getDomainTZ(xMin, xMax);
     const xTickValues = isTimeSeries
-      ? d3.time.scale
-          .utc()
-          .domain([xMinZone, xMaxZone])
-          .range([0, XY_WIDTH])
-          .ticks(X_TICK_TOTAL)
-          .map(x => {
-            const time = x.getTime();
-            return new Date(time + getTimezoneOffsetInMs(time));
-          })
+      ? getTimeTicksTZ({
+          domain: [xMinZone, xMaxZone],
+          totalTicks: X_TICK_TOTAL,
+          width: XY_WIDTH
+        })
       : undefined;
 
     const xDomain = x.domain();

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/helper/__test__/timezone.test.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/helper/__test__/timezone.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import moment from 'moment-timezone';
+import { getDomainTZ, getTimeTicksTZ } from '../timezone';
+
+describe('Timezone helper', () => {
+  let originalTimezone: moment.MomentZone | null;
+  const min = new Date('Tue Jan 28 2020 05:36:00 GMT+0100').valueOf();
+  const max = new Date('Wed Jan 29 2020 07:12:00 GMT+0100').valueOf();
+
+  afterAll(() => {
+    moment.tz.setDefault(originalTimezone ? originalTimezone.name : '');
+  });
+  describe('getTimeTicksTZ', () => {
+    it('returns ticks when in Ameca/New_York timezone', () => {
+      moment.tz.setDefault('America/New_York');
+      expect(
+        getTimeTicksTZ({ domain: [min, max], totalTicks: 8, width: 1138 })
+      ).toEqual([
+        new Date('2020-01-28T11:00:00.000Z'),
+        new Date('2020-01-28T14:00:00.000Z'),
+        new Date('2020-01-28T17:00:00.000Z'),
+        new Date('2020-01-28T20:00:00.000Z'),
+        new Date('2020-01-28T23:00:00.000Z'),
+        new Date('2020-01-29T02:00:00.000Z'),
+        new Date('2020-01-29T05:00:00.000Z'),
+        new Date('2020-01-29T08:00:00.000Z'),
+        new Date('2020-01-29T11:00:00.000Z')
+      ]);
+    });
+    it('returns ticks when in Europe/Amsterdam timezone', () => {
+      moment.tz.setDefault('Europe/Amsterdam');
+      expect(
+        getTimeTicksTZ({ domain: [min, max], totalTicks: 8, width: 1138 })
+      ).toEqual([
+        new Date('2020-01-28T05:00:00.000Z'),
+        new Date('2020-01-28T08:00:00.000Z'),
+        new Date('2020-01-28T11:00:00.000Z'),
+        new Date('2020-01-28T14:00:00.000Z'),
+        new Date('2020-01-28T17:00:00.000Z'),
+        new Date('2020-01-28T20:00:00.000Z'),
+        new Date('2020-01-28T23:00:00.000Z'),
+        new Date('2020-01-29T02:00:00.000Z'),
+        new Date('2020-01-29T05:00:00.000Z')
+      ]);
+    });
+  });
+
+  describe('getDomainTZ', () => {
+    it('returns domain when in Ameca/New_York timezone', () => {
+      moment.tz.setDefault('America/New_York');
+      expect(getDomainTZ(min, max)).toEqual([
+        new Date('Tue Jan 28 2020 00:36:00 GMT+0100').valueOf(),
+        new Date('Wed Jan 29 2020 02:12:00 GMT+0100').valueOf()
+      ]);
+    });
+    it('returns domain when in Europe/Amsterdam timezone', () => {
+      moment.tz.setDefault('Europe/Amsterdam');
+      expect(getDomainTZ(min, max)).toEqual([
+        new Date('Tue Jan 28 2020 06:36:00 GMT+0100').valueOf(),
+        new Date('Wed Jan 29 2020 08:12:00 GMT+0100').valueOf()
+      ]);
+    });
+  });
+});

--- a/x-pack/legacy/plugins/apm/public/components/shared/charts/helper/timezone.ts
+++ b/x-pack/legacy/plugins/apm/public/components/shared/charts/helper/timezone.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import d3 from 'd3';
+import { getTimezoneOffsetInMs } from '../CustomPlot/getTimezoneOffsetInMs';
+
+interface Params {
+  domain: [number, number];
+  totalTicks: number;
+  width: number;
+}
+
+export const getTimeTicksTZ = ({ domain, totalTicks, width }: Params) =>
+  d3.time.scale
+    .utc()
+    .domain(domain)
+    .range([0, width])
+    .ticks(totalTicks)
+    .map(x => {
+      const time = x.getTime();
+      return new Date(time + getTimezoneOffsetInMs(time));
+    });
+
+export const getDomainTZ = (min: number, max: number): [number, number] => {
+  const [xMinZone, xMaxZone] = [min, max].map(
+    time => time - getTimezoneOffsetInMs(time)
+  );
+  return [xMinZone, xMaxZone];
+};


### PR DESCRIPTION
fixes #55534
Localhost x apm.elstc.co
<img width="2482" alt="Screenshot 2020-01-29 at 09 16 11" src="https://user-images.githubusercontent.com/55978943/73339287-bc3f5f80-4278-11ea-8146-336e09328c5e.png">
<img width="2487" alt="Screenshot 2020-01-29 at 09 16 39" src="https://user-images.githubusercontent.com/55978943/73339288-bc3f5f80-4278-11ea-8fc8-df36bed60b0a.png">
<img width="2487" alt="Screenshot 2020-01-29 at 09 17 03" src="https://user-images.githubusercontent.com/55978943/73339289-bc3f5f80-4278-11ea-8675-3fb26183eb1f.png">
<img width="2482" alt="Screenshot 2020-01-29 at 09 17 51" src="https://user-images.githubusercontent.com/55978943/73339290-bc3f5f80-4278-11ea-8ee9-b204f98ee50b.png">
<img width="2486" alt="Screenshot 2020-01-29 at 09 18 17" src="https://user-images.githubusercontent.com/55978943/73339291-bcd7f600-4278-11ea-9750-33aecda21c63.png">
<img width="2480" alt="Screenshot 2020-01-29 at 09 18 35" src="https://user-images.githubusercontent.com/55978943/73339292-bcd7f600-4278-11ea-8592-1fdee6353bdb.png">
