### PR TITLE
[APM] fix size of the custom link popover

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/CustomLink/CustomLinkPopover.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/CustomLink/CustomLinkPopover.tsx
@@ -19,6 +19,7 @@ import { ManageCustomLink } from './ManageCustomLink';
 import { px } from '../../../../style/variables';
 
 const ScrollableContainer = styled.div`
+  -ms-overflow-style: none;
   max-height: ${px(535)};
   overflow: scroll;
 `;

--- a/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -124,7 +124,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = ({
           <ActionMenuButton onClick={() => setIsActionPopoverOpen(true)} />
         }
       >
-        <div style={{ maxHeight: px(600) }}>
+        <div style={{ maxHeight: px(600), width: px(335) }}>
           {isCustomLinksPopoverOpen ? (
             <CustomLinkPopover
               customLinks={customLinks.slice(3, customLinks.length)}


### PR DESCRIPTION
closes #63238
Before:
<img width="403" alt="Screenshot 2020-04-10 at 14 03 53" src="https://user-images.githubusercontent.com/55978943/78991846-2fe3cf80-7b3a-11ea-9e68-dff351cd6193.png">


After:
<img width="695" alt="Screenshot 2020-04-10 at 14 32 02" src="https://user-images.githubusercontent.com/55978943/78991825-20fd1d00-7b3a-11ea-9c1e-19b0e07f82f8.png">
