### PR TITLE
[Home] Fix missing registered features

### DIFF
--- a/src/legacy/core_plugins/kibana/public/home/kibana_services.ts
+++ b/src/legacy/core_plugins/kibana/public/home/kibana_services.ts
@@ -31,7 +31,7 @@ import { TelemetryPluginStart } from '../../../../../plugins/telemetry/public';
 import {
   Environment,
   HomePublicPluginSetup,
-  FeatureCatalogueEntry,
+  HomePublicPluginStart,
 } from '../../../../../plugins/home/public';
 import { KibanaLegacySetup } from '../../../../../plugins/kibana_legacy/public';
 
@@ -43,7 +43,7 @@ export interface HomeKibanaServices {
   uiSettings: IUiSettingsClient;
   config: KibanaLegacySetup['config'];
   homeConfig: HomePublicPluginSetup['config'];
-  directories: readonly FeatureCatalogueEntry[];
+  featureCatalogue: HomePublicPluginStart['featureCatalogue'];
   http: HttpStart;
   savedObjectsClient: SavedObjectsClientContract;
   toastNotifications: NotificationsSetup['toasts'];

--- a/src/legacy/core_plugins/kibana/public/home/np_ready/application.tsx
+++ b/src/legacy/core_plugins/kibana/public/home/np_ready/application.tsx
@@ -26,7 +26,11 @@ import { getServices } from '../kibana_services';
 
 export const renderApp = async (element: HTMLElement) => {
   const homeTitle = i18n.translate('kbn.home.breadcrumbs.homeTitle', { defaultMessage: 'Home' });
-  const { directories, chrome } = getServices();
+  const { featureCatalogue, chrome } = getServices();
+
+  // all the directories could be get in "start" phase of plugin after all of the legacy plugins will be moved to a NP
+  const directories = featureCatalogue.get();
+
   chrome.setBreadcrumbs([{ text: homeTitle }]);
 
   render(<HomeApp directories={directories} />, element);

--- a/src/legacy/core_plugins/kibana/public/home/plugin.ts
+++ b/src/legacy/core_plugins/kibana/public/home/plugin.ts
@@ -34,7 +34,6 @@ import {
   Environment,
   HomePublicPluginStart,
   HomePublicPluginSetup,
-  FeatureCatalogueEntry,
 } from '../../../../../plugins/home/public';
 
 export interface HomePluginStartDependencies {
@@ -53,7 +52,7 @@ export class HomePlugin implements Plugin {
   private dataStart: DataPublicPluginStart | null = null;
   private savedObjectsClient: any = null;
   private environment: Environment | null = null;
-  private directories: readonly FeatureCatalogueEntry[] | null = null;
+  private featureCatalogue: HomePublicPluginStart['featureCatalogue'] | null = null;
   private telemetry?: TelemetryPluginStart;
 
   constructor(private initializerContext: PluginInitializerContext) {}
@@ -83,7 +82,7 @@ export class HomePlugin implements Plugin {
           environment: this.environment!,
           config: kibanaLegacy.config,
           homeConfig: home.config,
-          directories: this.directories!,
+          featureCatalogue: this.featureCatalogue!,
         });
         const { renderApp } = await import('./np_ready/application');
         return await renderApp(params.element);
@@ -93,7 +92,7 @@ export class HomePlugin implements Plugin {
 
   start(core: CoreStart, { data, home, telemetry }: HomePluginStartDependencies) {
     this.environment = home.environment.get();
-    this.directories = home.featureCatalogue.get();
+    this.featureCatalogue = home.featureCatalogue;
     this.dataStart = data;
     this.telemetry = telemetry;
     this.savedObjectsClient = core.savedObjects.client;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/57574

The way of getting features was placed in `start` phase of the `home` plugin, which is correct. 
But while we have such legacy plugins as `discover`, `visualize` and so on, the registering of their features for the home plugin are happening after the `start` phase of the `home` plugin.
This workaround will help not to miss any of them, but this commit can be reverted when all of the legacy plugins will be moved to the new platform.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
