### PR TITLE
Fix service map popover transaction duration

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/ServiceMetricList.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Popover/ServiceMetricList.tsx
@@ -16,12 +16,7 @@ import { isNumber } from 'lodash';
 import React from 'react';
 import styled from 'styled-components';
 import { ServiceNodeMetrics } from '../../../../../../../../plugins/apm/common/service_map';
-import {
-  asDuration,
-  asPercent,
-  toMicroseconds,
-  tpmUnit
-} from '../../../../utils/formatters';
+import { asDuration, asPercent, tpmUnit } from '../../../../utils/formatters';
 
 function LoadingSpinner() {
   return (
@@ -70,7 +65,7 @@ export function ServiceMetricList({
         }
       ),
       description: isNumber(avgTransactionDuration)
-        ? asDuration(toMicroseconds(avgTransactionDuration, 'milliseconds'))
+        ? asDuration(avgTransactionDuration)
         : null
     },
     {


### PR DESCRIPTION
It's already microseconds, so not converting it fixes it.

Checked services to see if all metrics match now and they do!

Fixes #55679
