### PR TITLE
[Maps] use blended layer when linking discover to maps

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/components/field_chooser/lib/visualize_url_utils.ts
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/components/field_chooser/lib/visualize_url_utils.ts
@@ -84,6 +84,7 @@ export function getMapsAppUrl(
 
   // create initial layer descriptor
   const hasColumns = columns && columns.length && columns[0] !== '_source';
+  const supportsClustering = field.aggregatable;
   mapAppParams.set(
     'initialLayers',
     // @ts-ignore
@@ -97,9 +98,10 @@ export function getMapsAppUrl(
           geoField: field.name,
           tooltipProperties: hasColumns ? columns : [],
           indexPatternId: indexPattern.id,
+          scalingType: supportsClustering ? 'CLUSTERS' : 'LIMIT',
         },
         visible: true,
-        type: 'VECTOR',
+        type: supportsClustering ? 'BLENDED_VECTOR' : 'VECTOR',
       },
     ])
   );


### PR DESCRIPTION
Updates Discover link to maps to use blended layer when geo field supports aggregations.

Question: should this be backported to 7.7?