### PR TITLE
[Telemetry] Fix cloud tests (NP version of #59040)

### DIFF
--- a/src/plugins/telemetry/common/telemetry_config/get_telemetry_allow_changing_opt_in_status.ts
+++ b/src/plugins/telemetry/common/telemetry_config/get_telemetry_allow_changing_opt_in_status.ts
@@ -32,9 +32,9 @@ export function getTelemetryAllowChangingOptInStatus({
     return configTelemetryAllowChangingOptInStatus;
   }
 
-  if (typeof telemetrySavedObject.telemetryAllowChangingOptInStatus === 'undefined') {
+  if (typeof telemetrySavedObject.allowChangingOptInStatus === 'undefined') {
     return configTelemetryAllowChangingOptInStatus;
   }
 
-  return telemetrySavedObject.telemetryAllowChangingOptInStatus;
+  return telemetrySavedObject.allowChangingOptInStatus;
 }

--- a/src/plugins/telemetry/common/telemetry_config/types.ts
+++ b/src/plugins/telemetry/common/telemetry_config/types.ts
@@ -22,7 +22,7 @@ export interface TelemetrySavedObjectAttributes {
   lastVersionChecked?: string;
   sendUsageFrom?: 'browser' | 'server';
   lastReported?: number;
-  telemetryAllowChangingOptInStatus?: boolean;
+  allowChangingOptInStatus?: boolean;
   userHasSeenNotice?: boolean;
   reportFailureCount?: number;
   reportFailureVersion?: string;

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -143,6 +143,9 @@ export class TelemetryPlugin implements Plugin {
           reportFailureVersion: {
             type: 'keyword',
           },
+          allowChangingOptInStatus: {
+            type: 'boolean',
+          },
         },
       },
     });

--- a/x-pack/test/api_integration/apis/telemetry/opt_in.ts
+++ b/x-pack/test/api_integration/apis/telemetry/opt_in.ts
@@ -6,6 +6,7 @@
 
 import expect from '@kbn/expect';
 
+import { TelemetrySavedObjectAttributes } from 'src/plugins/telemetry/server/telemetry_repository';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function optInTest({ getService }: FtrProviderContext) {
@@ -13,28 +14,64 @@ export default function optInTest({ getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
 
   describe('/api/telemetry/v2/optIn API', () => {
+    let defaultAttributes: TelemetrySavedObjectAttributes;
     let kibanaVersion: any;
 
     before(async () => {
       const kibanaVersionAccessor = kibanaServer.version;
       kibanaVersion = await kibanaVersionAccessor.get();
+      defaultAttributes =
+        (await getSavedObjectAttributes(supertest).catch(err => {
+          if (err.message === 'expected 200 "OK", got 404 "Not Found"') {
+            return null;
+          }
+          throw err;
+        })) || {};
 
       expect(typeof kibanaVersion).to.eql('string');
       expect(kibanaVersion.length).to.be.greaterThan(0);
     });
 
-    it('should support sending false', async () => {
+    afterEach(async () => {
+      await updateSavedObjectAttributes(supertest, defaultAttributes);
+    });
+
+    it('should support sending false with allowChangingOptInStatus true', async () => {
+      await updateSavedObjectAttributes(supertest, {
+        ...defaultAttributes,
+        allowChangingOptInStatus: true,
+      });
       await postTelemetryV2Optin(supertest, false, 200);
       const { enabled, lastVersionChecked } = await getSavedObjectAttributes(supertest);
       expect(enabled).to.be(false);
       expect(lastVersionChecked).to.be(kibanaVersion);
     });
 
-    it('should support sending true', async () => {
+    it('should support sending true with allowChangingOptInStatus true', async () => {
+      await updateSavedObjectAttributes(supertest, {
+        ...defaultAttributes,
+        allowChangingOptInStatus: true,
+      });
       await postTelemetryV2Optin(supertest, true, 200);
       const { enabled, lastVersionChecked } = await getSavedObjectAttributes(supertest);
       expect(enabled).to.be(true);
       expect(lastVersionChecked).to.be(kibanaVersion);
+    });
+
+    it('should not support sending false with allowChangingOptInStatus false', async () => {
+      await updateSavedObjectAttributes(supertest, {
+        ...defaultAttributes,
+        allowChangingOptInStatus: false,
+      });
+      await postTelemetryV2Optin(supertest, false, 400);
+    });
+
+    it('should not support sending true with allowChangingOptInStatus false', async () => {
+      await updateSavedObjectAttributes(supertest, {
+        ...defaultAttributes,
+        allowChangingOptInStatus: false,
+      });
+      await postTelemetryV2Optin(supertest, true, 400);
     });
 
     it('should not support sending null', async () => {
@@ -57,7 +94,19 @@ async function postTelemetryV2Optin(supertest: any, value: any, statusCode: numb
   return body;
 }
 
-async function getSavedObjectAttributes(supertest: any): Promise<any> {
+async function updateSavedObjectAttributes(
+  supertest: any,
+  attributes: TelemetrySavedObjectAttributes
+): Promise<any> {
+  return await supertest
+    .post('/api/saved_objects/telemetry/telemetry')
+    .query({ overwrite: true })
+    .set('kbn-xsrf', 'xxx')
+    .send({ attributes })
+    .expect(200);
+}
+
+async function getSavedObjectAttributes(supertest: any): Promise<TelemetrySavedObjectAttributes> {
   const { body } = await supertest.get('/api/saved_objects/telemetry/telemetry').expect(200);
   return body.attributes;
 }


### PR DESCRIPTION
## Summary

Fix `allowChangingOptInStatus` savedObject attribute not being able to get updated. Fixes test case for opt in api failing on cloud with `allowChangingOptInStatus: false` config set.

Adds test cases for opt in route with respect to `allowChangingOptInStatus` flag.

Closes #51522

This is basically a reimplementation of #59040 for the NP. I thought it was easier than merging `master` into that one.

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
