### PR TITLE
[Ingest Manager] Add support for datastream to each template

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -276,6 +276,9 @@ export interface IndexTemplate {
     mappings: object;
     aliases: object;
   };
+  data_stream: {
+    timestamp_field: string;
+  };
 }
 
 export interface TemplateRef {

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
@@ -90,6 +90,9 @@ exports[`tests loading base.yml: base.yml 1`] = `
       }
     },
     "aliases": {}
+  },
+  "data_stream": {
+    "timestamp_field": "@timestamp"
   }
 }
 `;
@@ -184,6 +187,9 @@ exports[`tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
       }
     },
     "aliases": {}
+  },
+  "data_stream": {
+    "timestamp_field": "@timestamp"
   }
 }
 `;
@@ -1662,6 +1668,9 @@ exports[`tests loading system.yml: system.yml 1`] = `
       }
     },
     "aliases": {}
+  },
+  "data_stream": {
+    "timestamp_field": "@timestamp"
   }
 }
 `;

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -294,6 +294,9 @@ function getBaseTemplate(
       // To be filled with the aliases that we need
       aliases: {},
     },
+    data_stream: {
+      timestamp_field: '@timestamp',
+    },
   };
 }
 


### PR DESCRIPTION
All templates loaded by the Ingest Manager are now based on data streams.

To test this, start the agent and ingest data and check with `GET _data_streams` that datstreams and not normal indices were created.

Closes https://github.com/elastic/kibana/issues/66364