### PR TITLE
Skipping flaky dashboard functional tests

### DIFF
--- a/test/functional/apps/dashboard/panel_controls.js
+++ b/test/functional/apps/dashboard/panel_controls.js
@@ -54,7 +54,8 @@ export default function({ getService, getPageObjects }) {
       await PageObjects.dashboard.gotoDashboardLandingPage();
     });
 
-    describe('visualization object replace flyout', () => {
+    // unskip when issue is fixed https://github.com/elastic/kibana/issues/55992
+    describe.skip('visualization object replace flyout', () => {
       let intialDimensions;
       before(async () => {
         await PageObjects.dashboard.clickNewDashboard();


### PR DESCRIPTION
<img width="1665" alt="kbn  Failing Tests - Kibana 2020-01-27 13-32-50" src="https://user-images.githubusercontent.com/10977896/73175405-62208c00-410a-11ea-8b70-3f4c8cbd2407.png">

Fails once per day since Jan 21. It looks like a legit issue. Reported in #55992 