### PR TITLE
Add alt attribute to images on the Add data page

### DIFF
--- a/src/legacy/core_plugins/kibana/public/home/np_ready/components/__snapshots__/synopsis.test.js.snap
+++ b/src/legacy/core_plugins/kibana/public/home/np_ready/components/__snapshots__/synopsis.test.js.snap
@@ -9,6 +9,7 @@ exports[`props iconType 1`] = `
   href="link_to_item"
   icon={
     <EuiIcon
+      alt=""
       size="l"
       type="logoApache"
     />

--- a/src/legacy/core_plugins/kibana/public/home/np_ready/components/synopsis.js
+++ b/src/legacy/core_plugins/kibana/public/home/np_ready/components/synopsis.js
@@ -37,13 +37,7 @@ export function Synopsis({
   if (iconUrl) {
     optionalImg = <img className="synopsisIcon" src={iconUrl} alt="" />;
   } else if (iconType) {
-    optionalImg = (
-      <EuiIcon
-        type={iconType}
-        // color="primary"
-        size="l"
-      />
-    );
+    optionalImg = <EuiIcon type={iconType} alt="" size="l" />;
   }
 
   const classes = classNames('homSynopsis__card', {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/56493 

## Summary

Images (logos) within the cards on the _Add data to Kibana_ page were producing axe findings as they lacked `alt` text. This PR adds `alt=""` to these image as described in https://github.com/elastic/kibana/issues/56493.

Note: This fix resolves the axe violation related to alt text, however there is another violation for non-unique id's that is not addressed by this PR. The latter involved id's set within the svg code which might need cleaned up on the EUI side.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist) 
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
