### PR TITLE
[SIEM] skips 'Sorts by activated rules'

### DIFF
--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules.spec.ts
@@ -32,7 +32,7 @@ describe('Signal detection rules', () => {
     esArchiverUnload('prebuilt_rules_loaded');
   });
 
-  it('Sorts by activated rules', () => {
+  it.skip('Sorts by activated rules', () => {
     loginAndWaitForPageWithoutDateRange(DETECTIONS);
     goToManageSignalDetectionRules();
     waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded();


### PR DESCRIPTION
## Summary
 
Lately this test has started to fail a lot. Let's skip it for now until we have more time to investigate what is happening.