### PR TITLE
[SIEM] Slows down timeline creation in Cypress test

### DIFF
--- a/x-pack/legacy/plugins/siem/cypress/integration/url_state.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/url_state.spec.ts
@@ -249,6 +249,7 @@ describe('url state', () => {
     const timelineName = 'SIEM';
     addNameToTimeline(timelineName);
     addDescriptionToTimeline('This is the best timeline of the world');
+    cy.wait(5000);
 
     cy.url({ timeout: 30000 }).should('match', /\w*-\w*-\w*-\w*-\w*/);
     cy.url().then(url => {


### PR DESCRIPTION
## Summary

`Sets and reads the url state for timeline by id` is starting to fail a lot with the following error: `expected '<input.euiFieldText.NameField-sc-1esg8gm-2.edWHDY>' to have attribute 'value' with the value 'SIEM', but the value was 'S'`

The element refers to the Title once the timeline is opened using the id in the link and SIEM is the name of the created timeline.

As this test is working in local I suspect that what is happening here is that the test is faster than our graphql call that sets the timeline name.

This is why as a workaround we are adding a sleep. Note that this is a workaround in order to avoid flaky tests on CI and we need to work in a better solution for that.