### PR TITLE
Shows fixed version instructions in the newsfeed

### DIFF
--- a/src/core/public/pulse/index.ts
+++ b/src/core/public/pulse/index.ts
@@ -27,7 +27,7 @@ import { channelNames } from './config';
 import { Fetcher, sendPulse, sendUsageFrom } from '../../server/pulse/send_pulse';
 
 export interface PulseServiceContext {
-  getChannel: <T = PulseInstruction>(id: string) => PulseChannel<T>;
+  getChannel: <T extends PulseInstruction>(id: string) => PulseChannel<T>;
 }
 export type PulseServiceSetup = PulseServiceContext;
 export type PulseServiceStart = object;
@@ -59,12 +59,12 @@ export class PulseService {
     // poll for instructions every second for this deployment
 
     return {
-      getChannel: <T = PulseInstruction>(id: string): PulseChannel<T> => {
+      getChannel: <T extends PulseInstruction>(id: string): PulseChannel<T> => {
         const channel = this.channels.get(id);
         if (!channel) {
           throw new Error(`Unknown channel: ${id}`);
         }
-        return channel as any;
+        return (channel as unknown) as PulseChannel<T>;
       },
     };
   }
@@ -87,7 +87,15 @@ export class PulseService {
       }, 1000);
     }
 
-    return {};
+    return {
+      getChannel: <T extends PulseInstruction>(id: string) => {
+        const channel = this.channels.get(id);
+        if (!channel) {
+          throw new Error(`Unknown channel: ${id}`);
+        }
+        return (channel as unknown) as PulseChannel<T>;
+      },
+    };
   }
 
   public stop() {

--- a/src/core/server/pulse/collectors/notifications.ts
+++ b/src/core/server/pulse/collectors/notifications.ts
@@ -18,13 +18,14 @@
  */
 
 import { PulseCollector, CollectorSetupContext } from '../types';
+import { PulseInstruction } from '../channel';
 
 export interface Payload {
   records: NotificationInstruction[];
   deploymentId: string;
 }
 
-export interface NotificationInstruction {
+export interface NotificationInstruction extends PulseInstruction {
   hash: string;
   title: string;
   status: 'new' | 'seen';

--- a/src/plugins/newsfeed/public/plugin.tsx
+++ b/src/plugins/newsfeed/public/plugin.tsx
@@ -27,6 +27,8 @@ import { PluginInitializerContext, CoreSetup, CoreStart, Plugin } from 'src/core
 import { PulseChannel } from 'src/core/public/pulse/channel';
 // eslint-disable-next-line
 import { NotificationInstruction } from 'src/core/server/pulse/collectors/notifications';
+// eslint-disable-next-line
+import { ErrorInstruction } from 'src/core/server/pulse/collectors/errors';
 import { FetchResult, NewsfeedPluginInjectedConfig } from '../types';
 import { NewsfeedNavButton, NewsfeedApiFetchResult } from './components/newsfeed_header_nav_button';
 import { getApi } from './lib/api';
@@ -38,6 +40,7 @@ export class NewsfeedPublicPlugin implements Plugin<Setup, Start> {
   private readonly kibanaVersion: string;
   private readonly stop$ = new Rx.ReplaySubject(1);
   private notificationsChannel?: PulseChannel<NotificationInstruction>;
+  private errorsChannel?: PulseChannel<ErrorInstruction>;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.kibanaVersion = initializerContext.env.packageInfo.version;
@@ -45,6 +48,7 @@ export class NewsfeedPublicPlugin implements Plugin<Setup, Start> {
 
   public setup(core: CoreSetup): Setup {
     this.notificationsChannel = core.pulse.getChannel('notifications');
+    this.errorsChannel = core.pulse.getChannel('errors');
     return {};
   }
 
@@ -85,7 +89,11 @@ export class NewsfeedPublicPlugin implements Plugin<Setup, Start> {
 
     ReactDOM.render(
       <I18nProvider>
-        <NewsfeedNavButton apiFetchResult={api$} notificationsChannel={this.notificationsChannel} />
+        <NewsfeedNavButton
+          apiFetchResult={api$}
+          notificationsChannel={this.notificationsChannel}
+          errorsChannel={this.errorsChannel!}
+        />
       </I18nProvider>,
       targetDomElement
     );

--- a/src/plugins/pulse_errors/public/mock_data/errors.ts
+++ b/src/plugins/pulse_errors/public/mock_data/errors.ts
@@ -48,10 +48,10 @@ export const errorChannelPayloads: PulseErrorPayloadRecord[] = [
     message: 'The SampleDataSetCard [key=ecommerce] component failed to mount',
     hash: '[plugins][pulse_errors]: [Error]: fakeError:arbitraryError 1',
     status: 'new',
-    fixedVersion: 'v7.5.2',
+    fixedVersion: 'v7.4.2',
     currentKibanaVersion: 'v7.x',
     timestamp: moment()
-      .add(60, 'seconds')
+      .add(15, 'seconds')
       .toDate(),
   },
   {
@@ -60,10 +60,34 @@ export const errorChannelPayloads: PulseErrorPayloadRecord[] = [
     message: '[Error]: Test',
     hash: '[plugins][pulse_errors]: [Error]: fakeError:arbitraryError 2',
     status: 'new',
-    // fixedVersion: 'v7.5.2',
+    fixedVersion: 'v7.5.2',
     currentKibanaVersion: 'v7.x',
     timestamp: moment()
-      .add(90, 'seconds')
+      .add(20, 'seconds')
+      .toDate(),
+  },
+  {
+    channel_id: 'errors',
+    deployment_id: '123',
+    message: 'The SampleDataSetCard [key=ecommerce] component failed to mount',
+    hash: '[plugins][pulse_errors]: [Error]: fakeError:arbitraryError 3',
+    status: 'new',
+    fixedVersion: 'v7.5.1',
+    currentKibanaVersion: 'v7.x',
+    timestamp: moment()
+      .add(25, 'seconds')
+      .toDate(),
+  },
+  {
+    channel_id: 'errors',
+    deployment_id: '123',
+    message: '[Error]: Test2',
+    hash: '[plugins][pulse_errors]: [Error]: fakeError:arbitraryError 4',
+    status: 'new',
+    fixedVersion: 'v7.5.2',
+    currentKibanaVersion: 'v7.x',
+    timestamp: moment()
+      .add(30, 'seconds')
       .toDate(),
   },
 ];

--- a/src/plugins/pulse_errors/server/index.ts
+++ b/src/plugins/pulse_errors/server/index.ts
@@ -53,6 +53,7 @@ class Plugin {
       deployment_id: '123',
       hash: error.message, // TODO: Find a way to hash the message
       message: error.message,
+      status: 'new',
     };
     try {
       await errorsChannel.sendPulse(errorPayload);

--- a/x-pack/plugins/pulse_poc/server/channels/errors/check_receiving_errors.ts
+++ b/x-pack/plugins/pulse_poc/server/channels/errors/check_receiving_errors.ts
@@ -22,15 +22,10 @@ export async function check(es: IScopedClusterClient, { deploymentId, indexName 
             {
               term: { deployment_id: deploymentId },
             },
-          ],
-          filter: {
-            range: {
-              timestamp: {
-                gte: 'now-10s',
-                lte: 'now',
-              },
+            {
+              term: { status: 'new' },
             },
-          },
+          ],
         },
       },
     },


### PR DESCRIPTION
## Summary

Continues with the Fixed Versions (error tracking) pulse POC concept with cleanup of the origin work in #55943.
Resolves #54372

Adds notifications to the newsfeed when there are fixed versions for errors (currently controlled by the mock data we add). The records are then automatically updated to have been seen and are removed.

The newsfeed list updates dynamically as new instructions arrive.
![fixed_versions_in_newsfeed](https://user-images.githubusercontent.com/11909450/73732201-7421b080-4742-11ea-8141-49a33de277f1.gif)
