### PR TITLE
[SIEM] [Cases] Fixes 500 error on push_case route

### DIFF
--- a/x-pack/plugins/case/server/routes/api/cases/push_case.test.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/push_case.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { kibanaResponseFactory, RequestHandler } from 'src/core/server';
+import { httpServerMock } from 'src/core/server/mocks';
+
+import {
+  createMockSavedObjectsRepository,
+  createRoute,
+  createRouteContext,
+  mockCases,
+} from '../__fixtures__';
+import { initPushCaseUserActionApi } from './push_case';
+import { CASE_DETAILS_URL } from '../../../../common/constants';
+import { mockCaseConfigure } from '../__fixtures__/mock_saved_objects';
+
+describe('Push case', () => {
+  let routeHandler: RequestHandler<any, any, any>;
+  const mockDate = '2019-11-25T21:54:48.952Z';
+  const caseExternalServiceRequestBody = {
+    connector_id: 'connector_id',
+    connector_name: 'connector_name',
+    external_id: 'external_id',
+    external_title: 'external_title',
+    external_url: 'external_url',
+  };
+  beforeAll(async () => {
+    routeHandler = await createRoute(initPushCaseUserActionApi, 'post');
+    const spyOnDate = jest.spyOn(global, 'Date') as jest.SpyInstance<{}, []>;
+    spyOnDate.mockImplementation(() => ({
+      toISOString: jest.fn().mockReturnValue(mockDate),
+    }));
+  });
+  it(`Pushes a case`, async () => {
+    const request = httpServerMock.createKibanaRequest({
+      path: `${CASE_DETAILS_URL}/_push`,
+      method: 'post',
+      params: {
+        case_id: 'mock-id-3',
+      },
+      body: caseExternalServiceRequestBody,
+    });
+
+    const theContext = createRouteContext(
+      createMockSavedObjectsRepository({
+        caseSavedObject: mockCases,
+      })
+    );
+
+    const response = await routeHandler(theContext, request, kibanaResponseFactory);
+    expect(response.status).toEqual(200);
+    expect(response.payload.external_service.pushed_at).toEqual(mockDate);
+    expect(response.payload.external_service.connector_id).toEqual('connector_id');
+    expect(response.payload.closed_at).toEqual(null);
+  });
+  it(`Pushes a case and closes when closure_type: 'close-by-pushing'`, async () => {
+    const request = httpServerMock.createKibanaRequest({
+      path: `${CASE_DETAILS_URL}/_push`,
+      method: 'post',
+      params: {
+        case_id: 'mock-id-3',
+      },
+      body: caseExternalServiceRequestBody,
+    });
+
+    const theContext = createRouteContext(
+      createMockSavedObjectsRepository({
+        caseSavedObject: mockCases,
+        caseConfigureSavedObject: [
+          {
+            ...mockCaseConfigure[0],
+            attributes: {
+              ...mockCaseConfigure[0].attributes,
+              closure_type: 'close-by-pushing',
+            },
+          },
+        ],
+      })
+    );
+
+    const response = await routeHandler(theContext, request, kibanaResponseFactory);
+    expect(response.status).toEqual(200);
+    expect(response.payload.external_service.pushed_at).toEqual(mockDate);
+    expect(response.payload.external_service.connector_id).toEqual('connector_id');
+    expect(response.payload.closed_at).toEqual(mockDate);
+  });
+
+  it(`Returns an error if pushCaseUserAction throws`, async () => {
+    const request = httpServerMock.createKibanaRequest({
+      path: `${CASE_DETAILS_URL}/_push`,
+      method: 'post',
+      body: {
+        notagoodbody: 'Throw an error',
+      },
+    });
+
+    const theContext = createRouteContext(
+      createMockSavedObjectsRepository({
+        caseSavedObject: mockCases,
+      })
+    );
+
+    const response = await routeHandler(theContext, request, kibanaResponseFactory);
+    expect(response.status).toEqual(400);
+    expect(response.payload.isBoom).toEqual(true);
+  });
+});

--- a/x-pack/plugins/case/server/routes/api/cases/push_case.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/push_case.ts
@@ -94,7 +94,8 @@ export function initPushCaseUserActionApi({
             client,
             caseId,
             updatedAttributes: {
-              ...(myCaseConfigure.saved_objects[0].attributes.closure_type === 'close-by-pushing'
+              ...(myCaseConfigure.total > 0 &&
+              myCaseConfigure.saved_objects[0].attributes.closure_type === 'close-by-pushing'
                 ? {
                     status: 'closed',
                     closed_at: pushedDate,
@@ -124,7 +125,8 @@ export function initPushCaseUserActionApi({
           userActionService.postUserActions({
             client,
             actions: [
-              ...(myCaseConfigure.saved_objects[0].attributes.closure_type === 'close-by-pushing'
+              ...(myCaseConfigure.total > 0 &&
+              myCaseConfigure.saved_objects[0].attributes.closure_type === 'close-by-pushing'
                 ? [
                     buildCaseUserActionItem({
                       action: 'update',


### PR DESCRIPTION
## Summary

We were checking the `closure_type` of the default configuration, when you are able to push a case without ever setting a default configuration. Adds a check if the default exists, and tests. 

Steps to reproduce and a screenshot of the error:
- start with no `'cases-configure'` saved objects (either by deleting this SO type from your index or deleting your index)
- create a Jira connector
- do NOT save the connector as the default
- create a new case
- use the External Services dropdown to select Jira as the connector
- push
  - error behavior: does not push
<img width="1671" alt="Screenshot 2020-05-05 at 20 45 22" src="https://user-images.githubusercontent.com/6935300/81121320-aed6e880-8eeb-11ea-997b-3683c52ff1aa.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
