### PR TITLE
[Telemetry] Fix /api/telemetry/v2/userHasSeenNotice tests

### DIFF
--- a/x-pack/test/api_integration/apis/telemetry/telemetry_optin_notice_seen.ts
+++ b/x-pack/test/api_integration/apis/telemetry/telemetry_optin_notice_seen.ts
@@ -13,12 +13,18 @@ export default function optInTest({ getService }: FtrProviderContext) {
   const client: Client = getService('legacyEs');
   const supertest = getService('supertest');
 
-  describe('/api/telemetry/v2/optIn API Telemetry User has seen OptIn Notice', () => {
+  describe('/api/telemetry/v2/userHasSeenNotice API Telemetry User has seen OptIn Notice', () => {
     it('should update telemetry setting field via PUT', async () => {
-      await client.delete({
-        index: '.kibana',
-        id: 'telemetry:telemetry',
-      } as DeleteDocumentParams);
+      try {
+        await client.delete({
+          index: '.kibana',
+          id: 'telemetry:telemetry',
+        } as DeleteDocumentParams);
+      } catch (err) {
+        if (err.statusCode !== 404) {
+          throw err;
+        }
+      }
 
       await supertest
         .put('/api/telemetry/v2/userHasSeenNotice')


### PR DESCRIPTION
## Summary

Fixes the /api/telemetry/v2/userHasSeenNotice 404 errors in the functional tests.

Closes #51515

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
