### PR TITLE
[7.x] [Metrics UI] Migrating Docker network fields (#65133)

### DIFF
--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/rx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/rx.ts
@@ -7,6 +7,6 @@
 import { networkTrafficWithInterfaces } from '../../../shared/metrics/snapshot/network_traffic_with_interfaces';
 export const rx = networkTrafficWithInterfaces(
   'rx',
-  'docker.network.in.bytes',
+  'docker.network.inbound.bytes',
   'docker.network.interface'
 );

--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/tx.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/snapshot/tx.ts
@@ -7,6 +7,6 @@
 import { networkTrafficWithInterfaces } from '../../../shared/metrics/snapshot/network_traffic_with_interfaces';
 export const tx = networkTrafficWithInterfaces(
   'tx',
-  'docker.network.out.bytes',
+  'docker.network.outbound.bytes',
   'docker.network.interface'
 );

--- a/x-pack/plugins/infra/common/inventory_models/container/metrics/tsvb/container_network_traffic.ts
+++ b/x-pack/plugins/infra/common/inventory_models/container/metrics/tsvb/container_network_traffic.ts
@@ -20,37 +20,73 @@ export const containerNetworkTraffic: TSVBMetricModelCreator = (
   series: [
     {
       id: 'tx',
-      split_mode: 'everything',
       metrics: [
         {
-          field: 'docker.network.out.bytes',
-          id: 'avg-network-out',
-          type: 'avg',
+          field: 'docker.network.outbound.bytes',
+          id: 'max-net-out',
+          type: 'max',
+        },
+        {
+          field: 'max-net-out',
+          id: 'deriv-max-net-out',
+          type: 'derivative',
+          unit: '1s',
+        },
+        {
+          id: 'posonly-deriv-max-net-out',
+          type: 'calculation',
+          variables: [{ id: 'var-rate', name: 'rate', field: 'deriv-max-net-out' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
+        },
+        {
+          function: 'sum',
+          id: 'seriesagg-sum',
+          type: 'series_agg',
         },
       ],
+      split_mode: 'terms',
+      terms_field: 'docker.network.interface',
     },
     {
       id: 'rx',
-      split_mode: 'everything',
       metrics: [
         {
-          field: 'docker.network.in.bytes',
-          id: 'avg-network-in',
-          type: 'avg',
+          field: 'docker.network.inbound.bytes',
+          id: 'max-net-in',
+          type: 'max',
         },
         {
-          id: 'invert-posonly-deriv-max-network-in',
+          field: 'max-net-in',
+          id: 'deriv-max-net-in',
+          type: 'derivative',
+          unit: '1s',
+        },
+        {
+          id: 'posonly-deriv-max-net-in',
+          type: 'calculation',
+          variables: [{ id: 'var-rate', name: 'rate', field: 'deriv-max-net-in' }],
+          script: 'params.rate > 0.0 ? params.rate : 0.0',
+        },
+        {
+          id: 'calc-invert-rate',
           script: 'params.rate * -1',
           type: 'calculation',
           variables: [
             {
-              field: 'avg-network-in',
+              field: 'posonly-deriv-max-net-in',
               id: 'var-rate',
               name: 'rate',
             },
           ],
         },
+        {
+          function: 'sum',
+          id: 'seriesagg-sum',
+          type: 'series_agg',
+        },
       ],
+      split_mode: 'terms',
+      terms_field: 'docker.network.interface',
     },
   ],
 });


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Migrating Docker network fields (#65133)