### PR TITLE
[SIEM] Link ML Rule card CTA to license_management

### DIFF
--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/select_rule_type/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/select_rule_type/index.tsx
@@ -19,9 +19,16 @@ import {
 import { isMlRule } from '../../../../../../common/detection_engine/ml_helpers';
 import { RuleType } from '../../../../../../common/detection_engine/types';
 import { FieldHook } from '../../../../../shared_imports';
+import { useKibana } from '../../../../../lib/kibana';
 import * as i18n from './translations';
 
-const MlCardDescription = ({ hasValidLicense = false }: { hasValidLicense?: boolean }) => (
+const MlCardDescription = ({
+  subscriptionUrl,
+  hasValidLicense = false,
+}: {
+  subscriptionUrl: string;
+  hasValidLicense?: boolean;
+}) => (
   <EuiText size="s">
     {hasValidLicense ? (
       i18n.ML_TYPE_DESCRIPTION
@@ -31,9 +38,9 @@ const MlCardDescription = ({ hasValidLicense = false }: { hasValidLicense?: bool
         defaultMessage="Access to ML requires a {subscriptionsLink}."
         values={{
           subscriptionsLink: (
-            <EuiLink href="https://www.elastic.co/subscriptions" target="_blank">
+            <EuiLink href={subscriptionUrl} target="_blank">
               <FormattedMessage
-                id="xpack.siem.components.stepDefineRule.ruleTypeField.subscriptionsLink"
+                id="xpack.siem.components.stepDefineRule.ruleTypeField.platinumSubscription"
                 defaultMessage="Platinum subscription"
               />
             </EuiLink>
@@ -69,6 +76,9 @@ export const SelectRuleType: React.FC<SelectRuleTypeProps> = ({
   const setMl = useCallback(() => setType('machine_learning'), [setType]);
   const setQuery = useCallback(() => setType('query'), [setType]);
   const mlCardDisabled = isReadOnly || !hasValidLicense || !isMlAdmin;
+  const licensingUrl = useKibana().services.application.getUrlForApp('kibana', {
+    path: '#/management/elasticsearch/license_management',
+  });
 
   return (
     <EuiFormRow
@@ -95,7 +105,9 @@ export const SelectRuleType: React.FC<SelectRuleTypeProps> = ({
           <EuiCard
             data-test-subj="machineLearningRuleType"
             title={i18n.ML_TYPE_TITLE}
-            description={<MlCardDescription hasValidLicense={hasValidLicense} />}
+            description={
+              <MlCardDescription subscriptionUrl={licensingUrl} hasValidLicense={hasValidLicense} />
+            }
             icon={<EuiIcon size="l" type="machineLearningApp" />}
             isDisabled={mlCardDisabled}
             selectable={{

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/select_rule_type/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/select_rule_type/index.tsx
@@ -40,7 +40,7 @@ const MlCardDescription = ({
           subscriptionsLink: (
             <EuiLink href={subscriptionUrl} target="_blank">
               <FormattedMessage
-                id="xpack.siem.components.stepDefineRule.ruleTypeField.platinumSubscription"
+                id="xpack.siem.components.stepDefineRule.ruleTypeField.subscriptionsLink"
                 defaultMessage="Platinum subscription"
               />
             </EuiLink>


### PR DESCRIPTION
## Summary

Taking the user directly to the license management page within kibana
(where they can immediately start a trial subscription) is much more
actionable than taking them to the subscriptions marketing page.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
