### PR TITLE
[APM] Service map - fixes irrelevant services on data refresh

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -124,6 +124,12 @@ export function Cytoscape({
   // Trigger a custom "data" event when data changes
   useEffect(() => {
     if (cy && elements.length > 0) {
+      const renderedElements = cy.elements('node,edge');
+      const latestElementIds = elements.map(el => el.data.id);
+      const absentElements = renderedElements.filter(
+        el => !latestElementIds.includes(el.id())
+      );
+      cy.remove(absentElements);
       cy.add(elements);
       cy.trigger('data');
     }


### PR DESCRIPTION
Closes #62749 by removing rendered nodes which are absent in the API response.