### PR TITLE
[APM] Update tsconfig.json template in optimization script

### DIFF
--- a/x-pack/legacy/plugins/apm/readme.md
+++ b/x-pack/legacy/plugins/apm/readme.md
@@ -117,6 +117,6 @@ You can access the development environment at http://localhost:9001.
 
 #### Further resources
 
-- [Cypress integration tests](cypress/README.md)
+- [Cypress integration tests](./e2e/README.md)
 - [VSCode setup instructions](./dev_docs/vscode_setup.md)
 - [Github PR commands](./dev_docs/github_commands.md)

--- a/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
+++ b/x-pack/legacy/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
@@ -7,6 +7,6 @@
   ],
   "exclude": [
     "**/__fixtures__/**/*",
-    "./cypress/**/*"
+    "./e2e/cypress/**/*"
   ]
 }


### PR DESCRIPTION
The location of the cypress tests has changed, and those files are no longer excluded in the APM type check. This change updates the tsconfig.json template to exclude the new location.