### PR TITLE
[SIEM][Detections] ML services refactor

### DIFF
--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/find_ml_signals.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/find_ml_signals.ts
@@ -6,7 +6,7 @@
 
 import dateMath from '@elastic/datemath';
 
-import { AlertServices } from '../../../../../alerting/server';
+import { APICaller } from '../../../../../../../src/core/server';
 
 import { getAnomalies } from '../../machine_learning';
 
@@ -15,7 +15,7 @@ export const findMlSignals = async (
   anomalyThreshold: number,
   from: string,
   to: string,
-  callCluster: AlertServices['callCluster']
+  callCluster: APICaller
 ) => {
   const params = {
     jobIds: [jobId],

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/find_ml_signals.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/find_ml_signals.ts
@@ -6,24 +6,35 @@
 
 import dateMath from '@elastic/datemath';
 
-import { APICaller } from '../../../../../../../src/core/server';
-
+import { APICaller, KibanaRequest } from '../../../../../../../src/core/server';
+import { MlPluginSetup } from '../../../../../ml/server';
 import { getAnomalies } from '../../machine_learning';
 
-export const findMlSignals = async (
-  jobId: string,
-  anomalyThreshold: number,
-  from: string,
-  to: string,
-  callCluster: APICaller
-) => {
+export const findMlSignals = async ({
+  ml,
+  callCluster,
+  request,
+  jobId,
+  anomalyThreshold,
+  from,
+  to,
+}: {
+  ml: MlPluginSetup;
+  callCluster: APICaller;
+  request: KibanaRequest;
+  jobId: string;
+  anomalyThreshold: number;
+  from: string;
+  to: string;
+}) => {
+  const { mlSearch } = ml.mlSystemProvider(callCluster, request);
   const params = {
     jobIds: [jobId],
     threshold: anomalyThreshold,
     earliestMs: dateMath.parse(from)?.valueOf() ?? 0,
     latestMs: dateMath.parse(to)?.valueOf() ?? 0,
   };
-  const relevantAnomalies = await getAnomalies(params, callCluster);
+  const relevantAnomalies = await getAnomalies(params, mlSearch);
 
   return relevantAnomalies;
 };

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -5,7 +5,7 @@
  */
 
 import { performance } from 'perf_hooks';
-import { Logger } from 'src/core/server';
+import { Logger, KibanaRequest } from 'src/core/server';
 
 import { SIGNALS_ID, DEFAULT_SEARCH_AFTER_PAGE_SIZE } from '../../../../common/constants';
 import { isJobStarted, isMlRule } from '../../../../common/detection_engine/ml_helpers';
@@ -156,13 +156,17 @@ export const signalRulesAlertType = ({
           }
 
           const scopedMlCallCluster = services.getScopedCallCluster(ml.mlClient);
-          const anomalyResults = await findMlSignals(
-            machineLearningJobId,
+          const anomalyResults = await findMlSignals({
+            ml,
+            callCluster: scopedMlCallCluster,
+            // This is needed to satisfy the ML Services API, but can be empty as it is
+            // currently unused by the mlSearch function.
+            request: ({} as unknown) as KibanaRequest,
+            jobId: machineLearningJobId,
             anomalyThreshold,
             from,
             to,
-            scopedMlCallCluster
-          );
+          });
           // TODO What happens if the ML checks fail?
 
           const anomalyCount = anomalyResults.hits.hits.length;

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -167,7 +167,6 @@ export const signalRulesAlertType = ({
             from,
             to,
           });
-          // TODO What happens if the ML checks fail?
 
           const anomalyCount = anomalyResults.hits.hits.length;
           if (anomalyCount) {

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -155,13 +155,16 @@ export const signalRulesAlertType = ({
             await ruleStatusService.error(errorMessage);
           }
 
+          const scopedMlCallCluster = services.getScopedCallCluster(ml.mlClient);
           const anomalyResults = await findMlSignals(
             machineLearningJobId,
             anomalyThreshold,
             from,
             to,
-            services.callCluster
+            scopedMlCallCluster
           );
+          // TODO What happens if the ML checks fail?
+
           const anomalyCount = anomalyResults.hits.hits.length;
           if (anomalyCount) {
             logger.info(buildRuleMessage(`Found ${anomalyCount} signals from ML anomalies.`));

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -138,8 +138,9 @@ export const signalRulesAlertType = ({
             );
           }
 
+          const scopedMlCallCluster = services.getScopedCallCluster(ml.mlClient);
           const summaryJobs = await ml
-            .jobServiceProvider(ml.mlClient.callAsInternalUser)
+            .jobServiceProvider(scopedMlCallCluster)
             .jobsSummary([machineLearningJobId]);
           const jobSummary = summaryJobs.find(job => job.id === machineLearningJobId);
 
@@ -155,7 +156,6 @@ export const signalRulesAlertType = ({
             await ruleStatusService.error(errorMessage);
           }
 
-          const scopedMlCallCluster = services.getScopedCallCluster(ml.mlClient);
           const anomalyResults = await findMlSignals({
             ml,
             callCluster: scopedMlCallCluster,

--- a/x-pack/plugins/siem/server/lib/machine_learning/index.test.ts
+++ b/x-pack/plugins/siem/server/lib/machine_learning/index.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { getAnomalies, AnomaliesSearchParams } from '.';
+
+const getFiltersFromMock = (mock: jest.Mock) => {
+  const [[searchParams]] = mock.mock.calls;
+  return searchParams.body.query.bool.filter;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getBoolCriteriaFromFilters = (filters: any[]) => filters[1].bool.must;
+
+describe('getAnomalies', () => {
+  let searchParams: AnomaliesSearchParams;
+
+  beforeEach(() => {
+    searchParams = {
+      jobIds: ['jobId1'],
+      threshold: 5,
+      earliestMs: 1588517231429,
+      latestMs: 1588617231429,
+    };
+  });
+
+  it('calls the provided mlSearch function', () => {
+    const mockMlSearch = jest.fn();
+    getAnomalies(searchParams, mockMlSearch);
+
+    expect(mockMlSearch).toHaveBeenCalled();
+  });
+
+  it('passes anomalyThreshold as part of the query', () => {
+    const mockMlSearch = jest.fn();
+    getAnomalies(searchParams, mockMlSearch);
+    const filters = getFiltersFromMock(mockMlSearch);
+    const criteria = getBoolCriteriaFromFilters(filters);
+
+    expect(criteria).toEqual(
+      expect.arrayContaining([{ range: { record_score: { gte: searchParams.threshold } } }])
+    );
+  });
+
+  it('passes time range as part of the query', () => {
+    const mockMlSearch = jest.fn();
+    getAnomalies(searchParams, mockMlSearch);
+    const filters = getFiltersFromMock(mockMlSearch);
+    const criteria = getBoolCriteriaFromFilters(filters);
+
+    expect(criteria).toEqual(
+      expect.arrayContaining([
+        {
+          range: {
+            timestamp: {
+              gte: searchParams.earliestMs,
+              lte: searchParams.latestMs,
+              format: 'epoch_millis',
+            },
+          },
+        },
+      ])
+    );
+  });
+
+  it('passes a single jobId as part of the query', () => {
+    const mockMlSearch = jest.fn();
+    getAnomalies(searchParams, mockMlSearch);
+    const filters = getFiltersFromMock(mockMlSearch);
+    const criteria = getBoolCriteriaFromFilters(filters);
+
+    expect(criteria).toEqual(
+      expect.arrayContaining([
+        {
+          query_string: {
+            analyze_wildcard: false,
+            query: 'job_id:jobId1',
+          },
+        },
+      ])
+    );
+  });
+
+  it('passes multiple jobIds as part of the query', () => {
+    const mockMlSearch = jest.fn();
+    searchParams.jobIds = ['jobId1', 'jobId2'];
+    getAnomalies(searchParams, mockMlSearch);
+    const filters = getFiltersFromMock(mockMlSearch);
+    const criteria = getBoolCriteriaFromFilters(filters);
+
+    expect(criteria).toEqual(
+      expect.arrayContaining([
+        {
+          query_string: {
+            analyze_wildcard: false,
+            query: 'job_id:jobId1 OR job_id:jobId2',
+          },
+        },
+      ])
+    );
+  });
+});

--- a/x-pack/plugins/siem/server/lib/machine_learning/index.ts
+++ b/x-pack/plugins/siem/server/lib/machine_learning/index.ts
@@ -4,13 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { SearchResponse } from 'elasticsearch';
+import { SearchResponse, SearchParams } from 'elasticsearch';
 
-import { AlertServices } from '../../../../alerting/server';
 import { AnomalyRecordDoc as Anomaly } from '../../../../ml/common/types/anomalies';
 
 export { Anomaly };
 export type AnomalyResults = SearchResponse<Anomaly>;
+type MlSearch = <T>(searchParams: SearchParams) => Promise<SearchResponse<T>>;
 
 export interface AnomaliesSearchParams {
   jobIds: string[];
@@ -22,12 +22,11 @@ export interface AnomaliesSearchParams {
 
 export const getAnomalies = async (
   params: AnomaliesSearchParams,
-  callCluster: AlertServices['callCluster']
+  mlSearch: MlSearch
 ): Promise<AnomalyResults> => {
   const boolCriteria = buildCriteria(params);
 
-  return callCluster('search', {
-    index: '.ml-anomalies-*',
+  return mlSearch({
     size: params.maxRecords || 100,
     body: {
       query: {


### PR DESCRIPTION
## Summary

Closes #62223
This refactors our detections code to use all available ML services. Functionally, ML Admins are still the only users who can create/edit an ML Rule.

###  Functional changes with this PR:

* Adds a license check to each ML Service call
  * If the rule is run on a kibana instance with an invalid license, the rule execution will be marked as a failure, with a "license needed" error message:
    <img width="1008" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/81015267-0447c280-8e24-11ea-8452-054823f18891.png">
* Job Summary query is performed on behalf of the rule "owner"
  * "owner" here is defined as either the creator or the most recent editor
  * I'm not sure that this is a valid situation, but: if the rule owner were unable to access the jobs' status, the rule execution would fail similar to above.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
