### PR TITLE
Remove Placeholder from new embeddable dropdown

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/placeholder/placeholder_embeddable_factory.ts
+++ b/src/plugins/dashboard/public/application/embeddable/placeholder/placeholder_embeddable_factory.ts
@@ -33,6 +33,10 @@ export class PlaceholderEmbeddableFactory implements EmbeddableFactoryDefinition
     return false;
   }
 
+  public canCreateNew() {
+    return false;
+  }
+
   public async create(initialInput: EmbeddableInput, parent?: IContainer) {
     return new PlaceholderEmbeddable(initialInput, parent);
   }


### PR DESCRIPTION
## Summary

Fixes a small mistake in #61367 which allowed the placeholder embeddable shown during the loading of a clone to appear in the 'create new' listing in the add panel.

Before
<img width="533" alt="Screen Shot 2020-04-21 at 12 22 11 PM" src="https://user-images.githubusercontent.com/14276393/79891340-dcda0a00-83ce-11ea-99ae-a20616ad117d.png">

After
<img width="568" alt="Screen Shot 2020-04-21 at 12 49 14 PM" src="https://user-images.githubusercontent.com/14276393/79891358-e06d9100-83ce-11ea-898a-789f3ab3a31c.png">



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
