### PR TITLE
[7.x] [Metrics UI] Fix chart time range and percentile thresholds (#66128)

### DIFF
--- a/x-pack/plugins/infra/common/http_api/metrics_explorer.ts
+++ b/x-pack/plugins/infra/common/http_api/metrics_explorer.ts
@@ -58,6 +58,7 @@ export const metricsExplorerRequestBodyOptionalFieldsRT = rt.partial({
   limit: rt.union([rt.number, rt.null, rt.undefined]),
   filterQuery: rt.union([rt.string, rt.null, rt.undefined]),
   forceInterval: rt.boolean,
+  dropLastBucket: rt.boolean,
 });
 
 export const metricsExplorerRequestBodyRT = rt.intersection([

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -35,6 +35,7 @@ import { getChartTheme } from '../../../pages/metrics/metrics_explorer/component
 import { createFormatterForMetric } from '../../../pages/metrics/metrics_explorer/components/helpers/create_formatter_for_metric';
 import { calculateDomain } from '../../../pages/metrics/metrics_explorer/components/helpers/calculate_domain';
 import { useMetricsExplorerChartData } from '../hooks/use_metrics_explorer_chart_data';
+import { getMetricId } from '../../../pages/metrics/metrics_explorer/components/helpers/get_metric_id';
 
 interface Props {
   context: AlertsContextValue<AlertContextMeta>;
@@ -120,7 +121,7 @@ export const ExpressionChart: React.FC<Props> = ({
     rows: firstSeries.rows.map(row => {
       const newRow: MetricsExplorerRow = { ...row };
       thresholds.forEach((thresholdValue, index) => {
-        newRow[`metric_threshold_${index}`] = thresholdValue;
+        newRow[getMetricId(metric, `threshold_${index}`)] = thresholdValue;
       });
       return newRow;
     }),
@@ -140,7 +141,8 @@ export const ExpressionChart: React.FC<Props> = ({
 
   const isAbove = [Comparator.GT, Comparator.GT_OR_EQ].includes(expression.comparator);
   const opacity = 0.3;
-  const timeLabel = TIME_LABELS[expression.timeUnit];
+  const { timeSize, timeUnit } = expression;
+  const timeLabel = TIME_LABELS[timeUnit];
 
   return (
     <>
@@ -255,8 +257,8 @@ export const ExpressionChart: React.FC<Props> = ({
           <EuiText size="xs" color="subdued">
             <FormattedMessage
               id="xpack.infra.metrics.alerts.dataTimeRangeLabelWithGrouping"
-              defaultMessage="Last 20 {timeLabel} of data for {id}"
-              values={{ id: series.id, timeLabel }}
+              defaultMessage="Last {lookback} {timeLabel} of data for {id}"
+              values={{ id: series.id, timeLabel, lookback: timeSize * 20 }}
             />
           </EuiText>
         ) : (

--- a/x-pack/plugins/infra/public/alerting/metric_threshold/hooks/use_metrics_explorer_chart_data.ts
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/hooks/use_metrics_explorer_chart_data.ts
@@ -26,6 +26,7 @@ export const useMetricsExplorerChartData = (
     () => ({
       limit: 1,
       forceInterval: true,
+      dropLastBucket: false,
       groupBy,
       filterQuery,
       metrics: [

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.ts
@@ -60,6 +60,7 @@ export function useMetricsExplorerData(
             method: 'POST',
             body: JSON.stringify({
               forceInterval: options.forceInterval,
+              dropLastBucket: options.dropLastBucket != null ? options.dropLastBucket : true,
               metrics:
                 options.aggregation === 'count'
                   ? [{ aggregation: 'count' }]

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_options.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_options.ts
@@ -41,6 +41,7 @@ export interface MetricsExplorerOptions {
   filterQuery?: string;
   aggregation: MetricsExplorerAggregation;
   forceInterval?: boolean;
+  dropLastBucket?: boolean;
 }
 
 export interface MetricsExplorerTimeOptions {

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/create_metrics_model.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/create_metrics_model.ts
@@ -15,12 +15,15 @@ const percentileToVaue = (agg: 'p95' | 'p99') => {
 };
 
 export const createMetricModel = (options: MetricsExplorerRequestBody): TSVBMetricModel => {
+  // if dropLastBucket is set use the value otherwise default to true.
+  const dropLastBucket: boolean = options.dropLastBucket != null ? options.dropLastBucket : true;
   return {
     id: 'custom',
     requires: [],
     index_pattern: options.indexPattern,
     interval: options.timerange.interval,
     time_field: options.timerange.field,
+    drop_last_bucket: dropLastBucket,
     type: 'timeseries',
     // Create one series per metric requested. The series.id will be used to identify the metric
     // when the responses are processed and combined with the grouping request.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Fix chart time range and percentile thresholds (#66128)