### PR TITLE
[WIP][App Arch] migrate legacy CSS to new platform (core_plugins/visualizations)

### DIFF
--- a/src/legacy/core_plugins/visualizations/index.ts
+++ b/src/legacy/core_plugins/visualizations/index.ts
@@ -25,9 +25,6 @@ export const visualizations: LegacyPluginInitializer = kibana =>
     id: 'visualizations',
     publicDir: resolve(__dirname, 'public'),
     require: [],
-    uiExports: {
-      styleSheetPaths: resolve(__dirname, 'public/index.scss'),
-    },
   });
 
 // eslint-disable-next-line import/no-default-export

--- a/src/legacy/core_plugins/visualizations/index.ts
+++ b/src/legacy/core_plugins/visualizations/index.ts
@@ -25,6 +25,9 @@ export const visualizations: LegacyPluginInitializer = kibana =>
     id: 'visualizations',
     publicDir: resolve(__dirname, 'public'),
     require: [],
+    uiExports: {
+      styleSheetPaths: resolve(__dirname, 'public/np_ready/public/index.scss'),
+    },
   });
 
 // eslint-disable-next-line import/no-default-export

--- a/src/legacy/core_plugins/visualizations/public/index.scss
+++ b/src/legacy/core_plugins/visualizations/public/index.scss
@@ -1,2 +1,0 @@
-@import 'src/legacy/ui/public/styles/styling_constants';
-@import './np_ready/public/index';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/_index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/_index.scss
@@ -1,2 +1,0 @@
-@import 'wizard/index';
-@import 'embeddable/index';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/components/_index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/components/_index.scss
@@ -1,1 +1,1 @@
-@import 'visualization';
+@import './visualization';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/embeddable/_index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/embeddable/_index.scss
@@ -1,2 +1,2 @@
-@import 'visualize_lab_disabled';
-@import 'embeddables';
+@import './visualize_lab_disabled';
+@import './embeddables';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/index.scss
@@ -1,3 +1,2 @@
 @import './wizard/index';
 @import './embeddable/index';
-@import './components/index';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/index.scss
@@ -1,2 +1,6 @@
+// Due the plugin is located on the old platform we should leave import of constants.
+// It will be removed when "visualizations" will migrate to the new platform
+@import 'src/legacy/ui/public/styles/styling_constants';
+
 @import './wizard/index';
 @import './embeddable/index';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/index.scss
@@ -1,0 +1,3 @@
+@import './wizard/index';
+@import './embeddable/index';
+@import './components/index';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/index.ts
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/index.ts
@@ -29,8 +29,6 @@
  * either types, or static code.
  */
 
-import './index.scss';
-
 import { PublicContract } from '@kbn/utility-types';
 import { PluginInitializerContext } from '../../../../../../core/public';
 import { VisualizationsPlugin, VisualizationsSetup, VisualizationsStart } from './plugin';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/index.ts
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/index.ts
@@ -29,6 +29,8 @@
  * either types, or static code.
  */
 
+import './index.scss';
+
 import { PublicContract } from '@kbn/utility-types';
 import { PluginInitializerContext } from '../../../../../../core/public';
 import { VisualizationsPlugin, VisualizationsSetup, VisualizationsStart } from './plugin';

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/plugin.ts
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/plugin.ts
@@ -58,6 +58,8 @@ import { UiActionsStart } from '../../../../../../plugins/ui_actions/public';
 import { DataStart as LegacyDataStart } from '../../../../data/public';
 import { VisState } from './types';
 
+import './index.scss';
+
 /**
  * Interface for this plugin's returned setup/start contracts.
  *

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/wizard/_index.scss
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/wizard/_index.scss
@@ -1,1 +1,1 @@
-@import 'dialog';
+@import './dialog';

--- a/src/legacy/ui/public/_index.scss
+++ b/src/legacy/ui/public/_index.scss
@@ -23,3 +23,4 @@
 
 // Can't import vis folder here because of cascading issues, it's imported in core_plugins/kibana
 // @import './vis/index';
+@import '../../core_plugins/visualizations/public/np_ready/public/components/index';

--- a/src/legacy/ui/public/_index.scss
+++ b/src/legacy/ui/public/_index.scss
@@ -23,4 +23,3 @@
 
 // Can't import vis folder here because of cascading issues, it's imported in core_plugins/kibana
 // @import './vis/index';
-@import './visualize/index';

--- a/src/legacy/ui/public/visualize/_index.scss
+++ b/src/legacy/ui/public/visualize/_index.scss
@@ -1,1 +1,0 @@
-@import '../../../core_plugins/visualizations/public/np_ready/public/components/index';


### PR DESCRIPTION
Part of #55493

## Summary

Here's a list of app arch legacy items I've found so far which contain some scss (be sure to look around for anything I may have missed):

- [x] `core_plugins/visualizations`

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
