### PR TITLE
Replace Object.assign with destructuring in SelectWithPlaceholder

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/SelectWithPlaceholder/index.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/SelectWithPlaceholder/index.tsx
@@ -31,11 +31,13 @@ export const SelectWithPlaceholder: typeof EuiSelect = props => {
       value={isEmpty(props.value) ? NO_SELECTION : props.value}
       onChange={e => {
         if (props.onChange) {
-          const customEvent = Object.assign(e, {
-            target: Object.assign(e.target, {
+          const customEvent = {
+            ...e,
+            target: {
+              ...e.target,
               value: e.target.value === NO_SELECTION ? '' : e.target.value
-            })
-          });
+            }
+          };
           props.onChange(customEvent);
         }
       }}


### PR DESCRIPTION
`Object.assign` is not supported in IE11. Previously changing the selects did not work, but this fixes it.

Fixes #63131.
