### PR TITLE
[APM] Remove initial time range for service maps

### DIFF
--- a/x-pack/legacy/plugins/apm/index.ts
+++ b/x-pack/legacy/plugins/apm/index.ts
@@ -72,8 +72,7 @@ export const apm: LegacyPluginInitializer = kibana => {
         autocreateApmIndexPattern: Joi.boolean().default(true),
 
         // service map
-        serviceMapEnabled: Joi.boolean().default(false),
-        serviceMapInitialTimeRange: Joi.number().default(60 * 1000 * 60) // last 1 hour
+        serviceMapEnabled: Joi.boolean().default(false)
       }).default();
     },
 

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -116,13 +116,14 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
             }
           });
           setResponses(resp => resp.concat(data));
-          setIsLoading(false);
 
           const shouldGetNext =
             responses.length + 1 < MAX_REQUESTS && data.after;
 
           if (shouldGetNext) {
             await getNext({ after: data.after });
+          } else {
+            setIsLoading(false);
           }
         } catch (error) {
           setIsLoading(false);

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -27,10 +27,10 @@ import { useUrlParams } from '../../../hooks/useUrlParams';
 import { Controls } from './Controls';
 import { Cytoscape } from './Cytoscape';
 import { getCytoscapeElements } from './get_cytoscape_elements';
-import { LoadingOverlay } from './LoadingOverlay';
 import { PlatinumLicensePrompt } from './PlatinumLicensePrompt';
 import { Popover } from './Popover';
 import { useRefHeight } from './useRefHeight';
+import { useLoadingIndicator } from '../../../hooks/useLoadingIndicator';
 
 interface ServiceMapProps {
   serviceName?: string;
@@ -79,8 +79,9 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
   const openToast = useRef<string | null>(null);
 
   const [responses, setResponses] = useState<ServiceMapAPIResponse[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [percentageLoaded, setPercentageLoaded] = useState(0);
+
+  const { setIsLoading } = useLoadingIndicator();
+
   const [, _setUnusedState] = useState(false);
 
   const elements = useMemo(() => getCytoscapeElements(responses, search), [
@@ -121,7 +122,6 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
             responses.length + 1 < MAX_REQUESTS && data.after;
 
           if (shouldGetNext) {
-            setPercentageLoaded(value => value + 30); // increase loading bar 30%
             await getNext({ after: data.after });
           }
         } catch (error) {
@@ -134,14 +134,12 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
         }
       }
     },
-    [callApmApi, params, responses.length, notifications.toasts]
+    [params, setIsLoading, callApmApi, responses.length, notifications.toasts]
   );
 
   useEffect(() => {
     const loadServiceMaps = async () => {
-      setPercentageLoaded(5);
       await getNext({ reset: true });
-      setPercentageLoaded(100);
     };
 
     loadServiceMaps();
@@ -167,7 +165,7 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
       forceUpdate();
     };
 
-    if (newElements.length > 0 && percentageLoaded === 100) {
+    if (newElements.length > 0 && renderedElements.current.length > 0) {
       openToast.current = notifications.toasts.add({
         title: i18n.translate('xpack.apm.newServiceMapData', {
           defaultMessage: `Newly discovered connections are available.`
@@ -193,7 +191,7 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [elements, percentageLoaded]);
+  }, [elements]);
 
   const isValidPlatinumLicense =
     license?.isActive &&
@@ -212,10 +210,6 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
         height={height}
         style={cytoscapeDivStyle}
       >
-        <LoadingOverlay
-          isLoading={isLoading}
-          percentageLoaded={percentageLoaded}
-        />
         <Controls />
         <Popover focusedServiceName={serviceName} />
       </Cytoscape>

--- a/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
+++ b/x-pack/legacy/plugins/apm/public/hooks/useFetcher.tsx
@@ -9,10 +9,10 @@ import { i18n } from '@kbn/i18n';
 import { IHttpFetchError } from 'src/core/public';
 import { toMountPoint } from '../../../../../../src/plugins/kibana_react/public';
 import { LoadingIndicatorContext } from '../context/LoadingIndicatorContext';
-import { useComponentId } from './useComponentId';
 import { APMClient } from '../services/rest/createCallApmApi';
 import { useCallApmApi } from './useCallApmApi';
 import { useApmPluginContext } from './useApmPluginContext';
+import { useLoadingIndicator } from './useLoadingIndicator';
 
 export enum FETCH_STATUS {
   LOADING = 'loading',
@@ -44,7 +44,7 @@ export function useFetcher<TReturn>(
 ): Result<InferResponseType<TReturn>> & { refetch: () => void } {
   const { notifications } = useApmPluginContext().core;
   const { preservePreviousData = true } = options;
-  const id = useComponentId();
+  const { setIsLoading } = useLoadingIndicator();
 
   const callApmApi = useCallApmApi();
 
@@ -67,7 +67,7 @@ export function useFetcher<TReturn>(
         return;
       }
 
-      dispatchStatus({ id, isLoading: true });
+      setIsLoading(true);
 
       setResult(prevResult => ({
         data: preservePreviousData ? prevResult.data : undefined, // preserve data from previous state while loading next state
@@ -78,7 +78,7 @@ export function useFetcher<TReturn>(
       try {
         const data = await promise;
         if (!didCancel) {
-          dispatchStatus({ id, isLoading: false });
+          setIsLoading(false);
           setResult({
             data,
             status: FETCH_STATUS.SUCCESS,
@@ -109,7 +109,7 @@ export function useFetcher<TReturn>(
               </div>
             )
           });
-          dispatchStatus({ id, isLoading: false });
+          setIsLoading(false);
           setResult({
             data: undefined,
             status: FETCH_STATUS.FAILURE,
@@ -122,15 +122,15 @@ export function useFetcher<TReturn>(
     doFetch();
 
     return () => {
-      dispatchStatus({ id, isLoading: false });
+      setIsLoading(false);
       didCancel = true;
     };
     /* eslint-disable react-hooks/exhaustive-deps */
   }, [
     counter,
-    id,
     preservePreviousData,
     dispatchStatus,
+    setIsLoading,
     ...fnDeps
     /* eslint-enable react-hooks/exhaustive-deps */
   ]);

--- a/x-pack/legacy/plugins/apm/public/hooks/useLoadingIndicator.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useLoadingIndicator.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { useContext, useMemo } from 'react';
+import { LoadingIndicatorContext } from '../context/LoadingIndicatorContext';
+import { useComponentId } from './useComponentId';
+
+export function useLoadingIndicator() {
+  const { dispatchStatus } = useContext(LoadingIndicatorContext);
+  const id = useComponentId();
+
+  return useMemo(() => {
+    return {
+      setIsLoading: (loading: boolean) => {
+        dispatchStatus({ id, isLoading: loading });
+      }
+    };
+  }, [dispatchStatus, id]);
+}

--- a/x-pack/legacy/plugins/apm/public/hooks/useLoadingIndicator.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useLoadingIndicator.ts
@@ -4,13 +4,19 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, useEffect } from 'react';
 import { LoadingIndicatorContext } from '../context/LoadingIndicatorContext';
 import { useComponentId } from './useComponentId';
 
 export function useLoadingIndicator() {
   const { dispatchStatus } = useContext(LoadingIndicatorContext);
   const id = useComponentId();
+
+  useEffect(() => {
+    return () => {
+      dispatchStatus({ id, isLoading: false });
+    };
+  }, [dispatchStatus, id]);
 
   return useMemo(() => {
     return {

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -16,7 +16,6 @@ export const config = {
   },
   schema: schema.object({
     serviceMapEnabled: schema.boolean({ defaultValue: false }),
-    serviceMapInitialTimeRange: schema.number({ defaultValue: 60 * 1000 * 60 }), // last 1 hour
     autocreateApmIndexPattern: schema.boolean({ defaultValue: true }),
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
@@ -38,7 +37,6 @@ export function mergeConfigs(apmOssConfig: APMOSSConfig, apmConfig: APMXPackConf
     'apm_oss.onboardingIndices': apmOssConfig.onboardingIndices,
     'apm_oss.indexPattern': apmOssConfig.indexPattern,
     'xpack.apm.serviceMapEnabled': apmConfig.serviceMapEnabled,
-    'xpack.apm.serviceMapInitialTimeRange': apmConfig.serviceMapInitialTimeRange,
     'xpack.apm.ui.enabled': apmConfig.ui.enabled,
     'xpack.apm.ui.maxTraceItems': apmConfig.ui.maxTraceItems,
     'xpack.apm.ui.transactionGroupBucketSize': apmConfig.ui.transactionGroupBucketSize,


### PR DESCRIPTION
The initial time range for the service maps request might no longer be necessary, from what I can tell. Not having it improves the overall loading time and the user experience.

