### PR TITLE
[SIEM] Flaky test fix: Bump find_statuses timeout

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
@@ -50,17 +50,18 @@ export default ({ getService }: FtrProviderContext): void => {
         .send(getSimpleRule())
         .expect(200);
 
-      await new Promise(resolve => setTimeout(resolve, 5000)).then(async () => {
-        // query the single rule from _find
-        const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_find_statuses`)
-          .set('kbn-xsrf', 'true')
-          .send({ ids: [resBody.id] })
-          .expect(200);
+      // wait for Task Manager to execute the rule and update status
+      await new Promise(resolve => setTimeout(resolve, 5000));
 
-        // expected result for status should be 'going to run' or 'succeeded
-        expect(['succeeded', 'going to run']).to.contain(body[resBody.id].current_status.status);
-      });
+      // query the single rule from _find
+      const { body } = await supertest
+        .post(`${DETECTION_ENGINE_RULES_URL}/_find_statuses`)
+        .set('kbn-xsrf', 'true')
+        .send({ ids: [resBody.id] })
+        .expect(200);
+
+      // expected result for status should be 'going to run' or 'succeeded
+      expect(['succeeded', 'going to run']).to.contain(body[resBody.id].current_status.status);
     });
   });
 };

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
@@ -50,7 +50,7 @@ export default ({ getService }: FtrProviderContext): void => {
         .send(getSimpleRule())
         .expect(200);
 
-      await new Promise(resolve => setTimeout(resolve, 1000)).then(async () => {
+      await new Promise(resolve => setTimeout(resolve, 5000)).then(async () => {
         // query the single rule from _find
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_find_statuses`)


### PR DESCRIPTION
## Summary

Flaky test. Has not yet failed on master so there's no issue, but I'll link here if/when it does. This increases time between creating a rule and asserting its status from 1s -> 5s. In that time, task manager needs to run the rule and update its status in order for the test to succeed.
