### PR TITLE
[Lens] fix error for minInterval>computedInterval for XYChart

### DIFF
--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
@@ -184,7 +184,7 @@ describe('xy_expression', () => {
         Object {
           "max": 1546491600000,
           "min": 1546405200000,
-          "minInterval": 10000,
+          "minInterval": undefined,
         }
       `);
     });

--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
@@ -18,6 +18,10 @@ import {
 } from '@elastic/charts';
 import { xyChart, XYChart } from './xy_expression';
 import { LensMultiTable } from '../types';
+import {
+  KibanaDatatable,
+  KibanaDatatableRow,
+} from '../../../../../../src/plugins/expressions/public';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { XYArgs, LegendConfig, legendConfig, layerConfig, LayerArgs } from './types';
@@ -26,57 +30,61 @@ import { mountWithIntl } from 'test_utils/enzyme_helpers';
 
 const executeTriggerActions = jest.fn();
 
+const createSampleDatatableWithRows = (rows: KibanaDatatableRow[]): KibanaDatatable => ({
+  type: 'kibana_datatable',
+  columns: [
+    {
+      id: 'a',
+      name: 'a',
+      formatHint: { id: 'number', params: { pattern: '0,0.000' } },
+    },
+    { id: 'b', name: 'b', formatHint: { id: 'number', params: { pattern: '000,0' } } },
+    {
+      id: 'c',
+      name: 'c',
+      formatHint: { id: 'string' },
+      meta: { type: 'date-histogram', aggConfigParams: { interval: '10s' } },
+    },
+    { id: 'd', name: 'ColD', formatHint: { id: 'string' } },
+  ],
+  rows,
+});
+
+const sampleLayer: LayerArgs = {
+  layerId: 'first',
+  seriesType: 'line',
+  xAccessor: 'c',
+  accessors: ['a', 'b'],
+  splitAccessor: 'd',
+  columnToLabel: '{"a": "Label A", "b": "Label B", "d": "Label D"}',
+  xScaleType: 'ordinal',
+  yScaleType: 'linear',
+  isHistogram: false,
+};
+
+const createArgsWithLayers = (layers: LayerArgs[] = [sampleLayer]): XYArgs => ({
+  xTitle: '',
+  yTitle: '',
+  legend: {
+    type: 'lens_xy_legendConfig',
+    isVisible: false,
+    position: Position.Top,
+  },
+  layers,
+});
+
 function sampleArgs() {
   const data: LensMultiTable = {
     type: 'lens_multitable',
     tables: {
-      first: {
-        type: 'kibana_datatable',
-        columns: [
-          {
-            id: 'a',
-            name: 'a',
-            formatHint: { id: 'number', params: { pattern: '0,0.000' } },
-          },
-          { id: 'b', name: 'b', formatHint: { id: 'number', params: { pattern: '000,0' } } },
-          {
-            id: 'c',
-            name: 'c',
-            formatHint: { id: 'string' },
-            meta: { type: 'date-histogram', aggConfigParams: { interval: '10s' } },
-          },
-          { id: 'd', name: 'ColD', formatHint: { id: 'string' } },
-        ],
-        rows: [
-          { a: 1, b: 2, c: 'I', d: 'Foo' },
-          { a: 1, b: 5, c: 'J', d: 'Bar' },
-        ],
-      },
+      first: createSampleDatatableWithRows([
+        { a: 1, b: 2, c: 'I', d: 'Foo' },
+        { a: 1, b: 5, c: 'J', d: 'Bar' },
+      ]),
     },
   };
 
-  const args: XYArgs = {
-    xTitle: '',
-    yTitle: '',
-    legend: {
-      type: 'lens_xy_legendConfig',
-      isVisible: false,
-      position: Position.Top,
-    },
-    layers: [
-      {
-        layerId: 'first',
-        seriesType: 'line',
-        xAccessor: 'c',
-        accessors: ['a', 'b'],
-        splitAccessor: 'd',
-        columnToLabel: '{"a": "Label A", "b": "Label B", "d": "Label D"}',
-        xScaleType: 'ordinal',
-        yScaleType: 'linear',
-        isHistogram: false,
-      },
-    ],
-  };
+  const args: XYArgs = createArgsWithLayers();
 
   return { data, args };
 }
@@ -158,35 +166,208 @@ describe('xy_expression', () => {
       expect(component.find(LineSeries)).toHaveLength(1);
     });
 
-    test('it uses the full date range', () => {
-      const { data, args } = sampleArgs();
+    describe('date range', () => {
+      const timeSampleLayer: LayerArgs = {
+        layerId: 'first',
+        seriesType: 'line',
+        xAccessor: 'c',
+        accessors: ['a', 'b'],
+        splitAccessor: 'd',
+        columnToLabel: '{"a": "Label A", "b": "Label B", "d": "Label D"}',
+        xScaleType: 'time',
+        yScaleType: 'linear',
+        isHistogram: false,
+      };
+      const multiLayerArgs = createArgsWithLayers([
+        timeSampleLayer,
+        {
+          ...timeSampleLayer,
+          layerId: 'second',
+          seriesType: 'bar',
+          xScaleType: 'time',
+        },
+      ]);
+      test('it uses the full date range', () => {
+        const { data, args } = sampleArgs();
 
-      const component = shallow(
-        <XYChart
-          data={{
-            ...data,
-            dateRange: {
-              fromDate: new Date('2019-01-02T05:00:00.000Z'),
-              toDate: new Date('2019-01-03T05:00:00.000Z'),
-            },
-          }}
-          args={{
-            ...args,
-            layers: [{ ...args.layers[0], seriesType: 'line', xScaleType: 'time' }],
-          }}
-          formatFactory={getFormatSpy}
-          timeZone="UTC"
-          chartTheme={{}}
-          executeTriggerActions={executeTriggerActions}
-        />
-      );
-      expect(component.find(Settings).prop('xDomain')).toMatchInlineSnapshot(`
+        const component = shallow(
+          <XYChart
+            data={{
+              ...data,
+              dateRange: {
+                fromDate: new Date('2019-01-02T05:00:00.000Z'),
+                toDate: new Date('2019-01-03T05:00:00.000Z'),
+              },
+            }}
+            args={{
+              ...args,
+              layers: [{ ...args.layers[0], seriesType: 'line', xScaleType: 'time' }],
+            }}
+            formatFactory={getFormatSpy}
+            timeZone="UTC"
+            chartTheme={{}}
+            executeTriggerActions={executeTriggerActions}
+          />
+        );
+        expect(component.find(Settings).prop('xDomain')).toMatchInlineSnapshot(`
+          Object {
+            "max": 1546491600000,
+            "min": 1546405200000,
+            "minInterval": undefined,
+          }
+        `);
+      });
+
+      test('it generates correct xDomain for a layer with single value and a layer with no data (1-0) ', () => {
+        const data: LensMultiTable = {
+          type: 'lens_multitable',
+          tables: {
+            first: createSampleDatatableWithRows([{ a: 1, b: 2, c: 'I', d: 'Foo' }]),
+            second: createSampleDatatableWithRows([]),
+          },
+        };
+
+        const component = shallow(
+          <XYChart
+            data={{
+              ...data,
+              dateRange: {
+                fromDate: new Date('2019-01-02T05:00:00.000Z'),
+                toDate: new Date('2019-01-03T05:00:00.000Z'),
+              },
+            }}
+            args={multiLayerArgs}
+            formatFactory={getFormatSpy}
+            timeZone="UTC"
+            chartTheme={{}}
+            executeTriggerActions={executeTriggerActions}
+          />
+        );
+
+        expect(component.find(Settings).prop('xDomain')).toMatchInlineSnapshot(`
+          Object {
+            "max": 1546491600000,
+            "min": 1546405200000,
+            "minInterval": 10000,
+          }
+        `);
+      });
+
+      test('it generates correct xDomain for two layers with single value(1-1)', () => {
+        const data: LensMultiTable = {
+          type: 'lens_multitable',
+          tables: {
+            first: createSampleDatatableWithRows([{ a: 1, b: 2, c: 'I', d: 'Foo' }]),
+            second: createSampleDatatableWithRows([{ a: 10, b: 5, c: 'J', d: 'Bar' }]),
+          },
+        };
+        const component = shallow(
+          <XYChart
+            data={{
+              ...data,
+              dateRange: {
+                fromDate: new Date('2019-01-02T05:00:00.000Z'),
+                toDate: new Date('2019-01-03T05:00:00.000Z'),
+              },
+            }}
+            args={multiLayerArgs}
+            formatFactory={getFormatSpy}
+            timeZone="UTC"
+            chartTheme={{}}
+            executeTriggerActions={executeTriggerActions}
+          />
+        );
+
+        expect(component.find(Settings).prop('xDomain')).toMatchInlineSnapshot(`
+        Object {
+          "max": 1546491600000,
+          "min": 1546405200000,
+          "minInterval": 10000,
+        }
+      `);
+      });
+      test('it generates correct xDomain for a layer with single value and layer with multiple value data (1-n)', () => {
+        const data: LensMultiTable = {
+          type: 'lens_multitable',
+          tables: {
+            first: createSampleDatatableWithRows([
+              { a: 1, b: 2, c: 'I', d: 'Foo' },
+              { a: 8, b: 5, c: 'K', d: 'Buzz' },
+            ]),
+            second: createSampleDatatableWithRows([
+              { a: 10, b: 5, c: 'J', d: 'Bar' },
+              { a: 8, b: 5, c: 'K', d: 'Buzz' },
+            ]),
+          },
+        };
+        const component = shallow(
+          <XYChart
+            data={{
+              ...data,
+              dateRange: {
+                fromDate: new Date('2019-01-02T05:00:00.000Z'),
+                toDate: new Date('2019-01-03T05:00:00.000Z'),
+              },
+            }}
+            args={multiLayerArgs}
+            formatFactory={getFormatSpy}
+            timeZone="UTC"
+            chartTheme={{}}
+            executeTriggerActions={executeTriggerActions}
+          />
+        );
+
+        expect(component.find(Settings).prop('xDomain')).toMatchInlineSnapshot(`
+          Object {
+            "max": 1546491600000,
+            "min": 1546405200000,
+            "minInterval": undefined,
+          }
+        `);
+      });
+
+      test('it generates correct xDomain for 2 layers with multiple value data (n-n)', () => {
+        const data: LensMultiTable = {
+          type: 'lens_multitable',
+          tables: {
+            first: createSampleDatatableWithRows([
+              { a: 1, b: 2, c: 'I', d: 'Foo' },
+              { a: 8, b: 5, c: 'K', d: 'Buzz' },
+              { a: 9, b: 7, c: 'L', d: 'Bar' },
+              { a: 10, b: 2, c: 'G', d: 'Bear' },
+            ]),
+            second: createSampleDatatableWithRows([
+              { a: 10, b: 5, c: 'J', d: 'Bar' },
+              { a: 8, b: 4, c: 'K', d: 'Fi' },
+              { a: 1, b: 8, c: 'O', d: 'Pi' },
+            ]),
+          },
+        };
+        const component = shallow(
+          <XYChart
+            data={{
+              ...data,
+              dateRange: {
+                fromDate: new Date('2019-01-02T05:00:00.000Z'),
+                toDate: new Date('2019-01-03T05:00:00.000Z'),
+              },
+            }}
+            args={multiLayerArgs}
+            formatFactory={getFormatSpy}
+            timeZone="UTC"
+            chartTheme={{}}
+            executeTriggerActions={executeTriggerActions}
+          />
+        );
+
+        expect(component.find(Settings).prop('xDomain')).toMatchInlineSnapshot(`
         Object {
           "max": 1546491600000,
           "min": 1546405200000,
           "minInterval": undefined,
         }
       `);
+      });
     });
 
     test('it does not use date range if the x is not a time scale', () => {

--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.test.tsx
@@ -290,10 +290,7 @@ describe('xy_expression', () => {
         const data: LensMultiTable = {
           type: 'lens_multitable',
           tables: {
-            first: createSampleDatatableWithRows([
-              { a: 1, b: 2, c: 'I', d: 'Foo' },
-              { a: 8, b: 5, c: 'K', d: 'Buzz' },
-            ]),
+            first: createSampleDatatableWithRows([{ a: 1, b: 2, c: 'I', d: 'Foo' }]),
             second: createSampleDatatableWithRows([
               { a: 10, b: 5, c: 'J', d: 'Bar' },
               { a: 8, b: 5, c: 'K', d: 'Buzz' },

--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.tsx
@@ -211,14 +211,19 @@ export function XYChart({
   const shouldRotate = isHorizontalChart(layers);
 
   const xTitle = (xAxisColumn && xAxisColumn.name) || args.xTitle;
-  const interval = parseInterval(xAxisColumn?.meta?.aggConfigParams?.interval);
+
+  // add minInterval only for single row value as it cannot be determined from dataset
+  const minInterval =
+    data.tables[layers[0].layerId].rows.length === 1
+      ? parseInterval(xAxisColumn?.meta?.aggConfigParams?.interval)?.asMilliseconds()
+      : undefined;
 
   const xDomain =
     data.dateRange && layers.every(l => l.xScaleType === 'time')
       ? {
           min: data.dateRange.fromDate.getTime(),
           max: data.dateRange.toDate.getTime(),
-          minInterval: interval?.asMilliseconds(),
+          minInterval,
         }
       : undefined;
   return (

--- a/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.tsx
+++ b/x-pack/legacy/plugins/lens/public/xy_visualization/xy_expression.tsx
@@ -213,10 +213,10 @@ export function XYChart({
   const xTitle = (xAxisColumn && xAxisColumn.name) || args.xTitle;
 
   // add minInterval only for single row value as it cannot be determined from dataset
-  const minInterval =
-    data.tables[layers[0].layerId].rows.length === 1
-      ? parseInterval(xAxisColumn?.meta?.aggConfigParams?.interval)?.asMilliseconds()
-      : undefined;
+
+  const minInterval = layers.every(layer => data.tables[layer.layerId].rows.length <= 1)
+    ? parseInterval(xAxisColumn?.meta?.aggConfigParams?.interval)?.asMilliseconds()
+    : undefined;
 
   const xDomain =
     data.dateRange && layers.every(l => l.xScaleType === 'time')


### PR DESCRIPTION
## Summary

Fixes throwing an error for minInterval>computedInterval for XYChart - when user chooses timerange with Daylight Saving Time in between, the minInterval causes throwing an error in elastic-charts library. Fix: We don't need to pass minInterval to any other case except for single bar chart (that was the reason the bug was introduced here: (https://github.com/elastic/kibana/pull/61452) so I've just limited the case. Confirmed with @markov00 .

![image](https://user-images.githubusercontent.com/4283304/78029266-93af1100-7360-11ea-9b93-4771654dca5a.png)


In addition, when testing, I checked the following scenarios for multiple layers:

1. Chart of two layers, one layer with many values, second layer with 0
2. Chart of two layers, many to 1(value) 
3. Chart of two layers, many to many
4. Chart of two layers, 1 to 1(different timestamp)
5. Chart of two layers, 1 to 0
6. Chart of two duplicated layers

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
