### PR TITLE
[SIEM] Adds 'Deleting prebuilt rules' tests

### DIFF
--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_custom.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_custom.spec.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { newRule } from '../objects/rule';
+import { newRule, totalNumberOfPrebuiltRules } from '../objects/rule';
 
 import {
   ABOUT_FALSE_POSITIVES,
@@ -83,7 +83,7 @@ describe('Signal detection rules, custom', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = 93;
+    const expectedNumberOfRules = totalNumberOfPrebuiltRules + 1;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });

--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { machineLearningRule } from '../objects/rule';
+import { machineLearningRule, totalNumberOfPrebuiltRules } from '../objects/rule';
 
 import {
   ABOUT_FALSE_POSITIVES,
@@ -88,7 +88,7 @@ describe('Signal detection rules, machine learning', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = 93;
+    const expectedNumberOfRules = totalNumberOfPrebuiltRules + 1;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });

--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
@@ -18,12 +18,18 @@ import {
   waitForSignalsIndexToBeCreated,
   waitForSignalsPanelToBeLoaded,
 } from '../tasks/detections';
-import { esArchiverLoadEmptyKibana, esArchiverUnloadEmptyKibana } from '../tasks/es_archiver';
+import {
+  esArchiverLoad,
+  esArchiverLoadEmptyKibana,
+  esArchiverUnloadEmptyKibana,
+  esArchiverUnload,
+} from '../tasks/es_archiver';
 import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
 
 import { DETECTIONS } from '../urls/navigation';
+import { SIGNALS } from '../screens/detections';
 
-describe('Signal detection rules, prebuilt rules', () => {
+/* describe('Signal detection rules, prebuilt rules', () => {
   before(() => {
     esArchiverLoadEmptyKibana();
   });
@@ -53,5 +59,119 @@ describe('Signal detection rules, prebuilt rules', () => {
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });
+  });
+});*/
+
+describe('Deleting prebuilt rules', () => {
+  beforeEach(() => {
+    // esArchiverLoad('prebuilt_rules_loaded')
+    loginAndWaitForPageWithoutDateRange(DETECTIONS);
+    loginAndWaitForPageWithoutDateRange(DETECTIONS);
+    waitForSignalsPanelToBeLoaded();
+    waitForSignalsIndexToBeCreated();
+    goToManageSignalDetectionRules();
+  });
+
+  afterEach(() => {
+    // esArchiverUnload('prebuilt_rules_loaded')
+  });
+
+  it('Does not allow to delete one rule when more than one is selected', () => {
+    cy.get('.euiTableRow .euiCheckbox__input')
+      .first()
+      .click({ force: true });
+    cy.get('.euiTableRow .euiCheckbox__input')
+      .eq(1)
+      .click({ force: true });
+
+    cy.get('[data-test-subj="euiCollapsedItemActionsButton"]').each(collapsedItemActionBtn => {
+      cy.wrap(collapsedItemActionBtn).should('have.attr', 'disabled');
+    });
+  });
+
+  it('Deletes and recovers one rule', () => {
+    cy.get('[data-test-subj="euiCollapsedItemActionsButton"]')
+      .first()
+      .click({ force: true });
+    cy.get('[data-test-subj="deleteRuleAction"]').click();
+
+    cy.reload();
+    changeToThreeHundredRowsPerPage();
+    waitForRulesToBeLoaded();
+
+    cy.get('[data-test-subj="reloadPrebuiltRulesBtn"]').should('exist');
+
+    const expectedNumberOfRules = 91;
+
+    const expectedElasticRulesBtnText = 'Elastic rules (91)';
+    cy.get(ELASTIC_RULES_BTN)
+      .invoke('text')
+      .should('eql', expectedElasticRulesBtnText);
+
+    cy.get(RULES_TABLE).then($table => {
+      cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
+    });
+
+    cy.get('[data-test-subj="reloadPrebuiltRulesBtn"]').click({ force: true });
+    cy.get('[data-test-subj="reloadPrebuiltRulesBtn"]').should('not.exist');
+
+    cy.reload();
+    changeToThreeHundredRowsPerPage();
+    waitForRulesToBeLoaded();
+
+    const finalExpectedNumberOfRules = 92;
+    cy.get(RULES_TABLE).then($table => {
+      cy.wrap($table.find(RULES_ROW).length).should('eql', finalExpectedNumberOfRules);
+    });
+
+    const finalExpectedElasticRulesBtnText = 'Elastic rules (92)';
+    cy.get(ELASTIC_RULES_BTN)
+      .invoke('text')
+      .should('eql', finalExpectedElasticRulesBtnText);
+  });
+
+  it('Deletes and recovers more than one rule', () => {
+    cy.get('.euiTableRow .euiCheckbox__input')
+      .first()
+      .click({ force: true });
+    cy.get('.euiTableRow .euiCheckbox__input')
+      .eq(1)
+      .click({ force: true });
+    cy.get('[data-test-subj="bulkActions"] span').click({ force: true });
+    cy.get('[data-test-subj="deleteRuleBulk"]').click();
+
+    cy.reload();
+    changeToThreeHundredRowsPerPage();
+    waitForRulesToBeLoaded();
+
+    cy.get('[data-test-subj="reloadPrebuiltRulesBtn"]').should('exist');
+
+    const expectedNumberOfRules = 90;
+
+    const expectedElasticRulesBtnText = 'Elastic rules (90)';
+    cy.get(ELASTIC_RULES_BTN)
+      .invoke('text')
+      .should('eql', expectedElasticRulesBtnText);
+
+    cy.get(RULES_TABLE).then($table => {
+      cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
+    });
+
+    cy.get('[data-test-subj="reloadPrebuiltRulesBtn"]').click({ force: true });
+    cy.get('[data-test-subj="reloadPrebuiltRulesBtn"]').should('not.exist');
+
+    cy.reload();
+    changeToThreeHundredRowsPerPage();
+    waitForRulesToBeLoaded();
+
+    const finalExpectedNumberOfRules = 92;
+    cy.get(RULES_TABLE).then($table => {
+      cy.wrap($table.find(RULES_ROW).length).should('eql', finalExpectedNumberOfRules);
+    });
+
+    const finalExpectedElasticRulesBtnText = 'Elastic rules (92)';
+    cy.get(ELASTIC_RULES_BTN)
+      .invoke('text')
+      .should('eql', finalExpectedElasticRulesBtnText);
   });
 });

--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
@@ -38,6 +38,8 @@ import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
 
 import { DETECTIONS } from '../urls/navigation';
 
+import { totalNumberOfPrebuiltRules } from '../objects/rule';
+
 describe('Signal detection rules, prebuilt rules', () => {
   before(() => {
     esArchiverLoadEmptyKibana();
@@ -48,6 +50,9 @@ describe('Signal detection rules, prebuilt rules', () => {
   });
 
   it('Loads prebuilt rules', () => {
+    const expectedNumberOfRules = totalNumberOfPrebuiltRules;
+    const expectedElasticRulesBtnText = `Elastic rules (${expectedNumberOfRules})`;
+
     loginAndWaitForPageWithoutDateRange(DETECTIONS);
     waitForSignalsPanelToBeLoaded();
     waitForSignalsIndexToBeCreated();
@@ -56,7 +61,6 @@ describe('Signal detection rules, prebuilt rules', () => {
     loadPrebuiltDetectionRules();
     waitForPrebuiltDetectionRulesToBeLoaded();
 
-    const expectedElasticRulesBtnText = 'Elastic rules (92)';
     cy.get(ELASTIC_RULES_BTN)
       .invoke('text')
       .should('eql', expectedElasticRulesBtnText);
@@ -64,7 +68,6 @@ describe('Signal detection rules, prebuilt rules', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = 92;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });
@@ -94,8 +97,8 @@ describe('Deleting prebuilt rules', () => {
   });
 
   it('Deletes and recovers one rule', () => {
-    const expectedNumberOfRulesAfterDeletion = 91;
-    const expectedNumberOfRulesAfterRecovering = 92;
+    const expectedNumberOfRulesAfterDeletion = totalNumberOfPrebuiltRules - 1;
+    const expectedNumberOfRulesAfterRecovering = totalNumberOfPrebuiltRules;
 
     deleteFirstRule();
     cy.reload();
@@ -131,8 +134,8 @@ describe('Deleting prebuilt rules', () => {
 
   it('Deletes and recovers more than one rule', () => {
     const numberOfRulesToBeSelected = 2;
-    const expectedNumberOfRulesAfterDeletion = 90;
-    const expectedNumberOfRulesAfterRecovering = 92;
+    const expectedNumberOfRulesAfterDeletion = totalNumberOfPrebuiltRules - 2;
+    const expectedNumberOfRulesAfterRecovering = totalNumberOfPrebuiltRules;
 
     selectNumberOfRules(numberOfRulesToBeSelected);
     deleteSelectedRules();

--- a/x-pack/legacy/plugins/siem/cypress/objects/rule.ts
+++ b/x-pack/legacy/plugins/siem/cypress/objects/rule.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+export const totalNumberOfPrebuiltRules = 92;
+
 interface Mitre {
   tactic: string;
   techniques: string[];

--- a/x-pack/legacy/plugins/siem/cypress/screens/signal_detection_rules.ts
+++ b/x-pack/legacy/plugins/siem/cypress/screens/signal_detection_rules.ts
@@ -4,9 +4,17 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+export const BULK_ACTIONS_BTN = '[data-test-subj="bulkActions"] span';
+
 export const CREATE_NEW_RULE_BTN = '[data-test-subj="create-new-rule"]';
 
+export const COLLAPSED_ACTION_BTN = '[data-test-subj="euiCollapsedItemActionsButton"]';
+
 export const CUSTOM_RULES_BTN = '[data-test-subj="show-custom-rules-filter-button"]';
+
+export const DELETE_RULE_ACTION_BTN = '[data-test-subj="deleteRuleAction"]';
+
+export const DELETE_RULE_BULK_BTN = '[data-test-subj="deleteRuleBulk"]';
 
 export const ELASTIC_RULES_BTN = '[data-test-subj="show-elastic-rules-filter-button"]';
 
@@ -20,6 +28,10 @@ export const LOADING_SPINNER = '[data-test-subj="loading-spinner"]';
 export const PAGINATION_POPOVER_BTN = '[data-test-subj="tablePaginationPopoverButton"]';
 
 export const RISK_SCORE = '[data-test-subj="riskScore"]';
+
+export const RELOAD_PREBUILT_RULES_BTN = '[data-test-subj="reloadPrebuiltRulesBtn"]';
+
+export const RULE_CHECKBOX = '.euiTableRow .euiCheckbox__input';
 
 export const RULE_NAME = '[data-test-subj="ruleName"]';
 

--- a/x-pack/legacy/plugins/siem/cypress/tasks/signal_detection_rules.ts
+++ b/x-pack/legacy/plugins/siem/cypress/tasks/signal_detection_rules.ts
@@ -5,13 +5,21 @@
  */
 
 import {
+  BULK_ACTIONS_BTN,
+  COLLAPSED_ACTION_BTN,
   CREATE_NEW_RULE_BTN,
+  CUSTOM_RULES_BTN,
+  DELETE_RULE_ACTION_BTN,
+  DELETE_RULE_BULK_BTN,
   LOAD_PREBUILT_RULES_BTN,
   LOADING_INITIAL_PREBUILT_RULES_TABLE,
   LOADING_SPINNER,
   PAGINATION_POPOVER_BTN,
+  RULE_CHECKBOX,
+  RULE_NAME,
   RULES_TABLE,
   THREE_HUNDRED_ROWS,
+  RELOAD_PREBUILT_RULES_BTN,
 } from '../screens/signal_detection_rules';
 
 export const changeToThreeHundredRowsPerPage = () => {
@@ -19,10 +27,22 @@ export const changeToThreeHundredRowsPerPage = () => {
   cy.get(THREE_HUNDRED_ROWS).click();
 };
 
+export const deleteFirstRule = () => {
+  cy.get(COLLAPSED_ACTION_BTN)
+    .first()
+    .click({ force: true });
+  cy.get(DELETE_RULE_ACTION_BTN).click();
+};
+
+export const deleteSelectedRules = () => {
+  cy.get(BULK_ACTIONS_BTN).click({ force: true });
+  cy.get(DELETE_RULE_BULK_BTN).click();
+};
+
 export const filterByCustomRules = () => {
-  cy.get('[data-test-subj="show-custom-rules-filter-button"]').click({ force: true });
-  cy.get('[data-test-subj="loading-spinner"]').should('exist');
-  cy.get('[data-test-subj="loading-spinner"]').should('not.exist');
+  cy.get(CUSTOM_RULES_BTN).click({ force: true });
+  cy.get(LOADING_SPINNER).should('exist');
+  cy.get(LOADING_SPINNER).should('not.exist');
 };
 
 export const goToCreateNewRule = () => {
@@ -30,15 +50,25 @@ export const goToCreateNewRule = () => {
 };
 
 export const goToRuleDetails = () => {
-  cy.get('[data-test-subj="ruleName"]').click({ force: true });
-  cy.get('.euiLoadingSpinner').should('exist');
-  cy.get('.euiLoadingSpinner').should('not.exist');
+  cy.get(RULE_NAME).click({ force: true });
 };
 
 export const loadPrebuiltDetectionRules = () => {
   cy.get(LOAD_PREBUILT_RULES_BTN)
     .should('exist')
     .click({ force: true });
+};
+
+export const reloadDeletedRules = () => {
+  cy.get(RELOAD_PREBUILT_RULES_BTN).click({ force: true });
+};
+
+export const selectNumberOfRules = (numberOfRules: number) => {
+  for (let i = 0; i < numberOfRules; i++) {
+    cy.get(RULE_CHECKBOX)
+      .eq(i)
+      .click({ force: true });
+  }
 };
 
 export const waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded = () => {

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/batch_actions.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/batch_actions.tsx
@@ -108,6 +108,7 @@ export const getBatchItems = ({
       {i18n.BATCH_ACTION_DUPLICATE_SELECTED}
     </EuiContextMenuItem>,
     <EuiContextMenuItem
+      data-test-subj="deleteRuleBulk"
       key={i18n.BATCH_ACTION_DELETE_SELECTED}
       icon="trash"
       title={containsImmutable ? i18n.BATCH_ACTION_DELETE_SELECTED_IMMUTABLE : undefined}

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/columns.tsx
@@ -67,6 +67,7 @@ export const getActions = (
     enabled: (rowItem: Rule) => !rowItem.immutable,
   },
   {
+    'data-test-subj': 'deleteRuleAction',
     description: i18n.DELETE_RULE,
     icon: 'trash',
     name: i18n.DELETE_RULE,

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/index.tsx
@@ -307,6 +307,7 @@ export const AllRules = React.memo<AllRulesProps>(
                       <UtilityBarText>{i18n.SELECTED_RULES(selectedRuleIds.length)}</UtilityBarText>
                       {!hasNoPermissions && (
                         <UtilityBarAction
+                          dataTestSubj="bulkActions"
                           iconSide="right"
                           iconType="arrowDown"
                           popoverContent={getBatchItemsPopoverContent}

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/index.tsx
@@ -135,6 +135,7 @@ const RulesPageComponent: React.FC = () => {
             {prePackagedRuleStatus === 'someRuleUninstall' && (
               <EuiFlexItem grow={false}>
                 <EuiButton
+                  data-test-subj="reloadPrebuiltRulesBtn"
                   iconType="plusInCircle"
                   isLoading={loadingCreatePrePackagedRules}
                   isDisabled={userHasNoPermissions || loading}


### PR DESCRIPTION
## Summary

In this PR we are adding the following Cypress tests:
- Does not allow to delete one rule when more than one is selected
- Deletes and recovers one rule
- Deletes and recovers more than one rule

![signal_detection_rules_prebuilt spec ts](https://user-images.githubusercontent.com/17427073/77568001-3cc0bc00-6ec8-11ea-96ac-93c5733db4b9.gif)

**Does not allow to delete one rule when more than one is selected:**
1. Goes to detections page
2. Goes to manage signal detection rules
3. Selects more than one rule 
4. Checks for all the displayed rules that the "All actions" button is disabled

**Deletes and recovers one rule**
1. Goes to detections page
2. Goes to manage signal detection rules
3. Deletes one rule using "All actions"
4. Checks that the rule has been deleted
5. Recovers the rule
6. Checks that the rule has been recovered

We also check that the text in the recover button is correct

**Deletes and recovers more than one rule**
1. Goes to detections page
2. Goes to manage signal detection rules
3. Selects more than one rule
4. Deletes the rules using the bulk action
5. Checks that the rules have been deleted
5. Recovers the rules
6. Checks that the rules have been recovered

We also check that the text in the recover button is correct






