### PR TITLE
[Fix] Monitoring failing to start

### DIFF
--- a/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js
@@ -140,7 +140,7 @@ export class BulkUploader {
   async _fetchAndUpload(usageCollection) {
     const collectorsReady = await usageCollection.areAllCollectorsReady();
     const hasUsageCollectors = usageCollection.some(usageCollection.isUsageCollector);
-    if (!collectorsReady) {
+    if (!collectorsReady || this.kibanaStatusGetter === null) {
       this._log.debug('Skipping bulk uploading because not all collectors are ready');
       if (hasUsageCollectors) {
         this._lastFetchUsageTime = null;
@@ -151,7 +151,7 @@ export class BulkUploader {
 
     const data = await usageCollection.bulkFetch(this._cluster.callAsInternalUser);
     const payload = this.toBulkUploadFormat(compact(data), usageCollection);
-    if (payload) {
+    if (payload.length > 0) {
       try {
         this._log.debug(`Uploading bulk stats payload to the local cluster`);
         const result = await this._onPayload(payload);
@@ -244,7 +244,7 @@ export class BulkUploader {
    */
   toBulkUploadFormat(rawData, usageCollection) {
     if (rawData.length === 0) {
-      return;
+      return [];
     }
 
     // convert the raw data to a nested object by taking each payload through

--- a/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js
@@ -140,7 +140,7 @@ export class BulkUploader {
   async _fetchAndUpload(usageCollection) {
     const collectorsReady = await usageCollection.areAllCollectorsReady();
     const hasUsageCollectors = usageCollection.some(usageCollection.isUsageCollector);
-    if (!collectorsReady || this.kibanaStatusGetter === null) {
+    if (!collectorsReady || typeof this.kibanaStatusGetter !== 'function') {
       this._log.debug('Skipping bulk uploading because not all collectors are ready');
       if (hasUsageCollectors) {
         this._lastFetchUsageTime = null;

--- a/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js
+++ b/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js
@@ -151,7 +151,7 @@ export class BulkUploader {
 
     const data = await usageCollection.bulkFetch(this._cluster.callAsInternalUser);
     const payload = this.toBulkUploadFormat(compact(data), usageCollection);
-    if (payload.length > 0) {
+    if (payload && payload.length > 0) {
       try {
         this._log.debug(`Uploading bulk stats payload to the local cluster`);
         const result = await this._onPayload(payload);


### PR DESCRIPTION
## Summary

Closes #65486

Monitoring is starting to fetch the Kibana stats before the `start` lifecycle step has even started because of this line in the `setup` method: https://github.com/elastic/kibana/blob/dacc95fa85788bf0a3cd77074159b7512b6f61fb/x-pack/plugins/monitoring/server/plugin.ts#L227

This is making the fetch to fail because the legacy plugin has not been initialised yet and the legacy status getter is not registered yet. This PR is quick fix to avoid running the fetch when the legacy status getter is not registered yet.

Ideally, the bulkUploader should not start until the `start` lifecycle step has started.

The reason why we could only catch it when `telemetry.enabled: false` is because the plugin `telemetry` is also registering some usageCollectors and they keep reporting `not-ready` until the `start` lifecycle method because of their dependency to the savedObjectsClient:
https://github.com/elastic/kibana/blob/452193fdba7c77815472889d1715b1ca341530ba/src/plugins/telemetry/server/collectors/telemetry_plugin/telemetry_plugin_collector.ts#L86

The bulkUploader fetch method [checks if all the usageCollectors are ready](https://github.com/elastic/kibana/blob/dacc95fa85788bf0a3cd77074159b7512b6f61fb/x-pack/plugins/monitoring/server/kibana_monitoring/bulk_uploader.js#L141). So with telemetry enabled, it successfully waits until ready.

We need to move these collectors out of the telemetry plugin (created issue https://github.com/elastic/kibana/issues/65515 to fix that).

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
