### PR TITLE
[APM] Fix paths for ts optimization script

### DIFF
--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
@@ -5,7 +5,7 @@
  */
 const path = require('path');
 
-const xpackRoot = path.resolve(__dirname, '../../../../..');
+const xpackRoot = path.resolve(__dirname, '../../../..');
 const kibanaRoot = path.resolve(xpackRoot, '..');
 
 const tsconfigTpl = path.resolve(__dirname, './tsconfig.json');


### PR DESCRIPTION
After https://github.com/elastic/kibana/pull/64046 was merged, the TS optimisation script fails, due to one of the paths being incorrect now. This PR addresses that issue by updating the specific path.