### PR TITLE
[Lens] Fix bug when removing dimensions from non-XY chart

### DIFF
--- a/x-pack/legacy/plugins/lens/public/datatable_visualization/visualization.tsx
+++ b/x-pack/legacy/plugins/lens/public/datatable_visualization/visualization.tsx
@@ -150,6 +150,7 @@ export const datatableVisualization: Visualization<
           accessors: sortedColumns,
           supportsMoreColumns: true,
           filterOperations: () => true,
+          dataTestSubj: 'lnsDatatable_column',
         },
       ],
     };

--- a/x-pack/legacy/plugins/lens/public/editor_frame_service/editor_frame/config_panel_wrapper.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_service/editor_frame/config_panel_wrapper.tsx
@@ -129,7 +129,7 @@ function LayerPanels(
               },
             },
             visualization: {
-              activeId: activeVisualization.id,
+              ...prevState.visualization,
               state: newVisualizationState,
             },
             stagedPreview: undefined,

--- a/x-pack/test/functional/apps/lens/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/smokescreen.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
-export default function({ getService, getPageObjects, ...rest }: FtrProviderContext) {
+export default function({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects([
     'header',
     'common',
@@ -88,6 +88,17 @@ export default function({ getService, getPageObjects, ...rest }: FtrProviderCont
         operation: 'avg',
         field: 'bytes',
       });
+
+      await PageObjects.lens.configureDimension({
+        dimension:
+          '[data-test-subj="lnsXY_splitDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        operation: 'terms',
+        field: '@message.raw',
+      });
+
+      await PageObjects.lens.switchToVisualization('lnsChartSwitchPopover_lnsDatatable');
+      await PageObjects.lens.removeDimension('lnsDatatable_column');
+      await PageObjects.lens.switchToVisualization('lnsChartSwitchPopover_bar_stacked');
 
       await PageObjects.lens.configureDimension({
         dimension:

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -103,8 +103,8 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
     /**
      * Changes the specified dimension to the specified operation and (optinally) field.
      *
-     * @param opts.from - the text of the dimension being changed
-     * @param opts.to - the desired operation for the dimension
+     * @param opts.dimension - the selector of the dimension being changed
+     * @param opts.operation - the desired operation ID for the dimension
      * @param opts.field - the desired field for the dimension
      */
     async configureDimension(opts: { dimension: string; operation?: string; field?: string }) {
@@ -121,6 +121,15 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
         await testSubjects.click('indexPattern-dimension-field');
         await testSubjects.click(`lns-fieldOption-${opts.field}`);
       }
+    },
+
+    /**
+     * Removes the dimension matching a specific test subject
+     */
+    async removeDimension(dimensionTestSubj: string) {
+      await find.clickByCssSelector(
+        `[data-test-subj="${dimensionTestSubj}"] [data-test-subj="indexPattern-dimensionPopover-remove"]`
+      );
     },
 
     /**


### PR DESCRIPTION
## Summary

A one-line scope issue caused a crash when removing a dimension from a chart like Table or Metric, because the wrong state was being used in suggestions.

Fixes https://github.com/elastic/kibana/issues/60404

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
