### PR TITLE
[WIP] More embeddable saved object examples

### DIFF
--- a/examples/embeddable_examples/common/index.ts
+++ b/examples/embeddable_examples/common/index.ts
@@ -17,16 +17,4 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
-
-import { EmbeddableExamplesPlugin } from './plugin';
-
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export { TodoSavedObjectAttributes } from './todo_saved_object_attributes';

--- a/examples/embeddable_examples/common/note_saved_object_attributes.ts
+++ b/examples/embeddable_examples/common/note_saved_object_attributes.ts
@@ -17,5 +17,12 @@
  * under the License.
  */
 
-export { TodoSavedObjectAttributes } from './todo_saved_object_attributes';
-export { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from './note_saved_object_attributes';
+import { SavedObjectAttributes } from '../../../src/core/types';
+
+export const NOTE_SAVED_OBJECT = 'note';
+
+export interface NoteSavedObjectAttributes extends SavedObjectAttributes {
+  to?: string;
+  from?: string;
+  message: string;
+}

--- a/examples/embeddable_examples/common/todo_saved_object_attributes.ts
+++ b/examples/embeddable_examples/common/todo_saved_object_attributes.ts
@@ -17,16 +17,10 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
+import { SavedObjectAttributes } from '../../../src/core/types';
 
-import { EmbeddableExamplesPlugin } from './plugin';
-
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export interface TodoSavedObjectAttributes extends SavedObjectAttributes {
+  task: string;
+  icon?: string;
+  title?: string;
+}

--- a/examples/embeddable_examples/kibana.json
+++ b/examples/embeddable_examples/kibana.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "kibanaVersion": "kibana",
   "configPath": ["embeddable_examples"],
-  "server": false,
+  "server": true,
   "ui": true,
   "requiredPlugins": ["embeddable"],
   "optionalPlugins": []

--- a/examples/embeddable_examples/kibana.json
+++ b/examples/embeddable_examples/kibana.json
@@ -5,6 +5,6 @@
   "configPath": ["embeddable_examples"],
   "server": true,
   "ui": true,
-  "requiredPlugins": ["embeddable"],
+  "requiredPlugins": ["embeddable", "uiActions"],
   "optionalPlugins": []
 }

--- a/examples/embeddable_examples/public/create_sample_data.ts
+++ b/examples/embeddable_examples/public/create_sample_data.ts
@@ -17,16 +17,20 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
+import { SavedObjectsClientContract } from 'kibana/public';
+import { TodoSavedObjectAttributes } from '../common';
 
-import { EmbeddableExamplesPlugin } from './plugin';
-
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export async function createSampleData(client: SavedObjectsClientContract) {
+  await client.create<TodoSavedObjectAttributes>(
+    'todo',
+    {
+      task: 'Take the garbage out',
+      title: 'Garbage',
+      icon: 'trash',
+    },
+    {
+      id: 'sample-todo-saved-object',
+      overwrite: true,
+    }
+  );
+}

--- a/examples/embeddable_examples/public/create_sample_data.ts
+++ b/examples/embeddable_examples/public/create_sample_data.ts
@@ -18,9 +18,9 @@
  */
 
 import { SavedObjectsClientContract } from 'kibana/public';
-import { TodoSavedObjectAttributes } from '../common';
+import { TodoSavedObjectAttributes, NOTE_SAVED_OBJECT, NoteSavedObjectAttributes } from '../common';
 
-export async function createSampleData(client: SavedObjectsClientContract) {
+export async function createSampleData(client: SavedObjectsClientContract, overwrite = true) {
   await client.create<TodoSavedObjectAttributes>(
     'todo',
     {
@@ -30,7 +30,20 @@ export async function createSampleData(client: SavedObjectsClientContract) {
     },
     {
       id: 'sample-todo-saved-object',
-      overwrite: true,
+      overwrite,
+    }
+  );
+
+  await client.create<NoteSavedObjectAttributes>(
+    NOTE_SAVED_OBJECT,
+    {
+      to: 'Sue',
+      from: 'Bob',
+      message: 'Remember to pick up more bleach.',
+    },
+    {
+      id: 'sample-note-saved-object',
+      overwrite,
     }
   );
 }

--- a/examples/embeddable_examples/public/index.ts
+++ b/examples/embeddable_examples/public/index.ts
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+import { EmbeddableExamplesPlugin } from './plugin';
+
+export const plugin = () => new EmbeddableExamplesPlugin();
+
 export {
   HELLO_WORLD_EMBEDDABLE,
   HelloWorldEmbeddable,
@@ -25,8 +29,11 @@ export {
 export { ListContainer, LIST_CONTAINER } from './list_container';
 export { TODO_EMBEDDABLE } from './todo';
 
-import { EmbeddableExamplesPlugin } from './plugin';
-
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
+export { EmbeddableExamplesStart } from './plugin';
+export {
+  SearchableListContainer,
+  SEARCHABLE_LIST_CONTAINER,
+  SearchableContainerInput,
+} from './searchable_list_container';
 export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export { NOTE_EMBEDDABLE, NoteEmbeddableInput, NoteEmbeddableOutput, NoteEmbeddable } from './note';

--- a/examples/embeddable_examples/public/note/README.md
+++ b/examples/embeddable_examples/public/note/README.md
@@ -1,0 +1,33 @@
+The `../todo` folder has two separate examples: a "by reference" and a "by value" todo embeddable example.
+This folder combines both examples into a single embeddable, but since we can only have one embeddable factory
+represent a single saved object type, this is built off a `note` saved object type. There is more complexity
+invovled in making
+it a single embeddable - it not only takes in an optional saved object id but can also accept edits to
+the values.  This is closer to the real world use case we aim for with the Visualize Library.  A user
+may have an embeddable on a dashboard that is "by value" but they would like to promote it to "by reference".
+
+Similarly they could break the link and convert back from by reference to by value.
+
+The input data is:
+
+```ts
+{
+  savedObjectId?: string;
+  attributes: NoteSavedObjectAttributes;
+}
+```
+
+`attributes` represent either the "by value" data, or, edits on top of the saved object id.
+
+The output data is:
+
+```ts
+{
+  savedAttributes?: NoteSavedObjectAttributes;
+}
+```
+
+There is also an action that represents how this setup can be used with a save/create/edit action.
+
+You can only have one embeddable factory representation for a single saved object, so rather than use the
+`Todo` example, this is going to use a new embeddable - `note`.

--- a/examples/embeddable_examples/public/note/create_edit_note_component.tsx
+++ b/examples/embeddable_examples/public/note/create_edit_note_component.tsx
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useState } from 'react';
+import { EuiModalBody } from '@elastic/eui';
+import { EuiFieldText } from '@elastic/eui';
+import { EuiButton } from '@elastic/eui';
+import { EuiModalFooter } from '@elastic/eui';
+import { EuiModalHeader } from '@elastic/eui';
+import { EuiFormRow } from '@elastic/eui';
+import { NoteSavedObjectAttributes } from '../common';
+
+export function CreateEditNoteComponent({
+  savedObjectId,
+  attributes,
+  onSave,
+}: {
+  savedObjectId?: string;
+  attributes?: NoteSavedObjectAttributes;
+  onSave: (attributes: NoteSavedObjectAttributes, saveToLibrary: boolean) => void;
+}) {
+  const [to, setTo] = useState(attributes?.to ?? '');
+  const [from, setFrom] = useState(attributes?.from ?? '');
+  const [message, setMessage] = useState(attributes?.message ?? '');
+  return (
+    <EuiModalBody>
+      <EuiModalHeader>
+        <h1>{`${savedObjectId ? 'Create new ' : 'Edit '}`}</h1>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiFormRow label="To">
+          <EuiFieldText
+            data-test-subj="toInputField"
+            value={to}
+            placeholder="To"
+            onChange={e => setTo(e.target.value)}
+          />
+        </EuiFormRow>
+        <EuiFormRow label="From">
+          <EuiFieldText
+            data-test-subj="fromInputField"
+            value={from}
+            placeholder="From"
+            onChange={e => setFrom(e.target.value)}
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Message">
+          <EuiFieldText
+            data-test-subj="messageInputField"
+            value={message}
+            placeholder="Message"
+            onChange={e => setMessage(e.target.value)}
+          />
+        </EuiFormRow>
+      </EuiModalBody>
+      <EuiModalFooter>
+        {savedObjectId === undefined ? (
+          <EuiButton
+            data-test-subj="saveNoteEmbeddableByValue"
+            disabled={message === ''}
+            onClick={() => onSave({ message, to, from }, false)}
+          >
+            Save
+          </EuiButton>
+        ) : null}
+        <EuiButton
+          data-test-subj="saveNoteEmbeddableByRef"
+          disabled={message === ''}
+          onClick={() => onSave({ message, to, from }, true)}
+        >
+          {savedObjectId ? 'Update library item' : 'Save to library'}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModalBody>
+  );
+}

--- a/examples/embeddable_examples/public/note/edit_note_action.tsx
+++ b/examples/embeddable_examples/public/note/edit_note_action.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { OverlayStart, SavedObjectsClientContract } from 'kibana/public';
+import { i18n } from '@kbn/i18n';
+import { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from '../common';
+import { createAction } from '../../../../src/plugins/ui_actions/public';
+import { toMountPoint } from '../../../../src/plugins/kibana_react/public';
+import { ViewMode } from '../../../../src/plugins/embeddable/public';
+import { CreateEditNoteComponent } from './create_edit_note_component';
+import { NoteEmbeddable, NOTE_EMBEDDABLE } from './note_embeddable';
+
+interface StartServices {
+  openModal: OverlayStart['openModal'];
+  savedObjectsClient: SavedObjectsClientContract;
+}
+
+interface ActionContext {
+  embeddable: NoteEmbeddable;
+}
+
+export const ACTION_EDIT_NOTE = 'ACTION_EDIT_NOTE';
+
+export const createEditNoteAction = (getStartServices: () => Promise<StartServices>) =>
+  createAction({
+    getDisplayName: () =>
+      i18n.translate('embeddableExamples.note.edit', { defaultMessage: 'Edit' }),
+    type: ACTION_EDIT_NOTE,
+    isCompatible: async ({ embeddable }: ActionContext) => {
+      return (
+        embeddable.type === NOTE_EMBEDDABLE && embeddable.getInput().viewMode === ViewMode.EDIT
+      );
+    },
+    execute: async ({ embeddable }: ActionContext) => {
+      const { openModal, savedObjectsClient } = await getStartServices();
+      const onSave = async (attributes: NoteSavedObjectAttributes, includeInLibrary: boolean) => {
+        if (includeInLibrary) {
+          if (embeddable.getInput().savedObjectId) {
+            await savedObjectsClient.update(
+              NOTE_SAVED_OBJECT,
+              embeddable.getInput().savedObjectId!,
+              attributes
+            );
+            embeddable.updateInput({ attributes: undefined });
+            embeddable.reload();
+          } else {
+            const savedItem = await savedObjectsClient.create(NOTE_SAVED_OBJECT, attributes);
+            embeddable.updateInput({ savedObjectId: savedItem.id });
+          }
+        } else {
+          embeddable.updateInput({ attributes });
+        }
+      };
+      const overlay = openModal(
+        toMountPoint(
+          <CreateEditNoteComponent
+            savedObjectId={embeddable.getInput().savedObjectId}
+            attributes={embeddable.getInput().attributes ?? embeddable.getOutput().savedAttributes}
+            onSave={(attributes: NoteSavedObjectAttributes, includeInLibrary: boolean) => {
+              overlay.close();
+              onSave(attributes, includeInLibrary);
+            }}
+          />
+        )
+      );
+    },
+  });

--- a/examples/embeddable_examples/public/note/index.ts
+++ b/examples/embeddable_examples/public/note/index.ts
@@ -17,5 +17,6 @@
  * under the License.
  */
 
-export { TodoSavedObjectAttributes } from './todo_saved_object_attributes';
-export { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from './note_saved_object_attributes';
+export * from './note_embeddable';
+export * from './note_embeddable_factory';
+export * from './edit_note_action';

--- a/examples/embeddable_examples/public/note/note_component.tsx
+++ b/examples/embeddable_examples/public/note/note_component.tsx
@@ -20,21 +20,21 @@ import React from 'react';
 import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 
 import { EuiText } from '@elastic/eui';
-import { EuiAvatar } from '@elastic/eui';
-import { EuiIcon } from '@elastic/eui';
 import { EuiFlexGrid } from '@elastic/eui';
-import { withEmbeddableSubscription } from '../../../../src/plugins/embeddable/public';
-import { TodoRefInput, TodoRefOutput, TodoRefEmbeddable } from './todo_ref_embeddable';
+import {
+  withEmbeddableSubscription,
+  EmbeddableOutput,
+} from '../../../../src/plugins/embeddable/public';
+import { NoteEmbeddable, NoteEmbeddableInput, NoteEmbeddableOutput } from './note_embeddable';
 
 interface Props {
-  embeddable: TodoRefEmbeddable;
-  input: TodoRefInput;
-  output: TodoRefOutput;
+  embeddable: NoteEmbeddable;
+  input: NoteEmbeddableInput;
+  output: EmbeddableOutput;
 }
 
 function wrapSearchTerms(task?: string, search?: string) {
-  if (!search) return task;
-  if (!task) return task;
+  if (!search || !task) return task;
   const parts = task.split(new RegExp(`(${search})`, 'g'));
   return parts.map((part, i) =>
     part === search ? (
@@ -47,40 +47,42 @@ function wrapSearchTerms(task?: string, search?: string) {
   );
 }
 
-export function TodoRefEmbeddableComponentInner({
-  input: { search },
-  output: { savedAttributes },
-}: Props) {
-  const icon = savedAttributes?.icon;
-  const title = savedAttributes?.title;
-  const task = savedAttributes?.task;
+export function NoteEmbeddableComponentInner({ input: { search }, embeddable }: Props) {
+  const from = embeddable.getFrom();
+  const to = embeddable.getTo();
+  const message = embeddable.getMessage();
   return (
-    <EuiFlexGroup>
-      <EuiFlexItem grow={false}>
-        {icon ? (
-          <EuiIcon type={icon} size="l" />
-        ) : (
-          <EuiAvatar name={title || task || ''} size="l" />
-        )}
-      </EuiFlexItem>
+    <EuiFlexGroup gutterSize="none">
       <EuiFlexItem>
-        <EuiFlexGrid columns={1}>
+        <EuiFlexGrid columns={1} gutterSize="none">
+          {to ? (
+            <EuiFlexItem>
+              <EuiText data-test-subj="noteEmbeddableTo">
+                <h3>{`${wrapSearchTerms(to, search)},`}</h3>
+              </EuiText>
+            </EuiFlexItem>
+          ) : null}
           <EuiFlexItem>
-            <EuiText data-test-subj="todoEmbeddableTitle">
-              <h3>{wrapSearchTerms(title || '', search)}</h3>
+            <EuiText data-test-subj="noteEmbeddableMessage">
+              {wrapSearchTerms(message ?? '', search)}
             </EuiText>
           </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText data-test-subj="todoEmbeddableTask">{wrapSearchTerms(task, search)}</EuiText>
-          </EuiFlexItem>
+          {from ? (
+            <EuiFlexItem>
+              <EuiText data-test-subj="noteEmbeddableFrom">
+                <h3>{`- ${wrapSearchTerms(from, search)}`}</h3>
+              </EuiText>
+            </EuiFlexItem>
+          ) : null}
         </EuiFlexGrid>
       </EuiFlexItem>
     </EuiFlexGroup>
   );
 }
 
-export const TodoRefEmbeddableComponent = withEmbeddableSubscription<
-  TodoRefInput,
-  TodoRefOutput,
-  TodoRefEmbeddable
->(TodoRefEmbeddableComponentInner);
+export const NoteEmbeddableComponent = withEmbeddableSubscription<
+  NoteEmbeddableInput,
+  NoteEmbeddableOutput,
+  NoteEmbeddable,
+  {}
+>(NoteEmbeddableComponentInner);

--- a/examples/embeddable_examples/public/note/note_embeddable.tsx
+++ b/examples/embeddable_examples/public/note/note_embeddable.tsx
@@ -1,0 +1,160 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Subscription } from 'rxjs';
+import * as Rx from 'rxjs';
+import { SavedObjectsClientContract } from 'kibana/public';
+import { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from '../../common';
+import {
+  Embeddable,
+  IContainer,
+  EmbeddableOutput,
+  SavedObjectEmbeddableInput,
+} from '../../../../src/plugins/embeddable/public';
+import { NoteEmbeddableComponent } from './note_component';
+
+// Notice this is not the same value as the 'note' saved object type. Many of our
+// cases in prod today use the same value, but this is unnecessary.
+export const NOTE_EMBEDDABLE = 'NOTE_EMBEDDABLE';
+
+export interface NoteEmbeddableInput extends SavedObjectEmbeddableInput {
+  /**
+   * Optional search string to highlight in the note. Will also dictate output.hasMatch.
+   */
+  search?: string;
+  /**
+   * If undefined, then there are no local edits or overrides and a valid
+   * `savedObjectId` should be supplied.
+   */
+  attributes?: NoteSavedObjectAttributes;
+}
+
+export interface NoteEmbeddableOutput extends EmbeddableOutput {
+  /**
+   * Whether or not any values match the search string. Will check input.attributes first,
+   * otherwise will check output.savedAttributes.
+   */
+  hasMatch: boolean;
+  /**
+   * If a valid `input.savedObjectId` was given, this will hold the last retrieved attributes
+   * from the saved object.
+   */
+  savedAttributes?: NoteSavedObjectAttributes;
+}
+
+function getHasMatch(note: NoteEmbeddable): boolean {
+  const to = note.getTo();
+  const from = note.getFrom();
+  const message = note.getMessage();
+  const { search } = note.getInput();
+  if (!search) return true;
+  if (!message) return false;
+  return Boolean(message.match(search) || to?.match(search) || from?.match(search));
+}
+
+/**
+ * This is an example of an embeddable that can optionally be backed by a saved object.
+ */
+
+export class NoteEmbeddable extends Embeddable<NoteEmbeddableInput, NoteEmbeddableOutput> {
+  public readonly type = NOTE_EMBEDDABLE;
+  private subscription: Subscription;
+  private node?: HTMLElement;
+  private savedObjectsClient: SavedObjectsClientContract;
+  private savedObjectId?: string;
+
+  constructor(
+    input: NoteEmbeddableInput,
+    {
+      parent,
+      savedObjectsClient,
+    }: {
+      parent?: IContainer;
+      savedObjectsClient: SavedObjectsClientContract;
+    }
+  ) {
+    super(
+      input,
+      { hasMatch: false, defaultTitle: input.to ? `A note to ${input.to}` : `A note` },
+      parent
+    );
+    this.savedObjectsClient = savedObjectsClient;
+
+    this.subscription = Rx.merge(this.getOutput$(), this.getInput$()).subscribe(async () => {
+      const { savedObjectId } = this.getInput();
+      if (this.savedObjectId !== savedObjectId) {
+        this.savedObjectId = savedObjectId;
+        if (savedObjectId !== undefined) {
+          this.reload();
+        }
+      }
+      this.updateOutput({
+        hasMatch: getHasMatch(this),
+      });
+    });
+  }
+
+  public getTo() {
+    return this.input.attributes?.to ?? this.output.savedAttributes?.to;
+  }
+
+  public getFrom() {
+    return this.input.attributes?.from ?? this.output.savedAttributes?.from;
+  }
+
+  public getMessage() {
+    return this.input.attributes?.message ?? this.output.savedAttributes?.message;
+  }
+
+  public render(node: HTMLElement) {
+    this.node = node;
+    if (this.node) {
+      ReactDOM.unmountComponentAtNode(this.node);
+    }
+    ReactDOM.render(<NoteEmbeddableComponent embeddable={this} />, node);
+  }
+
+  public async reload() {
+    if (this.savedObjectId !== undefined) {
+      const savedObject = await this.savedObjectsClient.get<NoteSavedObjectAttributes>(
+        NOTE_SAVED_OBJECT,
+        this.savedObjectId
+      );
+      const defaultTitle = this.input.to ? `A note to ${this.input.to}` : `A note`;
+      this.updateOutput({
+        hasMatch: getHasMatch(this),
+        title: this.input.title ?? defaultTitle,
+        defaultTitle,
+        savedAttributes: savedObject.attributes,
+      });
+      if (this.node) {
+        this.render(this.node);
+      }
+    }
+  }
+
+  public destroy() {
+    super.destroy();
+    this.subscription.unsubscribe();
+    if (this.node) {
+      ReactDOM.unmountComponentAtNode(this.node);
+    }
+  }
+}

--- a/examples/embeddable_examples/public/note/note_embeddable_factory.tsx
+++ b/examples/embeddable_examples/public/note/note_embeddable_factory.tsx
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { SavedObjectsClientContract, OverlayStart } from 'kibana/public';
+import { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from '../../common';
+import { toMountPoint } from '../../../../src/plugins/kibana_react/public';
+import {
+  IContainer,
+  SavedObjectEmbeddableFactoryDefinition,
+  EmbeddableStart,
+  ErrorEmbeddable,
+} from '../../../../src/plugins/embeddable/public';
+import {
+  NoteEmbeddable,
+  NOTE_EMBEDDABLE,
+  NoteEmbeddableInput,
+  NoteEmbeddableOutput,
+} from './note_embeddable';
+import { CreateEditNoteComponent } from './create_edit_note_component';
+
+interface StartServices {
+  getEmbeddableFactory: EmbeddableStart['getEmbeddableFactory'];
+  savedObjectsClient: SavedObjectsClientContract;
+  openModal: OverlayStart['openModal'];
+}
+
+export class NoteEmbeddableFactory
+  implements
+    SavedObjectEmbeddableFactoryDefinition<
+      NoteEmbeddableInput,
+      NoteEmbeddableOutput,
+      NoteEmbeddable,
+      NoteSavedObjectAttributes
+    > {
+  public readonly type = NOTE_EMBEDDABLE;
+  public savedObjectMetaData = {
+    name: 'Note',
+    includeFields: ['to', 'from', 'message'],
+    type: NOTE_SAVED_OBJECT,
+    getIconForSavedObject: () => 'pencil',
+  };
+
+  constructor(private getStartServices: () => Promise<StartServices>) {}
+
+  public async isEditable() {
+    return true;
+  }
+
+  public createFromSavedObject = async (
+    savedObjectId: string,
+    input: Partial<NoteEmbeddableInput> & { id: string },
+    parent?: IContainer
+  ): Promise<NoteEmbeddable | ErrorEmbeddable> => {
+    const { savedObjectsClient } = await this.getStartServices();
+    const todoSavedObject = await savedObjectsClient.get<NoteSavedObjectAttributes>(
+      'todo',
+      savedObjectId
+    );
+    return this.create({ ...input, savedObjectId, attributes: todoSavedObject.attributes }, parent);
+  };
+
+  public async create(input: NoteEmbeddableInput, parent?: IContainer) {
+    const { savedObjectsClient } = await this.getStartServices();
+    return new NoteEmbeddable(input, {
+      parent,
+      savedObjectsClient,
+    });
+  }
+
+  public getDisplayName() {
+    return i18n.translate('embeddableExamples.note.displayName', {
+      defaultMessage: 'Note',
+    });
+  }
+
+  /**
+   * This function is used when dynamically creating a new embeddable to add to a
+   * container that is not neccessarily backed by a saved object.
+   */
+  public async getExplicitInput(): Promise<{
+    savedObjectId?: string;
+    attributes?: NoteSavedObjectAttributes;
+  }> {
+    const { openModal, savedObjectsClient } = await this.getStartServices();
+    return new Promise<{
+      savedObjectId?: string;
+      attributes?: NoteSavedObjectAttributes;
+    }>(resolve => {
+      const onSave = async (attributes: NoteSavedObjectAttributes, includeInLibrary: boolean) => {
+        if (includeInLibrary) {
+          const savedItem = await savedObjectsClient.create(NOTE_SAVED_OBJECT, attributes);
+          resolve({ savedObjectId: savedItem.id });
+        } else {
+          resolve({ attributes });
+        }
+      };
+      const overlay = openModal(
+        toMountPoint(
+          <CreateEditNoteComponent
+            onSave={(attributes: NoteSavedObjectAttributes, includeInLibrary: boolean) => {
+              onSave(attributes, includeInLibrary);
+              overlay.close();
+            }}
+          />
+        )
+      );
+    });
+  }
+}

--- a/examples/embeddable_examples/public/plugin.ts
+++ b/examples/embeddable_examples/public/plugin.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 
-import { EmbeddableSetup, EmbeddableStart } from '../../../src/plugins/embeddable/public';
+import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
+import {
+  EmbeddableSetup,
+  EmbeddableStart,
+  CONTEXT_MENU_TRIGGER,
+} from '../../../src/plugins/embeddable/public';
 import { Plugin, CoreSetup, CoreStart } from '../../../src/core/public';
 import { HelloWorldEmbeddableFactory, HELLO_WORLD_EMBEDDABLE } from './hello_world';
 import { TODO_EMBEDDABLE, TodoEmbeddableFactory, TodoInput, TodoOutput } from './todo';
@@ -35,9 +40,19 @@ import { LIST_CONTAINER, ListContainerFactory } from './list_container';
 import { createSampleData } from './create_sample_data';
 import { TodoRefInput, TodoRefOutput, TODO_REF_EMBEDDABLE } from './todo/todo_ref_embeddable';
 import { TodoRefEmbeddableFactory } from './todo/todo_ref_embeddable_factory';
+import {
+  ACTION_EDIT_NOTE,
+  NoteEmbeddable,
+  NOTE_EMBEDDABLE,
+  NoteEmbeddableInput,
+  NoteEmbeddableOutput,
+  NoteEmbeddableFactory,
+  createEditNoteAction,
+} from './note';
 
 export interface EmbeddableExamplesSetupDependencies {
   embeddable: EmbeddableSetup;
+  uiActions: UiActionsStart;
 }
 
 export interface EmbeddableExamplesStartDependencies {
@@ -45,7 +60,13 @@ export interface EmbeddableExamplesStartDependencies {
 }
 
 export interface EmbeddableExamplesStart {
-  createSampleData: () => Promise<void>;
+  createSampleData: (overwrite: boolean) => Promise<void>;
+}
+
+declare module '../../../src/plugins/ui_actions/public' {
+  export interface ActionContextMapping {
+    [ACTION_EDIT_NOTE]: { embeddable: NoteEmbeddable };
+  }
 }
 
 export class EmbeddableExamplesPlugin
@@ -98,6 +119,23 @@ export class EmbeddableExamplesPlugin
         getEmbeddableFactory: (await core.getStartServices())[1].embeddable.getEmbeddableFactory,
       }))
     );
+
+    deps.embeddable.registerEmbeddableFactory<NoteEmbeddableInput, NoteEmbeddableOutput>(
+      NOTE_EMBEDDABLE,
+      new NoteEmbeddableFactory(async () => ({
+        savedObjectsClient: (await core.getStartServices())[0].savedObjects.client,
+        getEmbeddableFactory: (await core.getStartServices())[1].embeddable.getEmbeddableFactory,
+        openModal: (await core.getStartServices())[0].overlays.openModal,
+      }))
+    );
+
+    const editNoteAction = createEditNoteAction(async () => ({
+      openModal: (await core.getStartServices())[0].overlays.openModal,
+      savedObjectsClient: (await core.getStartServices())[0].savedObjects.client,
+      getEmbeddableFactory: (await core.getStartServices())[1].embeddable.getEmbeddableFactory,
+    }));
+    deps.uiActions.registerAction(editNoteAction);
+    deps.uiActions.attachAction(CONTEXT_MENU_TRIGGER, editNoteAction);
   }
 
   public start(core: CoreStart, deps: EmbeddableExamplesStartDependencies) {

--- a/examples/embeddable_examples/public/searchable_list_container/index.ts
+++ b/examples/embeddable_examples/public/searchable_list_container/index.ts
@@ -17,5 +17,9 @@
  * under the License.
  */
 
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
+export {
+  SearchableListContainer,
+  SEARCHABLE_LIST_CONTAINER,
+  SearchableContainerInput,
+} from './searchable_list_container';
 export { SearchableListContainerFactory } from './searchable_list_container_factory';

--- a/examples/embeddable_examples/public/todo/README.md
+++ b/examples/embeddable_examples/public/todo/README.md
@@ -1,0 +1,43 @@
+There are two examples in here:
+ - TodoEmbeddable
+ - TodoRefEmbeddable
+
+ # TodoEmbeddable
+
+ The first example you should review is the HelloWorldEmbeddable.  That is as basic an embeddable as you can get.
+ This embeddable is the next step up - an embeddable that renders dynamic input data. The data is simple: 
+  - a required task string
+  - an optional title
+  - an optional icon string
+  - an optional search string
+
+It also has output data, which is `hasMatch` - whether or not the search string has matched any input data.
+
+`hasMatch` is a better fit for output data than input data, because it's state that is _derived_ from input data.
+
+For example, if it was input data, you could create a TodoEmbeddable with input like this:
+
+```ts
+ todoEmbeddableFactory.create({ task: 'take out the garabage', search: 'garbage', hasMatch: false });
+```
+
+That's wrong because there is actually a match from the search string inside the task.
+
+The TodoEmbeddable component itself doesn't do anything with the `hasMatch` variable other than set it, but
+if you check out `SearchableListContainer`, you can see an example where this output data is being used.
+
+## TodoRefEmbeddable
+
+This is an example of an embeddable based off of a saved object. The input is just the `savedObjectId` and
+the `search` string. It has even more output parameters, and this time, it does read it's own output parameters in
+order to calculate `hasMatch`.
+
+Output:
+```ts
+{ 
+  hasMatch: boolean,
+  savedAttributes?: TodoSavedAttributes
+}
+```
+
+`savedAttributes` is optional because it's possible a TodoSavedObject could not be found with the given savedObjectId.

--- a/examples/embeddable_examples/public/todo/todo_ref_component.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_component.tsx
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+
+import { EuiText } from '@elastic/eui';
+import { EuiAvatar } from '@elastic/eui';
+import { EuiIcon } from '@elastic/eui';
+import { EuiFlexGrid } from '@elastic/eui';
+import { withEmbeddableSubscription } from '../../../../src/plugins/embeddable/public';
+import { TodoRefInput, TodoRefOutput, TodoRefEmbeddable } from './todo_ref_embeddable';
+
+interface Props {
+  embeddable: TodoRefEmbeddable;
+  input: TodoRefInput;
+  output: TodoRefOutput;
+}
+
+function wrapSearchTerms(task?: string, search?: string) {
+  if (!search) return task;
+  if (!task) return task;
+  const parts = task.split(new RegExp(`(${search})`, 'g'));
+  return parts.map((part, i) =>
+    part === search ? (
+      <span key={i} style={{ backgroundColor: 'yellow' }}>
+        {part}
+      </span>
+    ) : (
+      part
+    )
+  );
+}
+
+export function TodoRefEmbeddableComponentInner({
+  input: { search },
+  output: { savedAttributes },
+}: Props) {
+  const icon = savedAttributes?.icon;
+  const title = savedAttributes?.title;
+  const task = savedAttributes?.task;
+  return (
+    <EuiFlexGroup>
+      <EuiFlexItem grow={false}>
+        {icon ? (
+          <EuiIcon type={icon} size="l" />
+        ) : (
+          <EuiAvatar name={title || task || ''} size="l" />
+        )}
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGrid columns={1}>
+          <EuiFlexItem>
+            <EuiText data-test-subj="todoEmbeddableTitle">
+              <h3>{wrapSearchTerms(title || '', search)}</h3>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText data-test-subj="todoEmbeddableTask">{wrapSearchTerms(task, search)}</EuiText>
+          </EuiFlexItem>
+        </EuiFlexGrid>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}
+
+export const TodoRefEmbeddableComponent = withEmbeddableSubscription(
+  TodoRefEmbeddableComponentInner
+);

--- a/examples/embeddable_examples/public/todo/todo_ref_embeddable.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_embeddable.tsx
@@ -19,8 +19,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Subscription } from 'rxjs';
-import { TodoSavedObjectAttributes } from 'examples/embeddable_examples/common';
 import { SavedObjectsClientContract } from 'kibana/public';
+import { TodoSavedObjectAttributes } from '../../common';
 import {
   Embeddable,
   IContainer,

--- a/examples/embeddable_examples/public/todo/todo_ref_embeddable.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_embeddable.tsx
@@ -1,0 +1,153 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Subscription } from 'rxjs';
+import { TodoSavedObjectAttributes } from 'examples/embeddable_examples/common';
+import { SavedObjectsClientContract } from 'kibana/public';
+import {
+  Embeddable,
+  IContainer,
+  EmbeddableOutput,
+  SavedObjectEmbeddableInput,
+} from '../../../../src/plugins/embeddable/public';
+import { TodoRefEmbeddableComponent } from './todo_ref_component';
+
+// Notice this is not the same value as the 'todo' saved object type. Many of our
+// cases in prod today use the same value, but this is unnecessary.
+export const TODO_REF_EMBEDDABLE = 'TODO_REF_EMBEDDABLE';
+
+export interface TodoRefInput extends SavedObjectEmbeddableInput {
+  /**
+   * Optional search string which will be used to highlight search terms as
+   * well as calculate `output.hasMatch`.
+   */
+  search?: string;
+}
+
+export interface TodoRefOutput extends EmbeddableOutput {
+  /**
+   * Should be true if input.search is defined and the task or title contain
+   * search as a substring.
+   */
+  hasMatch: boolean;
+  /**
+   * Will contain the saved object attributes of the Todo Saved Object that matches
+   * `input.savedObjectId`. If the id is invalid, this may be undefined.
+   */
+  savedAttributes?: TodoSavedObjectAttributes;
+}
+
+/**
+ * Returns whether any attributes contain the search string.  If search is empty, true is returned. If
+ * there are no savedAttributes, false is returned.
+ * @param search - the search string
+ * @param savedAttributes - the saved object attributes for the saved object with id `input.savedObjectId`
+ */
+function getHasMatch(search?: string, savedAttributes?: TodoSavedObjectAttributes): boolean {
+  if (!search) return true;
+  if (!savedAttributes) return false;
+  return Boolean(
+    (savedAttributes.task && savedAttributes.task.match(search)) ||
+      (savedAttributes.title && savedAttributes.title.match(search))
+  );
+}
+
+/**
+ * This is an example of an embeddable that is backed by a saved object. It's essentially the
+ * same as `TodoEmbeddable` but that is "by value", while this is "by reference".
+ */
+export class TodoRefEmbeddable extends Embeddable<TodoRefInput, TodoRefOutput> {
+  public readonly type = TODO_REF_EMBEDDABLE;
+  private subscription: Subscription;
+  private node?: HTMLElement;
+  private savedObjectsClient: SavedObjectsClientContract;
+  private savedObjectId?: string;
+
+  constructor(
+    initialInput: TodoRefInput,
+    {
+      parent,
+      savedObjectsClient,
+    }: {
+      parent?: IContainer;
+      savedObjectsClient: SavedObjectsClientContract;
+    }
+  ) {
+    super(initialInput, { hasMatch: false }, parent);
+    this.savedObjectsClient = savedObjectsClient;
+
+    this.subscription = this.getInput$().subscribe(async () => {
+      // There is a little more work today for this embeddable because it has
+      // more output it needs to update in response to input state changes.
+      let savedAttributes: TodoSavedObjectAttributes | undefined;
+
+      // Since this is an expensive task, we save a local copy of the previous
+      // savedObjectId locally and only retrieve the new saved object if the id
+      // actually changed.
+      if (this.savedObjectId !== this.input.savedObjectId) {
+        this.savedObjectId = this.input.savedObjectId;
+        const todoSavedObject = await this.savedObjectsClient.get<TodoSavedObjectAttributes>(
+          'todo',
+          this.input.savedObjectId
+        );
+        savedAttributes = todoSavedObject?.attributes;
+      }
+
+      // The search string might have changed as well so we need to make sure we recalculate
+      // hasMatch.
+      this.updateOutput({
+        hasMatch: getHasMatch(this.input.search, savedAttributes),
+        savedAttributes,
+      });
+    });
+  }
+
+  public render(node: HTMLElement) {
+    this.node = node;
+    if (this.node) {
+      ReactDOM.unmountComponentAtNode(this.node);
+    }
+    ReactDOM.render(<TodoRefEmbeddableComponent embeddable={this} />, node);
+  }
+
+  /**
+   * Lets re-sync our saved object to make sure it's up to date!
+   */
+  public async reload() {
+    this.savedObjectId = this.input.savedObjectId;
+    const todoSavedObject = await this.savedObjectsClient.get<TodoSavedObjectAttributes>(
+      'todo',
+      this.input.savedObjectId
+    );
+    const savedAttributes = todoSavedObject?.attributes;
+    this.updateOutput({
+      hasMatch: getHasMatch(this.input.search, savedAttributes),
+      savedAttributes,
+    });
+  }
+
+  public destroy() {
+    super.destroy();
+    this.subscription.unsubscribe();
+    if (this.node) {
+      ReactDOM.unmountComponentAtNode(this.node);
+    }
+  }
+}

--- a/examples/embeddable_examples/public/todo/todo_ref_embeddable_factory.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_embeddable_factory.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { i18n } from '@kbn/i18n';
+import { SavedObjectsClientContract } from 'kibana/public';
+import { TodoSavedObjectAttributes } from 'examples/embeddable_examples/common';
+import {
+  IContainer,
+  EmbeddableStart,
+  ErrorEmbeddable,
+  EmbeddableFactoryDefinition,
+} from '../../../../src/plugins/embeddable/public';
+import {
+  TodoRefEmbeddable,
+  TODO_REF_EMBEDDABLE,
+  TodoRefInput,
+  TodoRefOutput,
+} from './todo_ref_embeddable';
+
+interface StartServices {
+  getEmbeddableFactory: EmbeddableStart['getEmbeddableFactory'];
+  savedObjectsClient: SavedObjectsClientContract;
+}
+
+export class TodoRefEmbeddableFactory
+  implements
+    EmbeddableFactoryDefinition<
+      TodoRefInput,
+      TodoRefOutput,
+      TodoRefEmbeddable,
+      TodoSavedObjectAttributes
+    > {
+  public readonly type = TODO_REF_EMBEDDABLE;
+  public readonly savedObjectMetaData = {
+    name: 'Todo',
+    includeFields: ['task', 'icon', 'title'],
+    type: 'todo',
+    getIconForSavedObject: () => 'pencil',
+  };
+
+  constructor(private getStartServices: () => Promise<StartServices>) {}
+
+  public async isEditable() {
+    return true;
+  }
+
+  public createFromSavedObject = (
+    savedObjectId: string,
+    input: Partial<TodoRefInput> & { id: string },
+    parent?: IContainer
+  ): Promise<TodoRefEmbeddable | ErrorEmbeddable> => {
+    return this.create({ ...input, savedObjectId }, parent);
+  };
+
+  public async create(input: TodoRefInput, parent?: IContainer) {
+    const { savedObjectsClient } = await this.getStartServices();
+    return new TodoRefEmbeddable(input, {
+      parent,
+      savedObjectsClient,
+    });
+  }
+
+  public getDisplayName() {
+    return i18n.translate('embeddableExamples.todo.displayName', {
+      defaultMessage: 'Todo item',
+    });
+  }
+}

--- a/examples/embeddable_examples/public/todo/todo_ref_embeddable_factory.tsx
+++ b/examples/embeddable_examples/public/todo/todo_ref_embeddable_factory.tsx
@@ -18,7 +18,7 @@
  */
 import { i18n } from '@kbn/i18n';
 import { SavedObjectsClientContract } from 'kibana/public';
-import { TodoSavedObjectAttributes } from 'examples/embeddable_examples/common';
+import { TodoSavedObjectAttributes } from '../../common';
 import {
   IContainer,
   EmbeddableStart,

--- a/examples/embeddable_examples/public/types.ts
+++ b/examples/embeddable_examples/public/types.ts
@@ -17,5 +17,10 @@
  * under the License.
  */
 
-export { TodoSavedObjectAttributes } from './todo_saved_object_attributes';
-export { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from './note_saved_object_attributes';
+import { SavedObjectAttributes } from 'kibana/public';
+
+export interface TodoSavedObjectAttributes extends SavedObjectAttributes {
+  task: string;
+  icon?: string;
+  title?: string;
+}

--- a/examples/embeddable_examples/server/index.ts
+++ b/examples/embeddable_examples/server/index.ts
@@ -17,16 +17,8 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
+import { PluginInitializer } from 'kibana/server';
 
 import { EmbeddableExamplesPlugin } from './plugin';
 
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export const plugin: PluginInitializer<void, void> = () => new EmbeddableExamplesPlugin();

--- a/examples/embeddable_examples/server/note_saved_object.ts
+++ b/examples/embeddable_examples/server/note_saved_object.ts
@@ -17,5 +17,25 @@
  * under the License.
  */
 
-export { TodoSavedObjectAttributes } from './todo_saved_object_attributes';
-export { NoteSavedObjectAttributes, NOTE_SAVED_OBJECT } from './note_saved_object_attributes';
+import { SavedObjectsType } from 'kibana/server';
+import { NOTE_SAVED_OBJECT } from '../common';
+
+export const noteSavedObject: SavedObjectsType = {
+  name: NOTE_SAVED_OBJECT,
+  hidden: false,
+  namespaceAgnostic: true,
+  mappings: {
+    properties: {
+      message: {
+        type: 'text',
+      },
+      to: {
+        type: 'keyword',
+      },
+      from: {
+        type: 'keyword',
+      },
+    },
+  },
+  migrations: {},
+};

--- a/examples/embeddable_examples/server/plugin.ts
+++ b/examples/embeddable_examples/server/plugin.ts
@@ -17,16 +17,15 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
+import { Plugin, CoreSetup, CoreStart } from 'kibana/server';
+import { todoSavedObject } from './todo_saved_object';
 
-import { EmbeddableExamplesPlugin } from './plugin';
+export class EmbeddableExamplesPlugin implements Plugin {
+  public setup(core: CoreSetup) {
+    core.savedObjects.registerType(todoSavedObject);
+  }
 
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+  public start(core: CoreStart) {}
+
+  public stop() {}
+}

--- a/examples/embeddable_examples/server/plugin.ts
+++ b/examples/embeddable_examples/server/plugin.ts
@@ -19,10 +19,12 @@
 
 import { Plugin, CoreSetup, CoreStart } from 'kibana/server';
 import { todoSavedObject } from './todo_saved_object';
+import { noteSavedObject } from './note_saved_object';
 
 export class EmbeddableExamplesPlugin implements Plugin {
   public setup(core: CoreSetup) {
     core.savedObjects.registerType(todoSavedObject);
+    core.savedObjects.registerType(noteSavedObject);
   }
 
   public start(core: CoreStart) {}

--- a/examples/embeddable_examples/server/todo_saved_object.ts
+++ b/examples/embeddable_examples/server/todo_saved_object.ts
@@ -17,16 +17,24 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
+import { SavedObjectsType } from 'kibana/server';
 
-import { EmbeddableExamplesPlugin } from './plugin';
-
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export const todoSavedObject: SavedObjectsType = {
+  name: 'todo',
+  hidden: false,
+  namespaceAgnostic: true,
+  mappings: {
+    properties: {
+      title: {
+        type: 'keyword',
+      },
+      task: {
+        type: 'text',
+      },
+      icon: {
+        type: 'keyword',
+      },
+    },
+  },
+  migrations: {},
+};

--- a/examples/embeddable_examples/tsconfig.json
+++ b/examples/embeddable_examples/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "index.ts",
+    "common/**/*.ts",
     "public/**/*.ts",
     "public/**/*.tsx",
     "server/**/*.ts",

--- a/examples/embeddable_explorer/public/app.tsx
+++ b/examples/embeddable_explorer/public/app.tsx
@@ -23,21 +23,14 @@ import { BrowserRouter as Router, Route, withRouter, RouteComponentProps } from 
 
 import { EuiPage, EuiPageSideBar, EuiSideNav } from '@elastic/eui';
 
+import { EmbeddableExamplesStart } from 'examples/embeddable_examples/public/plugin';
 import { EmbeddableStart } from '../../../src/plugins/embeddable/public';
-import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
-import { Start as InspectorStartContract } from '../../../src/plugins/inspector/public';
-import {
-  AppMountContext,
-  AppMountParameters,
-  CoreStart,
-  SavedObjectsStart,
-  IUiSettingsClient,
-  OverlayStart,
-} from '../../../src/core/public';
+import { AppMountContext, AppMountParameters, CoreStart } from '../../../src/core/public';
 import { HelloWorldEmbeddableExample } from './hello_world_embeddable_example';
 import { TodoEmbeddableExample } from './todo_embeddable_example';
 import { ListContainerExample } from './list_container_example';
 import { EmbeddablePanelExample } from './embeddable_panel_example';
+import { SavedObjectEmbeddableExample } from './saved_object_embeddable_example';
 
 interface PageDef {
   title: string;
@@ -75,24 +68,14 @@ interface Props {
   basename: string;
   navigateToApp: CoreStart['application']['navigateToApp'];
   embeddableApi: EmbeddableStart;
-  uiActionsApi: UiActionsStart;
-  overlays: OverlayStart;
-  notifications: CoreStart['notifications'];
-  inspector: InspectorStartContract;
-  savedObject: SavedObjectsStart;
-  uiSettingsClient: IUiSettingsClient;
+  createSampleData: EmbeddableExamplesStart['createSampleData'];
 }
 
 const EmbeddableExplorerApp = ({
   basename,
   navigateToApp,
   embeddableApi,
-  inspector,
-  uiSettingsClient,
-  savedObject,
-  overlays,
-  uiActionsApi,
-  notifications,
+  createSampleData,
 }: Props) => {
   const pages: PageDef[] = [
     {
@@ -118,6 +101,16 @@ const EmbeddableExplorerApp = ({
       title: 'Dynamically adding children to a container',
       id: 'embeddablePanelExamplae',
       component: <EmbeddablePanelExample embeddableServices={embeddableApi} />,
+    },
+    {
+      title: 'Embeddables backed by saved objects',
+      id: 'savedObjectSection',
+      component: (
+        <SavedObjectEmbeddableExample
+          embeddableServices={embeddableApi}
+          createSampleData={createSampleData}
+        />
+      ),
     },
   ];
 

--- a/examples/embeddable_explorer/public/plugin.tsx
+++ b/examples/embeddable_explorer/public/plugin.tsx
@@ -18,6 +18,7 @@
  */
 
 import { Plugin, CoreSetup, AppMountParameters } from 'kibana/public';
+import { EmbeddableExamplesStart } from 'examples/embeddable_examples/public/plugin';
 import { UiActionsService } from '../../../src/plugins/ui_actions/public';
 import { EmbeddableStart } from '../../../src/plugins/embeddable/public';
 import { Start as InspectorStart } from '../../../src/plugins/inspector/public';
@@ -26,6 +27,7 @@ interface StartDeps {
   uiActions: UiActionsService;
   embeddable: EmbeddableStart;
   inspector: InspectorStart;
+  embeddableExamples: EmbeddableExamplesStart;
 }
 
 export class EmbeddableExplorerPlugin implements Plugin<void, void, {}, StartDeps> {
@@ -36,6 +38,7 @@ export class EmbeddableExplorerPlugin implements Plugin<void, void, {}, StartDep
       async mount(params: AppMountParameters) {
         const [coreStart, depsStart] = await core.getStartServices();
         const { renderApp } = await import('./app');
+        await depsStart.embeddableExamples.createSampleData();
         return renderApp(
           {
             notifications: coreStart.notifications,

--- a/examples/embeddable_explorer/public/plugin.tsx
+++ b/examples/embeddable_explorer/public/plugin.tsx
@@ -38,17 +38,11 @@ export class EmbeddableExplorerPlugin implements Plugin<void, void, {}, StartDep
       async mount(params: AppMountParameters) {
         const [coreStart, depsStart] = await core.getStartServices();
         const { renderApp } = await import('./app');
-        await depsStart.embeddableExamples.createSampleData();
         return renderApp(
           {
-            notifications: coreStart.notifications,
-            inspector: depsStart.inspector,
             embeddableApi: depsStart.embeddable,
-            uiActionsApi: depsStart.uiActions,
             basename: params.appBasePath,
-            uiSettingsClient: coreStart.uiSettings,
-            savedObject: coreStart.savedObjects,
-            overlays: coreStart.overlays,
+            createSampleData: depsStart.embeddableExamples.createSampleData,
             navigateToApp: coreStart.application.navigateToApp,
           },
           params.element

--- a/examples/embeddable_explorer/public/saved_object_embeddable_example.tsx
+++ b/examples/embeddable_explorer/public/saved_object_embeddable_example.tsx
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentBody,
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiTitle,
+  EuiText,
+  EuiSpacer,
+  EuiButton,
+  EuiLoadingSpinner,
+} from '@elastic/eui';
+import {
+  EmbeddableStart,
+  ViewMode,
+  IEmbeddable,
+  ContainerOutput,
+} from '../../../src/plugins/embeddable/public';
+import {
+  SEARCHABLE_LIST_CONTAINER,
+  NoteEmbeddableInput,
+  NOTE_EMBEDDABLE,
+  NoteEmbeddableOutput,
+  NoteEmbeddable,
+  SearchableContainerInput,
+  EmbeddableExamplesStart,
+  SearchableListContainer,
+} from '../../embeddable_examples/public';
+
+interface Props {
+  embeddableServices: EmbeddableStart;
+  createSampleData: EmbeddableExamplesStart['createSampleData'];
+}
+
+export function SavedObjectEmbeddableExample({ embeddableServices, createSampleData }: Props) {
+  const searchableInput = {
+    id: '1',
+    title: 'My searchable todo list',
+    viewMode: ViewMode.EDIT,
+    panels: {
+      '1': {
+        type: NOTE_EMBEDDABLE,
+        explicitInput: {
+          id: '1',
+          savedObjectId: 'sample-note-saved-object',
+        },
+      },
+      '2': {
+        type: NOTE_EMBEDDABLE,
+        explicitInput: {
+          id: '2',
+          attributes: {
+            message: 'How are you feeling today?',
+            to: 'Joe',
+            from: 'Mary',
+          },
+        },
+      },
+    },
+  };
+
+  const [container, setContainer] = useState<IEmbeddable | undefined>(undefined);
+  const [embeddable, setEmbeddable] = useState<IEmbeddable | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const ref = useRef(false);
+
+  useEffect(() => {
+    ref.current = true;
+    const loadData = async () => {
+      try {
+        await createSampleData(false);
+      } catch (e) {
+        // eslint-disable-next-line
+        console.log(e);
+      }
+
+      if (!container) {
+        const factory = embeddableServices.getEmbeddableFactory<
+          SearchableContainerInput,
+          ContainerOutput,
+          SearchableListContainer
+        >(SEARCHABLE_LIST_CONTAINER);
+        const promise = factory?.create(searchableInput);
+        if (promise) {
+          promise.then(e => {
+            if (ref.current) {
+              setContainer(e);
+            }
+          });
+        }
+      }
+
+      if (!embeddable) {
+        const factory = embeddableServices.getEmbeddableFactory<
+          NoteEmbeddableInput,
+          NoteEmbeddableOutput,
+          NoteEmbeddable
+        >(NOTE_EMBEDDABLE);
+        const promise = factory?.create({
+          savedObjectId: 'sample-note-saved-object',
+          id: '123',
+        });
+        if (promise) {
+          promise.then(e => {
+            if (ref.current) {
+              setEmbeddable(e);
+            }
+          });
+        }
+      }
+    };
+    loadData();
+    return () => {
+      ref.current = false;
+    };
+  });
+
+  const onCreateSampleDataClick = async () => {
+    setLoading(true);
+    await createSampleData(true);
+    if (embeddable) embeddable.reload();
+    if (container) container.reload();
+    setLoading(false);
+  };
+
+  return (
+    <EuiPageBody>
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l">
+            <h1>Saved object embeddable example</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
+      <EuiPageContent>
+        <EuiPageContentBody>
+          <EuiText>
+            <EuiButton data-test-subj="reset-sample-data" onClick={onCreateSampleDataClick}>
+              {loading ? <EuiLoadingSpinner /> : 'Load sample data'}
+            </EuiButton>
+            <p>Click load sample data first to get these examples to show up.</p>
+            <p>
+              This example showcases an embeddable that is backed by a saved object. Click the
+              context menu and click Edit action in the context menu to see how to edit and update
+              the saved object. Refreshing the page after editing this embeddable will preserve your
+              edits.
+            </p>
+          </EuiText>
+
+          <EuiSpacer />
+          {embeddable ? (
+            <embeddableServices.EmbeddablePanel embeddable={embeddable} />
+          ) : (
+            <EuiText>Loading...</EuiText>
+          )}
+          <EuiSpacer />
+          <EuiText>
+            <p>
+              This next example showcases a container embeddable that has children that can
+              optionally be backed by a saved object. The first child is linked to a saved object.
+              The second child has input that does not include a saved object id, so it is by value.
+              Click the context menu and you can see how to turn the by value version into a saved
+              object.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          {container ? (
+            <embeddableServices.EmbeddablePanel embeddable={container} />
+          ) : (
+            <EuiText>Loading...</EuiText>
+          )}
+        </EuiPageContentBody>
+      </EuiPageContent>
+    </EuiPageBody>
+  );
+}

--- a/src/plugins/dashboard/public/application/actions/replace_panel_flyout.tsx
+++ b/src/plugins/dashboard/public/application/actions/replace_panel_flyout.tsx
@@ -21,6 +21,7 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
 import { NotificationsStart, Toast } from 'src/core/public';
+
 import { DashboardPanelState } from '../embeddable';
 import {
   IContainer,
@@ -28,6 +29,7 @@ import {
   EmbeddableInput,
   EmbeddableOutput,
   EmbeddableStart,
+  SavedObjectEmbeddableInput,
 } from '../../embeddable_plugin';
 
 interface Props {
@@ -66,7 +68,7 @@ export class ReplacePanelFlyout extends React.Component<Props> {
     });
   };
 
-  public onReplacePanel = async (id: string, type: string, name: string) => {
+  public onReplacePanel = async (savedObjectId: string, type: string, name: string) => {
     const originalPanels = this.props.container.getInput().panels;
     const filteredPanels = { ...originalPanels };
 
@@ -76,7 +78,9 @@ export class ReplacePanelFlyout extends React.Component<Props> {
     const nny = (filteredPanels[this.props.panelToRemove.id] as DashboardPanelState).gridData.y;
 
     // add the new view
-    const newObj = await this.props.container.addSavedObjectEmbeddable(type, id);
+    const newObj = await this.props.container.addNewEmbeddable<SavedObjectEmbeddableInput>(type, {
+      savedObjectId,
+    });
 
     const finalPanels = _.cloneDeep(this.props.container.getInput().panels);
     (finalPanels[newObj.id] as DashboardPanelState).gridData.w = nnw;

--- a/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
@@ -53,6 +53,7 @@ import {
   isErrorEmbeddable,
   openAddPanelFlyout,
   ViewMode,
+  SavedObjectEmbeddableInput,
   ContainerOutput,
 } from '../../../embeddable/public';
 import { NavAction, SavedDashboardPanel } from '../types';
@@ -386,7 +387,7 @@ export class DashboardAppController {
             if ($routeParams[DashboardConstants.ADD_EMBEDDABLE_TYPE]) {
               const type = $routeParams[DashboardConstants.ADD_EMBEDDABLE_TYPE];
               const id = $routeParams[DashboardConstants.ADD_EMBEDDABLE_ID];
-              container.addSavedObjectEmbeddable(type, id);
+              container.addNewEmbeddable<SavedObjectEmbeddableInput>(type, { savedObjectId: id });
               removeQueryParam(history, DashboardConstants.ADD_EMBEDDABLE_TYPE);
               removeQueryParam(history, DashboardConstants.ADD_EMBEDDABLE_ID);
             }

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -55,7 +55,7 @@ export interface DashboardContainerInput extends ContainerInput {
   description?: string;
   isFullScreenMode: boolean;
   panels: {
-    [panelId: string]: DashboardPanelState;
+    [panelId: string]: DashboardPanelState<EmbeddableInput & { [k: string]: unknown }>;
   };
   isEmptyState?: boolean;
 }

--- a/src/plugins/dashboard/public/application/embeddable/types.ts
+++ b/src/plugins/dashboard/public/application/embeddable/types.ts
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { SavedObjectEmbeddableInput } from 'src/plugins/embeddable/public';
-import { PanelState, EmbeddableInput } from '../embeddable_plugin';
+import { PanelState, EmbeddableInput, SavedObjectEmbeddableInput } from '../../embeddable_plugin';
 export type PanelId = string;
 export type SavedObjectId = string;
 

--- a/src/plugins/dashboard/public/application/embeddable/types.ts
+++ b/src/plugins/dashboard/public/application/embeddable/types.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { PanelState, EmbeddableInput } from '../../embeddable_plugin';
+import { SavedObjectEmbeddableInput } from 'src/plugins/embeddable/public';
+import { PanelState, EmbeddableInput } from '../embeddable_plugin';
 export type PanelId = string;
 export type SavedObjectId = string;
 
@@ -28,7 +29,8 @@ export interface GridData {
   i: string;
 }
 
-export interface DashboardPanelState<TEmbeddableInput extends EmbeddableInput = EmbeddableInput>
-  extends PanelState<TEmbeddableInput> {
+export interface DashboardPanelState<
+  TEmbeddableInput extends EmbeddableInput | SavedObjectEmbeddableInput = SavedObjectEmbeddableInput
+> extends PanelState<TEmbeddableInput> {
   readonly gridData: GridData;
 }

--- a/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.test.ts
+++ b/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.test.ts
@@ -25,10 +25,6 @@ import { SavedDashboardPanel } from '../../types';
 import { DashboardPanelState } from '../embeddable';
 import { EmbeddableInput } from 'src/plugins/embeddable/public';
 
-interface CustomInput extends EmbeddableInput {
-  something: string;
-}
-
 test('convertSavedDashboardPanelToPanelState', () => {
   const savedDashboardPanel: SavedDashboardPanel = {
     type: 'search',
@@ -58,8 +54,8 @@ test('convertSavedDashboardPanelToPanelState', () => {
     explicitInput: {
       something: 'hi!',
       id: '123',
+      savedObjectId: 'savedObjectId',
     },
-    savedObjectId: 'savedObjectId',
     type: 'search',
   });
 });
@@ -86,7 +82,7 @@ test('convertSavedDashboardPanelToPanelState does not include undefined id', () 
 });
 
 test('convertPanelStateToSavedDashboardPanel', () => {
-  const dashboardPanel: DashboardPanelState<CustomInput> = {
+  const dashboardPanel: DashboardPanelState = {
     gridData: {
       x: 0,
       y: 0,
@@ -94,10 +90,10 @@ test('convertPanelStateToSavedDashboardPanel', () => {
       w: 15,
       i: '123',
     },
-    savedObjectId: 'savedObjectId',
     explicitInput: {
       something: 'hi!',
       id: '123',
+      savedObjectId: 'savedObjectId',
     },
     type: 'search',
   };
@@ -121,7 +117,7 @@ test('convertPanelStateToSavedDashboardPanel', () => {
 });
 
 test('convertPanelStateToSavedDashboardPanel will not add an undefined id when not needed', () => {
-  const dashboardPanel: DashboardPanelState<CustomInput> = {
+  const dashboardPanel: DashboardPanelState = {
     gridData: {
       x: 0,
       y: 0,

--- a/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.test.ts
+++ b/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.test.ts
@@ -23,7 +23,6 @@ import {
 } from './embeddable_saved_object_converters';
 import { SavedDashboardPanel } from '../../types';
 import { DashboardPanelState } from '../embeddable';
-import { EmbeddableInput } from 'src/plugins/embeddable/public';
 
 test('convertSavedDashboardPanelToPanelState', () => {
   const savedDashboardPanel: SavedDashboardPanel = {

--- a/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.ts
+++ b/src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters.ts
@@ -19,6 +19,7 @@
 import { omit } from 'lodash';
 import { SavedDashboardPanel } from '../../types';
 import { DashboardPanelState } from '../embeddable';
+import { SavedObjectEmbeddableInput } from '../../embeddable_plugin';
 
 export function convertSavedDashboardPanelToPanelState(
   savedDashboardPanel: SavedDashboardPanel
@@ -26,9 +27,9 @@ export function convertSavedDashboardPanelToPanelState(
   return {
     type: savedDashboardPanel.type,
     gridData: savedDashboardPanel.gridData,
-    ...(savedDashboardPanel.id !== undefined && { savedObjectId: savedDashboardPanel.id }),
     explicitInput: {
       id: savedDashboardPanel.panelIndex,
+      ...(savedDashboardPanel.id !== undefined && { savedObjectId: savedDashboardPanel.id }),
       ...(savedDashboardPanel.title !== undefined && { title: savedDashboardPanel.title }),
       ...savedDashboardPanel.embeddableConfig,
     },
@@ -42,13 +43,14 @@ export function convertPanelStateToSavedDashboardPanel(
   const customTitle: string | undefined = panelState.explicitInput.title
     ? (panelState.explicitInput.title as string)
     : undefined;
+  const savedObjectId = (panelState.explicitInput as SavedObjectEmbeddableInput).savedObjectId;
   return {
     version,
     type: panelState.type,
     gridData: panelState.gridData,
     panelIndex: panelState.explicitInput.id,
-    embeddableConfig: omit(panelState.explicitInput, 'id'),
+    embeddableConfig: omit(panelState.explicitInput, ['id', 'savedObjectId']),
     ...(customTitle && { title: customTitle }),
-    ...(panelState.savedObjectId !== undefined && { id: panelState.savedObjectId }),
+    ...(savedObjectId !== undefined && { id: savedObjectId }),
   };
 }

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -61,6 +61,8 @@ export {
   PropertySpec,
   ViewMode,
   withEmbeddableSubscription,
+  SavedObjectEmbeddableInput,
+  isSavedObjectEmbeddableInput,
 } from './lib';
 
 export function plugin(initializerContext: PluginInitializerContext) {

--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -63,6 +63,7 @@ export {
   withEmbeddableSubscription,
   SavedObjectEmbeddableInput,
   isSavedObjectEmbeddableInput,
+  SavedObjectEmbeddableFactoryDefinition,
 } from './lib';
 
 export function plugin(initializerContext: PluginInitializerContext) {

--- a/src/plugins/embeddable/public/lib/containers/container.ts
+++ b/src/plugins/embeddable/public/lib/containers/container.ts
@@ -30,6 +30,7 @@ import {
 import { IContainer, ContainerInput, ContainerOutput, PanelState } from './i_container';
 import { PanelNotFoundError, EmbeddableFactoryNotFoundError } from '../errors';
 import { EmbeddableStart } from '../../plugin';
+import { isSavedObjectEmbeddableInput } from '../embeddables/saved_object_embeddable';
 
 const getKeys = <T extends {}>(o: T): Array<keyof T> => Object.keys(o) as Array<keyof T>;
 
@@ -94,17 +95,6 @@ export abstract class Container<
     }
 
     const panelState = this.createNewPanelState<EEI, E>(factory, explicitInput);
-
-    return this.createAndSaveEmbeddable(type, panelState);
-  }
-
-  public async addSavedObjectEmbeddable<
-    TEmbeddableInput extends EmbeddableInput = EmbeddableInput,
-    TEmbeddable extends IEmbeddable<TEmbeddableInput> = IEmbeddable<TEmbeddableInput>
-  >(type: string, savedObjectId: string): Promise<TEmbeddable | ErrorEmbeddable> {
-    const factory = this.getFactory(type) as EmbeddableFactory<TEmbeddableInput, any, TEmbeddable>;
-    const panelState = this.createNewPanelState(factory);
-    panelState.savedObjectId = savedObjectId;
 
     return this.createAndSaveEmbeddable(type, panelState);
   }
@@ -304,8 +294,10 @@ export abstract class Container<
         throw new EmbeddableFactoryNotFoundError(panel.type);
       }
 
-      embeddable = panel.savedObjectId
-        ? await factory.createFromSavedObject(panel.savedObjectId, inputForChild, this)
+      // TODO: lets get rid of this distinction with factories, I don't think it will be needed
+      // anymore after this change.
+      embeddable = isSavedObjectEmbeddableInput(inputForChild)
+        ? await factory.createFromSavedObject(inputForChild.savedObjectId, inputForChild, this)
         : await factory.create(inputForChild, this);
     } catch (e) {
       embeddable = new ErrorEmbeddable(e, { id: panel.explicitInput.id }, this);
@@ -321,23 +313,6 @@ export abstract class Container<
       if (!this.input.panels[panel.explicitInput.id]) {
         embeddable.destroy();
         return;
-      }
-
-      if (embeddable.getOutput().savedObjectId) {
-        this.updateInput({
-          panels: {
-            ...this.input.panels,
-            [panel.explicitInput.id]: {
-              ...this.input.panels[panel.explicitInput.id],
-              ...(embeddable.getOutput().savedObjectId
-                ? { savedObjectId: embeddable.getOutput().savedObjectId }
-                : undefined),
-              explicitInput: {
-                ...this.input.panels[panel.explicitInput.id].explicitInput,
-              },
-            },
-          },
-        } as Partial<TContainerInput>);
       }
 
       this.children[embeddable.id] = embeddable;

--- a/src/plugins/embeddable/public/lib/containers/i_container.ts
+++ b/src/plugins/embeddable/public/lib/containers/i_container.ts
@@ -25,9 +25,7 @@ import {
   IEmbeddable,
 } from '../embeddables';
 
-export interface PanelState<E extends { id: string } = { id: string }> {
-  savedObjectId?: string;
-
+export interface PanelState<E extends { id: string; [key: string]: unknown } = { id: string }> {
   // The type of embeddable in this panel. Will be used to find the factory in which to
   // load the embeddable.
   type: string;
@@ -88,17 +86,6 @@ export interface IContainer<
    * @param embeddableId
    */
   removeEmbeddable(embeddableId: string): void;
-
-  /**
-   * Adds a new embeddable that is backed off of a saved object.
-   */
-  addSavedObjectEmbeddable<
-    EEI extends EmbeddableInput = EmbeddableInput,
-    E extends Embeddable<EEI> = Embeddable<EEI>
-  >(
-    type: string,
-    savedObjectId: string
-  ): Promise<E | ErrorEmbeddable>;
 
   /**
    * Adds a new embeddable to the container. `explicitInput` may partially specify the required embeddable input,

--- a/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/i_embeddable.ts
@@ -26,6 +26,11 @@ import { TriggerContextMapping } from '../../../../ui_actions/public';
 export interface EmbeddableInput {
   viewMode?: ViewMode;
   title?: string;
+  /**
+   * Note this is not a saved object id. It is used to uniquely identify this
+   * Embeddable instance from others (e.g. inside a container).  It's possible to
+   * have two Embeddables where everything else is the same but the id.
+   */
   id: string;
   lastReloadRequestTime?: number;
   hidePanelTitles?: boolean;
@@ -44,6 +49,8 @@ export interface EmbeddableInput {
    * Whether this embeddable should not execute triggers.
    */
   disableTriggers?: boolean;
+
+  [key: string]: unknown;
 }
 
 export interface EmbeddableOutput {

--- a/src/plugins/embeddable/public/lib/embeddables/index.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/index.ts
@@ -25,3 +25,4 @@ export { ErrorEmbeddable, isErrorEmbeddable } from './error_embeddable';
 export { withEmbeddableSubscription } from './with_subscription';
 export { EmbeddableFactoryRenderer } from './embeddable_factory_renderer';
 export { EmbeddableRoot } from './embeddable_root';
+export * from './saved_object_embeddable';

--- a/src/plugins/embeddable/public/lib/embeddables/index.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/index.ts
@@ -26,3 +26,4 @@ export { withEmbeddableSubscription } from './with_subscription';
 export { EmbeddableFactoryRenderer } from './embeddable_factory_renderer';
 export { EmbeddableRoot } from './embeddable_root';
 export * from './saved_object_embeddable';
+export * from './saved_object_embeddable_factory';

--- a/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable.ts
@@ -17,16 +17,14 @@
  * under the License.
  */
 
-export {
-  HELLO_WORLD_EMBEDDABLE,
-  HelloWorldEmbeddable,
-  HelloWorldEmbeddableFactory,
-} from './hello_world';
-export { ListContainer, LIST_CONTAINER } from './list_container';
-export { TODO_EMBEDDABLE } from './todo';
+import { EmbeddableInput } from '..';
 
-import { EmbeddableExamplesPlugin } from './plugin';
+export interface SavedObjectEmbeddableInput extends EmbeddableInput {
+  savedObjectId: string;
+}
 
-export { SearchableListContainer, SEARCHABLE_LIST_CONTAINER } from './searchable_list_container';
-export { MULTI_TASK_TODO_EMBEDDABLE } from './multi_task_todo';
-export const plugin = () => new EmbeddableExamplesPlugin();
+export function isSavedObjectEmbeddableInput(
+  input: EmbeddableInput | SavedObjectEmbeddableInput
+): input is SavedObjectEmbeddableInput {
+  return (input as SavedObjectEmbeddableInput).savedObjectId !== undefined;
+}

--- a/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable.ts
@@ -17,11 +17,13 @@
  * under the License.
  */
 
-import { EmbeddableInput } from '..';
+import { EmbeddableInput, EmbeddableOutput } from '..';
 
 export interface SavedObjectEmbeddableInput extends EmbeddableInput {
   savedObjectId: string;
 }
+
+export type SavedObjectEmbeddableOutput = EmbeddableOutput;
 
 export function isSavedObjectEmbeddableInput(
   input: EmbeddableInput | SavedObjectEmbeddableInput

--- a/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable_factory.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/saved_object_embeddable_factory.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SavedObjectAttributes } from 'kibana/public';
+import { SavedObjectMetaData } from 'src/plugins/saved_objects/public';
+import { SavedObjectEmbeddableInput, SavedObjectEmbeddableOutput } from './saved_object_embeddable';
+import { EmbeddableFactory } from './embeddable_factory';
+import { IEmbeddable } from './i_embeddable';
+import { EmbeddableFactoryDefinition } from './embeddable_factory_definition';
+import { IContainer, ErrorEmbeddable } from '..';
+
+export function isSavedObjectEmbeddableFactory(
+  factory: EmbeddableFactory | SavedObjectEmbeddableFactory
+): factory is SavedObjectEmbeddableFactory {
+  return (factory as SavedObjectEmbeddableFactory).savedObjectMetaData !== undefined;
+}
+
+export interface SavedObjectEmbeddableFactory<
+  I extends SavedObjectEmbeddableInput = SavedObjectEmbeddableInput,
+  O extends SavedObjectEmbeddableOutput = SavedObjectEmbeddableOutput,
+  E extends IEmbeddable<I, O> = IEmbeddable<I, O>,
+  SA extends SavedObjectAttributes = SavedObjectAttributes
+> extends EmbeddableFactory<I, O, E> {
+  /**
+   * Creates a new embeddable instance based off the saved object id.
+   * @param savedObjectId
+   * @param input - some input may come from a parent, or user, if it's not stored with the saved object. For example, the time
+   * range of the parent container.
+   * @param parent
+   */
+  createFromSavedObject(
+    savedObjectId: string,
+    input: Partial<I>,
+    parent?: IContainer
+  ): Promise<E | ErrorEmbeddable>;
+
+  savedObjectMetaData: SavedObjectMetaData<SA>;
+}
+
+export type SavedObjectEmbeddableFactoryDefinition<
+  I extends SavedObjectEmbeddableInput = SavedObjectEmbeddableInput,
+  O extends SavedObjectEmbeddableOutput = SavedObjectEmbeddableOutput,
+  E extends IEmbeddable<I, O> = IEmbeddable<I, O>,
+  SA extends SavedObjectAttributes = SavedObjectAttributes
+> =
+  // Required parameters
+  Pick<
+    SavedObjectEmbeddableFactory<I, O, E, SA>,
+    | 'savedObjectMetaData'
+    // TODO: get rid of this function:
+    | 'createFromSavedObject'
+  > &
+    EmbeddableFactoryDefinition;

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_actions/add_panel/add_panel_flyout.tsx
@@ -33,6 +33,7 @@ import { EmbeddableStart } from 'src/plugins/embeddable/public';
 import { IContainer } from '../../../../containers';
 import { EmbeddableFactoryNotFoundError } from '../../../../errors';
 import { SavedObjectFinderCreateNew } from './saved_object_finder_create_new';
+import { SavedObjectEmbeddableInput } from '../../../../embeddables';
 
 interface Props {
   onClose: () => void;
@@ -98,8 +99,18 @@ export class AddPanelFlyout extends React.Component<Props, State> {
     }
   };
 
-  public onAddPanel = async (id: string, type: string, name: string) => {
-    this.props.container.addSavedObjectEmbeddable(type, id);
+  public onAddPanel = async (savedObjectId: string, savedObjectType: string, name: string) => {
+    const factoryForSavedObjectType = [...this.props.getAllFactories()].find(
+      factory => factory.savedObjectMetaData && factory.savedObjectMetaData.type === savedObjectType
+    );
+    if (!factoryForSavedObjectType) {
+      throw new EmbeddableFactoryNotFoundError(savedObjectType);
+    }
+
+    this.props.container.addNewEmbeddable<SavedObjectEmbeddableInput>(
+      factoryForSavedObjectType.type,
+      { savedObjectId }
+    );
 
     this.showToast(name);
   };

--- a/src/plugins/embeddable/public/tests/container.test.ts
+++ b/src/plugins/embeddable/public/tests/container.test.ts
@@ -641,8 +641,7 @@ test('container stores ErrorEmbeddables when a saved object cannot be found', as
     panels: {
       '123': {
         type: 'vis',
-        explicitInput: { id: '123' },
-        savedObjectId: '456',
+        explicitInput: { id: '123', savedObjectId: '456' },
       },
     },
     viewMode: ViewMode.EDIT,
@@ -663,8 +662,7 @@ test('ErrorEmbeddables get updated when parent does', async done => {
     panels: {
       '123': {
         type: 'vis',
-        explicitInput: { id: '123' },
-        savedObjectId: '456',
+        explicitInput: { id: '123', savedObjectId: '456' },
       },
     },
     viewMode: ViewMode.EDIT,

--- a/test/examples/embeddables/adding_children.ts
+++ b/test/examples/embeddables/adding_children.ts
@@ -23,6 +23,7 @@ import { PluginFunctionalProviderContext } from 'test/plugin_functional/services
 // eslint-disable-next-line import/no-default-export
 export default function({ getService }: PluginFunctionalProviderContext) {
   const testSubjects = getService('testSubjects');
+  const flyout = getService('flyout');
 
   describe('creating and adding children', () => {
     before(async () => {
@@ -38,6 +39,16 @@ export default function({ getService }: PluginFunctionalProviderContext) {
       await testSubjects.click('createTodoEmbeddable');
       const tasks = await testSubjects.getVisibleTextAll('todoEmbeddableTask');
       expect(tasks).to.eql(['Goes out on Wednesdays!', 'new task']);
+    });
+
+    it('Can add a child backed off a saved object', async () => {
+      await testSubjects.click('embeddablePanelToggleMenuIcon');
+      await testSubjects.click('embeddablePanelAction-ACTION_ADD_PANEL');
+      await testSubjects.click('savedObjectTitleGarbage');
+      await testSubjects.moveMouseTo('euiFlyoutCloseButton');
+      await flyout.ensureClosed('dashboardAddPanel');
+      const tasks = await testSubjects.getVisibleTextAll('todoEmbeddableTask');
+      expect(tasks).to.eql(['Goes out on Wednesdays!', 'new task', 'Take the garbage out']);
     });
   });
 }

--- a/test/examples/embeddables/index.ts
+++ b/test/examples/embeddables/index.ts
@@ -40,5 +40,6 @@ export default function({
     loadTestFile(require.resolve('./todo_embeddable'));
     loadTestFile(require.resolve('./list_container'));
     loadTestFile(require.resolve('./adding_children'));
+    loadTestFile(require.resolve('./saved_object_embeddable'));
   });
 }

--- a/test/examples/embeddables/saved_object_embeddable.ts
+++ b/test/examples/embeddables/saved_object_embeddable.ts
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import expect from '@kbn/expect';
+
+import { PluginFunctionalProviderContext } from 'test/plugin_functional/services';
+
+// eslint-disable-next-line import/no-default-export
+export default function({ getService }: PluginFunctionalProviderContext) {
+  const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
+  const retry = getService('retry');
+  const dashboardPanelActions = getService('dashboardPanelActions');
+
+  describe('saved object embeddable', () => {
+    before(async () => {
+      await testSubjects.click('savedObjectSection');
+      await testSubjects.click('reset-sample-data');
+    });
+
+    it('renders', async () => {
+      await retry.try(async () => {
+        const texts = await testSubjects.getVisibleTextAll('noteEmbeddableMessage');
+        expect(texts).to.eql([
+          'Remember to pick up more bleach.',
+          'Remember to pick up more bleach.',
+          'How are you feeling today?',
+        ]);
+      });
+    });
+
+    it('can be edited when backed by saved object ', async () => {
+      const header = await dashboardPanelActions.getPanelHeading('A note to Joe');
+      await dashboardPanelActions.openContextMenu(header);
+      await testSubjects.click('embeddablePanelAction-ACTION_EDIT_NOTE');
+      await testSubjects.setValue('titleInputField', 'Trash');
+      await testSubjects.click('saveTodoEmbeddableByRef');
+
+      await retry.try(async () => {
+        const texts = await testSubjects.getVisibleTextAll('todoSoEmbeddableTitle');
+        expect(texts).to.eql(['Trash', 'Garbage', 'Take out the trash (By value example)']);
+      });
+    });
+
+    it('can be edited when not backed by saved object', async () => {
+      const header = await dashboardPanelActions.getPanelHeading(
+        'Take out the trash (By value example)'
+      );
+      await dashboardPanelActions.openContextMenu(header);
+      await testSubjects.click('embeddablePanelAction-EDIT_TODO_ACTION');
+      await testSubjects.setValue('titleInputField', 'Junk');
+      await testSubjects.click('saveTodoEmbeddableByValue');
+
+      await retry.try(async () => {
+        const texts = await testSubjects.getVisibleTextAll('todoSoEmbeddableTitle');
+        expect(texts).to.eql(['Trash', 'Garbage', 'Junk']);
+      });
+
+      const url = await browser.getCurrentUrl();
+      await browser.get(url.toString(), true);
+
+      await retry.try(async () => {
+        const texts2 = await testSubjects.getVisibleTextAll('todoSoEmbeddableTitle');
+        expect(texts2).to.eql(['Trash', 'Trash', 'Take out the trash (By value example)']);
+      });
+    });
+  });
+}

--- a/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/public/np_ready/public/app/dashboard_input.ts
+++ b/test/plugin_functional/plugins/kbn_tp_embeddable_explorer/public/np_ready/public/app/dashboard_input.ts
@@ -47,7 +47,7 @@ export const dashboardInput: DashboardContainerInput = {
       explicitInput: {
         id: '2',
         firstName: 'Sue',
-      } as any,
+      },
     },
     '822cd0f0-ce7c-419d-aeaa-1171cf452745': {
       gridData: {
@@ -60,8 +60,8 @@ export const dashboardInput: DashboardContainerInput = {
       type: 'visualization',
       explicitInput: {
         id: '822cd0f0-ce7c-419d-aeaa-1171cf452745',
+        savedObjectId: '3fe22200-3dcb-11e8-8660-4d65aa086b3c',
       },
-      savedObjectId: '3fe22200-3dcb-11e8-8660-4d65aa086b3c',
     },
     '66f0a265-7b06-4974-accd-d05f74f7aa82': {
       gridData: {
@@ -74,8 +74,8 @@ export const dashboardInput: DashboardContainerInput = {
       type: 'visualization',
       explicitInput: {
         id: '66f0a265-7b06-4974-accd-d05f74f7aa82',
+        savedObjectId: '4c0f47e0-3dcd-11e8-8660-4d65aa086b3c',
       },
-      savedObjectId: '4c0f47e0-3dcd-11e8-8660-4d65aa086b3c',
     },
     'b2861741-40b9-4dc8-b82b-080c6e29a551': {
       gridData: {
@@ -88,8 +88,8 @@ export const dashboardInput: DashboardContainerInput = {
       type: 'search',
       explicitInput: {
         id: 'b2861741-40b9-4dc8-b82b-080c6e29a551',
+        savedObjectId: 'be5accf0-3dca-11e8-8660-4d65aa086b3c',
       },
-      savedObjectId: 'be5accf0-3dca-11e8-8660-4d65aa086b3c',
     },
   },
   isFullScreenMode: false,


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/61692 shows a simpler example of an embeddable backed by a saved object.  This builds on the changes made in that PR to show an example of how you can combine an embeddable backed by a saved object and optionally, backed by reference. It's a bit more complicated than just being backed by a saved object so I created a new example for it specifically. And since you can only have one factory per saved object type, I added a new saved object `note`.

<img width="837" alt="Screen Shot 2020-04-06 at 4 07 52 PM" src="https://user-images.githubusercontent.com/16563603/78600346-cd7c8d80-7820-11ea-80cc-2ce3b750c5c2.png">
<img width="962" alt="Screen Shot 2020-04-06 at 4 07 49 PM" src="https://user-images.githubusercontent.com/16563603/78600351-cf465100-7820-11ea-8b3c-52b420ca55a3.png">
<img width="1595" alt="Screen Shot 2020-04-06 at 4 07 39 PM" src="https://user-images.githubusercontent.com/16563603/78600353-cfdee780-7820-11ea-868e-4cef7df277b6.png">


