### PR TITLE
 APM Service Map popover fixes round 1

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Contents.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Contents.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiPopover,
+  EuiTitle
+} from '@elastic/eui';
+import cytoscape from 'cytoscape';
+import React, { CSSProperties } from 'react';
+import { Buttons } from './Buttons';
+import { Info } from './Info';
+import { ServiceMetricList } from './ServiceMetricList';
+
+const popoverMinWidth = 280;
+
+interface ContentsProps {
+  button: JSX.Element;
+  data: cytoscape.NodeDataDefinition;
+  focusedServiceName?: string;
+  isOpen: boolean;
+  isService: boolean;
+  label: string;
+  onFocusClick: () => void;
+  selectedNodeServiceName: string;
+  style: CSSProperties;
+}
+
+export function Contents({
+  button,
+  data,
+  focusedServiceName,
+  isOpen,
+  isService,
+  label,
+  onFocusClick,
+  selectedNodeServiceName,
+  style
+}: ContentsProps) {
+  return (
+    <EuiPopover
+      anchorPosition={'upCenter'}
+      button={button}
+      closePopover={() => {}}
+      isOpen={isOpen}
+      style={style}
+    >
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="s"
+        style={{ minWidth: popoverMinWidth }}
+      >
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h3>{label}</h3>
+          </EuiTitle>
+          <EuiHorizontalRule margin="xs" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          {isService ? (
+            <ServiceMetricList serviceName={selectedNodeServiceName} />
+          ) : (
+            <Info {...data} />
+          )}
+        </EuiFlexItem>
+        {isService && (
+          <Buttons
+            focusedServiceName={focusedServiceName}
+            onFocusClick={onFocusClick}
+            selectedNodeServiceName={selectedNodeServiceName}
+          />
+        )}
+      </EuiFlexGroup>
+    </EuiPopover>
+  );
+}

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Contents.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Contents.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle
 } from '@elastic/eui';
 import cytoscape from 'cytoscape';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, MutableRefObject } from 'react';
 import { Buttons } from './Buttons';
 import { Info } from './Info';
 import { ServiceMetricList } from './ServiceMetricList';
@@ -27,6 +27,7 @@ interface ContentsProps {
   isService: boolean;
   label: string;
   onFocusClick: () => void;
+  popoverRef: MutableRefObject<EuiPopover | null>;
   selectedNodeServiceName: string;
   style: CSSProperties;
 }
@@ -39,6 +40,7 @@ export function Contents({
   isService,
   label,
   onFocusClick,
+  popoverRef,
   selectedNodeServiceName,
   style
 }: ContentsProps) {
@@ -48,6 +50,7 @@ export function Contents({
       button={button}
       closePopover={() => {}}
       isOpen={isOpen}
+      ref={popoverRef}
       style={style}
     >
       <EuiFlexGroup

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Contents.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Contents.tsx
@@ -8,11 +8,10 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
-  EuiPopover,
   EuiTitle
 } from '@elastic/eui';
 import cytoscape from 'cytoscape';
-import React, { CSSProperties, MutableRefObject } from 'react';
+import React from 'react';
 import { Buttons } from './Buttons';
 import { Info } from './Info';
 import { ServiceMetricList } from './ServiceMetricList';
@@ -20,65 +19,48 @@ import { ServiceMetricList } from './ServiceMetricList';
 const popoverMinWidth = 280;
 
 interface ContentsProps {
-  button: JSX.Element;
-  data: cytoscape.NodeDataDefinition;
   focusedServiceName?: string;
-  isOpen: boolean;
   isService: boolean;
   label: string;
   onFocusClick: () => void;
-  popoverRef: MutableRefObject<EuiPopover | null>;
+  selectedNodeData: cytoscape.NodeDataDefinition;
   selectedNodeServiceName: string;
-  style: CSSProperties;
 }
 
 export function Contents({
-  button,
-  data,
+  selectedNodeData,
   focusedServiceName,
-  isOpen,
   isService,
   label,
   onFocusClick,
-  popoverRef,
-  selectedNodeServiceName,
-  style
+  selectedNodeServiceName
 }: ContentsProps) {
   return (
-    <EuiPopover
-      anchorPosition={'upCenter'}
-      button={button}
-      closePopover={() => {}}
-      isOpen={isOpen}
-      ref={popoverRef}
-      style={style}
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      style={{ minWidth: popoverMinWidth }}
     >
-      <EuiFlexGroup
-        direction="column"
-        gutterSize="s"
-        style={{ minWidth: popoverMinWidth }}
-      >
-        <EuiFlexItem>
-          <EuiTitle size="xxs">
-            <h3>{label}</h3>
-          </EuiTitle>
-          <EuiHorizontalRule margin="xs" />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          {isService ? (
-            <ServiceMetricList serviceName={selectedNodeServiceName} />
-          ) : (
-            <Info {...data} />
-          )}
-        </EuiFlexItem>
-        {isService && (
-          <Buttons
-            focusedServiceName={focusedServiceName}
-            onFocusClick={onFocusClick}
-            selectedNodeServiceName={selectedNodeServiceName}
-          />
+      <EuiFlexItem>
+        <EuiTitle size="xxs">
+          <h3>{label}</h3>
+        </EuiTitle>
+        <EuiHorizontalRule margin="xs" />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        {isService ? (
+          <ServiceMetricList serviceName={selectedNodeServiceName} />
+        ) : (
+          <Info {...selectedNodeData} />
         )}
-      </EuiFlexGroup>
-    </EuiPopover>
+      </EuiFlexItem>
+      {isService && (
+        <Buttons
+          focusedServiceName={focusedServiceName}
+          onFocusClick={onFocusClick}
+          selectedNodeServiceName={selectedNodeServiceName}
+        />
+      )}
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Info.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Info.tsx
@@ -4,10 +4,11 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
-import { i18n } from '@kbn/i18n';
-import styled from 'styled-components';
 import lightTheme from '@elastic/eui/dist/eui_theme_light.json';
+import { i18n } from '@kbn/i18n';
+import cytoscape from 'cytoscape';
+import React from 'react';
+import styled from 'styled-components';
 
 const ItemRow = styled.div`
   line-height: 2;
@@ -19,8 +20,8 @@ const ItemTitle = styled.dt`
 
 const ItemDescription = styled.dd``;
 
-interface InfoProps {
-  type: string;
+interface InfoProps extends cytoscape.NodeDataDefinition {
+  type?: string;
   subtype?: string;
 }
 

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
@@ -5,7 +5,7 @@
  */
 
 import { storiesOf } from '@storybook/react';
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import { Contents } from './Contents';
 import {
   ApmPluginContext,
@@ -22,7 +22,8 @@ const data = {
 };
 
 function Example() {
-  const [isOpen, setIsOpen] = React.useState(true);
+  const [isOpen, setIsOpen] = useState(true);
+  const ref = useRef();
 
   return (
     <Contents
@@ -40,6 +41,7 @@ function Example() {
       isService={true}
       label="opbeans-node"
       onFocusClick={() => {}}
+      popoverRef={ref}
       selectedNodeServiceName="opbeans-node"
       style={{}}
     />

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import { Contents } from './Contents';
+import {
+  ApmPluginContext,
+  ApmPluginContextValue
+} from '../../../../context/ApmPluginContext';
+
+const data = {
+  id: 'opbeans-node',
+  label: 'opbeans-node',
+  href:
+    '#/services/opbeans-node/service-map?rangeFrom=now-24h&rangeTo=now&refreshPaused=true&refreshInterval=0',
+  agentName: 'nodejs',
+  type: 'service'
+};
+
+function Example() {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  return (
+    <Contents
+      button={
+        <button
+          onClick={() => {
+            setIsOpen(prevState => !prevState);
+          }}
+        >
+          toggle popover
+        </button>
+      }
+      data={data}
+      isOpen={isOpen}
+      isService={true}
+      label="opbeans-node"
+      onFocusClick={() => {}}
+      selectedNodeServiceName="opbeans-node"
+      style={{}}
+    />
+  );
+}
+
+storiesOf('app/ServiceMap/Popover/Contents', module).add(
+  'example',
+  () => {
+    return (
+      <ApmPluginContext.Provider
+        value={
+          ({ core: { notifications: {} } } as unknown) as ApmPluginContextValue
+        }
+      >
+        <Example />
+      </ApmPluginContext.Provider>
+    );
+  },
+  {
+    info: {
+      propTablesExclude: [ApmPluginContext.Provider, Example],
+      source: false
+    }
+  }
+);

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
@@ -5,14 +5,14 @@
  */
 
 import { storiesOf } from '@storybook/react';
-import React, { useState, useRef } from 'react';
-import { Contents } from './Contents';
+import React from 'react';
 import {
   ApmPluginContext,
   ApmPluginContextValue
 } from '../../../../context/ApmPluginContext';
+import { Contents } from './Contents';
 
-const data = {
+const selectedNodeData = {
   id: 'opbeans-node',
   label: 'opbeans-node',
   href:
@@ -20,33 +20,6 @@ const data = {
   agentName: 'nodejs',
   type: 'service'
 };
-
-function Example() {
-  const [isOpen, setIsOpen] = useState(true);
-  const ref = useRef();
-
-  return (
-    <Contents
-      button={
-        <button
-          onClick={() => {
-            setIsOpen(prevState => !prevState);
-          }}
-        >
-          toggle popover
-        </button>
-      }
-      data={data}
-      isOpen={isOpen}
-      isService={true}
-      label="opbeans-node"
-      onFocusClick={() => {}}
-      popoverRef={ref}
-      selectedNodeServiceName="opbeans-node"
-      style={{}}
-    />
-  );
-}
 
 storiesOf('app/ServiceMap/Popover/Contents', module).add(
   'example',
@@ -57,13 +30,19 @@ storiesOf('app/ServiceMap/Popover/Contents', module).add(
           ({ core: { notifications: {} } } as unknown) as ApmPluginContextValue
         }
       >
-        <Example />
+        <Contents
+          selectedNodeData={selectedNodeData}
+          isService={true}
+          label="opbeans-node"
+          onFocusClick={() => {}}
+          selectedNodeServiceName="opbeans-node"
+        />
       </ApmPluginContext.Provider>
     );
   },
   {
     info: {
-      propTablesExclude: [ApmPluginContext.Provider, Example],
+      propTablesExclude: [ApmPluginContext.Provider],
       source: false
     }
   }

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/index.tsx
@@ -4,27 +4,16 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiPopover,
-  EuiTitle
-} from '@elastic/eui';
 import cytoscape from 'cytoscape';
 import React, {
   CSSProperties,
+  useCallback,
   useContext,
   useEffect,
-  useState,
-  useCallback
+  useState
 } from 'react';
 import { CytoscapeContext } from '../Cytoscape';
-import { Buttons } from './Buttons';
-import { Info } from './Info';
-import { ServiceMetricList } from './ServiceMetricList';
-
-const popoverMinWidth = 280;
+import { Contents } from './Contents';
 
 interface PopoverProps {
   focusedServiceName?: string;
@@ -87,40 +76,15 @@ export function Popover({ focusedServiceName }: PopoverProps) {
   const label = data.label || selectedNodeServiceName;
 
   return (
-    <EuiPopover
-      anchorPosition={'upCenter'}
+    <Contents
       button={trigger}
-      closePopover={() => {}}
+      data={data}
       isOpen={isOpen}
+      isService={isService}
+      label={label}
+      onFocusClick={onFocusClick}
+      selectedNodeServiceName={selectedNodeServiceName}
       style={popoverStyle}
-    >
-      <EuiFlexGroup
-        direction="column"
-        gutterSize="s"
-        style={{ minWidth: popoverMinWidth }}
-      >
-        <EuiFlexItem>
-          <EuiTitle size="xxs">
-            <h3>{label}</h3>
-          </EuiTitle>
-          <EuiHorizontalRule margin="xs" />
-        </EuiFlexItem>
-
-        <EuiFlexItem>
-          {isService ? (
-            <ServiceMetricList serviceName={selectedNodeServiceName} />
-          ) : (
-            <Info {...data} />
-          )}
-        </EuiFlexItem>
-        {isService && (
-          <Buttons
-            focusedServiceName={focusedServiceName}
-            onFocusClick={onFocusClick}
-            selectedNodeServiceName={selectedNodeServiceName}
-          />
-        )}
-      </EuiFlexGroup>
-    </EuiPopover>
+    />
   );
 }


### PR DESCRIPTION
Some fixes for #54405.

* Use the `popoverPositionFluid` method of `EuiPopover` to properly position the arrow based on where the popover was opened
* Rearrange the variable declarations and effects in the popover index
* Create a `Contents` component to separate the internals of the popover from the index, where the poisitioning is done
* Add a story to show the contents rendering