### PR TITLE
[Dashboard] Refresh container after clone panel is complete

### DIFF
--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -177,6 +177,7 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
       };
       this.updateInput({
         panels: finalPanels,
+        lastReloadRequestTime: new Date().getTime(),
       });
     });
   }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/64521

It's possible that the values in the visualization changed since the last dashboard refresh, so when cloning the panel the values would be in discrepancy, as described in the issue above. This small fix causes the dashboard container to refresh, syncing the values after the clone is complete:

![dashobard_refresh](https://user-images.githubusercontent.com/1937956/81065569-9d81e200-8ed3-11ea-8ee7-fed3ac399fde.gif)

I tested this by loading the dashboard and then updating the necessary values in ES from dev console, eg:
<img width="693" alt="Screenshot 2020-05-05 at 13 24 17" src="https://user-images.githubusercontent.com/1937956/81065690-e0dc5080-8ed3-11ea-9fa2-26e162a41d87.png">

and then cloning the panel.

### Checklist

Delete any items that are not applicable to this PR.

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
~~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
~~- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
