### PR TITLE
[EPM] update endpoint to restrict removing with datasources

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
@@ -6,11 +6,12 @@
 
 import { SavedObjectsClientContract } from 'src/core/server';
 import Boom from 'boom';
-import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../constants';
+import { PACKAGES_SAVED_OBJECT_TYPE, DATASOURCE_SAVED_OBJECT_TYPE } from '../../../constants';
 import { AssetReference, AssetType, ElasticsearchAssetType } from '../../../types';
 import { CallESAsCurrentUser } from '../../../types';
 import { getInstallation, savedObjectTypes } from './index';
 import { installIndexPatterns } from '../kibana/index_pattern/install';
+import { datasourceService } from '../..';
 
 export async function removeInstallation(options: {
   savedObjectsClient: SavedObjectsClientContract;
@@ -25,6 +26,17 @@ export async function removeInstallation(options: {
   if (installation.removable === false)
     throw Boom.badRequest(`${pkgName} is installed by default and cannot be removed`);
   const installedObjects = installation.installed || [];
+
+  const { total } = await datasourceService.list(savedObjectsClient, {
+    kuery: `${DATASOURCE_SAVED_OBJECT_TYPE}.package.name:${pkgName}`,
+    page: 0,
+    perPage: 0,
+  });
+
+  if (total > 0)
+    throw Boom.badRequest(
+      `unable to remove package with existing datasource(s) in use by agent(s)`
+    );
 
   // Delete the manager saved object with references to the asset objects
   // could also update with [] or some other state


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/64976

This slipped by me when creating the UI.  We do not allow users to uninstall a package if datasources for the package exist. The endpoint needs to have the same behavior

To test:
1. Create a datasource using Ingest Manager UI
2. Try to delete via the endpoint:

<img width="1162" alt="Screen Shot 2020-04-30 at 6 38 41 PM" src="https://user-images.githubusercontent.com/1676003/80765792-e6234f00-8b11-11ea-9fa5-ad4faed56ef3.png">

1. Install a package using the settings page or endpoint and do not add datasources
2. Try to delete it through the endpoint or UI
<img width="1168" alt="Screen Shot 2020-04-30 at 6 40 40 PM" src="https://user-images.githubusercontent.com/1676003/80765896-21be1900-8b12-11ea-823d-d1406010c16f.png">
