### PR TITLE
Change apm oss plugin name from apm_oss to apmOss

### DIFF
--- a/src/plugins/apm_oss/kibana.json
+++ b/src/plugins/apm_oss/kibana.json
@@ -1,5 +1,5 @@
 {
-  "id": "apm_oss",
+  "id": "apmOss",
   "version": "8.0.0",
   "server": true,
   "kibanaVersion": "kibana",

--- a/x-pack/plugins/apm/kibana.json
+++ b/x-pack/plugins/apm/kibana.json
@@ -5,6 +5,6 @@
   "kibanaVersion": "kibana",
   "configPath": ["xpack", "apm"],
   "ui": false,
-  "requiredPlugins": ["apm_oss", "data", "home", "licensing"],
+  "requiredPlugins": ["apmOss", "data", "home", "licensing"],
   "optionalPlugins": ["cloud", "usageCollection"]
 }


### PR DESCRIPTION
Closes #59184 

## Summary

Snake case plugin names give warning in console. In this PR, APM OSS plugin's name is changed fro apm_oss to apmOss