### PR TITLE
[APM] Stabilize agent configuration API

### DIFF
--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -56,8 +56,6 @@ The following Agent configuration APIs are available:
 `agent_name`::
 (optional) The agent name is used by the UI to determine which settings to display.
 
-[[apm-update-config-body]]
-===== Response body
 
 [[apm-update-config-example]]
 ===== Example
@@ -134,7 +132,6 @@ DELETE /api/apm/settings/agent-configuration
 
 [[apm-list-config-body]]
 ===== Response body
-
 
 [source,js]
 --------------------------------------------------

--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -33,13 +33,10 @@ The following Agent configuration APIs are available:
 [[apm-update-config]]
 ==== Create or update configuration
 
-[[apm-update-config-req]]
-===== Request
-
-`PUT /api/apm/settings/agent-configuration`
-
-[[apm-update-config-query]]
-===== Query parameters
+[source,console]
+--------------------------------------------------
+PUT /api/apm/settings/agent-configuration
+--------------------------------------------------
 
 [[apm-update-config-req-body]]
 ===== Request body
@@ -63,7 +60,6 @@ The following Agent configuration APIs are available:
 --------------------------------------------------
 PUT /api/apm/settings/agent-configuration
 {
-    "agent_name": "nodejs"
     "service" : {
         "name" : "frontend",
         "environment" : "production"
@@ -72,7 +68,8 @@ PUT /api/apm/settings/agent-configuration
         "transaction_sample_rate" : 0.4,
         "capture_body" : "off",
         "transaction_max_spans" : 500
-    }
+    },
+    "agent_name": "nodejs"
 }
 --------------------------------------------------
 
@@ -86,14 +83,8 @@ PUT /api/apm/settings/agent-configuration
 
 [source,console]
 --------------------------------------------------
-POST  /api/apm/settings/agent-configuration
+DELETE /api/apm/settings/agent-configuration
 --------------------------------------------------
-
-[[apm-delete-config-req]]
-===== Request
-
-`DELETE /api/apm/settings/agent-configuration`
-
 
 [[apm-delete-config-req-body]]
 ===== Request body
@@ -133,15 +124,12 @@ DELETE /api/apm/settings/agent-configuration
 GET  /api/apm/settings/agent-configuration
 --------------------------------------------------
 
-[[apm-list-config-req]]
-===== Request
-
-`GET /api/apm/settings/agent-configuration`
-
 [[apm-list-config-body]]
 ===== Response body
 
-```
+
+[source,js]
+--------------------------------------------------
 [
   {
     "agent_name": "go",
@@ -185,7 +173,7 @@ GET  /api/apm/settings/agent-configuration
     "etag": "5080ed25785b7b19f32713681e79f46996801a5b"
   }
 ]
-```
+--------------------------------------------------
 
 ////
 *******************************************************
@@ -212,7 +200,8 @@ GET  /api/apm/settings/agent-configuration
 [[apm-search-config-body]]
 ===== Response body
 
-```
+[source,js]
+--------------------------------------------------
 {
   "_index": ".apm-agent-configuration",
   "_id": "CIaqXXABmQCdPphWj8EJ",
@@ -230,7 +219,7 @@ GET  /api/apm/settings/agent-configuration
     "etag": "5080ed25785b7b19f32713681e79f46996801a5b"
   }
 }
-```
+--------------------------------------------------
 
 [[apm-search-config-example]]
 ===== Example

--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -19,16 +19,10 @@ and general information on <<using-api,how to use APIs>>.
 The Agent configuration API allows you to fine-tune your APM agent configuration,
 without needing to redeploy your application.
 
-[source,console]
---------------------------------------------------
-POST  /api/apm/settings/agent-configuration/new
---------------------------------------------------
-
 The following Agent configuration APIs are available:
 
-* <<apm-create-config>> to create a new Agent configuration.
+* <<apm-update-config>> to create or update an Agent configuration
 * <<apm-delete-config>> to delete an Agent configuration.
-* <<apm-update-config>> to update a preexisting Agent configuration.
 * <<apm-list-config>> to list all Agent configurations.
 * <<apm-search-config>> to search for an Agent configuration.
 
@@ -36,160 +30,51 @@ The following Agent configuration APIs are available:
 *******************************************************
 ////
 
+[[apm-update-config]]
+==== Create or update configuration
 
-[[apm-create-config]]
-==== Create configuration
-
-////
-Add a description.
-Link to related APIs if appropriate.
-
-Guidelines for parameter documentation
-***************************************
-* Use a definition list.
-* End each definition with a period.
-* Include whether the parameter is Optional or Required and the data type.
-* Include default values as the last sentence of the first paragraph.
-* Include a range of valid values, if applicable.
-* If the parameter requires a specific delimiter for multiple values, say so.
-* If the parameter supports wildcards, ditto.
-* For large or nested objects, consider linking to a separate definition list.
-***************************************
-////
-
-[[apm-create-config-req]]
+[[apm-update-config-req]]
 ===== Request
-////
-This section show the basic endpoint, without the body or optional parameters.
-Variables should use <...> syntax.
-If an API supports both PUT and POST, include both here.
-////
 
-`POST /api/apm/settings/agent-configuration/new`
+`PUT /api/apm/settings/agent-configuration`
 
-[[apm-create-config-pre]]
-===== Prerequisites
-////
-Optional list of prerequisites.
-
-For example:
-
-* A snapshot of an index created in 5.x can be restored to 6.x. You must...
-* If the {es} {security-features} are enabled, you must have `write`, `monitor`,
-and `manage_follow_index` index privileges...
-////
-
-[[apm-create-config-params]]
-===== Parameters
-////
-A list of all the parameters within the path of the endpoint (before the query string (?)).
-
-For example:
-`<follower_index>`::
-(Required, string) Name of the follower index
-////
-
-
-[[apm-create-config-query]]
+[[apm-update-config-query]]
 ===== Query parameters
-////
-A list of the parameters in the query string of the endpoint (after the ?).
 
-For example:
-`wait_for_active_shards`::
-(Optional, integer) Specifies the number of shards to wait on being active before
-responding. A shard must be restored from the leader index being active.
-Restoring a follower shard requires transferring all the remote Lucene segment
-files to the follower index. The default is `0`, which means waiting on none of
-the shards to be active.
-////
-
-
-[[apm-create-config-req-body]]
+[[apm-update-config-req-body]]
 ===== Request body
-////
-A list of the properties you can specify in the body of the request.
 
-For example:
-`remote_cluster`::
-(Required, string) The <<modules-remote-clusters,remote cluster>> that contains
-the leader index.
+`service`::
+(required) Service object containing `name` and `environment` on the configuration that should be deleted.
 
-`leader_index`::
-(Required, string) The name of the index in the leader cluster to follow.
-////
+`settings`::
+(required) Key/value object with settings and their corresponding value.
 
+`agent_name`::
+(optional) The agent name is used by the UI to determine which settings to display.
 
-[[apm-create-config-body]]
+[[apm-update-config-body]]
 ===== Response body
-////
-Response body is only required for detailed responses.
 
-For example:
-`auto_follow_stats`::
-  (object) An object representing stats for the auto-follow coordinator. This
-  object consists of the following fields:
-
-`auto_follow_stats.number_of_successful_follow_indices`:::
-  (long) the number of indices that the auto-follow coordinator successfully
-  followed
-...
-
-////
-
-
-[[apm-create-config-codes]]
-===== Response code
-////
-Response codes are only required when needed to understand the response body.
-
-For example:
-`200`::
-Indicates all listed indices or index aliases exist.
-
- `404`::
-Indicates one or more listed indices or index aliases **do not** exist.
-////
-
-
-[[apm-create-config-example]]
+[[apm-update-config-example]]
 ===== Example
-////
-Optional additional examples.
-DO NOT repeat the basic example used earlier.
-
 
 [source,console]
-----
-PUT /follower_index/_ccr/follow?wait_for_active_shards=1
+--------------------------------------------------
+PUT /api/apm/settings/agent-configuration
 {
-  "remote_cluster" : "remote_cluster",
-  "leader_index" : "leader_index",
-  "max_read_request_operation_count" : 1024,
-  "max_outstanding_read_requests" : 16,
-  "max_read_request_size" : "1024k",
-  "max_write_request_operation_count" : 32768,
-  "max_write_request_size" : "16k",
-  "max_outstanding_write_requests" : 8,
-  "max_write_buffer_count" : 512,
-  "max_write_buffer_size" : "512k",
-  "max_retry_delay" : "10s",
-  "read_poll_timeout" : "30s"
+    "agent_name": "nodejs"
+    "service" : {
+        "name" : "frontend",
+        "environment" : "production"
+    },
+    "settings" : {
+        "transaction_sample_rate" : 0.4,
+        "capture_body" : "off",
+        "transaction_max_spans" : 500
+    }
 }
-----
-// TEST[setup:remote_cluster_and_leader_index]
-
-The API returns the following result:
-
-[source,console-result]
-----
-{
-  "follow_index_created" : true,
-  "follow_index_shards_acked" : true,
-  "index_following_started" : true
-}
-----
-////
+--------------------------------------------------
 
 ////
 *******************************************************
@@ -199,65 +84,41 @@ The API returns the following result:
 [[apm-delete-config]]
 ==== Delete configuration
 
+[source,console]
+--------------------------------------------------
+POST  /api/apm/settings/agent-configuration
+--------------------------------------------------
+
 [[apm-delete-config-req]]
 ===== Request
 
-`DELETE /api/apm/settings/agent-configuration/{configurationId}`
+`DELETE /api/apm/settings/agent-configuration`
 
-[[apm-delete-config-pre]]
-===== Prerequisites
-
-[[apm-delete-config-params]]
-===== Parameters
-
-[[apm-delete-config-query]]
-===== Query parameters
 
 [[apm-delete-config-req-body]]
 ===== Request body
 
+
+`service`::
+(required) Service object containing `name` and `environment` on the configuration that should be deleted.
+
 [[apm-delete-config-body]]
 ===== Response body
 
-[[apm-delete-config-codes]]
-===== Response code
 
 [[apm-delete-config-example]]
 ===== Example
 
-////
-*******************************************************
-////
-
-
-[[apm-update-config]]
-==== Update configuration
-
-[[apm-update-config-req]]
-===== Request
-
-`PUT /api/apm/settings/agent-configuration/{configurationId}`
-
-[[apm-update-config-pre]]
-===== Prerequisites
-
-[[apm-update-config-params]]
-===== Parameters
-
-[[apm-update-config-query]]
-===== Query parameters
-
-[[apm-update-config-req-body]]
-===== Request body
-
-[[apm-update-config-body]]
-===== Response body
-
-[[apm-update-config-codes]]
-===== Response code
-
-[[apm-update-config-example]]
-===== Example
+[source,console]
+--------------------------------------------------
+DELETE /api/apm/settings/agent-configuration
+{
+    "service" : {
+        "name" : "frontend",
+        "environment": "production"
+    }
+}
+--------------------------------------------------
 
 ////
 *******************************************************
@@ -267,31 +128,64 @@ The API returns the following result:
 [[apm-list-config]]
 ==== List configuration
 
+[source,console]
+--------------------------------------------------
+GET  /api/apm/settings/agent-configuration
+--------------------------------------------------
+
 [[apm-list-config-req]]
 ===== Request
 
 `GET /api/apm/settings/agent-configuration`
 
-[[apm-list-config-pre]]
-===== Prerequisites
-
-[[apm-list-config-params]]
-===== Parameters
-
-[[apm-list-config-query]]
-===== Query parameters
-
-[[apm-list-config-req-body]]
-===== Request body
-
 [[apm-list-config-body]]
 ===== Response body
 
-[[apm-list-config-codes]]
-===== Response code
-
-[[apm-list-config-example]]
-===== Example
+```
+[
+  {
+    "agent_name": "go",
+    "service": {
+      "name": "opbeans-go",
+      "environment": "production"
+    },
+    "settings": {
+      "transaction_sample_rate": 1,
+      "capture_body": "off",
+      "transaction_max_spans": 200
+    },
+    "@timestamp": 1581934104843,
+    "applied_by_agent": false,
+    "etag": "1e58c178efeebae15c25c539da740d21dee422fc"
+  },
+  {
+    "agent_name": "go",
+    "service": {
+      "name": "opbeans-go"
+    },
+    "settings": {
+      "transaction_sample_rate": 1,
+      "capture_body": "off",
+      "transaction_max_spans": 300
+    },
+    "@timestamp": 1581934111727,
+    "applied_by_agent": false,
+    "etag": "3eed916d3db434d9fb7f039daa681c7a04539a64"
+  },
+  {
+    "agent_name": "nodejs",
+    "service": {
+      "name": "frontend"
+    },
+    "settings": {
+      "transaction_sample_rate": 1,
+    },
+    "@timestamp": 1582031336265,
+    "applied_by_agent": false,
+    "etag": "5080ed25785b7b19f32713681e79f46996801a5b"
+  }
+]
+```
 
 ////
 *******************************************************
@@ -306,26 +200,52 @@ The API returns the following result:
 
 `POST /api/apm/settings/agent-configuration/search`
 
-[[apm-search-config-pre]]
-===== Prerequisites
-
-[[apm-search-config-params]]
-===== Parameters
-
-[[apm-search-config-query]]
-===== Query parameters
-
 [[apm-search-config-req-body]]
 ===== Request body
+
+`service`::
+(required) Service object containing `name` and `environment` on the configuration that should be deleted.
+
+`etag`::
+(required) etag is sent by the agent to indicate the etag of the last successfully applied configuration. If the etag matches an existing configuration its `applied_by_agent` property will be set to `true`. Every time a configuration is edited `applied_by_agent` is reset to `false`.
 
 [[apm-search-config-body]]
 ===== Response body
 
-[[apm-search-config-codes]]
-===== Response code
+```
+{
+  "_index": ".apm-agent-configuration",
+  "_id": "CIaqXXABmQCdPphWj8EJ",
+  "_score": 2,
+  "_source": {
+    "agent_name": "nodejs",
+    "service": {
+      "name": "frontend"
+    },
+    "settings": {
+      "transaction_sample_rate": 1,
+    },
+    "@timestamp": 1582031336265,
+    "applied_by_agent": false,
+    "etag": "5080ed25785b7b19f32713681e79f46996801a5b"
+  }
+}
+```
 
 [[apm-search-config-example]]
 ===== Example
+
+[source,console]
+--------------------------------------------------
+POST /api/apm/settings/agent-configuration/search
+{
+    "etag" : "1e58c178efeebae15c25c539da740d21dee422fc",
+    "service" : {
+        "name" : "frontend",
+        "environment": "production"
+    }
+}
+--------------------------------------------------
 
 ////
 *******************************************************

--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -33,16 +33,22 @@ The following Agent configuration APIs are available:
 [[apm-update-config]]
 ==== Create or update configuration
 
-[source,console]
---------------------------------------------------
-PUT /api/apm/settings/agent-configuration
---------------------------------------------------
+[[apm-update-config-req]]
+===== Request
+
+`PUT /api/apm/settings/agent-configuration`
 
 [[apm-update-config-req-body]]
 ===== Request body
 
 `service`::
-(required) Service object containing `name` and `environment` on the configuration that should be deleted.
+(required, object) Service identifying the configuration to create or update.
+
+`name` :::
+  (required, string) Name of service
+
+`environment` :::
+  (optional, string) Environment of service
 
 `settings`::
 (required) Key/value object with settings and their corresponding value.
@@ -81,20 +87,21 @@ PUT /api/apm/settings/agent-configuration
 [[apm-delete-config]]
 ==== Delete configuration
 
-[source,console]
---------------------------------------------------
-DELETE /api/apm/settings/agent-configuration
---------------------------------------------------
+[[apm-delete-config-req]]
+===== Request
+
+`DELETE /api/apm/settings/agent-configuration`
 
 [[apm-delete-config-req-body]]
 ===== Request body
-
-
 `service`::
-(required) Service object containing `name` and `environment` on the configuration that should be deleted.
+(required, object) Service identifying the configuration to delete
 
-[[apm-delete-config-body]]
-===== Response body
+`name` :::
+  (required, string) Name of service
+
+`environment` :::
+  (optional, string) Environment of service
 
 
 [[apm-delete-config-example]]
@@ -119,10 +126,11 @@ DELETE /api/apm/settings/agent-configuration
 [[apm-list-config]]
 ==== List configuration
 
-[source,console]
---------------------------------------------------
-GET  /api/apm/settings/agent-configuration
---------------------------------------------------
+
+[[apm-list-config-req]]
+===== Request
+
+`GET  /api/apm/settings/agent-configuration`
 
 [[apm-list-config-body]]
 ===== Response body
@@ -175,6 +183,14 @@ GET  /api/apm/settings/agent-configuration
 ]
 --------------------------------------------------
 
+[[apm-list-config-example]]
+===== Example
+
+[source,console]
+--------------------------------------------------
+GET  /api/apm/settings/agent-configuration
+--------------------------------------------------
+
 ////
 *******************************************************
 ////
@@ -192,7 +208,13 @@ GET  /api/apm/settings/agent-configuration
 ===== Request body
 
 `service`::
-(required) Service object containing `name` and `environment` on the configuration that should be deleted.
+(required, object) Service identifying the configuration.
+
+`name` :::
+  (required, string) Name of service
+
+`environment` :::
+  (optional, string) Environment of service
 
 `etag`::
 (required) etag is sent by the agent to indicate the etag of the last successfully applied configuration. If the etag matches an existing configuration its `applied_by_agent` property will be set to `true`. Every time a configuration is edited `applied_by_agent` is reset to `false`.

--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -1,0 +1,332 @@
+[role="xpack"]
+[[apm-api]]
+== API
+
+Some APM app features are provided via a REST API:
+
+* <<agent-config-api>>
+
+TIP: Kibana provides additional <<api,REST APIs>>,
+and general information on <<using-api,how to use APIs>>.
+
+////
+*******************************************************
+////
+
+[[agent-config-api]]
+=== Agent Configuration API
+
+The Agent configuration API allows you to fine-tune your APM agent configuration,
+without needing to redeploy your application.
+
+[source,console]
+--------------------------------------------------
+POST  /api/apm/settings/agent-configuration/new
+--------------------------------------------------
+
+The following Agent configuration APIs are available:
+
+* <<apm-create-config>> to create a new Agent configuration.
+* <<apm-delete-config>> to delete an Agent configuration.
+* <<apm-update-config>> to update a preexisting Agent configuration.
+* <<apm-list-config>> to list all Agent configurations.
+* <<apm-search-config>> to search for an Agent configuration.
+
+////
+*******************************************************
+////
+
+
+[[apm-create-config]]
+==== Create configuration
+
+////
+Add a description.
+Link to related APIs if appropriate.
+
+Guidelines for parameter documentation
+***************************************
+* Use a definition list.
+* End each definition with a period.
+* Include whether the parameter is Optional or Required and the data type.
+* Include default values as the last sentence of the first paragraph.
+* Include a range of valid values, if applicable.
+* If the parameter requires a specific delimiter for multiple values, say so.
+* If the parameter supports wildcards, ditto.
+* For large or nested objects, consider linking to a separate definition list.
+***************************************
+////
+
+[[apm-create-config-req]]
+===== Request
+////
+This section show the basic endpoint, without the body or optional parameters.
+Variables should use <...> syntax.
+If an API supports both PUT and POST, include both here.
+////
+
+`POST /api/apm/settings/agent-configuration/new`
+
+[[apm-create-config-pre]]
+===== Prerequisites
+////
+Optional list of prerequisites.
+
+For example:
+
+* A snapshot of an index created in 5.x can be restored to 6.x. You must...
+* If the {es} {security-features} are enabled, you must have `write`, `monitor`,
+and `manage_follow_index` index privileges...
+////
+
+[[apm-create-config-params]]
+===== Parameters
+////
+A list of all the parameters within the path of the endpoint (before the query string (?)).
+
+For example:
+`<follower_index>`::
+(Required, string) Name of the follower index
+////
+
+
+[[apm-create-config-query]]
+===== Query parameters
+////
+A list of the parameters in the query string of the endpoint (after the ?).
+
+For example:
+`wait_for_active_shards`::
+(Optional, integer) Specifies the number of shards to wait on being active before
+responding. A shard must be restored from the leader index being active.
+Restoring a follower shard requires transferring all the remote Lucene segment
+files to the follower index. The default is `0`, which means waiting on none of
+the shards to be active.
+////
+
+
+[[apm-create-config-req-body]]
+===== Request body
+////
+A list of the properties you can specify in the body of the request.
+
+For example:
+`remote_cluster`::
+(Required, string) The <<modules-remote-clusters,remote cluster>> that contains
+the leader index.
+
+`leader_index`::
+(Required, string) The name of the index in the leader cluster to follow.
+////
+
+
+[[apm-create-config-body]]
+===== Response body
+////
+Response body is only required for detailed responses.
+
+For example:
+`auto_follow_stats`::
+  (object) An object representing stats for the auto-follow coordinator. This
+  object consists of the following fields:
+
+`auto_follow_stats.number_of_successful_follow_indices`:::
+  (long) the number of indices that the auto-follow coordinator successfully
+  followed
+...
+
+////
+
+
+[[apm-create-config-codes]]
+===== Response code
+////
+Response codes are only required when needed to understand the response body.
+
+For example:
+`200`::
+Indicates all listed indices or index aliases exist.
+
+ `404`::
+Indicates one or more listed indices or index aliases **do not** exist.
+////
+
+
+[[apm-create-config-example]]
+===== Example
+////
+Optional additional examples.
+DO NOT repeat the basic example used earlier.
+
+
+[source,console]
+----
+PUT /follower_index/_ccr/follow?wait_for_active_shards=1
+{
+  "remote_cluster" : "remote_cluster",
+  "leader_index" : "leader_index",
+  "max_read_request_operation_count" : 1024,
+  "max_outstanding_read_requests" : 16,
+  "max_read_request_size" : "1024k",
+  "max_write_request_operation_count" : 32768,
+  "max_write_request_size" : "16k",
+  "max_outstanding_write_requests" : 8,
+  "max_write_buffer_count" : 512,
+  "max_write_buffer_size" : "512k",
+  "max_retry_delay" : "10s",
+  "read_poll_timeout" : "30s"
+}
+----
+// TEST[setup:remote_cluster_and_leader_index]
+
+The API returns the following result:
+
+[source,console-result]
+----
+{
+  "follow_index_created" : true,
+  "follow_index_shards_acked" : true,
+  "index_following_started" : true
+}
+----
+////
+
+////
+*******************************************************
+////
+
+
+[[apm-delete-config]]
+==== Delete configuration
+
+[[apm-delete-config-req]]
+===== Request
+
+`DELETE /api/apm/settings/agent-configuration/{configurationId}`
+
+[[apm-delete-config-pre]]
+===== Prerequisites
+
+[[apm-delete-config-params]]
+===== Parameters
+
+[[apm-delete-config-query]]
+===== Query parameters
+
+[[apm-delete-config-req-body]]
+===== Request body
+
+[[apm-delete-config-body]]
+===== Response body
+
+[[apm-delete-config-codes]]
+===== Response code
+
+[[apm-delete-config-example]]
+===== Example
+
+////
+*******************************************************
+////
+
+
+[[apm-update-config]]
+==== Update configuration
+
+[[apm-update-config-req]]
+===== Request
+
+`PUT /api/apm/settings/agent-configuration/{configurationId}`
+
+[[apm-update-config-pre]]
+===== Prerequisites
+
+[[apm-update-config-params]]
+===== Parameters
+
+[[apm-update-config-query]]
+===== Query parameters
+
+[[apm-update-config-req-body]]
+===== Request body
+
+[[apm-update-config-body]]
+===== Response body
+
+[[apm-update-config-codes]]
+===== Response code
+
+[[apm-update-config-example]]
+===== Example
+
+////
+*******************************************************
+////
+
+
+[[apm-list-config]]
+==== List configuration
+
+[[apm-list-config-req]]
+===== Request
+
+`GET /api/apm/settings/agent-configuration`
+
+[[apm-list-config-pre]]
+===== Prerequisites
+
+[[apm-list-config-params]]
+===== Parameters
+
+[[apm-list-config-query]]
+===== Query parameters
+
+[[apm-list-config-req-body]]
+===== Request body
+
+[[apm-list-config-body]]
+===== Response body
+
+[[apm-list-config-codes]]
+===== Response code
+
+[[apm-list-config-example]]
+===== Example
+
+////
+*******************************************************
+////
+
+
+[[apm-search-config]]
+==== Search configuration
+
+[[apm-search-config-req]]
+===== Request
+
+`POST /api/apm/settings/agent-configuration/search`
+
+[[apm-search-config-pre]]
+===== Prerequisites
+
+[[apm-search-config-params]]
+===== Parameters
+
+[[apm-search-config-query]]
+===== Query parameters
+
+[[apm-search-config-req-body]]
+===== Request body
+
+[[apm-search-config-body]]
+===== Response body
+
+[[apm-search-config-codes]]
+===== Response code
+
+[[apm-search-config-example]]
+===== Example
+
+////
+*******************************************************
+////

--- a/docs/apm/index.asciidoc
+++ b/docs/apm/index.asciidoc
@@ -24,3 +24,5 @@ include::getting-started.asciidoc[]
 include::bottlenecks.asciidoc[]
 
 include::using-the-apm-ui.asciidoc[]
+
+include::api.asciidoc[]

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/DeleteButton.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/DeleteButton.tsx
@@ -51,12 +51,18 @@ async function deleteConfig(
 ) {
   try {
     await callApmApi({
-      pathname: '/api/apm/settings/agent-configuration/{configurationId}',
+      pathname: '/api/apm/settings/agent-configuration',
       method: 'DELETE',
       params: {
-        path: { configurationId: selectedConfig.id }
+        body: {
+          service: {
+            name: selectedConfig.service.name,
+            environment: selectedConfig.service.environment
+          }
+        }
       }
     });
+
     toasts.addSuccess({
       title: i18n.translate(
         'xpack.apm.settings.agentConf.flyout.deleteSection.deleteConfigSucceededTitle',

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/index.tsx
@@ -136,7 +136,7 @@ export function AddEditFlyout({
       captureBody,
       transactionMaxSpans,
       agentName,
-      existingConfig: Boolean(selectedConfig),
+      isExistingConfig: Boolean(selectedConfig),
       toasts,
       trackApmEvent
     });

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/index.tsx
@@ -135,8 +135,8 @@ export function AddEditFlyout({
       sampleRate,
       captureBody,
       transactionMaxSpans,
-      configurationId: selectedConfig ? selectedConfig.id : undefined,
       agentName,
+      existingConfig: Boolean(selectedConfig),
       toasts,
       trackApmEvent
     });

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/saveConfig.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/saveConfig.ts
@@ -27,8 +27,8 @@ export async function saveConfig({
   sampleRate,
   captureBody,
   transactionMaxSpans,
-  configurationId,
   agentName,
+  existingConfig,
   toasts,
   trackApmEvent
 }: {
@@ -38,8 +38,8 @@ export async function saveConfig({
   sampleRate: string;
   captureBody: string;
   transactionMaxSpans: string;
-  configurationId?: string;
   agentName?: string;
+  existingConfig: boolean;
   toasts: NotificationsStart['toasts'];
   trackApmEvent: UiTracker;
 }) {
@@ -64,24 +64,14 @@ export async function saveConfig({
       settings
     };
 
-    if (configurationId) {
-      await callApmApi({
-        pathname: '/api/apm/settings/agent-configuration/{configurationId}',
-        method: 'PUT',
-        params: {
-          path: { configurationId },
-          body: configuration
-        }
-      });
-    } else {
-      await callApmApi({
-        pathname: '/api/apm/settings/agent-configuration/new',
-        method: 'POST',
-        params: {
-          body: configuration
-        }
-      });
-    }
+    await callApmApi({
+      pathname: '/api/apm/settings/agent-configuration',
+      method: 'PUT',
+      params: {
+        query: { overwrite: existingConfig },
+        body: configuration
+      }
+    });
 
     toasts.addSuccess({
       title: i18n.translate(

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/saveConfig.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AddEditFlyout/saveConfig.ts
@@ -28,7 +28,7 @@ export async function saveConfig({
   captureBody,
   transactionMaxSpans,
   agentName,
-  existingConfig,
+  isExistingConfig,
   toasts,
   trackApmEvent
 }: {
@@ -39,7 +39,7 @@ export async function saveConfig({
   captureBody: string;
   transactionMaxSpans: string;
   agentName?: string;
-  existingConfig: boolean;
+  isExistingConfig: boolean;
   toasts: NotificationsStart['toasts'];
   trackApmEvent: UiTracker;
 }) {
@@ -68,7 +68,7 @@ export async function saveConfig({
       pathname: '/api/apm/settings/agent-configuration',
       method: 'PUT',
       params: {
-        query: { overwrite: existingConfig },
+        query: { overwrite: isExistingConfig },
         body: configuration
       }
     });

--- a/x-pack/legacy/plugins/apm/readme.md
+++ b/x-pack/legacy/plugins/apm/readme.md
@@ -71,6 +71,28 @@ node scripts/jest.js plugins/apm --watch
 node scripts/jest.js plugins/apm --updateSnapshot
 ```
 
+### Functional tests
+
+**Start server**
+`node scripts/functional_tests_server --config x-pack/test/functional/config.js`
+
+**Run tests**
+`node scripts/functional_test_runner --config x-pack/test/functional/config.js --grep='APM specs'`
+
+APM tests are located in `x-pack/test/functional/apps/apm`.
+For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
+
+### API integration tests
+
+**Start server**
+`node scripts/functional_tests_server --config x-pack/test/api_integration/config.js`
+
+**Run tests**
+`node scripts/functional_test_runner --config x-pack/test/api_integration/config.js --grep='APM specs'`
+
+APM tests are located in `x-pack/test/api_integration/apis/apm`.
+For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
+
 ### Linting
 
 _Note: Run the following commands from `kibana/`._

--- a/x-pack/plugins/apm/common/runtime_types/agent_configuration_intake_rt/index.test.ts
+++ b/x-pack/plugins/apm/common/runtime_types/agent_configuration_intake_rt/index.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { agentConfigurationIntakeRt } from './index';
+import { isRight } from 'fp-ts/lib/Either';
+
+describe('agentConfigurationIntakeRt', () => {
+  it('is valid when required parameters are given', () => {
+    const config = {
+      service: {},
+      settings: {}
+    };
+
+    expect(isConfigValid(config)).toBe(true);
+  });
+
+  it('is valid when required and optional parameters are given', () => {
+    const config = {
+      service: { name: 'my-service', environment: 'my-environment' },
+      settings: {
+        transaction_sample_rate: 0.5,
+        capture_body: 'foo',
+        transaction_max_spans: 10
+      }
+    };
+
+    expect(isConfigValid(config)).toBe(true);
+  });
+
+  it('is invalid when required parameters are not given', () => {
+    const config = {};
+    expect(isConfigValid(config)).toBe(false);
+  });
+});
+
+function isConfigValid(config: any) {
+  return isRight(agentConfigurationIntakeRt.decode(config));
+}

--- a/x-pack/plugins/apm/common/runtime_types/agent_configuration_intake_rt/index.ts
+++ b/x-pack/plugins/apm/common/runtime_types/agent_configuration_intake_rt/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as t from 'io-ts';
+import { transactionSampleRateRt } from '../transaction_sample_rate_rt';
+import { transactionMaxSpansRt } from '../transaction_max_spans_rt';
+
+export const serviceRt = t.partial({
+  name: t.string,
+  environment: t.string
+});
+
+export const agentConfigurationIntakeRt = t.intersection([
+  t.partial({ agent_name: t.string }),
+  t.type({
+    service: serviceRt,
+    settings: t.partial({
+      transaction_sample_rate: transactionSampleRateRt,
+      capture_body: t.string,
+      transaction_max_spans: transactionMaxSpansRt
+    })
+  })
+]);

--- a/x-pack/plugins/apm/server/lib/helpers/es_client.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/es_client.ts
@@ -7,9 +7,10 @@
 /* eslint-disable no-console */
 import {
   IndexDocumentParams,
-  IndicesCreateParams,
   IndicesDeleteParams,
-  SearchParams
+  SearchParams,
+  IndicesCreateParams,
+  DeleteDocumentResponse
 } from 'elasticsearch';
 import { cloneDeep, isString, merge, uniqueId } from 'lodash';
 import { KibanaRequest } from 'src/core/server';
@@ -188,7 +189,7 @@ export function getESClient(
     index: <Body>(params: APMIndexDocumentParams<Body>) => {
       return withTime(() => callMethod('index', params));
     },
-    delete: (params: IndicesDeleteParams) => {
+    delete: (params: IndicesDeleteParams): Promise<DeleteDocumentResponse> => {
       return withTime(() => callMethod('delete', params));
     },
     indicesCreate: (params: IndicesCreateParams) => {

--- a/x-pack/plugins/apm/server/lib/services/get_service_node_metadata.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_node_metadata.ts
@@ -58,8 +58,8 @@ export async function getServiceNodeMetadata({
   const response = await client.search(query);
 
   return {
-    host: response.aggregations?.host.buckets[0].key || NOT_AVAILABLE_LABEL,
+    host: response.aggregations?.host.buckets[0]?.key || NOT_AVAILABLE_LABEL,
     containerId:
-      response.aggregations?.containerId.buckets[0].key || NOT_AVAILABLE_LABEL
+      response.aggregations?.containerId.buckets[0]?.key || NOT_AVAILABLE_LABEL
   };
 }

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/__snapshots__/queries.test.ts.snap
@@ -1,6 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`agent configuration queries fetches all environments 1`] = `
+exports[`agent configuration queries findExactConfiguration find configuration by service.environment 1`] = `
+Object {
+  "body": Object {
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "bar",
+            },
+          },
+        ],
+      },
+    },
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`agent configuration queries findExactConfiguration find configuration by service.name 1`] = `
+Object {
+  "body": Object {
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.environment",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`agent configuration queries findExactConfiguration find configuration by service.name and service.environment 1`] = `
+Object {
+  "body": Object {
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "service.environment": "bar",
+            },
+          },
+        ],
+      },
+    },
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`agent configuration queries getAllEnvironments fetches all environments 1`] = `
 Object {
   "body": Object {
     "aggs": Object {
@@ -41,124 +125,36 @@ Object {
 }
 `;
 
-exports[`agent configuration queries fetches configurations 1`] = `
-Object {
-  "index": "myIndex",
-  "size": 200,
-}
-`;
-
-exports[`agent configuration queries fetches filtered configurations with an environment 1`] = `
+exports[`agent configuration queries getExistingEnvironmentsForService fetches unavailable environments 1`] = `
 Object {
   "body": Object {
+    "aggs": Object {
+      "environments": Object {
+        "terms": Object {
+          "field": "service.environment",
+          "missing": "ALL_OPTION_VALUE",
+          "size": 50,
+        },
+      },
+    },
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 2,
-        "should": Array [
+        "filter": Array [
           Object {
-            "constant_score": Object {
-              "boost": 2,
-              "filter": Object {
-                "term": Object {
-                  "service.name": Object {
-                    "value": "foo",
-                  },
-                },
-              },
-            },
-          },
-          Object {
-            "constant_score": Object {
-              "boost": 1,
-              "filter": Object {
-                "term": Object {
-                  "service.environment": Object {
-                    "value": "bar",
-                  },
-                },
-              },
-            },
-          },
-          Object {
-            "bool": Object {
-              "must_not": Array [
-                Object {
-                  "exists": Object {
-                    "field": "service.name",
-                  },
-                },
-              ],
-            },
-          },
-          Object {
-            "bool": Object {
-              "must_not": Array [
-                Object {
-                  "exists": Object {
-                    "field": "service.environment",
-                  },
-                },
-              ],
+            "term": Object {
+              "service.name": "foo",
             },
           },
         ],
       },
     },
+    "size": 0,
   },
   "index": "myIndex",
 }
 `;
 
-exports[`agent configuration queries fetches filtered configurations without an environment 1`] = `
-Object {
-  "body": Object {
-    "query": Object {
-      "bool": Object {
-        "minimum_should_match": 2,
-        "should": Array [
-          Object {
-            "constant_score": Object {
-              "boost": 2,
-              "filter": Object {
-                "term": Object {
-                  "service.name": Object {
-                    "value": "foo",
-                  },
-                },
-              },
-            },
-          },
-          Object {
-            "bool": Object {
-              "must_not": Array [
-                Object {
-                  "exists": Object {
-                    "field": "service.name",
-                  },
-                },
-              ],
-            },
-          },
-          Object {
-            "bool": Object {
-              "must_not": Array [
-                Object {
-                  "exists": Object {
-                    "field": "service.environment",
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  },
-  "index": "myIndex",
-}
-`;
-
-exports[`agent configuration queries fetches service names 1`] = `
+exports[`agent configuration queries getServiceNames fetches service names 1`] = `
 Object {
   "body": Object {
     "aggs": Object {
@@ -194,30 +190,112 @@ Object {
 }
 `;
 
-exports[`agent configuration queries fetches unavailable environments 1`] = `
+exports[`agent configuration queries listConfigurations fetches configurations 1`] = `
+Object {
+  "index": "myIndex",
+  "size": 200,
+}
+`;
+
+exports[`agent configuration queries searchConfigurations fetches filtered configurations with an environment 1`] = `
 Object {
   "body": Object {
-    "aggs": Object {
-      "environments": Object {
-        "terms": Object {
-          "field": "service.environment",
-          "missing": "ALL_OPTION_VALUE",
-          "size": 50,
-        },
-      },
-    },
     "query": Object {
       "bool": Object {
-        "filter": Array [
+        "minimum_should_match": 2,
+        "should": Array [
           Object {
-            "term": Object {
-              "service.name": "foo",
+            "constant_score": Object {
+              "boost": 2,
+              "filter": Object {
+                "term": Object {
+                  "service.name": "foo",
+                },
+              },
+            },
+          },
+          Object {
+            "constant_score": Object {
+              "boost": 1,
+              "filter": Object {
+                "term": Object {
+                  "service.environment": "bar",
+                },
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.environment",
+                  },
+                },
+              ],
             },
           },
         ],
       },
     },
-    "size": 0,
+  },
+  "index": "myIndex",
+}
+`;
+
+exports[`agent configuration queries searchConfigurations fetches filtered configurations without an environment 1`] = `
+Object {
+  "body": Object {
+    "query": Object {
+      "bool": Object {
+        "minimum_should_match": 2,
+        "should": Array [
+          Object {
+            "constant_score": Object {
+              "boost": 2,
+              "filter": Object {
+                "term": Object {
+                  "service.name": "foo",
+                },
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.name",
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "bool": Object {
+              "must_not": Array [
+                Object {
+                  "exists": Object {
+                    "field": "service.environment",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
   },
   "index": "myIndex",
 }

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/configuration_types.d.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/configuration_types.d.ts
@@ -4,18 +4,15 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export interface AgentConfiguration {
+import t from 'io-ts';
+import { agentConfigurationIntakeRt } from '../../../../common/runtime_types/agent_configuration_intake_rt';
+
+export type AgentConfigurationIntake = t.TypeOf<
+  typeof agentConfigurationIntakeRt
+>;
+export type AgentConfiguration = {
   '@timestamp': number;
   applied_by_agent?: boolean;
   etag?: string;
   agent_name?: string;
-  service: {
-    name?: string;
-    environment?: string;
-  };
-  settings: {
-    transaction_sample_rate?: number;
-    capture_body?: string;
-    transaction_max_spans?: number;
-  };
-}
+} & AgentConfigurationIntake;

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/create_or_update_configuration.ts
@@ -6,19 +6,19 @@
 
 import hash from 'object-hash';
 import { Setup } from '../../helpers/setup_request';
-import { AgentConfiguration } from './configuration_types';
+import {
+  AgentConfiguration,
+  AgentConfigurationIntake
+} from './configuration_types';
 import { APMIndexDocumentParams } from '../../helpers/es_client';
 
 export async function createOrUpdateConfiguration({
   configurationId,
-  configuration,
+  configurationIntake,
   setup
 }: {
   configurationId?: string;
-  configuration: Omit<
-    AgentConfiguration,
-    '@timestamp' | 'applied_by_agent' | 'etag'
-  >;
+  configurationIntake: AgentConfigurationIntake;
   setup: Setup;
 }) {
   const { internalClient, indices } = setup;
@@ -27,15 +27,15 @@ export async function createOrUpdateConfiguration({
     refresh: true,
     index: indices.apmAgentConfigurationIndex,
     body: {
-      agent_name: configuration.agent_name,
+      agent_name: configurationIntake.agent_name,
       service: {
-        name: configuration.service.name,
-        environment: configuration.service.environment
+        name: configurationIntake.service.name,
+        environment: configurationIntake.service.environment
       },
-      settings: configuration.settings,
+      settings: configurationIntake.settings,
       '@timestamp': Date.now(),
       applied_by_agent: false,
-      etag: hash(configuration)
+      etag: hash(configurationIntake)
     }
   };
 

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/find_exact_configuration.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/find_exact_configuration.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  SERVICE_NAME,
+  SERVICE_ENVIRONMENT
+} from '../../../../common/elasticsearch_fieldnames';
+import { Setup } from '../../helpers/setup_request';
+import { AgentConfiguration } from './configuration_types';
+import { ESSearchHit } from '../../../../typings/elasticsearch';
+
+export async function findExactConfiguration({
+  service,
+  setup
+}: {
+  service: AgentConfiguration['service'];
+  setup: Setup;
+}) {
+  const { internalClient, indices } = setup;
+
+  const serviceNameFilter = service.name
+    ? { term: { [SERVICE_NAME]: service.name } }
+    : { bool: { must_not: [{ exists: { field: SERVICE_NAME } }] } };
+
+  const environmentFilter = service.environment
+    ? { term: { [SERVICE_ENVIRONMENT]: service.environment } }
+    : { bool: { must_not: [{ exists: { field: SERVICE_ENVIRONMENT } }] } };
+
+  const params = {
+    index: indices.apmAgentConfigurationIndex,
+    body: {
+      query: {
+        bool: { filter: [serviceNameFilter, environmentFilter] }
+      }
+    }
+  };
+
+  const resp = await internalClient.search<AgentConfiguration, typeof params>(
+    params
+  );
+
+  return resp.hits.hits[0] as ESSearchHit<AgentConfiguration> | undefined;
+}

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
@@ -51,5 +51,5 @@ export async function getAgentNameByService({
   const agentName = aggregations?.agent_names.buckets[0].key as
     | string
     | undefined;
-  return { agentName };
+  return agentName;
 }

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_agent_name_by_service.ts
@@ -48,8 +48,6 @@ export async function getAgentNameByService({
   };
 
   const { aggregations } = await client.search(params);
-  const agentName = aggregations?.agent_names.buckets[0].key as
-    | string
-    | undefined;
-  return agentName;
+  const agentName = aggregations?.agent_names.buckets[0]?.key;
+  return agentName as string | undefined;
 }

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/queries.test.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/queries.test.ts
@@ -8,11 +8,12 @@ import { getAllEnvironments } from './get_environments/get_all_environments';
 import { getExistingEnvironmentsForService } from './get_environments/get_existing_environments_for_service';
 import { getServiceNames } from './get_service_names';
 import { listConfigurations } from './list_configurations';
-import { searchConfigurations } from './search';
+import { searchConfigurations } from './search_configurations';
 import {
   SearchParamsMock,
   inspectSearchParams
 } from '../../../../../../legacy/plugins/apm/public/utils/testHelpers';
+import { findExactConfiguration } from './find_exact_configuration';
 
 describe('agent configuration queries', () => {
   let mock: SearchParamsMock;
@@ -21,68 +22,117 @@ describe('agent configuration queries', () => {
     mock.teardown();
   });
 
-  it('fetches all environments', async () => {
-    mock = await inspectSearchParams(setup =>
-      getAllEnvironments({
-        serviceName: 'foo',
-        setup
-      })
-    );
+  describe('getAllEnvironments', () => {
+    it('fetches all environments', async () => {
+      mock = await inspectSearchParams(setup =>
+        getAllEnvironments({
+          serviceName: 'foo',
+          setup
+        })
+      );
 
-    expect(mock.params).toMatchSnapshot();
+      expect(mock.params).toMatchSnapshot();
+    });
   });
 
-  it('fetches unavailable environments', async () => {
-    mock = await inspectSearchParams(setup =>
-      getExistingEnvironmentsForService({
-        serviceName: 'foo',
-        setup
-      })
-    );
+  describe('getExistingEnvironmentsForService', () => {
+    it('fetches unavailable environments', async () => {
+      mock = await inspectSearchParams(setup =>
+        getExistingEnvironmentsForService({
+          serviceName: 'foo',
+          setup
+        })
+      );
 
-    expect(mock.params).toMatchSnapshot();
+      expect(mock.params).toMatchSnapshot();
+    });
   });
 
-  it('fetches service names', async () => {
-    mock = await inspectSearchParams(setup =>
-      getServiceNames({
-        setup
-      })
-    );
+  describe('getServiceNames', () => {
+    it('fetches service names', async () => {
+      mock = await inspectSearchParams(setup =>
+        getServiceNames({
+          setup
+        })
+      );
 
-    expect(mock.params).toMatchSnapshot();
+      expect(mock.params).toMatchSnapshot();
+    });
   });
 
-  it('fetches configurations', async () => {
-    mock = await inspectSearchParams(setup =>
-      listConfigurations({
-        setup
-      })
-    );
+  describe('listConfigurations', () => {
+    it('fetches configurations', async () => {
+      mock = await inspectSearchParams(setup =>
+        listConfigurations({
+          setup
+        })
+      );
 
-    expect(mock.params).toMatchSnapshot();
+      expect(mock.params).toMatchSnapshot();
+    });
   });
 
-  it('fetches filtered configurations without an environment', async () => {
-    mock = await inspectSearchParams(setup =>
-      searchConfigurations({
-        serviceName: 'foo',
-        setup
-      })
-    );
+  describe('searchConfigurations', () => {
+    it('fetches filtered configurations without an environment', async () => {
+      mock = await inspectSearchParams(setup =>
+        searchConfigurations({
+          service: {
+            name: 'foo'
+          },
+          setup
+        })
+      );
 
-    expect(mock.params).toMatchSnapshot();
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('fetches filtered configurations with an environment', async () => {
+      mock = await inspectSearchParams(setup =>
+        searchConfigurations({
+          service: {
+            name: 'foo',
+            environment: 'bar'
+          },
+          setup
+        })
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
   });
 
-  it('fetches filtered configurations with an environment', async () => {
-    mock = await inspectSearchParams(setup =>
-      searchConfigurations({
-        serviceName: 'foo',
-        environment: 'bar',
-        setup
-      })
-    );
+  describe('findExactConfiguration', () => {
+    it('find configuration by service.name', async () => {
+      mock = await inspectSearchParams(setup =>
+        findExactConfiguration({
+          service: { name: 'foo' },
+          setup
+        })
+      );
 
-    expect(mock.params).toMatchSnapshot();
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('find configuration by service.environment', async () => {
+      mock = await inspectSearchParams(setup =>
+        findExactConfiguration({
+          service: { environment: 'bar' },
+          setup
+        })
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
+
+    it('find configuration by service.name and service.environment', async () => {
+      mock = await inspectSearchParams(setup =>
+        findExactConfiguration({
+          service: { name: 'foo', environment: 'bar' },
+          setup
+        })
+      );
+
+      expect(mock.params).toMatchSnapshot();
+    });
   });
 });

--- a/x-pack/plugins/apm/server/routes/create_apm_api.ts
+++ b/x-pack/plugins/apm/server/routes/create_apm_api.ts
@@ -23,11 +23,10 @@ import {
 import {
   agentConfigurationRoute,
   agentConfigurationSearchRoute,
-  createAgentConfigurationRoute,
   deleteAgentConfigurationRoute,
   listAgentConfigurationEnvironmentsRoute,
   listAgentConfigurationServicesRoute,
-  updateAgentConfigurationRoute,
+  createOrUpdateAgentConfigurationRoute,
   agentConfigurationAgentNameRoute
 } from './settings/agent_configuration';
 import {
@@ -83,11 +82,10 @@ const createApmApi = () => {
     .add(agentConfigurationAgentNameRoute)
     .add(agentConfigurationRoute)
     .add(agentConfigurationSearchRoute)
-    .add(createAgentConfigurationRoute)
     .add(deleteAgentConfigurationRoute)
     .add(listAgentConfigurationEnvironmentsRoute)
     .add(listAgentConfigurationServicesRoute)
-    .add(updateAgentConfigurationRoute)
+    .add(createOrUpdateAgentConfigurationRoute)
 
     // APM indices
     .add(apmIndexSettingsRoute)

--- a/x-pack/test/api_integration/apis/apm/agent_configuration.ts
+++ b/x-pack/test/api_integration/apis/apm/agent_configuration.ts
@@ -19,38 +19,26 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
       .set('kbn-xsrf', 'foo');
   }
 
-  async function createConfiguration(config: any) {
+  async function createConfiguration(config: AgentConfigurationIntake) {
     log.debug('creating configuration', config.service);
     const res = await supertest
       .put(`/api/apm/settings/agent-configuration`)
       .send(config)
       .set('kbn-xsrf', 'foo');
 
-    if (res.statusCode !== 200) {
-      throw new Error(
-        `Could not create config ${JSON.stringify(config.service)}. Received statuscode ${
-          res.statusCode
-        } and message: ${JSON.stringify(res.body)}`
-      );
-    }
+    throwOnError(res);
 
     return res;
   }
 
-  async function updateConfiguration(config: any) {
+  async function updateConfiguration(config: AgentConfigurationIntake) {
     log.debug('updating configuration', config.service);
     const res = await supertest
       .put(`/api/apm/settings/agent-configuration?overwrite=true`)
       .send(config)
       .set('kbn-xsrf', 'foo');
 
-    if (res.statusCode !== 200) {
-      throw new Error(
-        `Could not update config ${JSON.stringify(config.service)}. Received statuscode ${
-          res.statusCode
-        } and message: ${JSON.stringify(res.body)}`
-      );
-    }
+    throwOnError(res);
 
     return res;
   }
@@ -62,15 +50,20 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
       .send({ service })
       .set('kbn-xsrf', 'foo');
 
-    if (res.statusCode !== 200) {
-      throw new Error(
-        `Could not delete config ${JSON.stringify(service)}. Received statuscode ${
-          res.statusCode
-        } and message: ${JSON.stringify(res.body)}`
-      );
-    }
+    throwOnError(res);
 
     return res;
+  }
+
+  function throwOnError(res: any) {
+    const { statusCode, req, body } = res;
+    if (statusCode !== 200) {
+      throw new Error(`
+      Endpoint: ${req.method} ${req.path}
+      Service: ${JSON.stringify(res.request._data.service)}
+      Status code: ${statusCode}
+      Response: ${body.message}`);
+    }
   }
 
   describe('agent configuration', () => {

--- a/x-pack/test/api_integration/apis/apm/agent_configuration.ts
+++ b/x-pack/test/api_integration/apis/apm/agent_configuration.ts
@@ -116,15 +116,15 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
           settings: { transaction_sample_rate: 0.2 },
         },
         {
-          service: { environment: 'production' },
+          service: { name: 'my_service', environment: 'development' },
           settings: { transaction_sample_rate: 0.3 },
         },
         {
-          service: { environment: 'development' },
+          service: { environment: 'production' },
           settings: { transaction_sample_rate: 0.4 },
         },
         {
-          service: { name: 'my_service', environment: 'development' },
+          service: { environment: 'development' },
           settings: { transaction_sample_rate: 0.5 },
         },
       ];
@@ -143,19 +143,23 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
           expectedSettings: { transaction_sample_rate: 0.1 },
         },
         {
+          service: { name: 'my_service', environment: 'non_existing_env' },
+          expectedSettings: { transaction_sample_rate: 0.2 },
+        },
+        {
           service: { name: 'my_service', environment: 'production' },
           expectedSettings: { transaction_sample_rate: 0.2 },
         },
         {
-          service: { name: 'non_existing_service', environment: 'production' },
+          service: { name: 'my_service', environment: 'development' },
           expectedSettings: { transaction_sample_rate: 0.3 },
         },
         {
-          service: { name: 'non_existing_service', environment: 'development' },
+          service: { name: 'non_existing_service', environment: 'production' },
           expectedSettings: { transaction_sample_rate: 0.4 },
         },
         {
-          service: { name: 'my_service', environment: 'development' },
+          service: { name: 'non_existing_service', environment: 'development' },
           expectedSettings: { transaction_sample_rate: 0.5 },
         },
       ];

--- a/x-pack/test/api_integration/apis/apm/feature_controls.ts
+++ b/x-pack/test/api_integration/apis/apm/feature_controls.ts
@@ -4,8 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-/* eslint-disable no-console */
-
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -15,6 +13,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
   const security = getService('security');
   const spaces = getService('spaces');
   const es = getService('legacyEs');
+  const log = getService('log');
 
   const start = encodeURIComponent(new Date(Date.now() - 10000).toISOString());
   const end = encodeURIComponent(new Date().toISOString());
@@ -147,7 +146,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
           index: '.apm-agent-configuration',
         });
 
-        console.warn(JSON.stringify(res, null, 2));
+        log.error(JSON.stringify(res, null, 2));
       },
     },
   ];
@@ -215,9 +214,9 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     spaceId?: string;
   }) {
     for (const endpoint of endpoints) {
-      console.log(`Requesting: ${endpoint.req.url}. Expecting: ${expectation}`);
+      log.info(`Requesting: ${endpoint.req.url}. Expecting: ${expectation}`);
       const result = await executeAsUser(endpoint.req, username, password, spaceId);
-      console.log(`Responded: ${endpoint.req.url}`);
+      log.info(`Responded: ${endpoint.req.url}`);
 
       try {
         if (expectation === 'forbidden') {
@@ -248,17 +247,17 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
       settings: { transaction_sample_rate: 0.5 },
     };
     before(async () => {
-      console.log(`Creating agent configuration`);
+      log.info(`Creating agent configuration`);
       await executeAsAdmin({
         method: 'put',
         url: '/api/apm/settings/agent-configuration',
         body: config,
       });
-      console.log(`Agent configuration created`);
+      log.info(`Agent configuration created`);
     });
 
     after(async () => {
-      console.log('deleting agent configuration');
+      log.info('deleting agent configuration');
       await executeAsAdmin({
         method: 'delete',
         url: `/api/apm/settings/agent-configuration`,

--- a/x-pack/test/api_integration/apis/apm/index.ts
+++ b/x-pack/test/api_integration/apis/apm/index.ts
@@ -7,7 +7,7 @@
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function apmApiIntegrationTests({ loadTestFile }: FtrProviderContext) {
-  describe('APM', () => {
+  describe('APM specs', () => {
     loadTestFile(require.resolve('./feature_controls'));
     loadTestFile(require.resolve('./agent_configuration'));
   });

--- a/x-pack/test/functional/apps/apm/index.ts
+++ b/x-pack/test/functional/apps/apm/index.ts
@@ -6,7 +6,7 @@
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function({ loadTestFile }: FtrProviderContext) {
-  describe('APM', function() {
+  describe('APM specs', function() {
     this.tags('ciGroup6');
     loadTestFile(require.resolve('./feature_controls'));
   });


### PR DESCRIPTION
Closes #57018
Closes #57005
Closes #57659

This PR contains:
 - Public docs for Agent Configuration API
 - Improvements to the Agent Configuration API
 - Improvements to the API tests of Agent Configuration

**Create and update APIs are merged** 
Previously a config was created with `POST '/api/apm/settings/agent-configuration/new'` and a config was updated with `PUT /api/apm/settings/agent-configuration/{configurationId}`.

Now both are handled with `PUT /api/apm/settings/agent-configuration`. 
It is possible to overwrite an existing configuration (determined by `service.name` / `service.environment`) by providing `?overwrite=true`. Without it a 400 error will be returned if a matching config already exists.

**Delete API modified**
Before: `DELETE /api/apm/settings/agent-configuration/{configurationId}`.
After: `DELETE /api/apm/settings/agent-configuration`

To specify a config, the request body must contain:
```json
{
  "service": "my-service",
  "environment": "my-environment"
}
```

**To setup the docs locally**

Clone docs repo as a sibling to kibana
```
git clone git@github.com:elastic/docs.git
```

Run from Kibana:
```
node scripts/docs.js --open
```

Docs can be accessed on http://localhost:8000/guide/agent-config-api.html

**Improvements of flaky tests**
I did some changes to the API tests that should make them more stable. Related issue: https://github.com/elastic/kibana/issues/51764