### PR TITLE
[EPM] fix /packages response to return older packages

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -253,6 +253,10 @@ export enum DefaultPackages {
   system = 'system',
 }
 
+export enum HiddenPackages {
+  base = 'base',
+}
+
 export interface IndexTemplate {
   order: number;
   index_patterns: string[];

--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -253,10 +253,6 @@ export enum DefaultPackages {
   system = 'system',
 }
 
-export enum HiddenPackages {
-  base = 'base',
-}
-
 export interface IndexTemplate {
   order: number;
   index_patterns: string[];

--- a/x-pack/plugins/ingest_manager/server/saved_objects.ts
+++ b/x-pack/plugins/ingest_manager/server/saved_objects.ts
@@ -148,6 +148,7 @@ export const savedObjectMappings = {
     properties: {
       name: { type: 'keyword' },
       version: { type: 'keyword' },
+      internal: { type: 'boolean' },
       installed: {
         type: 'nested',
         properties: {

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
@@ -6,7 +6,7 @@
 
 import { SavedObjectsClientContract } from 'src/core/server';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../constants';
-import { Installation, InstallationStatus, PackageInfo, HiddenPackages } from '../../../types';
+import { Installation, InstallationStatus, PackageInfo } from '../../../types';
 import * as Registry from '../registry';
 import { createInstallableFrom } from './index';
 
@@ -35,10 +35,8 @@ export async function getPackages(
   const results = await savedObjectsClient.find<Installation>({
     type: PACKAGES_SAVED_OBJECT_TYPE,
   });
-  // filter out the base package
-  const savedObjectsVisible = results.saved_objects.filter(
-    o => o.attributes.name !== HiddenPackages.base
-  );
+  // filter out any internal packages
+  const savedObjectsVisible = results.saved_objects.filter(o => !o.attributes.internal);
   const packageList = registryItems
     .map(item =>
       createInstallableFrom(

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
@@ -87,7 +87,7 @@ export async function installPackage(options: {
 }): Promise<AssetReference[]> {
   const { savedObjectsClient, pkgkey, callCluster } = options;
   const registryPackageInfo = await Registry.fetchInfo(pkgkey);
-  const { name: pkgName, version: pkgVersion } = registryPackageInfo;
+  const { name: pkgName, version: pkgVersion, internal = false } = registryPackageInfo;
 
   const installKibanaAssetsPromise = installKibanaAssets({
     savedObjectsClient,
@@ -116,6 +116,7 @@ export async function installPackage(options: {
     pkgkey,
     pkgName,
     pkgVersion,
+    internal,
     toSave,
   });
   return toSave;
@@ -145,9 +146,10 @@ export async function saveInstallationReferences(options: {
   pkgkey: string;
   pkgName: string;
   pkgVersion: string;
+  internal: boolean;
   toSave: AssetReference[];
 }) {
-  const { savedObjectsClient, pkgkey, pkgName, pkgVersion, toSave } = options;
+  const { savedObjectsClient, pkgkey, pkgName, pkgVersion, internal, toSave } = options;
   const installation = await getInstallation({ savedObjectsClient, pkgkey });
   const savedRefs = installation?.installed || [];
   const mergeRefsReducer = (current: AssetReference[], pending: AssetReference) => {
@@ -159,7 +161,7 @@ export async function saveInstallationReferences(options: {
   const toInstall = toSave.reduce(mergeRefsReducer, savedRefs);
   await savedObjectsClient.create<Installation>(
     PACKAGES_SAVED_OBJECT_TYPE,
-    { installed: toInstall, name: pkgName, version: pkgVersion },
+    { installed: toInstall, name: pkgName, version: pkgVersion, internal },
     { id: pkgkey, overwrite: true }
   );
 

--- a/x-pack/plugins/ingest_manager/server/types/index.tsx
+++ b/x-pack/plugins/ingest_manager/server/types/index.tsx
@@ -46,7 +46,6 @@ export {
   RegistrySearchResults,
   RegistrySearchResult,
   DefaultPackages,
-  HiddenPackages,
 } from '../../common';
 
 export type CallESAsCurrentUser = ScopedClusterClient['callAsCurrentUser'];

--- a/x-pack/plugins/ingest_manager/server/types/index.tsx
+++ b/x-pack/plugins/ingest_manager/server/types/index.tsx
@@ -46,6 +46,7 @@ export {
   RegistrySearchResults,
   RegistrySearchResult,
   DefaultPackages,
+  HiddenPackages,
 } from '../../common';
 
 export type CallESAsCurrentUser = ScopedClusterClient['callAsCurrentUser'];


### PR DESCRIPTION
 Fixess https://github.com/elastic/kibana/issues/61679

The handler for `api/ingest_manager/epm/packages` compared against packages from the registry using the id which is `{pkgName}-{version}`. This caused packages that were not the latest version that were installed to not show up in the installed tab.  

- changes handler to find all epm packages instead of creating search objects of the entire registry package list of only the latest packages to search through saved objects
- uses name instead of id to compare if a package is installed in saved objects

Test:
1. POST an old version of nginx:
POST http://localhost:5603/ssg/api/ingest_manager/epm/packages/nginx-0.0.1

2. Go to installed packages and it should show up where before it was not
<img width="1175" alt="Screen Shot 2020-04-06 at 11 21 51 AM" src="https://user-images.githubusercontent.com/1676003/78575110-e7a27580-77f8-11ea-96fd-cf3065c77949.png">


