### PR TITLE
fix new dashboard memory leak

### DIFF
--- a/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
@@ -620,6 +620,12 @@ export class DashboardAppController {
       ReactDOM.render(<navigation.ui.TopNavMenu {...getNavBarProps()} />, dashboardNavBar);
     };
 
+    const unmountNavBar = () => {
+      if (dashboardNavBar) {
+        ReactDOM.unmountComponentAtNode(dashboardNavBar);
+      }
+    };
+
     $scope.timefilterSubscriptions$ = new Subscription();
 
     $scope.timefilterSubscriptions$.add(
@@ -968,6 +974,9 @@ export class DashboardAppController {
     });
 
     $scope.$on('$destroy', () => {
+      // we have to unmount nav bar manually to make sure all internal subscriptions are unsubscribed
+      unmountNavBar();
+
       updateSubscription.unsubscribe();
       stopSyncingQueryServiceStateWithUrl();
       stopSyncingAppFilters();
@@ -980,6 +989,9 @@ export class DashboardAppController {
       }
       if (outputSubscription) {
         outputSubscription.unsubscribe();
+      }
+      if (dashboardContainer) {
+        dashboardContainer.destroy();
       }
     });
   }


### PR DESCRIPTION
## Summary

Following up on https://github.com/elastic/kibana/pull/61611#discussion_r412831922

After deangularizing navbar there was a weird test failure caused by new error in console: `embeddable was destroyed`. To reproduce it you had to:

1. go to dashboard
2. go to discover
3. get back to dashboard
4. change time in time picker -> `embeddable was destroyed` in console 

This was fixed by stoping calling `dashboardContainer.destroy()`. But I think this means, that we never clean up embeddables after navigating away from dashboard without page reload.  https://github.com/elastic/kibana/pull/61611#discussion_r412831922

This pr returns `dashboardContainer.destroy()` and adds addition logic for manually unmounting navbar. This should clean up all subscriptions on navigating away. I think previously this was just handled by angular directive

So I think the `embeddable was destroyed` in previous pr was because:

1. Embeddable was destroyed in container
2. when we navigated away we didn't destroy old instance of navbar. when time range get updated afterwards it still was listening to it and tried to notify destroyed dashboard.

Let's see if tests pass with this 🙏 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
