### PR TITLE
[SIEM] Update validation schema for imported timeline

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/timeline/routes/schemas/schemas.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/timeline/routes/schemas/schemas.ts
@@ -139,9 +139,9 @@ export const kqlQuery = Joi.object({
     kuery: Joi.object({
       kind: allowEmptyString,
       expression: allowEmptyString,
-    }),
+    }).allow(null),
     serializedQuery: allowEmptyString,
-  }),
+  }).allow(null),
 });
 export const pinnedEventIds = Joi.array()
   .items(allowEmptyString)


### PR DESCRIPTION
## Summary

Updating schema for this case:
1. Let filterQuery allows `null`
2. Let kuery allows `null`

To verify please download the attachment and rename it with `.ndjson`
[timelines_export_noFilterQuery.ndjson.txt](https://github.com/elastic/kibana/files/4414770/timelines_export_noFilterQuery.ndjson.txt)

![no_filterquery_joi](https://user-images.githubusercontent.com/6295984/78266867-3ea90180-74fe-11ea-978b-92d30c183ada.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
