### PR TITLE
[7.5] Fix for URL field formatter not able to render relative URLs properly. 

### DIFF
--- a/src/legacy/core_plugins/kibana/common/field_formats/types/url.ts
+++ b/src/legacy/core_plugins/kibana/common/field_formats/types/url.ts
@@ -52,7 +52,7 @@ const URL_TYPES = [
 ];
 const DEFAULT_URL_TYPE = 'a';
 
-export function createUrlFormat(context: any) {
+export function createUrlFormat() {
   class UrlFormat extends FieldFormat {
     static basePath = undefined;
     static id = 'url';

--- a/src/legacy/core_plugins/kibana/common/field_formats/types/url.ts
+++ b/src/legacy/core_plugins/kibana/common/field_formats/types/url.ts
@@ -52,8 +52,9 @@ const URL_TYPES = [
 ];
 const DEFAULT_URL_TYPE = 'a';
 
-export function createUrlFormat() {
+export function createUrlFormat(context: any) {
   class UrlFormat extends FieldFormat {
+    static basePath = undefined;
     static id = 'url';
     static title = 'Url';
     static fieldType = [
@@ -140,6 +141,10 @@ export function createUrlFormat() {
       const url = escape(this.formatUrl(rawValue));
       const label = escape(this.formatLabel(rawValue, url));
 
+      if (!parsedUrl) {
+        parsedUrl = UrlFormat.defaultParsedUrl;
+      }
+
       switch (this.param('type')) {
         case 'audio':
           return `<audio controls preload="none" src="${url}">`;
@@ -200,6 +205,25 @@ export function createUrlFormat() {
       }
     };
   }
+
+  async function initializeDefaultParsedUrl() {
+    if (UrlFormat.defaultParsedUrl !== undefined) {
+      return;
+    }
+
+    try {
+      const platform = await import('ui/new_platform');
+      UrlFormat.defaultParsedUrl = {
+        origin: global.window.location.origin,
+        pathname: global.window.location.pathname,
+        basePath: platform.npSetup.core.http.basePath.get(),
+      };
+    } catch (err) {
+      UrlFormat.defaultParsedUrl = null;
+    }
+  }
+
+  initializeDefaultParsedUrl();
 
   return UrlFormat;
 }

--- a/src/legacy/core_plugins/kibana/common/field_formats/types/url.ts
+++ b/src/legacy/core_plugins/kibana/common/field_formats/types/url.ts
@@ -54,7 +54,6 @@ const DEFAULT_URL_TYPE = 'a';
 
 export function createUrlFormat() {
   class UrlFormat extends FieldFormat {
-    static basePath = undefined;
     static id = 'url';
     static title = 'Url';
     static fieldType = [


### PR DESCRIPTION
## Summary

Fields using a URL fielder formatter with a relative URL were not rendering correctly because the base URL information in Kibana was not being passed down into the formatter. This caused the formatter to not understand how to derive the full URL and instead just returned a <span> with the URL text inside.

### Checklist
~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

