### PR TITLE
Default EPM & Fleet to enabled

### DIFF
--- a/x-pack/plugins/ingest_manager/README.md
+++ b/x-pack/plugins/ingest_manager/README.md
@@ -1,9 +1,9 @@
 # Ingest Manager
 ## Plugin
-  - No features enabled by default. See the TypeScript type for the [the available plugin configuration options](https://github.com/elastic/kibana/blob/feature-ingest/x-pack/plugins/ingest_manager/common/types/index.ts#L9-L19)
-  - Setting `xpack.ingestManager.enabled=true` is required to enable the plugin. It adds the `DATASOURCE_API_ROUTES` and `AGENT_CONFIG_API_ROUTES` values in [`common/constants/routes.ts`](./common/constants/routes.ts)
-  - Adding `--xpack.ingestManager.epm.enabled=true` will add the EPM API & UI
-  - Adding `--xpack.ingestManager.fleet.enabled=true` will add the Fleet API & UI
+  - The plugin is disabled by default. See the TypeScript type for the [the available plugin configuration options](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ingest_manager/common/types/index.ts#L9-L27)
+  - Setting `xpack.ingestManager.enabled=true` enables the plugin including the EPM and Fleet features. It also adds the `DATASOURCE_API_ROUTES` and `AGENT_CONFIG_API_ROUTES` values in [`common/constants/routes.ts`](./common/constants/routes.ts)
+  - Adding `--xpack.ingestManager.epm.enabled=false` will disable the EPM API & UI
+  - Adding `--xpack.ingestManager.fleet.enabled=false` will disable the Fleet API & UI
     - [code for adding the routes](https://github.com/elastic/kibana/blob/1f27d349533b1c2865c10c45b2cf705d7416fb36/x-pack/plugins/ingest_manager/server/plugin.ts#L115-L133)
     - [Integration tests](server/integration_tests/router.test.ts)
   - Both EPM and Fleet require `ingestManager` be enabled. They are not standalone features.
@@ -25,7 +25,7 @@ One common development workflow is:
     ```
  - Start Kibana in another shell
     ```
-    yarn start --xpack.ingestManager.enabled=true --xpack.ingestManager.epm.enabled=true --xpack.ingestManager.fleet.enabled=true --no-base-path --xpack.endpoint.enabled=true
+    yarn start --xpack.ingestManager.enabled=true --no-base-path --xpack.endpoint.enabled=true
     ```
 
 This plugin follows the `common`, `server`, `public` structure from the [Architecture Style Guide

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -18,11 +18,11 @@ export const config = {
   schema: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
     epm: schema.object({
-      enabled: schema.boolean({ defaultValue: false }),
+      enabled: schema.boolean({ defaultValue: true }),
       registryUrl: schema.uri({ defaultValue: 'https://epr-staging.elastic.co' }),
     }),
     fleet: schema.object({
-      enabled: schema.boolean({ defaultValue: false }),
+      enabled: schema.boolean({ defaultValue: true }),
       kibana: schema.object({
         host: schema.maybe(schema.string()),
         ca_sha256: schema.maybe(schema.string()),

--- a/x-pack/test/api_integration/config.js
+++ b/x-pack/test/api_integration/config.js
@@ -30,7 +30,6 @@ export async function getApiIntegrationConfig({ readConfigFile }) {
         '--telemetry.optIn=true',
         '--xpack.endpoint.enabled=true',
         '--xpack.ingestManager.enabled=true',
-        '--xpack.ingestManager.fleet.enabled=true',
         '--xpack.endpoint.alertResultListDefaultDateRange.from=2018-01-10T00:00:00.000Z',
       ],
     },

--- a/x-pack/test/epm_api_integration/config.ts
+++ b/x-pack/test/epm_api_integration/config.ts
@@ -28,7 +28,6 @@ export default async function({ readConfigFile }: FtrConfigProviderContext) {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
-        '--xpack.ingestManager.epm.enabled=true',
         '--xpack.ingestManager.epm.registryUrl=http://localhost:6666',
       ],
     },

--- a/x-pack/test/functional_endpoint/config.ts
+++ b/x-pack/test/functional_endpoint/config.ts
@@ -30,8 +30,6 @@ export default async function({ readConfigFile }: FtrConfigProviderContext) {
         ...xpackFunctionalConfig.get('kbnTestServer.serverArgs'),
         '--xpack.endpoint.enabled=true',
         '--xpack.ingestManager.enabled=true',
-        '--xpack.ingestManager.epm.enabled=true',
-        '--xpack.ingestManager.fleet.enabled=true',
       ],
     },
   };


### PR DESCRIPTION
## Summary

`xpack.ingestManager.enabled` will also enable EPM & Fleet. They can still be disabled via the same `xpack.ingestManager.{epm,fleet}.enabled` flags