### PR TITLE
[Discover] Adapt SCSS to fix IE11 fieldname truncation

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/_discover.scss
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/_discover.scss
@@ -141,6 +141,7 @@ discover-app {
 .dscSidebarItem__label {
   overflow: hidden; /* 1 */
   text-overflow: ellipsis; /* 1 */
+  width: 100%;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes an IE11 bug when displaying the fieldname in Discover's sidebar. Before this PR it was displayed with an approx. width of 1px. Reason for this was, that the container of this FlexGroup wasn't scaled to 100%, just on IE11.
![image](https://user-images.githubusercontent.com/463851/78985653-a0cebb80-7b29-11ea-990e-63f8b42423e6.png)

With a small CSS adaption it's displayed correctly (Sorry for the ugly screen, virtual box scaling):

![Bildschirmfoto 2020-04-10 um 12 41 33](https://user-images.githubusercontent.com/463851/78985841-120e6e80-7b2a-11ea-80e3-05879dfff0f4.png) 🥚 

Fixes #63193



