### PR TITLE
[Hotfix] Clear saved query crashes kibana on Discover in some cases

### DIFF
--- a/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
+++ b/src/legacy/core_plugins/kibana/public/discover/np_ready/angular/discover.js
@@ -828,13 +828,9 @@ function discoverController(
     if (newSavedQueryId) {
       setAppState({ savedQuery: newSavedQueryId });
     } else {
-      //reset filters and query string, remove savedQuery from state
+      // remove savedQueryId from state
       const state = {
         ...appStateContainer.getState(),
-        query: getDefaultQuery(
-          localStorage.get('kibana.userQueryLanguage') || config.get('search:queryLanguage')
-        ),
-        filters: [],
       };
       delete state.savedQuery;
       appStateContainer.set(state);

--- a/src/plugins/data/public/ui/query_string_input/language_switcher.tsx
+++ b/src/plugins/data/public/ui/query_string_input/language_switcher.tsx
@@ -61,6 +61,7 @@ export function QueryLanguageSwitcher(props: Props) {
       size="xs"
       onClick={() => setIsPopoverOpen(!isPopoverOpen)}
       className="euiFormControlLayout__append"
+      data-test-subj={'switchQueryLanguageButton'}
     >
       {props.language === 'lucene' ? luceneLabel : kqlLabel}
     </EuiButtonEmpty>

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -124,7 +124,8 @@ export function createSearchBar({ core, storage, data }: StatefulSearchBarDeps) 
     const onQuerySubmitRef = useRef(props.onQuerySubmit);
     const defaultQuery = {
       query: '',
-      language: core.uiSettings.get('search:queryLanguage'),
+      language:
+        storage.get('kibana.userQueryLanguage') || core.uiSettings.get('search:queryLanguage'),
     };
     const [query, setQuery] = useState<Query>(props.query || defaultQuery);
 
@@ -161,7 +162,7 @@ export function createSearchBar({ core, storage, data }: StatefulSearchBarDeps) 
       setQuery,
       savedQueryId: props.savedQueryId,
       notifications: core.notifications,
-      uiSettings: core.uiSettings,
+      defaultLanguage: defaultQuery.language,
     });
 
     // Fire onQuerySubmit on query or timerange change

--- a/src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts
+++ b/src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts
@@ -29,8 +29,8 @@ interface UseSavedQueriesProps {
   queryService: DataPublicPluginStart['query'];
   setQuery: Function;
   notifications: CoreStart['notifications'];
-  uiSettings: CoreStart['uiSettings'];
   savedQueryId?: string;
+  defaultLanguage: string;
 }
 
 interface UseSavedQueriesReturn {
@@ -41,7 +41,7 @@ interface UseSavedQueriesReturn {
 
 export const useSavedQuery = (props: UseSavedQueriesProps): UseSavedQueriesReturn => {
   // Handle saved queries
-  const defaultLanguage = props.uiSettings.get('search:queryLanguage');
+  const defaultLanguage = props.defaultLanguage;
   const [savedQuery, setSavedQuery] = useState<SavedQuery | undefined>();
 
   // Effect is used to convert a saved query id into an object

--- a/test/functional/apps/discover/_saved_queries.js
+++ b/test/functional/apps/discover/_saved_queries.js
@@ -147,6 +147,25 @@ export default function({ getService, getPageObjects }) {
         await savedQueryManagementComponent.clearCurrentlyLoadedQuery();
         expect(await queryBar.getQueryString()).to.eql('');
       });
+
+      // https://github.com/elastic/kibana/issues/63505
+      it('allows clearing if non default language was remembered in localstorage', async () => {
+        await queryBar.switchQueryLanguage('lucene');
+        await PageObjects.common.navigateToApp('discover'); // makes sure discovered is reloaded without any state in url
+        await queryBar.expectQueryLanguageOrFail('lucene'); // make sure lucene is remembered after refresh (comes from localstorage)
+        await savedQueryManagementComponent.loadSavedQuery('OkResponse');
+        await queryBar.expectQueryLanguageOrFail('kql');
+        await savedQueryManagementComponent.clearCurrentlyLoadedQuery();
+        await queryBar.expectQueryLanguageOrFail('lucene');
+      });
+
+      // fails: bug in discover https://github.com/elastic/kibana/issues/63561
+      // unskip this test when bug is fixed
+      it.skip('changing language removes saved query', async () => {
+        await savedQueryManagementComponent.loadSavedQuery('OkResponse');
+        await queryBar.switchQueryLanguage('lucene');
+        expect(await queryBar.getQueryString()).to.eql('');
+      });
     });
   });
 }

--- a/test/functional/services/query_bar.ts
+++ b/test/functional/services/query_bar.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import expect from '@kbn/expect';
 import { FtrProviderContext } from '../ftr_provider_context';
 
 export function QueryBarProvider({ getService, getPageObjects }: FtrProviderContext) {
@@ -25,6 +26,7 @@ export function QueryBarProvider({ getService, getPageObjects }: FtrProviderCont
   const log = getService('log');
   const PageObjects = getPageObjects(['header', 'common']);
   const find = getService('find');
+  const browser = getService('browser');
 
   class QueryBar {
     async getQueryString(): Promise<string> {
@@ -61,6 +63,24 @@ export function QueryBarProvider({ getService, getPageObjects }: FtrProviderCont
 
     public async clickQuerySubmitButton(): Promise<void> {
       await testSubjects.click('querySubmitButton');
+    }
+
+    public async switchQueryLanguage(lang: 'kql' | 'lucene'): Promise<void> {
+      await testSubjects.click('switchQueryLanguageButton');
+      const kqlToggle = await testSubjects.find('languageToggle');
+      const currentLang =
+        (await kqlToggle.getAttribute('aria-checked')) === 'true' ? 'kql' : 'lucene';
+      if (lang !== currentLang) {
+        await kqlToggle.click();
+      }
+
+      await browser.pressKeys(browser.keys.ESCAPE); // close popover
+      await this.expectQueryLanguageOrFail(lang); // make sure lang is switched
+    }
+
+    public async expectQueryLanguageOrFail(lang: 'kql' | 'lucene'): Promise<void> {
+      const queryLanguageButton = await testSubjects.find('switchQueryLanguageButton');
+      expect((await queryLanguageButton.getVisibleText()).toLowerCase()).to.eql(lang);
     }
   }
 


### PR DESCRIPTION
## Summary

This hot fixes bug in Discover when clearing "Saved query". https://github.com/elastic/kibana/issues/63505
Bug is reproduced reliably in any environment if preferred query language in uiSettings is different from saved query language in localStorage. :

To reproduce: 

1. Assuming KQL is default language 
2. Go to discover and save a query with KQL
2. Clear the query
3. Switch to lucene
4. Reload the page (lucene should be in the query bar)
4. Apply the saved query (the one with KQL)
4. Clear query 
5. Browser is frozen

The bug causing the loop is happening on integration level between discover and search_bar `src/plugins/data/public/ui/search_bar/lib/use_saved_query.ts`. When clearing saved_query search_bar tried to switch query to value from uiSettings, but discover then updated it to the value from localStorage. Then there is a loop condition caused by this and this has to be fixed separately in a generic way. I'll create a tech-debt ticket. 

I don't believe this is a **proper** fix. It is just the simplest and with the least amount of risk one. 
This is the commit with the actual fix: https://github.com/elastic/kibana/commit/12c9c56b0e658e8966f438638238b6cbbcc4e3db

TODO: 

- [x] Add e2e test in this pr
- [x] Create a tech debt ticket for a `connected_search_bar` to not cause infinite loops depending on inputs - this would be a proper fix. We need to increase test coverage focused on redundant renderings.  https://github.com/elastic/kibana/issues/63675


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
