### PR TITLE
Change APM OSS plugin name from apm_oss to apmOss

### DIFF
--- a/src/plugins/apm_oss/kibana.json
+++ b/src/plugins/apm_oss/kibana.json
@@ -1,5 +1,5 @@
 {
-  "id": "apm_oss",
+  "id": "apmOss",
   "version": "8.0.0",
   "server": true,
   "kibanaVersion": "kibana",

--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -46,7 +46,7 @@ export class APMPlugin implements Plugin<APMPluginContract> {
   public async setup(
     core: CoreSetup,
     plugins: {
-      apm_oss: APMOSSPluginSetup;
+      apmOss: APMOSSPluginSetup;
       home: HomeServerPluginSetup;
       licensing: LicensingPluginSetup;
       cloud?: CloudSetup;
@@ -58,7 +58,7 @@ export class APMPlugin implements Plugin<APMPluginContract> {
   ) {
     const logger = this.initContext.logger.get();
     const config$ = this.initContext.config.create<APMXPackConfig>();
-    const mergedConfig$ = combineLatest(plugins.apm_oss.config$, config$).pipe(
+    const mergedConfig$ = combineLatest(plugins.apmOss.config$, config$).pipe(
       map(([apmOssConfig, apmConfig]) => mergeConfigs(apmOssConfig, apmConfig))
     );
 


### PR DESCRIPTION
Closes #59184 

**Summary**

Snake case plugin names give warning in console. In this PR, APM OSS plugin's name is changed fro apm_oss to apmOss