### PR TITLE
[SIEM][Detection Engine] Moves functional tests from "legacyEs" to "Es"

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/add_prepackaged_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/add_prepackaged_rules.ts
@@ -13,7 +13,7 @@ import { createSignalsIndex, deleteAllAlerts, deleteSignalsIndex } from './utils
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('add_prepackaged_rules', () => {
     describe('validation errors', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules.ts
@@ -25,7 +25,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('create_rules', () => {
     describe('validation errors', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules_bulk.ts
@@ -23,7 +23,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('create_rules_bulk', () => {
     describe('validation errors', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/delete_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/delete_rules.ts
@@ -23,7 +23,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('delete_rules', () => {
     describe('deleting rules', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/delete_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/delete_rules_bulk.ts
@@ -23,7 +23,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('delete_rules_bulk', () => {
     describe('deleting rules bulk using DELETE', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/export_rules.ts
@@ -21,7 +21,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('export_rules', () => {
     describe('exporting rules', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_rules.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('find_rules', () => {
     beforeEach(async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
@@ -19,7 +19,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('find_statuses', () => {
     beforeEach(async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/get_prepackaged_rules_status.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/get_prepackaged_rules_status.ts
@@ -16,7 +16,7 @@ import { createSignalsIndex, deleteAllAlerts, deleteSignalsIndex, getSimpleRule 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('get_prepackaged_rules_status', () => {
     describe('getting prepackaged rules status', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('import_rules', () => {
     describe('importing rules without an index', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/patch_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/patch_rules.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('patch_rules', () => {
     describe('patch rules', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/patch_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/patch_rules_bulk.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('patch_rules_bulk', () => {
     describe('patch rules bulk', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/read_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/read_rules.ts
@@ -23,7 +23,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('read_rules', () => {
     describe('reading rules', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/update_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/update_rules.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('update_rules', () => {
     describe('update rules', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/update_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/update_rules_bulk.ts
@@ -22,7 +22,7 @@ import {
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
-  const es = getService('legacyEs');
+  const es = getService('es');
 
   describe('update_rules_bulk', () => {
     describe('update rules bulk', () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/utils.ts
@@ -4,6 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { Client } from '@elastic/elasticsearch';
+import { SuperTest } from 'supertest';
+import supertestAsPromised from 'supertest-as-promised';
 import { OutputRuleAlertRest } from '../../../../plugins/siem/server/lib/detection_engine/types';
 import { DETECTION_ENGINE_INDEX_URL } from '../../../../plugins/siem/common/constants';
 
@@ -187,12 +190,13 @@ export const getSimpleMlRuleOutput = (ruleId = 'rule-1'): Partial<OutputRuleAler
  * Remove all alerts from the .kibana index
  * @param es The ElasticSearch handle
  */
-export const deleteAllAlerts = async (es: any): Promise<void> => {
+export const deleteAllAlerts = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
     index: '.kibana',
     q: 'type:alert',
-    waitForCompletion: true,
-    refresh: 'wait_for',
+    wait_for_completion: true,
+    refresh: true,
+    body: {},
   });
 };
 
@@ -200,12 +204,13 @@ export const deleteAllAlerts = async (es: any): Promise<void> => {
  * Remove all rules statuses from the .kibana index
  * @param es The ElasticSearch handle
  */
-export const deleteAllRulesStatuses = async (es: any): Promise<void> => {
+export const deleteAllRulesStatuses = async (es: Client): Promise<void> => {
   await es.deleteByQuery({
     index: '.kibana',
     q: 'type:siem-detection-engine-rule-status',
-    waitForCompletion: true,
-    refresh: 'wait_for',
+    wait_for_completion: true,
+    refresh: true,
+    body: {},
   });
 };
 
@@ -213,7 +218,9 @@ export const deleteAllRulesStatuses = async (es: any): Promise<void> => {
  * Creates the signals index for use inside of beforeEach blocks of tests
  * @param supertest The supertest client library
  */
-export const createSignalsIndex = async (supertest: any): Promise<void> => {
+export const createSignalsIndex = async (
+  supertest: SuperTest<supertestAsPromised.Test>
+): Promise<void> => {
   await supertest
     .post(DETECTION_ENGINE_INDEX_URL)
     .set('kbn-xsrf', 'true')
@@ -225,7 +232,9 @@ export const createSignalsIndex = async (supertest: any): Promise<void> => {
  * Deletes the signals index for use inside of afterEach blocks of tests
  * @param supertest The supertest client library
  */
-export const deleteSignalsIndex = async (supertest: any): Promise<void> => {
+export const deleteSignalsIndex = async (
+  supertest: SuperTest<supertestAsPromised.Test>
+): Promise<void> => {
   await supertest
     .delete(DETECTION_ENGINE_INDEX_URL)
     .set('kbn-xsrf', 'true')


### PR DESCRIPTION
Moves functional tests from "legacyEs" to "Es" and improves types

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
