### PR TITLE
[Snapshot Restore] Add cloud as optional plugin

### DIFF
--- a/x-pack/plugins/snapshot_restore/kibana.json
+++ b/x-pack/plugins/snapshot_restore/kibana.json
@@ -10,7 +10,8 @@
   ],
   "optionalPlugins": [
     "usageCollection",
-    "security"
+    "security",
+    "cloud"
   ],
   "configPath": ["xpack", "snapshot_restore"]
 }


### PR DESCRIPTION
This PR adds `cloud` as an optional plugin to Snapshot and Restore's plugin definition. Without it, invalid repositories will show in cloud (related code: [here](https://github.com/elastic/kibana/blob/master/x-pack/plugins/snapshot_restore/server/plugin.ts#L88) and [here](https://github.com/elastic/kibana/blob/master/x-pack/plugins/snapshot_restore/server/routes/api/repositories.ts#L179)). I believe this is a regression of the NP migration.

Current behavior on cloud:
<img width="1261" alt="Screen Shot 2020-03-26 at 3 07 44 PM" src="https://user-images.githubusercontent.com/5226211/77687378-ac8c8080-6f74-11ea-8967-b36cce704dde.png">

Expected behavior: Shared file system and Read-only URL repository types should not display on cloud.
