### PR TITLE
[7.6] [Metrics UI] Fix Metrics Explorer exception when deleting metric (#55893)

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart.tsx
@@ -117,7 +117,7 @@ export const MetricsExplorerChart = ({
         </EuiFlexGroup>
       )}
       <div className="infrastructureChart" style={{ height, width }}>
-        {series.rows.length > 0 ? (
+        {metrics.length && series.rows.length > 0 ? (
           <Chart>
             {metrics.map((metric, id) => (
               <MetricExplorerSeriesChart


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [Metrics UI] Fix Metrics Explorer exception when deleting metric (#55893)