### PR TITLE
Discover: Satisfy proptype check in no results component

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
@@ -556,8 +556,9 @@ function discoverController(
   $scope.opts = {
     // number of records to fetch, then paginate through
     sampleSize: config.get('discover:sampleSize'),
-    timefield:
-      indexPatternsUtils.isDefault($scope.indexPattern) && $scope.indexPattern.timeFieldName,
+    timefield: indexPatternsUtils.isDefault($scope.indexPattern)
+      ? $scope.indexPattern.timeFieldName
+      : undefined,
     savedSearch: savedSearch,
     indexPatternList: $route.current.locals.savedObjects.ip.list,
   };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/47295

If the current index pattern is not the default, `false` will be passed as `timefield` into the `NoResults` component in discover. This causes an error because the prop type is expecting an optional string.

This PR fixes this by passing in `undefined` if the current index pattern is not the default