### PR TITLE
[DOCS] APM Agent config: Option values must be string

### DIFF
--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -60,7 +60,7 @@ The following Agent configuration APIs are available:
 ======
 
 `settings`::
-(required) Key/value object with settings and their corresponding value.
+(required) Key/value object with option name and option value.
 
 `agent_name`::
 (optional) The agent name is used by the UI to determine which settings to display.
@@ -73,14 +73,14 @@ The following Agent configuration APIs are available:
 --------------------------------------------------
 PUT /api/apm/settings/agent-configuration
 {
-    "service" : {
-        "name" : "frontend",
-        "environment" : "production"
+    "service": {
+        "name": "frontend",
+        "environment": "production"
     },
-    "settings" : {
-        "transaction_sample_rate" : 0.4,
-        "capture_body" : "off",
-        "transaction_max_spans" : 500
+    "settings": {
+        "transaction_sample_rate": "0.4",
+        "capture_body": "off",
+        "transaction_max_spans": "500"
     },
     "agent_name": "nodejs"
 }
@@ -124,7 +124,7 @@ PUT /api/apm/settings/agent-configuration
 DELETE /api/apm/settings/agent-configuration
 {
     "service" : {
-        "name" : "frontend",
+        "name": "frontend",
         "environment": "production"
     }
 }
@@ -157,9 +157,9 @@ DELETE /api/apm/settings/agent-configuration
       "environment": "production"
     },
     "settings": {
-      "transaction_sample_rate": 1,
+      "transaction_sample_rate": "1",
       "capture_body": "off",
-      "transaction_max_spans": 200
+      "transaction_max_spans": "200"
     },
     "@timestamp": 1581934104843,
     "applied_by_agent": false,
@@ -171,9 +171,9 @@ DELETE /api/apm/settings/agent-configuration
       "name": "opbeans-go"
     },
     "settings": {
-      "transaction_sample_rate": 1,
+      "transaction_sample_rate": "1",
       "capture_body": "off",
-      "transaction_max_spans": 300
+      "transaction_max_spans": "300"
     },
     "@timestamp": 1581934111727,
     "applied_by_agent": false,
@@ -185,7 +185,7 @@ DELETE /api/apm/settings/agent-configuration
       "name": "frontend"
     },
     "settings": {
-      "transaction_sample_rate": 1,
+      "transaction_sample_rate": "1",
     },
     "@timestamp": 1582031336265,
     "applied_by_agent": false,
@@ -250,7 +250,7 @@ GET  /api/apm/settings/agent-configuration
       "name": "frontend"
     },
     "settings": {
-      "transaction_sample_rate": 1,
+      "transaction_sample_rate": "1",
     },
     "@timestamp": 1582031336265,
     "applied_by_agent": false,
@@ -266,9 +266,9 @@ GET  /api/apm/settings/agent-configuration
 --------------------------------------------------
 POST /api/apm/settings/agent-configuration/search
 {
-    "etag" : "1e58c178efeebae15c25c539da740d21dee422fc",
+    "etag": "1e58c178efeebae15c25c539da740d21dee422fc",
     "service" : {
-        "name" : "frontend",
+        "name": "frontend",
         "environment": "production"
     }
 }


### PR DESCRIPTION
Since [7.7](https://github.com/elastic/kibana/pull/59860) agent config option values must be stringified

Invalid:
```json
{
  "transaction_max_spans" : 500
}
```

Valid:
```json
{
  "transaction_max_spans" : "500"
}
```