### PR TITLE
[APM] Fix duplicate index patterns

### DIFF
--- a/x-pack/plugins/apm/server/tutorial/index.ts
+++ b/x-pack/plugins/apm/server/tutorial/index.ts
@@ -14,6 +14,9 @@ import {
   TutorialsCategory
 } from '../../../../../src/plugins/home/server';
 
+// duplicated in x-pack/plugins/apm/common/index_pattern_constants.ts
+const APM_STATIC_INDEX_PATTERN_ID = 'apm_static_index_pattern_id';
+
 const apmIntro = i18n.translate('xpack.apm.tutorial.introduction', {
   defaultMessage:
     'Collect in-depth performance metrics and errors from inside your applications.'
@@ -39,6 +42,7 @@ export const tutorialProvider = ({
   const savedObjects = [
     {
       ...apmIndexPattern,
+      id: APM_STATIC_INDEX_PATTERN_ID,
       attributes: {
         ...apmIndexPattern.attributes,
         title: indexPatternTitle

--- a/x-pack/plugins/apm/server/tutorial/index.ts
+++ b/x-pack/plugins/apm/server/tutorial/index.ts
@@ -13,9 +13,7 @@ import {
   ArtifactsSchema,
   TutorialsCategory
 } from '../../../../../src/plugins/home/server';
-
-// duplicated in x-pack/plugins/apm/common/index_pattern_constants.ts
-const APM_STATIC_INDEX_PATTERN_ID = 'apm_static_index_pattern_id';
+import { APM_STATIC_INDEX_PATTERN_ID } from '../../common/index_pattern_constants';
 
 const apmIntro = i18n.translate('xpack.apm.tutorial.introduction', {
   defaultMessage:


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/61378
Closes https://github.com/elastic/kibana/issues/64765

An index pattern with the id “apm_static_index_pattern_id” is automatically created when opening the APM app. It is also possible to manually create the index pattern by clicking “Load Kibana Objects” in the Getting Started Guide, however this will create an index pattern with a different id (“apm-*).

This fixes it by making sure the index pattern id is always “apm_static_index_pattern_id”.


![image](https://user-images.githubusercontent.com/209966/80706140-12c27100-8ae8-11ea-9c80-77d07201a681.png)
