### PR TITLE
[Drilldowns] dashboard url param to merge filters

### DIFF
--- a/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
@@ -59,7 +59,7 @@ import {
   SavedObjectEmbeddableInput,
   ContainerOutput,
 } from '../../../embeddable/public';
-import { DashboardInitialSavedFiltersHandling, NavAction, SavedDashboardPanel } from '../types';
+import { DashboardSavedFiltersHandling, NavAction, SavedDashboardPanel } from '../types';
 
 import { showOptionsPopover } from './top_nav/show_options_popover';
 import { DashboardSaveModal } from './top_nav/save_modal';
@@ -141,7 +141,7 @@ export class DashboardAppController {
       chrome.docTitle.change(dash.title);
     }
 
-    const savedFiltersHandling: DashboardInitialSavedFiltersHandling =
+    const savedFiltersHandling: DashboardSavedFiltersHandling =
       $routeParams[DashboardConstants.SAVED_FILTERS_HANDLING_PARAM];
     if (savedFiltersHandling) {
       removeQueryParam(history, DashboardConstants.SAVED_FILTERS_HANDLING_PARAM);

--- a/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
@@ -59,7 +59,7 @@ import {
   SavedObjectEmbeddableInput,
   ContainerOutput,
 } from '../../../embeddable/public';
-import { NavAction, SavedDashboardPanel } from '../types';
+import { DashboardInitialSavedFiltersHandling, NavAction, SavedDashboardPanel } from '../types';
 
 import { showOptionsPopover } from './top_nav/show_options_popover';
 import { DashboardSaveModal } from './top_nav/save_modal';
@@ -141,6 +141,12 @@ export class DashboardAppController {
       chrome.docTitle.change(dash.title);
     }
 
+    const savedFiltersHandling: DashboardInitialSavedFiltersHandling =
+      $routeParams[DashboardConstants.SAVED_FILTERS_HANDLING_PARAM];
+    if (savedFiltersHandling) {
+      removeQueryParam(history, DashboardConstants.SAVED_FILTERS_HANDLING_PARAM);
+    }
+
     const dashboardStateManager = new DashboardStateManager({
       savedDashboard: dash,
       hideWriteControls: dashboardConfig.getHideWriteControls(),
@@ -148,6 +154,7 @@ export class DashboardAppController {
       kbnUrlStateStorage,
       history,
       usageCollection,
+      savedFiltersHandling,
     });
 
     // sync initial app filters from state to filterManager

--- a/src/plugins/dashboard/public/application/dashboard_state_manager.ts
+++ b/src/plugins/dashboard/public/application/dashboard_state_manager.ts
@@ -36,7 +36,7 @@ import {
   DashboardAppStateDefaults,
   DashboardAppStateInUrl,
   DashboardAppStateTransitions,
-  DashboardInitialSavedFiltersHandling,
+  DashboardSavedFiltersHandling,
   SavedDashboardPanel,
 } from '../types';
 import {
@@ -110,7 +110,7 @@ export class DashboardStateManager {
     kbnUrlStateStorage: IKbnUrlStateStorage;
     history: History;
     usageCollection?: UsageCollectionSetup;
-    savedFiltersHandling?: DashboardInitialSavedFiltersHandling;
+    savedFiltersHandling?: DashboardSavedFiltersHandling;
   }) {
     this.history = history;
     this.kibanaVersion = kibanaVersion;

--- a/src/plugins/dashboard/public/dashboard_constants.ts
+++ b/src/plugins/dashboard/public/dashboard_constants.ts
@@ -25,6 +25,7 @@ export const DashboardConstants = {
   ADD_EMBEDDABLE_TYPE: 'addEmbeddableType',
   DASHBOARDS_ID: 'dashboards',
   DASHBOARD_ID: 'dashboard',
+  SAVED_FILTERS_HANDLING_PARAM: 'savedFiltersHandling',
 };
 
 export function createDashboardEditUrl(id: string) {

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -129,3 +129,14 @@ export interface StagedFilter {
   operator: string;
   index: string;
 }
+
+/**
+ * When dashboard is loaded filters could come from 2 places:
+ * 1. From url
+ * 2. From dashboard's saved object
+ *
+ * Filters could be handled in 2 different ways:
+ * * override (default) - if there is state in the url, url is source of truth and filters from url take precedence over filters in saved object
+ * * merge - filters from url are merge together with filters from saved object
+ */
+export type DashboardInitialSavedFiltersHandling = 'merge' | 'override';

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -139,4 +139,4 @@ export interface StagedFilter {
  * * override (default) - if there is state in the url, url is source of truth and filters from url take precedence over filters in saved object
  * * merge - filters from url are merge together with filters from saved object
  */
-export type DashboardInitialSavedFiltersHandling = 'merge' | 'override';
+export type DashboardSavedFiltersHandling = 'merge' | 'override';

--- a/src/plugins/dashboard/public/url_generator.test.ts
+++ b/src/plugins/dashboard/public/url_generator.test.ts
@@ -22,6 +22,7 @@ import { hashedItemStore } from '../../kibana_utils/public';
 // eslint-disable-next-line
 import { mockStorage } from '../../kibana_utils/public/storage/hashed_item_store/mock';
 import { esFilters } from '../../data/public';
+import { DashboardConstants } from './dashboard_constants';
 
 const APP_BASE_PATH: string = 'xyz/app/kibana';
 
@@ -126,7 +127,9 @@ describe('dashboard url generator', () => {
       Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
     );
     const url = await generator.createUrl!({});
-    expect(url).toEqual(expect.stringContaining('savedFiltersHandling=merge'));
+    expect(url).toEqual(
+      expect.stringContaining(`${DashboardConstants.SAVED_FILTERS_HANDLING_PARAM}=merge`)
+    );
   });
 
   test('can disable merging filters', async () => {
@@ -134,6 +137,8 @@ describe('dashboard url generator', () => {
       Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
     );
     const url = await generator.createUrl!({ savedFiltersHandling: 'override' });
-    expect(url).not.toEqual(expect.stringContaining('savedFiltersHandling'));
+    expect(url).not.toEqual(
+      expect.stringContaining(DashboardConstants.SAVED_FILTERS_HANDLING_PARAM)
+    );
   });
 });

--- a/src/plugins/dashboard/public/url_generator.test.ts
+++ b/src/plugins/dashboard/public/url_generator.test.ts
@@ -36,7 +36,9 @@ describe('dashboard url generator', () => {
       Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
     );
     const url = await generator.createUrl!({});
-    expect(url).toMatchInlineSnapshot(`"xyz/app/kibana#/dashboard?_a=()&_g=()"`);
+    expect(url).toMatchInlineSnapshot(
+      `"xyz/app/kibana#/dashboard?_a=()&_g=()&savedFiltersHandling=merge"`
+    );
   });
 
   test('creates a link with global time range set up', async () => {
@@ -47,7 +49,7 @@ describe('dashboard url generator', () => {
       timeRange: { to: 'now', from: 'now-15m', mode: 'relative' },
     });
     expect(url).toMatchInlineSnapshot(
-      `"xyz/app/kibana#/dashboard?_a=()&_g=(time:(from:now-15m,mode:relative,to:now))"`
+      `"xyz/app/kibana#/dashboard?_a=()&_g=(time:(from:now-15m,mode:relative,to:now))&savedFiltersHandling=merge"`
     );
   });
 
@@ -83,7 +85,7 @@ describe('dashboard url generator', () => {
       query: { query: 'bye', language: 'kuery' },
     });
     expect(url).toMatchInlineSnapshot(
-      `"xyz/app/kibana#/dashboard/123?_a=(filters:!((meta:(alias:!n,disabled:!f,negate:!f),query:(query:hi))),query:(language:kuery,query:bye))&_g=(filters:!(('$state':(store:globalState),meta:(alias:!n,disabled:!f,negate:!f),query:(query:hi))),refreshInterval:(pause:!f,value:300),time:(from:now-15m,mode:relative,to:now))"`
+      `"xyz/app/kibana#/dashboard/123?_a=(filters:!((meta:(alias:!n,disabled:!f,negate:!f),query:(query:hi))),query:(language:kuery,query:bye))&_g=(filters:!(('$state':(store:globalState),meta:(alias:!n,disabled:!f,negate:!f),query:(query:hi))),refreshInterval:(pause:!f,value:300),time:(from:now-15m,mode:relative,to:now))&savedFiltersHandling=merge"`
     );
   });
 
@@ -117,5 +119,21 @@ describe('dashboard url generator', () => {
       useHash: false,
     });
     expect(url.indexOf('relative')).toBeGreaterThan(1);
+  });
+
+  test('by default saved filters are merged', async () => {
+    const generator = createDirectAccessDashboardLinkGenerator(() =>
+      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
+    );
+    const url = await generator.createUrl!({});
+    expect(url).toEqual(expect.stringContaining('savedFiltersHandling=merge'));
+  });
+
+  test('can disable merging filters', async () => {
+    const generator = createDirectAccessDashboardLinkGenerator(() =>
+      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
+    );
+    const url = await generator.createUrl!({ savedFiltersHandling: 'override' });
+    expect(url).not.toEqual(expect.stringContaining('savedFiltersHandling'));
   });
 });

--- a/src/plugins/dashboard/public/url_generator.ts
+++ b/src/plugins/dashboard/public/url_generator.ts
@@ -27,7 +27,7 @@ import {
 } from '../../data/public';
 import { setStateToKbnUrl } from '../../kibana_utils/public';
 import { UrlGeneratorsDefinition, UrlGeneratorState } from '../../share/public';
-import { DashboardInitialSavedFiltersHandling } from './types';
+import { DashboardSavedFiltersHandling } from './types';
 import { DashboardConstants } from './dashboard_constants';
 
 export const STATE_STORAGE_KEY = '_a';
@@ -78,7 +78,7 @@ export type DashboardAppLinkGeneratorState = UrlGeneratorState<{
    *
    * Url generator uses `merge` handling as default
    */
-  savedFiltersHandling?: DashboardInitialSavedFiltersHandling;
+  savedFiltersHandling?: DashboardSavedFiltersHandling;
 }>;
 
 export const createDirectAccessDashboardLinkGenerator = (

--- a/test/functional/apps/dashboard/dashboard_filter_bar.js
+++ b/test/functional/apps/dashboard/dashboard_filter_bar.js
@@ -167,6 +167,21 @@ export default function({ getService, getPageObjects }) {
         expect(await filterBar.getFilterCount()).to.be(0);
         await pieChart.expectPieSliceCount(5);
       });
+
+      it('&savedFiltersHandling=merge merges incoming filters from url with saved filters', async () => {
+        await PageObjects.dashboard.gotoDashboardLandingPage();
+        await PageObjects.dashboard.loadSavedDashboard('with filters');
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        await filterBar.removeFilter('bytes');
+        await filterBar.addFilter('extension', 'is', 'jpg');
+        const currentUrl = await browser.getCurrentUrl();
+        const newUrl = `${currentUrl}&savedFiltersHandling=merge`;
+        await browser.get(newUrl);
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        const filterCount = await filterBar.getFilterCount();
+        expect(filterCount).to.equal(2);
+        await pieChart.expectPieSliceCount(1);
+      });
     });
 
     describe('saved search filtering', function() {


### PR DESCRIPTION
## Summary

Needed for #61219.

In drilldowns branch there is _a bug_ with filters right now: When url to drilldown is generated and navigated to, fillers from URL always take precedence which makes sense for normal url flow, but doesn't make sense for navigation with drilldown. 

This pr adds optional query param to dashboard url which allows to change default initial filters handling: 
it allows instead of overriding saved filters by filters from URL merge filters from 2 sources together. 

Please refer to original discussion for more context: https://github.com/elastic/kibana/pull/63108#discussion_r414104941

> So options:
Option 1: retrieve saved filters in Drilldowns code. Pass all filters to url generator
Option 2: retrieve saved filters inside url generator. merge them with incoming filters when generating url
Option 3: Url generator optionally adds additional flag in the url to also preserve saved filters: e.g. &savedFilters=merge. When dashboard is loaded it will use that flag to decided what to do with filters saved in dashboard.

This pr goes with `Option 3` ⬆️ 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
