### PR TITLE
[APM] Service map - fixes layout issues for maps with no rum services

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -171,8 +171,11 @@ export function Cytoscape({
         layout.run();
       }
     };
+    let layoutstopDelayTimeout: NodeJS.Timeout;
     const layoutstopHandler: cytoscape.EventHandler = event => {
-      setTimeout(() => {
+      // This 0ms timer is necessary to prevent a race condition
+      // between the layout finishing rendering and viewport centering
+      layoutstopDelayTimeout = setTimeout(() => {
         if (serviceName) {
           event.cy.animate({
             ...animationOptions,
@@ -187,7 +190,7 @@ export function Cytoscape({
         } else {
           event.cy.fit(undefined, nodeHeight);
         }
-      }, 1);
+      }, 0);
     };
     // debounce hover tracking so it doesn't spam telemetry with redundant events
     const trackNodeEdgeHover = debounce(
@@ -242,6 +245,7 @@ export function Cytoscape({
         cy.removeListener('select', 'node', selectHandler);
         cy.removeListener('unselect', 'node', unselectHandler);
       }
+      clearTimeout(layoutstopDelayTimeout);
     };
   }, [cy, height, serviceName, trackApmEvent, width]);
 

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -96,10 +96,15 @@ function getLayoutOptions(
 }
 
 function selectRoots(cy: cytoscape.Core): string[] {
-  const nodes = cy.nodes();
-  const roots = nodes.roots();
-  const rumNodes = nodes.filter(node => isRumAgentName(node.data(AGENT_NAME)));
-  return rumNodes.union(roots).map(node => node.id());
+  const bfs = cy.elements().bfs({
+    roots: cy.elements().leaves()
+  });
+  const furthestNodeFromLeaves = bfs.path.last();
+  return cy
+    .elements()
+    .roots()
+    .union(furthestNodeFromLeaves)
+    .map(el => el.id());
 }
 
 export function Cytoscape({

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -174,14 +174,22 @@ export function Cytoscape({
       }
     };
     const layoutstopHandler: cytoscape.EventHandler = event => {
-      event.cy.animate({
-        ...animationOptions,
-        center: {
-          eles: serviceName
-            ? event.cy.getElementById(serviceName)
-            : event.cy.collection()
+      setTimeout(() => {
+        if (serviceName) {
+          event.cy.animate({
+            ...animationOptions,
+            fit: {
+              eles: event.cy.elements(),
+              padding: nodeHeight
+            },
+            center: {
+              eles: event.cy.getElementById(serviceName)
+            }
+          });
+        } else {
+          event.cy.fit(undefined, nodeHeight);
         }
-      });
+      }, 1);
     };
     // debounce hover tracking so it doesn't spam telemetry with redundant events
     const trackNodeEdgeHover = debounce(

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -14,8 +14,6 @@ import React, {
   useState
 } from 'react';
 import { debounce } from 'lodash';
-import { isRumAgentName } from '../../../../../../../plugins/apm/common/agent_name';
-import { AGENT_NAME } from '../../../../../../../plugins/apm/common/elasticsearch_fieldnames';
 import {
   animationOptions,
   cytoscapeOptions,


### PR DESCRIPTION
Closes #62878 by improving the root selection algorithm. Instead of just using cytoscape's `elements.roots()` selector. We now also use `elements.leaves()`, then use breadth first search to get the furthest node from the leaves, and includes that in the set of root nodes. This addresses the issues where some service maps do not have any services without incoming edges, (those returned from the `elements.roots()` function alone).

Fixes service map layout:
![Screen Shot 2020-04-07 at 4 00 12 PM](https://user-images.githubusercontent.com/1967266/78729733-a640c180-78ef-11ea-9b6e-d6984a787b17.png)

Old service map layout for the same data:
![Screen Shot 2020-04-07 at 3 51 49 PM](https://user-images.githubusercontent.com/1967266/78729756-b9539180-78ef-11ea-8fb2-f1d050b3563f.png)
