### PR TITLE
[SIEM][CASE] Create comments sequentially

### DIFF
--- a/x-pack/plugins/actions/server/builtin_action_types/servicenow/lib/index.ts
+++ b/x-pack/plugins/actions/server/builtin_action_types/servicenow/lib/index.ts
@@ -147,7 +147,14 @@ class ServiceNow {
     comments: Comment[],
     field: string
   ): Promise<CommentResponse[]> {
-    const res = await Promise.all(comments.map(c => this.createComment(incidentId, c, field)));
+    // Create comments sequentially.
+    const promises = comments.reduce(async (prevPromise, currentComment) => {
+      const totalComments = await prevPromise;
+      const res = await this.createComment(incidentId, currentComment, field);
+      return [...totalComments, res];
+    }, Promise.resolve([] as CommentResponse[]));
+
+    const res = await promises;
     return res;
   }
 

--- a/x-pack/plugins/case/server/routes/api/cases/get_case.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/get_case.ts
@@ -40,6 +40,10 @@ export function initGetCaseApi({ caseService, router }: RouteDeps) {
         const theComments = await caseService.getAllCaseComments({
           client,
           caseId: request.params.case_id,
+          options: {
+            sortField: 'created_at',
+            sortOrder: 'asc',
+          },
         });
 
         return response.ok({


### PR DESCRIPTION
## Summary

Maintain the order of comments when pushing to ServiceNow. Ref: https://github.com/elastic/siem-team/issues/618

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
