### PR TITLE
[Fleet] Create a fleet_enroll user and role during fleet setup

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/output.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/output.ts
@@ -15,8 +15,8 @@ export interface NewOutput {
   hosts?: string[];
   ca_sha256?: string;
   api_key?: string;
-  admin_username?: string;
-  admin_password?: string;
+  fleet_enroll_username?: string;
+  fleet_enroll_password?: string;
   config?: Record<string, any>;
 }
 

--- a/x-pack/plugins/ingest_manager/common/types/rest_spec/fleet_setup.ts
+++ b/x-pack/plugins/ingest_manager/common/types/rest_spec/fleet_setup.ts
@@ -9,8 +9,8 @@ export interface GetFleetSetupRequest {}
 
 export interface CreateFleetSetupRequest {
   body: {
-    admin_username: string;
-    admin_password: string;
+    fleet_enroll_username: string;
+    fleet_enroll_password: string;
   };
 }
 

--- a/x-pack/plugins/ingest_manager/dev_docs/schema/saved_objects.mml
+++ b/x-pack/plugins/ingest_manager/dev_docs/schema/saved_objects.mml
@@ -76,7 +76,7 @@ classDiagram
     ca_sha256
     config
     // Encrypted - user to create API keys
-    admin_username
-    admin_password
+    fleet_enroll_username
+    fleet_enroll_password
   }
 

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -4,29 +4,26 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import React, { useState } from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
 import {
   EuiPageBody,
   EuiPageContent,
   EuiForm,
-  EuiFormRow,
-  EuiFieldText,
-  EuiFieldPassword,
   EuiText,
   EuiButton,
-  EuiCallOut,
   EuiTitle,
   EuiSpacer,
+  EuiIcon,
 } from '@elastic/eui';
-import { sendRequest, useInput, useCore } from '../../../hooks';
+import { sendRequest, useCore } from '../../../hooks';
 import { fleetSetupRouteService } from '../../../services';
+import { WithoutHeaderLayout } from '../../../layouts';
 
 export const SetupPage: React.FunctionComponent<{
   refresh: () => Promise<void>;
 }> = ({ refresh }) => {
   const [isFormLoading, setIsFormLoading] = useState<boolean>(false);
   const core = useCore();
-  const usernameInput = useInput();
-  const passwordInput = useInput();
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -35,10 +32,6 @@ export const SetupPage: React.FunctionComponent<{
       await sendRequest({
         method: 'post',
         path: fleetSetupRouteService.postFleetSetupPath(),
-        body: JSON.stringify({
-          admin_username: usernameInput.value,
-          admin_password: passwordInput.value,
-        }),
       });
       await refresh();
     } catch (error) {
@@ -48,33 +41,47 @@ export const SetupPage: React.FunctionComponent<{
   };
 
   return (
-    <EuiPageBody>
-      <EuiPageContent>
-        <EuiTitle>
-          <h1>Setup</h1>
-        </EuiTitle>
-        <EuiSpacer size="l" />
-        <EuiCallOut title="Warning!" color="warning" iconType="help">
-          <EuiText>
-            To setup fleet and ingest you need to a enable a user that can create API Keys and write
-            to logs-* and metrics-*
+    <WithoutHeaderLayout>
+      <EuiPageBody restrictWidth={528}>
+        <EuiPageContent
+          verticalPosition="center"
+          horizontalPosition="center"
+          className="eui-textCenter"
+          paddingSize="l"
+        >
+          <EuiSpacer size="m" />
+          <EuiIcon type="lock" color="subdued" size="xl" />
+          <EuiSpacer size="m" />
+          <EuiTitle size="l">
+            <h2>
+              <FormattedMessage
+                id="xpack.ingestManager.setupPage.title"
+                defaultMessage="Enable Fleet"
+              />
+            </h2>
+          </EuiTitle>
+          <EuiSpacer size="xl" />
+          <EuiText color="subdued">
+            <FormattedMessage
+              id="xpack.ingestManager.setupPage.description"
+              defaultMessage="In order to use Fleet, you must create an Elastic user. This user can create API keys
+                and write to logs-* and metrics-*."
+            />
           </EuiText>
-        </EuiCallOut>
-        <EuiSpacer size="l" />
-        <EuiForm>
-          <form onSubmit={onSubmit}>
-            <EuiFormRow label="Username">
-              <EuiFieldText name="username" {...usernameInput.props} />
-            </EuiFormRow>
-            <EuiFormRow label="Password">
-              <EuiFieldPassword name="password" {...passwordInput.props} />
-            </EuiFormRow>
-            <EuiButton isLoading={isFormLoading} type="submit">
-              Submit
-            </EuiButton>
-          </form>
-        </EuiForm>
-      </EuiPageContent>
-    </EuiPageBody>
+          <EuiSpacer size="l" />
+          <EuiForm>
+            <form onSubmit={onSubmit}>
+              <EuiButton fill isLoading={isFormLoading} type="submit">
+                <FormattedMessage
+                  id="xpack.ingestManager.setupPage.enableFleet"
+                  defaultMessage="Create user and enable Fleet"
+                />
+              </EuiButton>
+            </form>
+          </EuiForm>
+          <EuiSpacer size="m" />
+        </EuiPageContent>
+      </EuiPageBody>
+    </WithoutHeaderLayout>
   );
 };

--- a/x-pack/plugins/ingest_manager/server/saved_objects.ts
+++ b/x-pack/plugins/ingest_manager/server/saved_objects.ts
@@ -102,8 +102,8 @@ export const savedObjectMappings = {
       ca_sha256: { type: 'keyword' },
       // FIXME_INGEST https://github.com/elastic/kibana/issues/56554
       api_key: { type: 'keyword' },
-      admin_username: { type: 'binary' },
-      admin_password: { type: 'binary' },
+      fleet_enroll_username: { type: 'binary' },
+      fleet_enroll_password: { type: 'binary' },
       config: { type: 'flattened' },
     },
   },

--- a/x-pack/plugins/ingest_manager/server/services/output.ts
+++ b/x-pack/plugins/ingest_manager/server/services/output.ts
@@ -60,13 +60,13 @@ class OutputService {
       .getEncryptedSavedObjects()
       ?.getDecryptedAsInternalUser<Output>(OUTPUT_SAVED_OBJECT_TYPE, defaultOutputId);
 
-    if (!so || !so.attributes.admin_username || !so.attributes.admin_password) {
+    if (!so || !so.attributes.fleet_enroll_username || !so.attributes.fleet_enroll_password) {
       return null;
     }
 
     return {
-      username: so!.attributes.admin_username,
-      password: so!.attributes.admin_password,
+      username: so!.attributes.fleet_enroll_username,
+      password: so!.attributes.fleet_enroll_password,
     };
   }
 

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -22,8 +22,8 @@ import { getPackageInfo } from './epm/packages';
 import { datasourceService } from './datasource';
 import { generateEnrollmentAPIKey } from './api_keys';
 
-const FLEET_ADMIN_USERNAME = 'fleet_enroll';
-const FLEET_ADMIN_ROLE = 'fleet_enroll';
+const FLEET_ENROLL_USERNAME = 'fleet_enroll';
+const FLEET_ENROLL_ROLE = 'fleet_enroll';
 
 export async function setupIngestManager(
   soClient: SavedObjectsClientContract,
@@ -73,7 +73,7 @@ export async function setupFleet(
   // This should be done directly in ES at some point
   await callCluster('transport.request', {
     method: 'PUT',
-    path: `/_security/role/${FLEET_ADMIN_ROLE}`,
+    path: `/_security/role/${FLEET_ENROLL_ROLE}`,
     body: {
       cluster: ['monitor', 'manage_api_key'],
       indices: [
@@ -88,17 +88,17 @@ export async function setupFleet(
   // Create fleet enroll user
   await callCluster('transport.request', {
     method: 'PUT',
-    path: `/_security/user/${FLEET_ADMIN_USERNAME}`,
+    path: `/_security/user/${FLEET_ENROLL_USERNAME}`,
     body: {
       password,
-      roles: [FLEET_ADMIN_ROLE],
+      roles: [FLEET_ENROLL_ROLE],
     },
   });
 
   // save fleet admin user
   await outputService.updateOutput(soClient, await outputService.getDefaultOutputId(soClient), {
-    admin_username: FLEET_ADMIN_USERNAME,
-    admin_password: password,
+    fleet_enroll_username: FLEET_ENROLL_USERNAME,
+    fleet_enroll_password: password,
   });
 
   // Generate default enrollment key

--- a/x-pack/plugins/ingest_manager/server/types/models/output.ts
+++ b/x-pack/plugins/ingest_manager/server/types/models/output.ts
@@ -15,8 +15,8 @@ const OutputBaseSchema = {
   type: schema.oneOf([schema.literal(OutputType.Elasticsearch)]),
   hosts: schema.maybe(schema.arrayOf(schema.string())),
   api_key: schema.maybe(schema.string()),
-  admin_username: schema.maybe(schema.string()),
-  admin_password: schema.maybe(schema.string()),
+  fleet_enroll_username: schema.maybe(schema.string()),
+  fleet_enroll_password: schema.maybe(schema.string()),
   config: schema.maybe(schema.recordOf(schema.string(), schema.any())),
 };
 

--- a/x-pack/plugins/ingest_manager/server/types/rest_spec/fleet_setup.ts
+++ b/x-pack/plugins/ingest_manager/server/types/rest_spec/fleet_setup.ts
@@ -3,16 +3,10 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { schema } from '@kbn/config-schema';
 
 export const GetFleetSetupRequestSchema = {};
 
-export const CreateFleetSetupRequestSchema = {
-  body: schema.object({
-    admin_username: schema.string(),
-    admin_password: schema.string(),
-  }),
-};
+export const CreateFleetSetupRequestSchema = {};
 
 export interface CreateFleetSetupResponse {
   isInitialized: boolean;

--- a/x-pack/test/api_integration/apis/fleet/agents/services.ts
+++ b/x-pack/test/api_integration/apis/fleet/agents/services.ts
@@ -39,10 +39,6 @@ export function setupIngest({ getService }: FtrProviderContext) {
       .send();
     await getService('supertest')
       .post(`/api/ingest_manager/fleet/setup`)
-      .set('kbn-xsrf', 'xxx')
-      .send({
-        admin_username: 'elastic',
-        admin_password: 'changeme',
-      });
+      .set('kbn-xsrf', 'xxx');
   });
 }

--- a/x-pack/test/api_integration/apis/fleet/index.js
+++ b/x-pack/test/api_integration/apis/fleet/index.js
@@ -16,5 +16,6 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./enrollment_api_keys/crud'));
     loadTestFile(require.resolve('./install'));
     loadTestFile(require.resolve('./agents/actions'));
+    loadTestFile(require.resolve('./setup'));
   });
 }


### PR DESCRIPTION
## Summary

Resolves #56339 

Change fleet setup to create a user and a role in the background instead of asking the user to provide a user.

Done in this pr
 * update the UI to match latest design 
 * update the UI to stop asking for username and password
 * update the API to stop requiring username and password
 * add test 

## API change

Remove body parameters `admin_username` and `admin_password`

``` js
POST /api/ingest_manager/fleet/setup
// Request
{}
// Response
{ "isInitialized": true }
```
! Now the API is also doing the setup of ingest manager (default config, ...) if it's not already done.

## UI Change

<img width="1270" alt="Screen Shot 2020-03-18 at 3 33 14 PM" src="https://user-images.githubusercontent.com/1336873/77003424-bb9b7f00-6933-11ea-9ab7-db672ab591d5.png">
