### PR TITLE
[Discover] Show doc viewer action buttons on focus

### DIFF
--- a/src/plugins/discover/public/components/doc_viewer/_doc_viewer.scss
+++ b/src/plugins/discover/public/components/doc_viewer/_doc_viewer.scss
@@ -43,6 +43,14 @@
 }
 .kbnDocViewer__buttons {
   width: 60px;
+
+  // Show all icons if one is focused,
+  // IE doesn't support, but the fallback is just the focused button becomes visible
+  &:focus-within {
+    .kbnDocViewer__actionButton {
+      opacity: 1;
+    }
+  }
 }
 
 .kbnDocViewer__field {
@@ -51,7 +59,12 @@
 
 .kbnDocViewer__actionButton {
   opacity: 0;
+
+  &:focus {
+    opacity: 1;
+  }
 }
+
 .kbnDocViewer__warning {
   margin-right: $euiSizeS;
 }


### PR DESCRIPTION
## Fixes #64902

The filter buttons in the doc viewer were staying hidden when focused with the keyboard. The fix was to simply add some `:focus` and `:focus-within` selectors to put the `opacity` back at `1`.

**Before**

<img width="370" alt="Screen Shot 2020-04-30 at 11 12 35 AM" src="https://user-images.githubusercontent.com/549577/80727337-9756c480-8ad3-11ea-8ed7-ea1e16c1b1f9.png">


**After**

<img width="294" alt="Screen Shot 2020-04-30 at 10 53 49 AM" src="https://user-images.githubusercontent.com/549577/80727362-9f166900-8ad3-11ea-8de7-1f2364422082.png">

**IE11 / Fallback**

For any browser not supporting `:focus-within`, it will still at least reveal the focused button, but the other buttons will remain hidden.

<img width="296" alt="Screen Shot 2020-04-30 at 11 11 44 AM" src="https://user-images.githubusercontent.com/549577/80727755-1815c080-8ad4-11ea-86c5-1b5879850df5.png">



### Checklist

Delete any items that are not applicable to this PR.

- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
