### PR TITLE
Preserve filters on saved query changes

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
@@ -823,10 +823,6 @@ function discoverController(
       //reset filters and query string, remove savedQuery from state
       const state = {
         ...appStateContainer.getState(),
-        query: getDefaultQuery(
-          localStorage.get('kibana.userQueryLanguage') || config.get('search:queryLanguage')
-        ),
-        filters: [],
       };
       delete state.savedQuery;
       appStateContainer.set(state);

--- a/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.test.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.test.ts
@@ -21,7 +21,7 @@ import { clearStateFromSavedQuery } from './clear_saved_query';
 
 import { dataPluginMock } from '../../../mocks';
 import { DataPublicPluginStart } from '../../../types';
-import { Query, SavedQuery } from '../../..';
+import { Query } from '../../..';
 import { getFilter } from '../../../query/filter_manager/test_helpers/get_stub_filter';
 import { FilterStateStore } from '../../../../common/es_query/filters';
 

--- a/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.ts
@@ -16,14 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryStart } from '../../../query';
+
+import { each } from 'lodash';
+import { QueryStart, SavedQuery } from '../../../query';
+import { Filter } from '../../../../common';
 
 export const clearStateFromSavedQuery = (
   queryService: QueryStart,
   setQueryStringState: Function,
-  defaultLanguage: string
+  defaultLanguage: string,
+  prevSavedQuery?: SavedQuery
 ) => {
-  queryService.filterManager.removeAll();
+  each(prevSavedQuery?.attributes.filters || [], (filter: Filter) => {
+    queryService.filterManager.removeFilter(filter);
+  });
   setQueryStringState({
     query: '',
     language: defaultLanguage,

--- a/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/clear_saved_query.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { each } from 'lodash';
 import { QueryStart, SavedQuery } from '../../../query';
 import { Filter } from '../../../../common';
 
@@ -27,7 +26,7 @@ export const clearStateFromSavedQuery = (
   defaultLanguage: string,
   prevSavedQuery?: SavedQuery
 ) => {
-  each(prevSavedQuery?.attributes.filters || [], (filter: Filter) => {
+  (prevSavedQuery?.attributes.filters || []).forEach((filter: Filter) => {
     queryService.filterManager.removeFilter(filter);
   });
   setQueryStringState({

--- a/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.test.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.test.ts
@@ -43,7 +43,7 @@ describe('populateStateFromSavedQuery', () => {
   beforeEach(() => {
     dataMock = dataPluginMock.createStartContract();
     dataMock.query.filterManager.setFilters = jest.fn();
-    dataMock.query.filterManager.getGlobalFilters = jest.fn().mockReturnValue([]);
+    dataMock.query.filterManager.getFilters = jest.fn().mockReturnValue([]);
   });
 
   it('should set query', async () => {
@@ -51,7 +51,7 @@ describe('populateStateFromSavedQuery', () => {
     const savedQuery: SavedQuery = {
       ...baseSavedQuery,
     };
-    populateStateFromSavedQuery(dataMock.query, setQueryState, savedQuery);
+    populateStateFromSavedQuery(dataMock.query, setQueryState, undefined, savedQuery);
     expect(setQueryState).toHaveBeenCalled();
   });
 
@@ -62,21 +62,35 @@ describe('populateStateFromSavedQuery', () => {
     };
     const f1 = getFilter(FilterStateStore.APP_STATE, false, false, 'age', 34);
     savedQuery.attributes.filters = [f1];
-    populateStateFromSavedQuery(dataMock.query, setQueryState, savedQuery);
+    populateStateFromSavedQuery(dataMock.query, setQueryState, undefined, savedQuery);
     expect(setQueryState).toHaveBeenCalled();
     expect(dataMock.query.filterManager.setFilters).toHaveBeenCalledWith([f1]);
   });
 
+  it('should preserve app filters', async () => {
+    const setQueryState = jest.fn();
+    const savedQuery: SavedQuery = {
+      ...baseSavedQuery,
+    };
+    const f1 = getFilter(FilterStateStore.APP_STATE, false, false, 'age', 34);
+    const f2 = getFilter(FilterStateStore.APP_STATE, false, false, 'banana', 1);
+    dataMock.query.filterManager.getFilters = jest.fn().mockReturnValue([f2]);
+    savedQuery.attributes.filters = [f1];
+    populateStateFromSavedQuery(dataMock.query, setQueryState, undefined, savedQuery);
+    expect(setQueryState).toHaveBeenCalled();
+    expect(dataMock.query.filterManager.setFilters).toHaveBeenCalledWith([f2, f1]);
+  });
+
   it('should preserve global filters', async () => {
     const globalFilter = getFilter(FilterStateStore.GLOBAL_STATE, false, false, 'age', 34);
-    dataMock.query.filterManager.getGlobalFilters = jest.fn().mockReturnValue([globalFilter]);
+    dataMock.query.filterManager.getFilters = jest.fn().mockReturnValue([globalFilter]);
     const setQueryState = jest.fn();
     const savedQuery: SavedQuery = {
       ...baseSavedQuery,
     };
     const f1 = getFilter(FilterStateStore.APP_STATE, false, false, 'age', 34);
     savedQuery.attributes.filters = [f1];
-    populateStateFromSavedQuery(dataMock.query, setQueryState, savedQuery);
+    populateStateFromSavedQuery(dataMock.query, setQueryState, undefined, savedQuery);
     expect(setQueryState).toHaveBeenCalled();
     expect(dataMock.query.filterManager.setFilters).toHaveBeenCalledWith([globalFilter, f1]);
   });
@@ -97,7 +111,7 @@ describe('populateStateFromSavedQuery', () => {
     dataMock.query.timefilter.timefilter.setTime = jest.fn();
     dataMock.query.timefilter.timefilter.setRefreshInterval = jest.fn();
 
-    populateStateFromSavedQuery(dataMock.query, jest.fn(), savedQuery);
+    populateStateFromSavedQuery(dataMock.query, jest.fn(), undefined, savedQuery);
 
     expect(dataMock.query.timefilter.timefilter.setTime).toHaveBeenCalledWith({
       from: savedQuery.attributes.timefilter.from,

--- a/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/populate_state_from_saved_query.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import _ from 'lodash';
 import { QueryStart, SavedQuery, compareFilters, COMPARE_ALL_OPTIONS } from '../../../query';
 import { Filter } from '../../../../common';
 
@@ -52,7 +51,7 @@ export const populateStateFromSavedQuery = (
 
   // Remove filters added by the previous saved query
   const filtersToKeep = curFilters.filter((fmFilter: Filter) => {
-    return !_.find(prevSavedQueryFilters, (prevSavedQueryFilter: Filter) => {
+    return !prevSavedQueryFilters.find((prevSavedQueryFilter: Filter) => {
       return compareFilters(fmFilter, prevSavedQueryFilter, COMPARE_ALL_OPTIONS);
     });
   });

--- a/src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts
@@ -44,7 +44,6 @@ export const useSavedQuery = (props: UseSavedQueriesProps): UseSavedQueriesRetur
   const defaultLanguage = props.uiSettings.get('search:queryLanguage');
   const [savedQuery, setSavedQuery] = useState<SavedQuery | undefined>();
   const prevSavedQuery = useRef<SavedQuery | undefined>();
-  prevSavedQuery.current = savedQuery;
 
   // Effect is used to convert a saved query id into an object
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes part of the behavior described in https://github.com/elastic/kibana/issues/59303

 - Make sure app filters are preserved when switching saved queries
 - Make sure app filters are preserved when clearing a saved query
 - Make sure changing saved query ID works properly

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
