### PR TITLE
[ML] Fixing angular template string literals

### DIFF
--- a/x-pack/plugins/ml/public/datavisualizer/selector/directive.js
+++ b/x-pack/plugins/ml/public/datavisualizer/selector/directive.js
@@ -15,7 +15,10 @@ import { checkFindFileStructurePrivilege } from 'plugins/ml/privilege/check_priv
 
 import uiRoutes from 'ui/routes';
 
-const template = `<ml-nav-menu name="datavisualizer" /><datavisualizer-selector class="ml-datavisualizer-selector"/>`;
+const template = `
+  <ml-nav-menu name="datavisualizer" ></ml-nav-menu>
+  <datavisualizer-selector class="ml-datavisualizer-selector"></datavisualizer-selector>
+`;
 
 uiRoutes
   .when('/datavisualizer', {

--- a/x-pack/plugins/ml/public/file_datavisualizer/file_datavisualizer_directive.js
+++ b/x-pack/plugins/ml/public/file_datavisualizer/file_datavisualizer_directive.js
@@ -21,7 +21,7 @@ import { FileDataVisualizerPage } from './file_datavisualizer';
 
 import uiRoutes from 'ui/routes';
 
-const template = '<ml-nav-menu name="datavisualizer" /><file-datavisualizer-page />';
+const template = '<ml-nav-menu name="datavisualizer" ></ml-nav-menu><file-datavisualizer-page ></file-datavisualizer-page>';
 
 uiRoutes
   .when('/filedatavisualizer/?', {

--- a/x-pack/plugins/ml/public/jobs/jobs_list/directive.js
+++ b/x-pack/plugins/ml/public/jobs/jobs_list/directive.js
@@ -19,7 +19,7 @@ import { loadNewJobDefaults } from 'plugins/ml/jobs/new_job/utils/new_job_defaul
 
 import uiRoutes from 'ui/routes';
 
-const template = `<ml-nav-menu name="jobs" /><jobs-page />`;
+const template = `<ml-nav-menu name="jobs" ></ml-nav-menu><jobs-page ></jobs-page>`;
 
 uiRoutes
   .when('/jobs/?', {

--- a/x-pack/plugins/ml/public/settings/calendars/edit/directive.js
+++ b/x-pack/plugins/ml/public/settings/calendars/edit/directive.js
@@ -21,9 +21,9 @@ import uiRoutes from 'ui/routes';
 import { I18nContext } from 'ui/i18n';
 
 const template = `
-  <ml-nav-menu name="settings" />
+  <ml-nav-menu name="settings" ></ml-nav-menu>
   <div class="mlCalendarManagement">
-    <ml-new-calendar />
+    <ml-new-calendar ></ml-new-calendar>
   </div>
 `;
 

--- a/x-pack/plugins/ml/public/settings/calendars/list/directive.js
+++ b/x-pack/plugins/ml/public/settings/calendars/list/directive.js
@@ -21,9 +21,9 @@ import uiRoutes from 'ui/routes';
 import { I18nContext } from 'ui/i18n';
 
 const template = `
-  <ml-nav-menu name="settings" />
+  <ml-nav-menu name="settings" ></ml-nav-menu>
   <div class="mlCalendarManagement">
-    <ml-calendars-list />
+    <ml-calendars-list ></ml-calendars-list>
   </div>
 `;
 

--- a/x-pack/plugins/ml/public/settings/settings_directive.js
+++ b/x-pack/plugins/ml/public/settings/settings_directive.js
@@ -21,9 +21,9 @@ import uiRoutes from 'ui/routes';
 import { timefilter } from 'ui/timefilter';
 
 const template = `
-  <ml-nav-menu name="settings" />
+  <ml-nav-menu name="settings" ></ml-nav-menu>
   <div class="mlSettingsPage">
-    <ml-settings />
+    <ml-settings ></ml-settings>
   </div>
 `;
 


### PR DESCRIPTION
Removing self closing tags in html string literal templates. 
Missed in https://github.com/elastic/kibana/pull/65336

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
