### PR TITLE
[Fleet] Fix privileges for enrollment and access api keys

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/api_keys/enrollment_api_key.ts
+++ b/x-pack/plugins/ingest_manager/server/services/api_keys/enrollment_api_key.ts
@@ -93,7 +93,19 @@ export async function generateEnrollmentAPIKey(
 
   const name = providedKeyName ? `${providedKeyName} (${id})` : id;
 
-  const key = await createAPIKey(soClient, name, {});
+  const key = await createAPIKey(soClient, name, {
+    // Useless role to avoid to have the privilege of the user that created the key
+    'fleet-apikey-enroll': {
+      cluster: [],
+      applications: [
+        {
+          application: '.fleet',
+          privileges: ['no-privileges'],
+          resources: ['*'],
+        },
+      ],
+    },
+  });
 
   if (!key) {
     throw new Error('Unable to create an enrollment api key');

--- a/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
@@ -42,7 +42,17 @@ export async function generateAccessApiKey(
   configId: string
 ) {
   const key = await createAPIKey(soClient, agentId, {
-    'fleet-agent': {},
+    // Useless role to avoid to have the privilege of the user that created the key
+    'fleet-apikey-access': {
+      cluster: [],
+      applications: [
+        {
+          application: '.fleet',
+          privileges: ['no-privileges'],
+          resources: ['*'],
+        },
+      ],
+    },
   });
 
   if (!key) {

--- a/x-pack/test/api_integration/apis/fleet/agents/services.ts
+++ b/x-pack/test/api_integration/apis/fleet/agents/services.ts
@@ -5,7 +5,8 @@
  */
 
 import supertestAsPromised from 'supertest-as-promised';
-import url from 'url';
+import { Client } from '@elastic/elasticsearch';
+import { format as formatUrl } from 'url';
 
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
@@ -15,7 +16,19 @@ export function getSupertestWithoutAuth({ getService }: FtrProviderContext) {
   kibanaUrl.auth = null;
   kibanaUrl.password = null;
 
-  return supertestAsPromised(url.format(kibanaUrl));
+  return supertestAsPromised(formatUrl(kibanaUrl));
+}
+
+export function getEsClientForAPIKey({ getService }: FtrProviderContext, esApiKey: string) {
+  const config = getService('config');
+  const url = formatUrl({ ...config.get('servers.elasticsearch'), auth: false });
+  return new Client({
+    nodes: [url],
+    auth: {
+      apiKey: esApiKey,
+    },
+    requestTimeout: config.get('timeouts.esRequestTimeout'),
+  });
 }
 
 export function setupIngest({ getService }: FtrProviderContext) {


### PR DESCRIPTION
## Summary

Resolve #60514 

When you create an api key without anything in the role_descriptors, this api key inherit privileges from the users that created the key. This resulted in Access and enrollment key with too much privileges.

It's now fixed and I added some tests to validate that the api keys created have limited privileges.

