### PR TITLE
APM Service Map popover fixes round 2

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/index.tsx
@@ -26,12 +26,15 @@ export function Popover({ focusedServiceName }: PopoverProps) {
   const [selectedNode, setSelectedNode] = useState<
     cytoscape.NodeSingular | undefined
   >(undefined);
-  const deselect = useCallback(() => setSelectedNode(undefined), [
-    setSelectedNode
-  ]);
+  const deselect = useCallback(() => {
+    if (cy) {
+      cy.elements().unselect();
+    }
+    setSelectedNode(undefined);
+  }, [cy, setSelectedNode]);
   const renderedHeight = selectedNode?.renderedHeight() ?? 0;
   const renderedWidth = selectedNode?.renderedWidth() ?? 0;
-  const { x, y } = selectedNode?.renderedPosition() ?? { x: 0, y: 0 };
+  const { x, y } = selectedNode?.renderedPosition() ?? { x: -10000, y: -10000 };
   const isOpen = !!selectedNode;
   const isService = selectedNode?.data('type') === 'service';
   const triggerStyle: CSSProperties = {


### PR DESCRIPTION
Some more fixes for #54405:

* Position the popover offscreen when no node is selected
* Unselect all the nodes when setting the selected node to undefined
