### PR TITLE
[PoC] CSV Format Renderer

### DIFF
--- a/x-pack/legacy/plugins/canvas/.storybook/webpack.config.js
+++ b/x-pack/legacy/plugins/canvas/.storybook/webpack.config.js
@@ -184,6 +184,8 @@ module.exports = async ({ config }) => {
     KIBANA_ROOT,
     'packages/kbn-interpreter/target/common/registries'
   );
+  config.node = config.node || {};
+  config.node.fs = 'empty';
 
   return config;
 };

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/render.ts
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/functions/common/render.ts
@@ -36,6 +36,7 @@ export function render(): ExpressionFunction<'render', Render<any>, Arguments, R
         help: argHelp.as,
         options: [
           'advanced_filter',
+          'csv',
           'debug',
           'dropdown_filter',
           'error',

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/__examples__/__snapshots__/csv.examples.storyshot
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/__examples__/__snapshots__/csv.examples.storyshot
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots renderers/Csv default 1`] = `
+<div
+  className="canvasCsv"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    Object {
+      "height": 200,
+      "position": "relative",
+      "width": 400,
+    }
+  }
+>
+  <span
+    className="euiCodeBlock euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline canvasCsv__code"
+    style={Object {}}
+  >
+    <code
+      className="euiCodeBlock__code"
+    >
+      <pre
+        className="canvasCsv__content"
+      >
+        <p>
+          this,is,a,datatable
+        </p>
+        it's,in,CSV,format
+hover,me,to,download
+      </pre>
+    </code>
+  </span>
+  <button
+    className="euiButton euiButton--primary euiButton--small canvasCsv__button"
+    onClick={[Function]}
+    style={
+      Object {
+        "opacity": 0,
+      }
+    }
+    type="button"
+  >
+    <span
+      className="euiButton__content"
+    >
+      <span
+        className="euiButton__text"
+      >
+        Download
+      </span>
+    </span>
+  </button>
+</div>
+`;

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/__examples__/csv.examples.tsx
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/__examples__/csv.examples.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import { Datatable } from '../../../../types';
+import { Csv } from '../component';
+
+const demodata: Datatable = {
+  type: 'datatable',
+  columns: [
+    { name: 'this', type: 'string' },
+    { name: 'is', type: 'string' },
+    { name: 'a', type: 'string' },
+    { name: 'datatable', type: 'string' },
+  ],
+  rows: [
+    {
+      this: "it's",
+      is: 'in',
+      a: 'CSV',
+      datatable: 'format',
+    },
+    {
+      this: 'hover',
+      is: 'me',
+      a: 'to',
+      datatable: 'download',
+    },
+  ],
+};
+
+storiesOf('renderers/Csv', module).add('default', () => (
+  <Csv datatable={demodata} height={200} width={400} />
+));

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/component.tsx
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/component.tsx
@@ -4,9 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import fileSaver from 'file-saver';
-import { EuiCode, EuiButton } from '@elastic/eui';
+import { EuiCodeBlock, EuiButtonIcon } from '@elastic/eui';
 
 import { Datatable } from '../../../types';
 
@@ -17,8 +17,6 @@ interface Props {
 }
 
 export const Csv: FC<Props> = ({ datatable, height, width }) => {
-  const [isVisible, setIsVisible] = useState(false);
-
   const columns = datatable.columns.map(column => column.name).join(',');
   const rows = datatable.rows
     .map(row => datatable.columns.map(column => row[column.name]).join(','))
@@ -30,34 +28,20 @@ export const Csv: FC<Props> = ({ datatable, height, width }) => {
     fileSaver.saveAs(csvBlob, `datatable.csv`);
   };
 
-  const hover = () => setIsVisible(true);
-  const unHover = () => setIsVisible(false);
-
   return (
-    <div
-      className="canvasCsv"
-      style={{ width, height, position: 'relative' }}
-      onMouseEnter={hover}
-      onMouseLeave={unHover}
-      onFocus={hover}
-      onBlur={unHover}
-    >
-      <EuiCode className="canvasCsv__code">
+    <div className="canvasCsv" style={{ width, height, position: 'relative' }}>
+      <EuiCodeBlock className="canvasCsv__code" isCopyable paddingSize="m" overflowHeight={height}>
         <pre className="canvasCsv__content">
           <p>{columns}</p>
           {rows}
         </pre>
-      </EuiCode>
-      <EuiButton
-        className="canvasCsv__button"
+      </EuiCodeBlock>
+      <EuiButtonIcon
         {...{ onClick }}
-        size="s"
-        style={{
-          opacity: isVisible ? 1 : 0,
-        }}
-      >
-        Download
-      </EuiButton>
+        className="canvasCsv__button"
+        iconType="exportAction"
+        color="text"
+      />
     </div>
   );
 };

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/component.tsx
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/component.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { FC, useState } from 'react';
+import fileSaver from 'file-saver';
+import { EuiCode, EuiButton } from '@elastic/eui';
+
+import { Datatable } from '../../../types';
+
+interface Props {
+  datatable: Datatable;
+  height: number;
+  width: number;
+}
+
+export const Csv: FC<Props> = ({ datatable, height, width }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const columns = datatable.columns.map(column => column.name).join(',');
+  const rows = datatable.rows
+    .map(row => datatable.columns.map(column => row[column.name]).join(','))
+    .join('\n');
+  const onClick = () => {
+    const csvBlob = new Blob([columns, '\n', rows], {
+      type: 'text/csv',
+    });
+    fileSaver.saveAs(csvBlob, `datatable.csv`);
+  };
+
+  const hover = () => setIsVisible(true);
+  const unHover = () => setIsVisible(false);
+
+  return (
+    <div
+      className="canvasCsv"
+      style={{ width, height, position: 'relative' }}
+      onMouseEnter={hover}
+      onMouseLeave={unHover}
+      onFocus={hover}
+      onBlur={unHover}
+    >
+      <EuiCode className="canvasCsv__code">
+        <pre className="canvasCsv__content">
+          <p>{columns}</p>
+          {rows}
+        </pre>
+      </EuiCode>
+      <EuiButton
+        className="canvasCsv__button"
+        {...{ onClick }}
+        size="s"
+        style={{
+          opacity: isVisible ? 1 : 0,
+        }}
+      >
+        Download
+      </EuiButton>
+    </div>
+  );
+};

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/csv.scss
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/csv.scss
@@ -1,0 +1,25 @@
+.canvasCsv {
+  position: relative;
+
+  .canvasCsv__code {
+    padding: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .canvasCsv__content {
+    @include euiScrollBar;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    padding: $euiSize;
+  }
+
+  .canvasCsv__button {
+    position: absolute;
+    right: 16px;
+    top: 8px;
+    transition: opacity $euiAnimSpeedFast $euiAnimSlightResistance;
+    transition-delay: $euiAnimSpeedNormal;
+  }
+}

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/csv.scss
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/csv.scss
@@ -12,13 +12,12 @@
     width: 100%;
     height: 100%;
     overflow: auto;
-    padding: $euiSize;
   }
 
   .canvasCsv__button {
     position: absolute;
     right: 16px;
-    top: 8px;
+    top: 72px;
     transition: opacity $euiAnimSpeedFast $euiAnimSlightResistance;
     transition-delay: $euiAnimSpeedNormal;
   }

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/index.tsx
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/index.tsx
@@ -29,9 +29,10 @@ export const csv: RendererFactory<Config> = () => ({
       return;
     }
 
-    const { offsetHeight: height, offsetWidth: width } = domNode;
-
-    const renderCSV = () => <Csv {...{ datatable, height, width }} />;
+    const renderCSV = () => {
+      const { offsetHeight: height, offsetWidth: width } = domNode;
+      return <Csv {...{ datatable, height, width }} />;
+    };
 
     ReactDOM.render(renderCSV(), domNode, () => handlers.done());
 

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/index.tsx
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/csv/index.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import ReactDOM from 'react-dom';
+import React from 'react';
+
+import { RendererFactory, Datatable } from '../../../types';
+import { RendererStrings } from '../../../i18n';
+import { Csv } from './component';
+
+const { csv: strings } = RendererStrings;
+
+interface Config {
+  datatable: Datatable;
+}
+
+export const csv: RendererFactory<Config> = () => ({
+  name: 'csv',
+  displayName: strings.getDisplayName(),
+  help: strings.getHelpDescription(),
+  reuseDomNode: true,
+  render(domNode, config, handlers) {
+    const { datatable } = config;
+
+    if (!datatable) {
+      return;
+    }
+
+    const { offsetHeight: height, offsetWidth: width } = domNode;
+
+    const renderCSV = () => <Csv {...{ datatable, height, width }} />;
+
+    ReactDOM.render(renderCSV(), domNode, () => handlers.done());
+
+    handlers.onResize(() => {
+      ReactDOM.render(renderCSV(), domNode, () => handlers.done());
+    });
+
+    handlers.onDestroy(() => ReactDOM.unmountComponentAtNode(domNode));
+  },
+});

--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/index.js
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/index.js
@@ -5,6 +5,7 @@
  */
 
 import { advancedFilter } from './advanced_filter';
+import { csv } from './csv';
 import { debug } from './debug';
 import { dropdownFilter } from './dropdown_filter';
 import { embeddable } from './embeddable/embeddable';
@@ -24,6 +25,7 @@ import { timeFilter } from './time_filter';
 
 export const renderFunctions = [
   advancedFilter,
+  csv,
   debug,
   dropdownFilter,
   embeddable,

--- a/x-pack/legacy/plugins/canvas/i18n/renderers.ts
+++ b/x-pack/legacy/plugins/canvas/i18n/renderers.ts
@@ -5,7 +5,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { JSON, HTML, MARKDOWN } from './constants';
+import { JSON, HTML, MARKDOWN, CSV } from './constants';
 
 export const RendererStrings = {
   advancedFilter: {
@@ -16,6 +16,19 @@ export const RendererStrings = {
     getHelpDescription: () =>
       i18n.translate('xpack.canvas.renderer.advancedFilter.helpDescription', {
         defaultMessage: 'Render a Canvas filter expression',
+      }),
+  },
+  csv: {
+    getDisplayName: () =>
+      i18n.translate('xpack.canvas.renderer.csv.displayName', {
+        defaultMessage: 'CSV Format',
+      }),
+    getHelpDescription: () =>
+      i18n.translate('xpack.canvas.renderer.csv.helpDescription', {
+        defaultMessage: 'Render a datatable in {CSV} format',
+        values: {
+          CSV,
+        },
       }),
   },
   debug: {

--- a/x-pack/legacy/plugins/canvas/public/style/index.scss
+++ b/x-pack/legacy/plugins/canvas/public/style/index.scss
@@ -61,6 +61,7 @@
 
 @import '../../canvas_plugin_src/renderers/advanced_filter/component/advanced_filter.scss';
 @import '../../canvas_plugin_src/renderers/dropdown_filter/component/dropdown_filter.scss';
+@import '../../canvas_plugin_src/renderers/csv/csv.scss';
 @import '../../canvas_plugin_src/renderers/plot/plot.scss';
 @import '../../canvas_plugin_src/renderers/reveal_image/reveal_image.scss';
 @import '../../canvas_plugin_src/renderers/time_filter/components/datetime_calendar/datetime_calendar.scss';


### PR DESCRIPTION
## Summary

This is a proof-of-concept PR that allows viewers to render a `datatable` in CSV format using the `as` property of `render`, (similar to `debug`).

![Screen Shot 2020-01-28 at 11 17 42 AM](https://user-images.githubusercontent.com/297604/73288360-758e2e80-41c0-11ea-9361-08d91c42ced4.png)
![Screen Shot 2020-01-28 at 11 17 48 AM](https://user-images.githubusercontent.com/297604/73288361-7626c500-41c0-11ea-9280-19758536b71f.png)
![Screen Shot 2020-01-28 at 11 23 33 AM](https://user-images.githubusercontent.com/297604/73288465-a79f9080-41c0-11ea-9714-e60b1ae9c672.png)

Feedback welcome.  In the short term, interested clients can opt to use this renderer in a [plugin](https://discuss.elastic.co/t/custom-kibana-canvas-elements/202632/2?u=clintandrewhall) on their own deployments, if it meets their needs.
