### PR TITLE
[7.6] Convert discover_page to ts, remove redundunt methods (#59312)

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.html
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.html
@@ -28,7 +28,7 @@
 
   <main class="container-fluid">
     <div class="row">
-      <div class="col-md-2 sidebar-container collapsible-sidebar" id="discover-sidebar">
+      <div class="col-md-2 sidebar-container collapsible-sidebar" id="discover-sidebar" data-test-subj="discover-sidebar">
         <div class="dscFieldChooser">
           <disc-field-chooser
             columns="state.columns"

--- a/test/functional/apps/discover/_discover_histogram.js
+++ b/test/functional/apps/discover/_discover_histogram.js
@@ -23,6 +23,7 @@ export default function({ getService, getPageObjects }) {
   const log = getService('log');
   const esArchiver = getService('esArchiver');
   const browser = getService('browser');
+  const elasticChart = getService('elasticChart');
   const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['settings', 'common', 'discover', 'header', 'timePicker']);
   const defaultSettings = {
@@ -64,7 +65,7 @@ export default function({ getService, getPageObjects }) {
       await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
       await PageObjects.discover.setChartInterval('Monthly');
       await PageObjects.header.waitUntilLoadingHasFinished();
-      const chartCanvasExist = await PageObjects.discover.chartCanvasExist();
+      const chartCanvasExist = await elasticChart.canvasExists();
       expect(chartCanvasExist).to.be(true);
     });
     it('should visualize weekly data with within DST changes', async () => {
@@ -74,7 +75,7 @@ export default function({ getService, getPageObjects }) {
       await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
       await PageObjects.discover.setChartInterval('Weekly');
       await PageObjects.header.waitUntilLoadingHasFinished();
-      const chartCanvasExist = await PageObjects.discover.chartCanvasExist();
+      const chartCanvasExist = await elasticChart.canvasExists();
       expect(chartCanvasExist).to.be(true);
     });
     it('should visualize monthly data with different years Scaled to 30d', async () => {
@@ -84,7 +85,7 @@ export default function({ getService, getPageObjects }) {
       await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
       await PageObjects.discover.setChartInterval('Daily');
       await PageObjects.header.waitUntilLoadingHasFinished();
-      const chartCanvasExist = await PageObjects.discover.chartCanvasExist();
+      const chartCanvasExist = await elasticChart.canvasExists();
       expect(chartCanvasExist).to.be(true);
     });
   });

--- a/test/functional/apps/discover/_source_filters.js
+++ b/test/functional/apps/discover/_source_filters.js
@@ -49,7 +49,6 @@ export default function({ getService, getPageObjects }) {
     });
 
     it('should not get the field referer', async function() {
-      //let  fieldNames;
       const fieldNames = await PageObjects.discover.getAllFieldNames();
       expect(fieldNames).to.not.contain('referer');
       const relatedContentFields = fieldNames.filter(

--- a/test/functional/page_objects/index.ts
+++ b/test/functional/page_objects/index.ts
@@ -23,13 +23,11 @@ import { ConsolePageProvider } from './console_page';
 // @ts-ignore not TS yet
 import { ContextPageProvider } from './context_page';
 import { DashboardPageProvider } from './dashboard_page';
-// @ts-ignore not TS yet
 import { DiscoverPageProvider } from './discover_page';
 // @ts-ignore not TS yet
 import { ErrorPageProvider } from './error_page';
 // @ts-ignore not TS yet
 import { HeaderPageProvider } from './header_page';
-// @ts-ignore not TS yet
 import { HomePageProvider } from './home_page';
 // @ts-ignore not TS yet
 import { MonitoringPageProvider } from './monitoring_page';

--- a/test/functional/services/doc_table.ts
+++ b/test/functional/services/doc_table.ts
@@ -30,8 +30,8 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
   }
 
   class DocTable {
-    public async getTable() {
-      return await testSubjects.find('docTable');
+    public async getTable(selector?: string) {
+      return await testSubjects.find(selector ? selector : 'docTable');
     }
 
     public async getRowsText() {
@@ -107,8 +107,8 @@ export function DocTableProvider({ getService, getPageObjects }: FtrProviderCont
       return fields;
     }
 
-    public async getHeaderFields(): Promise<string[]> {
-      const table = await this.getTable();
+    public async getHeaderFields(selector?: string): Promise<string[]> {
+      const table = await this.getTable(selector);
       const $ = await table.parseDomContent();
       return $.findTestSubjects('~docTableHeaderField')
         .toArray()

--- a/test/functional/services/elastic_chart.ts
+++ b/test/functional/services/elastic_chart.ts
@@ -22,10 +22,19 @@ import { FtrProviderContext } from '../ftr_provider_context';
 
 export function ElasticChartProvider({ getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
+  const find = getService('find');
   const retry = getService('retry');
   const log = getService('log');
 
   class ElasticChart {
+    public async getCanvas() {
+      return await find.byCssSelector('.echChart canvas:last-of-type');
+    }
+
+    public async canvasExists() {
+      return await find.existsByCssSelector('.echChart canvas:last-of-type');
+    }
+
     public async waitForRenderComplete(dataTestSubj: string) {
       const chart = await testSubjects.find(dataTestSubj);
       const rendered = await chart.findAllByCssSelector('.echChart[data-ech-render-complete=true]');


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Convert discover_page to ts, remove redundunt methods (#59312)