### PR TITLE
[EPM] fix updates available filter

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -205,7 +205,6 @@ export interface RegistryVarsEntry {
 interface PackageAdditions {
   title: string;
   latestVersion: string;
-  installedVersion?: string;
   assets: AssetsGroupedByServiceByType;
 }
 

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/header.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/header.tsx
@@ -29,7 +29,12 @@ const Text = styled.span`
 type HeaderProps = PackageInfo & { iconType?: IconType };
 
 export function Header(props: HeaderProps) {
-  const { iconType, name, title, version, installedVersion, latestVersion } = props;
+  const { iconType, name, title, version, latestVersion } = props;
+
+  let installedVersion;
+  if ('savedObject' in props) {
+    installedVersion = props.savedObject.attributes.version;
+  }
   const hasWriteCapabilites = useCapabilities().write;
   const { toListView } = useLinks();
   const ADD_DATASOURCE_URI = useLink(`${EPM_PATH}/${name}-${version}/add-datasource`);

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/index.tsx
@@ -32,7 +32,10 @@ export function Detail() {
       const packageInfo = response.data?.response;
       const title = packageInfo?.title;
       const name = packageInfo?.name;
-      const installedVersion = packageInfo?.installedVersion;
+      let installedVersion;
+      if (packageInfo && 'savedObject' in packageInfo) {
+        installedVersion = packageInfo.savedObject.attributes.version;
+      }
       const status: InstallStatus = packageInfo?.status as any;
 
       // track install status state

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/home/index.tsx
@@ -77,17 +77,9 @@ function InstalledPackages() {
       ? allPackages.response.filter(pkg => pkg.status === 'installed')
       : [];
 
-  const updatablePackages = allInstalledPackages.reduce<PackageListItem[]>((acc, item) => {
-    if ('savedObject' in item) {
-      if (item.version > item.savedObject.attributes.version) {
-        return acc.concat(item);
-      }
-    }
-    return acc;
-  }, []);
-
-  const packages =
-    selectedCategory === 'updates_available' ? [...updatablePackages] : [...allInstalledPackages];
+  const updatablePackages = allInstalledPackages.filter(
+    item => 'savedObject' in item && item.version > item.savedObject.attributes.version
+  );
 
   const categories = [
     {
@@ -119,7 +111,7 @@ function InstalledPackages() {
       isLoading={isLoadingPackages}
       controls={controls}
       title={title}
-      list={packages}
+      list={selectedCategory === 'updates_available' ? updatablePackages : allInstalledPackages}
     />
   );
 }

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/home/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/home/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../../constants';
 import { useLink, useGetCategories, useGetPackages } from '../../../../hooks';
 import { WithHeaderLayout } from '../../../../layouts';
-import { CategorySummaryItem, PackageListItem } from '../../../../types';
+import { CategorySummaryItem } from '../../../../types';
 import { PackageListGrid } from '../../components/package_list_grid';
 import { CategoryFacets } from './category_facets';
 import { HeroCopy, HeroImage } from './header';

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/types/index.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/types/index.ts
@@ -90,4 +90,5 @@ export {
   DetailViewPanelName,
   InstallStatus,
   InstallationStatus,
+  Installable,
 } from '../../../../common';

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/index.ts
@@ -43,7 +43,6 @@ export function createInstallableFrom<T>(
     ? {
         ...from,
         status: InstallationStatus.installed,
-        installedVersion: savedObject.attributes.version,
         savedObject,
       }
     : {


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/64957
- gets the filter for "available updates" working
- A somewhat unrelated change, that I missed from @jfsiii's comment (https://github.com/elastic/kibana/pull/64689/files#r417328857) that I didn't need to add installedVersion in package info response because its in the SO

To test:
post an old package (this wont work after https://github.com/elastic/kibana/pull/64932 gets merged):
POST http://localhost:5603/ssg/api/ingest_manager/epm/packages/nginx-0.0.1
POST http://localhost:5603/ssg/api/ingest_manager/epm/packages/system-0.9.0
<img width="1168" alt="Screen Shot 2020-04-30 at 3 54 34 PM" src="https://user-images.githubusercontent.com/1676003/80754357-e36a2f00-8afc-11ea-9248-045f397da0d2.png">
<img width="1179" alt="Screen Shot 2020-04-30 at 3 54 47 PM" src="https://user-images.githubusercontent.com/1676003/80754373-e6651f80-8afc-11ea-9826-d3a0607b469f.png">
