### PR TITLE
[7.x] add tsvb tests to Firefox suite (#65425)

### DIFF
--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -29,6 +29,7 @@ export default function({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['visualize', 'visualBuilder', 'timePicker', 'visChart']);
 
   describe('visual builder', function describeIndexTests() {
+    this.tags('includeFirefox');
     beforeEach(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await PageObjects.visualize.navigateToNewVisualization();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - add tsvb tests to Firefox suite (#65425)