### PR TITLE
[HomeApp] Set breadcrumbs when coming back from add data dir

### DIFF
--- a/src/plugins/home/public/application/components/home.js
+++ b/src/plugins/home/public/application/components/home.js
@@ -36,6 +36,7 @@ import {
   EuiPageBody,
   EuiScreenReaderOnly,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { Welcome } from './welcome';
 import { getServices } from '../kibana_services';
@@ -69,6 +70,9 @@ export class Home extends Component {
   componentDidMount() {
     this._isMounted = true;
     this.fetchIsNewKibanaInstance();
+
+    const homeTitle = i18n.translate('home.breadcrumbs.homeTitle', { defaultMessage: 'Home' });
+    getServices().chrome.setBreadcrumbs([{ text: homeTitle }]);
   }
 
   fetchIsNewKibanaInstance = async () => {

--- a/src/plugins/home/public/application/components/home.test.js
+++ b/src/plugins/home/public/application/components/home.test.js
@@ -29,6 +29,9 @@ jest.mock('../kibana_services', () => ({
     getBasePath: () => 'path',
     tutorialVariables: () => ({}),
     homeConfig: { disableWelcomeScreen: false },
+    chrome: {
+      setBreadcrumbs: () => {},
+    },
   }),
 }));
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/61834

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
