### PR TITLE
Wrap APM alert action trigger with context provider

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/TransactionDurationAlertTrigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionDurationAlertTrigger/index.tsx
@@ -26,13 +26,15 @@ interface Params {
   transactionType: string;
 }
 
-interface Props {
+export interface TransactionDurationAlertTriggerProps {
   alertParams: Params;
   setAlertParams: (key: string, value: any) => void;
   setAlertProperty: (key: string, value: any) => void;
 }
 
-export function TransactionDurationAlertTrigger(props: Props) {
+export function TransactionDurationAlertTrigger(
+  props: TransactionDurationAlertTriggerProps
+) {
   const { setAlertParams, alertParams, setAlertProperty } = props;
 
   const { urlParams } = useUrlParams();

--- a/x-pack/plugins/apm/public/context/ApmPluginContext/index.tsx
+++ b/x-pack/plugins/apm/public/context/ApmPluginContext/index.tsx
@@ -17,4 +17,6 @@ export interface ApmPluginContextValue {
   plugins: ApmPluginSetupDeps;
 }
 
-export const ApmPluginContext = createContext({} as ApmPluginContextValue);
+export const ApmPluginContext = createContext(
+  {} as Partial<ApmPluginContextValue>
+);

--- a/x-pack/plugins/apm/public/registerAlertTypes.tsx
+++ b/x-pack/plugins/apm/public/registerAlertTypes.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { CoreStart } from '../../../../src/core/public';
+import { AlertType } from '../common/alert_types';
+import { ErrorRateAlertTrigger } from './components/shared/ErrorRateAlertTrigger';
+import {
+  TransactionDurationAlertTrigger,
+  TransactionDurationAlertTriggerProps
+} from './components/shared/TransactionDurationAlertTrigger';
+import { ApmPluginContext } from './context/ApmPluginContext';
+import { ApmPluginStartDeps } from './plugin';
+
+export function registerAlertTypes(
+  core: CoreStart,
+  plugins: ApmPluginStartDeps
+) {
+  // TransactionDurationAlertTrigger requires core.notifications from the context,
+  // so create a wrapper component for it
+  function WrappedTransactionDurationAlertTrigger(
+    props: TransactionDurationAlertTriggerProps
+  ) {
+    return (
+      <ApmPluginContext.Provider value={{ core }}>
+        <TransactionDurationAlertTrigger {...props} />
+      </ApmPluginContext.Provider>
+    );
+  }
+
+  plugins.triggers_actions_ui.alertTypeRegistry.register({
+    id: AlertType.ErrorRate,
+    name: i18n.translate('xpack.apm.alertTypes.errorRate', {
+      defaultMessage: 'Error rate'
+    }),
+    iconClass: 'bell',
+    alertParamsExpression: ErrorRateAlertTrigger,
+    validate: () => ({
+      errors: []
+    })
+  });
+
+  plugins.triggers_actions_ui.alertTypeRegistry.register({
+    id: AlertType.TransactionDuration,
+    name: i18n.translate('xpack.apm.alertTypes.transactionDuration', {
+      defaultMessage: 'Transaction duration'
+    }),
+    iconClass: 'bell',
+    alertParamsExpression: WrappedTransactionDurationAlertTrigger,
+    validate: () => ({
+      errors: []
+    })
+  });
+}


### PR DESCRIPTION
When registering the alert types with the triggers_actions_ui plugin, TransactionDurationAlertTrigger would fail when attempting to edit an alert in the alerts UI.

This is because `TransactionDurationAlertTrigger` uses `useServiceTransactionTypes` which uses `useFetcher`, which uses `core.notifications` from the `ApmPluginContext.Provider`.

When registering, wrap `TransactionDurationAlertTrigger` in a plugin that provides the context.

Also:

* Break out the registration of the alert types into a separate file
* Allow the `ApmPluginContext` to take a `Partial` value

Fixes #65399