### PR TITLE
[Fleet] Fix agent config yaml view to work without fleet

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/yaml/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/yaml/index.tsx
@@ -32,7 +32,7 @@ export const ConfigYamlView = memo<{ config: AgentConfig }>(({ config }) => {
 
   const fullConfigRequest = useGetOneAgentConfigFull(config.id);
   const apiKeysRequest = useGetEnrollmentAPIKeys();
-  const apiKeyRequest = useGetOneEnrollmentAPIKey(apiKeysRequest.data?.list?.[0].id as string);
+  const apiKeyRequest = useGetOneEnrollmentAPIKey(apiKeysRequest.data?.list?.[0]?.id as string);
 
   if (fullConfigRequest.isLoading && !fullConfigRequest.data) {
     return <Loading />;
@@ -49,30 +49,30 @@ export const ConfigYamlView = memo<{ config: AgentConfig }>(({ config }) => {
           })}
         </EuiCodeBlock>
       </EuiFlexItem>
-      <EuiFlexItem grow={3}>
-        <EuiTitle size="s">
-          <h3>
+      {apiKeyRequest.data && (
+        <EuiFlexItem grow={3}>
+          <EuiTitle size="s">
+            <h3>
+              <FormattedMessage
+                id="xpack.ingestManager.yamlConfig.instructionTittle"
+                defaultMessage="Enroll with fleet"
+              />
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <EuiText size="s">
             <FormattedMessage
-              id="xpack.ingestManager.yamlConfig.instructionTittle"
-              defaultMessage="Enroll with fleet"
+              id="xpack.ingestManager.yamlConfig.instructionDescription"
+              defaultMessage="To enroll an agent with this configuration, copy and run the following command on your host."
             />
-          </h3>
-        </EuiTitle>
-        <EuiSpacer size="m" />
-        <EuiText size="s">
-          <FormattedMessage
-            id="xpack.ingestManager.yamlConfig.instructionDescription"
-            defaultMessage="To enroll an agent with this configuration, copy and run the following command on your host."
-          />
-        </EuiText>
-        <EuiSpacer size="m" />
-        {apiKeyRequest.data && (
+          </EuiText>
+          <EuiSpacer size="m" />
           <ShellEnrollmentInstructions
             apiKey={apiKeyRequest.data.item}
             kibanaUrl={`${window.location.origin}${core.http.basePath.get()}`}
           />
-        )}
-      </EuiFlexItem>
+        </EuiFlexItem>
+      )}
     </EuiFlexGroup>
   );
 });


### PR DESCRIPTION
## Summary

Fix a type error when fleet is not enabled and an user try to access config yaml viw

## UI Change

With fleet enabled

<img width="1409" alt="Screen Shot 2020-03-24 at 8 07 53 PM" src="https://user-images.githubusercontent.com/1336873/77488441-9c0cc680-6e0b-11ea-9821-9fd3c5f77c53.png">

Without fleet enabled
<img width="1396" alt="Screen Shot 2020-03-24 at 8 07 38 PM" src="https://user-images.githubusercontent.com/1336873/77488442-9d3df380-6e0b-11ea-99f5-820dd31ddf71.png">
