### PR TITLE
[SIEM] Minimize plugin bundle size

### DIFF
--- a/x-pack/plugins/siem/public/lib/telemetry/middleware.ts
+++ b/x-pack/plugins/siem/public/lib/telemetry/middleware.ts
@@ -7,7 +7,7 @@
 import { Action, Dispatch, MiddlewareAPI } from 'redux';
 
 import { track, METRIC_TYPE, TELEMETRY_EVENT } from './';
-import { timelineActions } from '../../store/actions';
+import * as timelineActions from '../../store/timeline/actions';
 
 export const telemetryMiddleware = (api: MiddlewareAPI) => (next: Dispatch) => (action: Action) => {
   if (timelineActions.endTimelineSaving.match(action)) {

--- a/x-pack/plugins/siem/public/store/model.ts
+++ b/x-pack/plugins/siem/public/store/model.ts
@@ -9,15 +9,4 @@ export { dragAndDropModel } from './drag_and_drop';
 export { hostsModel } from './hosts';
 export { inputsModel } from './inputs';
 export { networkModel } from './network';
-
-export type KueryFilterQueryKind = 'kuery' | 'lucene';
-
-export interface KueryFilterQuery {
-  kind: KueryFilterQueryKind;
-  expression: string;
-}
-
-export interface SerializedFilterQuery {
-  kuery: KueryFilterQuery | null;
-  serializedQuery: string;
-}
+export * from './types';

--- a/x-pack/plugins/siem/public/store/timeline/actions.ts
+++ b/x-pack/plugins/siem/public/store/timeline/actions.ts
@@ -12,7 +12,7 @@ import {
   DataProvider,
   QueryOperator,
 } from '../../components/timeline/data_providers/data_provider';
-import { KueryFilterQuery, SerializedFilterQuery } from '../model';
+import { KueryFilterQuery, SerializedFilterQuery } from '../types';
 
 import { EventType, KqlMode, TimelineModel, ColumnHeaderOptions } from './model';
 import { TimelineNonEcsData } from '../../graphql/types';

--- a/x-pack/plugins/siem/public/store/types.ts
+++ b/x-pack/plugins/siem/public/store/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export type KueryFilterQueryKind = 'kuery' | 'lucene';
+
+export interface KueryFilterQuery {
+  kind: KueryFilterQueryKind;
+  expression: string;
+}
+
+export interface SerializedFilterQuery {
+  kuery: KueryFilterQuery | null;
+  serializedQuery: string;
+}


### PR DESCRIPTION
## Summary

Addresses #64589 to a reasonable extent; our plugin size is reduced from 579kB to 86kB. Approximately 70kB of the remaining size is due to our `serviceNowActionType` import, but #63450 should address that in part so I'm leaving that for now.

Before:
<img width="854" alt="Overview_-_Kibana" src="https://user-images.githubusercontent.com/657252/80504526-d866a180-8938-11ea-9510-3438e162804e.png">

After: 
<img width="860" alt="Overview_-_Kibana" src="https://user-images.githubusercontent.com/657252/80503640-c5070680-8937-11ea-8d01-d8481cecaa00.png">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
