### PR TITLE
[EPM] change index pattern id to be the same as index pattern title

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
@@ -95,10 +95,7 @@ export async function installIndexPatterns(
     // if this is an update because a package is being unisntalled (no pkgkey argument passed) and no other packages are installed, remove the index pattern
     if (!pkgkey && installedPackages.length === 0) {
       try {
-        await savedObjectsClient.delete(
-          INDEX_PATTERN_SAVED_OBJECT_TYPE,
-          `epm-ip-${indexPatternType}`
-        );
+        await savedObjectsClient.delete(INDEX_PATTERN_SAVED_OBJECT_TYPE, `${indexPatternType}-*`);
       } catch (err) {
         // index pattern was probably deleted by the user already
       }
@@ -111,7 +108,7 @@ export async function installIndexPatterns(
     const kibanaIndexPattern = createIndexPattern(indexPatternType, fields);
     // create or overwrite the index pattern
     await savedObjectsClient.create(INDEX_PATTERN_SAVED_OBJECT_TYPE, kibanaIndexPattern, {
-      id: `epm-ip-${indexPatternType}`,
+      id: `${indexPatternType}-*`,
       overwrite: true,
     });
   });


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/60388

Changes the index pattern ID to match the name of the index pattern title.  In the case of EPM, the ids will be `metrics-*`, `logs-*`, `events-*`