### PR TITLE
[Fleet] Fix display of local_metadata

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/agent_details.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/agent_details.tsx
@@ -30,7 +30,11 @@ export const AgentDetailsContent: React.FunctionComponent<{
           title: i18n.translate('xpack.ingestManager.agentDetails.hostNameLabel', {
             defaultMessage: 'Host name',
           }),
-          description: agent.local_metadata['host.hostname'],
+          description:
+            typeof agent.local_metadata.host === 'object' &&
+            typeof agent.local_metadata.host.hostname === 'string'
+              ? agent.local_metadata.host.hostname
+              : '-',
         },
         {
           title: i18n.translate('xpack.ingestManager.agentDetails.hostIdLabel', {
@@ -60,13 +64,21 @@ export const AgentDetailsContent: React.FunctionComponent<{
           title: i18n.translate('xpack.ingestManager.agentDetails.versionLabel', {
             defaultMessage: 'Agent version',
           }),
-          description: agent.local_metadata['agent.version'],
+          description:
+            typeof agent.local_metadata['elastic.agent'] === 'object' &&
+            typeof agent.local_metadata['elastic.agent'].version === 'string'
+              ? agent.local_metadata['elastic.agent'].version
+              : '-',
         },
         {
           title: i18n.translate('xpack.ingestManager.agentDetails.platformLabel', {
             defaultMessage: 'Platform',
           }),
-          description: agent.local_metadata['os.platform'],
+          description:
+            typeof agent.local_metadata.os === 'object' &&
+            typeof agent.local_metadata.os.platform === 'string'
+              ? agent.local_metadata.os.platform
+              : '-',
         },
       ].map(({ title, description }) => {
         return (

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/agent_details.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/agent_details.tsx
@@ -65,9 +65,10 @@ export const AgentDetailsContent: React.FunctionComponent<{
             defaultMessage: 'Agent version',
           }),
           description:
-            typeof agent.local_metadata['elastic.agent'] === 'object' &&
-            typeof agent.local_metadata['elastic.agent'].version === 'string'
-              ? agent.local_metadata['elastic.agent'].version
+            typeof agent.local_metadata.elastic === 'object' &&
+            typeof agent.local_metadata.elastic.agent === 'object' &&
+            typeof agent.local_metadata.elastic.agent.version === 'string'
+              ? agent.local_metadata.elastic.agent.version
               : '-',
         },
         {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/index.tsx
@@ -75,7 +75,10 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         <EuiFlexItem>
           <EuiText>
             <h1>
-              {agentData?.item?.local_metadata['host.hostname'] || (
+              {typeof agentData?.item?.local_metadata?.host === 'object' &&
+              typeof agentData?.item?.local_metadata?.host?.hostname === 'string' ? (
+                agentData.item.local_metadata.host.hostname
+              ) : (
                 <FormattedMessage
                   id="xpack.ingestManager.agentDetails.agentDetailsTitle"
                   defaultMessage="Agent '{id}'"

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
@@ -146,6 +146,13 @@ const RowActions = React.memo<{ agent: Agent; onReassignClick: () => void; refre
   }
 );
 
+function safeMetadata(val: any) {
+  if (typeof val !== 'string') {
+    return '-';
+  }
+  return val;
+}
+
 export const AgentListPage: React.FunctionComponent<{}> = () => {
   const defaultKuery: string = (useUrlParams().urlParams.kuery as string) || '';
   const hasWriteCapabilites = useCapabilities().write;
@@ -238,13 +245,13 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
 
   const columns = [
     {
-      field: 'local_metadata.host',
+      field: 'local_metadata.host.hostname',
       name: i18n.translate('xpack.ingestManager.agentList.hostColumnTitle', {
         defaultMessage: 'Host',
       }),
       render: (host: string, agent: Agent) => (
         <ConnectedLink color="primary" path={`${FLEET_AGENT_DETAIL_PATH}${agent.id}`}>
-          {agent.local_metadata['host.hostname'] || host || ''}
+          {safeMetadata(host)}
         </ConnectedLink>
       ),
     },
@@ -308,13 +315,12 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
       },
     },
     {
-      field: 'local_metadata.version',
+      field: 'local_metadata["elastic.agent"].version',
       width: '100px',
       name: i18n.translate('xpack.ingestManager.agentList.versionTitle', {
         defaultMessage: 'Version',
       }),
-      render: (version: string, agent: Agent) =>
-        agent.local_metadata['agent.version'] || version || '',
+      render: (version: string, agent: Agent) => safeMetadata(version),
     },
     {
       field: 'last_checkin',
@@ -505,7 +511,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         loading={isLoading && agentsRequest.isInitialRequest}
         hasActions={true}
         noItemsMessage={
-          isLoading ? (
+          isLoading && agentsRequest.isInitialRequest ? (
             <FormattedMessage
               id="xpack.ingestManager.agentList.loadingAgentsMessage"
               defaultMessage="Loading agents…"

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
@@ -315,7 +315,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
       },
     },
     {
-      field: 'local_metadata["elastic.agent"].version',
+      field: 'local_metadata.elastic.agent.version',
       width: '100px',
       name: i18n.translate('xpack.ingestManager.agentList.versionTitle', {
         defaultMessage: 'Version',


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/65238

fix display of `local_metadata`, I added some type guard also to be sure to not break the page if we have invalid metadata.

With the latest agent:
<img width="1430" alt="Screen Shot 2020-05-05 at 9 06 14 AM" src="https://user-images.githubusercontent.com/1336873/81070950-fe002780-8eb1-11ea-9104-294507600db9.png">
<img width="1259" alt="Screen Shot 2020-05-05 at 9 06 18 AM" src="https://user-images.githubusercontent.com/1336873/81070952-fe98be00-8eb1-11ea-95a8-f93a22103a27.png">

