### PR TITLE
[EPM] Restrict custom registry URL

### DIFF
--- a/x-pack/plugins/ingest_manager/common/constants/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/constants/epm.ts
@@ -6,3 +6,4 @@
 
 export const PACKAGES_SAVED_OBJECT_TYPE = 'epm-package';
 export const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
+export const DEFAULT_REGISTRY_URL = 'https://epr.elastic.co';

--- a/x-pack/plugins/ingest_manager/common/types/index.ts
+++ b/x-pack/plugins/ingest_manager/common/types/index.ts
@@ -10,7 +10,7 @@ export interface IngestManagerConfigType {
   enabled: boolean;
   epm: {
     enabled: boolean;
-    registryUrl: string;
+    registryUrl?: string;
   };
   fleet: {
     enabled: boolean;

--- a/x-pack/plugins/ingest_manager/server/constants/index.ts
+++ b/x-pack/plugins/ingest_manager/server/constants/index.ts
@@ -33,4 +33,5 @@ export {
   // Defaults
   DEFAULT_AGENT_CONFIG,
   DEFAULT_OUTPUT,
+  DEFAULT_REGISTRY_URL,
 } from '../../common';

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -22,7 +22,7 @@ export const config = {
     enabled: schema.boolean({ defaultValue: false }),
     epm: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
-      registryUrl: schema.uri({ defaultValue: 'https://epr-staging.elastic.co' }),
+      registryUrl: schema.maybe(schema.uri()),
     }),
     fleet: schema.object({
       enabled: schema.boolean({ defaultValue: true }),

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/index.ts
@@ -16,11 +16,11 @@ import {
   RegistrySearchResults,
   RegistrySearchResult,
 } from '../../../types';
-import { appContextService } from '../../';
 import { cacheGet, cacheSet } from './cache';
 import { ArchiveEntry, untarBuffer } from './extract';
 import { fetchUrl, getResponse, getResponseStream } from './requests';
 import { streamToBuffer } from './streams';
+import { getRegistryUrl } from './registry_url';
 
 export { ArchiveEntry } from './extract';
 
@@ -32,7 +32,7 @@ export const pkgToPkgKey = ({ name, version }: { name: string; version: string }
   `${name}-${version}`;
 
 export async function fetchList(params?: SearchParams): Promise<RegistrySearchResults> {
-  const registryUrl = appContextService.getConfig()?.epm.registryUrl;
+  const registryUrl = getRegistryUrl();
   const url = new URL(`${registryUrl}/search`);
   if (params && params.category) {
     url.searchParams.set('category', params.category);
@@ -45,7 +45,7 @@ export async function fetchFindLatestPackage(
   packageName: string,
   internal: boolean = true
 ): Promise<RegistrySearchResult> {
-  const registryUrl = appContextService.getConfig()?.epm.registryUrl;
+  const registryUrl = getRegistryUrl();
   const url = new URL(`${registryUrl}/search?package=${packageName}&internal=${internal}`);
   const res = await fetchUrl(url.toString());
   const searchResults = JSON.parse(res);
@@ -57,17 +57,17 @@ export async function fetchFindLatestPackage(
 }
 
 export async function fetchInfo(pkgName: string, pkgVersion: string): Promise<RegistryPackage> {
-  const registryUrl = appContextService.getConfig()?.epm.registryUrl;
+  const registryUrl = getRegistryUrl();
   return fetchUrl(`${registryUrl}/package/${pkgName}/${pkgVersion}`).then(JSON.parse);
 }
 
 export async function fetchFile(filePath: string): Promise<Response> {
-  const registryUrl = appContextService.getConfig()?.epm.registryUrl;
+  const registryUrl = getRegistryUrl();
   return getResponse(`${registryUrl}${filePath}`);
 }
 
 export async function fetchCategories(): Promise<CategorySummaryList> {
-  const registryUrl = appContextService.getConfig()?.epm.registryUrl;
+  const registryUrl = getRegistryUrl();
   return fetchUrl(`${registryUrl}/categories`).then(JSON.parse);
 }
 
@@ -151,7 +151,7 @@ async function getOrFetchArchiveBuffer(pkgName: string, pkgVersion: string): Pro
 
 async function fetchArchiveBuffer(pkgName: string, pkgVersion: string): Promise<Buffer> {
   const { download: archivePath } = await fetchInfo(pkgName, pkgVersion);
-  const registryUrl = appContextService.getConfig()?.epm.registryUrl;
+  const registryUrl = getRegistryUrl();
   return getResponseStream(`${registryUrl}${archivePath}`).then(streamToBuffer);
 }
 

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { DEFAULT_REGISTRY_URL } from '../../../constants';
+import { appContextService, licenseService } from '../../';
+
+export const getRegistryUrl = (): string => {
+  const license = licenseService.getLicenseInformation();
+  const customUrl = appContextService.getConfig()?.epm.registryUrl;
+
+  if (
+    customUrl &&
+    license &&
+    license.isAvailable &&
+    license.hasAtLeast('gold') &&
+    license.isActive
+  ) {
+    return customUrl;
+  }
+
+  return DEFAULT_REGISTRY_URL;
+};

--- a/x-pack/plugins/ingest_manager/server/services/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/index.ts
@@ -6,7 +6,6 @@
 import { SavedObjectsClientContract } from 'kibana/server';
 import { AgentStatus } from '../../common/types/models';
 
-export { appContextService } from './app_context';
 export { ESIndexPatternSavedObjectService } from './es_index_pattern';
 
 /**
@@ -36,3 +35,7 @@ export interface AgentService {
 export { datasourceService } from './datasource';
 export { agentConfigService } from './agent_config';
 export { outputService } from './output';
+
+// Plugin services
+export { appContextService } from './app_context';
+export { licenseService } from './license';


### PR DESCRIPTION
## Summary

This PR:

- Changes default registry URL to production registry (`epr-staging.elastic.co` -> `epr.elastic.co`)
- Restricts custom registry URL config based on license

#### Testing instructions
1. Add `console.log('using registry URL', registryUrl);` after [L35](https://github.com/elastic/kibana/compare/master...jen-huang:ingest/epr-config?expand=1#diff-f9a9efa8b6acced00995daf7e3279893R35)
2. Start ES and Kibana normally with trial license
3. Navigate to Integrations page, verify production URL in Kibana console
4. Restart Kibana with the flag `--xpack.ingestManager.epm.registryUrl=https://epr-staging.elastic.co`
5. Navigate to Integrations page, verify staging URL in Kibana console
6. Navigate to Management > License Management and click Revert to basic
7. Navigate back to Integrations page, verify production URL in Kibana console (means that custom registry URL was not applied)