### PR TITLE
Code coverage: run more configs with functional tests

### DIFF
--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -22,7 +22,7 @@ else
 
   echo " -> running tests from the clone folder"
   #yarn run grunt "run:functionalTests_ciGroup${CI_GROUP}";
-  node scripts/functional_tests --debug --include-tag "ciGroup$CI_GROUP"  --config test/functional/config.coverage.js || true;
+  node scripts/functional_tests --debug --include-tag "ciGroup$CI_GROUP"  --exclude-tag "skipCoverage" || true;
 
   if [[ -d target/kibana-coverage/functional ]]; then
     echo " -> replacing kibana${CI_GROUP} with kibana in json files"

--- a/test/scripts/jenkins_xpack.sh
+++ b/test/scripts/jenkins_xpack.sh
@@ -39,7 +39,7 @@ else
   # build runtime for canvas
   echo "NODE_ENV=$NODE_ENV"
   node ./legacy/plugins/canvas/scripts/shareable_runtime
-  node scripts/jest --ci --verbose --coverage
+  node --max-old-space-size=6144 scripts/jest --ci --verbose --coverage
   # rename file in order to be unique one
   test -f ../target/kibana-coverage/jest/coverage-final.json \
     && mv ../target/kibana-coverage/jest/coverage-final.json \

--- a/test/scripts/jenkins_xpack_ci_group.sh
+++ b/test/scripts/jenkins_xpack_ci_group.sh
@@ -23,7 +23,7 @@ else
   cd "kibana${CI_GROUP}/x-pack"
 
   echo " -> running tests from the clone folder"
-  node scripts/functional_tests --debug --include-tag "ciGroup$CI_GROUP"  --config test/functional/config.coverage.js || true;
+  node scripts/functional_tests --debug --include-tag "ciGroup$CI_GROUP"  --exclude-tag "skipCoverage" || true;
 
   if [[ -d ../target/kibana-coverage/functional ]]; then
     echo " -> replacing kibana${CI_GROUP} with kibana in json files"

--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -4,7 +4,11 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-const alwaysImportedTests = [require.resolve('../test/functional/config.js')];
+const alwaysImportedTests = [
+  // require.resolve('../test/functional/config.js'),
+  require.resolve('../test/functional_endpoint_ingest_failure/config.ts'),
+  require.resolve('../test/functional_endpoint/config.ts'),
+];
 const onlyNotInCoverageTests = [
   require.resolve('../test/reporting/configs/chromium_api.js'),
   require.resolve('../test/reporting/configs/chromium_functional.js'),
@@ -43,8 +47,6 @@ const onlyNotInCoverageTests = [
   require.resolve('../test/licensing_plugin/config.ts'),
   require.resolve('../test/licensing_plugin/config.public.ts'),
   require.resolve('../test/licensing_plugin/config.legacy.ts'),
-  require.resolve('../test/functional_endpoint_ingest_failure/config.ts'),
-  require.resolve('../test/functional_endpoint/config.ts'),
 ];
 
 require('@kbn/plugin-helpers').babelRegister();

--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -5,16 +5,16 @@
  */
 
 const alwaysImportedTests = [
-  // require.resolve('../test/functional/config.js'),
+  require.resolve('../test/functional/config.js'),
   require.resolve('../test/functional_endpoint_ingest_failure/config.ts'),
   require.resolve('../test/functional_endpoint/config.ts'),
+  require.resolve('../test/functional_with_es_ssl/config.ts'),
+  require.resolve('../test/functional/config_security_basic.js'),
 ];
 const onlyNotInCoverageTests = [
   require.resolve('../test/reporting/configs/chromium_api.js'),
   require.resolve('../test/reporting/configs/chromium_functional.js'),
   require.resolve('../test/reporting/configs/generate_api.js'),
-  require.resolve('../test/functional_with_es_ssl/config.ts'),
-  require.resolve('../test/functional/config_security_basic.js'),
   require.resolve('../test/api_integration/config_security_basic.js'),
   require.resolve('../test/api_integration/config.js'),
   require.resolve('../test/alerting_api_integration/basic/config.ts'),

--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -10,6 +10,7 @@ const alwaysImportedTests = [
   require.resolve('../test/functional_endpoint/config.ts'),
   require.resolve('../test/functional_with_es_ssl/config.ts'),
   require.resolve('../test/functional/config_security_basic.js'),
+  require.resolve('../test/plugin_functional/config.ts'),
 ];
 const onlyNotInCoverageTests = [
   require.resolve('../test/reporting/configs/chromium_api.js'),
@@ -22,7 +23,6 @@ const onlyNotInCoverageTests = [
   require.resolve('../test/alerting_api_integration/security_and_spaces/config.ts'),
   require.resolve('../test/detection_engine_api_integration/security_and_spaces/config.ts'),
   require.resolve('../test/plugin_api_integration/config.ts'),
-  require.resolve('../test/plugin_functional/config.ts'),
   require.resolve('../test/kerberos_api_integration/config.ts'),
   require.resolve('../test/kerberos_api_integration/anonymous_access.config.ts'),
   require.resolve('../test/saml_api_integration/config.ts'),


### PR DESCRIPTION
## Summary

This PR extends set of functional tests configs that we execute to collect code coverage:
- Endpoint tests
- Tests with ES SSL
- Security tests with Basic license

Note: I think I didn't miss any other config with functional tests (running in Chrome browser), but if you think I did - please let me know.

Code coverage report is available [here](https://console.cloud.google.com/storage/kibana-ci-artifacts/jobs/elastic+kibana+code-coverage/623/coverage/coverage/functional-combined/kibana-functional-coverage.tar.gz)

Before:

<img width="849" alt="coverage_1" src="https://user-images.githubusercontent.com/10977896/79445142-cf92d900-7fe4-11ea-8d65-e226b63e2ad9.png">

After:

<img width="830" alt="coverage_2" src="https://user-images.githubusercontent.com/10977896/79445145-d3266000-7fe4-11ea-9ed1-15edd0290348.png">

Endpoint plugin sources are listed in the report now
<img width="576" alt="endpoint" src="https://user-images.githubusercontent.com/10977896/79445348-31534300-7fe5-11ea-964e-246333e5102f.png">

