### PR TITLE
Add vis straight to dashboard example

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dashboard/legacy.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/legacy.ts
@@ -26,5 +26,8 @@ import { plugin } from './index';
     env: npSetup.plugins.kibanaLegacy.env,
   } as PluginInitializerContext);
   instance.setup(npSetup.core, npSetup.plugins);
-  instance.start(npStart.core, npStart.plugins);
+  instance.start(npStart.core, {
+    ...npStart.plugins,
+    dashboardEmbeddableContainer: npStart.plugins.dashboard_embeddable_container,
+  });
 })();

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/application.ts
@@ -28,6 +28,7 @@ import {
   SavedObjectsClientContract,
   PluginInitializerContext,
 } from 'kibana/public';
+import { DashboardStart } from '../../../../../../plugins/dashboard_embeddable_container/public';
 import { Storage } from '../../../../../../plugins/kibana_utils/public';
 import {
   configureAppAngularModule,
@@ -65,6 +66,7 @@ export interface RenderDeps {
   localStorage: Storage;
   share: SharePluginStart;
   config: KibanaLegacyStart['config'];
+  dashboardEmbeddableContainer: DashboardStart;
 }
 
 let angularModuleInstance: IModule | null = null;

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
@@ -292,11 +292,6 @@ export class DashboardAppController {
     dashboardFactory
       .create(getDashboardInput())
       .then((container: DashboardContainer | ErrorEmbeddable) => {
-        if (container.type === DASHBOARD_CONTAINER_TYPE) {
-          dashboardEmbeddableContainer.setCurrentDashboard(container);
-        } else {
-          dashboardEmbeddableContainer.setCurrentDashboard(undefined);
-        }
         if (!isErrorEmbeddable(container)) {
           dashboardContainer = container;
 
@@ -916,12 +911,12 @@ export class DashboardAppController {
       if (outputSubscription) {
         outputSubscription.unsubscribe();
       }
-      // Temp hack - there is an issue with destroying, you'll get an error if you call `updateInput` on a
-      // destroyed embeddable. Maybe we need to instead call this "unmount" or something to differentiate
-      // cleaning up the rendering from destroying, when an embeddable may be in memory but not on screen.
-      // if (dashboardContainer) {
-      //   dashboardContainer.destroy();
-      // }
+      if (dashboardContainer) {
+        dashboardEmbeddableContainer.setLastLoadedDashboardAppDashboardInput(
+          dashboardContainer.getInput()
+        );
+        dashboardContainer.destroy();
+      }
     });
   }
 }

--- a/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
+++ b/src/legacy/core_plugins/kibana/public/dashboard/np_ready/dashboard_app_controller.tsx
@@ -120,6 +120,7 @@ export class DashboardAppController {
     },
     history,
     kbnUrlStateStorage,
+    dashboardEmbeddableContainer,
   }: DashboardAppControllerDependencies) {
     const filterManager = queryService.filterManager;
     const queryFilter = filterManager;
@@ -291,6 +292,11 @@ export class DashboardAppController {
     dashboardFactory
       .create(getDashboardInput())
       .then((container: DashboardContainer | ErrorEmbeddable) => {
+        if (container.type === DASHBOARD_CONTAINER_TYPE) {
+          dashboardEmbeddableContainer.setCurrentDashboard(container);
+        } else {
+          dashboardEmbeddableContainer.setCurrentDashboard(undefined);
+        }
         if (!isErrorEmbeddable(container)) {
           dashboardContainer = container;
 
@@ -910,9 +916,12 @@ export class DashboardAppController {
       if (outputSubscription) {
         outputSubscription.unsubscribe();
       }
-      if (dashboardContainer) {
-        dashboardContainer.destroy();
-      }
+      // Temp hack - there is an issue with destroying, you'll get an error if you call `updateInput` on a
+      // destroyed embeddable. Maybe we need to instead call this "unmount" or something to differentiate
+      // cleaning up the rendering from destroying, when an embeddable may be in memory but not on screen.
+      // if (dashboardContainer) {
+      //   dashboardContainer.destroy();
+      // }
     });
   }
 }

--- a/src/legacy/core_plugins/kibana/public/dashboard/plugin.ts
+++ b/src/legacy/core_plugins/kibana/public/dashboard/plugin.ts
@@ -47,6 +47,7 @@ import {
 import { createSavedDashboardLoader } from './saved_dashboard/saved_dashboards';
 import { createKbnUrlTracker } from '../../../../../plugins/kibana_utils/public';
 import { getQueryStateContainer } from '../../../../../plugins/data/public';
+import { DashboardStart } from '../../../../../plugins/dashboard_embeddable_container/public';
 
 export interface DashboardPluginStartDependencies {
   data: DataPublicPluginStart;
@@ -54,6 +55,7 @@ export interface DashboardPluginStartDependencies {
   navigation: NavigationStart;
   share: SharePluginStart;
   kibanaLegacy: KibanaLegacyStart;
+  dashboardEmbeddableContainer: DashboardStart;
 }
 
 export interface DashboardPluginSetupDependencies {
@@ -69,6 +71,7 @@ export class DashboardPlugin implements Plugin {
     embeddable: IEmbeddableStart;
     navigation: NavigationStart;
     share: SharePluginStart;
+    dashboardEmbeddableContainer: DashboardStart;
     dashboardConfig: KibanaLegacyStart['dashboardConfig'];
   } | null = null;
 
@@ -114,6 +117,7 @@ export class DashboardPlugin implements Plugin {
           share,
           data: dataStart,
           dashboardConfig,
+          dashboardEmbeddableContainer,
         } = this.startDependencies;
         const savedDashboards = createSavedDashboardLoader({
           savedObjectsClient,
@@ -139,6 +143,7 @@ export class DashboardPlugin implements Plugin {
           embeddable,
           dashboardCapabilities: coreStart.application.capabilities.dashboard,
           localStorage: new Storage(localStorage),
+          dashboardEmbeddableContainer,
         };
         const { renderApp } = await import('./np_ready/application');
         const unmount = renderApp(params.element, params.appBasePath, deps);
@@ -178,6 +183,7 @@ export class DashboardPlugin implements Plugin {
       embeddable,
       navigation,
       data,
+      dashboardEmbeddableContainer,
       share,
       kibanaLegacy: { dashboardConfig },
     }: DashboardPluginStartDependencies
@@ -189,6 +195,7 @@ export class DashboardPlugin implements Plugin {
       navigation,
       share,
       dashboardConfig,
+      dashboardEmbeddableContainer,
     };
   }
 

--- a/src/legacy/core_plugins/kibana/public/visualize/kibana_services.ts
+++ b/src/legacy/core_plugins/kibana/public/visualize/kibana_services.ts
@@ -27,6 +27,7 @@ import {
   PluginInitializerContext,
 } from 'kibana/public';
 
+import { DashboardStart } from '../../../../../plugins/dashboard_embeddable_container/public';
 import { NavigationPublicPluginStart as NavigationStart } from '../../../../../plugins/navigation/public';
 import { Storage } from '../../../../../plugins/kibana_utils/public';
 import { IEmbeddableStart } from '../../../../../plugins/embeddable/public';
@@ -60,6 +61,7 @@ export interface VisualizeKibanaServices {
   usageCollection?: UsageCollectionSetup;
   I18nContext: I18nStart['Context'];
   setActiveUrl: (newUrl: string) => void;
+  dashboardEmbeddableContainer: DashboardStart;
 }
 
 let services: VisualizeKibanaServices | null = null;

--- a/src/legacy/core_plugins/kibana/public/visualize/legacy.ts
+++ b/src/legacy/core_plugins/kibana/public/visualize/legacy.ts
@@ -29,4 +29,5 @@ instance.setup(npSetup.core, npSetup.plugins);
 instance.start(npStart.core, {
   ...npStart.plugins,
   visualizations,
+  dashboardEmbeddableContainer: npStart.plugins.dashboard_embeddable_container,
 });

--- a/src/legacy/core_plugins/kibana/public/visualize/plugin.ts
+++ b/src/legacy/core_plugins/kibana/public/visualize/plugin.ts
@@ -29,6 +29,7 @@ import {
   SavedObjectsClientContract,
 } from 'kibana/public';
 
+import { DashboardStart } from '../../../../../plugins/dashboard_embeddable_container/public';
 import { Storage, createKbnUrlTracker } from '../../../../../plugins/kibana_utils/public';
 import {
   DataPublicPluginStart,
@@ -57,6 +58,7 @@ export interface VisualizePluginStartDependencies {
   navigation: NavigationStart;
   share: SharePluginStart;
   visualizations: VisualizationsStart;
+  dashboardEmbeddableContainer: DashboardStart;
 }
 
 export interface VisualizePluginSetupDependencies {
@@ -74,6 +76,7 @@ export class VisualizePlugin implements Plugin {
     savedObjectsClient: SavedObjectsClientContract;
     share: SharePluginStart;
     visualizations: VisualizationsStart;
+    dashboardEmbeddableContainer: DashboardStart;
   } | null = null;
   private appStateUpdater = new BehaviorSubject<AngularRenderedAppUpdater>(() => ({}));
   private stopUrlTracking: (() => void) | undefined = undefined;
@@ -125,6 +128,7 @@ export class VisualizePlugin implements Plugin {
           visualizations,
           data: dataStart,
           share,
+          dashboardEmbeddableContainer,
         } = this.startDependencies;
 
         const deps: VisualizeKibanaServices = {
@@ -150,6 +154,7 @@ export class VisualizePlugin implements Plugin {
           usageCollection,
           I18nContext: coreStart.i18n.Context,
           setActiveUrl,
+          dashboardEmbeddableContainer,
         };
         setServices(deps);
 
@@ -178,7 +183,14 @@ export class VisualizePlugin implements Plugin {
 
   public start(
     core: CoreStart,
-    { embeddable, navigation, data, share, visualizations }: VisualizePluginStartDependencies
+    {
+      embeddable,
+      navigation,
+      data,
+      share,
+      visualizations,
+      dashboardEmbeddableContainer,
+    }: VisualizePluginStartDependencies
   ) {
     this.startDependencies = {
       data,
@@ -187,6 +199,7 @@ export class VisualizePlugin implements Plugin {
       savedObjectsClient: core.savedObjects.client,
       share,
       visualizations,
+      dashboardEmbeddableContainer,
     };
   }
 

--- a/src/legacy/core_plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/legacy/core_plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -152,12 +152,33 @@ export class VisualizeEmbeddableFactory extends EmbeddableFactory<
     }
   }
 
-  public async create() {
-    // TODO: This is a bit of a hack to preserve the original functionality. Ideally we will clean this up
-    // to allow for in place creation of visualizations without having to navigate away to a new URL.
-    showNewVisModal({
-      editorParams: ['addToDashboard'],
-    });
-    return undefined;
+  // These changes don't actually get called because I ran into issues serializing `savedVis` but
+  // we might be able to reuse this embeddable type by doing something like this. If not, you could
+  // create a new embeddable type.
+  public async create(input: Partial<VisualizeInput>) {
+    if (!input) {
+      // TODO: This is a bit of a hack to preserve the original functionality. Ideally we will clean this up
+      // to allow for in place creation of visualizations without having to navigate away to a new URL.
+      showNewVisModal({
+        editorParams: ['addToDashboard'],
+      });
+      return undefined;
+    } else {
+      const indexPattern = await getIndexPattern(input.savedVis);
+      const indexPatterns = indexPattern ? [indexPattern] : [];
+      return new VisualizeEmbeddable(
+        this.timefilter,
+        {
+          savedVisualization: input.savedVis,
+          indexPatterns,
+          editUrl: '',
+          editable: this.isEditable(),
+          appState: input.appState,
+          uiState: input.uiState,
+        },
+        input,
+        parent
+      );
+    }
   }
 }

--- a/src/legacy/core_plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/legacy/core_plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -156,29 +156,36 @@ export class VisualizeEmbeddableFactory extends EmbeddableFactory<
   // we might be able to reuse this embeddable type by doing something like this. If not, you could
   // create a new embeddable type.
   public async create(input: Partial<VisualizeInput>) {
-    if (!input) {
-      // TODO: This is a bit of a hack to preserve the original functionality. Ideally we will clean this up
-      // to allow for in place creation of visualizations without having to navigate away to a new URL.
-      showNewVisModal({
-        editorParams: ['addToDashboard'],
-      });
-      return undefined;
-    } else {
-      const indexPattern = await getIndexPattern(input.savedVis);
-      const indexPatterns = indexPattern ? [indexPattern] : [];
-      return new VisualizeEmbeddable(
-        this.timefilter,
-        {
-          savedVisualization: input.savedVis,
-          indexPatterns,
-          editUrl: '',
-          editable: this.isEditable(),
-          appState: input.appState,
-          uiState: input.uiState,
-        },
-        input,
-        parent
-      );
-    }
+    // TODO: This is a bit of a hack to preserve the original functionality. Ideally we will clean this up
+    // to allow for in place creation of visualizations without having to navigate away to a new URL.
+    showNewVisModal({
+      editorParams: ['addToDashboard'],
+    });
+    return undefined;
   }
+  //   if (!input) {
+  //     // TODO: This is a bit of a hack to preserve the original functionality. Ideally we will clean this up
+  //     // to allow for in place creation of visualizations without having to navigate away to a new URL.
+  //     showNewVisModal({
+  //       editorParams: ['addToDashboard'],
+  //     });
+  //     return undefined;
+  //   } else {
+  //     const indexPattern = await getIndexPattern(input.savedVis);
+  //     const indexPatterns = indexPattern ? [indexPattern] : [];
+  //     return new VisualizeEmbeddable(
+  //       this.timefilter,
+  //       {
+  //         savedVisualization: input.savedVis,
+  //         indexPatterns,
+  //         editUrl: '',
+  //         editable: this.isEditable(),
+  //         appState: input.appState,
+  //         uiState: input.uiState,
+  //       },
+  //       input,
+  //       parent
+  //     );
+  //   }
+  // }
 }

--- a/src/legacy/ui/public/new_platform/new_platform.ts
+++ b/src/legacy/ui/public/new_platform/new_platform.ts
@@ -20,6 +20,7 @@ import { IScope } from 'angular';
 
 import { UiActionsStart, UiActionsSetup } from 'src/plugins/ui_actions/public';
 import { IEmbeddableStart, IEmbeddableSetup } from 'src/plugins/embeddable/public';
+import { DashboardStart } from 'src/plugins/dashboard_embeddable_container/public';
 import { LegacyCoreSetup, LegacyCoreStart, App, AppMountDeprecated } from '../../../../core/public';
 import { Plugin as DataPlugin } from '../../../../plugins/data/public';
 import { Plugin as ExpressionsPlugin } from '../../../../plugins/expressions/public';
@@ -82,6 +83,7 @@ export interface PluginsStart {
   management: ManagementStart;
   advancedSettings: AdvancedSettingsStart;
   telemetry?: TelemetryPluginStart;
+  dashboard_embeddable_container: DashboardStart;
 }
 
 export const npSetup = {

--- a/src/plugins/dashboard_embeddable_container/public/index.ts
+++ b/src/plugins/dashboard_embeddable_container/public/index.ts
@@ -31,3 +31,5 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export { DashboardEmbeddableContainerPublicPlugin as Plugin };
+
+export { DashboardStart } from './plugin';

--- a/src/plugins/dashboard_embeddable_container/public/plugin.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/plugin.tsx
@@ -31,7 +31,7 @@ import {
   ExitFullScreenButton as ExitFullScreenButtonUi,
   ExitFullScreenButtonProps,
 } from '../../../plugins/kibana_react/public';
-import { DashboardContainer } from './embeddable';
+import { DashboardContainer, DashboardContainerInput } from './embeddable';
 
 interface SetupDependencies {
   embeddable: IEmbeddableSetup;
@@ -47,13 +47,13 @@ interface StartDependencies {
 export type Setup = void;
 
 export interface DashboardStart {
-  getCurrentDashboard: () => DashboardContainer | undefined;
-  setCurrentDashboard: (dashboard: DashboardContainer | undefined) => void;
+  getLastLoadedDashboardAppDashboardInput: () => DashboardContainerInput | undefined;
+  setLastLoadedDashboardAppDashboardInput: (dashboard: DashboardContainerInput | undefined) => void;
 }
 
 export class DashboardEmbeddableContainerPublicPlugin
   implements Plugin<Setup, DashboardStart, SetupDependencies, StartDependencies> {
-  private currentDashboard: DashboardContainer | undefined;
+  private currentDashboardInput: DashboardContainerInput | undefined;
 
   constructor(initializerContext: PluginInitializerContext) {}
 
@@ -104,8 +104,9 @@ export class DashboardEmbeddableContainerPublicPlugin
     embeddable.registerEmbeddableFactory(factory.type, factory);
 
     return {
-      getCurrentDashboard: () => this.currentDashboard,
-      setCurrentDashboard: dashboard => (this.currentDashboard = dashboard),
+      getLastLoadedDashboardAppDashboardInput: () => this.currentDashboardInput,
+      setLastLoadedDashboardAppDashboardInput: dashboardInput =>
+        (this.currentDashboardInput = dashboardInput),
     };
   }
 

--- a/src/plugins/dashboard_embeddable_container/public/plugin.tsx
+++ b/src/plugins/dashboard_embeddable_container/public/plugin.tsx
@@ -31,6 +31,7 @@ import {
   ExitFullScreenButton as ExitFullScreenButtonUi,
   ExitFullScreenButtonProps,
 } from '../../../plugins/kibana_react/public';
+import { DashboardContainer } from './embeddable';
 
 interface SetupDependencies {
   embeddable: IEmbeddableSetup;
@@ -44,10 +45,16 @@ interface StartDependencies {
 }
 
 export type Setup = void;
-export type Start = void;
+
+export interface DashboardStart {
+  getCurrentDashboard: () => DashboardContainer | undefined;
+  setCurrentDashboard: (dashboard: DashboardContainer | undefined) => void;
+}
 
 export class DashboardEmbeddableContainerPublicPlugin
-  implements Plugin<Setup, Start, SetupDependencies, StartDependencies> {
+  implements Plugin<Setup, DashboardStart, SetupDependencies, StartDependencies> {
+  private currentDashboard: DashboardContainer | undefined;
+
   constructor(initializerContext: PluginInitializerContext) {}
 
   public setup(core: CoreSetup, { embeddable, uiActions }: SetupDependencies): Setup {
@@ -56,7 +63,7 @@ export class DashboardEmbeddableContainerPublicPlugin
     uiActions.attachAction(CONTEXT_MENU_TRIGGER, expandPanelAction.id);
   }
 
-  public start(core: CoreStart, plugins: StartDependencies): Start {
+  public start(core: CoreStart, plugins: StartDependencies): DashboardStart {
     const { application, notifications, overlays } = core;
     const { embeddable, inspector, uiActions } = plugins;
 
@@ -95,6 +102,11 @@ export class DashboardEmbeddableContainerPublicPlugin
     });
 
     embeddable.registerEmbeddableFactory(factory.type, factory);
+
+    return {
+      getCurrentDashboard: () => this.currentDashboard,
+      setCurrentDashboard: dashboard => (this.currentDashboard = dashboard),
+    };
   }
 
   public stop() {}


### PR DESCRIPTION
![addvis](https://user-images.githubusercontent.com/16563603/74782255-17111900-5271-11ea-8a9f-e721c90c61f8.gif)


I used one of the example embeddables and input, but the idea would be to use configuration from `savedVis` object to create the Embeddable.  If needed, you can create a new embeddable type.

```ts
                const currentDashboard = dashboardEmbeddableContainer.getCurrentDashboard();
                if (currentDashboard) {
                  currentDashboard
                    // We need to extract out the serializable data from savedVis, trying it this way will
                    // cause max call stack size exceeded from parent references inside the `savedVis` object.
                    // .addNewEmbeddable('visualization', { savedVis }).then(() => {
                    .addNewEmbeddable('TODO_EMBEDDABLE', { task: 'do something!' })
                    .then(() => {
                      const dashInput = currentDashboard.getInput();

                      // We would use the URL service for this. I have a PR up here:
                      // https://github.com/elastic/kibana/pull/57496/files. I'd probably register a
                      // new generator that just takes in dashboard embeddable input and returns the
                      // dashboard app id.  For now, I just hacked in minimum to get it to show the
                      // added panel.
                      const hash = dashInput.id ? `dashboard/${dashInput.id}` : `dashboard`;
                      const parsedUrl = url.parse(window.location.href);
                      const dashboardAppUrl = url.format({
                        protocol: parsedUrl.protocol,
                        host: parsedUrl.host,
                        pathname: `app/kibana`,
                        hash,
                      });
                      const dashUrl = setStateToKbnUrl(
                        '_a',
                        {
                          query: dashInput.query,
                          filters: dashInput.filters,
                          panels: Object.values(dashInput.panels).map(panel =>
                            convertPanelStateToSavedDashboardPanel(panel)
                          ),
                        },
                        { useHash: false },
                        dashboardAppUrl
                      );

                      window.location.hash = url.parse(dashUrl).hash;
                    });
```