### PR TITLE
[SIEM] Mark rule run as failure if there was an error

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -55,6 +55,7 @@ export const signalRulesAlertType = ({
         index,
         filters,
         language,
+        maxSignals,
         meta,
         machineLearningJobId,
         outputIndex,
@@ -63,6 +64,14 @@ export const signalRulesAlertType = ({
         to,
         type,
       } = params;
+      const searchAfterSize = Math.min(maxSignals, DEFAULT_SEARCH_AFTER_PAGE_SIZE);
+      let hasError: boolean = false;
+      let result: SearchAfterAndBulkCreateReturnType = {
+        success: false,
+        bulkCreateTimes: [],
+        searchAfterTimes: [],
+        lastLookBackDate: null,
+      };
       const ruleStatusClient = ruleStatusSavedObjectsClientFactory(services.savedObjectsClient);
       const ruleStatusService = await ruleStatusServiceFactory({
         alertId,
@@ -104,16 +113,9 @@ export const signalRulesAlertType = ({
         );
         logger.warn(gapMessage);
 
+        hasError = true;
         await ruleStatusService.error(gapMessage, { gap: gapString });
       }
-
-      const searchAfterSize = Math.min(params.maxSignals, DEFAULT_SEARCH_AFTER_PAGE_SIZE);
-      let result: SearchAfterAndBulkCreateReturnType = {
-        success: false,
-        bulkCreateTimes: [],
-        searchAfterTimes: [],
-        lastLookBackDate: null,
-      };
 
       try {
         if (isMlRule(type)) {
@@ -143,6 +145,7 @@ export const signalRulesAlertType = ({
               `datafeed status: "${jobSummary?.datafeedState}"`
             );
             logger.warn(errorMessage);
+            hasError = true;
             await ruleStatusService.error(errorMessage);
           }
 
@@ -270,11 +273,13 @@ export const signalRulesAlertType = ({
           }
 
           logger.debug(buildRuleMessage('[+] Signal Rule execution completed.'));
-          await ruleStatusService.success('succeeded', {
-            bulkCreateTimeDurations: result.bulkCreateTimes,
-            searchAfterTimeDurations: result.searchAfterTimes,
-            lastLookBackDate: result.lastLookBackDate?.toISOString(),
-          });
+          if (!hasError) {
+            await ruleStatusService.success('succeeded', {
+              bulkCreateTimeDurations: result.bulkCreateTimes,
+              searchAfterTimeDurations: result.searchAfterTimes,
+              lastLookBackDate: result.lastLookBackDate?.toISOString(),
+            });
+          }
         } else {
           const errorMessage = buildRuleMessage(
             'Bulk Indexing of signals failed. Check logs for further details.'


### PR DESCRIPTION
## Summary

Because of the binary nature of Rule Statuses (success/fail), we need to collapse multiple Rule execution states. We currently have two recoverable errors that may occur during rule execution: a gap error, and a "ML Job not running" error.

While we have always been recording these errors and displaying them in the "Last Failures" tab, we were marking those executions as successful as they could still have generated signals and notifications (assuming they did not encounter another unrecoverable error).

However, marking the execution as successful meant that the user could easily miss the error, as there would be no CTA on the Rule Details, nor would the error be shown on the Monitoring page.

For now, until we revisit Rule execution/statuses, we're going to mark any rule execution that encounters an error as a failure, with the goal of increasing the error's visibility to the user. NB that a failed execution still has the potential to generate signals/notifications, depending on the error.

### Checklist

- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
