### PR TITLE
Guard against disabled Dev Tools in legacy kibana/public/dev_tools.

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dev_tools/index.ts
+++ b/src/legacy/core_plugins/kibana/public/dev_tools/index.ts
@@ -22,7 +22,7 @@ import 'uiExports/devTools';
 
 import { npStart } from 'ui/new_platform';
 
-if (npStart.plugins.devTools.getSortedDevTools().length === 0) {
+if (!npStart.plugins.devTools || npStart.plugins.devTools.getSortedDevTools().length === 0) {
   npStart.core.chrome.navLinks.update('kibana:dev_tools', {
     hidden: true,
   });


### PR DESCRIPTION
@smith Reported disabling Dev Tools by setting `dev_tools.enabled: false` in `kibana.yml` and then seeing this fatal error:

![image](https://user-images.githubusercontent.com/1238659/81730683-c01b7a00-9442-11ea-9d82-daaa0c6a523e.png)

This change fixes this.

## Release note

Setting `dev_tools.enabled: false` in `kibana.yml` will no longer crash Kibana.