### PR TITLE
[Ingest Manager] Make bottom bar custom styling account for navigation setting

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/index.scss
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/index.scss
@@ -5,7 +5,7 @@
  * 1. Hack EUI so the bottom bar doesn't obscure the nav drawer flyout.
  */
 .ingestManager__bottomBar {
-  z-index: 0; /* 1 */
+  z-index: 5; /* 1 */
   left: $euiNavDrawerWidthCollapsed;
 }
 

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/index.tsx
@@ -40,6 +40,7 @@ export const CreateDatasourcePage: React.FunctionComponent = () => {
   const {
     notifications,
     chrome: { getIsNavDrawerLocked$ },
+    uiSettings,
   } = useCore();
   const {
     fleet: { enabled: isFleetEnabled },
@@ -291,12 +292,14 @@ export const CreateDatasourcePage: React.FunctionComponent = () => {
       )}
       <EuiSteps steps={steps} />
       <EuiSpacer size="l" />
+      {/* TODO #64541 - Remove classes */}
       <EuiBottomBar
-        css={{ zIndex: 5 }}
         className={
-          isNavDrawerLocked
-            ? 'ingestManager__bottomBar-isNavDrawerLocked'
-            : 'ingestManager__bottomBar'
+          uiSettings.get('pageNavigation') === 'legacy'
+            ? isNavDrawerLocked
+              ? 'ingestManager__bottomBar-isNavDrawerLocked'
+              : 'ingestManager__bottomBar'
+            : undefined
         }
       >
         <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/settings/index.tsx
@@ -36,6 +36,7 @@ export const ConfigSettingsView = memo<{ config: AgentConfig }>(
     const {
       notifications,
       chrome: { getIsNavDrawerLocked$ },
+      uiSettings,
     } = useCore();
     const {
       fleet: { enabled: isFleetEnabled },
@@ -149,13 +150,15 @@ export const ConfigSettingsView = memo<{ config: AgentConfig }>(
             history.push(AGENT_CONFIG_PATH);
           }}
         />
+        {/* TODO #64541 - Remove classes */}
         {hasChanges ? (
           <EuiBottomBar
-            css={{ zIndex: 5 }}
             className={
-              isNavDrawerLocked
-                ? 'ingestManager__bottomBar-isNavDrawerLocked'
-                : 'ingestManager__bottomBar'
+              uiSettings.get('pageNavigation') === 'legacy'
+                ? isNavDrawerLocked
+                  ? 'ingestManager__bottomBar-isNavDrawerLocked'
+                  : 'ingestManager__bottomBar'
+                : undefined
             }
           >
             <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/edit_datasource_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/edit_datasource_page/index.tsx
@@ -41,7 +41,11 @@ import { StepConfigureDatasource } from '../create_datasource_page/step_configur
 import { StepDefineDatasource } from '../create_datasource_page/step_define_datasource';
 
 export const EditDatasourcePage: React.FunctionComponent = () => {
-  const { notifications } = useCore();
+  const {
+    notifications,
+    chrome: { getIsNavDrawerLocked$ },
+    uiSettings,
+  } = useCore();
   const {
     fleet: { enabled: isFleetEnabled },
   } = useConfig();
@@ -49,6 +53,15 @@ export const EditDatasourcePage: React.FunctionComponent = () => {
     params: { configId, datasourceId },
   } = useRouteMatch();
   const history = useHistory();
+  const [isNavDrawerLocked, setIsNavDrawerLocked] = useState(false);
+
+  useEffect(() => {
+    const subscription = getIsNavDrawerLocked$().subscribe((newIsNavDrawerLocked: boolean) => {
+      setIsNavDrawerLocked(newIsNavDrawerLocked);
+    });
+
+    return () => subscription.unsubscribe();
+  });
 
   // Agent config, package info, and datasource states
   const [isLoadingData, setIsLoadingData] = useState<boolean>(true);
@@ -296,7 +309,16 @@ export const EditDatasourcePage: React.FunctionComponent = () => {
             ]}
           />
           <EuiSpacer size="l" />
-          <EuiBottomBar css={{ zIndex: 5 }} paddingSize="s">
+          {/* TODO #64541 - Remove classes */}
+          <EuiBottomBar
+            className={
+              uiSettings.get('pageNavigation') === 'legacy'
+                ? isNavDrawerLocked
+                  ? 'ingestManager__bottomBar-isNavDrawerLocked'
+                  : 'ingestManager__bottomBar'
+                : undefined
+            }
+          >
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty color="ghost" href={cancelUrl}>


### PR DESCRIPTION
## Summary

Resolves #65885. With the nav drawer changes that landed in 7.8, custom styling is no longer needed for `EuiBottomBar` to be positioned correctly (even when nav is docked). However users can still revert back to `legacy` navigation via an Advanced Setting, so this PR accounts for the navigation setting when applying styles.

![image](https://user-images.githubusercontent.com/1965714/81737871-a3387400-944d-11ea-90ed-55bd9e519d7d.png)

![image](https://user-images.githubusercontent.com/1965714/81849379-4d2a0600-950b-11ea-95f2-b0d63ec0f5e1.png)