### PR TITLE
[CONTRIBUTING] run functional tests from a local ES snapshot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -536,6 +536,12 @@ yarn test:mocha
 yarn test:karma:debug # remove the debug flag to run them once and close
 ```
 
+### Running Functional Tests 
+
+When executing `node scripts functional_tests_server`, the script will attempt to download a new ES snapshot. This is expected, as tests run their own ES instance to load and unload the data. 
+However, if you wish to avoid that and already have ES snapshot locally, you can point the tests to use the local snapshot. Snapshot will be located in `.es/<latest_master_version>` of your Kibana directory.
+`TEST_ES_FROM=/path/to/my/kibana/.es/<lastest_master_version> node scripts/functional_tests_server.js` will start the functional tests server using the local snapshot.
+
 ### Automated Accessibility Testing
 
 To run the tests locally:


### PR DESCRIPTION
## Summary

Lately, my Internet connection has been miserable, and downloading ES snapshots was a particular pain of mine. This little hack from @flash1293 to make functional tests run from a local snapshot was a lifesaver, so I thought I'd add it to contributing doc, in case someone else finds it useful.

### Checklist

Delete any items that are not applicable to this PR.

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
~~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
