### PR TITLE
[7.x] [Metrics UI] Add 99th and 95th percentiles to Metric Explorer (#64699)

### DIFF
--- a/x-pack/plugins/infra/common/http_api/metrics_explorer.ts
+++ b/x-pack/plugins/infra/common/http_api/metrics_explorer.ts
@@ -14,6 +14,8 @@ export const METRIC_EXPLORER_AGGREGATIONS = [
   'rate',
   'count',
   'sum',
+  'p95',
+  'p99',
 ] as const;
 
 type MetricExplorerAggregations = typeof METRIC_EXPLORER_AGGREGATIONS[number];

--- a/x-pack/plugins/infra/common/inventory_models/types.ts
+++ b/x-pack/plugins/infra/common/inventory_models/types.ts
@@ -152,11 +152,26 @@ export const TSVBMetricModelSeriesAggRT = rt.type({
   type: rt.literal('series_agg'),
 });
 
+export const TSVBPercentileItemRT = rt.type({
+  id: rt.string,
+  value: rt.number,
+});
+
+export const TSVBMetricModePercentileAggRT = rt.intersection([
+  rt.type({
+    id: rt.string,
+    type: rt.literal('percentile'),
+    percentiles: rt.array(TSVBPercentileItemRT),
+  }),
+  rt.partial({ field: rt.string }),
+]);
+
 export const TSVBMetricRT = rt.union([
   TSVBMetricModelCountRT,
   TSVBMetricModelBasicMetricRT,
   TSVBMetricModelBucketScriptRT,
   TSVBMetricModelDerivativeRT,
+  TSVBMetricModePercentileAggRT,
   TSVBMetricModelSeriesAggRT,
 ]);
 export type TSVBMetric = rt.TypeOf<typeof TSVBMetricRT>;

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/aggregation.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/aggregation.tsx
@@ -41,6 +41,12 @@ export const MetricsExplorerAggregationPicker = ({ options, onChange }: Props) =
     ['rate']: i18n.translate('xpack.infra.metricsExplorer.aggregationLables.rate', {
       defaultMessage: 'Rate',
     }),
+    ['p95']: i18n.translate('xpack.infra.metricsExplorer.aggregationLables.p95', {
+      defaultMessage: '95th Percentile',
+    }),
+    ['p99']: i18n.translate('xpack.infra.metricsExplorer.aggregationLables.p99', {
+      defaultMessage: '99th Percentile',
+    }),
     ['count']: i18n.translate('xpack.infra.metricsExplorer.aggregationLables.count', {
       defaultMessage: 'Document count',
     }),

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/calculate_domain.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/calculate_domain.ts
@@ -6,6 +6,7 @@
 import { min, max, sum, isNumber } from 'lodash';
 import { MetricsExplorerSeries } from '../../../../../../common/http_api/metrics_explorer';
 import { MetricsExplorerOptionsMetric } from '../../hooks/use_metrics_explorer_options';
+import { getMetricId } from './get_metric_id';
 
 const getMin = (values: Array<number | null>) => {
   const minValue = min(values);
@@ -26,7 +27,7 @@ export const calculateDomain = (
     .reduce((acc, row) => {
       const rowValues = metrics
         .map((m, index) => {
-          return (row[`metric_${index}`] as number) || null;
+          return (row[getMetricId(m, index)] as number) || null;
         })
         .filter(v => isNumber(v));
       const minValue = getMin(rowValues);

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/get_metric_id.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/get_metric_id.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MetricsExplorerOptionsMetric } from '../../hooks/use_metrics_explorer_options';
+
+export const getMetricId = (metric: MetricsExplorerOptionsMetric, index: string | number) => {
+  if (['p95', 'p99'].includes(metric.aggregation)) {
+    return `metric_${index}:percentile_0`;
+  }
+  return `metric_${index}`;
+};


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Add 99th and 95th percentiles to Metric Explorer (#64699)