### PR TITLE
Add test util for creating server root for x-pack plugins

### DIFF
--- a/x-pack/test_utils/kbn_server.ts
+++ b/x-pack/test_utils/kbn_server.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { resolve } from 'path';
+import { createRoot } from '../../src/test_utils/kbn_server';
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { CliArgs } from '../../src/core/server/config';
+
+/**
+ * Creates a root with the specified list of x-pack plugins enabled.
+ * @param xpackPlugins list of X-Pack plugins, should match directory name of plugin (eg. task_manager)
+ * @param settings
+ * @param cliArgs
+ */
+export function createRootWithXpackPlugins(
+  xpackPlugins: string[] = [],
+  settings: any = {},
+  cliArgs: Partial<CliArgs> = {}
+) {
+  return createRoot(
+    {
+      ...settings,
+      plugins: {
+        ...settings?.plugins,
+        paths: xpackPlugins.map(name => resolve(__dirname, `../../x-pack/plugins/${name}`)),
+      },
+    },
+    cliArgs
+  );
+}


### PR DESCRIPTION
## Summary

In an attempt to create a test util for starting an in-memory Kibana server for x-pack integration tests, I found that there are a lot of problems with starting up Kibana without Elasticsearch when using x-pack plugins:

- The NP spaces plugin requires the legacy spaces plugin gets started
- When all legacy x-pack plugins are enabled, they require all legacy core_plugins are enabled
- When all core_plugins are enabled, the elasticsearch plugin blocks all requests due to Elasticsearch not being available
  - This I am only 50% sure of. It appears that it sets its status to 'red' which causes everything else to start failing

Due to these limitations, I was only able to add a function that takes a list of x-pack NP plugins to load for testing.

Note: there's also some old unused configurations in `src/x-pack/test_utils/kbn_server_config.ts` which is similar but not the same. I put this new utility in a file that matches OSS's `src/test_utils/kbn_server.ts`

I'll add an example test that uses this utility a bit later.

This is still useful when trying to test specific backend behaviors.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
