### PR TITLE
[APM] add service map config options to legacy plugin

### DIFF
--- a/x-pack/legacy/plugins/apm/index.ts
+++ b/x-pack/legacy/plugins/apm/index.ts
@@ -71,7 +71,12 @@ export const apm: LegacyPluginInitializer = kibana => {
         autocreateApmIndexPattern: Joi.boolean().default(true),
 
         // service map
-        serviceMapEnabled: Joi.boolean().default(true)
+        serviceMapEnabled: Joi.boolean().default(true),
+        serviceMapFingerprintBucketSize: Joi.number().default(100),
+        serviceMapTraceIdBucketSize: Joi.number().default(65),
+        serviceMapFingerprintGlobalBucketSize: Joi.number().default(1000),
+        serviceMapTraceIdGlobalBucketSize: Joi.number().default(6),
+        serviceMapMaxTracesPerRequest: Joi.number().default(50)
       }).default();
     },
 


### PR DESCRIPTION
Exposing the service map options to both plugins (they were already in NP) so users can tweak their aggregations if necessary.