### PR TITLE
[7.x] [functional/page_objects] wait for infra ops page is loaded (#65050)

### DIFF
--- a/x-pack/plugins/infra/public/components/loading_page.tsx
+++ b/x-pack/plugins/infra/public/components/loading_page.tsx
@@ -27,7 +27,7 @@ export const LoadingPage = ({ message }: LoadingPageProps) => (
           <EuiFlexItem grow={false}>
             <EuiLoadingSpinner size="xl" />
           </EuiFlexItem>
-          <EuiFlexItem>{message}</EuiFlexItem>
+          <EuiFlexItem data-test-subj="loadingMessage">{message}</EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageContent>
     </EuiPageBody>

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -33,6 +33,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       before(async () => {
         await esArchiver.load('infra/metrics_and_logs');
         await pageObjects.common.navigateToApp('infraOps');
+        await pageObjects.infraHome.waitForLoading();
       });
       after(async () => await esArchiver.unload('infra/metrics_and_logs'));
 

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -74,5 +74,9 @@ export function InfraHomePageProvider({ getService }: FtrProviderContext) {
       await testSubjects.click('configureSourceButton');
       await testSubjects.exists('sourceConfigurationFlyout');
     },
+
+    async waitForLoading() {
+      await testSubjects.missingOrFail('loadingMessage', { timeout: 20000 });
+    },
   };
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [functional/page_objects] wait for infra ops page is loaded (#65050)