### PR TITLE
Use globe icon for "ext" span type on service map

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.stories.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.stories.tsx
@@ -85,6 +85,7 @@ storiesOf('app/ServiceMap/Cytoscape', module)
           }
         },
         { data: { id: 'external', 'span.type': 'external' } },
+        { data: { id: 'ext', 'span.type': 'ext' } },
         { data: { id: 'messaging', 'span.type': 'messaging' } },
         {
           data: {

--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/icons.ts
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/icons.ts
@@ -32,6 +32,7 @@ export const defaultIcon = defaultIconImport;
 const icons: { [key: string]: string } = {
   cache: databaseIcon,
   db: databaseIcon,
+  ext: globeIcon,
   external: globeIcon,
   messaging: documentsIcon,
   resource: globeIcon


### PR DESCRIPTION
Both "external" and "ext" can be returned and should have the same icon.
