### PR TITLE
[Drilldowns] Dashboard url generator to preserve saved filters from destination dashboard

### DIFF
--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -141,10 +141,14 @@ export class DashboardPlugin
 
     if (share) {
       share.urlGenerators.registerUrlGenerator(
-        createDirectAccessDashboardLinkGenerator(async () => ({
-          appBasePath: (await startServices)[0].application.getUrlForApp('dashboard'),
-          useHashedUrl: (await startServices)[0].uiSettings.get('state:storeInSessionStorage'),
-        }))
+        createDirectAccessDashboardLinkGenerator(async () => {
+          const [coreStart, , selfStart] = await startServices;
+          return {
+            appBasePath: coreStart.application.getUrlForApp('dashboard'),
+            useHashedUrl: coreStart.uiSettings.get('state:storeInSessionStorage'),
+            savedDashboardLoader: selfStart.getSavedDashboardLoader(),
+          };
+        })
       );
     }
 

--- a/src/plugins/dashboard/public/url_generator.test.ts
+++ b/src/plugins/dashboard/public/url_generator.test.ts
@@ -21,9 +21,32 @@ import { createDirectAccessDashboardLinkGenerator } from './url_generator';
 import { hashedItemStore } from '../../kibana_utils/public';
 // eslint-disable-next-line
 import { mockStorage } from '../../kibana_utils/public/storage/hashed_item_store/mock';
-import { esFilters } from '../../data/public';
+import { esFilters, Filter } from '../../data/public';
+import { SavedObjectLoader } from '../../saved_objects/public';
 
 const APP_BASE_PATH: string = 'xyz/app/kibana';
+
+const createMockDashboardLoader = (
+  dashboardToFilters: {
+    [dashboardId: string]: () => Filter[];
+  } = {}
+) => {
+  return {
+    get: async (dashboardId: string) => {
+      return {
+        searchSource: {
+          getField: (field: string) => {
+            if (field === 'filter')
+              return dashboardToFilters[dashboardId] ? dashboardToFilters[dashboardId]() : [];
+            throw new Error(
+              `createMockDashboardLoader > searchSource > getField > ${field} is not mocked`
+            );
+          },
+        },
+      };
+    },
+  } as SavedObjectLoader;
+};
 
 describe('dashboard url generator', () => {
   beforeEach(() => {
@@ -33,7 +56,11 @@ describe('dashboard url generator', () => {
 
   test('creates a link to a saved dashboard', async () => {
     const generator = createDirectAccessDashboardLinkGenerator(() =>
-      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
+      Promise.resolve({
+        appBasePath: APP_BASE_PATH,
+        useHashedUrl: false,
+        savedDashboardLoader: createMockDashboardLoader(),
+      })
     );
     const url = await generator.createUrl!({});
     expect(url).toMatchInlineSnapshot(`"xyz/app/kibana#/dashboard?_a=()&_g=()"`);
@@ -41,7 +68,11 @@ describe('dashboard url generator', () => {
 
   test('creates a link with global time range set up', async () => {
     const generator = createDirectAccessDashboardLinkGenerator(() =>
-      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
+      Promise.resolve({
+        appBasePath: APP_BASE_PATH,
+        useHashedUrl: false,
+        savedDashboardLoader: createMockDashboardLoader(),
+      })
     );
     const url = await generator.createUrl!({
       timeRange: { to: 'now', from: 'now-15m', mode: 'relative' },
@@ -53,7 +84,11 @@ describe('dashboard url generator', () => {
 
   test('creates a link with filters, time range, refresh interval and query to a saved object', async () => {
     const generator = createDirectAccessDashboardLinkGenerator(() =>
-      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
+      Promise.resolve({
+        appBasePath: APP_BASE_PATH,
+        useHashedUrl: false,
+        savedDashboardLoader: createMockDashboardLoader(),
+      })
     );
     const url = await generator.createUrl!({
       timeRange: { to: 'now', from: 'now-15m', mode: 'relative' },
@@ -89,7 +124,11 @@ describe('dashboard url generator', () => {
 
   test('if no useHash setting is given, uses the one was start services', async () => {
     const generator = createDirectAccessDashboardLinkGenerator(() =>
-      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: true })
+      Promise.resolve({
+        appBasePath: APP_BASE_PATH,
+        useHashedUrl: true,
+        savedDashboardLoader: createMockDashboardLoader(),
+      })
     );
     const url = await generator.createUrl!({
       timeRange: { to: 'now', from: 'now-15m', mode: 'relative' },
@@ -99,7 +138,11 @@ describe('dashboard url generator', () => {
 
   test('can override a false useHash ui setting', async () => {
     const generator = createDirectAccessDashboardLinkGenerator(() =>
-      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: false })
+      Promise.resolve({
+        appBasePath: APP_BASE_PATH,
+        useHashedUrl: false,
+        savedDashboardLoader: createMockDashboardLoader(),
+      })
     );
     const url = await generator.createUrl!({
       timeRange: { to: 'now', from: 'now-15m', mode: 'relative' },
@@ -110,12 +153,162 @@ describe('dashboard url generator', () => {
 
   test('can override a true useHash ui setting', async () => {
     const generator = createDirectAccessDashboardLinkGenerator(() =>
-      Promise.resolve({ appBasePath: APP_BASE_PATH, useHashedUrl: true })
+      Promise.resolve({
+        appBasePath: APP_BASE_PATH,
+        useHashedUrl: true,
+        savedDashboardLoader: createMockDashboardLoader(),
+      })
     );
     const url = await generator.createUrl!({
       timeRange: { to: 'now', from: 'now-15m', mode: 'relative' },
       useHash: false,
     });
     expect(url.indexOf('relative')).toBeGreaterThan(1);
+  });
+
+  describe('preserving saved filters', () => {
+    const savedFilter1 = {
+      meta: {
+        alias: null,
+        disabled: false,
+        negate: false,
+      },
+      query: { query: 'savedfilter1' },
+    };
+
+    const savedFilter2 = {
+      meta: {
+        alias: null,
+        disabled: false,
+        negate: false,
+      },
+      query: { query: 'savedfilter2' },
+    };
+
+    const appliedFilter = {
+      meta: {
+        alias: null,
+        disabled: false,
+        negate: false,
+      },
+      query: { query: 'appliedfilter' },
+    };
+
+    test('attaches filters from destination dashboard', async () => {
+      const generator = createDirectAccessDashboardLinkGenerator(() =>
+        Promise.resolve({
+          appBasePath: APP_BASE_PATH,
+          useHashedUrl: false,
+          savedDashboardLoader: createMockDashboardLoader({
+            ['dashboard1']: () => [savedFilter1],
+            ['dashboard2']: () => [savedFilter2],
+          }),
+        })
+      );
+
+      const urlToDashboard1 = await generator.createUrl!({
+        dashboardId: 'dashboard1',
+        filters: [appliedFilter],
+      });
+
+      expect(urlToDashboard1).toEqual(expect.stringContaining('query:savedfilter1'));
+      expect(urlToDashboard1).toEqual(expect.stringContaining('query:appliedfilter'));
+
+      const urlToDashboard2 = await generator.createUrl!({
+        dashboardId: 'dashboard2',
+        filters: [appliedFilter],
+      });
+
+      expect(urlToDashboard2).toEqual(expect.stringContaining('query:savedfilter2'));
+      expect(urlToDashboard2).toEqual(expect.stringContaining('query:appliedfilter'));
+    });
+
+    test("doesn't fail if can't retrieve filters from destination dashboard", async () => {
+      const generator = createDirectAccessDashboardLinkGenerator(() =>
+        Promise.resolve({
+          appBasePath: APP_BASE_PATH,
+          useHashedUrl: false,
+          savedDashboardLoader: createMockDashboardLoader({
+            ['dashboard1']: () => {
+              throw new Error('Not found');
+            },
+          }),
+        })
+      );
+
+      const url = await generator.createUrl!({
+        dashboardId: 'dashboard1',
+        filters: [appliedFilter],
+      });
+
+      expect(url).not.toEqual(expect.stringContaining('query:savedfilter1'));
+      expect(url).toEqual(expect.stringContaining('query:appliedfilter'));
+    });
+
+    test('can enforce empty filters', async () => {
+      const generator = createDirectAccessDashboardLinkGenerator(() =>
+        Promise.resolve({
+          appBasePath: APP_BASE_PATH,
+          useHashedUrl: false,
+          savedDashboardLoader: createMockDashboardLoader({
+            ['dashboard1']: () => [savedFilter1],
+          }),
+        })
+      );
+
+      const url = await generator.createUrl!({
+        dashboardId: 'dashboard1',
+        filters: [],
+        preserveSavedFilters: false,
+      });
+
+      expect(url).not.toEqual(expect.stringContaining('query:savedfilter1'));
+      expect(url).not.toEqual(expect.stringContaining('query:appliedfilter'));
+      expect(url).toMatchInlineSnapshot(
+        `"xyz/app/kibana#/dashboard/dashboard1?_a=(filters:!())&_g=(filters:!())"`
+      );
+    });
+
+    test('no filters in result url if no filters applied', async () => {
+      const generator = createDirectAccessDashboardLinkGenerator(() =>
+        Promise.resolve({
+          appBasePath: APP_BASE_PATH,
+          useHashedUrl: false,
+          savedDashboardLoader: createMockDashboardLoader({
+            ['dashboard1']: () => [savedFilter1],
+          }),
+        })
+      );
+
+      const url = await generator.createUrl!({
+        dashboardId: 'dashboard1',
+      });
+      expect(url).not.toEqual(expect.stringContaining('filters'));
+      expect(url).toMatchInlineSnapshot(`"xyz/app/kibana#/dashboard/dashboard1?_a=()&_g=()"`);
+    });
+
+    test('can turn off preserving filters', async () => {
+      const generator = createDirectAccessDashboardLinkGenerator(() =>
+        Promise.resolve({
+          appBasePath: APP_BASE_PATH,
+          useHashedUrl: false,
+          savedDashboardLoader: createMockDashboardLoader({
+            ['dashboard1']: () => [savedFilter1],
+          }),
+        })
+      );
+      const urlWithPreservedFiltersTurnedOff = await generator.createUrl!({
+        dashboardId: 'dashboard1',
+        filters: [appliedFilter],
+        preserveSavedFilters: false,
+      });
+
+      expect(urlWithPreservedFiltersTurnedOff).not.toEqual(
+        expect.stringContaining('query:savedfilter1')
+      );
+      expect(urlWithPreservedFiltersTurnedOff).toEqual(
+        expect.stringContaining('query:appliedfilter')
+      );
+    });
   });
 });

--- a/src/plugins/dashboard/public/url_generator.ts
+++ b/src/plugins/dashboard/public/url_generator.ts
@@ -27,6 +27,7 @@ import {
 } from '../../data/public';
 import { setStateToKbnUrl } from '../../kibana_utils/public';
 import { UrlGeneratorsDefinition, UrlGeneratorState } from '../../share/public';
+import { SavedObjectLoader } from '../../saved_objects/public';
 
 export const STATE_STORAGE_KEY = '_a';
 export const GLOBAL_STATE_STORAGE_KEY = '_g';
@@ -64,10 +65,22 @@ export type DashboardAppLinkGeneratorState = UrlGeneratorState<{
    * whether to hash the data in the url to avoid url length issues.
    */
   useHash?: boolean;
+
+  /**
+   * When `true` filters from saved filters from destination dashboard as merged with applied filters
+   * When `false` applied filters take precedence and override saved filters
+   *
+   * true is default
+   */
+  preserveSavedFilters?: boolean;
 }>;
 
 export const createDirectAccessDashboardLinkGenerator = (
-  getStartServices: () => Promise<{ appBasePath: string; useHashedUrl: boolean }>
+  getStartServices: () => Promise<{
+    appBasePath: string;
+    useHashedUrl: boolean;
+    savedDashboardLoader: SavedObjectLoader;
+  }>
 ): UrlGeneratorsDefinition<typeof DASHBOARD_APP_URL_GENERATOR> => ({
   id: DASHBOARD_APP_URL_GENERATOR,
   createUrl: async state => {
@@ -75,6 +88,19 @@ export const createDirectAccessDashboardLinkGenerator = (
     const useHash = state.useHash ?? startServices.useHashedUrl;
     const appBasePath = startServices.appBasePath;
     const hash = state.dashboardId ? `dashboard/${state.dashboardId}` : `dashboard`;
+
+    const getSavedFiltersFromDestinationDashboardIfNeeded = async (): Promise<Filter[]> => {
+      if (state.preserveSavedFilters === false) return [];
+      if (!state.dashboardId) return [];
+      try {
+        const dashboard = await startServices.savedDashboardLoader.get(state.dashboardId);
+        return dashboard?.searchSource?.getField('filter') ?? [];
+      } catch (e) {
+        // in case dashboard is missing, built the url without those filters
+        // dashboard app will handle redirect to landing page with toast message
+        return [];
+      }
+    };
 
     const cleanEmptyKeys = (stateObj: Record<string, unknown>) => {
       Object.keys(stateObj).forEach(key => {
@@ -85,11 +111,18 @@ export const createDirectAccessDashboardLinkGenerator = (
       return stateObj;
     };
 
+    // leave filters `undefined` if no filters was applied
+    // in this case dashboard will restore saved filters on its own
+    const filters = state.filters && [
+      ...(await getSavedFiltersFromDestinationDashboardIfNeeded()),
+      ...state.filters,
+    ];
+
     const appStateUrl = setStateToKbnUrl(
       STATE_STORAGE_KEY,
       cleanEmptyKeys({
         query: state.query,
-        filters: state.filters?.filter(f => !esFilters.isFilterPinned(f)),
+        filters: filters?.filter(f => !esFilters.isFilterPinned(f)),
       }),
       { useHash },
       `${appBasePath}#/${hash}`
@@ -99,7 +132,7 @@ export const createDirectAccessDashboardLinkGenerator = (
       GLOBAL_STATE_STORAGE_KEY,
       cleanEmptyKeys({
         time: state.timeRange,
-        filters: state.filters?.filter(f => esFilters.isFilterPinned(f)),
+        filters: filters?.filter(f => esFilters.isFilterPinned(f)),
         refreshInterval: state.refreshInterval,
       }),
       { useHash },


### PR DESCRIPTION
## Summary

Needed for #61219.

In drilldowns branch there is _a bug_ with filters right now: When url to drilldown is generated and navigated to, fillers from URL always take precedence which makes sense for normal url flow, but doesn't make sense for navigation with drilldown. 

This pr fetches destination dashboard in url generator and adds it's saved filters into resulting url.
Url generator doesn't do any error handling and just swallows errors if retrieving those filters wasn't successful. 

Please refer to original discussion for more context: https://github.com/elastic/kibana/pull/63108#discussion_r414104941

> So options:
Option 1: retrieve saved filters in Drilldowns code. Pass all filters to url generator
Option 2: retrieve saved filters inside url generator. merge them with incoming filters when generating url
Option 3: Url generator optionally adds additional flag in the url to also preserve saved filters: e.g. &savedFilters=merge. When dashboard is loaded it will use that flag to decided what to do with filters saved in dashboard.

This pr goes with `Option 2` ⬆️ 
Initially I built `Option 3`: https://github.com/elastic/kibana/pull/64633

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
