### PR TITLE
[Telemetry] Fix license.issuer validation in tests

### DIFF
--- a/x-pack/test/api_integration/apis/telemetry/telemetry_local.js
+++ b/x-pack/test/api_integration/apis/telemetry/telemetry_local.js
@@ -63,7 +63,7 @@ export default function({ getService }) {
       const stats = body[0];
 
       expect(stats.collection).to.be('local');
-      expect(stats.license.issuer).to.be('elasticsearch');
+      expect(stats.license.issuer).to.be.a('string');
       expect(stats.license.status).to.be('active');
 
       expect(stats.stack_stats.kibana.count).to.be(1);


### PR DESCRIPTION
## Summary

Fix `license.issuer` validation in telemetry tests (general `'string'` instead of constant `'elasticsearch'`).

Closes #51490

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
