### PR TITLE
[SIEM] 7.7. NP Cleanup

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/index/create_index_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/index/create_index_route.ts
@@ -30,8 +30,12 @@ export const createIndexRoute = (router: IRouter) => {
 
       try {
         const clusterClient = context.core.elasticsearch.dataClient;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
         const callCluster = clusterClient.callAsCurrentUser;
+
+        if (!siemClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
         const index = siemClient.signalsIndex;
         const indexExists = await getIndexExists(callCluster, index);

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/index/delete_index_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/index/delete_index_route.ts
@@ -38,7 +38,11 @@ export const deleteIndexRoute = (router: IRouter) => {
 
       try {
         const clusterClient = context.core.elasticsearch.dataClient;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
+
+        if (!siemClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
         const callCluster = clusterClient.callAsCurrentUser;
         const index = siemClient.signalsIndex;

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/index/read_index_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/index/read_index_route.ts
@@ -23,7 +23,11 @@ export const readIndexRoute = (router: IRouter) => {
 
       try {
         const clusterClient = context.core.elasticsearch.dataClient;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
+
+        if (!siemClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
         const index = siemClient.signalsIndex;
         const indexExists = await getIndexExists(clusterClient.callAsCurrentUser, index);

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
@@ -62,6 +62,13 @@ describe('read_privileges route', () => {
       expect(response.status).toEqual(500);
       expect(response.body).toEqual({ message: 'Test error', status_code: 500 });
     });
+
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(getPrivilegeRequest(), contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
   });
 
   describe('when security plugin is disabled', () => {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
@@ -27,9 +27,14 @@ export const readPrivilegesRoute = (
     },
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
+
       try {
         const clusterClient = context.core.elasticsearch.dataClient;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
+
+        if (!siemClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
         const index = siemClient.signalsIndex;
         const clusterPrivileges = await readPrivileges(clusterClient.callAsCurrentUser, index);

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/add_prepackaged_rules_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/add_prepackaged_rules_route.test.ts
@@ -63,7 +63,7 @@ describe('add_prepackaged_rules_route', () => {
     addPrepackedRulesRoute(server.router);
   });
 
-  describe('status codes with actionClient and alertClient', () => {
+  describe('status codes', () => {
     test('returns 200 when creating with a valid actionClient and alertClient', async () => {
       const request = addPrepackagedRulesRequest();
       const response = await server.inject(request, context);
@@ -95,6 +95,13 @@ describe('add_prepackaged_rules_route', () => {
           'Pre-packaged rules cannot be installed until the signals index is created'
         ),
       });
+    });
+
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(addPrepackagedRulesRequest(), contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
     });
   });
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/add_prepackaged_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/add_prepackaged_rules_route.ts
@@ -33,16 +33,13 @@ export const addPrepackedRulesRoute = (router: IRouter) => {
       const siemResponse = buildSiemResponse(response);
 
       try {
-        if (!context.alerting || !context.actions) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-        const alertsClient = context.alerting.getAlertsClient();
-        const actionsClient = context.actions.getActionsClient();
+        const alertsClient = context.alerting?.getAlertsClient();
+        const actionsClient = context.actions?.getActionsClient();
         const clusterClient = context.core.elasticsearch.dataClient;
         const savedObjectsClient = context.core.savedObjects.client;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
 
-        if (!actionsClient || !alertsClient) {
+        if (!siemClient || !actionsClient || !alertsClient) {
           return siemResponse.error({ statusCode: 404 });
         }
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_bulk_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_bulk_route.test.ts
@@ -42,7 +42,7 @@ describe('create_rules_bulk', () => {
     createRulesBulkRoute(server.router);
   });
 
-  describe('status codes with actionClient and alertClient', () => {
+  describe('status codes', () => {
     test('returns 200 when creating a single rule with a valid actionClient and alertClient', async () => {
       const response = await server.inject(getReadBulkRequest(), context);
       expect(response.status).toEqual(200);
@@ -51,6 +51,13 @@ describe('create_rules_bulk', () => {
     test('returns 404 if alertClient is not available on the route', async () => {
       context.alerting!.getAlertsClient = jest.fn();
       const response = await server.inject(getReadBulkRequest(), context);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
+
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(getReadBulkRequest(), contextWithoutSiem);
       expect(response.status).toEqual(404);
       expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
     });

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_bulk_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_bulk_route.ts
@@ -37,15 +37,12 @@ export const createRulesBulkRoute = (router: IRouter) => {
     },
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
-      if (!context.alerting || !context.actions) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
-      const actionsClient = context.actions.getActionsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
+      const actionsClient = context.actions?.getActionsClient();
       const clusterClient = context.core.elasticsearch.dataClient;
-      const siemClient = context.siem.getSiemClient();
+      const siemClient = context.siem?.getSiemClient();
 
-      if (!actionsClient || !alertsClient) {
+      if (!siemClient || !actionsClient || !alertsClient) {
         return siemResponse.error({ statusCode: 404 });
       }
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_route.test.ts
@@ -60,6 +60,13 @@ describe('create_rules', () => {
       expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
     });
 
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(getCreateRequest(), contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
+
     it('returns 200 if license is not platinum', async () => {
       (context.licensing.license.hasAtLeast as jest.Mock).mockReturnValue(false);
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/create_rules_route.ts
@@ -72,16 +72,13 @@ export const createRulesRoute = (router: IRouter): void => {
 
       try {
         validateLicenseForRuleType({ license: context.licensing.license, ruleType: type });
-        if (!context.alerting || !context.actions) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-        const alertsClient = context.alerting.getAlertsClient();
-        const actionsClient = context.actions.getActionsClient();
+        const alertsClient = context.alerting?.getAlertsClient();
+        const actionsClient = context.actions?.getActionsClient();
         const clusterClient = context.core.elasticsearch.dataClient;
         const savedObjectsClient = context.core.savedObjects.client;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
 
-        if (!actionsClient || !alertsClient) {
+        if (!siemClient || !actionsClient || !alertsClient) {
           return siemResponse.error({ statusCode: 404 });
         }
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/delete_rules_bulk_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/delete_rules_bulk_route.ts
@@ -35,11 +35,8 @@ export const deleteRulesBulkRoute = (router: IRouter) => {
   const handler: Handler = async (context, request, response) => {
     const siemResponse = buildSiemResponse(response);
 
-    if (!context.alerting || !context.actions) {
-      return siemResponse.error({ statusCode: 404 });
-    }
-    const alertsClient = context.alerting.getAlertsClient();
-    const actionsClient = context.actions.getActionsClient();
+    const alertsClient = context.alerting?.getAlertsClient();
+    const actionsClient = context.actions?.getActionsClient();
     const savedObjectsClient = context.core.savedObjects.client;
 
     if (!actionsClient || !alertsClient) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/delete_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/delete_rules_route.ts
@@ -34,12 +34,9 @@ export const deleteRulesRoute = (router: IRouter) => {
 
       try {
         const { id, rule_id: ruleId } = request.query;
-        if (!context.alerting || !context.actions) {
-          return siemResponse.error({ statusCode: 404 });
-        }
 
-        const alertsClient = context.alerting.getAlertsClient();
-        const actionsClient = context.actions.getActionsClient();
+        const alertsClient = context.alerting?.getAlertsClient();
+        const actionsClient = context.actions?.getActionsClient();
         const savedObjectsClient = context.core.savedObjects.client;
 
         if (!actionsClient || !alertsClient) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/export_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/export_rules_route.ts
@@ -28,10 +28,7 @@ export const exportRulesRoute = (router: IRouter, config: LegacyServices['config
     },
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
-      if (!context.alerting) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
 
       if (!alertsClient) {
         return siemResponse.error({ statusCode: 404 });

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/find_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/find_rules_route.ts
@@ -32,10 +32,7 @@ export const findRulesRoute = (router: IRouter) => {
 
       try {
         const { query } = request;
-        if (!context.alerting) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-        const alertsClient = context.alerting.getAlertsClient();
+        const alertsClient = context.alerting?.getAlertsClient();
         const savedObjectsClient = context.core.savedObjects.client;
 
         if (!alertsClient) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/find_rules_status_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/find_rules_status_route.ts
@@ -35,10 +35,7 @@ export const findRulesStatusesRoute = (router: IRouter) => {
     async (context, request, response) => {
       const { query } = request;
       const siemResponse = buildSiemResponse(response);
-      if (!context.alerting) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
       const savedObjectsClient = context.core.savedObjects.client;
 
       if (!alertsClient) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/get_prepackaged_rules_status_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/get_prepackaged_rules_status_route.ts
@@ -29,10 +29,7 @@ export const getPrepackagedRulesStatusRoute = (router: IRouter) => {
     },
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
-      if (!context.alerting) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
 
       if (!alertsClient) {
         return siemResponse.error({ statusCode: 404 });

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/import_rules_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/import_rules_route.test.ts
@@ -101,6 +101,13 @@ describe('import_rules_route', () => {
       expect(response.status).toEqual(404);
       expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
     });
+
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(request, contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
   });
 
   describe('unhappy paths', () => {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/patch_rules_bulk_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/patch_rules_bulk_route.ts
@@ -37,11 +37,8 @@ export const patchRulesBulkRoute = (router: IRouter) => {
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
 
-      if (!context.alerting || !context.actions) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
-      const actionsClient = context.actions.getActionsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
+      const actionsClient = context.actions?.getActionsClient();
       const savedObjectsClient = context.core.savedObjects.client;
 
       if (!actionsClient || !alertsClient) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/patch_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/patch_rules_route.ts
@@ -74,12 +74,8 @@ export const patchRulesRoute = (router: IRouter) => {
           validateLicenseForRuleType({ license: context.licensing.license, ruleType: type });
         }
 
-        if (!context.alerting || !context.actions) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-
-        const alertsClient = context.alerting.getAlertsClient();
-        const actionsClient = context.actions.getActionsClient();
+        const alertsClient = context.alerting?.getAlertsClient();
+        const actionsClient = context.actions?.getActionsClient();
         const savedObjectsClient = context.core.savedObjects.client;
 
         if (!actionsClient || !alertsClient) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/read_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/read_rules_route.ts
@@ -32,10 +32,7 @@ export const readRulesRoute = (router: IRouter) => {
       const { id, rule_id: ruleId } = request.query;
       const siemResponse = buildSiemResponse(response);
 
-      if (!context.alerting) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
       const savedObjectsClient = context.core.savedObjects.client;
 
       try {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_bulk_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_bulk_route.test.ts
@@ -69,6 +69,13 @@ describe('update_rules_bulk', () => {
       expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
     });
 
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(getUpdateBulkRequest(), contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
+
     test('returns an error if update throws', async () => {
       clients.alertsClient.update.mockImplementation(() => {
         throw new Error('Test error');

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_bulk_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_bulk_route.ts
@@ -37,15 +37,12 @@ export const updateRulesBulkRoute = (router: IRouter) => {
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
 
-      if (!context.alerting || !context.actions) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
-      const actionsClient = context.actions.getActionsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
+      const actionsClient = context.actions?.getActionsClient();
       const savedObjectsClient = context.core.savedObjects.client;
-      const siemClient = context.siem.getSiemClient();
+      const siemClient = context.siem?.getSiemClient();
 
-      if (!actionsClient || !alertsClient) {
+      if (!siemClient || !actionsClient || !alertsClient) {
         return siemResponse.error({ statusCode: 404 });
       }
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_route.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_route.test.ts
@@ -67,6 +67,13 @@ describe('update_rules', () => {
       expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
     });
 
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(getUpdateRequest(), contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
+
     test('returns error when updating non-rule', async () => {
       clients.alertsClient.find.mockResolvedValue(nonRuleFindResult());
       const response = await server.inject(getUpdateRequest(), context);

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/rules/update_rules_route.ts
@@ -74,15 +74,12 @@ export const updateRulesRoute = (router: IRouter) => {
       try {
         validateLicenseForRuleType({ license: context.licensing.license, ruleType: type });
 
-        if (!context.alerting || !context.actions) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-        const alertsClient = context.alerting.getAlertsClient();
-        const actionsClient = context.actions.getActionsClient();
+        const alertsClient = context.alerting?.getAlertsClient();
+        const actionsClient = context.actions?.getActionsClient();
         const savedObjectsClient = context.core.savedObjects.client;
-        const siemClient = context.siem.getSiemClient();
+        const siemClient = context.siem?.getSiemClient();
 
-        if (!actionsClient || !alertsClient) {
+        if (!siemClient || !actionsClient || !alertsClient) {
           return siemResponse.error({ statusCode: 404 });
         }
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/signals/open_close_signals.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/signals/open_close_signals.test.ts
@@ -49,6 +49,13 @@ describe('set signal status', () => {
       expect(response.status).toEqual(200);
     });
 
+    it('returns 404 if siem client is unavailable', async () => {
+      const { siem, ...contextWithoutSiem } = context;
+      const response = await server.inject(getSetSignalStatusByQueryRequest(), contextWithoutSiem);
+      expect(response.status).toEqual(404);
+      expect(response.body).toEqual({ message: 'Not Found', status_code: 404 });
+    });
+
     test('catches error if callAsCurrentUser throws error', async () => {
       clients.clusterClient.callAsCurrentUser.mockImplementation(async () => {
         throw new Error('Test error');

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/signals/open_close_signals_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/signals/open_close_signals_route.ts
@@ -24,8 +24,12 @@ export const setSignalsStatusRoute = (router: IRouter) => {
     async (context, request, response) => {
       const { signal_ids: signalIds, query, status } = request.body;
       const clusterClient = context.core.elasticsearch.dataClient;
-      const siemClient = context.siem.getSiemClient();
+      const siemClient = context.siem?.getSiemClient();
       const siemResponse = buildSiemResponse(response);
+
+      if (!siemClient) {
+        return siemResponse.error({ statusCode: 404 });
+      }
 
       let queryObject;
       if (signalIds) {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/signals/query_signals_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/signals/query_signals_route.ts
@@ -24,7 +24,7 @@ export const querySignalsRoute = (router: IRouter) => {
     async (context, request, response) => {
       const { query, aggs, _source, track_total_hits, size } = request.body;
       const clusterClient = context.core.elasticsearch.dataClient;
-      const siemClient = context.siem.getSiemClient();
+      const siemClient = context.siem!.getSiemClient();
       const siemResponse = buildSiemResponse(response);
 
       try {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/tags/read_tags_route.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/routes/tags/read_tags_route.ts
@@ -20,11 +20,7 @@ export const readTagsRoute = (router: IRouter) => {
     },
     async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
-
-      if (!context.alerting) {
-        return siemResponse.error({ statusCode: 404 });
-      }
-      const alertsClient = context.alerting.getAlertsClient();
+      const alertsClient = context.alerting?.getAlertsClient();
 
       if (!alertsClient) {
         return siemResponse.error({ statusCode: 404 });

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/rules/types.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/rules/types.ts
@@ -16,7 +16,6 @@ import {
 import { AlertsClient, PartialAlert } from '../../../../../../../plugins/alerting/server';
 import { Alert } from '../../../../../../../plugins/alerting/common';
 import { SIGNALS_ID } from '../../../../common/constants';
-import { LegacyRequest } from '../../../types';
 import { ActionsClient } from '../../../../../../../plugins/actions/server';
 import { RuleAlertParams, RuleTypeParams, RuleAlertParamsRest } from '../types';
 
@@ -37,14 +36,6 @@ export interface FindParamsRest {
   sort_order: 'asc' | 'desc';
   fields: string[];
   filter: string;
-}
-
-export interface PatchRulesRequest extends LegacyRequest {
-  payload: PatchRuleAlertParamsRest;
-}
-
-export interface UpdateRulesRequest extends LegacyRequest {
-  payload: UpdateRuleAlertParamsRest;
 }
 
 export interface RuleAlertType extends Alert {

--- a/x-pack/legacy/plugins/siem/server/types.ts
+++ b/x-pack/legacy/plugins/siem/server/types.ts
@@ -7,8 +7,6 @@
 import { Legacy } from 'kibana';
 import { SiemClient } from './client';
 
-export { LegacyRequest } from '../../../../../src/core/server';
-
 export interface LegacyServices {
   config: Legacy.Server['config'];
 }

--- a/x-pack/legacy/plugins/siem/server/types.ts
+++ b/x-pack/legacy/plugins/siem/server/types.ts
@@ -19,6 +19,6 @@ export interface SiemRequestContext {
 
 declare module 'src/core/server' {
   interface RequestHandlerContext {
-    siem: SiemRequestContext;
+    siem?: SiemRequestContext;
   }
 }

--- a/x-pack/legacy/plugins/siem/server/types.ts
+++ b/x-pack/legacy/plugins/siem/server/types.ts
@@ -10,9 +10,7 @@ import { SiemClient } from './client';
 export { LegacyRequest } from '../../../../../src/core/server';
 
 export interface LegacyServices {
-  alerting?: Legacy.Server['plugins']['alerting'];
   config: Legacy.Server['config'];
-  route: Legacy.Server['route'];
 }
 
 export { SiemClient };


### PR DESCRIPTION
## Summary

A few housekeeping tasks following NP changes made since 7.6.

* Removes unused Legacy types
* Declares `siemClient` as optional for other plugins (as siem may be disabled)
  * Returns a 404 if unavailable within SIEM
  * Removes redundant guards in routes

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
