### PR TITLE
[Metrics UI] Fix isAbove to only display when threshold set

### DIFF
--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -224,7 +224,7 @@ export const ExpressionChart: React.FC<Props> = ({
               />
             </>
           ) : null}
-          {isAbove ? (
+          {isAbove && first(expression.threshold) != null ? (
             <RectAnnotation
               id="upper-threshold"
               style={{


### PR DESCRIPTION
## Summary

This PR fixes #65528 by checking to see if the threshold is actual set before rendering.

### Before

![image](https://user-images.githubusercontent.com/41702/81212849-5c003e00-8f8a-11ea-874a-b1d6bf4d3087.png)

### After

![image](https://user-images.githubusercontent.com/41702/81212904-74705880-8f8a-11ea-892b-dcda25a4ed43.png)
