### PR TITLE
[Metrics UI] Fix Metrics Explorer exception when deleting metric

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart.tsx
@@ -118,7 +118,7 @@ export const MetricsExplorerChart = ({
         </EuiFlexGroup>
       )}
       <div className="infrastructureChart" style={{ height, width }}>
-        {series.rows.length > 0 ? (
+        {metrics.length && series.rows.length > 0 ? (
           <Chart>
             {metrics.map((metric, id) => (
               <MetricExplorerSeriesChart


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Metrics Explorer throw the exception below when the metric is deleted from the UI.

![image](https://user-images.githubusercontent.com/41702/73100712-571bf080-3eab-11ea-9318-d2800985d122.png)

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~
- ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~