### PR TITLE
[SIEM][Detection Engine] Fixes export of single rule and the icons

### DIFF
--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/__snapshots__/index.test.tsx.snap
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleActionsOverflow renders correctly against snapshot 1`] = `
+exports[`RuleActionsOverflow snapshots renders correctly against snapshot 1`] = `
 <Fragment>
   <EuiPopover
     anchorPosition="leftCenter"

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/__snapshots__/index.test.tsx.snap
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/__snapshots__/index.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`RuleActionsOverflow renders correctly against snapshot 1`] = `
       >
         <ForwardRef(Styled(EuiButtonIcon))
           aria-label="All actions"
+          data-test-subj="rules-details-popover-button-icon"
           iconType="boxesHorizontal"
           isDisabled={false}
           onClick={[Function]}
@@ -19,6 +20,7 @@ exports[`RuleActionsOverflow renders correctly against snapshot 1`] = `
       </EuiToolTip>
     }
     closePopover={[Function]}
+    data-test-subj="rules-details-popover"
     display="inlineBlock"
     hasArrow={true}
     id="ruleActionsOverflow"
@@ -27,24 +29,28 @@ exports[`RuleActionsOverflow renders correctly against snapshot 1`] = `
     panelPaddingSize="none"
   >
     <EuiContextMenuPanel
+      data-test-subj="rules-details-menu-panel"
       hasFocus={true}
       items={
         Array [
           <EuiContextMenuItem
+            data-test-subj="rules-details-duplicate-rule"
             disabled={false}
-            icon="exportAction"
+            icon="copy"
             onClick={[Function]}
           >
             Duplicate rule…
           </EuiContextMenuItem>,
           <EuiContextMenuItem
+            data-test-subj="rules-details-export-rule"
             disabled={false}
-            icon="indexEdit"
+            icon="exportAction"
             onClick={[Function]}
           >
             Export rule
           </EuiContextMenuItem>,
           <EuiContextMenuItem
+            data-test-subj="rules-details-delete-rule"
             disabled={false}
             icon="trash"
             onClick={[Function]}
@@ -56,6 +62,7 @@ exports[`RuleActionsOverflow renders correctly against snapshot 1`] = `
     />
   </EuiPopover>
   <GenericDownloader
+    data-test-subj="rules-details-generic-downloader"
     exportSelectedData={[Function]}
     filename="rules_export.ndjson"
     ids={Array []}

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/index.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/index.test.tsx
@@ -23,162 +23,273 @@ jest.mock('../../all/actions', () => ({
 }));
 
 describe('RuleActionsOverflow', () => {
-  test('renders correctly against snapshot', () => {
-    const wrapper = shallow(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    expect(wrapper).toMatchSnapshot();
+  describe('snapshots', () => {
+    test('renders correctly against snapshot', () => {
+      const wrapper = shallow(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
-  test('there is at least one item when there is a rule within the rules-details-menu-panel', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    const items: unknown[] = wrapper
-      .find('[data-test-subj="rules-details-menu-panel"]')
-      .first()
-      .prop('items');
-
-    expect(items.length).toBeGreaterThan(0);
-  });
-
-  test('items are empty when there is a null rule within the rules-details-menu-panel', () => {
-    const wrapper = mount(<RuleActionsOverflow rule={null} userHasNoPermissions={false} />);
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    expect(
-      wrapper
+  describe('rules details menu panel', () => {
+    test('there is at least one item when there is a rule within the rules-details-menu-panel', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      const items: unknown[] = wrapper
         .find('[data-test-subj="rules-details-menu-panel"]')
         .first()
-        .prop('items')
-    ).toEqual([]);
+        .prop('items');
+
+      expect(items.length).toBeGreaterThan(0);
+    });
+
+    test('items are empty when there is a null rule within the rules-details-menu-panel', () => {
+      const wrapper = mount(<RuleActionsOverflow rule={null} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-menu-panel"]')
+          .first()
+          .prop('items')
+      ).toEqual([]);
+    });
+
+    test('items are empty when there is an undefined rule within the rules-details-menu-panel', () => {
+      const wrapper = mount(<RuleActionsOverflow rule={null} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-menu-panel"]')
+          .first()
+          .prop('items')
+      ).toEqual([]);
+    });
+
+    test('it opens the popover when rules-details-popover-button-icon is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(true);
+    });
   });
 
-  test('it opens the popover when rules-details-popover-button-icon is clicked', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    expect(
-      wrapper
-        .find('[data-test-subj="rules-details-popover"]')
-        .first()
-        .prop('isOpen')
-    ).toEqual(true);
+  describe('rules details pop over button icon', () => {
+    test('it does not open the popover when rules-details-popover-button-icon is clicked when the user does not have permission', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={true} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(false);
+    });
   });
 
-  test('it closes the popover when rules-details-export-rule is clicked', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
-    wrapper.update();
-    expect(
-      wrapper
-        .find('[data-test-subj="rules-details-popover"]')
-        .first()
-        .prop('isOpen')
-    ).toEqual(false);
+  describe('rules details duplicate rule', () => {
+    test('it does not open the popover when rules-details-popover-button-icon is clicked and the user does not have permission', () => {
+      const rule = mockRule('id');
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={true} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(wrapper.find('[data-test-subj="rules-details-delete-rule"] button').exists()).toEqual(
+        false
+      );
+    });
+
+    test('it opens the popover when rules-details-popover-button-icon is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(true);
+    });
+
+    test('it closes the popover when rules-details-duplicate-rule is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(false);
+    });
+
+    test('it calls duplicateRulesAction when rules-details-duplicate-rule is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
+      wrapper.update();
+      expect(duplicateRulesAction).toHaveBeenCalled();
+    });
+
+    test('it calls duplicateRulesAction with the rule and rule.id when rules-details-duplicate-rule is clicked', () => {
+      const rule = mockRule('id');
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
+      wrapper.update();
+      expect(duplicateRulesAction).toHaveBeenCalledWith(
+        [rule],
+        [rule.id],
+        expect.anything(),
+        expect.anything()
+      );
+    });
   });
 
-  test('it closes the popover when rules-details-duplicate-rule is clicked', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
-    wrapper.update();
-    expect(
-      wrapper
-        .find('[data-test-subj="rules-details-popover"]')
-        .first()
-        .prop('isOpen')
-    ).toEqual(false);
+  describe('rules details export rule', () => {
+    test('it does not open the popover when rules-details-popover-button-icon is clicked and the user does not have permission', () => {
+      const rule = mockRule('id');
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={true} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(wrapper.find('[data-test-subj="rules-details-export-rule"] button').exists()).toEqual(
+        false
+      );
+    });
+
+    test('it closes the popover when rules-details-export-rule is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(false);
+    });
+
+    test('it sets the rule.rule_id on the generic downloader when rules-details-export-rule is clicked', () => {
+      const rule = mockRule('id');
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper.find('[data-test-subj="rules-details-generic-downloader"]').prop('ids')
+      ).toEqual([rule.rule_id]);
+    });
+
+    test('it does not close the pop over on rules-details-export-rule when the rule is an immutable rule and the user does a click', () => {
+      const rule = mockRule('id');
+      rule.immutable = true;
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(true);
+    });
+
+    test('it does not set the rule.rule_id on rules-details-export-rule when the rule is an immutable rule', () => {
+      const rule = mockRule('id');
+      rule.immutable = true;
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper.find('[data-test-subj="rules-details-generic-downloader"]').prop('ids')
+      ).toEqual([]);
+    });
   });
 
-  test('it closes the popover when rules-details-delete-rule is clicked', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
-    wrapper.update();
-    expect(
-      wrapper
-        .find('[data-test-subj="rules-details-popover"]')
-        .first()
-        .prop('isOpen')
-    ).toEqual(false);
-  });
+  describe('rules details delete rule', () => {
+    test('it does not open the popover when rules-details-popover-button-icon is clicked and the user does not have permission', () => {
+      const rule = mockRule('id');
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={true} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      expect(wrapper.find('[data-test-subj="rules-details-delete-rule"] button').exists()).toEqual(
+        false
+      );
+    });
 
-  test('it calls deleteRulesAction when rules-details-delete-rule is clicked', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
-    wrapper.update();
-    expect(deleteRulesAction).toHaveBeenCalled();
-  });
+    test('it closes the popover when rules-details-delete-rule is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
+      wrapper.update();
+      expect(
+        wrapper
+          .find('[data-test-subj="rules-details-popover"]')
+          .first()
+          .prop('isOpen')
+      ).toEqual(false);
+    });
 
-  test('it calls deleteRulesAction with the rule.id when rules-details-delete-rule is clicked', () => {
-    const rule = mockRule('id');
-    const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
-    wrapper.update();
-    expect(deleteRulesAction).toHaveBeenCalledWith(
-      [rule.id],
-      expect.anything(),
-      expect.anything(),
-      expect.anything()
-    );
-  });
+    test('it calls deleteRulesAction when rules-details-delete-rule is clicked', () => {
+      const wrapper = mount(
+        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+      );
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
+      wrapper.update();
+      expect(deleteRulesAction).toHaveBeenCalled();
+    });
 
-  test('it calls duplicateRulesAction when rules-details-duplicate-rule is clicked', () => {
-    const wrapper = mount(
-      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
-    );
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
-    wrapper.update();
-    expect(duplicateRulesAction).toHaveBeenCalled();
-  });
-
-  test('it calls duplicateRulesAction with the rule and rule.id when rules-details-duplicate-rule is clicked', () => {
-    const rule = mockRule('id');
-    const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
-    wrapper.update();
-    expect(duplicateRulesAction).toHaveBeenCalledWith(
-      [rule],
-      [rule.id],
-      expect.anything(),
-      expect.anything()
-    );
-  });
-
-  test('it sets the rule.rule_id on the generic downloader when rules-details-export-rule is clicked', () => {
-    const rule = mockRule('id');
-    const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
-    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
-    wrapper.update();
-    wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
-    wrapper.update();
-    expect(
-      wrapper.find('[data-test-subj="rules-details-generic-downloader"]').prop('ids')
-    ).toEqual([rule.rule_id]);
+    test('it calls deleteRulesAction with the rule.id when rules-details-delete-rule is clicked', () => {
+      const rule = mockRule('id');
+      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+      wrapper.update();
+      wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
+      wrapper.update();
+      expect(deleteRulesAction).toHaveBeenCalledWith(
+        [rule.id],
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+    });
   });
 });

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/index.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/index.test.tsx
@@ -4,9 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
+import { deleteRulesAction, duplicateRulesAction } from '../../all/actions';
 import { RuleActionsOverflow } from './index';
 import { mockRule } from '../../all/__mocks__/mock';
 
@@ -16,11 +17,168 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+jest.mock('../../all/actions', () => ({
+  deleteRulesAction: jest.fn(),
+  duplicateRulesAction: jest.fn(),
+}));
+
 describe('RuleActionsOverflow', () => {
   test('renders correctly against snapshot', () => {
     const wrapper = shallow(
       <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  test('there is at least one item when there is a rule within the rules-details-menu-panel', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    const items: unknown[] = wrapper
+      .find('[data-test-subj="rules-details-menu-panel"]')
+      .first()
+      .prop('items');
+
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  test('items are empty when there is a null rule within the rules-details-menu-panel', () => {
+    const wrapper = mount(<RuleActionsOverflow rule={null} userHasNoPermissions={false} />);
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    expect(
+      wrapper
+        .find('[data-test-subj="rules-details-menu-panel"]')
+        .first()
+        .prop('items')
+    ).toEqual([]);
+  });
+
+  test('it opens the popover when rules-details-popover-button-icon is clicked', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    expect(
+      wrapper
+        .find('[data-test-subj="rules-details-popover"]')
+        .first()
+        .prop('isOpen')
+    ).toEqual(true);
+  });
+
+  test('it closes the popover when rules-details-export-rule is clicked', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
+    wrapper.update();
+    expect(
+      wrapper
+        .find('[data-test-subj="rules-details-popover"]')
+        .first()
+        .prop('isOpen')
+    ).toEqual(false);
+  });
+
+  test('it closes the popover when rules-details-duplicate-rule is clicked', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
+    wrapper.update();
+    expect(
+      wrapper
+        .find('[data-test-subj="rules-details-popover"]')
+        .first()
+        .prop('isOpen')
+    ).toEqual(false);
+  });
+
+  test('it closes the popover when rules-details-delete-rule is clicked', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
+    wrapper.update();
+    expect(
+      wrapper
+        .find('[data-test-subj="rules-details-popover"]')
+        .first()
+        .prop('isOpen')
+    ).toEqual(false);
+  });
+
+  test('it calls deleteRulesAction when rules-details-delete-rule is clicked', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
+    wrapper.update();
+    expect(deleteRulesAction).toHaveBeenCalled();
+  });
+
+  test('it calls deleteRulesAction with the rule.id when rules-details-delete-rule is clicked', () => {
+    const rule = mockRule('id');
+    const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');
+    wrapper.update();
+    expect(deleteRulesAction).toHaveBeenCalledWith(
+      [rule.id],
+      expect.anything(),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  test('it calls duplicateRulesAction when rules-details-duplicate-rule is clicked', () => {
+    const wrapper = mount(
+      <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+    );
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
+    wrapper.update();
+    expect(duplicateRulesAction).toHaveBeenCalled();
+  });
+
+  test('it calls duplicateRulesAction with the rule and rule.id when rules-details-duplicate-rule is clicked', () => {
+    const rule = mockRule('id');
+    const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
+    wrapper.update();
+    expect(duplicateRulesAction).toHaveBeenCalledWith(
+      [rule],
+      [rule.id],
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  test('it sets the rule.rule_id on the generic downloader when rules-details-export-rule is clicked', () => {
+    const rule = mockRule('id');
+    const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+    wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
+    wrapper.update();
+    wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
+    wrapper.update();
+    expect(
+      wrapper.find('[data-test-subj="rules-details-generic-downloader"]').prop('ids')
+    ).toEqual([rule.rule_id]);
   });
 });

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/rule_actions_overflow/index.tsx
@@ -62,8 +62,9 @@ const RuleActionsOverflowComponent = ({
         ? [
             <EuiContextMenuItem
               key={i18nActions.DUPLICATE_RULE}
-              icon="exportAction"
+              icon="copy"
               disabled={userHasNoPermissions}
+              data-test-subj="rules-details-duplicate-rule"
               onClick={async () => {
                 setIsPopoverOpen(false);
                 await duplicateRulesAction([rule], [rule.id], noop, dispatchToaster);
@@ -73,11 +74,12 @@ const RuleActionsOverflowComponent = ({
             </EuiContextMenuItem>,
             <EuiContextMenuItem
               key={i18nActions.EXPORT_RULE}
-              icon="indexEdit"
+              icon="exportAction"
               disabled={userHasNoPermissions || rule.immutable}
+              data-test-subj="rules-details-export-rule"
               onClick={() => {
                 setIsPopoverOpen(false);
-                setRulesToExport([rule.id]);
+                setRulesToExport([rule.rule_id]);
               }}
             >
               {i18nActions.EXPORT_RULE}
@@ -86,6 +88,7 @@ const RuleActionsOverflowComponent = ({
               key={i18nActions.DELETE_RULE}
               icon="trash"
               disabled={userHasNoPermissions}
+              data-test-subj="rules-details-delete-rule"
               onClick={async () => {
                 setIsPopoverOpen(false);
                 await deleteRulesAction([rule.id], noop, dispatchToaster, onRuleDeletedCallback);
@@ -109,6 +112,7 @@ const RuleActionsOverflowComponent = ({
           iconType="boxesHorizontal"
           aria-label={i18n.ALL_ACTIONS}
           isDisabled={userHasNoPermissions}
+          data-test-subj="rules-details-popover-button-icon"
           onClick={handlePopoverOpen}
         />
       </EuiToolTip>
@@ -124,15 +128,17 @@ const RuleActionsOverflowComponent = ({
         closePopover={() => setIsPopoverOpen(false)}
         id="ruleActionsOverflow"
         isOpen={isPopoverOpen}
+        data-test-subj="rules-details-popover"
         ownFocus={true}
         panelPaddingSize="none"
       >
-        <EuiContextMenuPanel items={actions} />
+        <EuiContextMenuPanel data-test-subj="rules-details-menu-panel" items={actions} />
       </EuiPopover>
       <GenericDownloader
         filename={`${i18nActions.EXPORT_FILENAME}.ndjson`}
         ids={rulesToExport}
         exportSelectedData={exportRules}
+        data-test-subj="rules-details-generic-downloader"
         onExportSuccess={exportCount => {
           displaySuccessToast(
             i18nActions.SUCCESSFULLY_EXPORTED_RULES(exportCount),


### PR DESCRIPTION
## Summary

Fixes export of single rule and the icons.
* https://github.com/elastic/kibana/issues/62378
* Single export of rules was using the `rule.id` instead of the `rule.rule_id` where now it flips it and works as expected.
* This adds data-test-subj for testing
* This adds jest unit tests to the menu component

Icons Before:
<img width="396" alt="Screen Shot 2020-04-02 at 5 12 43 PM" src="https://user-images.githubusercontent.com/1151048/78315482-5b533280-751a-11ea-8378-d5e106ebd36f.png">

Icons After:
<img width="407" alt="Screen Shot 2020-04-02 at 7 40 28 PM" src="https://user-images.githubusercontent.com/1151048/78315449-3fe82780-751a-11ea-9d16-2f8c2ea22a78.png">

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
