### PR TITLE
[APM] Agent config select box doesn't work on IE

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/SettingsPage/SettingFormRow.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/SettingsPage/SettingFormRow.tsx
@@ -73,7 +73,10 @@ function FormRow({
       return (
         <SelectWithPlaceholder
           placeholder={setting.placeholder}
-          options={[{ text: 'true' }, { text: 'false' }]}
+          options={[
+            { text: 'true', value: 'true' },
+            { text: 'false', value: 'false' }
+          ]}
           value={value}
           onChange={e => onChange(setting.key, e.target.value)}
         />
@@ -105,7 +108,7 @@ function FormRow({
                 defaultMessage: 'Select unit'
               })}
               value={unit}
-              options={setting.units?.map(text => ({ text }))}
+              options={setting.units?.map(text => ({ text, value: text }))}
               onChange={e =>
                 onChange(
                   setting.key,

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
@@ -29,15 +29,19 @@ Array [
     "options": Array [
       Object {
         "text": "off",
+        "value": "off",
       },
       Object {
         "text": "errors",
+        "value": "errors",
       },
       Object {
         "text": "transactions",
+        "value": "transactions",
       },
       Object {
         "text": "all",
+        "value": "all",
       },
     ],
     "type": "select",

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -67,10 +67,10 @@ export const generalSettings: RawSettingDefinition[] = [
       }
     ),
     options: [
-      { text: 'off' },
-      { text: 'errors' },
-      { text: 'transactions' },
-      { text: 'all' }
+      { text: 'off', value: 'off' },
+      { text: 'errors', value: 'errors' },
+      { text: 'transactions', value: 'transactions' },
+      { text: 'all', value: 'all' }
     ],
     excludeAgents: ['js-base', 'rum-js']
   },

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/types.d.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/types.d.ts
@@ -76,7 +76,7 @@ interface FloatSetting extends BaseSetting {
 
 interface SelectSetting extends BaseSetting {
   type: 'select';
-  options: Array<{ text: string }>;
+  options: Array<{ text: string; value: string }>;
 }
 
 interface BooleanSetting extends BaseSetting {


### PR DESCRIPTION
fixes #63131

when a user selects an option in the select box, the value isn't really selected. It keeps with the `Select option:`  selected. After investigating it, I noticed that the problem is caused because the `<option>`  tags don't have the `value` attribute.

<img width="840" alt="Screenshot 2020-04-10 at 11 59 36" src="https://user-images.githubusercontent.com/55978943/78986885-a2e64980-7b2c-11ea-9bec-6de2ef020d96.png">

