### PR TITLE
[APM] Disable client caching for Service map API call

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -42,6 +42,7 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
     const { start, end, environment } = urlParams;
     if (start && end) {
       return callApmApi({
+        isCachable: false,
         pathname: '/api/apm/service-map',
         params: {
           query: {

--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/ServicePage/ServicePage.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/ServicePage/ServicePage.tsx
@@ -36,7 +36,7 @@ export function ServicePage({ newConfig, setNewConfig, onClickNext }: Props) {
     callApmApi => {
       return callApmApi({
         pathname: '/api/apm/settings/agent-configuration/services',
-        forceCache: true
+        isCachable: true
       });
     },
     [],

--- a/x-pack/legacy/plugins/apm/public/hooks/useDynamicIndexPattern.ts
+++ b/x-pack/legacy/plugins/apm/public/hooks/useDynamicIndexPattern.ts
@@ -14,7 +14,7 @@ export function useDynamicIndexPattern(
     callApmApi => {
       return callApmApi({
         pathname: '/api/apm/index_pattern/dynamic',
-        forceCache: true,
+        isCachable: true,
         params: {
           query: {
             processorEvent

--- a/x-pack/legacy/plugins/apm/public/services/__test__/callApi.test.ts
+++ b/x-pack/legacy/plugins/apm/public/services/__test__/callApi.test.ts
@@ -157,6 +157,46 @@ describe('callApi', () => {
 
         expect(http.get).toHaveBeenCalledTimes(1);
       });
+
+      it('should not return cached response with `isCachable: false` option', async () => {
+        await callApi(http, {
+          isCachable: false,
+          pathname: `/api/kibana`,
+          query: { start: '2010', end: '2011' }
+        });
+        await callApi(http, {
+          isCachable: false,
+          pathname: `/api/kibana`,
+          query: { start: '2010', end: '2011' }
+        });
+        await callApi(http, {
+          isCachable: false,
+          pathname: `/api/kibana`,
+          query: { start: '2010', end: '2011' }
+        });
+
+        expect(http.get).toHaveBeenCalledTimes(3);
+      });
+
+      it('should return cached response with `isCachable: true` option', async () => {
+        await callApi(http, {
+          isCachable: true,
+          pathname: `/api/kibana`,
+          query: { end: '2030' }
+        });
+        await callApi(http, {
+          isCachable: true,
+          pathname: `/api/kibana`,
+          query: { end: '2030' }
+        });
+        await callApi(http, {
+          isCachable: true,
+          pathname: `/api/kibana`,
+          query: { end: '2030' }
+        });
+
+        expect(http.get).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/legacy/plugins/apm/public/services/rest/callApi.ts
@@ -11,7 +11,7 @@ import { HttpSetup, HttpFetchOptions } from 'kibana/public';
 
 export type FetchOptions = Omit<HttpFetchOptions, 'body'> & {
   pathname: string;
-  forceCache?: boolean;
+  isCachable?: boolean;
   method?: string;
   body?: any;
 };
@@ -74,8 +74,8 @@ export async function callApi<T = void>(
 // only cache items that has a time range with `start` and `end` params,
 // and where `end` is not a timestamp in the future
 function isCachable(fetchOptions: FetchOptions) {
-  if (fetchOptions.forceCache) {
-    return true;
+  if (fetchOptions.isCachable !== undefined) {
+    return fetchOptions.isCachable;
   }
 
   if (


### PR DESCRIPTION
Closes #60173 by turning off client caching for the main service map API call