### PR TITLE
[APM] Simplify element updates

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -126,19 +126,9 @@ export function Cytoscape({
 
   // Trigger a custom "data" event when data changes
   useEffect(() => {
-    if (cy && elements.length > 0) {
-      const renderedElements = cy.elements('node,edge');
-      const latestElementIds = elements.map(el => el.data.id);
-      const absentElements = renderedElements.filter(
-        el => !latestElementIds.includes(el.id())
-      );
-      cy.remove(absentElements);
+    if (cy) {
+      cy.remove(cy.elements());
       cy.add(elements);
-      // ensure all elements get latest data properties
-      elements.forEach(elementDefinition => {
-        const el = cy.getElementById(elementDefinition.data.id as string);
-        el.data(elementDefinition.data);
-      });
       cy.trigger('data');
     }
   }, [cy, elements]);


### PR DESCRIPTION
There's some complexity in the Cytoscape component that was initially there to handle smooth transitions when adding elements to a graph, back when we were incrementally updating them, and for udpating the data
when the date range changes.

Remove this and instead remove all elements and add new elements when the elements change.

Fixes #66184.
