### PR TITLE
[Lens] Fix bug in field list when _source contained fields with dots

### DIFF
--- a/x-pack/plugins/lens/server/routes/existing_fields.test.ts
+++ b/x-pack/plugins/lens/server/routes/existing_fields.test.ts
@@ -57,6 +57,24 @@ describe('existingFields', () => {
     expect(result).toEqual(['geo.coordinates']);
   });
 
+  it('should handle objects with dotted fields', () => {
+    const result = existingFields(
+      [indexPattern({ 'geo.country_name': 'US' })],
+      [field('geo.country_name')]
+    );
+
+    expect(result).toEqual(['geo.country_name']);
+  });
+
+  it('should handle arrays with dotted fields on both sides', () => {
+    const result = existingFields(
+      [indexPattern({ 'process.cpu': [{ 'user.pct': 50 }] })],
+      [field('process.cpu.user.pct')]
+    );
+
+    expect(result).toEqual(['process.cpu.user.pct']);
+  });
+
   it('should be false if it hits a positive leaf before the end of the path', () => {
     const result = existingFields(
       [indexPattern({ geo: { coordinates: 32 } })],


### PR DESCRIPTION
To reproduce this bug, you can create an index with a mapping such as:

```
PUT my_index
{
  "mappings": {
    "properties": { 
      "system": { 
        "properties": {
          "cpu": {
            "properties": {
              "pct": { "type": "float" }
            }
          }
        }
      }
    }
  }
}
```

And then index a document:

```
POST my_index/_doc/1
{
  "system.cpu.pct": 12.40
}
```

And then create an index pattern in Kibana, which you visit in Lens. It will show the field on the left:

<img width="290" alt="Screenshot 2020-04-16 15 32 48" src="https://user-images.githubusercontent.com/666475/79498650-acbdf000-7ff7-11ea-8850-9803b9e8cec6.png">


Fixes https://github.com/elastic/kibana/issues/63630

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
