### PR TITLE
[7.x] FTR: Enable w3c for chromedriver (#62542)

### DIFF
--- a/test/functional/apps/discover/_discover.js
+++ b/test/functional/apps/discover/_discover.js
@@ -46,7 +46,6 @@ export default function({ getService, getPageObjects }) {
     });
 
     describe('query', function() {
-      this.tags(['skipFirefox']);
       const queryName1 = 'Query # 1';
 
       it('should show correct time range string by timepicker', async function() {
@@ -99,9 +98,10 @@ export default function({ getService, getPageObjects }) {
         const newDurationHours = await PageObjects.timePicker.getTimeDurationInHours();
         expect(Math.round(newDurationHours)).to.be(25);
         const rowData = await PageObjects.discover.getDocTableField(1);
+        log.debug(`The first timestamp value in doc table: ${rowData}`);
         expect(Date.parse(rowData)).to.be.within(
-          Date.parse('Sep 20, 2015 @ 22:00:00.000'),
-          Date.parse('Sep 20, 2015 @ 23:30:00.000')
+          Date.parse('Sep 20, 2015 @ 21:30:00.000'),
+          Date.parse('Sep 20, 2015 @ 23:00:00.000')
         );
       });
 

--- a/test/functional/page_objects/discover_page.ts
+++ b/test/functional/page_objects/discover_page.ts
@@ -138,7 +138,7 @@ export function DiscoverPageProvider({ getService, getPageObjects }: FtrProvider
 
       await browser
         .getActions()
-        .move({ x: 200, y: 20, origin: el._webElement })
+        .move({ x: 0, y: 20, origin: el._webElement })
         .click()
         .perform();
     }
@@ -147,8 +147,8 @@ export function DiscoverPageProvider({ getService, getPageObjects }: FtrProvider
       const el = await elasticChart.getCanvas();
 
       await browser.dragAndDrop(
-        { location: el, offset: { x: 200, y: 20 } },
-        { location: el, offset: { x: 400, y: 30 } }
+        { location: el, offset: { x: -300, y: 20 } },
+        { location: el, offset: { x: -100, y: 30 } }
       );
     }
 

--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -109,9 +109,10 @@ async function attemptToCreateCommand(
           chromeOptions.push('headless', 'disable-gpu', 'remote-debugging-port=9222');
         }
         chromeCapabilities.set('goog:chromeOptions', {
-          w3c: false,
+          w3c: true,
           args: chromeOptions,
         });
+        chromeCapabilities.set('unexpectedAlertBehaviour', 'accept');
         chromeCapabilities.set('goog:loggingPrefs', { browser: 'ALL' });
 
         const session = await new Builder()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - FTR: Enable w3c for chromedriver (#62542)