### PR TITLE
[SIEM] Removes prebuilt rules number dependency

### DIFF
--- a/x-pack/plugins/siem/cypress/integration/signal_detection_rules_custom.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/signal_detection_rules_custom.spec.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { newRule, totalLoadedRules } from '../objects/rule';
+import { newRule, totalNumberOfPrebuiltRulesInEsArchive } from '../objects/rule';
 
 import {
   ABOUT_FALSE_POSITIVES,
@@ -91,7 +91,7 @@ describe('Signal detection rules, custom', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = totalLoadedRules + 1;
+    const expectedNumberOfRules = totalNumberOfPrebuiltRulesInEsArchive + 1;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });

--- a/x-pack/plugins/siem/cypress/integration/signal_detection_rules_custom.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/signal_detection_rules_custom.spec.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { newRule, totalNumberOfPrebuiltRules } from '../objects/rule';
+import { newRule, totalLoadedRules } from '../objects/rule';
 
 import {
   ABOUT_FALSE_POSITIVES,
@@ -91,7 +91,7 @@ describe('Signal detection rules, custom', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = totalNumberOfPrebuiltRules + 1;
+    const expectedNumberOfRules = totalLoadedRules + 1;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });

--- a/x-pack/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { machineLearningRule, totalNumberOfPrebuiltRules } from '../objects/rule';
+import { machineLearningRule, totalLoadedRules } from '../objects/rule';
 
 import {
   ABOUT_FALSE_POSITIVES,
@@ -88,7 +88,7 @@ describe('Signal detection rules, machine learning', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = totalNumberOfPrebuiltRules + 1;
+    const expectedNumberOfRules = totalLoadedRules + 1;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });

--- a/x-pack/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { machineLearningRule, totalLoadedRules } from '../objects/rule';
+import { machineLearningRule, totalNumberOfPrebuiltRulesInEsArchive } from '../objects/rule';
 
 import {
   ABOUT_FALSE_POSITIVES,
@@ -88,7 +88,7 @@ describe('Signal detection rules, machine learning', () => {
     changeToThreeHundredRowsPerPage();
     waitForRulesToBeLoaded();
 
-    const expectedNumberOfRules = totalLoadedRules + 1;
+    const expectedNumberOfRules = totalNumberOfPrebuiltRulesInEsArchive + 1;
     cy.get(RULES_TABLE).then($table => {
       cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
     });

--- a/x-pack/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
@@ -71,6 +71,9 @@ describe('Signal detection rules, prebuilt rules', () => {
 
 describe('Deleting prebuilt rules', () => {
   beforeEach(() => {
+    const expectedNumberOfRules = totalNumberOfPrebuiltRules;
+    const expectedElasticRulesBtnText = `Elastic rules (${expectedNumberOfRules})`;
+
     esArchiverLoadEmptyKibana();
     loginAndWaitForPageWithoutDateRange(DETECTIONS);
     waitForSignalsPanelToBeLoaded();
@@ -79,6 +82,17 @@ describe('Deleting prebuilt rules', () => {
     waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded();
     loadPrebuiltDetectionRules();
     waitForPrebuiltDetectionRulesToBeLoaded();
+
+    cy.get(ELASTIC_RULES_BTN)
+      .invoke('text')
+      .should('eql', expectedElasticRulesBtnText);
+
+    changeToThreeHundredRowsPerPage();
+    waitForRulesToBeLoaded();
+
+    cy.get(RULES_TABLE).then($table => {
+      cy.wrap($table.find(RULES_ROW).length).should('eql', expectedNumberOfRules);
+    });
   });
 
   afterEach(() => {

--- a/x-pack/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/signal_detection_rules_prebuilt.spec.ts
@@ -28,12 +28,7 @@ import {
   waitForSignalsIndexToBeCreated,
   waitForSignalsPanelToBeLoaded,
 } from '../tasks/detections';
-import {
-  esArchiverLoad,
-  esArchiverLoadEmptyKibana,
-  esArchiverUnloadEmptyKibana,
-  esArchiverUnload,
-} from '../tasks/es_archiver';
+import { esArchiverLoadEmptyKibana, esArchiverUnloadEmptyKibana } from '../tasks/es_archiver';
 import { loginAndWaitForPageWithoutDateRange } from '../tasks/login';
 
 import { DETECTIONS } from '../urls/navigation';
@@ -76,15 +71,18 @@ describe('Signal detection rules, prebuilt rules', () => {
 
 describe('Deleting prebuilt rules', () => {
   beforeEach(() => {
-    esArchiverLoad('prebuilt_rules_loaded');
+    esArchiverLoadEmptyKibana();
     loginAndWaitForPageWithoutDateRange(DETECTIONS);
     waitForSignalsPanelToBeLoaded();
     waitForSignalsIndexToBeCreated();
     goToManageSignalDetectionRules();
+    waitForLoadElasticPrebuiltDetectionRulesTableToBeLoaded();
+    loadPrebuiltDetectionRules();
+    waitForPrebuiltDetectionRulesToBeLoaded();
   });
 
   afterEach(() => {
-    esArchiverUnload('prebuilt_rules_loaded');
+    esArchiverUnloadEmptyKibana();
   });
 
   it('Does not allow to delete one rule when more than one is selected', () => {

--- a/x-pack/plugins/siem/cypress/objects/rule.ts
+++ b/x-pack/plugins/siem/cypress/objects/rule.ts
@@ -9,7 +9,7 @@ import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_ru
 
 export const totalNumberOfPrebuiltRules = rawRules.length;
 
-export const totalLoadedRules = 127;
+export const totalNumberOfPrebuiltRulesInEsArchive = 127;
 
 interface Mitre {
   tactic: string;

--- a/x-pack/plugins/siem/cypress/objects/rule.ts
+++ b/x-pack/plugins/siem/cypress/objects/rule.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-// eslint-disable-next-line
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_rules/index';
 
 export const totalNumberOfPrebuiltRules = rawRules.length;

--- a/x-pack/plugins/siem/cypress/objects/rule.ts
+++ b/x-pack/plugins/siem/cypress/objects/rule.ts
@@ -4,7 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export const totalNumberOfPrebuiltRules = 127;
+// eslint-disable-next-line
+import { rawRules } from '../../server/lib/detection_engine/rules/prepackaged_rules/index';
+
+export const totalNumberOfPrebuiltRules = rawRules.length;
+
+export const totalLoadedRules = 127;
 
 interface Mitre {
   tactic: string;

--- a/x-pack/plugins/siem/cypress/tsconfig.json
+++ b/x-pack/plugins/siem/cypress/tsconfig.json
@@ -8,6 +8,7 @@
     "types": [
       "cypress",
       "node"
-    ]
-  }
+    ],
+    "resolveJsonModule": true,
+  },
 }


### PR DESCRIPTION
## Summary

In this PR we are removing the number of prebuilt rules dependency. 

Now we are getting the number of expected prebuilt rules from the `rawRules` array located in `x-pack/plugins/siem/server/lib/detection_engine/rules/prepackaged_rules/index.ts`. In this way we don't need to updated the test every time that we add or remove a new prebuilt rule.