### PR TITLE
[7.x] [Metrics UI] Fix isAbove to only display when threshold set (#65540)

### DIFF
--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -224,7 +224,7 @@ export const ExpressionChart: React.FC<Props> = ({
               />
             </>
           ) : null}
-          {isAbove ? (
+          {isAbove && first(expression.threshold) != null ? (
             <RectAnnotation
               id="upper-threshold"
               style={{


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Fix isAbove to only display when threshold set (#65540)