### PR TITLE
[Telemetry] Re-enable telemetry.config

### DIFF
--- a/src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.test.ts
+++ b/src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.test.ts
@@ -119,7 +119,7 @@ describe('telemetry_usage_collector', () => {
       const usageCollector = mockUsageCollector() as any;
       const collectorOptions = createTelemetryUsageCollector(
         usageCollector,
-        () => tempFiles.unreadable
+        async () => tempFiles.unreadable
       );
 
       expect(collectorOptions.type).toBe('static_telemetry');

--- a/src/plugins/telemetry/server/config.ts
+++ b/src/plugins/telemetry/server/config.ts
@@ -18,6 +18,8 @@
  */
 
 import { schema, TypeOf } from '@kbn/config-schema';
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { getConfigPath } from '../../../core/server/path';
 import { ENDPOINT_VERSION } from '../common/constants';
 
 export const configSchema = schema.object({
@@ -31,7 +33,7 @@ export const configSchema = schema.object({
     { defaultValue: true }
   ),
   // `config` is used internally and not intended to be set
-  // config: Joi.string().default(getConfigPath()), TODO: Get it in some other way
+  config: schema.string({ defaultValue: getConfigPath() }),
   banner: schema.boolean({ defaultValue: true }),
   url: schema.conditional(
     schema.contextRef('dev'),

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -163,7 +163,7 @@ export class TelemetryPlugin implements Plugin {
       config$: this.config$,
       getSavedObjectsClient,
     });
-    registerTelemetryUsageCollector(usageCollection);
+    registerTelemetryUsageCollector(usageCollection, this.config$);
     registerManagementUsageCollector(usageCollection, getUiSettingsClient);
     registerUiMetricUsageCollector(usageCollection, registerType, getSavedObjectsClient);
     registerApplicationUsageCollector(usageCollection, registerType, getSavedObjectsClient);


### PR DESCRIPTION
## Summary

Re-enables the telemetry config parameter `telemetry.config`.

Fixes #61347

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
