### PR TITLE
[APM] Update monospace font family variable

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`ErrorGroupOverview -> List should render empty state 1`] = `
 
 exports[`ErrorGroupOverview -> List should render with data 1`] = `
 .c0 {
-  font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-family: "Roboto Mono",Consolas,Menlo,Courier,monospace;
 }
 
 .c1 {
@@ -316,7 +316,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
 }
 
 .c2 {
-  font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-family: "Roboto Mono",Consolas,Menlo,Courier,monospace;
   font-size: 16px;
   max-width: 100%;
   white-space: nowrap;
@@ -325,7 +325,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
 }
 
 .c3 {
-  font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-family: "Roboto Mono",Consolas,Menlo,Courier,monospace;
 }
 
 <Memo(UnoptimizedManagedTable)

--- a/x-pack/legacy/plugins/apm/public/components/shared/Stacktrace/__test__/__snapshots__/Stackframe.test.tsx.snap
+++ b/x-pack/legacy/plugins/apm/public/components/shared/Stacktrace/__test__/__snapshots__/Stackframe.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Stackframe when stackframe has source lines should render correctly 1`]
 .c0 {
   color: #69707d;
   padding: 8px 0;
-  font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-family: "Roboto Mono",Consolas,Menlo,Courier,monospace;
   font-size: 14px;
 }
 
@@ -97,7 +97,7 @@ exports[`Stackframe when stackframe has source lines should render correctly 1`]
 
 .c2 {
   position: relative;
-  font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
+  font-family: "Roboto Mono",Consolas,Menlo,Courier,monospace;
   font-size: 14px;
   border: 1px solid #d3dae6;
   border-radius: 4px;

--- a/x-pack/legacy/plugins/apm/public/style/variables.ts
+++ b/x-pack/legacy/plugins/apm/public/style/variables.ts
@@ -32,7 +32,7 @@ export const borderRadius = '4px';
 
 // Fonts
 export const fontFamilyCode =
-  '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace';
+  '"Roboto Mono", Consolas, Menlo, Courier, monospace';
 
 // Font sizes
 export const fontSize = '14px';

--- a/x-pack/legacy/plugins/apm/public/style/variables.ts
+++ b/x-pack/legacy/plugins/apm/public/style/variables.ts
@@ -31,7 +31,6 @@ export function pct(value: number): string {
 export const borderRadius = '4px';
 
 // Fonts
-export const fontFamily = '"Open Sans", Helvetica, Arial, sans-serif';
 export const fontFamilyCode =
   '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace';
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/57445

Updating the monospace font family used in various places in APM UI to match the [EUI theme](https://github.com/elastic/eui/blob/master/src/global_styling/variables/_typography.scss).

<img width="1442" alt="Screenshot 2020-02-13 at 13 02 28" src="https://user-images.githubusercontent.com/4104278/74433669-24896600-4e61-11ea-9092-7e4936fb4430.png">
<img width="939" alt="Screenshot 2020-02-13 at 13 02 36" src="https://user-images.githubusercontent.com/4104278/74433675-26532980-4e61-11ea-965b-75a160175506.png">
<img width="766" alt="Screenshot 2020-02-13 at 13 02 43" src="https://user-images.githubusercontent.com/4104278/74433680-281ced00-4e61-11ea-96eb-7392ba196fd0.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
- [ ] ~~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
