### PR TITLE
[Fleet] Redirect user to fleet setup in enrollment flyout

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/index.tsx
@@ -23,8 +23,10 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { AgentConfig } from '../../../../types';
 import { EnrollmentStepAgentConfig } from './config_selection';
-import { useGetOneEnrollmentAPIKey, useCore, useGetSettings } from '../../../../hooks';
+import { useGetOneEnrollmentAPIKey, useCore, useGetSettings, useLink } from '../../../../hooks';
 import { ManualInstructions } from '../../../../components/enrollment_instructions';
+import { FLEET_PATH } from '../../../../constants';
+import { useFleetStatus } from '../../../../hooks/use_fleet_status';
 
 interface Props {
   onClose: () => void;
@@ -36,6 +38,9 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
   agentConfigs = [],
 }) => {
   const core = useCore();
+  const fleetStatus = useFleetStatus();
+  const fleetLink = useLink(FLEET_PATH);
+
   const [selectedAPIKeyId, setSelectedAPIKeyId] = useState<string | undefined>();
 
   const settings = useGetSettings();
@@ -104,7 +109,28 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiSteps steps={steps} />
+        {fleetStatus.isReady ? (
+          <>
+            <EuiSteps steps={steps} />
+          </>
+        ) : (
+          <>
+            <FormattedMessage
+              id="xpack.ingestManager.agentEnrollment.fleetNotInitializedText"
+              defaultMessage="Fleet needs to be set up before agents can be enrolled. {link}"
+              values={{
+                link: (
+                  <EuiLink href={fleetLink}>
+                    <FormattedMessage
+                      id="xpack.ingestManager.agentEnrollment.goToFleetButton"
+                      defaultMessage="Go to Fleet."
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
+          </>
+        )}
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">


### PR DESCRIPTION
## Summary

Display a message that redirect user to fleet setup if a user try to open the enrollment flyout before set up fleet.

This has been merged before, but I loose it in a merge conflict. #65027 

<img width="1677" alt="Screen Shot 2020-05-05 at 9 30 09 AM" src="https://user-images.githubusercontent.com/1336873/81072165-bb3f4f00-8eb3-11ea-9280-fb4075fb0d0b.png">
