### PR TITLE
[SIEM][CASE] Change configuration button title

### DIFF
--- a/x-pack/legacy/plugins/siem/public/pages/case/translations.ts
+++ b/x-pack/legacy/plugins/siem/public/pages/case/translations.ts
@@ -130,7 +130,7 @@ export const CONFIGURE_CASES_PAGE_TITLE = i18n.translate(
 );
 
 export const CONFIGURE_CASES_BUTTON = i18n.translate('xpack.siem.case.configureCasesButton', {
-  defaultMessage: 'Edit third-party connection',
+  defaultMessage: 'Edit external connection',
 });
 
 export const ADD_COMMENT = i18n.translate('xpack.siem.case.caseView.comment.addComment', {


### PR DESCRIPTION
## Summary

The PR changes the configuration button title from "Edit third-party connection" to "Edit external connection".

Ref: https://github.com/elastic/siem-team/issues/538

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
