### PR TITLE
[7.6] [Metrics UI] Fixing title truncation in Metrics Explorer (#55917)

### DIFF
--- a/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart.tsx
+++ b/x-pack/legacy/plugins/infra/public/components/metrics_explorer/chart.tsx
@@ -85,7 +85,7 @@ export const MetricsExplorerChart = ({
         <EuiTitle size="xs">
           <EuiFlexGroup alignItems="center">
             <ChartTitle>
-              <EuiToolTip content={title}>
+              <EuiToolTip content={title} anchorClassName="metricsExplorerTitleAnchor">
                 <span>{title}</span>
               </EuiToolTip>
             </ChartTitle>
@@ -158,7 +158,7 @@ export const MetricsExplorerChart = ({
 };
 
 const ChartTitle = euiStyled.div`
-  width: 100%
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/x-pack/legacy/plugins/infra/public/index.scss
+++ b/x-pack/legacy/plugins/infra/public/index.scss
@@ -36,6 +36,12 @@
 
 .infrastructureChart .echTooltip__label {
   overflow-x: hidden;
-  white-space: no-wrap;
+  white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.metricsExplorerTitleAnchor {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: inline;
 }


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [Metrics UI] Fixing title truncation in Metrics Explorer (#55917)