### PR TITLE
[SIEM][CASE] Fix bug when connector is deleted.

### DIFF
--- a/x-pack/plugins/case/server/routes/api/__mocks__/request_responses.ts
+++ b/x-pack/plugins/case/server/routes/api/__mocks__/request_responses.ts
@@ -27,7 +27,7 @@ export const getActions = (): FindActionResult[] => [
     referencedByCount: 0,
   },
   {
-    id: 'd611af27-3532-4da9-8034-271fee81d634',
+    id: '123',
     actionTypeId: '.servicenow',
     name: 'ServiceNow',
     config: {

--- a/x-pack/plugins/case/server/routes/api/cases/push_case.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/push_case.ts
@@ -37,15 +37,23 @@ export function initPushCaseUserActionApi({
     async (context, request, response) => {
       try {
         const client = context.core.savedObjects.client;
+        const actionsClient = await context.actions?.getActionsClient();
+
         const caseId = request.params.case_id;
         const query = pipe(
           CaseExternalServiceRequestRt.decode(request.body),
           fold(throwErrors(Boom.badRequest), identity)
         );
+
+        if (actionsClient == null) {
+          throw Boom.notFound('Action client have not been found');
+        }
+
         const { username, full_name, email } = await caseService.getUser({ request, response });
+
         const pushedDate = new Date().toISOString();
 
-        const [myCase, myCaseConfigure, totalCommentsFindByCases] = await Promise.all([
+        const [myCase, myCaseConfigure, totalCommentsFindByCases, connectors] = await Promise.all([
           caseService.getCase({
             client,
             caseId: request.params.case_id,
@@ -60,6 +68,7 @@ export function initPushCaseUserActionApi({
               perPage: 1,
             },
           }),
+          actionsClient.getAll(),
         ]);
 
         if (myCase.attributes.status === 'closed') {
@@ -85,9 +94,15 @@ export function initPushCaseUserActionApi({
         };
 
         const caseConfigureConnectorId = getConnectorId(myCaseConfigure);
+
         // old case may not have new attribute connector_id, so we default to the configured system
-        const updateConnectorId =
-          myCase.attributes.connector_id == null ? { connector_id: caseConfigureConnectorId } : {};
+        const updateConnectorId = {
+          connector_id: myCase.attributes.connector_id ?? caseConfigureConnectorId,
+        };
+
+        if (!connectors.some(connector => connector.id === updateConnectorId.connector_id)) {
+          throw Boom.notFound('Connector not found or set to none');
+        }
 
         const [updatedCase, updatedComments] = await Promise.all([
           caseService.patchCase({

--- a/x-pack/plugins/siem/cypress/integration/cases.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/cases.spec.ts
@@ -27,7 +27,7 @@ import {
   ACTION,
   CASE_DETAILS_DESCRIPTION,
   CASE_DETAILS_PAGE_TITLE,
-  CASE_DETAILS_PUSH_AS_SERVICE_NOW_BTN,
+  CASE_DETAILS_PUSH_TO_EXTERNAL_SERVICE_BTN,
   CASE_DETAILS_STATUS,
   CASE_DETAILS_TAGS,
   CASE_DETAILS_TIMELINE_MARKDOWN,
@@ -102,7 +102,7 @@ describe('Cases', () => {
       .eq(PARTICIPANTS)
       .should('have.text', case1.reporter);
     cy.get(CASE_DETAILS_TAGS).should('have.text', expectedTags);
-    cy.get(CASE_DETAILS_PUSH_AS_SERVICE_NOW_BTN).should('have.attr', 'disabled');
+    cy.get(CASE_DETAILS_PUSH_TO_EXTERNAL_SERVICE_BTN).should('not.exist');
     cy.get(CASE_DETAILS_TIMELINE_MARKDOWN).then($element => {
       const timelineLink = $element.prop('href').match(/http(s?):\/\/\w*:\w*(\S*)/)[0];
       openCaseTimeline(timelineLink);

--- a/x-pack/plugins/siem/cypress/integration/cases.spec.ts
+++ b/x-pack/plugins/siem/cypress/integration/cases.spec.ts
@@ -102,7 +102,7 @@ describe('Cases', () => {
       .eq(PARTICIPANTS)
       .should('have.text', case1.reporter);
     cy.get(CASE_DETAILS_TAGS).should('have.text', expectedTags);
-    cy.get(CASE_DETAILS_PUSH_TO_EXTERNAL_SERVICE_BTN).should('not.exist');
+    cy.get(CASE_DETAILS_PUSH_TO_EXTERNAL_SERVICE_BTN).should('have.attr', 'disabled');
     cy.get(CASE_DETAILS_TIMELINE_MARKDOWN).then($element => {
       const timelineLink = $element.prop('href').match(/http(s?):\/\/\w*:\w*(\S*)/)[0];
       openCaseTimeline(timelineLink);

--- a/x-pack/plugins/siem/cypress/screens/case_details.ts
+++ b/x-pack/plugins/siem/cypress/screens/case_details.ts
@@ -10,7 +10,8 @@ export const CASE_DETAILS_DESCRIPTION = '[data-test-subj="markdown-root"]';
 
 export const CASE_DETAILS_PAGE_TITLE = '[data-test-subj="header-page-title"]';
 
-export const CASE_DETAILS_PUSH_AS_SERVICE_NOW_BTN = '[data-test-subj="push-to-external-service"]';
+export const CASE_DETAILS_PUSH_TO_EXTERNAL_SERVICE_BTN =
+  '[data-test-subj="push-to-external-service"]';
 
 export const CASE_DETAILS_STATUS = '[data-test-subj="case-view-status"]';
 

--- a/x-pack/plugins/siem/public/cases/components/case_view/index.test.tsx
+++ b/x-pack/plugins/siem/public/cases/components/case_view/index.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../../containers/use_update_case');
 jest.mock('../../containers/use_get_case_user_actions');
 jest.mock('../../containers/use_get_case');
 jest.mock('../use_push_to_service');
-jest.mock('../../../../containers/case/configure/use_connectors');
+jest.mock('../../containers/configure/use_connectors');
 
 const useUpdateCaseMock = useUpdateCase as jest.Mock;
 const useGetCaseUserActionsMock = useGetCaseUserActions as jest.Mock;

--- a/x-pack/plugins/siem/public/cases/components/case_view/index.tsx
+++ b/x-pack/plugins/siem/public/cases/components/case_view/index.tsx
@@ -341,7 +341,7 @@ export const CaseComponent = React.memo<CaseProps>(
                   isLoading={isLoadingConnectors}
                   onSubmit={onSubmitConnector}
                   connectors={connectors}
-                  selectedConnector={caseData.connectorId}
+                  selectedConnector={isValidConnector ? caseData.connectorId : 'none'}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/siem/public/cases/components/case_view/index.tsx
+++ b/x-pack/plugins/siem/public/cases/components/case_view/index.tsx
@@ -160,10 +160,11 @@ export const CaseComponent = React.memo<CaseProps>(
     );
 
     const { loading: isLoadingConnectors, connectors } = useConnectors();
-    const caseConnectorName = useMemo(
-      () => connectors.find(c => c.id === caseData.connectorId)?.name ?? 'none',
-      [connectors, caseData.connectorId]
-    );
+
+    const [caseConnectorName, isValidConnector] = useMemo(() => {
+      const connector = connectors.find(c => c.id === caseData.connectorId);
+      return [connector?.name ?? 'none', !!connector];
+    }, [connectors, caseData.connectorId]);
 
     const currentExternalIncident = useMemo(
       () =>
@@ -174,7 +175,7 @@ export const CaseComponent = React.memo<CaseProps>(
     );
 
     const { pushButton, pushCallouts } = usePushToService({
-      caseConnectorId: caseData.connectorId,
+      caseConnectorId: isValidConnector ? caseData.connectorId : 'none',
       caseConnectorName,
       caseServices,
       caseId: caseData.id,
@@ -306,7 +307,7 @@ export const CaseComponent = React.memo<CaseProps>(
                           onChange={toggleStatusCase}
                         />
                       </EuiFlexItem>
-                      {hasDataToPush && (
+                      {hasDataToPush && isValidConnector && (
                         <EuiFlexItem data-test-subj="has-data-to-push-button" grow={false}>
                           {pushButton}
                         </EuiFlexItem>

--- a/x-pack/plugins/siem/public/cases/components/case_view/index.tsx
+++ b/x-pack/plugins/siem/public/cases/components/case_view/index.tsx
@@ -175,7 +175,7 @@ export const CaseComponent = React.memo<CaseProps>(
     );
 
     const { pushButton, pushCallouts } = usePushToService({
-      caseConnectorId: isValidConnector ? caseData.connectorId : 'none',
+      caseConnectorId: caseData.connectorId,
       caseConnectorName,
       caseServices,
       caseId: caseData.id,
@@ -183,6 +183,7 @@ export const CaseComponent = React.memo<CaseProps>(
       connectors,
       updateCase: handleUpdateCase,
       userCanCrud,
+      isValidConnector,
     });
 
     const onSubmitConnector = useCallback(
@@ -307,7 +308,7 @@ export const CaseComponent = React.memo<CaseProps>(
                           onChange={toggleStatusCase}
                         />
                       </EuiFlexItem>
-                      {hasDataToPush && isValidConnector && (
+                      {hasDataToPush && (
                         <EuiFlexItem data-test-subj="has-data-to-push-button" grow={false}>
                           {pushButton}
                         </EuiFlexItem>
@@ -341,7 +342,7 @@ export const CaseComponent = React.memo<CaseProps>(
                   isLoading={isLoadingConnectors}
                   onSubmit={onSubmitConnector}
                   connectors={connectors}
-                  selectedConnector={isValidConnector ? caseData.connectorId : 'none'}
+                  selectedConnector={caseData.connectorId}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/siem/public/cases/components/use_push_to_service/index.test.tsx
+++ b/x-pack/plugins/siem/public/cases/components/use_push_to_service/index.test.tsx
@@ -46,7 +46,9 @@ describe('usePushToService', () => {
     connectors: connectorsMock,
     updateCase,
     userCanCrud: true,
+    isValidConnector: true,
   };
+
   beforeEach(() => {
     jest.resetAllMocks();
     (usePostPushToService as jest.Mock).mockImplementation(() => mockPostPush);
@@ -55,6 +57,7 @@ describe('usePushToService', () => {
       actionLicense,
     }));
   });
+
   it('push case button posts the push with correct args', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
@@ -75,6 +78,7 @@ describe('usePushToService', () => {
       expect(result.current.pushCallouts).toBeNull();
     });
   });
+
   it('Displays message when user does not have premium license', async () => {
     (useGetActionLicense as jest.Mock).mockImplementation(() => ({
       isLoading: false,
@@ -96,6 +100,7 @@ describe('usePushToService', () => {
       expect(errorsMsg[0].title).toEqual(getLicenseError().title);
     });
   });
+
   it('Displays message when user does not have case enabled in config', async () => {
     (useGetActionLicense as jest.Mock).mockImplementation(() => ({
       isLoading: false,
@@ -117,6 +122,7 @@ describe('usePushToService', () => {
       expect(errorsMsg[0].title).toEqual(getKibanaConfigError().title);
     });
   });
+
   it('Displays message when user does not have a connector configured', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
@@ -135,6 +141,27 @@ describe('usePushToService', () => {
       expect(errorsMsg[0].title).toEqual(i18n.PUSH_DISABLE_BY_NO_CASE_CONFIG_TITLE);
     });
   });
+
+  it('Displays message when connector is deleted', async () => {
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(
+        () =>
+          usePushToService({
+            ...defaultArgs,
+            caseConnectorId: 'not-exist',
+            isValidConnector: false,
+          }),
+        {
+          wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+        }
+      );
+      await waitForNextUpdate();
+      const errorsMsg = result.current.pushCallouts?.props.messages;
+      expect(errorsMsg).toHaveLength(1);
+      expect(errorsMsg[0].title).toEqual(i18n.PUSH_DISABLE_BY_NO_CASE_CONFIG_TITLE);
+    });
+  });
+
   it('Displays message when case is closed', async () => {
     await act(async () => {
       const { result, waitForNextUpdate } = renderHook<UsePushToService, ReturnUsePushToService>(

--- a/x-pack/plugins/siem/public/cases/components/use_push_to_service/index.tsx
+++ b/x-pack/plugins/siem/public/cases/components/use_push_to_service/index.tsx
@@ -29,6 +29,7 @@ export interface UsePushToService {
   connectors: Connector[];
   updateCase: (newCase: Case) => void;
   userCanCrud: boolean;
+  isValidConnector: boolean;
 }
 
 export interface ReturnUsePushToService {
@@ -45,6 +46,7 @@ export const usePushToService = ({
   connectors,
   updateCase,
   userCanCrud,
+  isValidConnector,
 }: UsePushToService): ReturnUsePushToService => {
   const urlSearch = useGetUrlSearch(navTabs.case);
 
@@ -102,6 +104,19 @@ export const usePushToService = ({
           ),
         },
       ];
+    } else if (!isValidConnector && !loadingLicense) {
+      errors = [
+        ...errors,
+        {
+          title: i18n.PUSH_DISABLE_BY_NO_CASE_CONFIG_TITLE,
+          description: (
+            <FormattedMessage
+              defaultMessage="The connector used to send updates to external service has been deleted. To update cases in external systems, select a different connector or create a new one."
+              id="xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDesc"
+            />
+          ),
+        },
+      ];
     }
     if (caseStatus === 'closed') {
       errors = [
@@ -130,7 +145,9 @@ export const usePushToService = ({
         fill
         iconType="importAction"
         onClick={handlePushToService}
-        disabled={isLoading || loadingLicense || errorsMsg.length > 0 || !userCanCrud}
+        disabled={
+          isLoading || loadingLicense || errorsMsg.length > 0 || !userCanCrud || !isValidConnector
+        }
         isLoading={isLoading}
       >
         {caseServices[caseConnectorId]
@@ -147,6 +164,7 @@ export const usePushToService = ({
     isLoading,
     loadingLicense,
     userCanCrud,
+    isValidConnector,
   ]);
 
   const objToReturn = useMemo(() => {

--- a/x-pack/plugins/siem/public/cases/components/use_push_to_service/index.tsx
+++ b/x-pack/plugins/siem/public/cases/components/use_push_to_service/index.tsx
@@ -79,7 +79,7 @@ export const usePushToService = ({
           description: (
             <FormattedMessage
               defaultMessage="To open and update cases in external systems, you must configure a {link}."
-              id="xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDescription"
+              id="xpack.siem.case.caseView.pushToServiceDisableByNoConnectors"
               values={{
                 link: (
                   <EuiLink href={getConfigureCasesUrl(urlSearch)} target="_blank">
@@ -99,7 +99,7 @@ export const usePushToService = ({
           description: (
             <FormattedMessage
               defaultMessage="To open and update cases in external systems, you must select an external incident management system for this case."
-              id="xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDesc"
+              id="xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDescription"
             />
           ),
         },
@@ -112,7 +112,7 @@ export const usePushToService = ({
           description: (
             <FormattedMessage
               defaultMessage="The connector used to send updates to external service has been deleted. To update cases in external systems, select a different connector or create a new one."
-              id="xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDesc"
+              id="xpack.siem.case.caseView.pushToServiceDisableByInvalidConnector"
             />
           ),
         },

--- a/x-pack/plugins/siem/public/cases/components/use_push_to_service/translations.ts
+++ b/x-pack/plugins/siem/public/cases/components/use_push_to_service/translations.ts
@@ -13,11 +13,6 @@ export const ERROR_PUSH_SERVICE_CALLOUT_TITLE = i18n.translate(
   }
 );
 export const PUSH_THIRD = (thirdParty: string) => {
-  if (thirdParty === 'none') {
-    return i18n.translate('xpack.siem.case.caseView.pushThirdPartyIncident', {
-      defaultMessage: 'Push as third party incident',
-    });
-  }
   return i18n.translate('xpack.siem.case.caseView.pushNamedIncident', {
     values: { thirdParty },
     defaultMessage: 'Push as { thirdParty } incident',
@@ -25,11 +20,6 @@ export const PUSH_THIRD = (thirdParty: string) => {
 };
 
 export const UPDATE_THIRD = (thirdParty: string) => {
-  if (thirdParty === 'none') {
-    return i18n.translate('xpack.siem.case.caseView.updateThirdPartyIncident', {
-      defaultMessage: 'Update third party incident',
-    });
-  }
   return i18n.translate('xpack.siem.case.caseView.updateNamedIncident', {
     values: { thirdParty },
     defaultMessage: 'Update { thirdParty } incident',

--- a/x-pack/plugins/siem/public/cases/components/use_push_to_service/translations.ts
+++ b/x-pack/plugins/siem/public/cases/components/use_push_to_service/translations.ts
@@ -13,6 +13,12 @@ export const ERROR_PUSH_SERVICE_CALLOUT_TITLE = i18n.translate(
   }
 );
 export const PUSH_THIRD = (thirdParty: string) => {
+  if (thirdParty === 'none') {
+    return i18n.translate('xpack.siem.case.caseView.pushThirdPartyIncident', {
+      defaultMessage: 'Push as external incident',
+    });
+  }
+
   return i18n.translate('xpack.siem.case.caseView.pushNamedIncident', {
     values: { thirdParty },
     defaultMessage: 'Push as { thirdParty } incident',
@@ -20,6 +26,12 @@ export const PUSH_THIRD = (thirdParty: string) => {
 };
 
 export const UPDATE_THIRD = (thirdParty: string) => {
+  if (thirdParty === 'none') {
+    return i18n.translate('xpack.siem.case.caseView.updateThirdPartyIncident', {
+      defaultMessage: 'Update external incident',
+    });
+  }
+
   return i18n.translate('xpack.siem.case.caseView.updateNamedIncident', {
     values: { thirdParty },
     defaultMessage: 'Update { thirdParty } incident',

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -13132,7 +13132,6 @@
     "xpack.siem.case.caseView.pushToServiceDisableByConfigTitle": "Kibana の構成ファイルで ServiceNow を有効にする",
     "xpack.siem.case.caseView.pushToServiceDisableByLicenseDescription": "外部システムでケースを開くには、ライセンスをプラチナに更新するか、30 日間の無料トライアルを開始するか、AWS、GCP、または Azure で {link} にサインアップする必要があります。",
     "xpack.siem.case.caseView.pushToServiceDisableByLicenseTitle": "E lastic Platinum へのアップグレード",
-    "xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDescription": "外部システムでケースを開いて更新するには、{link} を設定する必要があります。",
     "xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigTitle": "外部コネクターを構成",
     "xpack.siem.case.caseView.reopenCase": "ケースを再開",
     "xpack.siem.case.caseView.reopenedCase": "ケースを再開する",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13139,7 +13139,6 @@
     "xpack.siem.case.caseView.pushToServiceDisableByConfigTitle": "在 Kibana 配置文件中启用 ServiceNow",
     "xpack.siem.case.caseView.pushToServiceDisableByLicenseDescription": "要在外部系统中打开案例，必须将许可证更新到白金级，开始为期 30 天的免费试用，或在 AWS、GCP 或 Azure 上快速部署 {link}。",
     "xpack.siem.case.caseView.pushToServiceDisableByLicenseTitle": "升级到 Elastic 白金级",
-    "xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigDescription": "要在外部系统上打开和更新案例，必须配置 {link}。",
     "xpack.siem.case.caseView.pushToServiceDisableByNoCaseConfigTitle": "配置外部连接器",
     "xpack.siem.case.caseView.reopenCase": "重新打开案例",
     "xpack.siem.case.caseView.reopenedCase": "重新打开的案例",

--- a/x-pack/test/case_api_integration/basic/config.ts
+++ b/x-pack/test/case_api_integration/basic/config.ts
@@ -9,6 +9,6 @@ import { createTestConfig } from '../common/config';
 // eslint-disable-next-line import/no-default-export
 export default createTestConfig('basic', {
   disabledPlugins: [],
-  license: 'basic',
+  license: 'trial',
   ssl: true,
 });

--- a/x-pack/test/case_api_integration/basic/tests/cases/push_case.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/push_case.ts
@@ -6,6 +6,7 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import { ObjectRemover as ActionsRemover } from '../../../../alerting_api_integration/common/lib';
 
 import { CASE_CONFIGURE_URL, CASES_URL } from '../../../../../plugins/case/common/constants';
 import { postCaseReq, defaultUser, postCommentReq } from '../../../common/lib/mock';
@@ -15,6 +16,7 @@ import {
   deleteComments,
   deleteConfiguration,
   getConfiguration,
+  getConnector,
 } from '../../../common/lib/utils';
 
 // eslint-disable-next-line import/no-default-export
@@ -23,19 +25,31 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
 
   describe('push_case', () => {
+    const actionsRemover = new ActionsRemover(supertest);
+
     afterEach(async () => {
       await deleteCases(es);
       await deleteComments(es);
       await deleteConfiguration(es);
       await deleteCasesUserActions(es);
+      await actionsRemover.removeAll();
     });
 
     it('should push a case', async () => {
+      const { body: connector } = await supertest
+        .post('/api/action')
+        .set('kbn-xsrf', 'true')
+        .send(getConnector())
+        .expect(200);
+
+      actionsRemover.add('default', connector.id, 'action');
+
       const { body: configure } = await supertest
         .post(CASE_CONFIGURE_URL)
         .set('kbn-xsrf', 'true')
-        .send(getConfiguration())
+        .send(getConfiguration(connector.id))
         .expect(200);
+
       const { body: postedCase } = await supertest
         .post(CASES_URL)
         .set('kbn-xsrf', 'true')
@@ -58,11 +72,20 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('pushes a comment appropriately', async () => {
+      const { body: connector } = await supertest
+        .post('/api/action')
+        .set('kbn-xsrf', 'true')
+        .send(getConnector())
+        .expect(200);
+
+      actionsRemover.add('default', connector.id, 'action');
+
       const { body: configure } = await supertest
         .post(CASE_CONFIGURE_URL)
         .set('kbn-xsrf', 'true')
-        .send(getConfiguration())
+        .send(getConfiguration(connector.id))
         .expect(200);
+
       const { body: postedCase } = await supertest
         .post(CASES_URL)
         .set('kbn-xsrf', 'true')
@@ -99,6 +122,7 @@ export default ({ getService }: FtrProviderContext): void => {
         .expect(200);
       expect(body.comments[0].pushed_by).to.eql(defaultUser);
     });
+
     it('unhappy path - 404s when case does not exist', async () => {
       await supertest
         .post(`${CASES_URL}/fake-id/_push`)

--- a/x-pack/test/case_api_integration/common/config.ts
+++ b/x-pack/test/case_api_integration/common/config.ts
@@ -24,6 +24,7 @@ const enabledActionTypes = [
   '.pagerduty',
   '.server-log',
   '.servicenow',
+  '.jira',
   '.slack',
   '.webhook',
   'test.authorization',

--- a/x-pack/test/case_api_integration/common/lib/utils.ts
+++ b/x-pack/test/case_api_integration/common/lib/utils.ts
@@ -23,6 +23,37 @@ export const getConfigurationOutput = (update = false): Partial<CasesConfigureRe
   };
 };
 
+export const getConnector = () => ({
+  name: 'ServiceNow Connector',
+  actionTypeId: '.servicenow',
+  secrets: {
+    username: 'admin',
+    password: 'password',
+  },
+  config: {
+    apiUrl: 'http://some.non.existent.com',
+    casesConfiguration: {
+      mapping: [
+        {
+          source: 'title',
+          target: 'short_description',
+          actionType: 'overwrite',
+        },
+        {
+          source: 'description',
+          target: 'description',
+          actionType: 'append',
+        },
+        {
+          source: 'comments',
+          target: 'comments',
+          actionType: 'append',
+        },
+      ],
+    },
+  },
+});
+
 export const removeServerGeneratedPropertiesFromConfigure = (
   config: Partial<CasesConfigureResponse>
 ): Partial<CasesConfigureResponse> => {


### PR DESCRIPTION
## Summary

When a connector is deleted and a case uses that connector the pushed at service button is being shown. This PR fixes the issue: https://github.com/elastic/siem-team/issues/658

![b](https://user-images.githubusercontent.com/7871006/81693557-c58bbb00-9468-11ea-9957-5aeaead7cc22.gif)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
