### PR TITLE
[SIEM] Fix AlertsTable id

### DIFF
--- a/x-pack/legacy/plugins/siem/public/components/alerts_viewer/alerts_table.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/alerts_viewer/alerts_table.tsx
@@ -17,7 +17,7 @@ export interface OwnProps {
   start: number;
 }
 
-const ALERTS_TABLE_ID = 'timeline-alerts-table';
+const ALERTS_TABLE_ID = 'alerts-table';
 const defaultAlertsFilters: Filter[] = [
   {
     meta: {


### PR DESCRIPTION
## Summary
`id` should not be starting with `timeline`, because it causes to create unnecessary timelines 
