### PR TITLE
Fixing Newsfeed Cloud test bug

### DIFF
--- a/test/functional/apps/home/_newsfeed.ts
+++ b/test/functional/apps/home/_newsfeed.ts
@@ -47,10 +47,17 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
 
     it('shows all news from newsfeed', async () => {
       const objects = await PageObjects.newsfeed.getNewsfeedList();
-      expect(objects).to.eql([
-        '21 June 2019\nYou are functionally testing the newsfeed widget with fixtures!\nSee test/common/fixtures/plugins/newsfeed/newsfeed_simulation\nGeneric feed-viewer could go here',
-        '21 June 2019\nStaging too!\nHello world\nGeneric feed-viewer could go here',
-      ]);
+
+      if (await PageObjects.common.isOss()) {
+        expect(objects).to.eql([
+          '21 June 2019\nYou are functionally testing the newsfeed widget with fixtures!\nSee test/common/fixtures/plugins/newsfeed/newsfeed_simulation\nGeneric feed-viewer could go here',
+          '21 June 2019\nStaging too!\nHello world\nGeneric feed-viewer could go here',
+        ]);
+      } else {
+        // can't shim the API in cloud so going to check that at least something is rendered
+        // to test that the API was called and returned something that could be rendered
+        expect(objects.length).to.be.above(0);
+      }
     });
 
     it('clicking on newsfeed icon should close opened newsfeed', async () => {


### PR DESCRIPTION
## Summary

Can't mock the API on cloud so falling back to a simpler test of confirming that text is rendered instead of confirming the text.

Unable to run cloud tests on my machine at the moment so I haven't tested this yet... (If someone has a moment and can run these quickly, that'd be a huge help!)

Sorry for tagging so many folks but I've got no idea who owns this.

Resolves #51455