### PR TITLE
[SIEM] Fix race condition in integration tests

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/utils.ts
@@ -18,6 +18,8 @@ export const removeServerGeneratedProperties = (
     created_at,
     updated_at,
     id,
+    last_failure_at,
+    last_failure_message,
     last_success_at,
     last_success_message,
     status,


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/61995

There appears to be a race condition in our tests that will sometimes result in the response of an ML Rule's creation containing a failure status. My theory is that, if tests are slow enough, the following can happen:

| main process        | kibana task process  |
|---------------------|----------------------|
| rule created        |                      |
|                     | rule executed, fails |
| rule status queried |                      |
| response generated  |                      |

Normally the response happens before the failure, but that's not always the case.

This ultimately seems like a bug with this `removeServerGeneratedProperties` helper, which already ignores any _failure_ statuses. It's now been updated to remove those failure properties as well.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
