### PR TITLE
[Discover] Fix legacy url invalid conversion

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover_state.test.ts
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover_state.test.ts
@@ -76,3 +76,30 @@ describe('Test discover state', () => {
     expect(state.getPreviousAppState()).toEqual(stateA);
   });
 });
+
+describe('Test discover state with legacy migration', () => {
+  test('migration of legacy query ', async () => {
+    history = createBrowserHistory();
+    history.push(
+      "/#?_a=(query:(query_string:(analyze_wildcard:!t,query:'type:nice%20name:%22yeah%22')))"
+    );
+    state = getState({
+      defaultAppState: { index: 'test' },
+      history,
+    });
+    expect(state.appStateContainer.getState()).toMatchInlineSnapshot(`
+      Object {
+        "index": "test",
+        "query": Object {
+          "language": "lucene",
+          "query": Object {
+            "query_string": Object {
+              "analyze_wildcard": true,
+              "query": "type:nice name:\\"yeah\\"",
+            },
+          },
+        },
+      }
+    `);
+  });
+});

--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover_state.ts
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover_state.ts
@@ -129,6 +129,11 @@ export function getState({
   });
 
   const appStateFromUrl = stateStorage.get(APP_STATE_URL_KEY) as AppState;
+
+  if (appStateFromUrl && appStateFromUrl.query && !appStateFromUrl.query.language) {
+    appStateFromUrl.query = migrateLegacyQuery(appStateFromUrl.query);
+  }
+
   let initialAppState = {
     ...defaultAppState,
     ...appStateFromUrl,
@@ -179,9 +184,6 @@ export function setState(stateContainer: ReduxLikeStateContainer<AppState>, newS
   const oldState = stateContainer.getState();
   const mergedState = { ...oldState, ...newState };
   if (!isEqualState(oldState, mergedState)) {
-    if (mergedState.query) {
-      mergedState.query = migrateLegacyQuery(mergedState.query);
-    }
     stateContainer.set(mergedState);
   }
 }


### PR DESCRIPTION
## Summary

Legacy URLs were not converted correctly until this PR. When you used a legacy url, that's a url without defining the language like this query:(language:kuery,query:''), it wasn't converted, here is an example

http://localhost:5601/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2019-07-18T14:00:00.000Z',mode:absolute,to:'2019-07-23T08:45:00.000Z'))&_a=(columns:!(build_url,build_step.name,build_step.status),filters:!(),index:ff959d40-b880-11e8-a6d9-e546fe2bba5f,interval:auto,query:(query_string:(analyze_wildcard:!t,query:'type:build_step%20build_step.name:%22FuncTest.step_flash_wait_verify%22%20AND%20dut_name:%22COORD-Q6055-E-3%22')),sort:!())

The SearchBar was empty in this case.

Fixes #59126

### Checklist
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
