### PR TITLE
Aggregate queue types being used by Beats

### DIFF
--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/__mocks__/fixtures/beats_stats_results.json
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/__mocks__/fixtures/beats_stats_results.json
@@ -12,6 +12,9 @@
                   "functions": {
                     "count": 1
                   }
+                },
+                "queue": {
+                  "name": "mem"
                 }
               }
             }
@@ -27,6 +30,9 @@
                   "functions": {
                     "count": 3
                   }
+                },
+                "queue": {
+                  "name": "mem"
                 }
               }
             }
@@ -53,6 +59,9 @@
                     "endpoints" : 1
                   },
                   "monitors" : 2
+                },
+                "queue": {
+                  "name": "spool"
                 }
               }
             }

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.test.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.test.ts
@@ -110,6 +110,10 @@ describe('Get Beats Stats', () => {
             count: 0,
             names: [],
           },
+          queue: {
+            mem: 0,
+            spool: 0,
+          },
           architecture: {
             count: 0,
             architectures: [],
@@ -141,6 +145,10 @@ describe('Get Beats Stats', () => {
           input: {
             count: 1,
             names: ['firehose'],
+          },
+          queue: {
+            mem: 0,
+            spool: 0,
           },
           architecture: {
             count: 1,
@@ -197,6 +205,10 @@ describe('Get Beats Stats', () => {
           module: {
             count: 0,
             names: [],
+          },
+          queue: {
+            mem: 0,
+            spool: 0,
           },
           architecture: {
             count: 0,

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.test.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.test.ts
@@ -147,8 +147,8 @@ describe('Get Beats Stats', () => {
             names: ['firehose'],
           },
           queue: {
-            mem: 0,
-            spool: 0,
+            mem: 2,
+            spool: 1,
           },
           architecture: {
             count: 1,

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
@@ -29,6 +29,10 @@ const getBaseStats = () => ({
     count: 0,
     names: [],
   },
+  queue: {
+    mem: 0,
+    spool: 0,
+  },
   architecture: {
     count: 0,
     architectures: [],
@@ -68,6 +72,9 @@ export interface BeatsStats {
       module?: {
         names: string[];
         count: number;
+      };
+      queue?: {
+        name?: string;
       };
       heartbeat?: HeartbeatBase;
       functionbeat?: {
@@ -213,6 +220,11 @@ export function processResults(
         stateModule.names.forEach(name => moduleSet.add(statsType + '.' + name));
         clusters[clusterUuid].module.names = Array.from(moduleSet);
         clusters[clusterUuid].module.count += stateModule.count;
+      }
+
+      const stateQueue = hit._source.beats_state?.state?.queue?.name;
+      if (clusters[clusterUuid].queue.hasOwnProperty(stateQueue)) {
+        clusters[clusterUuid].queue[stateQueue] += 1;
       }
 
       const heartbeatState = hit._source.beats_state?.state?.heartbeat;

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
@@ -115,8 +115,7 @@ export interface BeatsBaseStats {
     names: string[];
   };
   queue: {
-    mem: number;
-    spool: number;
+    [queueType: string]: number;
   };
   architecture: {
     count: number;
@@ -228,9 +227,7 @@ export function processResults(
 
       const stateQueue = hit._source.beats_state?.state?.queue?.name;
       if (stateQueue !== undefined) {
-        if (clusters[clusterUuid].queue.hasOwnProperty(stateQueue)) {
-          clusters[clusterUuid].queue[stateQueue] += 1;
-        }
+        clusters[clusterUuid].queue[stateQueue] += 1;
       }
 
       const heartbeatState = hit._source.beats_state?.state?.heartbeat;

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
@@ -343,6 +343,7 @@ async function fetchBeatsByType(
       'hits.hits._source.beats_stats.metrics.libbeat.output.type',
       'hits.hits._source.beats_state.state.input',
       'hits.hits._source.beats_state.state.module',
+      'hits.hits._source.beats_state.state.queue',
       'hits.hits._source.beats_state.state.host',
       'hits.hits._source.beats_state.state.heartbeat',
       'hits.hits._source.beats_state.beat.type',

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
@@ -227,8 +227,10 @@ export function processResults(
       }
 
       const stateQueue = hit._source.beats_state?.state?.queue?.name;
-      if (clusters[clusterUuid].queue.hasOwnProperty(stateQueue)) {
-        clusters[clusterUuid].queue[stateQueue] += 1;
+      if (stateQueue !== undefined) {
+        if (clusters[clusterUuid].queue.hasOwnProperty(stateQueue)) {
+          clusters[clusterUuid].queue[stateQueue] += 1;
+        }
       }
 
       const heartbeatState = hit._source.beats_state?.state?.heartbeat;

--- a/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
+++ b/x-pack/legacy/plugins/monitoring/server/telemetry_collection/get_beats_stats.ts
@@ -114,6 +114,10 @@ export interface BeatsBaseStats {
     count: number;
     names: string[];
   };
+  queue: {
+    mem: number;
+    spool: number;
+  };
   architecture: {
     count: number;
     architectures: BeatsArchitecture[];


### PR DESCRIPTION
## Summary

This PR teaches the telemetry collection code in Kibana to count the various queue types (mem or spool) used by Beats in a cluster.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support]~(https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] ~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~
- [ ] ~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- [ ] ~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~

### For maintainers

- [ ] ~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
