### PR TITLE
[Lens] Use Top 5 instead of Top 3 for first suggestion

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -1380,5 +1380,43 @@ describe('IndexPatternDimensionEditorPanel', () => {
         },
       });
     });
+
+    it('does not set the size of the terms aggregation', () => {
+      const dragging = {
+        field: { type: 'string', name: 'mystring', aggregatable: true },
+        indexPatternId: 'foo',
+      };
+      const testState = dragDropState();
+      onDrop({
+        ...defaultProps,
+        dragDropContext: {
+          ...dragDropContext,
+          dragging,
+        },
+        droppedItem: dragging,
+        state: testState,
+        columnId: 'col2',
+        filterOperations: (op: OperationMetadata) => op.isBucketed,
+        layerId: 'myLayer',
+      });
+
+      expect(setState).toBeCalledTimes(1);
+      expect(setState).toHaveBeenCalledWith({
+        ...testState,
+        layers: {
+          myLayer: {
+            ...testState.layers.myLayer,
+            columnOrder: ['col1', 'col2'],
+            columns: {
+              ...testState.layers.myLayer.columns,
+              col2: expect.objectContaining({
+                operationType: 'terms',
+                params: expect.objectContaining({ size: 3 }),
+              }),
+            },
+          },
+        },
+      });
+    });
   });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -184,6 +184,7 @@ describe('IndexPattern Data Source suggestions', () => {
                     id2: expect.objectContaining({
                       operationType: 'terms',
                       sourceField: 'source',
+                      params: expect.objectContaining({ size: 5 }),
                     }),
                     id3: expect.objectContaining({
                       operationType: 'count',
@@ -388,6 +389,7 @@ describe('IndexPattern Data Source suggestions', () => {
                     id1: expect.objectContaining({
                       operationType: 'terms',
                       sourceField: 'source',
+                      params: expect.objectContaining({ size: 5 }),
                     }),
                     id2: expect.objectContaining({
                       operationType: 'count',
@@ -779,7 +781,7 @@ describe('IndexPattern Data Source suggestions', () => {
         expect(suggestions[0].table.columns[0].operation.isBucketed).toBeFalsy();
       });
 
-      it('appends a terms column on string field', () => {
+      it('appends a terms column with default size on string field', () => {
         const initialState = stateWithNonEmptyTables();
         const suggestions = getDatasourceSuggestionsForField(initialState, '1', {
           name: 'dest',
@@ -800,6 +802,7 @@ describe('IndexPattern Data Source suggestions', () => {
                     id1: expect.objectContaining({
                       operationType: 'terms',
                       sourceField: 'dest',
+                      params: expect.objectContaining({ size: 3 }),
                     }),
                   },
                 }),

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
@@ -17,6 +17,7 @@ import {
   OperationType,
 } from './operations';
 import { operationDefinitions } from './operations/definitions';
+import { TermsIndexPatternColumn } from './operations/definitions/terms';
 import { hasField } from './utils';
 import {
   IndexPattern,
@@ -232,6 +233,10 @@ function addFieldAsBucketOperation(
     [newColumnId]: newColumn,
   };
 
+  if (buckets.length === 0 && operation === 'terms') {
+    (newColumn as TermsIndexPatternColumn).params.size = 5;
+  }
+
   const oldDateHistogramIndex = layer.columnOrder.findIndex(
     columnId => layer.columns[columnId].operationType === 'date_histogram'
   );
@@ -327,6 +332,9 @@ function createNewLayerWithBucketAggregation(
     field,
     suggestedPriority: undefined,
   });
+  if (operation === 'terms') {
+    (column as TermsIndexPatternColumn).params.size = 5;
+  }
 
   return {
     indexPatternId: indexPattern.id,


### PR DESCRIPTION
This PR only affects **suggestions that are dragged into the workspace panel in Lens**, it does not affect the behavior of suggestions when dragging onto a specific dimension.

Some example scenarios:

* Completely empty visualization
    1. Drag a string field
    2. The suggested XY chart is the Top 5 values of your string
* Already has a string field, adding string
    * The second string is added with Top 3
* Already has a string field, adding date
    * The first string field keeps its size
* Already has a date histogram, adding string
    * The string is added with Top 3
* Dragging a string onto a dimension
    * Always added with default size of 3

Fixes https://github.com/elastic/kibana/issues/62386

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
