### PR TITLE
use fixed table layout

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/markdown_renderers.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/markdown_renderers.tsx
@@ -28,9 +28,7 @@ export const markdownRenderers = {
     <EuiText grow={true}>{children}</EuiText>
   ),
   table: ({ children }: { children: React.ReactNode[] }) => (
-    <table className="euiTable euiTable--responsive" style={{ tableLayout: 'auto' }}>
-      {children}
-    </table>
+    <table className="euiTable euiTable--responsive">{children}</table>
   ),
   tableRow: ({ children }: { children: React.ReactNode[] }) => (
     <EuiTableRow>{children}</EuiTableRow>


### PR DESCRIPTION
Removed an inline style from the markdown renderer so that tables now render all columns equally. There is more we can do to improve the table layout, but this is a good first step.

**Before:**
![image](https://user-images.githubusercontent.com/847805/77559315-6c54d180-6e92-11ea-951c-e5486daaeef7.png)

**After:**
![image](https://user-images.githubusercontent.com/847805/77558576-79bd8c00-6e91-11ea-91ce-9d99f3421058.png)
