### PR TITLE
EMT-357: Move Exported Ingest Manager Services to plugin Start

### DIFF
--- a/x-pack/plugins/endpoint/server/endpoint_app_context_services.test.ts
+++ b/x-pack/plugins/endpoint/server/endpoint_app_context_services.test.ts
@@ -3,11 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { endpointAppContextServices } from './endpoint_app_context_services';
+import { EndpointAppContextService } from './endpoint_app_context_services';
 
 describe('test endpoint app context services', () => {
   it('should throw error if start is not called', async () => {
-    expect(() => endpointAppContextServices.getIndexPatternRetriever()).toThrow(Error);
-    expect(() => endpointAppContextServices.getAgentService()).toThrow(Error);
+    const endpointAppContextService = new EndpointAppContextService();
+    expect(() => endpointAppContextService.getIndexPatternRetriever()).toThrow(Error);
+    expect(() => endpointAppContextService.getAgentService()).toThrow(Error);
   });
 });

--- a/x-pack/plugins/endpoint/server/endpoint_app_context_services.test.ts
+++ b/x-pack/plugins/endpoint/server/endpoint_app_context_services.test.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { endpointAppContextServices } from './endpoint_app_context_services';
+
+describe('test endpoint app context services', () => {
+  it('should throw error if start is not called', async () => {
+    expect(() => endpointAppContextServices.getIndexPatternRetriever()).toThrow(Error);
+    expect(() => endpointAppContextServices.getAgentService()).toThrow(Error);
+  });
+});

--- a/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
+++ b/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
@@ -6,6 +6,10 @@
 import { IndexPatternRetriever } from './index_pattern';
 import { AgentService } from '../../ingest_manager/common/types';
 
+/**
+ * A singleton that holds shared services that are initialized during the start up phase
+ * of the plugin lifecycle. And stop during the stop phase, if needed.
+ */
 class EndpointAppContextService {
   private indexPatternRetriever: IndexPatternRetriever | undefined;
   private agentService: AgentService | undefined;

--- a/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
+++ b/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
@@ -10,7 +10,7 @@ import { AgentService } from '../../ingest_manager/common/types';
  * A singleton that holds shared services that are initialized during the start up phase
  * of the plugin lifecycle. And stop during the stop phase, if needed.
  */
-class EndpointAppContextService {
+export class EndpointAppContextService {
   private indexPatternRetriever: IndexPatternRetriever | undefined;
   private agentService: AgentService | undefined;
 
@@ -38,5 +38,3 @@ class EndpointAppContextService {
     return this.indexPatternRetriever;
   }
 }
-
-export const endpointAppContextServices = new EndpointAppContextService();

--- a/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
+++ b/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { IndexPatternRetriever } from './index_pattern';
+import { AgentService } from '../../ingest_manager/common/types';
+
+class EndpointAppContextService {
+  private indexPatternRetriever: IndexPatternRetriever | undefined;
+  private agentService: AgentService | undefined;
+
+  public start(dependencies: {
+    indexPatternRetriever: IndexPatternRetriever;
+    agentService: AgentService;
+  }) {
+    this.indexPatternRetriever = dependencies.indexPatternRetriever;
+    this.agentService = dependencies.agentService;
+  }
+
+  public stop() {}
+
+  public getAgentService(): AgentService {
+    if (!this.agentService) {
+      throw new Error(`must call start on ${EndpointAppContextService.name} to call getter`);
+    }
+    return this.agentService;
+  }
+
+  public getIndexPatternRetriever(): IndexPatternRetriever {
+    if (!this.indexPatternRetriever) {
+      throw new Error(`must call start on ${EndpointAppContextService.name} to call getter`);
+    }
+    return this.indexPatternRetriever;
+  }
+}
+
+export const endpointAppContextServices = new EndpointAppContextService();

--- a/x-pack/plugins/endpoint/server/index_pattern.ts
+++ b/x-pack/plugins/endpoint/server/index_pattern.ts
@@ -4,8 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { Logger, LoggerFactory, RequestHandlerContext } from 'kibana/server';
-import { ESIndexPatternService } from '../../ingest_manager/server';
 import { EndpointAppConstants } from '../common/types';
+import { ESIndexPatternService } from '../../ingest_manager/common/types';
 
 export interface IndexPatternRetriever {
   getIndexPattern(ctx: RequestHandlerContext, datasetPath: string): Promise<string>;

--- a/x-pack/plugins/endpoint/server/mocks.ts
+++ b/x-pack/plugins/endpoint/server/mocks.ts
@@ -4,8 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { IngestManagerSetupContract } from '../../ingest_manager/server';
-import { AgentService } from '../../ingest_manager/common/types';
+import { AgentService, IngestManagerStartupContract } from '../../ingest_manager/common/types';
 
 /**
  * Creates a mock IndexPatternRetriever for use in tests.
@@ -47,9 +46,9 @@ export const createMockAgentService = (): jest.Mocked<AgentService> => {
  * @param indexPattern a string index pattern to return when called by a test
  * @returns the same value as `indexPattern` parameter
  */
-export const createMockIngestManagerSetupContract = (
+export const createMockIngestManagerStartupContract = (
   indexPattern: string
-): IngestManagerSetupContract => {
+): IngestManagerStartupContract => {
   return {
     esIndexPatternService: {
       getESIndexPattern: jest.fn().mockResolvedValue(indexPattern),

--- a/x-pack/plugins/endpoint/server/plugin.test.ts
+++ b/x-pack/plugins/endpoint/server/plugin.test.ts
@@ -12,7 +12,6 @@ import {
 import { coreMock } from '../../../../src/core/server/mocks';
 import { PluginSetupContract } from '../../features/server';
 import { createMockIngestManagerStartupContract } from './mocks';
-import { endpointAppContextServices } from './endpoint_app_context_services';
 
 describe('test endpoint plugin', () => {
   let plugin: EndpointPlugin;
@@ -46,6 +45,8 @@ describe('test endpoint plugin', () => {
     await plugin.setup(mockCoreSetup, mockedEndpointPluginSetupDependencies);
     expect(mockedPluginSetupContract.registerFeature).toBeCalledTimes(1);
     expect(mockCoreSetup.http.createRouter).toBeCalledTimes(1);
+    expect(() => plugin.getEndpointAppContextService().getIndexPatternRetriever()).toThrow(Error);
+    expect(() => plugin.getEndpointAppContextService().getAgentService()).toThrow(Error);
   });
 
   it('test properly start plugin', async () => {
@@ -53,7 +54,7 @@ describe('test endpoint plugin', () => {
       ingestManager: createMockIngestManagerStartupContract(''),
     };
     await plugin.start(mockCoreStart, mockedEndpointPluginStartDependencies);
-    expect(endpointAppContextServices.getAgentService()).toBeTruthy();
-    expect(endpointAppContextServices.getIndexPatternRetriever()).toBeTruthy();
+    expect(plugin.getEndpointAppContextService().getAgentService()).toBeTruthy();
+    expect(plugin.getEndpointAppContextService().getIndexPatternRetriever()).toBeTruthy();
   });
 });

--- a/x-pack/plugins/endpoint/server/plugin.test.ts
+++ b/x-pack/plugins/endpoint/server/plugin.test.ts
@@ -4,15 +4,22 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EndpointPlugin, EndpointPluginSetupDependencies } from './plugin';
+import {
+  EndpointPlugin,
+  EndpointPluginSetupDependencies,
+  EndpointPluginStartDependencies,
+} from './plugin';
 import { coreMock } from '../../../../src/core/server/mocks';
 import { PluginSetupContract } from '../../features/server';
-import { createMockIngestManagerSetupContract } from './mocks';
+import { createMockIngestManagerStartupContract } from './mocks';
+import { endpointAppContextServices } from './endpoint_app_context_services';
 
 describe('test endpoint plugin', () => {
   let plugin: EndpointPlugin;
   let mockCoreSetup: ReturnType<typeof coreMock.createSetup>;
+  let mockCoreStart: ReturnType<typeof coreMock.createStart>;
   let mockedEndpointPluginSetupDependencies: jest.Mocked<EndpointPluginSetupDependencies>;
+  let mockedEndpointPluginStartDependencies: jest.Mocked<EndpointPluginStartDependencies>;
   let mockedPluginSetupContract: jest.Mocked<PluginSetupContract>;
   beforeEach(() => {
     plugin = new EndpointPlugin(
@@ -23,21 +30,30 @@ describe('test endpoint plugin', () => {
     );
 
     mockCoreSetup = coreMock.createSetup();
+    mockCoreStart = coreMock.createStart();
     mockedPluginSetupContract = {
       registerFeature: jest.fn(),
       getFeatures: jest.fn(),
       getFeaturesUICapabilities: jest.fn(),
       registerLegacyAPI: jest.fn(),
     };
-    mockedEndpointPluginSetupDependencies = {
-      features: mockedPluginSetupContract,
-      ingestManager: createMockIngestManagerSetupContract(''),
-    };
   });
 
   it('test properly setup plugin', async () => {
+    mockedEndpointPluginSetupDependencies = {
+      features: mockedPluginSetupContract,
+    };
     await plugin.setup(mockCoreSetup, mockedEndpointPluginSetupDependencies);
     expect(mockedPluginSetupContract.registerFeature).toBeCalledTimes(1);
     expect(mockCoreSetup.http.createRouter).toBeCalledTimes(1);
+  });
+
+  it('test properly start plugin', async () => {
+    mockedEndpointPluginStartDependencies = {
+      ingestManager: createMockIngestManagerStartupContract(''),
+    };
+    await plugin.start(mockCoreStart, mockedEndpointPluginStartDependencies);
+    expect(endpointAppContextServices.getAgentService()).toBeTruthy();
+    expect(endpointAppContextServices.getIndexPatternRetriever()).toBeTruthy();
   });
 });

--- a/x-pack/plugins/endpoint/server/plugin.ts
+++ b/x-pack/plugins/endpoint/server/plugin.ts
@@ -36,10 +36,9 @@ export class EndpointPlugin
       EndpointPluginStartDependencies
     > {
   private readonly logger: Logger;
-  private readonly endpointAppContextService: EndpointAppContextService;
+  private readonly endpointAppContextService: EndpointAppContextService = new EndpointAppContextService();
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.logger = this.initializerContext.logger.get('endpoint');
-    this.endpointAppContextService = new EndpointAppContextService();
   }
 
   public getEndpointAppContextService(): EndpointAppContextService {

--- a/x-pack/plugins/endpoint/server/routes/alerts/alerts.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/alerts.test.ts
@@ -13,6 +13,7 @@ import { registerAlertRoutes } from './index';
 import { EndpointConfigSchema } from '../../config';
 import { alertingIndexGetQuerySchema } from '../../../common/schema/alert_index';
 import { createMockAgentService, createMockIndexPatternRetriever } from '../../mocks';
+import { endpointAppContextServices } from '../../endpoint_app_context_services';
 
 describe('test alerts route', () => {
   let routerMock: jest.Mocked<IRouter>;
@@ -24,13 +25,19 @@ describe('test alerts route', () => {
     mockScopedClient = elasticsearchServiceMock.createScopedClusterClient();
     mockClusterClient.asScoped.mockReturnValue(mockScopedClient);
     routerMock = httpServiceMock.createRouter();
-    registerAlertRoutes(routerMock, {
+
+    endpointAppContextServices.start({
       indexPatternRetriever: createMockIndexPatternRetriever('events-endpoint-*'),
       agentService: createMockAgentService(),
+    });
+
+    registerAlertRoutes(routerMock, {
       logFactory: loggingServiceMock.create(),
       config: () => Promise.resolve(EndpointConfigSchema.validate({})),
     });
   });
+
+  afterEach(() => endpointAppContextServices.stop());
 
   it('should fail to validate when `page_size` is not a number', async () => {
     const validate = () => {

--- a/x-pack/plugins/endpoint/server/routes/alerts/details/handlers.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/details/handlers.ts
@@ -10,6 +10,7 @@ import { EndpointAppContext } from '../../../types';
 import { AlertDetailsRequestParams } from '../types';
 import { AlertDetailsPagination } from './lib';
 import { getHostData } from '../../metadata';
+import { endpointAppContextServices } from '../../../endpoint_app_context_services';
 
 export const alertDetailsHandlerWrapper = function(
   endpointAppContext: EndpointAppContext
@@ -26,7 +27,9 @@ export const alertDetailsHandlerWrapper = function(
         id: alertId,
       })) as GetResponse<AlertEvent>;
 
-      const indexPattern = await endpointAppContext.indexPatternRetriever.getEventIndexPattern(ctx);
+      const indexPattern = await endpointAppContextServices
+        .getIndexPatternRetriever()
+        .getEventIndexPattern(ctx);
 
       const config = await endpointAppContext.config();
       const pagination: AlertDetailsPagination = new AlertDetailsPagination(

--- a/x-pack/plugins/endpoint/server/routes/alerts/details/handlers.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/details/handlers.ts
@@ -10,7 +10,6 @@ import { EndpointAppContext } from '../../../types';
 import { AlertDetailsRequestParams } from '../types';
 import { AlertDetailsPagination } from './lib';
 import { getHostData } from '../../metadata';
-import { endpointAppContextServices } from '../../../endpoint_app_context_services';
 
 export const alertDetailsHandlerWrapper = function(
   endpointAppContext: EndpointAppContext
@@ -27,7 +26,7 @@ export const alertDetailsHandlerWrapper = function(
         id: alertId,
       })) as GetResponse<AlertEvent>;
 
-      const indexPattern = await endpointAppContextServices
+      const indexPattern = await endpointAppContext.service
         .getIndexPatternRetriever()
         .getEventIndexPattern(ctx);
 

--- a/x-pack/plugins/endpoint/server/routes/alerts/list/handlers.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/list/handlers.ts
@@ -8,6 +8,7 @@ import { EndpointAppContext } from '../../../types';
 import { searchESForAlerts } from '../lib';
 import { getRequestData, mapToAlertResultList } from './lib';
 import { AlertingIndexGetQueryResult } from '../../../../common/types';
+import { endpointAppContextServices } from '../../../endpoint_app_context_services';
 
 export const alertListHandlerWrapper = function(
   endpointAppContext: EndpointAppContext
@@ -18,7 +19,9 @@ export const alertListHandlerWrapper = function(
     res
   ) => {
     try {
-      const indexPattern = await endpointAppContext.indexPatternRetriever.getEventIndexPattern(ctx);
+      const indexPattern = await endpointAppContextServices
+        .getIndexPatternRetriever()
+        .getEventIndexPattern(ctx);
       const reqData = await getRequestData(req, endpointAppContext);
       const response = await searchESForAlerts(
         ctx.core.elasticsearch.dataClient,

--- a/x-pack/plugins/endpoint/server/routes/alerts/list/handlers.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/list/handlers.ts
@@ -8,7 +8,6 @@ import { EndpointAppContext } from '../../../types';
 import { searchESForAlerts } from '../lib';
 import { getRequestData, mapToAlertResultList } from './lib';
 import { AlertingIndexGetQueryResult } from '../../../../common/types';
-import { endpointAppContextServices } from '../../../endpoint_app_context_services';
 
 export const alertListHandlerWrapper = function(
   endpointAppContext: EndpointAppContext
@@ -19,7 +18,7 @@ export const alertListHandlerWrapper = function(
     res
   ) => {
     try {
-      const indexPattern = await endpointAppContextServices
+      const indexPattern = await endpointAppContext.service
         .getIndexPatternRetriever()
         .getEventIndexPattern(ctx);
       const reqData = await getRequestData(req, endpointAppContext);

--- a/x-pack/plugins/endpoint/server/routes/index_pattern.ts
+++ b/x-pack/plugins/endpoint/server/routes/index_pattern.ts
@@ -8,14 +8,12 @@ import { IRouter, Logger, RequestHandler } from 'kibana/server';
 import { EndpointAppContext } from '../types';
 import { IndexPatternGetParamsResult, EndpointAppConstants } from '../../common/types';
 import { indexPatternGetParamsSchema } from '../../common/schema/index_pattern';
-import { IndexPatternRetriever } from '../index_pattern';
+import { endpointAppContextServices } from '../endpoint_app_context_services';
 
-function handleIndexPattern(
-  log: Logger,
-  indexRetriever: IndexPatternRetriever
-): RequestHandler<IndexPatternGetParamsResult> {
+function handleIndexPattern(log: Logger): RequestHandler<IndexPatternGetParamsResult> {
   return async (context, req, res) => {
     try {
+      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
       return res.ok({
         body: {
           indexPattern: await indexRetriever.getIndexPattern(context, req.params.datasetPath),
@@ -37,6 +35,6 @@ export function registerIndexPatternRoute(router: IRouter, endpointAppContext: E
       validate: { params: indexPatternGetParamsSchema },
       options: { authRequired: true },
     },
-    handleIndexPattern(log, endpointAppContext.indexPatternRetriever)
+    handleIndexPattern(log)
   );
 }

--- a/x-pack/plugins/endpoint/server/routes/index_pattern.ts
+++ b/x-pack/plugins/endpoint/server/routes/index_pattern.ts
@@ -8,12 +8,14 @@ import { IRouter, Logger, RequestHandler } from 'kibana/server';
 import { EndpointAppContext } from '../types';
 import { IndexPatternGetParamsResult, EndpointAppConstants } from '../../common/types';
 import { indexPatternGetParamsSchema } from '../../common/schema/index_pattern';
-import { endpointAppContextServices } from '../endpoint_app_context_services';
 
-function handleIndexPattern(log: Logger): RequestHandler<IndexPatternGetParamsResult> {
+function handleIndexPattern(
+  log: Logger,
+  endpointAppContext: EndpointAppContext
+): RequestHandler<IndexPatternGetParamsResult> {
   return async (context, req, res) => {
     try {
-      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
+      const indexRetriever = endpointAppContext.service.getIndexPatternRetriever();
       return res.ok({
         body: {
           indexPattern: await indexRetriever.getIndexPattern(context, req.params.datasetPath),
@@ -35,6 +37,6 @@ export function registerIndexPatternRoute(router: IRouter, endpointAppContext: E
       validate: { params: indexPatternGetParamsSchema },
       options: { authRequired: true },
     },
-    handleIndexPattern(log)
+    handleIndexPattern(log, endpointAppContext)
   );
 }

--- a/x-pack/plugins/endpoint/server/routes/metadata/index.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/index.ts
@@ -12,7 +12,6 @@ import { getESQueryHostMetadataByID, kibanaRequestToMetadataListESQuery } from '
 import { HostInfo, HostMetadata, HostResultList, HostStatus } from '../../../common/types';
 import { EndpointAppContext } from '../../types';
 import { AgentStatus } from '../../../../ingest_manager/common/types/models';
-import { endpointAppContextServices } from '../../endpoint_app_context_services';
 
 interface HitSource {
   _source: HostMetadata;
@@ -62,7 +61,7 @@ export function registerEndpointRoutes(router: IRouter, endpointAppContext: Endp
     },
     async (context, req, res) => {
       try {
-        const index = await endpointAppContextServices
+        const index = await endpointAppContext.service
           .getIndexPatternRetriever()
           .getMetadataIndexPattern(context);
         const queryParams = await kibanaRequestToMetadataListESQuery(
@@ -118,7 +117,7 @@ export async function getHostData(
   metadataRequestContext: MetadataRequestContext,
   id: string
 ): Promise<HostInfo | undefined> {
-  const index = await endpointAppContextServices
+  const index = await metadataRequestContext.endpointAppContext.service
     .getIndexPatternRetriever()
     .getMetadataIndexPattern(metadataRequestContext.requestHandlerContext);
   const query = getESQueryHostMetadataByID(id, index);
@@ -180,7 +179,7 @@ async function enrichHostMetadata(
       log.warn(`Missing elastic agent id, using host id instead ${elasticAgentId}`);
     }
 
-    const status = await endpointAppContextServices
+    const status = await metadataRequestContext.endpointAppContext.service
       .getAgentService()
       .getAgentStatusById(
         metadataRequestContext.requestHandlerContext.core.savedObjects.client,

--- a/x-pack/plugins/endpoint/server/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/metadata.test.ts
@@ -28,6 +28,7 @@ import * as data from '../../test_data/all_metadata_data.json';
 import { createMockAgentService, createMockMetadataIndexPatternRetriever } from '../../mocks';
 import { AgentService } from '../../../../ingest_manager/common/types';
 import Boom from 'boom';
+import { endpointAppContextServices } from '../../endpoint_app_context_services';
 
 describe('test endpoint route', () => {
   let routerMock: jest.Mocked<IRouter>;
@@ -49,13 +50,19 @@ describe('test endpoint route', () => {
     routerMock = httpServiceMock.createRouter();
     mockResponse = httpServerMock.createResponseFactory();
     mockAgentService = createMockAgentService();
-    registerEndpointRoutes(routerMock, {
+
+    endpointAppContextServices.start({
       indexPatternRetriever: createMockMetadataIndexPatternRetriever(),
       agentService: mockAgentService,
+    });
+
+    registerEndpointRoutes(routerMock, {
       logFactory: loggingServiceMock.create(),
       config: () => Promise.resolve(EndpointConfigSchema.validate({})),
     });
   });
+
+  afterEach(() => endpointAppContextServices.stop());
 
   function createRouteHandlerContext(
     dataClient: jest.Mocked<IScopedClusterClient>,

--- a/x-pack/plugins/endpoint/server/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/metadata.test.ts
@@ -28,7 +28,7 @@ import * as data from '../../test_data/all_metadata_data.json';
 import { createMockAgentService, createMockMetadataIndexPatternRetriever } from '../../mocks';
 import { AgentService } from '../../../../ingest_manager/common/types';
 import Boom from 'boom';
-import { endpointAppContextServices } from '../../endpoint_app_context_services';
+import { EndpointAppContextService } from '../../endpoint_app_context_services';
 
 describe('test endpoint route', () => {
   let routerMock: jest.Mocked<IRouter>;
@@ -39,6 +39,7 @@ describe('test endpoint route', () => {
   let routeHandler: RequestHandler<any, any, any>;
   let routeConfig: RouteConfig<any, any, any, any>;
   let mockAgentService: jest.Mocked<AgentService>;
+  let endpointAppContextService: EndpointAppContextService;
 
   beforeEach(() => {
     mockClusterClient = elasticsearchServiceMock.createClusterClient() as jest.Mocked<
@@ -50,19 +51,20 @@ describe('test endpoint route', () => {
     routerMock = httpServiceMock.createRouter();
     mockResponse = httpServerMock.createResponseFactory();
     mockAgentService = createMockAgentService();
-
-    endpointAppContextServices.start({
+    endpointAppContextService = new EndpointAppContextService();
+    endpointAppContextService.start({
       indexPatternRetriever: createMockMetadataIndexPatternRetriever(),
       agentService: mockAgentService,
     });
 
     registerEndpointRoutes(routerMock, {
       logFactory: loggingServiceMock.create(),
+      service: endpointAppContextService,
       config: () => Promise.resolve(EndpointConfigSchema.validate({})),
     });
   });
 
-  afterEach(() => endpointAppContextServices.stop());
+  afterEach(() => endpointAppContextService.stop());
 
   function createRouteHandlerContext(
     dataClient: jest.Mocked<IScopedClusterClient>,

--- a/x-pack/plugins/endpoint/server/routes/metadata/query_builders.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/query_builders.test.ts
@@ -7,6 +7,7 @@ import { httpServerMock, loggingServiceMock } from '../../../../../../src/core/s
 import { EndpointConfigSchema } from '../../config';
 import { kibanaRequestToMetadataListESQuery, getESQueryHostMetadataByID } from './query_builders';
 import { MetadataIndexPattern } from '../../mocks';
+import { EndpointAppContextService } from '../../endpoint_app_context_services';
 
 describe('query builder', () => {
   describe('MetadataListESQuery', () => {
@@ -18,6 +19,7 @@ describe('query builder', () => {
         mockRequest,
         {
           logFactory: loggingServiceMock.create(),
+          service: new EndpointAppContextService(),
           config: () => Promise.resolve(EndpointConfigSchema.validate({})),
         },
         MetadataIndexPattern
@@ -68,6 +70,7 @@ describe('query builder', () => {
         mockRequest,
         {
           logFactory: loggingServiceMock.create(),
+          service: new EndpointAppContextService(),
           config: () => Promise.resolve(EndpointConfigSchema.validate({})),
         },
         MetadataIndexPattern

--- a/x-pack/plugins/endpoint/server/routes/metadata/query_builders.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/query_builders.test.ts
@@ -6,11 +6,7 @@
 import { httpServerMock, loggingServiceMock } from '../../../../../../src/core/server/mocks';
 import { EndpointConfigSchema } from '../../config';
 import { kibanaRequestToMetadataListESQuery, getESQueryHostMetadataByID } from './query_builders';
-import {
-  createMockAgentService,
-  createMockMetadataIndexPatternRetriever,
-  MetadataIndexPattern,
-} from '../../mocks';
+import { MetadataIndexPattern } from '../../mocks';
 
 describe('query builder', () => {
   describe('MetadataListESQuery', () => {
@@ -21,8 +17,6 @@ describe('query builder', () => {
       const query = await kibanaRequestToMetadataListESQuery(
         mockRequest,
         {
-          indexPatternRetriever: createMockMetadataIndexPatternRetriever(),
-          agentService: createMockAgentService(),
           logFactory: loggingServiceMock.create(),
           config: () => Promise.resolve(EndpointConfigSchema.validate({})),
         },
@@ -73,8 +67,6 @@ describe('query builder', () => {
       const query = await kibanaRequestToMetadataListESQuery(
         mockRequest,
         {
-          indexPatternRetriever: createMockMetadataIndexPatternRetriever(),
-          agentService: createMockAgentService(),
           logFactory: loggingServiceMock.create(),
           config: () => Promise.resolve(EndpointConfigSchema.validate({})),
         },

--- a/x-pack/plugins/endpoint/server/routes/resolver.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver.ts
@@ -19,7 +19,7 @@ export function registerResolverRoutes(router: IRouter, endpointAppContext: Endp
       validate: validateRelatedEvents,
       options: { authRequired: true },
     },
-    handleRelatedEvents(log)
+    handleRelatedEvents(log, endpointAppContext)
   );
 
   router.get(
@@ -28,7 +28,7 @@ export function registerResolverRoutes(router: IRouter, endpointAppContext: Endp
       validate: validateChildren,
       options: { authRequired: true },
     },
-    handleChildren(log)
+    handleChildren(log, endpointAppContext)
   );
 
   router.get(
@@ -37,6 +37,6 @@ export function registerResolverRoutes(router: IRouter, endpointAppContext: Endp
       validate: validateLifecycle,
       options: { authRequired: true },
     },
-    handleLifecycle(log)
+    handleLifecycle(log, endpointAppContext)
   );
 }

--- a/x-pack/plugins/endpoint/server/routes/resolver.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver.ts
@@ -12,7 +12,6 @@ import { handleLifecycle, validateLifecycle } from './resolver/lifecycle';
 
 export function registerResolverRoutes(router: IRouter, endpointAppContext: EndpointAppContext) {
   const log = endpointAppContext.logFactory.get('resolver');
-  const indexPatternService = endpointAppContext.indexPatternRetriever;
 
   router.get(
     {
@@ -20,7 +19,7 @@ export function registerResolverRoutes(router: IRouter, endpointAppContext: Endp
       validate: validateRelatedEvents,
       options: { authRequired: true },
     },
-    handleRelatedEvents(log, indexPatternService)
+    handleRelatedEvents(log)
   );
 
   router.get(
@@ -29,7 +28,7 @@ export function registerResolverRoutes(router: IRouter, endpointAppContext: Endp
       validate: validateChildren,
       options: { authRequired: true },
     },
-    handleChildren(log, indexPatternService)
+    handleChildren(log)
   );
 
   router.get(
@@ -38,6 +37,6 @@ export function registerResolverRoutes(router: IRouter, endpointAppContext: Endp
       validate: validateLifecycle,
       options: { authRequired: true },
     },
-    handleLifecycle(log, indexPatternService)
+    handleLifecycle(log)
   );
 }

--- a/x-pack/plugins/endpoint/server/routes/resolver/children.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/children.ts
@@ -11,7 +11,7 @@ import { extractEntityID } from './utils/normalize';
 import { getPaginationParams } from './utils/pagination';
 import { LifecycleQuery } from './queries/lifecycle';
 import { ChildrenQuery } from './queries/children';
-import { IndexPatternRetriever } from '../../index_pattern';
+import { endpointAppContextServices } from '../../endpoint_app_context_services';
 
 interface ChildrenQueryParams {
   after?: string;
@@ -46,8 +46,7 @@ export const validateChildren = {
 };
 
 export function handleChildren(
-  log: Logger,
-  indexRetriever: IndexPatternRetriever
+  log: Logger
 ): RequestHandler<ChildrenPathParams, ChildrenQueryParams> {
   return async (context, req, res) => {
     const {
@@ -55,6 +54,7 @@ export function handleChildren(
       query: { limit, after, legacyEndpointID },
     } = req;
     try {
+      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
       const pagination = getPaginationParams(limit, after);
       const indexPattern = await indexRetriever.getEventIndexPattern(context);
 

--- a/x-pack/plugins/endpoint/server/routes/resolver/children.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/children.ts
@@ -11,7 +11,7 @@ import { extractEntityID } from './utils/normalize';
 import { getPaginationParams } from './utils/pagination';
 import { LifecycleQuery } from './queries/lifecycle';
 import { ChildrenQuery } from './queries/children';
-import { endpointAppContextServices } from '../../endpoint_app_context_services';
+import { EndpointAppContext } from '../../types';
 
 interface ChildrenQueryParams {
   after?: string;
@@ -46,7 +46,8 @@ export const validateChildren = {
 };
 
 export function handleChildren(
-  log: Logger
+  log: Logger,
+  endpointAppContext: EndpointAppContext
 ): RequestHandler<ChildrenPathParams, ChildrenQueryParams> {
   return async (context, req, res) => {
     const {
@@ -54,7 +55,7 @@ export function handleChildren(
       query: { limit, after, legacyEndpointID },
     } = req;
     try {
-      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
+      const indexRetriever = endpointAppContext.service.getIndexPatternRetriever();
       const pagination = getPaginationParams(limit, after);
       const indexPattern = await indexRetriever.getEventIndexPattern(context);
 

--- a/x-pack/plugins/endpoint/server/routes/resolver/lifecycle.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/lifecycle.ts
@@ -9,7 +9,7 @@ import { RequestHandler, Logger } from 'kibana/server';
 import { extractParentEntityID } from './utils/normalize';
 import { LifecycleQuery } from './queries/lifecycle';
 import { ResolverEvent } from '../../../common/types';
-import { endpointAppContextServices } from '../../endpoint_app_context_services';
+import { EndpointAppContext } from '../../types';
 
 interface LifecycleQueryParams {
   ancestors: number;
@@ -46,7 +46,8 @@ function getParentEntityID(results: ResolverEvent[]) {
 }
 
 export function handleLifecycle(
-  log: Logger
+  log: Logger,
+  endpointAppContext: EndpointAppContext
 ): RequestHandler<LifecyclePathParams, LifecycleQueryParams> {
   return async (context, req, res) => {
     const {
@@ -54,7 +55,7 @@ export function handleLifecycle(
       query: { ancestors, legacyEndpointID },
     } = req;
     try {
-      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
+      const indexRetriever = endpointAppContext.service.getIndexPatternRetriever();
       const ancestorLifecycles = [];
       const client = context.core.elasticsearch.dataClient;
       const indexPattern = await indexRetriever.getEventIndexPattern(context);

--- a/x-pack/plugins/endpoint/server/routes/resolver/lifecycle.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/lifecycle.ts
@@ -4,13 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import _ from 'lodash';
 import { schema } from '@kbn/config-schema';
 import { RequestHandler, Logger } from 'kibana/server';
 import { extractParentEntityID } from './utils/normalize';
 import { LifecycleQuery } from './queries/lifecycle';
 import { ResolverEvent } from '../../../common/types';
-import { IndexPatternRetriever } from '../../index_pattern';
+import { endpointAppContextServices } from '../../endpoint_app_context_services';
 
 interface LifecycleQueryParams {
   ancestors: number;
@@ -47,8 +46,7 @@ function getParentEntityID(results: ResolverEvent[]) {
 }
 
 export function handleLifecycle(
-  log: Logger,
-  indexRetriever: IndexPatternRetriever
+  log: Logger
 ): RequestHandler<LifecyclePathParams, LifecycleQueryParams> {
   return async (context, req, res) => {
     const {
@@ -56,6 +54,7 @@ export function handleLifecycle(
       query: { ancestors, legacyEndpointID },
     } = req;
     try {
+      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
       const ancestorLifecycles = [];
       const client = context.core.elasticsearch.dataClient;
       const indexPattern = await indexRetriever.getEventIndexPattern(context);

--- a/x-pack/plugins/endpoint/server/routes/resolver/related_events.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/related_events.ts
@@ -8,7 +8,7 @@ import { schema } from '@kbn/config-schema';
 import { RequestHandler, Logger } from 'kibana/server';
 import { getPaginationParams } from './utils/pagination';
 import { RelatedEventsQuery } from './queries/related_events';
-import { IndexPatternRetriever } from '../../index_pattern';
+import { endpointAppContextServices } from '../../endpoint_app_context_services';
 
 interface RelatedEventsQueryParams {
   after?: string;
@@ -43,8 +43,7 @@ export const validateRelatedEvents = {
 };
 
 export function handleRelatedEvents(
-  log: Logger,
-  indexRetriever: IndexPatternRetriever
+  log: Logger
 ): RequestHandler<RelatedEventsPathParams, RelatedEventsQueryParams> {
   return async (context, req, res) => {
     const {
@@ -52,6 +51,7 @@ export function handleRelatedEvents(
       query: { limit, after, legacyEndpointID },
     } = req;
     try {
+      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
       const pagination = getPaginationParams(limit, after);
 
       const client = context.core.elasticsearch.dataClient;

--- a/x-pack/plugins/endpoint/server/routes/resolver/related_events.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/related_events.ts
@@ -8,7 +8,7 @@ import { schema } from '@kbn/config-schema';
 import { RequestHandler, Logger } from 'kibana/server';
 import { getPaginationParams } from './utils/pagination';
 import { RelatedEventsQuery } from './queries/related_events';
-import { endpointAppContextServices } from '../../endpoint_app_context_services';
+import { EndpointAppContext } from '../../types';
 
 interface RelatedEventsQueryParams {
   after?: string;
@@ -43,7 +43,8 @@ export const validateRelatedEvents = {
 };
 
 export function handleRelatedEvents(
-  log: Logger
+  log: Logger,
+  endpointAppContext: EndpointAppContext
 ): RequestHandler<RelatedEventsPathParams, RelatedEventsQueryParams> {
   return async (context, req, res) => {
     const {
@@ -51,7 +52,7 @@ export function handleRelatedEvents(
       query: { limit, after, legacyEndpointID },
     } = req;
     try {
-      const indexRetriever = endpointAppContextServices.getIndexPatternRetriever();
+      const indexRetriever = endpointAppContext.service.getIndexPatternRetriever();
       const pagination = getPaginationParams(limit, after);
 
       const client = context.core.elasticsearch.dataClient;

--- a/x-pack/plugins/endpoint/server/types.ts
+++ b/x-pack/plugins/endpoint/server/types.ts
@@ -5,6 +5,7 @@
  */
 import { LoggerFactory } from 'kibana/server';
 import { EndpointConfigType } from './config';
+import { EndpointAppContextService } from './endpoint_app_context_services';
 
 /**
  * The context for Endpoint apps.
@@ -12,4 +13,9 @@ import { EndpointConfigType } from './config';
 export interface EndpointAppContext {
   logFactory: LoggerFactory;
   config(): Promise<EndpointConfigType>;
+
+  /**
+   * Object readiness is tied to plugin start method
+   */
+  service: EndpointAppContextService;
 }

--- a/x-pack/plugins/endpoint/server/types.ts
+++ b/x-pack/plugins/endpoint/server/types.ts
@@ -5,15 +5,11 @@
  */
 import { LoggerFactory } from 'kibana/server';
 import { EndpointConfigType } from './config';
-import { IndexPatternRetriever } from './index_pattern';
-import { AgentService } from '../../ingest_manager/common/types';
 
 /**
  * The context for Endpoint apps.
  */
 export interface EndpointAppContext {
-  indexPatternRetriever: IndexPatternRetriever;
-  agentService: AgentService;
   logFactory: LoggerFactory;
   config(): Promise<EndpointConfigType>;
 }

--- a/x-pack/plugins/ingest_manager/common/types/index.ts
+++ b/x-pack/plugins/ingest_manager/common/types/index.ts
@@ -10,6 +10,25 @@ export * from './models';
 export * from './rest_spec';
 
 /**
+ * Service to return the index pattern of EPM packages
+ */
+export interface ESIndexPatternService {
+  getESIndexPattern(
+    savedObjectsClient: SavedObjectsClientContract,
+    pkgName: string,
+    datasetPath: string
+  ): Promise<string | undefined>;
+}
+
+/**
+ * Describes public IngestManager plugin contract returned at the `startup` stage.
+ */
+export interface IngestManagerStartupContract {
+  esIndexPatternService: ESIndexPatternService;
+  agentService: AgentService;
+}
+
+/**
  * A service that provides exported functions that return information about an Agent
  */
 export interface AgentService {

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -7,9 +7,6 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginInitializerContext } from 'src/core/server';
 import { IngestManagerPlugin } from './plugin';
 
-export { ESIndexPatternService } from './services';
-export { IngestManagerSetupContract } from './plugin';
-
 export const config = {
   exposeToBrowser: {
     epm: true,

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -39,21 +39,9 @@ import {
   registerInstallScriptRoutes,
 } from './routes';
 
-import { AgentService, IngestManagerConfigType } from '../common';
-import {
-  appContextService,
-  ESIndexPatternService,
-  ESIndexPatternSavedObjectService,
-} from './services';
+import { IngestManagerConfigType, IngestManagerStartupContract } from '../common';
+import { appContextService, ESIndexPatternSavedObjectService } from './services';
 import { getAgentStatusById } from './services/agents';
-
-/**
- * Describes public IngestManager plugin contract returned at the `setup` stage.
- */
-export interface IngestManagerSetupContract {
-  esIndexPatternService: ESIndexPatternService;
-  agentService: AgentService;
-}
 
 export interface IngestManagerSetupDeps {
   licensing: LicensingPluginSetup;
@@ -78,7 +66,7 @@ const allSavedObjectTypes = [
   ENROLLMENT_API_KEYS_SAVED_OBJECT_TYPE,
 ];
 
-export class IngestManagerPlugin implements Plugin<IngestManagerSetupContract> {
+export class IngestManagerPlugin implements Plugin<void, IngestManagerStartupContract> {
   private config$: Observable<IngestManagerConfigType>;
   private security: SecurityPluginSetup | undefined;
 
@@ -86,10 +74,7 @@ export class IngestManagerPlugin implements Plugin<IngestManagerSetupContract> {
     this.config$ = this.initializerContext.config.create<IngestManagerConfigType>();
   }
 
-  public async setup(
-    core: CoreSetup,
-    deps: IngestManagerSetupDeps
-  ): Promise<RecursiveReadonly<IngestManagerSetupContract>> {
+  public async setup(core: CoreSetup, deps: IngestManagerSetupDeps) {
     if (deps.security) {
       this.security = deps.security;
     }
@@ -148,12 +133,6 @@ export class IngestManagerPlugin implements Plugin<IngestManagerSetupContract> {
         basePath: core.http.basePath,
       });
     }
-    return deepFreeze({
-      esIndexPatternService: new ESIndexPatternSavedObjectService(),
-      agentService: {
-        getAgentStatusById,
-      },
-    });
   }
 
   public async start(
@@ -161,12 +140,18 @@ export class IngestManagerPlugin implements Plugin<IngestManagerSetupContract> {
     plugins: {
       encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
     }
-  ) {
+  ): Promise<RecursiveReadonly<IngestManagerStartupContract>> {
     appContextService.start({
       encryptedSavedObjects: plugins.encryptedSavedObjects,
       security: this.security,
       config$: this.config$,
       savedObjects: core.savedObjects,
+    });
+    return deepFreeze({
+      esIndexPatternService: new ESIndexPatternSavedObjectService(),
+      agentService: {
+        getAgentStatusById,
+      },
     });
   }
 

--- a/x-pack/plugins/ingest_manager/server/services/es_index_pattern.ts
+++ b/x-pack/plugins/ingest_manager/server/services/es_index_pattern.ts
@@ -4,15 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { SavedObjectsClientContract } from 'kibana/server';
-import { getInstallation } from './epm/packages/get';
-
-export interface ESIndexPatternService {
-  getESIndexPattern(
-    savedObjectsClient: SavedObjectsClientContract,
-    pkgName: string,
-    datasetPath: string
-  ): Promise<string | undefined>;
-}
+import { getInstallation } from './epm/packages';
+import { ESIndexPatternService } from '../../common/types';
 
 export class ESIndexPatternSavedObjectService implements ESIndexPatternService {
   public async getESIndexPattern(

--- a/x-pack/plugins/ingest_manager/server/services/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/index.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 export { appContextService } from './app_context';
-export { ESIndexPatternService, ESIndexPatternSavedObjectService } from './es_index_pattern';
+export { ESIndexPatternSavedObjectService } from './es_index_pattern';
 
 // Saved object services
 export { datasourceService } from './datasource';


### PR DESCRIPTION
## Summary
During the implementation the aforementioned stories we exposed some services in the Ingest Manager plugin at the plugin start up phase. This ticket is to move this to the startup phase, to avoid stability issue during the setup phase.

https://github.com/elastic/endpoint-app-team/issues/357
- [x] move exported service intialization to startup stage.
- [x] refactored endpoint to consume the exported services from the startup phase.
- [x] update all tests, and add new tests. 

### Checklist

Delete any items that are not applicable to this PR.
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

