### PR TITLE
[SIEM] Check auth status for privileges via security plugin

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/__mocks__/request_responses.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/__mocks__/request_responses.ts
@@ -514,7 +514,7 @@ export const updateActionResult = (): ActionResult => ({
   config: {},
 });
 
-export const getMockPrivileges = () => ({
+export const getMockPrivilegesResult = () => ({
   username: 'test-space',
   has_all_requested: false,
   cluster: {
@@ -565,8 +565,6 @@ export const getMockPrivileges = () => ({
     },
   },
   application: {},
-  is_authenticated: false,
-  has_encryption_key: true,
 });
 
 export const getFindResultStatusEmpty = (): SavedObjectsFindResponse<IRuleSavedAttributesSavedObjectAttributes> => ({

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
@@ -4,20 +4,24 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { securityMock } from '../../../../../../../../plugins/security/server/mocks';
 import { readPrivilegesRoute } from './read_privileges_route';
 import { serverMock, requestContextMock } from '../__mocks__';
-import { getPrivilegeRequest, getMockPrivileges } from '../__mocks__/request_responses';
+import { getPrivilegeRequest, getMockPrivilegesResult } from '../__mocks__/request_responses';
 
-describe('read_privileges', () => {
+describe('read_privileges route', () => {
   let server: ReturnType<typeof serverMock.create>;
   let { clients, context } = requestContextMock.createTools();
+  let mockSecurity: ReturnType<typeof securityMock.createSetup>;
 
   beforeEach(() => {
     server = serverMock.create();
     ({ clients, context } = requestContextMock.createTools());
 
-    clients.clusterClient.callAsCurrentUser.mockResolvedValue(getMockPrivileges());
-    readPrivilegesRoute(server.router, false);
+    mockSecurity = securityMock.createSetup();
+    mockSecurity.authc.isAuthenticated.mockReturnValue(false);
+    clients.clusterClient.callAsCurrentUser.mockResolvedValue(getMockPrivilegesResult());
+    readPrivilegesRoute(server.router, mockSecurity, false);
   });
 
   describe('normal status codes', () => {
@@ -26,10 +30,28 @@ describe('read_privileges', () => {
       expect(response.status).toEqual(200);
     });
 
-    test.skip('returns the payload when doing a normal request', async () => {
+    test('returns the payload when doing a normal request', async () => {
+      const response = await server.inject(getPrivilegeRequest(), context);
+      const expectedBody = {
+        ...getMockPrivilegesResult(),
+        is_authenticated: false,
+        has_encryption_key: true,
+      };
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(expectedBody);
+    });
+
+    test('is authenticated when security says so', async () => {
+      mockSecurity.authc.isAuthenticated.mockReturnValue(true);
+      const expectedBody = {
+        ...getMockPrivilegesResult(),
+        is_authenticated: true,
+        has_encryption_key: true,
+      };
+
       const response = await server.inject(getPrivilegeRequest(), context);
       expect(response.status).toEqual(200);
-      expect(response.body).toEqual(getMockPrivileges());
+      expect(response.body).toEqual(expectedBody);
     });
 
     test('returns 500 when bad response from cluster', async () => {
@@ -39,6 +61,28 @@ describe('read_privileges', () => {
       const response = await server.inject(getPrivilegeRequest(), context);
       expect(response.status).toEqual(500);
       expect(response.body).toEqual({ message: 'Test error', status_code: 500 });
+    });
+  });
+
+  describe('when security plugin is disabled', () => {
+    beforeEach(() => {
+      server = serverMock.create();
+      ({ clients, context } = requestContextMock.createTools());
+
+      clients.clusterClient.callAsCurrentUser.mockResolvedValue(getMockPrivilegesResult());
+      readPrivilegesRoute(server.router, undefined, false);
+    });
+
+    it('returns unauthenticated', async () => {
+      const expectedBody = {
+        ...getMockPrivilegesResult(),
+        is_authenticated: false,
+        has_encryption_key: true,
+      };
+
+      const response = await server.inject(getPrivilegeRequest(), context);
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(expectedBody);
     });
   });
 });

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
@@ -8,10 +8,15 @@ import { merge } from 'lodash/fp';
 
 import { IRouter } from '../../../../../../../../../src/core/server';
 import { DETECTION_ENGINE_PRIVILEGES_URL } from '../../../../../common/constants';
+import { SetupPlugins } from '../../../../plugin';
 import { buildSiemResponse, transformError } from '../utils';
 import { readPrivileges } from '../../privileges/read_privileges';
 
-export const readPrivilegesRoute = (router: IRouter, usingEphemeralEncryptionKey: boolean) => {
+export const readPrivilegesRoute = (
+  router: IRouter,
+  security: SetupPlugins['security'],
+  usingEphemeralEncryptionKey: boolean
+) => {
   router.get(
     {
       path: DETECTION_ENGINE_PRIVILEGES_URL,
@@ -29,7 +34,7 @@ export const readPrivilegesRoute = (router: IRouter, usingEphemeralEncryptionKey
         const index = siemClient.signalsIndex;
         const clusterPrivileges = await readPrivileges(clusterClient.callAsCurrentUser, index);
         const privileges = merge(clusterPrivileges, {
-          is_authenticated: true, // until we support optional auth: https://github.com/elastic/kibana/pull/55327#issuecomment-577159911
+          is_authenticated: security?.authc.isAuthenticated(request) ?? false,
           has_encryption_key: !usingEphemeralEncryptionKey,
         });
 

--- a/x-pack/legacy/plugins/siem/server/lib/framework/kibana_framework_adapter.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/framework/kibana_framework_adapter.ts
@@ -122,7 +122,7 @@ export class KibanaBackendFrameworkAdapter implements FrameworkAdapter {
 
   private async getCurrentUserInfo(request: KibanaRequest): Promise<AuthenticatedUser | null> {
     try {
-      const user = await this.security.authc.getCurrentUser(request);
+      const user = (await this.security?.authc.getCurrentUser(request)) ?? null;
       return user;
     } catch {
       return null;

--- a/x-pack/legacy/plugins/siem/server/lib/timeline/routes/import_timelines_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/timeline/routes/import_timelines_route.ts
@@ -30,6 +30,7 @@ import {
 
 import { IRouter } from '../../../../../../../../src/core/server';
 import { TIMELINE_IMPORT_URL } from '../../../../common/constants';
+import { SetupPlugins } from '../../../plugin';
 import { importTimelinesPayloadSchema } from './schemas/import_timelines_schema';
 import { importRulesSchema } from '../../detection_engine/routes/schemas/response/import_rules_schema';
 import { LegacyServices } from '../../../types';
@@ -37,7 +38,6 @@ import { LegacyServices } from '../../../types';
 import { Timeline } from '../saved_object';
 import { validate } from '../../detection_engine/routes/rules/validate';
 import { FrameworkRequest } from '../../framework';
-import { SecurityPluginSetup } from '../../../../../../../plugins/security/server';
 
 const CHUNK_PARSED_OBJECT_SIZE = 10;
 
@@ -46,7 +46,7 @@ const timelineLib = new Timeline();
 export const importTimelinesRoute = (
   router: IRouter,
   config: LegacyServices['config'],
-  securityPluginSetup: SecurityPluginSetup
+  security: SetupPlugins['security']
 ) => {
   router.post(
     {
@@ -96,7 +96,7 @@ export const importTimelinesRoute = (
         const chunkParseObjects = chunk(CHUNK_PARSED_OBJECT_SIZE, uniqueParsedObjects);
         let importTimelineResponse: ImportTimelineResponse[] = [];
 
-        const user = await securityPluginSetup.authc.getCurrentUser(request);
+        const user = await security?.authc.getCurrentUser(request);
         let frameworkRequest = set('context.core.savedObjects.client', savedObjectsClient, request);
         frameworkRequest = set('user', user, frameworkRequest);
 

--- a/x-pack/legacy/plugins/siem/server/plugin.ts
+++ b/x-pack/legacy/plugins/siem/server/plugin.ts
@@ -46,7 +46,7 @@ export interface SetupPlugins {
   encryptedSavedObjects: EncryptedSavedObjectsSetup;
   features: FeaturesSetup;
   licensing: LicensingPluginSetup;
-  security: SecuritySetup;
+  security?: SecuritySetup;
   spaces?: SpacesSetup;
 }
 

--- a/x-pack/legacy/plugins/siem/server/routes/index.ts
+++ b/x-pack/legacy/plugins/siem/server/routes/index.ts
@@ -31,13 +31,13 @@ import { findRulesStatusesRoute } from '../lib/detection_engine/routes/rules/fin
 import { getPrepackagedRulesStatusRoute } from '../lib/detection_engine/routes/rules/get_prepackaged_rules_status_route';
 import { importTimelinesRoute } from '../lib/timeline/routes/import_timelines_route';
 import { exportTimelinesRoute } from '../lib/timeline/routes/export_timelines_route';
-import { SecurityPluginSetup } from '../../../../../plugins/security/server/';
+import { SetupPlugins } from '../plugin';
 
 export const initRoutes = (
   router: IRouter,
   config: LegacyServices['config'],
   usingEphemeralEncryptionKey: boolean,
-  security: SecurityPluginSetup
+  security: SetupPlugins['security']
 ) => {
   // Detection Engine Rule routes that have the REST endpoints of /api/detection_engine/rules
   // All REST rule creation, deletion, updating, etc......
@@ -79,5 +79,5 @@ export const initRoutes = (
   readTagsRoute(router);
 
   // Privileges API to get the generic user privileges
-  readPrivilegesRoute(router, usingEphemeralEncryptionKey);
+  readPrivilegesRoute(router, security, usingEphemeralEncryptionKey);
 };


### PR DESCRIPTION
## Summary
Addresses #59225

* Accounts for security being disabled, adds tests
* Updates other auth-aware endpoints (import timeline, graphql) to
account for security being disabled.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
