### PR TITLE
[EPM] Update UI to handle package versions and updates

### DIFF
--- a/x-pack/plugins/ingest_manager/common/services/package_to_config.test.ts
+++ b/x-pack/plugins/ingest_manager/common/services/package_to_config.test.ts
@@ -11,6 +11,7 @@ describe('Ingest Manager - packageToConfig', () => {
     name: 'mock-package',
     title: 'Mock package',
     version: '0.0.0',
+    latestVersion: '0.0.0',
     description: 'description',
     type: 'mock',
     categories: [],

--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -204,6 +204,7 @@ export interface RegistryVarsEntry {
 interface PackageAdditions {
   title: string;
   latestVersion: string;
+  installedVersion?: string;
   assets: AssetsGroupedByServiceByType;
 }
 

--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -203,6 +203,7 @@ export interface RegistryVarsEntry {
 // internal until we need them
 interface PackageAdditions {
   title: string;
+  latestVersion: string;
   assets: AssetsGroupedByServiceByType;
 }
 

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/components/icons.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/components/icons.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { EuiIcon } from '@elastic/eui';
+import React from 'react';
+import styled from 'styled-components';
+
+export const StyledAlert = styled(EuiIcon)`
+  color: ${props => props.theme.eui.euiColorWarning};
+  padding: 0 5px;
+`;
+
+export const UpdateIcon = () => <StyledAlert type="alert" size="l" />;

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/components/package_card.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/components/package_card.tsx
@@ -30,9 +30,15 @@ export function PackageCard({
   showInstalledBadge,
   status,
   icons,
+  ...restProps
 }: PackageCardProps) {
   const { toDetailView } = useLinks();
-  const url = toDetailView({ name, version });
+  let urlVersion = version;
+  // if this is an installed package, link to the version installed
+  if ('savedObject' in restProps) {
+    urlVersion = restProps.savedObject.attributes.version || version;
+  }
+  const url = toDetailView({ name, version: urlVersion });
 
   return (
     <Card

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/hooks/use_package_install.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/hooks/use_package_install.tsx
@@ -62,7 +62,13 @@ function usePackageInstall({ notifications }: { notifications: NotificationsStar
 
       const res = await sendInstallPackage(pkgkey);
       if (res.error) {
-        setPackageInstallStatus({ name, status: InstallStatus.notInstalled, version });
+        if (fromUpdate) {
+          // if there is an error during update, set it back to the previous version
+          // as handling of bad update is not implemented yet
+          setPackageInstallStatus({ ...currStatus, name });
+        } else {
+          setPackageInstallStatus({ name, status: InstallStatus.notInstalled, version });
+        }
         notifications.toasts.addWarning({
           title: toMountPoint(
             <FormattedMessage

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/hooks/use_package_install.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/hooks/use_package_install.tsx
@@ -46,9 +46,18 @@ function usePackageInstall({ notifications }: { notifications: NotificationsStar
     []
   );
 
+  const getPackageInstallStatus = useCallback(
+    (pkg: string): PackageInstallItem => {
+      return packages[pkg];
+    },
+    [packages]
+  );
+
   const installPackage = useCallback(
     async ({ name, version, title, fromUpdate = false }: InstallPackageProps) => {
-      setPackageInstallStatus({ name, status: InstallStatus.installing, version });
+      const currStatus = getPackageInstallStatus(name);
+      const newStatus = { ...currStatus, name, status: InstallStatus.installing };
+      setPackageInstallStatus(newStatus);
       const pkgkey = `${name}-${version}`;
 
       const res = await sendInstallPackage(pkgkey);
@@ -98,14 +107,7 @@ function usePackageInstall({ notifications }: { notifications: NotificationsStar
         });
       }
     },
-    [notifications.toasts, setPackageInstallStatus, toDetailView]
-  );
-
-  const getPackageInstallStatus = useCallback(
-    (pkg: string): PackageInstallItem => {
-      return packages[pkg];
-    },
-    [packages]
+    [getPackageInstallStatus, notifications.toasts, setPackageInstallStatus, toDetailView]
   );
 
   const uninstallPackage = useCallback(
@@ -133,7 +135,7 @@ function usePackageInstall({ notifications }: { notifications: NotificationsStar
           iconType: 'alert',
         });
       } else {
-        setPackageInstallStatus({ name, status: InstallStatus.notInstalled, version });
+        setPackageInstallStatus({ name, status: InstallStatus.notInstalled, version: null });
 
         notifications.toasts.addSuccess({
           title: toMountPoint(

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/content.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/content.tsx
@@ -50,7 +50,7 @@ export function Content(props: ContentProps) {
 
 type ContentPanelProps = PackageInfo & Pick<DetailParams, 'panel'>;
 export function ContentPanel(props: ContentPanelProps) {
-  const { panel, name, version, assets, title, removable } = props;
+  const { panel, name, version, assets, title, removable, latestVersion } = props;
   switch (panel) {
     case 'settings':
       return (
@@ -60,6 +60,7 @@ export function ContentPanel(props: ContentPanelProps) {
           assets={assets}
           title={title}
           removable={removable}
+          latestVersion={latestVersion}
         />
       );
     case 'data-sources':

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/data_sources_panel.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/data_sources_panel.tsx
@@ -20,7 +20,7 @@ export const DataSourcesPanel = ({ name, version }: DataSourcesPanelProps) => {
   const packageInstallStatus = getPackageInstallStatus(name);
   // if they arrive at this page and the package is not installed, send them to overview
   // this happens if they arrive with a direct url or they uninstall while on this tab
-  if (packageInstallStatus !== InstallStatus.installed)
+  if (packageInstallStatus.status !== InstallStatus.installed)
     return (
       <Redirect
         to={toDetailView({

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/header.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/header.tsx
@@ -29,11 +29,11 @@ const Text = styled.span`
 type HeaderProps = PackageInfo & { iconType?: IconType };
 
 export function Header(props: HeaderProps) {
-  const { iconType, name, title, version, latestVersion } = props;
+  const { iconType, name, title, version, installedVersion, latestVersion } = props;
   const hasWriteCapabilites = useCapabilities().write;
   const { toListView } = useLinks();
   const ADD_DATASOURCE_URI = useLink(`${EPM_PATH}/${name}-${version}/add-datasource`);
-  const updateAvailable = latestVersion > version ? true : false;
+  const updateAvailable = installedVersion && installedVersion < latestVersion ? true : false;
   return (
     <Fragment>
       <FullWidthNavRow>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/header.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/header.tsx
@@ -13,9 +13,9 @@ import { EPM_PATH } from '../../../../constants';
 import { useCapabilities, useLink } from '../../../../hooks';
 import { IconPanel } from '../../components/icon_panel';
 import { NavButtonBack } from '../../components/nav_button_back';
-import { Version } from '../../components/version';
 import { useLinks } from '../../hooks';
 import { CenterColumn, LeftColumn, RightColumn } from './layout';
+import { UpdateIcon } from '../../components/icons';
 
 const FullWidthNavRow = styled(EuiPage)`
   /* no left padding so link is against column left edge  */
@@ -26,19 +26,14 @@ const Text = styled.span`
   margin-right: ${props => props.theme.eui.euiSizeM};
 `;
 
-const StyledVersion = styled(Version)`
-  font-size: ${props => props.theme.eui.euiFontSizeS};
-  color: ${props => props.theme.eui.euiColorDarkShade};
-`;
-
 type HeaderProps = PackageInfo & { iconType?: IconType };
 
 export function Header(props: HeaderProps) {
-  const { iconType, name, title, version } = props;
+  const { iconType, name, title, version, latestVersion } = props;
   const hasWriteCapabilites = useCapabilities().write;
   const { toListView } = useLinks();
   const ADD_DATASOURCE_URI = useLink(`${EPM_PATH}/${name}-${version}/add-datasource`);
-
+  const updateAvailable = latestVersion > version ? true : false;
   return (
     <Fragment>
       <FullWidthNavRow>
@@ -59,7 +54,11 @@ export function Header(props: HeaderProps) {
           <EuiTitle size="l">
             <h1>
               <Text>{title}</Text>
-              <StyledVersion version={version} />
+              <EuiTitle size="xs">
+                <span>
+                  {version} {updateAvailable && <UpdateIcon />}
+                </span>
+              </EuiTitle>
             </h1>
           </EuiTitle>
         </CenterColumn>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/index.tsx
@@ -32,11 +32,12 @@ export function Detail() {
       const packageInfo = response.data?.response;
       const title = packageInfo?.title;
       const name = packageInfo?.name;
+      const installedVersion = packageInfo?.installedVersion;
       const status: InstallStatus = packageInfo?.status as any;
 
       // track install status state
       if (name) {
-        setPackageInstallStatus({ name, status });
+        setPackageInstallStatus({ name, status, version: installedVersion || null });
       }
       if (packageInfo) {
         setInfo({ ...packageInfo, title: title || '' });
@@ -64,7 +65,6 @@ type LayoutProps = PackageInfo & Pick<DetailParams, 'panel'> & Pick<EuiPageProps
 export function DetailLayout(props: LayoutProps) {
   const { name: packageName, version, icons, restrictWidth } = props;
   const iconType = usePackageIconType({ packageName, version, icons });
-
   return (
     <Fragment>
       <FullWidthHeader>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/installation_button.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/installation_button.tsx
@@ -89,9 +89,6 @@ export function InstallationButton(props: InstallationButtonProps) {
       <FormattedMessage
         id="xpack.ingestManager.integrations.updatePackage.updatePackageButtonLabel"
         defaultMessage="Update to latest version"
-        values={{
-          title,
-        }}
       />
     </EuiButton>
   );

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/installation_button.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/installation_button.tsx
@@ -22,7 +22,7 @@ export function InstallationButton(props: InstallationButtonProps) {
   const installPackage = useInstallPackage();
   const uninstallPackage = useUninstallPackage();
   const getPackageInstallStatus = useGetPackageInstallStatus();
-  const installationStatus = getPackageInstallStatus(name);
+  const { status: installationStatus } = getPackageInstallStatus(name);
 
   const isInstalling = installationStatus === InstallStatus.installing;
   const isRemoving = installationStatus === InstallStatus.uninstalling;

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/installation_button.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/installation_button.tsx
@@ -27,7 +27,7 @@ export function InstallationButton(props: InstallationButtonProps) {
   const isInstalling = installationStatus === InstallStatus.installing;
   const isRemoving = installationStatus === InstallStatus.uninstalling;
   const isInstalled = installationStatus === InstallStatus.installed;
-  const showUninstallButton = isInstalled || isInstalling || isRemoving;
+  const showUninstallButton = isInstalled || isRemoving;
   const [isModalVisible, setModalVisible] = useState<boolean>(false);
   const toggleModal = useCallback(() => {
     setModalVisible(!isModalVisible);

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
@@ -8,11 +8,22 @@ import React from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { EuiTitle, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
+import styled from 'styled-components';
 import { InstallStatus, PackageInfo } from '../../../../types';
 import { useGetDatasources } from '../../../../hooks';
 import { DATASOURCE_SAVED_OBJECT_TYPE } from '../../../../constants';
 import { useGetPackageInstallStatus } from '../../hooks';
 import { InstallationButton } from './installation_button';
+import { UpdateIcon } from '../../components/icons';
+
+const SettingsTitleCell = styled.td`
+  padding-right: ${props => props.theme.eui.spacerSizes.xl};
+  padding-bottom: ${props => props.theme.eui.spacerSizes.m};
+`;
+
+const UpdatesAvailableMsgContainer = styled.span`
+  padding-left: ${props => props.theme.eui.spacerSizes.s};
+`;
 
 const NoteLabel = () => (
   <FormattedMessage
@@ -20,8 +31,18 @@ const NoteLabel = () => (
     defaultMessage="Note:"
   />
 );
+const UpdatesAvailableMsg = () => (
+  <UpdatesAvailableMsgContainer>
+    <UpdateIcon />
+    <FormattedMessage
+      id="xpack.ingestManager.integrations.settings.versionInfo.updatesAvailable"
+      defaultMessage="Updates are available"
+    />
+  </UpdatesAvailableMsgContainer>
+);
+
 export const SettingsPanel = (
-  props: Pick<PackageInfo, 'assets' | 'name' | 'title' | 'version' | 'removable'>
+  props: Pick<PackageInfo, 'assets' | 'name' | 'title' | 'version' | 'removable' | 'latestVersion'>
 ) => {
   const getPackageInstallStatus = useGetPackageInstallStatus();
   const { data: datasourcesData } = useGetDatasources({
@@ -29,9 +50,10 @@ export const SettingsPanel = (
     page: 1,
     kuery: `${DATASOURCE_SAVED_OBJECT_TYPE}.package.name:${props.name}`,
   });
-  const { name, title, removable } = props;
+  const { name, title, removable, version, latestVersion } = props;
   const packageInstallStatus = getPackageInstallStatus(name);
   const packageHasDatasources = !!datasourcesData?.total;
+  const updatesAvailable = latestVersion > version;
   return (
     <EuiText>
       <EuiTitle>
@@ -42,6 +64,52 @@ export const SettingsPanel = (
           />
         </h3>
       </EuiTitle>
+      <EuiSpacer size="s" />
+      <div>
+        <EuiTitle>
+          <h4>
+            <FormattedMessage
+              id="xpack.ingestManager.integrations.settings.packageVersionTitle"
+              defaultMessage="{title} version"
+              values={{
+                title,
+              }}
+            />
+          </h4>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText>
+          <table>
+            <tr>
+              <SettingsTitleCell>
+                <FormattedMessage
+                  id="xpack.ingestManager.integrations.settings.versionInfo.installedVersion"
+                  defaultMessage="Installed version"
+                />
+              </SettingsTitleCell>
+              <td>
+                <EuiTitle size="xs">
+                  <span>{props.version}</span>
+                </EuiTitle>
+                {updatesAvailable && <UpdatesAvailableMsg />}
+              </td>
+            </tr>
+            <tr>
+              <SettingsTitleCell>
+                <FormattedMessage
+                  id="xpack.ingestManager.integrations.settings.versionInfo.latestVersion"
+                  defaultMessage="Latest version"
+                />
+              </SettingsTitleCell>
+              <td>
+                <EuiTitle size="xs">
+                  <span>{props.latestVersion}</span>
+                </EuiTitle>
+              </td>
+            </tr>
+          </table>
+        </EuiText>
+      </div>
       <EuiSpacer size="s" />
       {packageInstallStatus === InstallStatus.notInstalled ||
       packageInstallStatus === InstallStatus.installing ? (

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
@@ -44,16 +44,23 @@ const UpdatesAvailableMsg = () => (
 export const SettingsPanel = (
   props: Pick<PackageInfo, 'assets' | 'name' | 'title' | 'version' | 'removable' | 'latestVersion'>
 ) => {
+  const { name, title, removable, latestVersion, version } = props;
   const getPackageInstallStatus = useGetPackageInstallStatus();
   const { data: datasourcesData } = useGetDatasources({
     perPage: 0,
     page: 1,
     kuery: `${DATASOURCE_SAVED_OBJECT_TYPE}.package.name:${props.name}`,
   });
-  const { name, title, removable, version, latestVersion } = props;
-  const packageInstallStatus = getPackageInstallStatus(name);
+  const { status: installationStatus, version: installedVersion } = getPackageInstallStatus(name);
   const packageHasDatasources = !!datasourcesData?.total;
-  const updatesAvailable = latestVersion > version;
+  const updateAvailable = installedVersion && installedVersion < latestVersion ? true : false;
+  const isViewingOldPackage = version < latestVersion;
+
+  // hide install/remove options if the user has version of the package is installed
+  // and this package is out of date or if they do have a version installed but it's not this one
+  const hideInstallOptions =
+    (installationStatus === InstallStatus.notInstalled && isViewingOldPackage) ||
+    (installationStatus === InstallStatus.installed && installedVersion !== version);
   return (
     <EuiText>
       <EuiTitle>
@@ -65,70 +72,13 @@ export const SettingsPanel = (
         </h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <div>
-        <EuiTitle>
-          <h4>
-            <FormattedMessage
-              id="xpack.ingestManager.integrations.settings.packageVersionTitle"
-              defaultMessage="{title} version"
-              values={{
-                title,
-              }}
-            />
-          </h4>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <table>
-          <tbody>
-            <tr>
-              <SettingsTitleCell>
-                <FormattedMessage
-                  id="xpack.ingestManager.integrations.settings.versionInfo.installedVersion"
-                  defaultMessage="Installed version"
-                />
-              </SettingsTitleCell>
-              <td>
-                <EuiTitle size="xs">
-                  <span>{props.version}</span>
-                </EuiTitle>
-                {updatesAvailable && <UpdatesAvailableMsg />}
-              </td>
-            </tr>
-            <tr>
-              <SettingsTitleCell>
-                <FormattedMessage
-                  id="xpack.ingestManager.integrations.settings.versionInfo.latestVersion"
-                  defaultMessage="Latest version"
-                />
-              </SettingsTitleCell>
-              <td>
-                <EuiTitle size="xs">
-                  <span>{props.latestVersion}</span>
-                </EuiTitle>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        {updatesAvailable && (
-          <p>
-            <InstallationButton
-              {...props}
-              version={latestVersion}
-              disabled={false}
-              isUpdate={true}
-            />
-          </p>
-        )}
-      </div>
-      <EuiSpacer size="s" />
-      {packageInstallStatus === InstallStatus.notInstalled ||
-      packageInstallStatus === InstallStatus.installing ? (
+      {installationStatus === InstallStatus.installed && (
         <div>
           <EuiTitle>
             <h4>
               <FormattedMessage
-                id="xpack.ingestManager.integrations.settings.packageInstallTitle"
-                defaultMessage="Install {title}"
+                id="xpack.ingestManager.integrations.settings.packageVersionTitle"
+                defaultMessage="{title} version"
                 values={{
                   title,
                 }}
@@ -136,79 +86,142 @@ export const SettingsPanel = (
             </h4>
           </EuiTitle>
           <EuiSpacer size="s" />
-          <p>
-            <FormattedMessage
-              id="xpack.ingestManager.integrations.settings.packageInstallDescription"
-              defaultMessage="Install this integration to setup Kibana and Elasticsearch assets designed for {title} data."
-              values={{
-                title,
-              }}
-            />
-          </p>
+          <table>
+            <tbody>
+              <tr>
+                <SettingsTitleCell>
+                  <FormattedMessage
+                    id="xpack.ingestManager.integrations.settings.versionInfo.installedVersion"
+                    defaultMessage="Installed version"
+                  />
+                </SettingsTitleCell>
+                <td>
+                  <EuiTitle size="xs">
+                    <span>{installedVersion}</span>
+                  </EuiTitle>
+                  {updateAvailable && <UpdatesAvailableMsg />}
+                </td>
+              </tr>
+              <tr>
+                <SettingsTitleCell>
+                  <FormattedMessage
+                    id="xpack.ingestManager.integrations.settings.versionInfo.latestVersion"
+                    defaultMessage="Latest version"
+                  />
+                </SettingsTitleCell>
+                <td>
+                  <EuiTitle size="xs">
+                    <span>{latestVersion}</span>
+                  </EuiTitle>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          {updateAvailable && (
+            <p>
+              <InstallationButton
+                {...props}
+                version={latestVersion}
+                disabled={false}
+                isUpdate={true}
+              />
+            </p>
+          )}
         </div>
-      ) : (
+      )}
+      {!hideInstallOptions && (
         <div>
-          <EuiTitle>
-            <h4>
+          <EuiSpacer size="s" />
+          {installationStatus === InstallStatus.notInstalled ||
+          installationStatus === InstallStatus.installing ? (
+            <div>
+              <EuiTitle>
+                <h4>
+                  <FormattedMessage
+                    id="xpack.ingestManager.integrations.settings.packageInstallTitle"
+                    defaultMessage="Install {title}"
+                    values={{
+                      title,
+                    }}
+                  />
+                </h4>
+              </EuiTitle>
+              <EuiSpacer size="s" />
+              <p>
+                <FormattedMessage
+                  id="xpack.ingestManager.integrations.settings.packageInstallDescription"
+                  defaultMessage="Install this integration to setup Kibana and Elasticsearch assets designed for {title} data."
+                  values={{
+                    title,
+                  }}
+                />
+              </p>
+            </div>
+          ) : (
+            <div>
+              <EuiTitle>
+                <h4>
+                  <FormattedMessage
+                    id="xpack.ingestManager.integrations.settings.packageUninstallTitle"
+                    defaultMessage="Uninstall {title}"
+                    values={{
+                      title,
+                    }}
+                  />
+                </h4>
+              </EuiTitle>
+              <EuiSpacer size="s" />
+              <p>
+                <FormattedMessage
+                  id="xpack.ingestManager.integrations.settings.packageUninstallDescription"
+                  defaultMessage="Remove Kibana and Elasticsearch assets that were installed by this Integration."
+                />
+              </p>
+            </div>
+          )}
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false}>
+              <p>
+                <InstallationButton
+                  {...props}
+                  disabled={!datasourcesData || removable === false ? true : packageHasDatasources}
+                />
+              </p>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          {packageHasDatasources && removable === true && (
+            <p>
               <FormattedMessage
-                id="xpack.ingestManager.integrations.settings.packageUninstallTitle"
-                defaultMessage="Uninstall {title}"
+                id="xpack.ingestManager.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail"
+                defaultMessage="{strongNote} {title} cannot be uninstalled because there are active agents that use this integration. To uninstall, remove all {title} data sources from your agent configurations."
                 values={{
                   title,
+                  strongNote: (
+                    <strong>
+                      <NoteLabel />
+                    </strong>
+                  ),
                 }}
               />
-            </h4>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-          <p>
-            <FormattedMessage
-              id="xpack.ingestManager.integrations.settings.packageUninstallDescription"
-              defaultMessage="Remove Kibana and Elasticsearch assets that were installed by this Integration."
-            />
-          </p>
+            </p>
+          )}
+          {removable === false && (
+            <p>
+              <FormattedMessage
+                id="xpack.ingestManager.integrations.settings.packageUninstallNoteDescription.packageUninstallUninstallableNoteDetail"
+                defaultMessage="{strongNote} The {title} integration is installed by default and cannot be removed."
+                values={{
+                  title,
+                  strongNote: (
+                    <strong>
+                      <NoteLabel />
+                    </strong>
+                  ),
+                }}
+              />
+            </p>
+          )}
         </div>
-      )}
-      <EuiFlexGroup>
-        <EuiFlexItem grow={false}>
-          <p>
-            <InstallationButton
-              {...props}
-              disabled={!datasourcesData || removable === false ? true : packageHasDatasources}
-            />
-          </p>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      {packageHasDatasources && removable === true && (
-        <p>
-          <FormattedMessage
-            id="xpack.ingestManager.integrations.settings.packageUninstallNoteDescription.packageUninstallNoteDetail"
-            defaultMessage="{strongNote} {title} cannot be uninstalled because there are active agents that use this integration. To uninstall, remove all {title} data sources from your agent configurations."
-            values={{
-              title,
-              strongNote: (
-                <strong>
-                  <NoteLabel />
-                </strong>
-              ),
-            }}
-          />
-        </p>
-      )}
-      {removable === false && (
-        <p>
-          <FormattedMessage
-            id="xpack.ingestManager.integrations.settings.packageUninstallNoteDescription.packageUninstallUninstallableNoteDetail"
-            defaultMessage="{strongNote} The {title} integration is installed by default and cannot be removed."
-            values={{
-              title,
-              strongNote: (
-                <strong>
-                  <NoteLabel />
-                </strong>
-              ),
-            }}
-          />
-        </p>
       )}
     </EuiText>
   );

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
@@ -55,12 +55,13 @@ export const SettingsPanel = (
   const packageHasDatasources = !!datasourcesData?.total;
   const updateAvailable = installedVersion && installedVersion < latestVersion ? true : false;
   const isViewingOldPackage = version < latestVersion;
-
   // hide install/remove options if the user has version of the package is installed
   // and this package is out of date or if they do have a version installed but it's not this one
   const hideInstallOptions =
     (installationStatus === InstallStatus.notInstalled && isViewingOldPackage) ||
     (installationStatus === InstallStatus.installed && installedVersion !== version);
+
+  const isUpdating = installationStatus === InstallStatus.installing && installedVersion;
   return (
     <EuiText>
       <EuiTitle>
@@ -72,7 +73,7 @@ export const SettingsPanel = (
         </h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      {installationStatus === InstallStatus.installed && (
+      {installedVersion !== null && (
         <div>
           <EuiTitle>
             <h4>
@@ -129,7 +130,7 @@ export const SettingsPanel = (
           )}
         </div>
       )}
-      {!hideInstallOptions && (
+      {!hideInstallOptions && !isUpdating && (
         <div>
           <EuiSpacer size="s" />
           {installationStatus === InstallStatus.notInstalled ||

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/settings_panel.tsx
@@ -78,8 +78,8 @@ export const SettingsPanel = (
           </h4>
         </EuiTitle>
         <EuiSpacer size="s" />
-        <EuiText>
-          <table>
+        <table>
+          <tbody>
             <tr>
               <SettingsTitleCell>
                 <FormattedMessage
@@ -107,8 +107,18 @@ export const SettingsPanel = (
                 </EuiTitle>
               </td>
             </tr>
-          </table>
-        </EuiText>
+          </tbody>
+        </table>
+        {updatesAvailable && (
+          <p>
+            <InstallationButton
+              {...props}
+              version={latestVersion}
+              disabled={false}
+              isUpdate={true}
+            />
+          </p>
+        )}
       </div>
       <EuiSpacer size="s" />
       {packageInstallStatus === InstallStatus.notInstalled ||

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/side_nav_links.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/side_nav_links.tsx
@@ -37,7 +37,7 @@ export function SideNavLinks({ name, version, active }: NavLinkProps) {
               : p.theme.eui.euiFontWeightRegular};
         `;
         // don't display Data Sources tab if the package is not installed
-        if (packageInstallStatus !== InstallStatus.installed && panel === 'data-sources')
+        if (packageInstallStatus.status !== InstallStatus.installed && panel === 'data-sources')
           return null;
 
         return (

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
@@ -67,9 +67,10 @@ export async function getPackageInfo(options: {
   pkgVersion: string;
 }): Promise<PackageInfo> {
   const { savedObjectsClient, pkgName, pkgVersion } = options;
-  const [item, savedObject, assets] = await Promise.all([
+  const [item, savedObject, latestPackage, assets] = await Promise.all([
     Registry.fetchInfo(pkgName, pkgVersion),
     getInstallationObject({ savedObjectsClient, pkgName }),
+    Registry.fetchFindLatestPackage(pkgName),
     Registry.getArchiveInfo(pkgName, pkgVersion),
   ] as const);
   // adding `as const` due to regression in TS 3.7.2
@@ -79,6 +80,7 @@ export async function getPackageInfo(options: {
   // add properties that aren't (or aren't yet) on Registry response
   const updated = {
     ...item,
+    latestVersion: latestPackage.version,
     title: item.title || nameAsTitle(item.name),
     assets: Registry.groupPathsByService(assets || []),
   };

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/index.ts
@@ -43,6 +43,7 @@ export function createInstallableFrom<T>(
     ? {
         ...from,
         status: InstallationStatus.installed,
+        installedVersion: savedObject.attributes.version,
         savedObject,
       }
     : {

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
@@ -106,7 +106,7 @@ export async function installPackage(options: {
     try {
       await deleteKibanaSavedObjectsAssets(savedObjectsClient, installedPkg.attributes.installed);
     } catch (err) {
-      // some assets may not exist if deleting during a failed update
+      // log these errors, some assets may not exist if deleted during a failed update
     }
   }
 

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
@@ -121,8 +121,12 @@ export async function deleteKibanaSavedObjectsAssets(
   const deletePromises = installedObjects.map(({ id, type }) => {
     const assetType = type as AssetType;
     if (savedObjectTypes.includes(assetType)) {
-      savedObjectsClient.delete(assetType, id);
+      return savedObjectsClient.delete(assetType, id);
     }
   });
-  await Promise.all(deletePromises);
+  try {
+    await Promise.all(deletePromises);
+  } catch (err) {
+    throw new Error('error deleting saved object asset');
+  }
 }


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/64255

- Does not check for whether the user has auto updates turned on or make any mention of it because auto updating functionality doesn't exist yet and unlikely will for Alpha
- Update the Settings tab for package detail page to display version information and update option
- When the user clicks on a package from the list page they will go to the version they have installed
- Fixes a bug where delete promises of saved objects assets were not being returned and awaited and resolving after some assets were installed so that the next time a delete or reinstall occurred, they did not exist

## Testing instructions:
This scenario where user's have out of date packages in the UI would happen if the user had auto updates turned off which will be the case for alpha but the plan is to make auto updates default.   

1. - Install an out of date package through the API: 
POST http://localhost:5603/ssg/api/ingest_manager/epm/packages/nginx-0.0.1
2. - Go to the package list page and click on the "installed integrations" tab.  
3. - Click on the installed Nginx package and notice you are redirected to the version installed (0.0.1) and not the latest (0.0.2)
4. - Try to update the package

User has the most up to date version of package installed
<img width="1140" alt="Screen Shot 2020-04-28 at 2 19 09 PM" src="https://user-images.githubusercontent.com/1676003/80522898-3efcb700-895b-11ea-9db5-a1d5709c0bc5.png">

User has out of date version installed
<img width="1179" alt="Screen Shot 2020-04-28 at 2 22 01 PM" src="https://user-images.githubusercontent.com/1676003/80523162-a4e93e80-895b-11ea-8f09-a31ee3f44e82.png">

User clicks the "update" button.  Uninstall button is hidden so they don't try to uninstall during an update
<img width="1343" alt="Screen Shot 2020-04-28 at 2 22 42 PM" src="https://user-images.githubusercontent.com/1676003/80523276-cba77500-895b-11ea-9acb-d378aa03653c.png">

A successful update.  they are redirected to the new package version page (change route) and there is a success toast
<img width="1132" alt="Screen Shot 2020-04-28 at 2 23 54 PM" src="https://user-images.githubusercontent.com/1676003/80523347-ec6fca80-895b-11ea-9289-e16394bb2396.png">

An unsuccessful update attempt
<img width="1417" alt="Screen Shot 2020-04-28 at 2 42 41 PM" src="https://user-images.githubusercontent.com/1676003/80524998-905a7580-895e-11ea-80c6-39d2a2a47346.png">

#### Edgecases where the user navigates to a version that is not the one they have installed (perhaps from a bookmark or history as we always link to the version they have installed or the most recent if not installed).  

User goes to package version that is newer than the one they have installed.  I am not too concerned about this view because they would have had to guess this URL as they always get sent to the version they have installed if they have one installed and update from that version
Navigate to http://localhost:5601/ssg/app/ingestManager#/epm/detail/nginx-0.0.2 with nginx-0.0.1 installed
<img width="1136" alt="Screen Shot 2020-04-28 at 2 49 30 PM" src="https://user-images.githubusercontent.com/1676003/80525622-88e79c00-895f-11ea-98f6-e6d3fd7e4b8b.png">

Navigate to http://localhost:5601/ssg/app/ingestManager#/epm/detail/nginx-0.0.1 with nginx-0.0.2 installed
User directly navigates to the url of a package that is older than the version they have installed.  There are no options for installing or removing the package because its not the version they have installed.
<img width="1127" alt="Screen Shot 2020-04-28 at 2 56 25 PM" src="https://user-images.githubusercontent.com/1676003/80526246-76219700-8960-11ea-9319-9a837d94bc19.png">

For the edgecases, Henry and I discussed possibility of changing the package detail route from  `/detail/nginx-0.0.1/` to `/detail/nginx` to simplify things, but this would be an issue for when we support installing multiple versions at once

@ruflin should we be blocking installations or updates to a version that is not the latest version?



