### PR TITLE
[APM] Don’t include UI filters when fetching a specific transaction

### DIFF
--- a/x-pack/legacy/plugins/apm/public/utils/testHelpers.tsx
+++ b/x-pack/legacy/plugins/apm/public/utils/testHelpers.tsx
@@ -151,23 +151,10 @@ export async function inspectSearchParams(
   const mockSetup = {
     start: 1528113600000,
     end: 1528977600000,
-    client: {
-      search: spy
-    } as any,
-    internalClient: {
-      search: spy
-    } as any,
-    config: new Proxy(
-      {},
-      {
-        get: () => 'myIndex'
-      }
-    ) as APMConfig,
-    uiFiltersES: [
-      {
-        term: { 'service.environment': 'prod' }
-      }
-    ],
+    client: { search: spy } as any,
+    internalClient: { search: spy } as any,
+    config: new Proxy({}, { get: () => 'myIndex' }) as APMConfig,
+    uiFiltersES: [{ term: { 'my.custom.ui.filter': 'foo-bar' } }],
     indices: {
       'apm_oss.sourcemapIndices': 'myIndex',
       'apm_oss.errorIndices': 'myIndex',

--- a/x-pack/legacy/plugins/apm/server/lib/errors/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/__snapshots__/queries.test.ts.snap
@@ -32,7 +32,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -119,7 +119,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -194,7 +194,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],

--- a/x-pack/legacy/plugins/apm/server/lib/errors/distribution/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/distribution/__snapshots__/queries.test.ts.snap
@@ -40,7 +40,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -92,7 +92,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {

--- a/x-pack/legacy/plugins/apm/server/lib/errors/get_error_group.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/errors/get_error_group.ts
@@ -64,7 +64,7 @@ export async function getErrorGroup({
 
   let transaction;
   if (transactionId && traceId) {
-    transaction = await getTransaction(transactionId, traceId, setup);
+    transaction = await getTransaction({ transactionId, traceId, setup });
   }
 
   return {

--- a/x-pack/legacy/plugins/apm/server/lib/metrics/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/metrics/__snapshots__/queries.test.ts.snap
@@ -87,7 +87,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -176,7 +176,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -272,7 +272,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -371,7 +371,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -455,7 +455,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -565,7 +565,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -660,7 +660,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -762,7 +762,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -867,7 +867,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -957,7 +957,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -1056,7 +1056,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -1140,7 +1140,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -1231,7 +1231,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -1325,7 +1325,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -1404,7 +1404,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {

--- a/x-pack/legacy/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/service_nodes/__snapshots__/queries.test.ts.snap
@@ -51,7 +51,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -120,7 +120,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -190,7 +190,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],

--- a/x-pack/legacy/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/services/__snapshots__/queries.test.ts.snap
@@ -169,7 +169,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],

--- a/x-pack/legacy/plugins/apm/server/lib/transaction_groups/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/transaction_groups/__snapshots__/queries.test.ts.snap
@@ -80,7 +80,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -194,7 +194,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
@@ -30,11 +30,6 @@ Object {
               },
             },
           },
-          Object {
-            "term": Object {
-              "service.environment": "prod",
-            },
-          },
         ],
       },
     },

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
@@ -162,7 +162,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -297,7 +297,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -394,7 +394,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],
@@ -486,7 +486,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -583,7 +583,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
           Object {
@@ -649,7 +649,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/get_transaction/index.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/get_transaction/index.ts
@@ -18,12 +18,16 @@ import {
 } from '../../helpers/setup_request';
 import { ProcessorEvent } from '../../../../common/processor_event';
 
-export async function getTransaction(
-  transactionId: string,
-  traceId: string,
-  setup: Setup & SetupTimeRange & SetupUIFilters
-) {
-  const { start, end, uiFiltersES, client, indices } = setup;
+export async function getTransaction({
+  transactionId,
+  traceId,
+  setup
+}: {
+  transactionId: string;
+  traceId: string;
+  setup: Setup & SetupTimeRange & SetupUIFilters;
+}) {
+  const { start, end, client, indices } = setup;
 
   const params = {
     index: indices['apm_oss.transactionIndices'],
@@ -35,8 +39,7 @@ export async function getTransaction(
             { term: { [PROCESSOR_EVENT]: ProcessorEvent.transaction } },
             { term: { [TRANSACTION_ID]: transactionId } },
             { term: { [TRACE_ID]: traceId } },
-            { range: rangeFilter(start, end) },
-            ...uiFiltersES
+            { range: rangeFilter(start, end) }
           ]
         }
       }

--- a/x-pack/legacy/plugins/apm/server/lib/transactions/queries.test.ts
+++ b/x-pack/legacy/plugins/apm/server/lib/transactions/queries.test.ts
@@ -99,7 +99,7 @@ describe('transaction queries', () => {
 
   it('fetches a transaction', async () => {
     mock = await inspectSearchParams(setup =>
-      getTransaction('foo', 'bar', setup)
+      getTransaction({ transactionId: 'foo', traceId: 'bar', setup })
     );
 
     expect(mock.params).toMatchSnapshot();

--- a/x-pack/legacy/plugins/apm/server/lib/ui_filters/local_ui_filters/__snapshots__/queries.test.ts.snap
+++ b/x-pack/legacy/plugins/apm/server/lib/ui_filters/local_ui_filters/__snapshots__/queries.test.ts.snap
@@ -48,7 +48,7 @@ Object {
           },
           Object {
             "term": Object {
-              "service.environment": "prod",
+              "my.custom.ui.filter": "foo-bar",
             },
           },
         ],


### PR DESCRIPTION
Closes #57855

On the error groups page an error sample and the related transaction is shown. This transaction is currently fetched by id, and filtered by ui filters as usual. However, the ui filters may cause the transaction to not be found, since they are written with the error document in mind, and thus will contain error specific parameters which will never match the transaction. Therefore I suggest to remove the ui filters from the query for fetching the transaction.

As a general rule of thumb I think the ui filters (query bar + local filters) should only affect the primary document type on a page. Thus when the primary document type on a page is X, any secondary data types on the same page should not be filtered by ui filters.

For more details [this issue](https://github.com/elastic/kibana/issues/57855).

**Before**
![image](https://user-images.githubusercontent.com/209966/74784486-47c07500-52a8-11ea-9d95-bd583bb467b2.png)

**After**
![image](https://user-images.githubusercontent.com/209966/74784490-498a3880-52a8-11ea-9da4-bda06fa8afe8.png)
