### PR TITLE
[SIEM] Adds sort rules Cypress test

### DIFF
--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */

--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
@@ -3,15 +3,25 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+import {
+  FIFTH_RULE,
+  FIRST_RULE,
+  RULE_NAME,
+  SECOND_RULE,
+  SEVENTH_RULE,
+} from '../screens/signal_detection_rules';
 
+import { goToManageSignalDetectionRules } from '../tasks/detections';
 import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
 import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
-import { DETECTIONS } from '../urls/navigation';
-import { goToManageSignalDetectionRules } from '../tasks/detections';
 import {
+  activateRule,
+  sortByActivatedRules,
   waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded,
-  waitForRulesToBeLoaded,
+  waitForRuleToBeActivated,
 } from '../tasks/signal_detection_rules';
+
+import { DETECTIONS } from '../urls/navigation';
 
 describe('Signal detection rules', () => {
   before(() => {
@@ -26,37 +36,25 @@ describe('Signal detection rules', () => {
     loginAndWaitForPageWithoutDateRange(DETECTIONS);
     goToManageSignalDetectionRules();
     waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded();
-
-    cy.get('[data-test-subj="ruleName"]')
-      .eq(4)
+    cy.get(RULE_NAME)
+      .eq(FIFTH_RULE)
       .invoke('text')
       .then(fifthRuleName => {
-        cy.get('[data-test-subj="rule-switch"]')
-          .eq(4)
-          .click({ force: true });
-        cy.get('[data-test-subj="rule-switch-loader"]').should('exist');
-        cy.get('[data-test-subj="rule-switch-loader"]').should('not.exist');
-
-        cy.get('[data-test-subj="ruleName"]')
-          .eq(6)
+        activateRule(FIFTH_RULE);
+        waitForRuleToBeActivated();
+        cy.get(RULE_NAME)
+          .eq(SEVENTH_RULE)
           .invoke('text')
           .then(seventhRuleName => {
-            cy.get('[data-test-subj="rule-switch"]')
-              .eq(6)
-              .click({ force: true });
-            cy.get('[data-test-subj="rule-switch-loader"]').should('exist');
-            cy.get('[data-test-subj="rule-switch-loader"]').should('not.exist');
+            activateRule(SEVENTH_RULE);
+            waitForRuleToBeActivated();
+            sortByActivatedRules();
 
-            cy.get('[data-test-subj="tableHeaderSortButton"]').click({ force: true });
-            waitForRulesToBeLoaded();
-            cy.get('[data-test-subj="tableHeaderSortButton"]').click({ force: true });
-            waitForRulesToBeLoaded();
-
-            cy.get('[data-test-subj="ruleName"]')
-              .eq(0)
+            cy.get(RULE_NAME)
+              .eq(FIRST_RULE)
               .should('have.text', fifthRuleName);
-            cy.get('[data-test-subj="ruleName"]')
-              .eq(1)
+            cy.get(RULE_NAME)
+              .eq(SECOND_RULE)
               .should('have.text', seventhRuleName);
           });
       });

--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
@@ -3,10 +3,62 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
+import { esArchiverLoad, esArchiverUnload } from '../tasks/es_archiver';
+import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
+import { DETECTIONS } from '../urls/navigation';
+import { goToManageSignalDetectionRules } from '../tasks/detections';
+import {
+  waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded,
+  waitForRulesToBeLoaded,
+} from '../tasks/signal_detection_rules';
+
 describe('Signal detection rules', () => {
-  before(() => {});
+  before(() => {
+    esArchiverLoad('prebuilt_rules_loaded');
+  });
 
-  after(() => {});
+  after(() => {
+    esArchiverUnload('prebuilt_rules_loaded');
+  });
 
-  it('Sorts by activated rules', () => {});
+  it('Sorts by activated rules', () => {
+    loginAndWaitForPageWithoutDateRange(DETECTIONS);
+    goToManageSignalDetectionRules();
+    waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded();
+
+    cy.get('[data-test-subj="ruleName"]')
+      .eq(4)
+      .invoke('text')
+      .then(fifthRuleName => {
+        cy.get('[data-test-subj="rule-switch"]')
+          .eq(4)
+          .click({ force: true });
+        cy.get('[data-test-subj="rule-switch-loader"]').should('exist');
+        cy.get('[data-test-subj="rule-switch-loader"]').should('not.exist');
+
+        cy.get('[data-test-subj="ruleName"]')
+          .eq(6)
+          .invoke('text')
+          .then(seventhRuleName => {
+            cy.get('[data-test-subj="rule-switch"]')
+              .eq(6)
+              .click({ force: true });
+            cy.get('[data-test-subj="rule-switch-loader"]').should('exist');
+            cy.get('[data-test-subj="rule-switch-loader"]').should('not.exist');
+
+            cy.get('[data-test-subj="tableHeaderSortButton"]').click({ force: true });
+            waitForRulesToBeLoaded();
+            cy.get('[data-test-subj="tableHeaderSortButton"]').click({ force: true });
+            waitForRulesToBeLoaded();
+
+            cy.get('[data-test-subj="ruleName"]')
+              .eq(0)
+              .should('have.text', fifthRuleName);
+            cy.get('[data-test-subj="ruleName"]')
+              .eq(1)
+              .should('have.text', seventhRuleName);
+          });
+      });
+  });
 });

--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
@@ -3,3 +3,10 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+describe('Signal detection rules', () => {
+  before(() => {});
+
+  after(() => {});
+
+  it('Sorts by activated rules', () => {});
+});

--- a/x-pack/legacy/plugins/siem/cypress/screens/signal_detection_rules.ts
+++ b/x-pack/legacy/plugins/siem/cypress/screens/signal_detection_rules.ts
@@ -18,6 +18,10 @@ export const DELETE_RULE_BULK_BTN = '[data-test-subj="deleteRuleBulk"]';
 
 export const ELASTIC_RULES_BTN = '[data-test-subj="show-elastic-rules-filter-button"]';
 
+export const FIFTH_RULE = 5;
+
+export const FIRST_RULE = 0;
+
 export const LOAD_PREBUILT_RULES_BTN = '[data-test-subj="load-prebuilt-rules"]';
 
 export const LOADING_INITIAL_PREBUILT_RULES_TABLE =
@@ -31,18 +35,26 @@ export const RISK_SCORE = '[data-test-subj="riskScore"]';
 
 export const RELOAD_PREBUILT_RULES_BTN = '[data-test-subj="reloadPrebuiltRulesBtn"]';
 
+export const SECOND_RULE = 1;
+
 export const RULE_CHECKBOX = '.euiTableRow .euiCheckbox__input';
 
 export const RULE_NAME = '[data-test-subj="ruleName"]';
 
 export const RULE_SWITCH = '[data-test-subj="rule-switch"]';
 
+export const RULE_SWITCH_LOADER = '[data-test-subj="rule-switch-loader"]';
+
 export const RULES_TABLE = '[data-test-subj="rules-table"]';
 
 export const RULES_ROW = '.euiTableRow';
 
+export const SEVENTH_RULE = 6;
+
 export const SEVERITY = '[data-test-subj="severity"]';
 
 export const SHOWING_RULES_TEXT = '[data-test-subj="showingRules"]';
+
+export const SORT_RULES_BTN = '[data-test-subj="tableHeaderSortButton"]';
 
 export const THREE_HUNDRED_ROWS = '[data-test-subj="tablePagination-300-rows"]';

--- a/x-pack/legacy/plugins/siem/cypress/screens/signal_detection_rules.ts
+++ b/x-pack/legacy/plugins/siem/cypress/screens/signal_detection_rules.ts
@@ -18,7 +18,7 @@ export const DELETE_RULE_BULK_BTN = '[data-test-subj="deleteRuleBulk"]';
 
 export const ELASTIC_RULES_BTN = '[data-test-subj="show-elastic-rules-filter-button"]';
 
-export const FIFTH_RULE = 5;
+export const FIFTH_RULE = 4;
 
 export const FIRST_RULE = 0;
 

--- a/x-pack/legacy/plugins/siem/cypress/tasks/signal_detection_rules.ts
+++ b/x-pack/legacy/plugins/siem/cypress/tasks/signal_detection_rules.ts
@@ -15,12 +15,21 @@ import {
   LOADING_INITIAL_PREBUILT_RULES_TABLE,
   LOADING_SPINNER,
   PAGINATION_POPOVER_BTN,
+  RELOAD_PREBUILT_RULES_BTN,
   RULE_CHECKBOX,
   RULE_NAME,
+  RULE_SWITCH,
+  RULE_SWITCH_LOADER,
   RULES_TABLE,
+  SORT_RULES_BTN,
   THREE_HUNDRED_ROWS,
-  RELOAD_PREBUILT_RULES_BTN,
 } from '../screens/signal_detection_rules';
+
+export const activateRule = (rulePosition: number) => {
+  cy.get(RULE_SWITCH)
+    .eq(rulePosition)
+    .click({ force: true });
+};
 
 export const changeToThreeHundredRowsPerPage = () => {
   cy.get(PAGINATION_POPOVER_BTN).click({ force: true });
@@ -71,6 +80,13 @@ export const selectNumberOfRules = (numberOfRules: number) => {
   }
 };
 
+export const sortByActivatedRules = () => {
+  cy.get(SORT_RULES_BTN).click({ force: true });
+  waitForRulesToBeLoaded();
+  cy.get(SORT_RULES_BTN).click({ force: true });
+  waitForRulesToBeLoaded();
+};
+
 export const waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded = () => {
   cy.get(LOADING_INITIAL_PREBUILT_RULES_TABLE).should('exist');
   cy.get(LOADING_INITIAL_PREBUILT_RULES_TABLE).should('not.exist');
@@ -79,6 +95,11 @@ export const waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded = () => {
 export const waitForPrebuiltDetectionRulesToBeLoaded = () => {
   cy.get(LOAD_PREBUILT_RULES_BTN).should('not.exist');
   cy.get(RULES_TABLE).should('exist');
+};
+
+export const waitForRuleToBeActivated = () => {
+  cy.get(RULE_SWITCH_LOADER).should('exist');
+  cy.get(RULE_SWITCH_LOADER).should('not.exist');
 };
 
 export const waitForRulesToBeLoaded = () => {


### PR DESCRIPTION
## Summary

In this PR we are adding a test in order to check that rules can be correctly sorted.

![signal_detection_rules spec ts (1)](https://user-images.githubusercontent.com/17427073/78600546-5f9d8980-7853-11ea-9bee-2ebaa35f5559.gif)

In order to test it:
1. Loads the prebuilt rules using es_archiver
2. Go to manage signal detection rules
3. Saves the name of the fifth and seventh rule
4. Activates the fifth and seventh rule
5. Sorts the rules by activated
6. Checks that the name of the first and second rules are the previous fifth and seventh rule.
