### PR TITLE
[SIEM] [Cases] Insert timeline and reporters/tags in table bug fixes

### DIFF
--- a/x-pack/legacy/plugins/siem/public/components/timeline/insert_timeline_popover/index.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/insert_timeline_popover/index.test.tsx
@@ -26,6 +26,7 @@ const mockLocationWithState = {
   state: {
     insertTimeline: {
       timelineId: 'timeline-id',
+      timelineSavedObjectId: '34578-3497-5893-47589-34759',
       timelineTitle: 'Timeline title',
     },
   },

--- a/x-pack/legacy/plugins/siem/public/components/timeline/insert_timeline_popover/index.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/insert_timeline_popover/index.test.tsx
@@ -50,7 +50,7 @@ describe('Insert timeline popover ', () => {
       payload: { id: 'timeline-id', show: false },
       type: 'x-pack/siem/local/timeline/SHOW_TIMELINE',
     });
-    expect(onTimelineChange).toBeCalledWith('Timeline title', 'timeline-id');
+    expect(onTimelineChange).toBeCalledWith('Timeline title', '34578-3497-5893-47589-34759');
   });
   it('should do nothing when router state', () => {
     jest.spyOn(routeData, 'useLocation').mockReturnValue(mockLocation);

--- a/x-pack/legacy/plugins/siem/public/components/timeline/insert_timeline_popover/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/insert_timeline_popover/index.tsx
@@ -23,6 +23,7 @@ interface InsertTimelinePopoverProps {
 interface RouterState {
   insertTimeline: {
     timelineId: string;
+    timelineSavedObjectId: string;
     timelineTitle: string;
   };
 }
@@ -46,7 +47,7 @@ export const InsertTimelinePopoverComponent: React.FC<Props> = ({
       );
       onTimelineChange(
         routerState.insertTimeline.timelineTitle,
-        routerState.insertTimeline.timelineId
+        routerState.insertTimeline.timelineSavedObjectId
       );
       setRouterState(null);
     }

--- a/x-pack/legacy/plugins/siem/public/components/timeline/properties/helpers.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/properties/helpers.tsx
@@ -21,6 +21,7 @@ import React, { useCallback } from 'react';
 import uuid from 'uuid';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { Note } from '../../../lib/note';
 import { Notes } from '../../notes';
@@ -29,6 +30,8 @@ import { NOTES_PANEL_WIDTH } from './notes_size';
 import { ButtonContainer, DescriptionContainer, LabelText, NameField, StyledStar } from './styles';
 import * as i18n from './translations';
 import { SiemPageName } from '../../../pages/home/types';
+import { timelineActions, timelineSelectors } from '../../../store/timeline';
+import { State } from '../../../store';
 
 export const historyToolTip = 'The chronological history of actions related to this timeline';
 export const streamLiveToolTip = 'Update the Timeline as new data arrives';
@@ -121,6 +124,9 @@ interface NewCaseProps {
 
 export const NewCase = React.memo<NewCaseProps>(({ onClosePopover, timelineId, timelineTitle }) => {
   const history = useHistory();
+  const { savedObjectId } = useSelector((state: State) =>
+    timelineSelectors.selectTimeline(state, timelineId)
+  );
   const handleClick = useCallback(() => {
     onClosePopover();
     history.push({
@@ -128,6 +134,7 @@ export const NewCase = React.memo<NewCaseProps>(({ onClosePopover, timelineId, t
       state: {
         insertTimeline: {
           timelineId,
+          timelineSavedObjectId: savedObjectId,
           timelineTitle: timelineTitle.length > 0 ? timelineTitle : i18n.UNTITLED_TIMELINE,
         },
       },

--- a/x-pack/legacy/plugins/siem/public/components/timeline/properties/helpers.tsx
+++ b/x-pack/legacy/plugins/siem/public/components/timeline/properties/helpers.tsx
@@ -21,7 +21,7 @@ import React, { useCallback } from 'react';
 import uuid from 'uuid';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { Note } from '../../../lib/note';
 import { Notes } from '../../notes';
@@ -30,7 +30,7 @@ import { NOTES_PANEL_WIDTH } from './notes_size';
 import { ButtonContainer, DescriptionContainer, LabelText, NameField, StyledStar } from './styles';
 import * as i18n from './translations';
 import { SiemPageName } from '../../../pages/home/types';
-import { timelineActions, timelineSelectors } from '../../../store/timeline';
+import { timelineSelectors } from '../../../store/timeline';
 import { State } from '../../../store';
 
 export const historyToolTip = 'The chronological history of actions related to this timeline';

--- a/x-pack/legacy/plugins/siem/public/containers/case/use_get_reporters.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/containers/case/use_get_reporters.test.tsx
@@ -61,6 +61,19 @@ describe('useGetReporters', () => {
     });
   });
 
+  it('refetch reporters', async () => {
+    const spyOnGetReporters = jest.spyOn(api, 'getReporters');
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook<string, UseGetReporters>(() =>
+        useGetReporters()
+      );
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+      result.current.fetchReporters();
+      expect(spyOnGetReporters).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('unhappy path', async () => {
     const spyOnGetReporters = jest.spyOn(api, 'getReporters');
     spyOnGetReporters.mockImplementation(() => {

--- a/x-pack/legacy/plugins/siem/public/containers/case/use_get_tags.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/containers/case/use_get_tags.test.tsx
@@ -26,6 +26,7 @@ describe('useGetTags', () => {
         tags: [],
         isLoading: true,
         isError: false,
+        fetchTags: result.current.fetchTags,
       });
     });
   });
@@ -49,7 +50,19 @@ describe('useGetTags', () => {
         tags,
         isLoading: false,
         isError: false,
+        fetchTags: result.current.fetchTags,
       });
+    });
+  });
+
+  it('refetch tags', async () => {
+    const spyOnGetTags = jest.spyOn(api, 'getTags');
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook<string, UseGetTags>(() => useGetTags());
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+      result.current.fetchTags();
+      expect(spyOnGetTags).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -68,6 +81,7 @@ describe('useGetTags', () => {
         tags: [],
         isLoading: false,
         isError: true,
+        fetchTags: result.current.fetchTags,
       });
     });
   });

--- a/x-pack/legacy/plugins/siem/public/containers/case/use_get_tags.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/containers/case/use_get_tags.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { useGetTags, TagsState } from './use_get_tags';
+import { useGetTags, UseGetTags } from './use_get_tags';
 import { tags } from './mock';
 import * as api from './api';
 
@@ -20,7 +20,7 @@ describe('useGetTags', () => {
 
   it('init', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, TagsState>(() => useGetTags());
+      const { result, waitForNextUpdate } = renderHook<string, UseGetTags>(() => useGetTags());
       await waitForNextUpdate();
       expect(result.current).toEqual({
         tags: [],
@@ -33,7 +33,7 @@ describe('useGetTags', () => {
   it('calls getTags api', async () => {
     const spyOnGetTags = jest.spyOn(api, 'getTags');
     await act(async () => {
-      const { waitForNextUpdate } = renderHook<string, TagsState>(() => useGetTags());
+      const { waitForNextUpdate } = renderHook<string, UseGetTags>(() => useGetTags());
       await waitForNextUpdate();
       await waitForNextUpdate();
       expect(spyOnGetTags).toBeCalledWith(abortCtrl.signal);
@@ -42,7 +42,7 @@ describe('useGetTags', () => {
 
   it('fetch tags', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, TagsState>(() => useGetTags());
+      const { result, waitForNextUpdate } = renderHook<string, UseGetTags>(() => useGetTags());
       await waitForNextUpdate();
       await waitForNextUpdate();
       expect(result.current).toEqual({
@@ -60,7 +60,7 @@ describe('useGetTags', () => {
     });
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<string, TagsState>(() => useGetTags());
+      const { result, waitForNextUpdate } = renderHook<string, UseGetTags>(() => useGetTags());
       await waitForNextUpdate();
       await waitForNextUpdate();
 

--- a/x-pack/legacy/plugins/siem/public/containers/case/use_get_tags.tsx
+++ b/x-pack/legacy/plugins/siem/public/containers/case/use_get_tags.tsx
@@ -20,6 +20,10 @@ type Action =
   | { type: 'FETCH_SUCCESS'; payload: string[] }
   | { type: 'FETCH_FAILURE' };
 
+export interface UseGetTags extends TagsState {
+  fetchTags: () => void;
+}
+
 const dataFetchReducer = (state: TagsState, action: Action): TagsState => {
   switch (action.type) {
     case 'FETCH_INIT':
@@ -47,7 +51,7 @@ const dataFetchReducer = (state: TagsState, action: Action): TagsState => {
 };
 const initialData: string[] = [];
 
-export const useGetTags = (): TagsState => {
+export const useGetTags = (): UseGetTags => {
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: true,
     isError: false,
@@ -55,7 +59,7 @@ export const useGetTags = (): TagsState => {
   });
   const [, dispatchToaster] = useStateToaster();
 
-  useEffect(() => {
+  const callFetch = () => {
     let didCancel = false;
     const abortCtrl = new AbortController();
 
@@ -82,6 +86,9 @@ export const useGetTags = (): TagsState => {
       abortCtrl.abort();
       didCancel = true;
     };
+  };
+  useEffect(() => {
+    callFetch();
   }, []);
-  return state;
+  return { ...state, fetchTags: callFetch };
 };

--- a/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/index.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/index.tsx
@@ -129,13 +129,20 @@ export const AllCases = React.memo<AllCasesProps>(({ userCanCrud }) => {
     id: '',
   });
   const [deleteBulk, setDeleteBulk] = useState<DeleteCase[]>([]);
-
-  const refreshCases = useCallback(() => {
-    refetchCases();
-    fetchCasesStatus();
-    setSelectedCases([]);
-    setDeleteBulk([]);
-  }, []);
+  const [isRefetchFilters, setIsRefetchFilters] = useState(false);
+  const refreshCases = useCallback(
+    (dataRefresh = true) => {
+      if (dataRefresh) refetchCases();
+      fetchCasesStatus();
+      setSelectedCases([]);
+      setDeleteBulk([]);
+      setIsRefetchFilters(true);
+    },
+    [filterOptions, queryParams]
+  );
+  useEffect(() => {
+    refreshCases(false);
+  }, [filterOptions, queryParams]);
 
   useEffect(() => {
     if (isDeleted) {
@@ -347,6 +354,8 @@ export const AllCases = React.memo<AllCasesProps>(({ userCanCrud }) => {
             tags: filterOptions.tags,
             status: filterOptions.status,
           }}
+          isRefetchFilters={isRefetchFilters}
+          setIsRefetchFilters={setIsRefetchFilters}
         />
         {isCasesLoading && isDataEmpty ? (
           <Div>

--- a/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/table_filters.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/table_filters.test.tsx
@@ -20,15 +20,14 @@ jest.mock('../../../../containers/case/use_get_tags');
 const onFilterChanged = jest.fn();
 const fetchReporters = jest.fn();
 const fetchTags = jest.fn();
-const setIsRefetchFilters = jest.fn();
+const setFilterRefetch = jest.fn();
 
 const props = {
   countClosedCases: 1234,
   countOpenCases: 99,
   onFilterChanged,
   initial: DEFAULT_FILTER_OPTIONS,
-  isRefetchFilters: false,
-  setIsRefetchFilters,
+  setFilterRefetch,
 };
 describe('CasesTableFilters ', () => {
   beforeEach(() => {
@@ -122,15 +121,13 @@ describe('CasesTableFilters ', () => {
 
     expect(onFilterChanged).toBeCalledWith({ status: 'closed' });
   });
-  it('should refetch tags and reporters when isRefetchFilters is true', () => {
+  it('should call on load setFilterRefetch', () => {
     mount(
       <TestProviders>
-        <CasesTableFilters {...{ ...props, isRefetchFilters: true }} />
+        <CasesTableFilters {...props} />
       </TestProviders>
     );
-    expect(fetchReporters).toHaveBeenCalledTimes(1);
-    expect(fetchTags).toHaveBeenCalledTimes(1);
-    expect(setIsRefetchFilters).toHaveBeenCalledWith(false);
+    expect(setFilterRefetch).toHaveBeenCalled();
   });
   it('should remove tag from selected tags when tag no longer exists', () => {
     const ourProps = {

--- a/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/table_filters.test.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/table_filters.test.tsx
@@ -19,17 +19,21 @@ jest.mock('../../../../containers/case/use_get_tags');
 
 const onFilterChanged = jest.fn();
 const fetchReporters = jest.fn();
+const fetchTags = jest.fn();
+const setIsRefetchFilters = jest.fn();
 
 const props = {
   countClosedCases: 1234,
   countOpenCases: 99,
   onFilterChanged,
   initial: DEFAULT_FILTER_OPTIONS,
+  isRefetchFilters: false,
+  setIsRefetchFilters,
 };
 describe('CasesTableFilters ', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    (useGetTags as jest.Mock).mockReturnValue({ tags: ['coke', 'pepsi'] });
+    (useGetTags as jest.Mock).mockReturnValue({ tags: ['coke', 'pepsi'], fetchTags });
     (useGetReporters as jest.Mock).mockReturnValue({
       reporters: ['casetester'],
       respReporters: [{ username: 'casetester' }],
@@ -57,7 +61,7 @@ describe('CasesTableFilters ', () => {
         .text()
     ).toEqual('Closed cases (1234)');
   });
-  it('should call onFilterChange when tags change', () => {
+  it('should call onFilterChange when selected tags change', () => {
     const wrapper = mount(
       <TestProviders>
         <CasesTableFilters {...props} />
@@ -74,7 +78,7 @@ describe('CasesTableFilters ', () => {
 
     expect(onFilterChanged).toBeCalledWith({ tags: ['coke'] });
   });
-  it('should call onFilterChange when reporters change', () => {
+  it('should call onFilterChange when selected reporters change', () => {
     const wrapper = mount(
       <TestProviders>
         <CasesTableFilters {...props} />
@@ -117,5 +121,48 @@ describe('CasesTableFilters ', () => {
       .simulate('click');
 
     expect(onFilterChanged).toBeCalledWith({ status: 'closed' });
+  });
+  it('should refetch tags and reporters when isRefetchFilters is true', () => {
+    mount(
+      <TestProviders>
+        <CasesTableFilters {...{ ...props, isRefetchFilters: true }} />
+      </TestProviders>
+    );
+    expect(fetchReporters).toHaveBeenCalledTimes(1);
+    expect(fetchTags).toHaveBeenCalledTimes(1);
+    expect(setIsRefetchFilters).toHaveBeenCalledWith(false);
+  });
+  it('should remove tag from selected tags when tag no longer exists', () => {
+    const ourProps = {
+      ...props,
+      initial: {
+        ...DEFAULT_FILTER_OPTIONS,
+        tags: ['pepsi', 'rc'],
+      },
+    };
+    mount(
+      <TestProviders>
+        <CasesTableFilters {...ourProps} />
+      </TestProviders>
+    );
+    expect(onFilterChanged).toHaveBeenCalledWith({ tags: ['pepsi'] });
+  });
+  it('should remove reporter from selected reporters when reporter no longer exists', () => {
+    const ourProps = {
+      ...props,
+      initial: {
+        ...DEFAULT_FILTER_OPTIONS,
+        reporters: [
+          { username: 'casetester', full_name: null, email: null },
+          { username: 'batman', full_name: null, email: null },
+        ],
+      },
+    };
+    mount(
+      <TestProviders>
+        <CasesTableFilters {...ourProps} />
+      </TestProviders>
+    );
+    expect(onFilterChanged).toHaveBeenCalledWith({ reporters: [{ username: 'casetester' }] });
   });
 });

--- a/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/table_filters.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/case/components/all_cases/table_filters.tsx
@@ -25,8 +25,7 @@ interface CasesTableFiltersProps {
   countOpenCases: number | null;
   onFilterChanged: (filterOptions: Partial<FilterOptions>) => void;
   initial: FilterOptions;
-  isRefetchFilters: boolean;
-  setIsRefetchFilters: (val: boolean) => void;
+  setFilterRefetch: (val: () => void) => void;
 }
 
 /**
@@ -43,8 +42,7 @@ const CasesTableFiltersComponent = ({
   countOpenCases,
   onFilterChanged,
   initial = defaultInitial,
-  isRefetchFilters,
-  setIsRefetchFilters,
+  setFilterRefetch,
 }: CasesTableFiltersProps) => {
   const [selectedReporters, setSelectedReporters] = useState(
     initial.reporters.map(r => r.full_name ?? r.username ?? '')
@@ -54,14 +52,15 @@ const CasesTableFiltersComponent = ({
   const [showOpenCases, setShowOpenCases] = useState(initial.status === 'open');
   const { tags, fetchTags } = useGetTags();
   const { reporters, respReporters, fetchReporters } = useGetReporters();
-
+  const refetch = useCallback(() => {
+    fetchTags();
+    fetchReporters();
+  }, [fetchReporters, fetchTags]);
   useEffect(() => {
-    if (isRefetchFilters) {
-      fetchTags();
-      fetchReporters();
-      setIsRefetchFilters(false);
+    if (setFilterRefetch != null) {
+      setFilterRefetch(refetch);
     }
-  }, [isRefetchFilters]);
+  }, [refetch, setFilterRefetch]);
   useEffect(() => {
     if (selectedReporters.length) {
       const newReporters = selectedReporters.filter(r => reporters.includes(r));


### PR DESCRIPTION
## Summary

This PR fixes the following bugs

1. Resolves https://github.com/elastic/siem-team/issues/616 The timeline id of `timeline-1` was being used to generate the timeline url when creating a new case from timeline rather than the correct timeline saved object id. Fixed!
2. Resolves https://github.com/elastic/siem-team/issues/617 "Reporter" and "Tags" need to be refetched when all the other table gets refetched
3. When debugging https://github.com/elastic/siem-team/issues/617, I found another bug where only the cases data was getting refetched when filterOptions and queryParams updated. I added a `useEffect` to update the other data (case status header and reporters/tags)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios