### PR TITLE
[APM] Fix timeout in APM setup

### DIFF
--- a/src/plugins/apm_oss/server/index.ts
+++ b/src/plugins/apm_oss/server/index.ts
@@ -38,4 +38,4 @@ export function plugin(initializerContext: PluginInitializerContext) {
 
 export type APMOSSConfig = TypeOf<typeof config.schema>;
 
-export { APMOSSPlugin as Plugin };
+export { APMOSSPluginSetup } from './plugin';

--- a/src/plugins/apm_oss/server/plugin.ts
+++ b/src/plugins/apm_oss/server/plugin.ts
@@ -20,7 +20,7 @@ import { Plugin, CoreSetup, PluginInitializerContext } from 'src/core/server';
 import { Observable } from 'rxjs';
 import { APMOSSConfig } from './';
 
-export class APMOSSPlugin implements Plugin<{ config$: Observable<APMOSSConfig> }> {
+export class APMOSSPlugin implements Plugin<APMOSSPluginSetup> {
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
   }
@@ -35,4 +35,8 @@ export class APMOSSPlugin implements Plugin<{ config$: Observable<APMOSSConfig> 
 
   start() {}
   stop() {}
+}
+
+export interface APMOSSPluginSetup {
+  config$: Observable<APMOSSConfig>;
 }

--- a/x-pack/plugins/apm/server/lib/index_pattern/get_dynamic_index_pattern.ts
+++ b/x-pack/plugins/apm/server/lib/index_pattern/get_dynamic_index_pattern.ts
@@ -62,8 +62,7 @@ export const getDynamicIndexPattern = async ({
     cache.set(CACHE_KEY, undefined);
     const notExists = e.output?.statusCode === 404;
     if (notExists) {
-      // eslint-disable-next-line no-console
-      console.error(
+      context.logger.error(
         `Could not get dynamic index pattern because indices "${indexPatternTitle}" don't exist`
       );
       return;

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/create_agent_config_index.ts
@@ -4,17 +4,19 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { IClusterClient } from 'src/core/server';
+import { IClusterClient, Logger } from 'src/core/server';
 import { CallCluster } from 'src/legacy/core_plugins/elasticsearch';
 import { APMConfig } from '../../..';
 import { getApmIndicesConfig } from '../apm_indices/get_apm_indices';
 
 export async function createApmAgentConfigurationIndex({
   esClient,
-  config
+  config,
+  logger
 }: {
   esClient: IClusterClient;
   config: APMConfig;
+  logger: Logger;
 }) {
   try {
     const index = getApmIndicesConfig(config).apmAgentConfigurationIndex;
@@ -32,8 +34,7 @@ export async function createApmAgentConfigurationIndex({
       );
     }
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Could not create APM Agent configuration:', e.message);
+    logger.error(`Could not create APM Agent configuration: ${e.message}`);
   }
 }
 

--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -11,7 +11,6 @@ import { once } from 'lodash';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 import { APMOSSPluginSetup } from '../../../../src/plugins/apm_oss/server';
 import { makeApmUsageCollector } from './lib/apm_telemetry';
-import {} from '../../../../src/plugins/apm_oss/server';
 import { createApmAgentConfigurationIndex } from './lib/settings/agent_configuration/create_agent_config_index';
 import { createApmApi } from './routes/create_apm_api';
 import { getApmIndices } from './lib/settings/apm_indices/get_apm_indices';

--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -5,12 +5,13 @@
  */
 import { PluginInitializerContext, Plugin, CoreSetup } from 'src/core/server';
 import { Observable, combineLatest, AsyncSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { Server } from 'hapi';
 import { once } from 'lodash';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
+import { APMOSSPluginSetup } from '../../../../src/plugins/apm_oss/server';
 import { makeApmUsageCollector } from './lib/apm_telemetry';
-import { Plugin as APMOSSPlugin } from '../../../../src/plugins/apm_oss/server';
+import {} from '../../../../src/plugins/apm_oss/server';
 import { createApmAgentConfigurationIndex } from './lib/settings/agent_configuration/create_agent_config_index';
 import { createApmApi } from './routes/create_apm_api';
 import { getApmIndices } from './lib/settings/apm_indices/get_apm_indices';
@@ -33,26 +34,23 @@ export interface APMPluginContract {
 
 export class APMPlugin implements Plugin<APMPluginContract> {
   legacySetup$: AsyncSubject<LegacySetup>;
-  currentConfig: APMConfig;
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
     this.legacySetup$ = new AsyncSubject();
-    this.currentConfig = {} as APMConfig;
   }
 
   public async setup(
     core: CoreSetup,
     plugins: {
-      apm_oss: APMOSSPlugin extends Plugin<infer TSetup> ? TSetup : never;
+      apm_oss: APMOSSPluginSetup;
       home: HomeServerPluginSetup;
       licensing: LicensingPluginSetup;
       cloud?: CloudSetup;
       usageCollection?: UsageCollectionSetup;
     }
   ) {
-    const config$ = this.initContext.config.create<APMXPackConfig>();
     const logger = this.initContext.logger.get('apm');
-
+    const config$ = this.initContext.config.create<APMXPackConfig>();
     const mergedConfig$ = combineLatest(plugins.apm_oss.config$, config$).pipe(
       map(([apmOssConfig, apmConfig]) => mergeConfigs(apmOssConfig, apmConfig))
     );
@@ -61,28 +59,26 @@ export class APMPlugin implements Plugin<APMPluginContract> {
       createApmApi().init(core, { config$: mergedConfig$, logger, __LEGACY });
     });
 
-    await new Promise(resolve => {
-      mergedConfig$.subscribe(async config => {
-        this.currentConfig = config;
-        await createApmAgentConfigurationIndex({
-          esClient: core.elasticsearch.dataClient,
-          config
-        });
-        resolve();
-      });
+    const currentConfig = await mergedConfig$.pipe(take(1)).toPromise();
+
+    // create agent configuration index without blocking setup lifecycle
+    createApmAgentConfigurationIndex({
+      esClient: core.elasticsearch.dataClient,
+      config: currentConfig,
+      logger
     });
 
     plugins.home.tutorials.registerTutorial(
       tutorialProvider({
-        isEnabled: this.currentConfig['xpack.apm.ui.enabled'],
-        indexPatternTitle: this.currentConfig['apm_oss.indexPattern'],
+        isEnabled: currentConfig['xpack.apm.ui.enabled'],
+        indexPatternTitle: currentConfig['apm_oss.indexPattern'],
         cloud: plugins.cloud,
         indices: {
-          errorIndices: this.currentConfig['apm_oss.errorIndices'],
-          metricsIndices: this.currentConfig['apm_oss.metricsIndices'],
-          onboardingIndices: this.currentConfig['apm_oss.onboardingIndices'],
-          sourcemapIndices: this.currentConfig['apm_oss.sourcemapIndices'],
-          transactionIndices: this.currentConfig['apm_oss.transactionIndices']
+          errorIndices: currentConfig['apm_oss.errorIndices'],
+          metricsIndices: currentConfig['apm_oss.metricsIndices'],
+          onboardingIndices: currentConfig['apm_oss.onboardingIndices'],
+          sourcemapIndices: currentConfig['apm_oss.sourcemapIndices'],
+          transactionIndices: currentConfig['apm_oss.transactionIndices']
         }
       })
     );
@@ -108,7 +104,7 @@ export class APMPlugin implements Plugin<APMPluginContract> {
       getApmIndices: async () =>
         getApmIndices({
           savedObjectsClient: await getInternalSavedObjectsClient(core),
-          config: this.currentConfig
+          config: currentConfig
         })
     };
   }


### PR DESCRIPTION
Closes #57931

 - Do not block setup lifecycle while creating agent configuration index
 - replace `console.error` with platform logger
 - change exported interface from apm_oss plugin


If the call to create the agent config index fails during setup, it will not be possible to agent configuration in the ui:
![image](https://user-images.githubusercontent.com/209966/75457140-5380fb00-597c-11ea-9408-83f518c0547d.png)

The following error is outputted by the server:
```json
{
  "error": {
    "root_cause": [
      {
        "type": "index_not_found_exception",
        "reason": "no such index [.apm-agent-configuration]",
        "resource.type": "index_or_alias",
        "resource.id": ".apm-agent-configuration",
        "index_uuid": "_na_",
        "index": ".apm-agent-configuration"
      }
    ],
    "type": "index_not_found_exception",
    "reason": "no such index [.apm-agent-configuration]",
    "resource.type": "index_or_alias",
    "resource.id": ".apm-agent-configuration",
    "index_uuid": "_na_",
    "index": ".apm-agent-configuration"
  },
  "status": 404
}
```

We can look into better ways to handle this in the future.
