### PR TITLE
[7.7] [SIEM] print detailed bulk response error message

### DIFF
--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/single_bulk_create.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/single_bulk_create.ts
@@ -138,7 +138,7 @@ export const singleBulkCreate = async ({
   logger.debug(`took property says bulk took: ${response.took} milliseconds`);
 
   if (response.errors) {
-    const itemsWithErrors = response.items.filter(item => item.create.error);
+    const itemsWithErrors = response.items.filter(item => item.create.error).filter(item => item.create.status !== 409);
     const errorCountsByStatus = countBy(itemsWithErrors, item => item.create.status);
     delete errorCountsByStatus['409']; // Duplicate signals are expected
 

--- a/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/single_bulk_create.ts
+++ b/x-pack/legacy/plugins/siem/server/lib/detection_engine/signals/single_bulk_create.ts
@@ -62,6 +62,10 @@ export interface SingleBulkCreateResponse {
   createdItemsCount: number;
 }
 
+function stringBreviate(text, count, insertDots){
+  return text.slice(0, count) + (((text.length > count) && insertDots) ? "..." : "");
+}
+
 // Bulk Index documents.
 export const singleBulkCreate = async ({
   someResult,
@@ -139,8 +143,9 @@ export const singleBulkCreate = async ({
     delete errorCountsByStatus['409']; // Duplicate signals are expected
 
     if (!isEmpty(errorCountsByStatus)) {
+      const errmsg = stringBreviate(JSON.stringify(itemsWithErrors), 1000, true);
       logger.error(
-        `[-] bulkResponse had errors with response statuses:counts of...\n${JSON.stringify(
+        `[-] bulkResponse had errors ${errmsg} with response statuses:counts of...\n${JSON.stringify(
           errorCountsByStatus,
           null,
           2


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
elastic siem keeps prints error 400 but it does not indicate what is wrong as show in the screen shot
![image](https://user-images.githubusercontent.com/44448956/79099404-e4d3e300-7d18-11ea-96d6-48ed408b6672.png)

the fix is to print the detailed error from the response. after the fix it nows includes the errors.

[-] bulkResponse had errors [{"create":{"_index":".siem-signals-default-000001","_type":"_doc","_id":"dc2e284becb41e00a76541440aa55d93f2c94a0caf0003a403c80bd5197abaa7","status":409,"error":{"type":"version_conflict_engine_exception","reason":"[dc2e284becb41e00a76541440aa55d93f2c94a0caf0003a403c80bd5197abaa7]: version conflict, document already exists (current version [1])","index_uuid":"1ZHR_A3PTXevZv49ok4oaQ","shard":"0","index":".siem-signals-default-000001"}}},{"create":{"_index":".siem-signals-default-000001","_type":"_doc","_id":"19bc7fe89cdfa6303812dcce37103cbf5037faeba0fd173c13f428b863a9999f","status":409,"error":{"type":"version_conflict_engine_exception","reason":"[19bc7fe89cdfa6303812dcce37103cbf5037faeba0fd173c13f428b863a9999f]: version conflict, document already exists (current version [1])","index_uuid":"1ZHR_A3PTXevZv49ok4oaQ","shard":"0","index":".siem-signals-default-000001"}}},{"create":{"_index":".siem-signals-default-000001","_type":"_doc","_id":"30d34bebebd65b06373f65a36961de4c22842c5f968953aa... with response statuses:counts of... {   "400": 2 }
--




### Checklist



--



Delete any items that are not applicable to this PR.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
