### PR TITLE
Fix anomalies display on focused APM service map

### DIFF
--- a/x-pack/plugins/apm/common/service_map.ts
+++ b/x-pack/plugins/apm/common/service_map.ts
@@ -5,22 +5,23 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import cytoscape from 'cytoscape';
 import { ILicense } from '../../licensing/public';
 import {
   AGENT_NAME,
   SERVICE_ENVIRONMENT,
   SERVICE_NAME,
+  SPAN_DESTINATION_SERVICE_RESOURCE,
   SPAN_SUBTYPE,
-  SPAN_TYPE,
-  SPAN_DESTINATION_SERVICE_RESOURCE
+  SPAN_TYPE
 } from './elasticsearch_fieldnames';
 
-export interface ServiceConnectionNode {
+export interface ServiceConnectionNode extends cytoscape.NodeDataDefinition {
   [SERVICE_NAME]: string;
   [SERVICE_ENVIRONMENT]: string | null;
   [AGENT_NAME]: string;
 }
-export interface ExternalConnectionNode {
+export interface ExternalConnectionNode extends cytoscape.NodeDataDefinition {
   [SPAN_DESTINATION_SERVICE_RESOURCE]: string;
   [SPAN_TYPE]: string;
   [SPAN_SUBTYPE]: string;

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map.ts
@@ -9,16 +9,15 @@ import {
   SERVICE_ENVIRONMENT,
   SERVICE_NAME
 } from '../../../common/elasticsearch_fieldnames';
+import { getMlIndex } from '../../../common/ml_job_constants';
 import { getServicesProjection } from '../../../common/projections/services';
 import { mergeProjection } from '../../../common/projections/util/merge_projection';
 import { PromiseReturnType } from '../../../typings/common';
+import { rangeFilter } from '../helpers/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
-import { dedupeConnections } from './dedupe_connections';
+import { transformServiceMapResponses } from './transform_service_map_responses';
 import { getServiceMapFromTraceIds } from './get_service_map_from_trace_ids';
 import { getTraceSampleIds } from './get_trace_sample_ids';
-import { addAnomaliesToServicesData } from './ml_helpers';
-import { getMlIndex } from '../../../common/ml_job_constants';
-import { rangeFilter } from '../helpers/range_filter';
 
 export interface IEnvOptions {
   setup: Setup & SetupTimeRange;
@@ -179,13 +178,9 @@ export async function getServiceMap(options: IEnvOptions) {
     getAnomaliesData(options)
   ]);
 
-  const servicesDataWithAnomalies = addAnomaliesToServicesData(
-    servicesData,
-    anomaliesData
-  );
-
-  return dedupeConnections({
+  return transformServiceMapResponses({
     ...connectionData,
-    services: servicesDataWithAnomalies
+    anomalies: anomaliesData,
+    services: servicesData
   });
 }

--- a/x-pack/plugins/apm/server/lib/service_map/ml_helpers.test.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/ml_helpers.test.ts
@@ -5,11 +5,11 @@
  */
 
 import { AnomaliesResponse } from './get_service_map';
-import { addAnomaliesToServicesData } from './ml_helpers';
+import { addAnomaliesDataToNodes } from './ml_helpers';
 
-describe('addAnomaliesToServicesData', () => {
-  it('adds anomalies to services data', () => {
-    const servicesData = [
+describe('addAnomaliesDataToNodes', () => {
+  it('adds anomalies to nodes', () => {
+    const nodes = [
       {
         'service.name': 'opbeans-ruby',
         'agent.name': 'ruby',
@@ -89,8 +89,8 @@ describe('addAnomaliesToServicesData', () => {
     ];
 
     expect(
-      addAnomaliesToServicesData(
-        servicesData,
+      addAnomaliesDataToNodes(
+        nodes,
         (anomaliesResponse as unknown) as AnomaliesResponse
       )
     ).toEqual(result);

--- a/x-pack/plugins/apm/server/lib/service_map/ml_helpers.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/ml_helpers.ts
@@ -9,10 +9,11 @@ import {
   getMlJobServiceName,
   getSeverity
 } from '../../../common/ml_job_constants';
-import { AnomaliesResponse, ServicesResponse } from './get_service_map';
+import { ConnectionNode } from '../../../common/service_map';
+import { AnomaliesResponse } from './get_service_map';
 
-export function addAnomaliesToServicesData(
-  servicesData: ServicesResponse,
+export function addAnomaliesDataToNodes(
+  nodes: ConnectionNode[],
   anomaliesResponse: AnomaliesResponse
 ) {
   const anomaliesMap = (
@@ -52,7 +53,7 @@ export function addAnomaliesToServicesData(
     };
   }, {});
 
-  const servicesDataWithAnomalies = servicesData.map(service => {
+  const servicesDataWithAnomalies = nodes.map(service => {
     const serviceAnomalies = anomaliesMap[service[SERVICE_NAME]];
     if (serviceAnomalies) {
       const maxScore = serviceAnomalies.max_score;


### PR DESCRIPTION
The map anomlies rings display was working on the global map and on the focused service of a focused map, but not on the other services on a focused map.

This is because we were adding the anomlies to the list of services from the initial query, but not to the list of services derived from the connections data.

Make the transformation that add anomalies happen after the derived services nodes are added.

This is done in the function that was called `dedupeConnections`, but since it does much more than dedupe connections has been renamed to `transformServiceMapResponses`.

Also make the node types extend `cytoscape.NodeDataDefinition` in order to simplify the types in the transformation (we were adding `& { id: string }` in some places which this replaces.)

Fixes #65403.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
