### PR TITLE
[APM] service maps: avoid unnecesary `useDeepObjectIdentity`

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -28,33 +28,27 @@ interface ServiceMapProps {
 export function ServiceMap({ serviceName }: ServiceMapProps) {
   const license = useLicense();
   const { urlParams, uiFilters } = useUrlParams();
-  const params = useDeepObjectIdentity({
-    start: urlParams.start,
-    end: urlParams.end,
-    environment: urlParams.environment,
-    serviceName,
-    uiFilters: {
-      ...uiFilters,
-      environment: undefined
-    }
-  });
 
   const { data } = useFetcher(() => {
-    const { start, end } = params;
+    const { start, end, environment } = urlParams;
     if (start && end) {
       return callApmApi({
         pathname: '/api/apm/service-map',
         params: {
           query: {
-            ...params,
             start,
             end,
-            uiFilters: JSON.stringify(params.uiFilters)
+            environment,
+            serviceName,
+            uiFilters: JSON.stringify({
+              ...uiFilters,
+              environment: undefined
+            })
           }
         }
       });
     }
-  }, [params]);
+  }, [serviceName, uiFilters, urlParams]);
 
   const { ref, height, width } = useRefDimensions();
 

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -7,7 +7,6 @@
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 import React from 'react';
 import { isValidPlatinumLicense } from '../../../../../../../plugins/apm/common/service_map';
-import { useDeepObjectIdentity } from '../../../hooks/useDeepObjectIdentity';
 import { useFetcher } from '../../../hooks/useFetcher';
 import { useLicense } from '../../../hooks/useLicense';
 import { useUrlParams } from '../../../hooks/useUrlParams';


### PR DESCRIPTION
Minor improvement to service maps data fetching