### PR TITLE
[Ingest] add updates available to overview

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/integration_section.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/integration_section.tsx
@@ -22,10 +22,11 @@ import { InstallationStatus } from '../../../types';
 
 export const OverviewIntegrationSection: React.FC = () => {
   const packagesRequest = useGetPackages();
-
-  const total = packagesRequest.data?.response?.length ?? 0;
-  const installed =
-    packagesRequest.data?.response?.filter(p => p.status === InstallationStatus.installed)
+  const res = packagesRequest.data?.response;
+  const total = res?.length ?? 0;
+  const installed = res?.filter(p => p.status === InstallationStatus.installed)?.length ?? 0;
+  const updatablePackages =
+    res?.filter(item => 'savedObject' in item && item.version > item.savedObject.attributes.version)
       ?.length ?? 0;
   return (
     <EuiFlexItem component="section">
@@ -68,6 +69,15 @@ export const OverviewIntegrationSection: React.FC = () => {
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription>
                 <EuiI18nNumber value={installed} />
+              </EuiDescriptionListDescription>
+              <EuiDescriptionListTitle>
+                <FormattedMessage
+                  id="xpack.ingestManager.overviewIntegrationsUpdatesAvailableTitle"
+                  defaultMessage="Updates available"
+                />
+              </EuiDescriptionListTitle>
+              <EuiDescriptionListDescription>
+                <EuiI18nNumber value={updatablePackages} />
               </EuiDescriptionListDescription>
             </>
           )}


### PR DESCRIPTION
As part of https://github.com/elastic/kibana/pull/65024, add "Updates Available" to the Integrations section

To test this you need to have an outdated package installed which isn't possible to do unless a new package has been published since you installed, so you need to comment out the code [here](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts#L105), POST an old version of a package, and then go to the overview page

POST http://localhost:5603/ssg/api/ingest_manager/epm/packages/nginx-0.0.1