### PR TITLE
[APM] Service map - add page load and interaction telemetry

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -20,6 +20,7 @@ import {
   cytoscapeOptions,
   nodeHeight
 } from './cytoscapeOptions';
+import { useUiTracker } from '../../../../../../../plugins/observability/public';
 
 export const CytoscapeContext = createContext<cytoscape.Core | undefined>(
   undefined
@@ -117,6 +118,8 @@ export function Cytoscape({
   // is required and can trigger rendering when changed.
   const divStyle = { ...style, height };
 
+  const trackApmEvent = useUiTracker({ app: 'apm' });
+
   // Trigger a custom "data" event when data changes
   useEffect(() => {
     if (cy && elements.length > 0) {
@@ -169,6 +172,7 @@ export function Cytoscape({
       });
     };
     const mouseoverHandler: cytoscape.EventHandler = event => {
+      trackApmEvent({ metric: 'service_map_object_hover' });
       event.target.addClass('hover');
       event.target.connectedEdges().addClass('nodeHover');
     };
@@ -177,6 +181,7 @@ export function Cytoscape({
       event.target.connectedEdges().removeClass('nodeHover');
     };
     const selectHandler: cytoscape.EventHandler = event => {
+      trackApmEvent({ metric: 'service_map_node_select' });
       resetConnectedEdgeStyle(event.target);
     };
     const unselectHandler: cytoscape.EventHandler = event => {
@@ -215,7 +220,7 @@ export function Cytoscape({
         cy.removeListener('unselect', 'node', unselectHandler);
       }
     };
-  }, [cy, height, serviceName, width]);
+  }, [cy, height, serviceName, trackApmEvent, width]);
 
   return (
     <CytoscapeContext.Provider value={cy}>

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -23,10 +23,7 @@ import { EmptyBanner } from './EmptyBanner';
 import { Popover } from './Popover';
 import { useRefDimensions } from './useRefDimensions';
 import { BetaBadge } from './BetaBadge';
-import {
-  useTrackPageview,
-  useUiTracker
-} from '../../../../../../../plugins/observability/public';
+import { useTrackPageview } from '../../../../../../../plugins/observability/public';
 
 interface ServiceMapProps {
   serviceName?: string;
@@ -61,7 +58,6 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
 
   useTrackPageview({ app: 'apm', path: 'service_map' });
   useTrackPageview({ app: 'apm', path: 'service_map', delay: 15000 });
-  const trackApmEvent = useUiTracker({ app: 'apm' });
 
   if (!license) {
     return null;
@@ -71,9 +67,6 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
     <div
       style={{ height: height - parseInt(theme.gutterTypes.gutterLarge, 10) }}
       ref={ref}
-      onMouseDown={() => {
-        trackApmEvent({ metric: 'service_map_click_interaction' });
-      }}
     >
       <Cytoscape
         elements={data?.elements ?? []}

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -23,6 +23,10 @@ import { EmptyBanner } from './EmptyBanner';
 import { Popover } from './Popover';
 import { useRefDimensions } from './useRefDimensions';
 import { BetaBadge } from './BetaBadge';
+import {
+  useTrackPageview,
+  useUiTracker
+} from '../../../../../../../plugins/observability/public';
 
 interface ServiceMapProps {
   serviceName?: string;
@@ -55,6 +59,10 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
 
   const { ref, height, width } = useRefDimensions();
 
+  useTrackPageview({ app: 'apm', path: 'service_map' });
+  useTrackPageview({ app: 'apm', path: 'service_map', delay: 15000 });
+  const trackApmEvent = useUiTracker({ app: 'apm' });
+
   if (!license) {
     return null;
   }
@@ -63,6 +71,9 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
     <div
       style={{ height: height - parseInt(theme.gutterTypes.gutterLarge, 10) }}
       ref={ref}
+      onMouseDown={() => {
+        trackApmEvent({ metric: 'service_map_click_interaction' });
+      }}
     >
       <Cytoscape
         elements={data?.elements ?? []}


### PR DESCRIPTION
Closes #60527 by adding called to shared observability usage tracking function when service map page is loaded, and if the user interacts with it.