### PR TITLE
[SIEM][Detections Engine] - Minor text overflow fix on signals table

### DIFF
--- a/x-pack/plugins/siem/public/components/timeline/styles.tsx
+++ b/x-pack/plugins/siem/public/components/timeline/styles.tsx
@@ -241,6 +241,7 @@ export const EventsTdContent = styled.div.attrs(({ className }) => ({
   min-width: 0;
   padding: ${({ theme }) => theme.eui.paddingSizes.xs};
   text-align: ${({ textAlign }) => textAlign};
+  overflow: hidden;
   width: 100%; /* Using width: 100% instead of flex: 1 and max-width: 100% for IE11 */
 `;
 


### PR DESCRIPTION
## Summary

Text in signals table cells were overflowing into adjacent cells. Added `overflow:hidden`. Content can still be viewed by expanding column width.

**Before**
![Screen Shot 2020-05-04 at 12 30 07 PM](https://user-images.githubusercontent.com/10927944/80990093-da7ea380-8e03-11ea-9357-10d298ea6557.png)

**After**
![Screen Shot 2020-05-04 at 12 28 57 PM](https://user-images.githubusercontent.com/10927944/80990120-e4a0a200-8e03-11ea-85f6-c126129fe85b.png)

### Checklist

- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
      - tested cells behavior, not over all table/page
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
