### PR TITLE
[Ingest Manager] Use cloudId for ES & Kibana URLs if available.

### DIFF
--- a/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.test.ts
+++ b/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { decodeCloudId } from './decode_cloud_id';
+
+describe('Ingest Manager - decodeCloudId', () => {
+  it('parses various CloudID formats', () => {
+    const tests = [
+      {
+        cloudID:
+          'staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        expectedEsURL: 'https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443',
+        expectedKibanaURL: 'https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443',
+      },
+      {
+        cloudID:
+          'dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        expectedEsURL: 'https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443',
+        expectedKibanaURL: 'https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443',
+      },
+      {
+        cloudID:
+          ':dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        expectedEsURL: 'https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443',
+        expectedKibanaURL: 'https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443',
+      },
+      {
+        cloudID:
+          'gcp-cluster:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZmNlJDBjZDVjZDU2OGVlYmU1M2M4OWViN2NhZTViYWM4YjM3',
+        expectedEsURL: 'https://8a0283af041f195f7729bc04c66a0fce.us-central1.gcp.cloud.es.io:443',
+        expectedKibanaURL:
+          'https://0cd5cd568eebe53c89eb7cae5bac8b37.us-central1.gcp.cloud.es.io:443',
+      },
+      {
+        cloudID:
+          'custom-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA=',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9243',
+      },
+      {
+        cloudID:
+          'different-es-kb-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244',
+      },
+      {
+        cloudID:
+          'only-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwOjkyNDQ=',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244',
+      },
+      {
+        cloudID:
+          'host-and-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244',
+      },
+      {
+        cloudID:
+          'extra-items:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwJGFub3RoZXJpZCRhbmRhbm90aGVy',
+        expectedEsURL: 'https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443',
+        expectedKibanaURL:
+          'https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:443',
+      },
+    ];
+
+    for (const test of tests) {
+      const decoded = decodeCloudId(test.cloudID);
+      expect(decoded).toBeTruthy();
+      expect(decoded?.elasticsearchUrl === test.expectedEsURL).toBe(true);
+      expect(decoded?.kibanaUrl === test.expectedKibanaURL).toBe(true);
+    }
+  });
+
+  it('returns undefined for invalid formats', () => {
+    const tests = [
+      {
+        cloudID:
+          'staging:garbagedXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==',
+        errorMsg: 'base64 decoding failed',
+      },
+      {
+        cloudID: 'dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZg==',
+        errorMsg: 'Expected at least 3 parts',
+      },
+    ];
+
+    for (const test of tests) {
+      const decoded = decodeCloudId(test.cloudID);
+      expect(decoded).toBe(undefined);
+      // decodeCloudId currently only logs; not throws errors
+    }
+  });
+});

--- a/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.ts
+++ b/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.ts
@@ -20,7 +20,7 @@ export function decodeCloudId(
   if (!id) {
     // throw new Error(`Unable to decode ${id}`);
     // eslint-disable-next-line no-console
-    console.log(`Unable to decode ${id}`);
+    console.debug(`Unable to decode ${id}`);
     return;
   }
 
@@ -31,7 +31,7 @@ export function decodeCloudId(
   } catch {
     // throw new Error(`base64 decoding failed on ${id}`);
     // eslint-disable-next-line no-console
-    console.log(`base64 decoding failed on ${id}`);
+    console.debug(`base64 decoding failed on ${id}`);
     return;
   }
 
@@ -40,7 +40,7 @@ export function decodeCloudId(
   if (words.length < 3) {
     // throw new Error(`Expected at least 3 parts in ${decoded}`);
     // eslint-disable-next-line no-console
-    console.log(`Expected at least 3 parts in ${decoded}`);
+    console.debug(`Expected at least 3 parts in ${decoded}`);
     return;
   }
   // 4. extract port from the ES and Kibana host

--- a/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.ts
+++ b/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.ts
@@ -41,6 +41,7 @@ export function decodeCloudId(
     // throw new Error(`Expected at least 3 parts in ${decoded}`);
     // eslint-disable-next-line no-console
     console.log(`Expected at least 3 parts in ${decoded}`);
+    return;
   }
   // 4. extract port from the ES and Kibana host
   const [host, defaultPort] = extractPortFromName(words[0]);

--- a/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.ts
+++ b/x-pack/plugins/ingest_manager/common/services/decode_cloud_id.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+// decodeCloudId decodes the c.id into c.esURL and c.kibURL
+export function decodeCloudId(
+  cid: string
+):
+  | {
+      host: string;
+      defaultPort: string;
+      elasticsearchUrl: string;
+      kibanaUrl: string;
+    }
+  | undefined {
+  // 1. Ignore anything before `:`.
+  const id = cid.split(':').pop();
+  if (!id) {
+    // throw new Error(`Unable to decode ${id}`);
+    // eslint-disable-next-line no-console
+    console.log(`Unable to decode ${id}`);
+    return;
+  }
+
+  // 2. base64 decode
+  let decoded: string | undefined;
+  try {
+    decoded = Buffer.from(id, 'base64').toString('utf8');
+  } catch {
+    // throw new Error(`base64 decoding failed on ${id}`);
+    // eslint-disable-next-line no-console
+    console.log(`base64 decoding failed on ${id}`);
+    return;
+  }
+
+  // 3. separate based on `$`
+  const words = decoded.split('$');
+  if (words.length < 3) {
+    // throw new Error(`Expected at least 3 parts in ${decoded}`);
+    // eslint-disable-next-line no-console
+    console.log(`Expected at least 3 parts in ${decoded}`);
+  }
+  // 4. extract port from the ES and Kibana host
+  const [host, defaultPort] = extractPortFromName(words[0]);
+  const [esId, esPort] = extractPortFromName(words[1], defaultPort);
+  const [kbId, kbPort] = extractPortFromName(words[2], defaultPort);
+  // 5. form the URLs
+  const esUrl = `https://${esId}.${host}:${esPort}`;
+  const kbUrl = `https://${kbId}.${host}:${kbPort}`;
+  return {
+    host,
+    defaultPort,
+    elasticsearchUrl: esUrl,
+    kibanaUrl: kbUrl,
+  };
+}
+// extractPortFromName takes a string in the form `id:port` and returns the
+// Id and the port. If there's no `:`, the default port is returned
+function extractPortFromName(word: string, defaultPort = '443') {
+  const [host, port = defaultPort] = word.split(':');
+  return [host, port];
+}

--- a/x-pack/plugins/ingest_manager/common/services/index.ts
+++ b/x-pack/plugins/ingest_manager/common/services/index.ts
@@ -9,3 +9,4 @@ export * from './routes';
 export { packageToConfigDatasourceInputs, packageToConfigDatasource } from './package_to_config';
 export { storedDatasourceToAgentDatasource } from './datasource_to_agent_datasource';
 export { AgentStatusKueryHelper };
+export { decodeCloudId } from './decode_cloud_id';

--- a/x-pack/plugins/ingest_manager/common/types/index.ts
+++ b/x-pack/plugins/ingest_manager/common/types/index.ts
@@ -15,7 +15,6 @@ export interface IngestManagerConfigType {
   fleet: {
     enabled: boolean;
     tlsCheckDisabled: boolean;
-    defaultOutputHost: string;
     kibana: {
       host?: string;
       ca_sha256?: string;

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -32,7 +32,7 @@ export const config = {
         ca_sha256: schema.maybe(schema.string()),
       }),
       elasticsearch: schema.object({
-        host: schema.string({ defaultValue: 'http://localhost:9200' }),
+        host: schema.maybe(schema.string()),
         ca_sha256: schema.maybe(schema.string()),
       }),
     }),

--- a/x-pack/plugins/ingest_manager/server/services/output.ts
+++ b/x-pack/plugins/ingest_manager/server/services/output.ts
@@ -7,6 +7,7 @@ import { SavedObjectsClientContract } from 'src/core/server';
 import { NewOutput, Output } from '../types';
 import { DEFAULT_OUTPUT, OUTPUT_SAVED_OBJECT_TYPE } from '../constants';
 import { appContextService } from './app_context';
+import { decodeCloudId } from '../../common';
 
 const SAVED_OBJECT_TYPE = OUTPUT_SAVED_OBJECT_TYPE;
 
@@ -16,11 +17,17 @@ class OutputService {
       type: OUTPUT_SAVED_OBJECT_TYPE,
       filter: `${OUTPUT_SAVED_OBJECT_TYPE}.attributes.is_default:true`,
     });
+    const cloud = appContextService.getCloud();
+    const cloudId = cloud?.isCloudEnabled && cloud.cloudId;
+    const cloudUrl = cloudId && decodeCloudId(cloudId)?.elasticsearchUrl;
+    const flagsUrl = appContextService.getConfig()!.fleet.elasticsearch.host;
+    const defaultUrl = 'http://localhost:9200';
+    const defaultOutputUrl = cloudUrl || flagsUrl || defaultUrl;
 
     if (!outputs.saved_objects.length) {
       const newDefaultOutput = {
         ...DEFAULT_OUTPUT,
-        hosts: [appContextService.getConfig()!.fleet.elasticsearch.host],
+        hosts: [defaultOutputUrl],
         ca_sha256: appContextService.getConfig()!.fleet.elasticsearch.ca_sha256,
       } as NewOutput;
 

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -18,6 +18,7 @@ import {
   Installation,
   Output,
   DEFAULT_AGENT_CONFIGS_PACKAGES,
+  decodeCloudId,
 } from '../../common';
 import { getPackageInfo } from './epm/packages';
 import { datasourceService } from './datasource';
@@ -43,7 +44,11 @@ export async function setupIngestManager(
         const serverInfo = http.getServerInfo();
         const basePath = http.basePath;
 
-        const defaultKibanaUrl = url.format({
+        const cloud = appContextService.getCloud();
+        const cloudId = cloud?.isCloudEnabled && cloud.cloudId;
+        const cloudUrl = cloudId && decodeCloudId(cloudId)?.kibanaUrl;
+        const flagsUrl = appContextService.getConfig()?.fleet?.kibana?.host;
+        const defaultUrl = url.format({
           protocol: serverInfo.protocol,
           hostname: serverInfo.host,
           port: serverInfo.port,
@@ -53,7 +58,7 @@ export async function setupIngestManager(
         return settingsService.saveSettings(soClient, {
           agent_auto_upgrade: true,
           package_auto_upgrade: true,
-          kibana_url: appContextService.getConfig()?.fleet?.kibana?.host ?? defaultKibanaUrl,
+          kibana_url: cloudUrl || flagsUrl || defaultUrl,
         });
       }
 


### PR DESCRIPTION
## Summary
closes https://github.com/elastic/kibana/issues/64513

 * Adds `decodeCloudId` function based on [code](https://github.com/elastic/beats/blob/master/libbeat/cloudid/cloudid.go) & [tests](https://github.com/elastic/beats/blob/master/libbeat/cloudid/cloudid_test.go) in libbeat. Tests added in https://github.com/elastic/kibana/commit/cf7b45a3faae6558c763b4f6a4fa0a78eca3afd9
 * If there's a cloudId, use those hosts. Otherwise, use anything passed in from the command line. Use localhost if all else fails.
  * Ideally we'd set this config earlier & centrally, but we currently only use each in one place (and we're staring down Feature Freeze) 

## Test
This only takes effect when creating the default host, so start ES fresh to ensure a default output is created.

### Cloud
Start kibana with cloud plugin & ID
```
yarn start --no-base-path --xpack.ingestManager.enabled=true \
  --xpack.ingestManager.fleet.elasticsearch.host='http://from-ingest-manager-cli-flags' \
  --xpack.cloud.enabled=true \
  --xpack.cloud.id='custom-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA='
```
See the values [that corresponds to here](https://github.com/elastic/beats/blob/master/libbeat/cloudid/cloudid_test.go#L54-L58) or
<img width="837" alt="Screen Shot 2020-05-05 at 3 53 24 PM" src="https://user-images.githubusercontent.com/57655/81111573-4d167e80-8eeb-11ea-820d-9a86d9fa1f41.png">

Default output has the cloud value, even though a CLI flag was passed:
<img width="1056" alt="Screen Shot 2020-05-05 at 3 53 47 PM" src="https://user-images.githubusercontent.com/57655/81111576-4daf1500-8eeb-11ea-8221-950e5a1d9f9d.png">

Kibana URL is Cloud URL not local
<img width="1903" alt="Screen Shot 2020-05-05 at 3 55 07 PM" src="https://user-images.githubusercontent.com/57655/81111578-4daf1500-8eeb-11ea-84d6-5e9fa1106e9e.png">

### Local
Start Kibana without cloud & with one host via CLI
```
yarn start --no-base-path --xpack.ingestManager.enabled=true \
  --xpack.ingestManager.fleet.elasticsearch.host='http://from-ingest-manager-cli-flags' \
```

Default output has CLI value
<img width="804" alt="Screen Shot 2020-05-05 at 4 11 28 PM" src="https://user-images.githubusercontent.com/57655/81111621-5c95c780-8eeb-11ea-98e1-4b098a066a0e.png">

Kibana URL is local (port 5603 + basepath in this example)
<img width="1774" alt="Screen Shot 2020-05-05 at 4 11 46 PM" src="https://user-images.githubusercontent.com/57655/81111622-5c95c780-8eeb-11ea-9784-cc7652df448a.png">
