### PR TITLE
[Bugfix][State Management] 'state:storeInSessionStorage' doesn’t take effect for dashboard without full page reload

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts
@@ -19,7 +19,6 @@
 
 import { EuiConfirmModal, EuiIcon } from '@elastic/eui';
 import angular, { IModule } from 'angular';
-import { History } from 'history';
 import { i18nDirective, i18nFilter, I18nProvider } from '@kbn/i18n/angular';
 import {
   AppMountContext,
@@ -28,7 +27,7 @@ import {
   LegacyCoreStart,
   SavedObjectsClientContract,
 } from 'kibana/public';
-import { IKbnUrlStateStorage, Storage } from '../../../../../../plugins/kibana_utils/public';
+import { Storage } from '../../../../../../plugins/kibana_utils/public';
 import {
   configureAppAngularModule,
   confirmModalFactory,

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts
@@ -66,8 +66,6 @@ export interface RenderDeps {
   embeddables: IEmbeddableStart;
   localStorage: Storage;
   share: SharePluginStart;
-  history: History;
-  kbnUrlStateStorage: IKbnUrlStateStorage;
 }
 
 let angularModuleInstance: IModule | null = null;

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app.tsx
@@ -19,6 +19,7 @@
 
 import moment from 'moment';
 import { Subscription } from 'rxjs';
+import { History } from 'history';
 
 import { IInjector } from '../legacy_imports';
 
@@ -35,6 +36,7 @@ import {
 
 import { DashboardAppController } from './dashboard_app_controller';
 import { RenderDeps } from './application';
+import { IKbnUrlStateStorage } from '../../../../../../plugins/kibana_utils/public/';
 
 export interface DashboardAppScope extends ng.IScope {
   dash: SavedObjectDashboard;
@@ -96,7 +98,9 @@ export function initDashboardAppDirective(app: any, deps: RenderDeps) {
         $route: any,
         $routeParams: {
           id?: string;
-        }
+        },
+        kbnUrlStateStorage: IKbnUrlStateStorage,
+        history: History
       ) =>
         new DashboardAppController({
           $route,
@@ -105,6 +109,8 @@ export function initDashboardAppDirective(app: any, deps: RenderDeps) {
           config,
           confirmModal,
           indexPatterns: deps.npDataStart.indexPatterns,
+          kbnUrlStateStorage,
+          history,
           ...deps,
         }),
     };

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
@@ -24,6 +24,7 @@ import angular from 'angular';
 
 import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { History } from 'history';
 import { DashboardEmptyScreen, DashboardEmptyScreenProps } from './dashboard_empty_screen';
 
 import {
@@ -77,7 +78,11 @@ import {
   SavedObjectFinderProps,
   SavedObjectFinderUi,
 } from '../../../../../../plugins/kibana_react/public';
-import { removeQueryParam, unhashUrl } from '../../../../../../plugins/kibana_utils/public';
+import {
+  IKbnUrlStateStorage,
+  removeQueryParam,
+  unhashUrl,
+} from '../../../../../../plugins/kibana_utils/public';
 
 export interface DashboardAppControllerDependencies extends RenderDeps {
   $scope: DashboardAppScope;
@@ -87,6 +92,8 @@ export interface DashboardAppControllerDependencies extends RenderDeps {
   dashboardConfig: any;
   config: any;
   confirmModal: ConfirmModalFn;
+  history: History;
+  kbnUrlStateStorage: IKbnUrlStateStorage;
 }
 
 export class DashboardAppController {

--- a/src/legacy/core_plugins/kibana/public/dashboard/plugin.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/plugin.ts
@@ -25,13 +25,12 @@ import {
   Plugin,
   SavedObjectsClientContract,
 } from 'kibana/public';
-import { createHashHistory } from 'history';
 import { i18n } from '@kbn/i18n';
 import { RenderDeps } from './np_ready/application';
 import { DataStart } from '../../../data/public';
 import { DataPublicPluginStart as NpDataStart } from '../../../../../plugins/data/public';
 import { IEmbeddableStart } from '../../../../../plugins/embeddable/public';
-import { createKbnUrlStateStorage, Storage } from '../../../../../plugins/kibana_utils/public';
+import { Storage } from '../../../../../plugins/kibana_utils/public';
 import { NavigationPublicPluginStart as NavigationStart } from '../../../../../plugins/navigation/public';
 import { DashboardConstants } from './np_ready/dashboard_constants';
 import {
@@ -97,12 +96,6 @@ export class DashboardPlugin implements Plugin {
           overlays: contextCore.overlays,
         });
 
-        const history = createHashHistory();
-        const kbnUrlStateStorage = createKbnUrlStateStorage({
-          history,
-          useHash: core.uiSettings.get('state:storeInSessionStorage'),
-        });
-
         const deps: RenderDeps = {
           core: contextCore as LegacyCoreStart,
           ...angularDependencies,
@@ -118,8 +111,6 @@ export class DashboardPlugin implements Plugin {
           embeddables,
           dashboardCapabilities: contextCore.application.capabilities.dashboard,
           localStorage: new Storage(localStorage),
-          history,
-          kbnUrlStateStorage,
         };
         const { renderApp } = await import('./np_ready/application');
         return renderApp(params.element, params.appBasePath, deps);


### PR DESCRIPTION
## Summary

This fixes a regression noticed by @majagrubic when working on #55443. 
The regression caused by: #55158

### The bug

**'state:storeInSessionStorage' doesn’t take effect for dashboard without full page reload**


### To reproduce

1. Go to dashboard, see the unhashed state in the url 
2. Via chrome's nav navigate to Management. Change 'state:storeInSessionStorage' setting. 
3. Navigate back to dashboard using chrome's nav. - The state hashing option didn't take effect. 
It starts working after page reload. 


### The fix 

`kbnUrlStateStorage` is responsible for updating the state in the url. The problem is, that it was initialised with uiSettings('state:storeInSessionStorage') only once! Together with angular modules initialisation. - https://github.com/elastic/kibana/blob/d010abc816c2b2fd9575eac5e1ef4db83eaaed9d/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts#L73

I had to move the initialisation inside angular so each time angular app gets mounted, it creates new instance with proper value from uiSettings. 

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

