### PR TITLE
[SIEM][CASE] Delete endpoints return noContent

### DIFF
--- a/x-pack/plugins/case/server/routes/api/cases/comments/delete_all_comments.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/comments/delete_all_comments.ts
@@ -53,7 +53,7 @@ export function initDeleteAllCommentsApi({ caseService, router, userActionServic
           ),
         });
 
-        return response.ok({ body: 'true' });
+        return response.noContent();
       } catch (error) {
         return response.customError(wrapError(error));
       }

--- a/x-pack/plugins/case/server/routes/api/cases/comments/delete_comment.test.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/comments/delete_comment.test.ts
@@ -21,7 +21,7 @@ describe('DELETE comment', () => {
   beforeAll(async () => {
     routeHandler = await createRoute(initDeleteCommentApi, 'delete');
   });
-  it(`deletes the comment. responds with 200`, async () => {
+  it(`deletes the comment. responds with 204`, async () => {
     const request = httpServerMock.createKibanaRequest({
       path: '/api/cases/{case_id}/comments/{comment_id}',
       method: 'delete',
@@ -39,7 +39,7 @@ describe('DELETE comment', () => {
     );
 
     const response = await routeHandler(theContext, request, kibanaResponseFactory);
-    expect(response.status).toEqual(200);
+    expect(response.status).toEqual(204);
   });
   it(`returns an error when thrown from deleteComment service`, async () => {
     const request = httpServerMock.createKibanaRequest({

--- a/x-pack/plugins/case/server/routes/api/cases/comments/delete_comment.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/comments/delete_comment.ts
@@ -64,7 +64,7 @@ export function initDeleteCommentApi({ caseService, router, userActionService }:
           ],
         });
 
-        return response.ok({ body: 'true' });
+        return response.noContent();
       } catch (error) {
         return response.customError(wrapError(error));
       }

--- a/x-pack/plugins/case/server/routes/api/cases/delete_cases.test.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/delete_cases.test.ts
@@ -22,7 +22,7 @@ describe('DELETE case', () => {
   beforeAll(async () => {
     routeHandler = await createRoute(initDeleteCasesApi, 'delete');
   });
-  it(`deletes the case. responds with 200`, async () => {
+  it(`deletes the case. responds with 204`, async () => {
     const request = httpServerMock.createKibanaRequest({
       path: '/api/cases',
       method: 'delete',
@@ -39,7 +39,7 @@ describe('DELETE case', () => {
     );
 
     const response = await routeHandler(theContext, request, kibanaResponseFactory);
-    expect(response.status).toEqual(200);
+    expect(response.status).toEqual(204);
   });
   it(`returns an error when thrown from deleteCase service`, async () => {
     const request = httpServerMock.createKibanaRequest({

--- a/x-pack/plugins/case/server/routes/api/cases/delete_cases.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/delete_cases.ts
@@ -70,7 +70,7 @@ export function initDeleteCasesApi({ caseService, router, userActionService }: R
           ),
         });
 
-        return response.ok({ body: 'true' });
+        return response.noContent();
       } catch (error) {
         return response.customError(wrapError(error));
       }


### PR DESCRIPTION
## Summary

All delete endpoints return status code 204 and an empty body.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
