### PR TITLE
[Ingest] Fix config value type and schema

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/datasource.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/datasource.ts
@@ -19,7 +19,7 @@ export interface DatasourceInputStream {
     string,
     {
       type?: string;
-      value: any;
+      value?: any;
     }
   >;
 }

--- a/x-pack/plugins/ingest_manager/server/types/models/datasource.ts
+++ b/x-pack/plugins/ingest_manager/server/types/models/datasource.ts
@@ -35,7 +35,7 @@ const DatasourceBaseSchema = {
             schema.string(),
             schema.object({
               type: schema.maybe(schema.string()),
-              value: schema.any(),
+              value: schema.maybe(schema.any()),
             })
           ),
         })


### PR DESCRIPTION
## Summary

Due to changes in #60406, adding a datasource with config fields that have `{value: unknown}` fails. This PR allows `value` to be undefined.