### PR TITLE
[SIEM] Prevent undefined behavior in our ML popover

### DIFF
--- a/x-pack/legacy/plugins/siem/public/components/ml_popover/ml_popover.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/ml_popover/ml_popover.tsx
@@ -83,7 +83,7 @@ const defaultFilterProps: JobsFilters = {
 };
 
 export const MlPopover = React.memo(() => {
-  const [{ refreshToggle }, dispatch] = useReducer(mlPopoverReducer, initialState);
+  const [{ isLoading, refreshToggle }, dispatch] = useReducer(mlPopoverReducer, initialState);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [filterProperties, setFilterProperties] = useState(defaultFilterProps);
@@ -192,7 +192,7 @@ export const MlPopover = React.memo(() => {
           )}
 
           <JobsTable
-            isLoading={isLoadingSiemJobs}
+            isLoading={isLoadingSiemJobs || isLoading}
             jobs={filteredJobs}
             onJobStateChange={handleJobStateChange}
           />
@@ -216,6 +216,7 @@ const enableDatafeed = async (
   submitTelemetry(job, enable);
 
   if (!job.isInstalled) {
+    dispatch({ type: 'loading' });
     try {
       await setupMlJob({
         configTemplate: job.moduleId,
@@ -223,8 +224,10 @@ const enableDatafeed = async (
         jobIdErrorFilter: [job.id],
         groups: job.groups,
       });
+      dispatch({ type: 'success' });
     } catch (error) {
       errorToToaster({ title: i18n.CREATE_JOB_FAILURE, error, dispatchToaster });
+      dispatch({ type: 'failure' });
       dispatch({ type: 'refresh' });
       return;
     }

--- a/x-pack/legacy/plugins/siem/public/components/ml_popover/ml_popover.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/ml_popover/ml_popover.tsx
@@ -22,7 +22,7 @@ import { JobsTable } from './jobs_table/jobs_table';
 import { ShowingCount } from './jobs_table/showing_count';
 import { PopoverDescription } from './popover_description';
 import * as i18n from './translations';
-import { JobsFilters, JobSummary, SiemJob } from './types';
+import { JobsFilters, SiemJob } from './types';
 import { UpgradeContents } from './upgrade_contents';
 import { useMlCapabilities } from './hooks/use_ml_capabilities';
 

--- a/x-pack/legacy/plugins/siem/public/components/ml_popover/ml_popover.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/ml_popover/ml_popover.tsx
@@ -34,15 +34,10 @@ PopoverContentsDiv.displayName = 'PopoverContentsDiv';
 
 interface State {
   isLoading: boolean;
-  jobs: JobSummary[];
   refreshToggle: boolean;
 }
 
-type Action =
-  | { type: 'refresh' }
-  | { type: 'loading' }
-  | { type: 'success'; results: JobSummary[] }
-  | { type: 'failure' };
+type Action = { type: 'refresh' } | { type: 'loading' } | { type: 'success' } | { type: 'failure' };
 
 function mlPopoverReducer(state: State, action: Action): State {
   switch (action.type) {
@@ -62,14 +57,12 @@ function mlPopoverReducer(state: State, action: Action): State {
       return {
         ...state,
         isLoading: false,
-        jobs: action.results,
       };
     }
     case 'failure': {
       return {
         ...state,
         isLoading: false,
-        jobs: [],
       };
     }
     default:
@@ -79,7 +72,6 @@ function mlPopoverReducer(state: State, action: Action): State {
 
 const initialState: State = {
   isLoading: false,
-  jobs: [],
   refreshToggle: true,
 };
 


### PR DESCRIPTION
## Summary

Addresses #62490 by marking all jobs as "loading" during job installation. An alternate solution would be to disable the switches, but loading accomplishes the same goal (the user cannot interact with the job) while being closer to reality: the job is likely being installed during that period.

A finer-grained approach would be to mark as loading _only_ the jobs in the group currently being installed, but I opted not to implement that now as it would provide little value to the user.

Old behavior is shown on the referenced issue. New behavior:

![siem_job](https://user-images.githubusercontent.com/657252/78394320-0d3d3e00-75b1-11ea-9af3-c269a45a0dc1.gif)

### Checklist

- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
