### PR TITLE
[EPM] Handle constant_keyword type in KB index patterns and ES index templates

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.test.ts
@@ -309,3 +309,21 @@ test('tests processing object field with property, reverse order', () => {
   const mappings = generateMappings(processedFields);
   expect(JSON.stringify(mappings)).toEqual(JSON.stringify(objectFieldWithPropertyReversedMapping));
 });
+
+test('tests constant_keyword field type handling', () => {
+  const constantKeywordLiteralYaml = `
+- name: constantKeyword
+  type: constant_keyword
+  `;
+  const constantKeywordMapping = {
+    properties: {
+      constantKeyword: {
+        type: 'constant_keyword',
+      },
+    },
+  };
+  const fields: Field[] = safeLoad(constantKeywordLiteralYaml);
+  const processedFields = processFields(fields);
+  const mappings = generateMappings(processedFields);
+  expect(JSON.stringify(mappings)).toEqual(JSON.stringify(constantKeywordMapping));
+});

--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.test.ts
@@ -150,6 +150,7 @@ describe('creating index patterns from yaml fields', () => {
       { fields: [{ name: 'testField', type: 'text' }], expect: 'string' },
       { fields: [{ name: 'testField', type: 'date' }], expect: 'date' },
       { fields: [{ name: 'testField', type: 'geo_point' }], expect: 'geo_point' },
+      { fields: [{ name: 'testField', type: 'constant_keyword' }], expect: 'string' },
     ];
 
     tests.forEach(test => {
@@ -191,6 +192,7 @@ describe('creating index patterns from yaml fields', () => {
         attr: 'aggregatable',
       },
       { fields: [{ name, type: 'keyword' }], expect: true, attr: 'aggregatable' },
+      { fields: [{ name, type: 'constant_keyword' }], expect: true, attr: 'aggregatable' },
       { fields: [{ name, type: 'text', aggregatable: true }], expect: false, attr: 'aggregatable' },
       { fields: [{ name, type: 'text' }], expect: false, attr: 'aggregatable' },
       {

--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
@@ -47,6 +47,7 @@ const typeMap: TypeMap = {
   date: 'date',
   ip: 'ip',
   boolean: 'boolean',
+  constant_keyword: 'string',
 };
 
 export interface IndexPatternField {


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/61112

For index templates, adds a unit test to verify the behavior as the type was already handled by default.
For index patterns, `constant_keyword` is treated like a `keyword`, i.e. as an `aggregatable` `string`.

## To test this:
* Package installation should work as before.
* Check the newly added unit tests if the behavior is correct.