### PR TITLE
[i18n] exclude target and vendor when extracting files

### DIFF
--- a/src/dev/i18n/__snapshots__/integrate_locale_files.test.ts.snap
+++ b/src/dev/i18n/__snapshots__/integrate_locale_files.test.ts.snap
@@ -64,7 +64,8 @@ Array [
     \\"plugin-1.message-id-1\\": \\"Translated text 1\\",
     \\"plugin-1.message-id-2\\": \\"Translated text 2\\"
   }
-}",
+}
+",
 ]
 `;
 
@@ -131,7 +132,8 @@ Array [
   \\"messages\\": {
     \\"plugin-2.message-id\\": \\"Translated text\\"
   }
-}",
+}
+",
 ]
 `;
 

--- a/src/dev/i18n/extract_default_translations.js
+++ b/src/dev/i18n/extract_default_translations.js
@@ -63,6 +63,9 @@ export async function matchEntriesWithExctractors(inputPath, options = {}) {
   const ignore = [
     '**/node_modules/**',
     '**/__tests__/**',
+    '**/dist/**',
+    '**/target/**',
+    '**/vendor/**',
     '**/*.test.{js,jsx,ts,tsx}',
     '**/*.d.ts',
   ].concat(additionalIgnore);

--- a/src/dev/i18n/serializers/__snapshots__/json.test.ts.snap
+++ b/src/dev/i18n/serializers/__snapshots__/json.test.ts.snap
@@ -85,5 +85,6 @@ exports[`dev/i18n/serializers/json should serialize default messages to JSON 1`]
       \\"comment\\": \\"Message description\\"
     }
   }
-}"
+}
+"
 `;

--- a/src/dev/i18n/serializers/json.ts
+++ b/src/dev/i18n/serializers/json.ts
@@ -34,5 +34,5 @@ export const serializeToJson: Serializer = (messages, formats = i18n.formats) =>
     }
   }
 
-  return JSON.stringify(resultJsonObject, undefined, 2);
+  return JSON.stringify(resultJsonObject, undefined, 2).concat('\n');
 };


### PR DESCRIPTION
Yesterday CI started failing when `i18n_check` started checking for files inside `target`. I believe this started happening after our new CI was pushed which builds each plugin individually.

This PR solves this issue by ignoring all target folders since there is no need to check anything inside those. Additionally i've added `vendor` and `dist` dirs to ignore as well.

`i18n_check --fix` now appends a newline at the end of the translation files to adhere to our editorconfig rules. Closes https://github.com/elastic/kibana/issues/42241

