### PR TITLE
[SIEM] Ensure rule message do not span multiple lines

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/rule_messages.test.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/rule_messages.test.ts
@@ -28,25 +28,23 @@ describe('buildRuleMessageFactory', () => {
     expect(message).toEqual(expect.stringContaining('signals index: "index"'));
   });
 
-  it('joins message parts with newlines', () => {
+  it('joins message parts with spaces', () => {
     const buildMessage = buildRuleMessageFactory(factoryParams);
 
     const message = buildMessage('my message');
-    const messageParts = message.split('\n');
-    expect(messageParts).toContain('my message');
-    expect(messageParts).toContain('name: "name"');
-    expect(messageParts).toContain('id: "id"');
-    expect(messageParts).toContain('rule id: "ruleId"');
-    expect(messageParts).toContain('signals index: "index"');
+    expect(message).toEqual(expect.stringContaining('my message '));
+    expect(message).toEqual(expect.stringContaining(' name: "name" '));
+    expect(message).toEqual(expect.stringContaining(' id: "id" '));
+    expect(message).toEqual(expect.stringContaining(' rule id: "ruleId" '));
+    expect(message).toEqual(expect.stringContaining(' signals index: "index"'));
   });
 
-  it('joins multiple arguments with newlines', () => {
+  it('joins multiple arguments with spaces', () => {
     const buildMessage = buildRuleMessageFactory(factoryParams);
 
     const message = buildMessage('my message', 'here is more');
-    const messageParts = message.split('\n');
-    expect(messageParts).toContain('my message');
-    expect(messageParts).toContain('here is more');
+    expect(message).toEqual(expect.stringContaining('my message '));
+    expect(message).toEqual(expect.stringContaining(' here is more'));
   });
 
   it('defaults the rule ID if not provided ', () => {

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/rule_messages.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/rule_messages.ts
@@ -24,4 +24,4 @@ export const buildRuleMessageFactory = ({
     `id: "${id}"`,
     `rule id: "${ruleId ?? '(unknown rule id)'}"`,
     `signals index: "${index}"`,
-  ].join('\n');
+  ].join(' ');

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -126,7 +126,7 @@ export const signalRulesAlertType = ({
                 'Machine learning rule is missing job id and/or anomaly threshold:',
                 `job id: "${machineLearningJobId}"`,
                 `anomaly threshold: "${anomalyThreshold}"`,
-              ].join('\n')
+              ].join(' ')
             );
           }
 


### PR DESCRIPTION
## Summary

Because these messages are used for logging, we should ensure they do
not span multiple lines and confuse log parsers. Since the frontend does
not currently display these newlines, anyway, there is no impact to the
UI.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
