### PR TITLE
Fix major severity service map ring colors

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
@@ -17,7 +17,8 @@ export const getSeverityColor = (nodeSeverity: string) => {
   switch (nodeSeverity) {
     case severity.warning:
       return theme.euiColorVis0;
-    case severity.minor || severity.major:
+    case severity.minor:
+    case severity.major:
       return theme.euiColorVis5;
     case severity.critical:
       return theme.euiColorVis9;


### PR DESCRIPTION
Using `||` in the switch statement made it so "major" did not work, and we would get the border width but not the color. Change to splitting case statements.

Fixes #66081
