### PR TITLE
[Discover] Encode context link filter part

### DIFF
--- a/src/plugins/discover/public/application/angular/doc_table/components/table_row.ts
+++ b/src/plugins/discover/public/application/angular/doc_table/components/table_row.ts
@@ -112,13 +112,17 @@ export function createTableRowDirective($compile: ng.ICompileService, $httpParam
         const globalFilters: any = getServices().filterManager.getGlobalFilters();
         const appFilters: any = getServices().filterManager.getAppFilters();
         const hash = $httpParamSerializer({
-          _g: rison.encode({
-            filters: globalFilters || [],
-          }),
-          _a: rison.encode({
-            columns: $scope.columns,
-            filters: (appFilters || []).map(esFilters.disableFilter),
-          }),
+          _g: encodeURI(
+            rison.encode({
+              filters: globalFilters || [],
+            })
+          ),
+          _a: encodeURI(
+            rison.encode({
+              columns: $scope.columns,
+              filters: (appFilters || []).map(esFilters.disableFilter),
+            })
+          ),
         });
 
         return `${path}?${hash}`;

--- a/test/functional/apps/context/_context_navigation.js
+++ b/test/functional/apps/context/_context_navigation.js
@@ -23,6 +23,10 @@ const TEST_COLUMN_NAMES = ['@message'];
 const TEST_FILTER_COLUMN_NAMES = [
   ['extension', 'jpg'],
   ['geo.src', 'IN'],
+  [
+    'agent',
+    'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24',
+  ],
 ];
 
 export default function({ getService, getPageObjects }) {
@@ -55,7 +59,7 @@ export default function({ getService, getPageObjects }) {
       await browser.goBack();
       await PageObjects.discover.waitForDocTableLoadingComplete();
       const hitCount = await PageObjects.discover.getHitCount();
-      expect(hitCount).to.be('1,556');
+      expect(hitCount).to.be('522');
     });
   });
 }


### PR DESCRIPTION
## Summary

When you added a filter in Discover that contained a whitespace, navigate to context view  (surrounding documents), you couldn't navigate back with the browser's back button. This PR fixes this by encoding the filter part of the context link. 

Fixes #63674

Steps to reproduce:

* Use kibana_sample_data_logs
* Navigate to Discover
* Add a filter for an agent field (those usually contain whitespaces)
* Expand a document and click on "View surrounding documents"
* Try to navigate back with the browsers back button
* Doesn't work in Chrome, Firefox

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
