### PR TITLE
Endpoint: Metadata API schema type used in client

### DIFF
--- a/x-pack/plugins/endpoint/common/schema/metadata_index.ts
+++ b/x-pack/plugins/endpoint/common/schema/metadata_index.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { schema } from '@kbn/config-schema';
+
+export const metadataIndexGetBodySchema = schema.nullable(
+  schema.object({
+    paging_properties: schema.nullable(
+      schema.arrayOf(
+        schema.oneOf([
+          /**
+           * the number of results to return for this request per page
+           */
+          schema.object({
+            page_size: schema.number({ defaultValue: 10, min: 1, max: 10000 }),
+          }),
+          /**
+           * the zero based page index of the the total number of pages of page size
+           */
+          schema.object({ page_index: schema.number({ defaultValue: 0, min: 0 }) }),
+        ])
+      )
+    ),
+    /**
+     * filter to be applied, it could be a kql expression or discrete filter to be implemented
+     */
+    filter: schema.nullable(schema.oneOf([schema.string()])),
+  })
+);

--- a/x-pack/plugins/endpoint/common/types.ts
+++ b/x-pack/plugins/endpoint/common/types.ts
@@ -410,5 +410,7 @@ export type AlertingIndexGetQueryResult = TypeOf<typeof alertingIndexGetQuerySch
 /**
  * Request body for the 'metadata' API index
  */
-export type MetadataIndexGetBodyInput = TypeOf<typeof metadataIndexGetBodySchema>;
+export type MetadataIndexGetBodyInput = KbnConfigSchemaInputTypeOf<
+  typeof metadataIndexGetBodySchema
+>;
 export type MetadataIndexGetBodyResult = TypeOf<typeof metadataIndexGetBodySchema>;

--- a/x-pack/plugins/endpoint/common/types.ts
+++ b/x-pack/plugins/endpoint/common/types.ts
@@ -411,6 +411,7 @@ export type AlertingIndexGetQueryResult = TypeOf<typeof alertingIndexGetQuerySch
  * Request body for the 'metadata' API index
  */
 export type MetadataIndexGetBodyInput = KbnConfigSchemaInputTypeOf<
-  typeof metadataIndexGetBodySchema
+  TypeOf<typeof metadataIndexGetBodySchema>
 >;
+
 export type MetadataIndexGetBodyResult = TypeOf<typeof metadataIndexGetBodySchema>;

--- a/x-pack/plugins/endpoint/common/types.ts
+++ b/x-pack/plugins/endpoint/common/types.ts
@@ -7,6 +7,7 @@
 import { SearchResponse } from 'elasticsearch';
 import { TypeOf } from '@kbn/config-schema';
 import { alertingIndexGetQuerySchema } from './schema/alert_index';
+import { metadataIndexGetBodySchema } from './schema/metadata_index';
 
 /**
  * A deep readonly type that will make all children of a given object readonly recursively
@@ -405,3 +406,9 @@ export type AlertingIndexGetQueryInput = KbnConfigSchemaInputTypeOf<
  * Result of the validated query params when handling alert index requests.
  */
 export type AlertingIndexGetQueryResult = TypeOf<typeof alertingIndexGetQuerySchema>;
+
+/**
+ * Request body for the 'metadata' API index
+ */
+export type MetadataIndexGetBodyInput = TypeOf<typeof metadataIndexGetBodySchema>;
+export type MetadataIndexGetBodyResult = TypeOf<typeof metadataIndexGetBodySchema>;

--- a/x-pack/plugins/endpoint/public/applications/endpoint/store/managing/middleware.ts
+++ b/x-pack/plugins/endpoint/public/applications/endpoint/store/managing/middleware.ts
@@ -30,7 +30,6 @@ export const managementMiddlewareFactory: MiddlewareFactory<ManagementListState>
       const managementPageSize = pageSize(state);
       const body: MetadataIndexGetBodyInput = {
         paging_properties: [{ page_index: managementPageIndex }, { page_size: managementPageSize }],
-        filter: null,
       };
       const response = await coreStart.http.post('/api/endpoint/metadata', {
         body: JSON.stringify(body),

--- a/x-pack/plugins/endpoint/public/applications/endpoint/store/managing/middleware.ts
+++ b/x-pack/plugins/endpoint/public/applications/endpoint/store/managing/middleware.ts
@@ -14,6 +14,7 @@ import {
 } from './selectors';
 import { ManagementListState } from '../../types';
 import { AppAction } from '../action';
+import { MetadataIndexGetBodyInput } from '../../../../../common/types';
 
 export const managementMiddlewareFactory: MiddlewareFactory<ManagementListState> = coreStart => {
   return ({ getState, dispatch }) => next => async (action: AppAction) => {
@@ -27,13 +28,12 @@ export const managementMiddlewareFactory: MiddlewareFactory<ManagementListState>
     ) {
       const managementPageIndex = pageIndex(state);
       const managementPageSize = pageSize(state);
+      const body: MetadataIndexGetBodyInput = {
+        paging_properties: [{ page_index: managementPageIndex }, { page_size: managementPageSize }],
+        filter: null,
+      };
       const response = await coreStart.http.post('/api/endpoint/metadata', {
-        body: JSON.stringify({
-          paging_properties: [
-            { page_index: managementPageIndex },
-            { page_size: managementPageSize },
-          ],
-        }),
+        body: JSON.stringify(body),
       });
       response.request_page_index = managementPageIndex;
       dispatch({

--- a/x-pack/plugins/endpoint/server/routes/metadata/index.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/index.test.ts
@@ -17,12 +17,12 @@ import {
   httpServerMock,
   httpServiceMock,
   loggingServiceMock,
-} from '../../../../../src/core/server/mocks';
-import { EndpointMetadata, EndpointResultList } from '../../common/types';
+} from '../../../../../../src/core/server/mocks';
+import { EndpointMetadata, EndpointResultList } from '../../../common/types';
 import { SearchResponse } from 'elasticsearch';
-import { registerEndpointRoutes } from './metadata';
-import { EndpointConfigSchema } from '../config';
-import * as data from '../test_data/all_metadata_data.json';
+import { registerEndpointRoutes } from '../metadata';
+import { EndpointConfigSchema } from '../../config';
+import * as data from '../../test_data/all_metadata_data.json';
 
 describe('test endpoint route', () => {
   let routerMock: jest.Mocked<IRouter>;

--- a/x-pack/plugins/endpoint/server/routes/metadata/query_builders.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/query_builders.test.ts
@@ -3,12 +3,13 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 import { httpServerMock, loggingServiceMock } from '../../../../../../src/core/server/mocks';
-import { EndpointConfigSchema } from '../../config';
 import {
   kibanaRequestToMetadataListESQuery,
   kibanaRequestToMetadataGetESQuery,
-} from './metadata_query_builders';
+} from './query_builders';
+import { EndpointConfigSchema } from '../../config';
 import { EndpointAppConstants } from '../../../common/types';
 
 describe('query builder', () => {
@@ -123,10 +124,7 @@ describe('query builder', () => {
           id: mockID,
         },
       });
-      const query = kibanaRequestToMetadataGetESQuery(mockRequest, {
-        logFactory: loggingServiceMock.create(),
-        config: () => Promise.resolve(EndpointConfigSchema.validate({})),
-      });
+      const query = kibanaRequestToMetadataGetESQuery(mockRequest);
       expect(query).toEqual({
         body: {
           query: { match: { 'host.id.keyword': mockID } },

--- a/x-pack/plugins/endpoint/server/routes/metadata/query_builders.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/query_builders.ts
@@ -9,7 +9,9 @@ import { EndpointAppContext } from '../../types';
 import { esKuery } from '../../../../../../src/plugins/data/server';
 
 /**
- * TODO, add comment to exported function.
+ * Takes the POST body from the metadata index API.
+ * Returns the client params for an Elasticsearch query.
+ * Documents used in the 'host' UI
  */
 export const kibanaRequestToMetadataListESQuery = async (
   request: KibanaRequest<unknown, unknown, MetadataIndexGetBodyResult>,
@@ -63,7 +65,7 @@ async function getPagingProperties(
       }
     }
   }
-  // If page_size or page_index are 0 or undefined, use the defaults instead. TODO, is this logic right?
+  // If page_size or page_index are 0 or undefined, use the defaults instead.
   return {
     pageSize: pagingProperties.page_size || config.endpointResultListDefaultPageSize,
     pageIndex: pagingProperties.page_index || config.endpointResultListDefaultFirstPageIndex,
@@ -82,7 +84,7 @@ function buildQueryBody(
 }
 
 /**
- * TODO, add comment to exported function.
+ * Takes an 'metadata' ID and returns the client params for an Elasticsearch query which returns a metadata document.
  */
 export const kibanaRequestToMetadataGetESQuery = (
   request: KibanaRequest<{ id: string }, unknown, unknown>

--- a/x-pack/plugins/endpoint/server/routes/metadata/query_builders.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/query_builders.ts
@@ -4,14 +4,17 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { KibanaRequest } from 'kibana/server';
-import { EndpointAppConstants } from '../../../common/types';
+import { EndpointAppConstants, MetadataIndexGetBodyResult } from '../../../common/types';
 import { EndpointAppContext } from '../../types';
 import { esKuery } from '../../../../../../src/plugins/data/server';
 
+/**
+ * TODO, add comment to exported function.
+ */
 export const kibanaRequestToMetadataListESQuery = async (
-  request: KibanaRequest<any, any, any>,
+  request: KibanaRequest<unknown, unknown, MetadataIndexGetBodyResult>,
   endpointAppContext: EndpointAppContext
-): Promise<Record<string, any>> => {
+): Promise<Record<string, unknown> & { size: number; from: number }> => {
   const pagingProperties = await getPagingProperties(request, endpointAppContext);
   return {
     body: {
@@ -46,27 +49,31 @@ export const kibanaRequestToMetadataListESQuery = async (
 };
 
 async function getPagingProperties(
-  request: KibanaRequest<any, any, any>,
+  request: KibanaRequest<unknown, unknown, MetadataIndexGetBodyResult>,
   endpointAppContext: EndpointAppContext
 ) {
   const config = await endpointAppContext.config();
   const pagingProperties: { page_size?: number; page_index?: number } = {};
-  if (request?.body?.paging_properties) {
+  if (request.body?.paging_properties) {
     for (const property of request.body.paging_properties) {
-      Object.assign(
-        pagingProperties,
-        ...Object.keys(property).map(key => ({ [key]: property[key] }))
-      );
+      if ('page_size' in property) {
+        pagingProperties.page_size = property.page_size;
+      } else {
+        pagingProperties.page_index = property.page_index;
+      }
     }
   }
+  // If page_size or page_index are 0 or undefined, use the defaults instead. TODO, is this logic right?
   return {
     pageSize: pagingProperties.page_size || config.endpointResultListDefaultPageSize,
     pageIndex: pagingProperties.page_index || config.endpointResultListDefaultFirstPageIndex,
   };
 }
 
-function buildQueryBody(request: KibanaRequest<any, any, any>): Record<string, any> {
-  if (typeof request?.body?.filter === 'string') {
+function buildQueryBody(
+  request: KibanaRequest<unknown, unknown, MetadataIndexGetBodyResult>
+): Record<string, unknown> {
+  if (typeof request.body?.filter === 'string') {
     return esKuery.toElasticsearchQuery(esKuery.fromKueryExpression(request.body.filter));
   }
   return {
@@ -74,9 +81,11 @@ function buildQueryBody(request: KibanaRequest<any, any, any>): Record<string, a
   };
 }
 
+/**
+ * TODO, add comment to exported function.
+ */
 export const kibanaRequestToMetadataGetESQuery = (
-  request: KibanaRequest<any, any, any>,
-  endpointAppContext: EndpointAppContext
+  request: KibanaRequest<{ id: string }, unknown, unknown>
 ) => {
   return {
     body: {


### PR DESCRIPTION
## Summary

* Use a type based on the metadata's API schema in the client when creating the request.
* Swap `any` out for regular types in various places.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
