### PR TITLE
add tsvb smoke test to Firefox suite

### DIFF
--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -29,6 +29,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['visualize', 'visualBuilder', 'timePicker', 'visChart']);
 
   describe('visual builder', function describeIndexTests() {
+    this.tags('includeFirefox');
     beforeEach(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await PageObjects.visualize.navigateToNewVisualization();


### PR DESCRIPTION
## Summary

Adding basic tsvb test that creates a new viz in Firefox suite to cover recent regression #65090

Flaky test runner check:

- [20 times](https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/427/) passed
- [20 times](https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/425/) passed
