### PR TITLE
[Metrics UI] Fixes for editing alerts in alert management

### DIFF
--- a/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
+++ b/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { useCallback, useMemo, useEffect, useState } from 'react';
+import React, { ChangeEvent, useCallback, useMemo, useEffect, useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -225,6 +225,11 @@ export const Expressions: React.FC<Props> = props => {
     }
   }, [alertsContext.metadata, defaultExpression, source]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const handleFieldSearchChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => onFilterQuerySubmit(e.target.value),
+    [onFilterQuerySubmit]
+  );
+
   return (
     <>
       <EuiSpacer size={'m'} />
@@ -297,7 +302,7 @@ export const Expressions: React.FC<Props> = props => {
           />
         )) || (
           <EuiFieldSearch
-            onSearch={onFilterQuerySubmit}
+            onChange={handleFieldSearchChange}
             value={alertParams.filterQuery}
             fullWidth
           />

--- a/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
+++ b/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
@@ -13,6 +13,7 @@ import {
   EuiText,
   EuiFormRow,
   EuiButtonEmpty,
+  EuiFieldSearch,
 } from '@elastic/eui';
 import { IFieldType } from 'src/plugins/data/public';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -215,7 +216,12 @@ export const Expressions: React.FC<Props> = props => {
       }
       setAlertParams('sourceId', source?.id);
     } else {
-      setAlertParams('criteria', [defaultExpression]);
+      if (!alertParams.criteria) {
+        setAlertParams('criteria', [defaultExpression]);
+      }
+      if (!alertParams.sourceId) {
+        setAlertParams('sourceId', source?.id || 'default');
+      }
     }
   }, [alertsContext.metadata, defaultExpression, source]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -273,48 +279,52 @@ export const Expressions: React.FC<Props> = props => {
 
       <EuiSpacer size={'m'} />
 
-      {alertsContext.metadata && (
-        <>
-          <EuiFormRow
-            label={i18n.translate('xpack.infra.metrics.alertFlyout.filterLabel', {
-              defaultMessage: 'Filter (optional)',
-            })}
-            helpText={i18n.translate('xpack.infra.metrics.alertFlyout.filterHelpText', {
-              defaultMessage: 'Use a KQL expression to limit the scope of your alert trigger.',
-            })}
+      <EuiFormRow
+        label={i18n.translate('xpack.infra.metrics.alertFlyout.filterLabel', {
+          defaultMessage: 'Filter (optional)',
+        })}
+        helpText={i18n.translate('xpack.infra.metrics.alertFlyout.filterHelpText', {
+          defaultMessage: 'Use a KQL expression to limit the scope of your alert trigger.',
+        })}
+        fullWidth
+        compressed
+      >
+        {(alertsContext.metadata && (
+          <MetricsExplorerKueryBar
+            derivedIndexPattern={derivedIndexPattern}
+            onSubmit={onFilterQuerySubmit}
+            value={alertParams.filterQuery}
+          />
+        )) || (
+          <EuiFieldSearch
+            onSearch={onFilterQuerySubmit}
+            value={alertParams.filterQuery}
             fullWidth
-            compressed
-          >
-            <MetricsExplorerKueryBar
-              derivedIndexPattern={derivedIndexPattern}
-              onSubmit={onFilterQuerySubmit}
-              value={alertParams.filterQuery}
-            />
-          </EuiFormRow>
+          />
+        )}
+      </EuiFormRow>
 
-          <EuiSpacer size={'m'} />
-          <EuiFormRow
-            label={i18n.translate('xpack.infra.metrics.alertFlyout.createAlertPerText', {
-              defaultMessage: 'Create alert per (optional)',
-            })}
-            helpText={i18n.translate('xpack.infra.metrics.alertFlyout.createAlertPerHelpText', {
-              defaultMessage:
-                'Create an alert for every unique value. For example: "host.id" or "cloud.region".',
-            })}
-            fullWidth
-            compressed
-          >
-            <MetricsExplorerGroupBy
-              onChange={onGroupByChange}
-              fields={derivedIndexPattern.fields}
-              options={{
-                ...options,
-                groupBy: alertParams.groupBy || undefined,
-              }}
-            />
-          </EuiFormRow>
-        </>
-      )}
+      <EuiSpacer size={'m'} />
+      <EuiFormRow
+        label={i18n.translate('xpack.infra.metrics.alertFlyout.createAlertPerText', {
+          defaultMessage: 'Create alert per (optional)',
+        })}
+        helpText={i18n.translate('xpack.infra.metrics.alertFlyout.createAlertPerHelpText', {
+          defaultMessage:
+            'Create an alert for every unique value. For example: "host.id" or "cloud.region".',
+        })}
+        fullWidth
+        compressed
+      >
+        <MetricsExplorerGroupBy
+          onChange={onGroupByChange}
+          fields={derivedIndexPattern.fields}
+          options={{
+            ...options,
+            groupBy: alertParams.groupBy || undefined,
+          }}
+        />
+      </EuiFormRow>
     </>
   );
 };

--- a/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
+++ b/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
@@ -148,7 +148,7 @@ export const Expressions: React.FC<Props> = props => {
 
   const onGroupByChange = useCallback(
     (group: string | null) => {
-      setAlertParams('groupBy', group || undefined);
+      setAlertParams('groupBy', group || '');
     },
     [setAlertParams]
   );
@@ -212,7 +212,7 @@ export const Expressions: React.FC<Props> = props => {
           setAlertParams('filterQuery', filter);
         }
 
-        setAlertParams('groupBy', md.currentOptions.groupBy || '');
+        setAlertParams('groupBy', md.currentOptions.groupBy);
       }
       setAlertParams('sourceId', source?.id);
     } else {

--- a/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
+++ b/x-pack/plugins/infra/public/components/alerting/metrics/expression.tsx
@@ -212,7 +212,7 @@ export const Expressions: React.FC<Props> = props => {
           setAlertParams('filterQuery', filter);
         }
 
-        setAlertParams('groupBy', md.currentOptions.groupBy);
+        setAlertParams('groupBy', md.currentOptions.groupBy || '');
       }
       setAlertParams('sourceId', source?.id);
     } else {


### PR DESCRIPTION
## Summary

This PR closes #64012 by setting the `sourceId` when it's not properly set and this also fixes the missing filter and group-by fields.
