### PR TITLE
Graph: Remove reference to local application service in graph

### DIFF
--- a/x-pack/plugins/graph/public/_main.scss
+++ b/x-pack/plugins/graph/public/_main.scss
@@ -25,3 +25,9 @@
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
 }
+
+.gphAppWrapper {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}

--- a/x-pack/plugins/graph/public/application.ts
+++ b/x-pack/plugins/graph/public/application.ts
@@ -96,7 +96,7 @@ export const renderApp = ({ appBasePath, element, ...deps }: GraphDependencies) 
   };
 };
 
-const mainTemplate = (basePath: string) => `<div ng-view class="kbnLocalApplicationWrapper">
+const mainTemplate = (basePath: string) => `<div ng-view class="gphAppWrapper">
   <base href="${basePath}" />
 </div>
 `;
@@ -107,14 +107,14 @@ const thirdPartyAngularDependencies = ['ngSanitize', 'ngRoute', 'react', 'ui.boo
 
 function mountGraphApp(appBasePath: string, element: HTMLElement) {
   const mountpoint = document.createElement('div');
-  mountpoint.setAttribute('class', 'kbnLocalApplicationWrapper');
+  mountpoint.setAttribute('class', 'gphAppWrapper');
   // eslint-disable-next-line
   mountpoint.innerHTML = mainTemplate(appBasePath);
   // bootstrap angular into detached element and attach it later to
   // make angular-within-angular possible
   const $injector = angular.bootstrap(mountpoint, [moduleName]);
   element.appendChild(mountpoint);
-  element.setAttribute('class', 'kbnLocalApplicationWrapper');
+  element.setAttribute('class', 'gphAppWrapper');
   return $injector;
 }
 

--- a/x-pack/plugins/graph/public/index.scss
+++ b/x-pack/plugins/graph/public/index.scss
@@ -12,5 +12,3 @@
 @import './main';
 @import './angular/templates/index';
 @import './components/index';
-// Local application mount wrapper styles
-@import 'src/legacy/core_plugins/kibana/public/local_application_service/index';


### PR DESCRIPTION
The graph styles relied on a css class of the local application service.

This PR inlines the class in the graph app to make it independent.