### PR TITLE
[APM] Renames service map metric event to be more clear

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -172,7 +172,7 @@ export function Cytoscape({
       });
     };
     const mouseoverHandler: cytoscape.EventHandler = event => {
-      trackApmEvent({ metric: 'service_map_object_hover' });
+      trackApmEvent({ metric: 'service_map_node_or_edge_hover' });
       event.target.addClass('hover');
       event.target.connectedEdges().addClass('nodeHover');
     };


### PR DESCRIPTION
Renames apm metric event `'service_map_object_hover'` to `'service_map_node_or_edge_hover'` for more clarity.
This is a followup to post-merge feedback in #61009 (https://github.com/elastic/kibana/pull/61009#discussion_r397469922)