### PR TITLE
[APM] Service Map - Separate overlapping edges by rotating nodes

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -57,6 +57,20 @@ function useCytoscape(options: cytoscape.CytoscapeOptions) {
   return [ref, cy] as [React.MutableRefObject<any>, cytoscape.Core | undefined];
 }
 
+function rotatePoint(
+  { x, y }: { x: number; y: number },
+  degreesRotated: number
+) {
+  const radiansPerDegree = Math.PI / 180;
+  const θ = radiansPerDegree * degreesRotated;
+  const cosθ = Math.cos(θ);
+  const sinθ = Math.sin(θ);
+  return {
+    x: x * cosθ - y * sinθ,
+    y: x * sinθ + y * cosθ
+  };
+}
+
 function getLayoutOptions(
   selectedRoots: string[],
   height: number,
@@ -71,10 +85,11 @@ function getLayoutOptions(
     animate: true,
     animationEasing: animationOptions.easing,
     animationDuration: animationOptions.duration,
-    // Rotate nodes from top -> bottom to display left -> right
     // @ts-ignore
-    transform: (node: any, { x, y }: cytoscape.Position) => ({ x: y, y: -x }),
-    // swap width/height of boundingBox to compensation for the rotation
+    // Rotate nodes counter-clockwise to transform layout from top→bottom to left→right.
+    // The extra 5° achieves the effect of separating overlapping taxi-styled edges.
+    transform: (node: any, pos: cytoscape.Position) => rotatePoint(pos, -95),
+    // swap width/height of boundingBox to compensate for the rotation
     boundingBox: { x1: 0, y1: 0, w: height, h: width }
   };
 }

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
@@ -121,15 +121,18 @@ const style: cytoscape.Stylesheet[] = [
   {
     selector: 'edge.nodeHover',
     style: {
-      width: 4,
+      width: 2,
       // @ts-ignore
-      'z-index': zIndexEdgeHover
+      'z-index': zIndexEdgeHover,
+      'line-color': theme.euiColorDarkShade,
+      'source-arrow-color': theme.euiColorDarkShade,
+      'target-arrow-color': theme.euiColorDarkShade
     }
   },
   {
     selector: 'node.hover',
     style: {
-      'border-width': 4
+      'border-width': 2
     }
   },
   {

--- a/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/KueryBar/index.tsx
@@ -79,7 +79,7 @@ export function KueryBar() {
   const disabled = /\/service-map$/.test(location.pathname);
   const disabledPlaceholder = i18n.translate(
     'xpack.apm.kueryBar.disabledPlaceholder',
-    { defaultMessage: 'Search is not available for service maps' }
+    { defaultMessage: 'Search is not available for service map' }
   );
 
   async function onChange(inputValue: string, selectionStart: number) {


### PR DESCRIPTION
Closes #59779. Adds rotation transform which does the top->bottom to left->right transformation + an extra 5 degrees which results in taxi edges separating when rendered.
![service-maps-layout-8](https://user-images.githubusercontent.com/1967266/77147906-9e59d400-6a4b-11ea-9de0-34a8bc792613.gif)

