### PR TITLE
Move some server lifecycle types out of common.

### DIFF
--- a/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
+++ b/x-pack/plugins/endpoint/server/endpoint_app_context_services.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { IndexPatternRetriever } from './index_pattern';
-import { AgentService } from '../../ingest_manager/common/types';
+import { AgentService } from '../../ingest_manager/server';
 
 /**
  * A singleton that holds shared services that are initialized during the start up phase

--- a/x-pack/plugins/endpoint/server/index_pattern.ts
+++ b/x-pack/plugins/endpoint/server/index_pattern.ts
@@ -5,7 +5,7 @@
  */
 import { Logger, LoggerFactory, RequestHandlerContext } from 'kibana/server';
 import { EndpointAppConstants } from '../common/types';
-import { ESIndexPatternService } from '../../ingest_manager/common/types';
+import { ESIndexPatternService } from '../../ingest_manager/server';
 
 export interface IndexPatternRetriever {
   getIndexPattern(ctx: RequestHandlerContext, datasetPath: string): Promise<string>;

--- a/x-pack/plugins/endpoint/server/mocks.ts
+++ b/x-pack/plugins/endpoint/server/mocks.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { AgentService, IngestManagerStartupContract } from '../../ingest_manager/common/types';
+import { AgentService, IngestManagerStartContract } from '../../ingest_manager/server';
 
 /**
  * Creates a mock IndexPatternRetriever for use in tests.
@@ -46,9 +46,9 @@ export const createMockAgentService = (): jest.Mocked<AgentService> => {
  * @param indexPattern a string index pattern to return when called by a test
  * @returns the same value as `indexPattern` parameter
  */
-export const createMockIngestManagerStartupContract = (
+export const createMockIngestManagerStartContract = (
   indexPattern: string
-): IngestManagerStartupContract => {
+): IngestManagerStartContract => {
   return {
     esIndexPatternService: {
       getESIndexPattern: jest.fn().mockResolvedValue(indexPattern),

--- a/x-pack/plugins/endpoint/server/plugin.test.ts
+++ b/x-pack/plugins/endpoint/server/plugin.test.ts
@@ -11,7 +11,7 @@ import {
 } from './plugin';
 import { coreMock } from '../../../../src/core/server/mocks';
 import { PluginSetupContract } from '../../features/server';
-import { createMockIngestManagerStartupContract } from './mocks';
+import { createMockIngestManagerStartContract } from './mocks';
 
 describe('test endpoint plugin', () => {
   let plugin: EndpointPlugin;
@@ -51,7 +51,7 @@ describe('test endpoint plugin', () => {
 
   it('test properly start plugin', async () => {
     mockedEndpointPluginStartDependencies = {
-      ingestManager: createMockIngestManagerStartupContract(''),
+      ingestManager: createMockIngestManagerStartContract(''),
     };
     await plugin.start(mockCoreStart, mockedEndpointPluginStartDependencies);
     expect(plugin.getEndpointAppContextService().getAgentService()).toBeTruthy();

--- a/x-pack/plugins/endpoint/server/plugin.ts
+++ b/x-pack/plugins/endpoint/server/plugin.ts
@@ -14,13 +14,13 @@ import { registerResolverRoutes } from './routes/resolver';
 import { registerIndexPatternRoute } from './routes/index_pattern';
 import { registerEndpointRoutes } from './routes/metadata';
 import { IngestIndexPatternRetriever } from './index_pattern';
-import { IngestManagerStartupContract } from '../../ingest_manager/common/types';
+import { IngestManagerStartContract } from '../../ingest_manager/server';
 import { EndpointAppContextService } from './endpoint_app_context_services';
 
 export type EndpointPluginStart = void;
 export type EndpointPluginSetup = void;
 export interface EndpointPluginStartDependencies {
-  ingestManager: IngestManagerStartupContract;
+  ingestManager: IngestManagerStartContract;
 }
 
 export interface EndpointPluginSetupDependencies {

--- a/x-pack/plugins/endpoint/server/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/endpoint/server/routes/metadata/metadata.test.ts
@@ -26,7 +26,7 @@ import { registerEndpointRoutes } from './index';
 import { EndpointConfigSchema } from '../../config';
 import * as data from '../../test_data/all_metadata_data.json';
 import { createMockAgentService, createMockMetadataIndexPatternRetriever } from '../../mocks';
-import { AgentService } from '../../../../ingest_manager/common/types';
+import { AgentService } from '../../../../ingest_manager/server';
 import Boom from 'boom';
 import { EndpointAppContextService } from '../../endpoint_app_context_services';
 

--- a/x-pack/plugins/ingest_manager/common/types/index.ts
+++ b/x-pack/plugins/ingest_manager/common/types/index.ts
@@ -3,42 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { SavedObjectsClientContract } from 'kibana/server';
-import { AgentStatus } from './models';
-
 export * from './models';
 export * from './rest_spec';
-
-/**
- * Service to return the index pattern of EPM packages
- */
-export interface ESIndexPatternService {
-  getESIndexPattern(
-    savedObjectsClient: SavedObjectsClientContract,
-    pkgName: string,
-    datasetPath: string
-  ): Promise<string | undefined>;
-}
-
-/**
- * Describes public IngestManager plugin contract returned at the `startup` stage.
- */
-export interface IngestManagerStartupContract {
-  esIndexPatternService: ESIndexPatternService;
-  agentService: AgentService;
-}
-
-/**
- * A service that provides exported functions that return information about an Agent
- */
-export interface AgentService {
-  /**
-   * Return the status by the Agent's id
-   * @param soClient
-   * @param agentId
-   */
-  getAgentStatusById(soClient: SavedObjectsClientContract, agentId: string): Promise<AgentStatus>;
-}
 
 export interface IngestManagerConfigType {
   enabled: boolean;

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -6,6 +6,12 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginInitializerContext } from 'src/core/server';
 import { IngestManagerPlugin } from './plugin';
+export { AgentService, ESIndexPatternService } from './services';
+export {
+  IngestManagerSetupContract,
+  IngestManagerSetupDeps,
+  IngestManagerStartContract,
+} from './plugin';
 
 export const config = {
   exposeToBrowser: {

--- a/x-pack/plugins/ingest_manager/server/services/es_index_pattern.ts
+++ b/x-pack/plugins/ingest_manager/server/services/es_index_pattern.ts
@@ -5,7 +5,7 @@
  */
 import { SavedObjectsClientContract } from 'kibana/server';
 import { getInstallation } from './epm/packages';
-import { ESIndexPatternService } from '../../common/types';
+import { ESIndexPatternService } from '../../server';
 
 export class ESIndexPatternSavedObjectService implements ESIndexPatternService {
   public async getESIndexPattern(

--- a/x-pack/plugins/ingest_manager/server/services/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/index.ts
@@ -3,8 +3,34 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+import { SavedObjectsClientContract } from 'kibana/server';
+import { AgentStatus } from '../../common/types/models';
+
 export { appContextService } from './app_context';
 export { ESIndexPatternSavedObjectService } from './es_index_pattern';
+
+/**
+ * Service to return the index pattern of EPM packages
+ */
+export interface ESIndexPatternService {
+  getESIndexPattern(
+    savedObjectsClient: SavedObjectsClientContract,
+    pkgName: string,
+    datasetPath: string
+  ): Promise<string | undefined>;
+}
+
+/**
+ * A service that provides exported functions that return information about an Agent
+ */
+export interface AgentService {
+  /**
+   * Return the status by the Agent's id
+   * @param soClient
+   * @param agentId
+   */
+  getAgentStatusById(soClient: SavedObjectsClientContract, agentId: string): Promise<AgentStatus>;
+}
 
 // Saved object services
 export { datasourceService } from './datasource';


### PR DESCRIPTION
## Summary

The `AgentService`, `ESIndexPatternService`, and `IngestManager{Setup,Start}{Deps,Contract}` values were in `common`, but they are server-only (at least for now)


