### PR TITLE
handle viewing sample dashboards on default dist

### DIFF
--- a/src/legacy/core_plugins/kibana/public/home/np_ready/components/__snapshots__/sample_data_view_data_button.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/home/np_ready/components/__snapshots__/sample_data_view_data_button.test.js.snap
@@ -14,6 +14,7 @@ exports[`should render popover when appLinks is not empty 1`] = `
     </EuiButton>
   }
   closePopover={[Function]}
+  data-test-subj="launchSampleDataSetecommerce"
   display="inlineBlock"
   hasArrow={true}
   id="sampleDataLinksecommerce"

--- a/src/legacy/core_plugins/kibana/public/home/np_ready/components/sample_data_view_data_button.js
+++ b/src/legacy/core_plugins/kibana/public/home/np_ready/components/sample_data_view_data_button.js
@@ -112,6 +112,7 @@ export class SampleDataViewDataButton extends React.Component {
         closePopover={this.closePopover}
         panelPaddingSize="none"
         anchorPosition="downCenter"
+        data-test-subj={`launchSampleDataSet${this.props.id}`}
       >
         <EuiContextMenu initialPanelId={0} panels={panels} />
       </EuiPopover>

--- a/test/functional/apps/home/_sample_data.ts
+++ b/test/functional/apps/home/_sample_data.ts
@@ -84,7 +84,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample flights data set dashboard', async () => {
-        await PageObjects.home.launchSampleDataSet('flights');
+        await PageObjects.home.launchSampleDashboard('flights');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
         const todayYearMonthDay = moment().format('MMM D, YYYY');
@@ -96,7 +96,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should render visualizations', async () => {
-        await PageObjects.home.launchSampleDataSet('flights');
+        await PageObjects.home.launchSampleDashboard('flights');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
         log.debug('Checking pie charts rendered');
@@ -115,7 +115,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample logs data set dashboard', async () => {
-        await PageObjects.home.launchSampleDataSet('logs');
+        await PageObjects.home.launchSampleDashboard('logs');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
         const todayYearMonthDay = moment().format('MMM D, YYYY');
@@ -127,7 +127,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should launch sample ecommerce data set dashboard', async () => {
-        await PageObjects.home.launchSampleDataSet('ecommerce');
+        await PageObjects.home.launchSampleDashboard('ecommerce');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await renderable.waitForRender();
         const todayYearMonthDay = moment().format('MMM D, YYYY');

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -19,9 +19,12 @@
 
 import { FtrProviderContext } from '../ftr_provider_context';
 
-export function HomePageProvider({ getService }: FtrProviderContext) {
+export function HomePageProvider({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
+  const find = getService('find');
+  const PageObjects = getPageObjects(['common']);
+  let isOss = true;
 
   class HomePage {
     async clickSynopsis(title: string) {
@@ -66,6 +69,15 @@ export function HomePageProvider({ getService }: FtrProviderContext) {
     async launchSampleDataSet(id: string) {
       await this.addSampleDataSet(id);
       await testSubjects.click(`launchSampleDataSet${id}`);
+      // On OSS there's currently only sample dashboards so the launch button opens the dashboard
+      // but on default dist there's more items. The only tests that are calling this method are in OSS
+      // so they always expect Dashboard.  isOss isn't really the right test. It should be based on
+      // the number of items.
+      // x-pack sample data tests seem to skip this navigation and open the saved objects directly.
+      isOss = await PageObjects.common.isOss();
+      if (!isOss) {
+        await find.clickByLinkText('Dashboard');
+      }
     }
 
     async loadSavedObjects() {

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -66,18 +66,17 @@ export function HomePageProvider({ getService, getPageObjects }: FtrProviderCont
       });
     }
 
-    async launchSampleDataSet(id: string) {
-      await this.addSampleDataSet(id);
-      await testSubjects.click(`launchSampleDataSet${id}`);
-      // On OSS there's currently only sample dashboards so the launch button opens the dashboard
-      // but on default dist there's more items. The only tests that are calling this method are in OSS
-      // so they always expect Dashboard.  isOss isn't really the right test. It should be based on
-      // the number of items.
-      // x-pack sample data tests seem to skip this navigation and open the saved objects directly.
+    async launchSampleDashboard(id: string) {
+      await this.launchSampleDataSet(id);
       isOss = await PageObjects.common.isOss();
       if (!isOss) {
         await find.clickByLinkText('Dashboard');
       }
+    }
+
+    async launchSampleDataSet(id: string) {
+      await this.addSampleDataSet(id);
+      await testSubjects.click(`launchSampleDataSet${id}`);
     }
 
     async loadSavedObjects() {


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/55795

Fixes sample data oss tests so they can launch the sample Dashboards regardless of an OSS or Default Dist build (including Cloud).  The difference mainly being the View button in the sample data panels in OSS opens the dashboards directly because it's the only sample item.  But on the default distribution there are other items that appear in a list so we have to select Dashboard for that method to work the same.

I used isOss, but in Kibana it's really "is there more than one item".  So if we add some other sample data app to OSS, we'll have to fix this differently.

### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

~- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
