### PR TITLE
[7.x] [Metrics UI] Remove remaining field filtering (#63398)

### DIFF
--- a/x-pack/plugins/infra/public/components/metrics_explorer/group_by.tsx
+++ b/x-pack/plugins/infra/public/components/metrics_explorer/group_by.tsx
@@ -10,7 +10,6 @@ import { i18n } from '@kbn/i18n';
 import React, { useCallback } from 'react';
 import { IFieldType } from 'src/plugins/data/public';
 import { MetricsExplorerOptions } from '../../containers/metrics_explorer/use_metrics_explorer_options';
-import { isDisplayable } from '../../utils/is_displayable';
 
 interface Props {
   options: MetricsExplorerOptions;
@@ -27,18 +26,6 @@ export const MetricsExplorerGroupBy = ({ options, onChange, fields }: Props) => 
     [onChange]
   );
 
-  const metricPrefixes = options.metrics
-    .map(
-      metric =>
-        (metric.field &&
-          metric.field
-            .split(/\./)
-            .slice(0, 2)
-            .join('.')) ||
-        null
-    )
-    .filter(metric => metric) as string[];
-
   return (
     <EuiComboBox
       placeholder={i18n.translate('xpack.infra.metricsExplorer.groupByLabel', {
@@ -51,7 +38,7 @@ export const MetricsExplorerGroupBy = ({ options, onChange, fields }: Props) => 
       singleSelection={true}
       selectedOptions={(options.groupBy && [{ label: options.groupBy }]) || []}
       options={fields
-        .filter(f => isDisplayable(f, metricPrefixes) && f.aggregatable && f.type === 'string')
+        .filter(f => f.aggregatable && f.type === 'string')
         .map(f => ({ label: f.name }))}
       onChange={handleChange}
       isClearable={true}

--- a/x-pack/plugins/infra/public/components/metrics_explorer/kuery_bar.tsx
+++ b/x-pack/plugins/infra/public/components/metrics_explorer/kuery_bar.tsx
@@ -9,7 +9,6 @@ import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
 import { WithKueryAutocompletion } from '../../containers/with_kuery_autocompletion';
 import { AutocompleteField } from '../autocomplete_field';
-import { isDisplayable } from '../../utils/is_displayable';
 import { esKuery, IIndexPattern } from '../../../../../../src/plugins/data/public';
 
 interface Props {
@@ -51,7 +50,7 @@ export const MetricsExplorerKueryBar = ({
 
   const filteredDerivedIndexPattern = {
     ...derivedIndexPattern,
-    fields: derivedIndexPattern.fields.filter(field => isDisplayable(field)),
+    fields: derivedIndexPattern.fields,
   };
 
   const defaultPlaceholder = i18n.translate(

--- a/x-pack/plugins/infra/public/components/metrics_explorer/metrics.tsx
+++ b/x-pack/plugins/infra/public/components/metrics_explorer/metrics.tsx
@@ -12,7 +12,6 @@ import { IFieldType } from 'src/plugins/data/public';
 import { colorTransformer, MetricsExplorerColor } from '../../../common/color_palette';
 import { MetricsExplorerMetric } from '../../../common/http_api/metrics_explorer';
 import { MetricsExplorerOptions } from '../../containers/metrics_explorer/use_metrics_explorer_options';
-import { isDisplayable } from '../../utils/is_displayable';
 
 interface Props {
   autoFocus?: boolean;
@@ -54,9 +53,7 @@ export const MetricsExplorerMetrics = ({ options, onChange, fields, autoFocus = 
     [onChange, options.aggregation, colors]
   );
 
-  const comboOptions = fields
-    .filter(field => isDisplayable(field))
-    .map(field => ({ label: field.name, value: field.name }));
+  const comboOptions = fields.map(field => ({ label: field.name, value: field.name }));
   const selectedOptions = options.metrics
     .filter(m => m.aggregation !== 'count')
     .map(metric => ({


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Remove remaining field filtering (#63398)