### PR TITLE
Add owners for monitoring plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,7 @@
 /x-pack/plugins/ingest_manager/ @elastic/ingest
 /x-pack/legacy/plugins/ingest_manager/ @elastic/ingest
 /x-pack/plugins/observability/ @elastic/logs-metrics-ui @elastic/apm-ui @elastic/uptime @elastic/ingest
+/x-pack/legacy/plugins/monitoring/ @elastic/stack-monitoring-ui
 
 # Machine Learning
 /x-pack/legacy/plugins/ml/  @elastic/ml-ui


### PR DESCRIPTION
## Summary

Adding @elastic/stack-monitoring-ui as code owners for monitoring plugin