### PR TITLE
[APM] Custom links section inside the Actions menu is showing outside of the menu.

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.tsx
@@ -27,7 +27,6 @@ import { CustomLink } from './CustomLink';
 import { CustomLinkPopover } from './CustomLink/CustomLinkPopover';
 import { getSections } from './sections';
 import { useLicense } from '../../../hooks/useLicense';
-import { px } from '../../../style/variables';
 import { convertFiltersToQuery } from '../../app/Settings/CustomizeUI/CustomLink/CustomLinkFlyout/helper';
 
 interface Props {
@@ -124,7 +123,7 @@ export const TransactionActionMenu: FunctionComponent<Props> = ({
           <ActionMenuButton onClick={() => setIsActionPopoverOpen(true)} />
         }
       >
-        <div style={{ maxHeight: px(600), width: px(335) }}>
+        <div>
           {isCustomLinksPopoverOpen ? (
             <CustomLinkPopover
               customLinks={customLinks.slice(3, customLinks.length)}


### PR DESCRIPTION
closes #64404

<img width="532" alt="Screenshot 2020-05-06 at 10 31 24" src="https://user-images.githubusercontent.com/55978943/81157394-37569700-8f87-11ea-93c0-a1f452454ae9.png">
<img width="419" alt="Screenshot 2020-05-06 at 10 31 30" src="https://user-images.githubusercontent.com/55978943/81157403-3a518780-8f87-11ea-9cc5-5bb820a57710.png">
