### PR TITLE
[7.x] [Metric Alerts] Align date histogram buckets to the last bucket (#60714)

### DIFF
--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
@@ -11,6 +11,10 @@ import { getAllCompositeData } from '../../../utils/get_all_composite_data';
 import { networkTraffic } from '../../../../common/inventory_models/shared/metrics/snapshot/network_traffic';
 import { MetricExpressionParams, Comparator, AlertStates } from './types';
 import { AlertServices, AlertExecutorOptions } from '../../../../../alerting/server';
+import { getIntervalInSeconds } from '../../../utils/get_interval_in_seconds';
+import { getDateHistogramOffset } from '../../snapshot/query_helpers';
+
+const TOTAL_BUCKETS = 5;
 
 interface Aggregation {
   aggregatedIntervals: {
@@ -70,6 +74,12 @@ export const getElasticsearchMetricQuery = (
     throw new Error('Can only aggregate without a metric if using the document count aggregator');
   }
   const interval = `${timeSize}${timeUnit}`;
+  const to = Date.now();
+  const intervalAsSeconds = getIntervalInSeconds(interval);
+  // We need enough data for 5 buckets worth of data. We also need
+  // to convert the intervalAsSeconds to milliseconds.
+  const from = to - intervalAsSeconds * 1000 * TOTAL_BUCKETS;
+  const offset = getDateHistogramOffset(from, interval);
 
   const aggregations =
     aggType === 'count'
@@ -89,6 +99,11 @@ export const getElasticsearchMetricQuery = (
       date_histogram: {
         field: '@timestamp',
         fixed_interval: interval,
+        offset,
+        extended_bounds: {
+          min: from,
+          max: to,
+        },
       },
       aggregations,
     },
@@ -118,7 +133,9 @@ export const getElasticsearchMetricQuery = (
     {
       range: {
         '@timestamp': {
-          gte: `now-${interval}`,
+          gte: from,
+          lte: to,
+          format: 'epoch_millis',
         },
       },
     },

--- a/x-pack/plugins/infra/server/lib/snapshot/query_helpers.ts
+++ b/x-pack/plugins/infra/server/lib/snapshot/query_helpers.ts
@@ -87,8 +87,7 @@ export const getMetricsAggregations = (options: InfraSnapshotRequestOptions): Sn
   return aggregation;
 };
 
-export const getDateHistogramOffset = (options: InfraSnapshotRequestOptions): string => {
-  const { from, interval } = options.timerange;
+export const getDateHistogramOffset = (from: number, interval: string): string => {
   const fromInSeconds = Math.floor(from / 1000);
   const bucketSizeInSeconds = getIntervalInSeconds(interval);
 

--- a/x-pack/plugins/infra/server/lib/snapshot/snapshot.ts
+++ b/x-pack/plugins/infra/server/lib/snapshot/snapshot.ts
@@ -159,7 +159,7 @@ const requestNodeMetrics = async (
               date_histogram: {
                 field: options.sourceConfiguration.fields.timestamp,
                 interval: options.timerange.interval || '1m',
-                offset: getDateHistogramOffset(options),
+                offset: getDateHistogramOffset(options.timerange.from, options.timerange.interval),
                 extended_bounds: {
                   min: options.timerange.from,
                   max: options.timerange.to,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metric Alerts] Align date histogram buckets to the last bucket (#60714)