### PR TITLE
[SDH] Cache-Control optimizations

### DIFF
--- a/src/optimize/bundles_route/dynamic_asset_response.js
+++ b/src/optimize/bundles_route/dynamic_asset_response.js
@@ -81,13 +81,18 @@ export async function createDynamicAssetResponse(options) {
     const content = replacePublicPath ? replacePlaceholder(read, publicPath) : read;
     const etag = replacePublicPath ? `${hash}-${publicPath}` : hash;
 
-    return h
-      .response(content)
-      .takeover()
-      .code(200)
-      .etag(etag)
-      .header('cache-control', 'must-revalidate')
-      .type(request.server.mime.path(path).type);
+    return (
+      h
+        .response(content)
+        .takeover()
+        .code(200)
+        .etag(etag)
+        // We want to allow the browsers to use the cached versions onload,
+        // but they must-revalidate and download the newer versions in the background
+        // (https://github.com/elastic/support-known-issues/issues/18)
+        .header('cache-control', 'stale-while-revalidate=86400; max-age=0; must-revalidate')
+        .type(request.server.mime.path(path).type)
+    );
   } catch (error) {
     if (fd) {
       try {


### PR DESCRIPTION
## Summary

Our Cache policy for serving JS and CSS bundled assets is `"must-revalidate"`, enforcing every request to actually reach the Kibana server to revalidate the the `etag` via the `If-None-Match` header. 

This makes Kibana super slow under connections with a high latency. It is easy to check with the network throttling the Dev Tools: In Chrome, if you set it to limit the network speed to `Slow 3G`, you can tell that, even when all the requests receive a `304` response, it takes MINUTES!! to load all the resources in the Home application:
![image](https://user-images.githubusercontent.com/5469006/80376879-5fad0a00-8892-11ea-98ad-80452bb879df.png)
_Mind the timings in the bottom of the screenshot_

I tested locally changing the cache policy to `cache-control: max-age=30; must-revalidate` (allow the browser to use the local files if they were validating less than 30s ago). With this, if I refresh the page before those 30s expire, the load time (with the throttling still on) is highly reduced:
![image](https://user-images.githubusercontent.com/5469006/80377747-92a3cd80-8893-11ea-93f4-18e0fb0cc57a.png)

Maybe we want to mark the assets as stale as soon as they are served but allow the browsers to use them to load the pages as quick as possible while revalidating and downloading in the background. This PR adds a combination of [`stale-while-revalidate`](https://web.dev/stale-while-revalidate/) with `max-age` and `must-revalidate`?

### Checklist

Delete any items that are not applicable to this PR.

- [X] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
