### PR TITLE
[APM] Don't mutating the original waterfall item while reparenting spans

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -13,8 +13,7 @@ import {
   sortBy,
   sum,
   uniq,
-  zipObject,
-  cloneDeep
+  zipObject
 } from 'lodash';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { TraceAPIResponse } from '../../../../../../../../server/lib/traces/get_trace';
@@ -237,30 +236,33 @@ const getWaterfallItems = (items: TraceAPIResponse['trace']['items']) =>
     }
   });
 
-/**
- * Changes the parent_id of items based on the child.id property.
- * Solves the problem of Inferred spans that are created as child of trace spans
- * when it actually should be its parent.
- * @param waterfallItems
- */
-const reparentSpans = (waterfallItems: IWaterfallItem[]) => {
-  // clones the waterfall items to avoid mutating the original
-  const clonedWaterfallItems = cloneDeep(waterfallItems);
-  return clonedWaterfallItems.map(waterfallItem => {
-    if (waterfallItem.docType === 'span') {
-      const childId = waterfallItem.doc.child?.id;
-      if (childId) {
-        childId.forEach(id => {
-          const item = clonedWaterfallItems.find(_item => _item.id === id);
-          if (item) {
-            item.parentId = waterfallItem.id;
-          }
-        });
-      }
+function reparentSpans(waterfallItems: IWaterfallItem[]) {
+  // find children that needs to be re-parented and map them to their correct parent id
+  const childIdToParentIdMapping = Object.fromEntries(
+    flatten(
+      waterfallItems.map(waterfallItem => {
+        if (waterfallItem.docType === 'span') {
+          const childIds = waterfallItem.doc.child?.id ?? [];
+          return childIds.map(id => [id, waterfallItem.id]);
+        }
+        return [];
+      })
+    )
+  );
+
+  // update parent id for children that needs it or return unchanged
+  return waterfallItems.map(waterfallItem => {
+    const newParentId = childIdToParentIdMapping[waterfallItem.id];
+    if (newParentId) {
+      return {
+        ...waterfallItem,
+        parentId: newParentId
+      };
     }
+
     return waterfallItem;
   });
-};
+}
 
 const getChildrenGroupedByParentId = (waterfallItems: IWaterfallItem[]) =>
   groupBy(waterfallItems, item => (item.parentId ? item.parentId : ROOT_ID));

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -13,7 +13,8 @@ import {
   sortBy,
   sum,
   uniq,
-  zipObject
+  zipObject,
+  cloneDeep
 } from 'lodash';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { TraceAPIResponse } from '../../../../../../../../server/lib/traces/get_trace';
@@ -243,12 +244,14 @@ const getWaterfallItems = (items: TraceAPIResponse['trace']['items']) =>
  * @param waterfallItems
  */
 const reparentSpans = (waterfallItems: IWaterfallItem[]) => {
-  return waterfallItems.map(waterfallItem => {
+  // clones the waterfall items to avoid mutating the original
+  const clonedWaterfallItems = cloneDeep(waterfallItems);
+  return clonedWaterfallItems.map(waterfallItem => {
     if (waterfallItem.docType === 'span') {
       const childId = waterfallItem.doc.child?.id;
       if (childId) {
         childId.forEach(id => {
-          const item = waterfallItems.find(_item => _item.id === id);
+          const item = clonedWaterfallItems.find(_item => _item.id === id);
           if (item) {
             item.parentId = waterfallItem.id;
           }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/waterfallContainer.stories.data.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/waterfallContainer.stories.data.ts
@@ -2027,7 +2027,7 @@ export const inferredSpans = {
           id: '41226ae63af4f235',
           type: 'unknown'
         },
-        child: { ids: ['8d80de06aa11a6fc'] }
+        child: { id: ['8d80de06aa11a6fc'] }
       },
       {
         container: {


### PR DESCRIPTION
The original implementation was mutating the original waterfall item array, now it creates a deep copy of it before reparenting the spans.