### PR TITLE
[APM] Service map fix focused node edges on unselect

### DIFF
--- a/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/legacy/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -211,7 +211,9 @@ export function Cytoscape({
       resetConnectedEdgeStyle(event.target);
     };
     const unselectHandler: cytoscape.EventHandler = event => {
-      resetConnectedEdgeStyle();
+      resetConnectedEdgeStyle(
+        serviceName ? event.cy.getElementById(serviceName) : undefined
+      );
     };
     const debugHandler: cytoscape.EventHandler = event => {
       const debugEnabled = sessionStorage.getItem('apm_debug') === 'true';


### PR DESCRIPTION
Closes #63109 by resetting edges styles for the selected node.

Selected node styles reset correctly after fix:
![service-maps-12](https://user-images.githubusercontent.com/1967266/79416673-117c3a80-7f65-11ea-9161-a545375c2656.gif)
