### PR TITLE
Fix discover preserve url

### DIFF
--- a/x-pack/test/functional/apps/discover/preserve_url.ts
+++ b/x-pack/test/functional/apps/discover/preserve_url.ts
@@ -10,7 +10,6 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const PageObjects = getPageObjects(['common', 'discover', 'spaceSelector', 'header']);
-  const appsMenu = getService('appsMenu');
   const globalNav = getService('globalNav');
 
   describe('preserve url', function() {
@@ -26,8 +25,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.common.navigateToApp('discover');
       await PageObjects.discover.saveSearch('A Search');
       await PageObjects.common.navigateToApp('home');
-      await appsMenu.clickLink('Discover');
-      await PageObjects.discover.waitUntilSearchingHasFinished();
+      await PageObjects.header.clickDiscover();
       const activeTitle = await globalNav.getLastBreadcrumb();
       expect(activeTitle).to.be('A Search');
     });
@@ -42,7 +40,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.spaceSelector.expectHomePage('another-space');
 
       // other space
-      await appsMenu.clickLink('Discover');
+      await PageObjects.header.clickDiscover();
       await PageObjects.discover.saveSearch('A Search in another space');
 
       await PageObjects.spaceSelector.openSpacesNav();
@@ -50,7 +48,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.spaceSelector.expectHomePage('default');
 
       // default space
-      await appsMenu.clickLink('Discover');
+      await PageObjects.header.clickDiscover();
       await PageObjects.discover.waitUntilSearchingHasFinished();
       const activeTitleDefaultSpace = await globalNav.getLastBreadcrumb();
       expect(activeTitleDefaultSpace).to.be('A Search');
@@ -60,7 +58,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.spaceSelector.expectHomePage('another-space');
 
       // other space
-      await appsMenu.clickLink('Discover');
+      await PageObjects.header.clickDiscover();
       await PageObjects.discover.waitUntilSearchingHasFinished();
       const activeTitleOtherSpace = await globalNav.getLastBreadcrumb();
       expect(activeTitleOtherSpace).to.be('A Search in another space');

--- a/x-pack/test/functional/apps/discover/preserve_url.ts
+++ b/x-pack/test/functional/apps/discover/preserve_url.ts
@@ -12,8 +12,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'discover', 'spaceSelector', 'header']);
   const globalNav = getService('globalNav');
 
-  // eslint-disable-next-line ban/ban
-  describe.only('preserve url', function() {
+  describe('preserve url', function() {
     before(async function() {
       await esArchiver.load('spaces/multi_space');
     });

--- a/x-pack/test/functional/apps/discover/preserve_url.ts
+++ b/x-pack/test/functional/apps/discover/preserve_url.ts
@@ -12,7 +12,8 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'discover', 'spaceSelector', 'header']);
   const globalNav = getService('globalNav');
 
-  describe('preserve url', function() {
+  // eslint-disable-next-line ban/ban
+  describe.only('preserve url', function() {
     before(async function() {
       await esArchiver.load('spaces/multi_space');
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/62902

This stabilizes the discover test - instead of using a combination of `appsMenu.clickLink` and `discover.waitUntilSearchingHasFinished` to wait for stabilization of the discover page, this PR switches to the battle-tested `header.clickDiscover` shortcut.