### PR TITLE
[SIEM] [Detection Engine] Fixes all rules sorting

### DIFF
--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/columns.tsx
@@ -144,7 +144,6 @@ export const getColumns = ({
           </LocalizedDateTooltip>
         );
       },
-      sortable: true,
       truncateText: true,
       width: '20%',
     },
@@ -180,7 +179,7 @@ export const getColumns = ({
     },
     {
       align: 'center',
-      field: 'activate',
+      field: 'enabled',
       name: i18n.COLUMN_ACTIVATE,
       render: (value: Rule['enabled'], item: Rule) => (
         <RuleSwitch
@@ -283,7 +282,6 @@ export const getMonitoringColumns = (): RulesStatusesColumns[] => {
           </LocalizedDateTooltip>
         );
       },
-      sortable: true,
       truncateText: true,
       width: '20%',
     },

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/index.tsx
@@ -41,11 +41,12 @@ import { showRulesTable } from './helpers';
 import { allRulesReducer, State } from './reducer';
 import { RulesTableFilters } from './rules_table_filters/rules_table_filters';
 
+const SORT_FIELD = 'enabled';
 const initialState: State = {
   exportRuleIds: [],
   filterOptions: {
     filter: '',
-    sortField: 'enabled',
+    sortField: SORT_FIELD,
     sortOrder: 'desc',
   },
   loadingRuleIds: [],
@@ -127,9 +128,7 @@ export const AllRules = React.memo<AllRulesProps>(
     });
 
     const sorting = useMemo(
-      () => ({
-        sort: { field: 'enabled', direction: filterOptions.sortOrder },
-      }),
+      () => ({ sort: { field: 'enabled', direction: filterOptions.sortOrder } }),
       [filterOptions.sortOrder]
     );
 
@@ -171,7 +170,7 @@ export const AllRules = React.memo<AllRulesProps>(
         dispatch({
           type: 'updateFilterOptions',
           filterOptions: {
-            sortField: 'enabled', // Only enabled is supported for sorting currently
+            sortField: SORT_FIELD, // Only enabled is supported for sorting currently
             sortOrder: sort?.direction ?? 'desc',
           },
           pagination: { page: page.index + 1, perPage: page.size },

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/reducer.ts
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/all/reducer.ts
@@ -66,7 +66,10 @@ export const allRulesReducer = (
         tableRef.current != null &&
         tableRef.current.changeSelection != null
       ) {
-        tableRef.current.changeSelection([]);
+        // for future devs: eui basic table is not giving us a prop to set the value, so
+        // we are using the ref in setTimeout to reset on the next loop so that we
+        // do not get a warning telling us we are trying to update during a render
+        window.setTimeout(() => tableRef?.current?.changeSelection([]), 0);
       }
 
       return {

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/all_rules_tables/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/all_rules_tables/index.tsx
@@ -97,7 +97,7 @@ const AllRulesTablesComponent: React.FC<AllRulesTablesProps> = ({
           onChange={tableOnChangeCallback}
           pagination={paginationMemo}
           ref={tableRef}
-          {...sorting}
+          sorting={sorting}
           selection={hasNoPermissions ? undefined : euiBasicTableSelectionProps}
         />
       )}
@@ -111,7 +111,7 @@ const AllRulesTablesComponent: React.FC<AllRulesTablesProps> = ({
           noItemsMessage={emptyPrompt}
           onChange={tableOnChangeCallback}
           pagination={paginationMemo}
-          {...sorting}
+          sorting={sorting}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Rule activity monitoring disabled sorting. This PR enables sorting to what it was in 7.6.1. Unfortunately, sorting broke in 7.6.1 and is still broken in 7.6.2. ~~Need to do further investigation at some point.~~ https://github.com/elastic/kibana/pull/62039/commits/d43b8dc3ed54d4fdf18e587d1abea432a2fff4db fixes https://github.com/elastic/kibana/issues/61624 sorting back to 7.6.0 functionality.

7.6.0 sorting:
![7-6-0-rules-sorting](https://user-images.githubusercontent.com/915763/78059996-ce14b000-7358-11ea-9bad-8b12aa5b3608.gif)


7.6.1 / 7.6.2 sorting (sorts once, won't sort after first click):
![7-6-1-rules-sorting](https://user-images.githubusercontent.com/915763/78060021-d5d45480-7358-11ea-8078-2bd2e7588d91.gif)


### Checklist

Delete any items that are not applicable to this PR.

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
~~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
