### PR TITLE
Fix short url in spaces

### DIFF
--- a/src/plugins/share/server/routes/goto.ts
+++ b/src/plugins/share/server/routes/goto.ts
@@ -23,6 +23,7 @@ import { schema } from '@kbn/config-schema';
 import { shortUrlAssertValid } from './lib/short_url_assert_valid';
 import { ShortUrlLookupService } from './lib/short_url_lookup';
 import { getGotoPath } from '../../common/short_url_routes';
+import { modifyUrl } from '../../../../core/utils';
 
 export const createGotoRoute = ({
   router,
@@ -49,9 +50,16 @@ export const createGotoRoute = ({
       const uiSettings = context.core.uiSettings.client;
       const stateStoreInSessionStorage = await uiSettings.get('state:storeInSessionStorage');
       if (!stateStoreInSessionStorage) {
+        const basePath = http.basePath.get(request);
+
+        const prependedUrl = modifyUrl(url, parts => {
+          if (!parts.hostname && parts.pathname && parts.pathname.startsWith('/')) {
+            parts.pathname = `${basePath}${parts.pathname}`;
+          }
+        });
         return response.redirected({
           headers: {
-            location: http.basePath.prepend(url),
+            location: prependedUrl,
           },
         });
       }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/58201

The short url service was using the core service `prepend` function to add the base path which is not request-aware. Because of this the space-specific-part of the URL was not prepended.

This PR changes the logic to use `http.basePath.get(request)` and prepends the basepath itself which makes sure space prefixes are also added.