### PR TITLE
Fixing a small typo

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/doc_table/components/pager/tool_bar_pager_buttons.tsx
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/doc_table/components/pager/tool_bar_pager_buttons.tsx
@@ -49,7 +49,7 @@ export function ToolBarPagerButtons(props: Props) {
         disabled={!props.hasNextPage}
         data-test-subj="btnNextPage"
         aria-label={i18n.translate(
-          'kbn.ddiscover.docTable.pager.toolbarPagerButtons.nextButtonAriaLabel',
+          'kbn.discover.docTable.pager.toolbarPagerButtons.nextButtonAriaLabel',
           {
             defaultMessage: 'Next page in table',
           }


### PR DESCRIPTION
## Summary

Leftover of:
https://github.com/elastic/kibana/pull/58122

It probably somehow got mixed up in the rebase

### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~
~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
~- [ ] This was checked for cross-browser compatibility, [including a check against IE11]~(https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
