### PR TITLE
[Discover][Visualize] Fix visualizing a selected field in discover search

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
@@ -275,7 +275,6 @@ function discoverController(
       filterManager.getUpdates$(),
       {
         next: () => {
-          $scope.state.filters = filterManager.getAppFilters();
           $scope.updateDataSource();
         },
       },

--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
@@ -275,6 +275,7 @@ function discoverController(
       filterManager.getUpdates$(),
       {
         next: () => {
+          $scope.state.filters = filterManager.getAppFilters();
           $scope.updateDataSource();
         },
       },

--- a/src/legacy/core_plugins/kibana/public/visualize/np_ready/editor/editor.js
+++ b/src/legacy/core_plugins/kibana/public/visualize/np_ready/editor/editor.js
@@ -332,7 +332,7 @@ function VisualizeAppController($scope, $route, $injector, $timeout, kbnUrlState
   if (!_.isEqual(stateContainer.getState().vis, stateDefaults.vis)) {
     try {
       const { aggs, ...visState } = stateContainer.getState().vis;
-      vis.setState({ ...visState, data: { aggs: _.cloneDeep(aggs) } });
+      vis.setState({ ...visState, data: { aggs } });
     } catch (error) {
       // stop syncing url updtes with the state to prevent extra syncing
       stopAllSyncing();

--- a/src/legacy/core_plugins/kibana/public/visualize/np_ready/editor/editor.js
+++ b/src/legacy/core_plugins/kibana/public/visualize/np_ready/editor/editor.js
@@ -332,7 +332,7 @@ function VisualizeAppController($scope, $route, $injector, $timeout, kbnUrlState
   if (!_.isEqual(stateContainer.getState().vis, stateDefaults.vis)) {
     try {
       const { aggs, ...visState } = stateContainer.getState().vis;
-      vis.setState({ ...visState, data: { aggs } });
+      vis.setState({ ...visState, data: { aggs: _.cloneDeep(aggs) } });
     } catch (error) {
       // stop syncing url updtes with the state to prevent extra syncing
       stopAllSyncing();

--- a/src/legacy/core_plugins/visualizations/public/np_ready/public/vis.ts
+++ b/src/legacy/core_plugins/visualizations/public/np_ready/public/vis.ts
@@ -132,8 +132,10 @@ export class Vis {
       this.data.savedSearchId = state.data.savedSearchId;
     }
     if (state.data && state.data.aggs) {
-      let configStates = state.data.aggs;
-      configStates = this.initializeDefaultsFromSchemas(configStates, this.type.schemas.all || []);
+      const configStates = this.initializeDefaultsFromSchemas(
+        cloneDeep(state.data.aggs),
+        this.type.schemas.all || []
+      );
       if (!this.data.indexPattern) {
         if (state.data.aggs.length) {
           throw new Error('trying to initialize aggs without index pattern');

--- a/test/functional/apps/discover/_field_visualize.ts
+++ b/test/functional/apps/discover/_field_visualize.ts
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function({ getService, getPageObjects }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const inspector = getService('inspector');
+  const kibanaServer = getService('kibanaServer');
+  const log = getService('log');
+  const PageObjects = getPageObjects(['common', 'discover', 'header', 'timePicker']);
+  const defaultSettings = {
+    defaultIndex: 'logstash-*',
+  };
+
+  describe('discover field visualize button', () => {
+    before(async function() {
+      log.debug('load kibana index with default index pattern');
+      await esArchiver.load('discover');
+
+      // and load a set of makelogs data
+      await esArchiver.loadIfNeeded('logstash_functional');
+      await kibanaServer.uiSettings.replace(defaultSettings);
+    });
+
+    beforeEach(async () => {
+      log.debug('go to discover');
+      await PageObjects.common.navigateToApp('discover');
+      await PageObjects.timePicker.setDefaultAbsoluteRange();
+    });
+
+    it('should visualize a field in area chart', async () => {
+      await PageObjects.discover.clickFieldListItem('phpmemory');
+      log.debug('visualize a phpmemory field');
+      await PageObjects.discover.clickFieldListItemVisualize('phpmemory');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      const expectedTableData = [
+        ['0', '10'],
+        ['58,320', '2'],
+        ['171,080', '2'],
+        ['3,240', '1'],
+        ['3,520', '1'],
+        ['3,880', '1'],
+        ['4,120', '1'],
+        ['4,640', '1'],
+        ['4,760', '1'],
+        ['5,680', '1'],
+        ['7,160', '1'],
+        ['7,400', '1'],
+        ['8,400', '1'],
+        ['8,800', '1'],
+        ['8,960', '1'],
+        ['9,400', '1'],
+        ['10,280', '1'],
+        ['10,840', '1'],
+        ['13,080', '1'],
+        ['13,360', '1'],
+      ];
+      await inspector.open();
+      await inspector.expectTableData(expectedTableData);
+      await inspector.close();
+    });
+  });
+}

--- a/test/functional/apps/discover/index.js
+++ b/test/functional/apps/discover/index.js
@@ -35,6 +35,7 @@ export default function({ getService, loadTestFile }) {
     loadTestFile(require.resolve('./_saved_queries'));
     loadTestFile(require.resolve('./_discover'));
     loadTestFile(require.resolve('./_discover_histogram'));
+    loadTestFile(require.resolve('./_field_visualize'));
     loadTestFile(require.resolve('./_filter_editor'));
     loadTestFile(require.resolve('./_errors'));
     loadTestFile(require.resolve('./_field_data'));


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/61213
Fixes https://github.com/elastic/kibana/issues/61103

Data should be deep cloned since the object is freezed on mutations.
The mutation was occurred in `AggConfig.ensureIds` while creating new `AggConfigs` object .

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
