### PR TITLE
[SIEM] Retrieving persisted note once it is created

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/timeline/routes/utils/import_timelines.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/timeline/routes/utils/import_timelines.ts
@@ -127,7 +127,7 @@ export const saveNotes = (
   existingNoteIds?: string[],
   newNotes?: NoteResult[]
 ) => {
-  return (
+  return Promise.all(
     newNotes?.map(note => {
       const newNote: SavedNote = {
         eventId: note.eventId,


### PR DESCRIPTION
## Summary

https://github.com/elastic/siem-team/issues/585
Before: The result of getAllTimelines after importing timeline came back without notes
<img width="1677" alt="Screenshot 2020-04-03 at 12 56 11" src="https://user-images.githubusercontent.com/6295984/78380711-30c1b200-75cc-11ea-812d-7dfc2fefd971.png">

After: Notes can be fetched correctly
![save_timeline](https://user-images.githubusercontent.com/6295984/78367574-36160100-75ba-11ea-8b49-417ee2d59a9a.gif)

To verify this PR:

1. Go to Timelines
2. Create a timeline with more than one note and a query and mark it as favourite
3. Export the created timeline
4. Delete the created timeline
5. Import the exported timeline
6. Check if there is an arrow at the left hand side of the timeline's name

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials - In progress
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios - In progress
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- ~[ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
