### PR TITLE
[Lens] Fix display single bar in XYChart Bar Vis

### DIFF
--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
@@ -39,7 +39,12 @@ function sampleArgs() {
             formatHint: { id: 'number', params: { pattern: '0,0.000' } },
           },
           { id: 'b', name: 'b', formatHint: { id: 'number', params: { pattern: '000,0' } } },
-          { id: 'c', name: 'c', formatHint: { id: 'string' } },
+          {
+            id: 'c',
+            name: 'c',
+            formatHint: { id: 'string' },
+            meta: { type: 'date-histogram', aggConfigParams: { interval: '10s' } },
+          },
           { id: 'd', name: 'ColD', formatHint: { id: 'string' } },
         ],
         rows: [
@@ -179,6 +184,7 @@ describe('xy_expression', () => {
         Object {
           "max": 1546491600000,
           "min": 1546405200000,
+          "minInterval": 10000,
         }
       `);
     });

--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.tsx
@@ -35,6 +35,7 @@ import { XYArgs, SeriesType, visualizationTypes } from './types';
 import { VisualizationContainer } from '../visualization_container';
 import { isHorizontalChart } from './state_helpers';
 import { UiActionsStart } from '../../../../../../src/plugins/ui_actions/public';
+import { parseInterval } from '../../../../../../src/plugins/data/common';
 import { getExecuteTriggerActions } from './services';
 
 type InferPropType<T> = T extends React.FunctionComponent<infer P> ? P : T;
@@ -210,11 +211,14 @@ export function XYChart({
   const shouldRotate = isHorizontalChart(layers);
 
   const xTitle = (xAxisColumn && xAxisColumn.name) || args.xTitle;
+  const interval = parseInterval(xAxisColumn?.meta?.aggConfigParams?.interval);
+
   const xDomain =
     data.dateRange && layers.every(l => l.xScaleType === 'time')
       ? {
           min: data.dateRange.fromDate.getTime(),
           max: data.dateRange.toDate.getTime(),
+          minInterval: interval?.asMilliseconds(),
         }
       : undefined;
   return (


### PR DESCRIPTION
## Summary

Fixes the issue of not proper displaying of a single bar in Lens Bar Chart Vis.

Fixes https://github.com/elastic/kibana/issues/60730

`minInterval` is being passed to elastic-charts (taken from aggsConfig of the column defined as xAccessor). Here's the example screenshot of solution: 
![image](https://user-images.githubusercontent.com/4283304/77665461-fcbd1000-6f7f-11ea-8ed5-46dca6fee847.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

