### PR TITLE
[EPM] Handle object type fields with properties in mappings

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.test.ts
@@ -284,3 +284,28 @@ test('tests processing object field with property', () => {
   const mappings = generateMappings(processedFields);
   expect(JSON.stringify(mappings)).toEqual(JSON.stringify(objectFieldWithPropertyMapping));
 });
+
+test('tests processing object field with property, reverse order', () => {
+  const objectFieldWithPropertyReversedLiteralYml = `
+- name: a.b
+  type: keyword
+- name: a
+  type: object
+  `;
+  const objectFieldWithPropertyReversedMapping = {
+    properties: {
+      a: {
+        properties: {
+          b: {
+            ignore_above: 1024,
+            type: 'keyword',
+          },
+        },
+      },
+    },
+  };
+  const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
+  const processedFields = processFields(fields);
+  const mappings = generateMappings(processedFields);
+  expect(JSON.stringify(mappings)).toEqual(JSON.stringify(objectFieldWithPropertyReversedMapping));
+});

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.test.ts
@@ -259,3 +259,28 @@ test('tests processing object field with dynamic set to strict', () => {
   const mappings = generateMappings(processedFields);
   expect(JSON.stringify(mappings)).toEqual(JSON.stringify(objectFieldDynamicStrictMapping));
 });
+
+test('tests processing object field with property', () => {
+  const objectFieldWithPropertyLiteralYml = `
+- name: a
+  type: object
+- name: a.b
+  type: keyword
+  `;
+  const objectFieldWithPropertyMapping = {
+    properties: {
+      a: {
+        properties: {
+          b: {
+            ignore_above: 1024,
+            type: 'keyword',
+          },
+        },
+      },
+    },
+  };
+  const fields: Field[] = safeLoad(objectFieldWithPropertyLiteralYml);
+  const processedFields = processFields(fields);
+  const mappings = generateMappings(processedFields);
+  expect(JSON.stringify(mappings)).toEqual(JSON.stringify(objectFieldWithPropertyMapping));
+});

--- a/x-pack/plugins/ingest_manager/server/services/epm/fields/field.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/fields/field.test.ts
@@ -179,4 +179,35 @@ describe('processFields', () => {
       JSON.stringify(mixedFieldsExpanded)
     );
   });
+
+  const objectFieldWithProperty = [
+    {
+      name: 'a',
+      type: 'object',
+      dynamic: true,
+    },
+    {
+      name: 'a.b',
+      type: 'keyword',
+    },
+  ];
+
+  const objectFieldWithPropertyExpanded = [
+    {
+      name: 'a',
+      type: 'group',
+      dynamic: true,
+      fields: [
+        {
+          name: 'b',
+          type: 'keyword',
+        },
+      ],
+    },
+  ];
+  test('correctly handles properties of object type fields', () => {
+    expect(JSON.stringify(processFields(objectFieldWithProperty))).toEqual(
+      JSON.stringify(objectFieldWithPropertyExpanded)
+    );
+  });
 });

--- a/x-pack/plugins/ingest_manager/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/fields/field.ts
@@ -108,7 +108,15 @@ function dedupFields(fields: Fields): Fields {
       return f.name === field.name;
     });
     if (found) {
-      if (found.type === 'group' && field.type === 'group' && found.fields && field.fields) {
+      if (
+        (found.type === 'group' || found.type === 'object') &&
+        field.type === 'group' &&
+        field.fields
+      ) {
+        if (!found.fields) {
+          found.fields = [];
+        }
+        found.type = 'group';
         found.fields = dedupFields(found.fields.concat(field.fields));
       } else {
         // only 'group' fields can be merged in this way


### PR DESCRIPTION
## Summary

This fixes a problem in the mapping generation for fields of type `object` with additional properties.

A field definition of
```
- name: a
  type: object
- name: a.b
  type: keyword
```

now generates a mapping of the form
```
properties: {
      a: {
        properties: {
          b: {
            ignore_above: 1024,
            type: 'keyword',
          },
        },
      },
    },
```
Before this change, the field `a.b` did not get correctly deduped and nested under field `a`.

Thanks to @jonathan-buttner for the analysis!

# How to test this
* Inspect the added test cases. Is this the desired behaviour?
* Installation of packages should work as before.