### PR TITLE
[SIEM] Increases Cypress default command timeout

### DIFF
--- a/x-pack/legacy/plugins/siem/cypress.json
+++ b/x-pack/legacy/plugins/siem/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:5601",
-  "defaultCommandTimeout": 60000,
+  "defaultCommandTimeout": 120000,
   "screenshotsFolder": "../../../../target/kibana-siem/cypress/screenshots",
   "trashAssetsBeforeRuns": false,
   "video": false,


### PR DESCRIPTION
## Summary

In this PR we are increasing the Cypress default command timeout. With this change the close and open signals flaky test should be fixed and should prevent also future flakiness due to Kibana slowness. 

Note that once Kibana is stabilised we should decrease this timeout. 