### PR TITLE
Use HDR for percentiles

### DIFF
--- a/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/fetcher.test.ts.snap
@@ -16,6 +16,9 @@ Array [
               "p95": Object {
                 "percentiles": Object {
                   "field": "transaction.duration.us",
+                  "hdr": Object {
+                    "number_of_significant_value_digits": 2,
+                  },
                   "percents": Array [
                     95,
                   ],
@@ -126,6 +129,9 @@ Array [
               "p95": Object {
                 "percentiles": Object {
                   "field": "transaction.duration.us",
+                  "hdr": Object {
+                    "number_of_significant_value_digits": 2,
+                  },
                   "percents": Array [
                     95,
                   ],

--- a/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/queries.test.ts.snap
@@ -14,6 +14,9 @@ Object {
           "p95": Object {
             "percentiles": Object {
               "field": "transaction.duration.us",
+              "hdr": Object {
+                "number_of_significant_value_digits": 2,
+              },
               "percents": Array [
                 95,
               ],
@@ -120,6 +123,9 @@ Object {
           "p95": Object {
             "percentiles": Object {
               "field": "transaction.duration.us",
+              "hdr": Object {
+                "number_of_significant_value_digits": 2,
+              },
               "percents": Array [
                 95,
               ],

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -83,7 +83,11 @@ export function transactionGroupsFetcher(
             sample: { top_hits: { size: 1, sort } },
             avg: { avg: { field: TRANSACTION_DURATION } },
             p95: {
-              percentiles: { field: TRANSACTION_DURATION, percents: [95] }
+              percentiles: {
+                field: TRANSACTION_DURATION,
+                percents: [95],
+                hdr: { number_of_significant_value_digits: 2 }
+              }
             },
             sum: { sum: { field: TRANSACTION_DURATION } }
           }

--- a/x-pack/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
@@ -333,6 +333,9 @@ Object {
           "pct": Object {
             "percentiles": Object {
               "field": "transaction.duration.us",
+              "hdr": Object {
+                "number_of_significant_value_digits": 2,
+              },
               "percents": Array [
                 95,
                 99,
@@ -425,6 +428,9 @@ Object {
           "pct": Object {
             "percentiles": Object {
               "field": "transaction.duration.us",
+              "hdr": Object {
+                "number_of_significant_value_digits": 2,
+              },
               "percents": Array [
                 95,
                 99,
@@ -522,6 +528,9 @@ Object {
           "pct": Object {
             "percentiles": Object {
               "field": "transaction.duration.us",
+              "hdr": Object {
+                "number_of_significant_value_digits": 2,
+              },
               "percents": Array [
                 95,
                 99,

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/__snapshots__/fetcher.test.ts.snap
@@ -21,6 +21,9 @@ Array [
               "pct": Object {
                 "percentiles": Object {
                   "field": "transaction.duration.us",
+                  "hdr": Object {
+                    "number_of_significant_value_digits": 2,
+                  },
                   "percents": Array [
                     95,
                     99,

--- a/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/charts/get_timeseries_data/fetcher.ts
@@ -69,7 +69,11 @@ export function timeseriesFetcher({
           aggs: {
             avg: { avg: { field: TRANSACTION_DURATION } },
             pct: {
-              percentiles: { field: TRANSACTION_DURATION, percents: [95, 99] }
+              percentiles: {
+                field: TRANSACTION_DURATION,
+                percents: [95, 99],
+                hdr: { number_of_significant_value_digits: 2 }
+              }
             }
           }
         },

--- a/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
+++ b/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
@@ -86,6 +86,7 @@ export interface AggregationOptionsByType {
   percentiles: {
     field: string;
     percents?: number[];
+    hdr?: { number_of_significant_value_digits: number };
   };
   extended_stats: {
     field: string;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/62399

This seems like a simple optimisation that we should do (previously discussed on Slack). Additional benchmarks would be nice but I'm not sure it's absolutely necessary.