### PR TITLE
Update kuery.asciidoc

### DIFF
--- a/docs/discover/kuery.asciidoc
+++ b/docs/discover/kuery.asciidoc
@@ -54,6 +54,8 @@ Instead of `bytes:>1000`, we omit the colon: `bytes > 1000`.
 
 `>, >=, <, <=` are all valid range operators.
 
+`AND, NOT` are valid comparison operators.
+
 Exist queries are simple and do not require a special operator. `response:*` will find all docs where the response
 field exists.
 

--- a/docs/discover/kuery.asciidoc
+++ b/docs/discover/kuery.asciidoc
@@ -54,7 +54,7 @@ Instead of `bytes:>1000`, we omit the colon: `bytes > 1000`.
 
 `>, >=, <, <=` are all valid range operators.
 
-`AND, NOT` are valid comparison operators.
+`AND, NOT` are valid logical operators.
 
 Exist queries are simple and do not require a special operator. `response:*` will find all docs where the response
 field exists.


### PR DESCRIPTION
Adding comparison operators.

## Summary

Adding the logical operators to the page as only the range operators were listed.

### Checklist

Delete any items that are not applicable to this PR.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [X] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [X] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
