### PR TITLE
[Metrics UI] Fixing chart label for ungrouped alerts

### DIFF
--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -265,8 +265,8 @@ export const ExpressionChart: React.FC<Props> = ({
           <EuiText size="xs" color="subdued">
             <FormattedMessage
               id="xpack.infra.metrics.alerts.dataTimeRangeLabel"
-              defaultMessage="Last 20 {timeLabel}"
-              values={{ timeLabel }}
+              defaultMessage="Last {lookback} {timeLabel}"
+              values={{ timeLabel, lookback: timeSize * 20 }}
             />
           </EuiText>
         )}


### PR DESCRIPTION
## Summary

This PR corrects the label for ungroup alerts. We fixed the group alerts label in #66128 but we missed this one.

**Before**

![image](https://user-images.githubusercontent.com/41702/81846313-bce9c200-9506-11ea-88ef-94002b0fb519.png)

**After**

![image](https://user-images.githubusercontent.com/41702/81846443-ef93ba80-9506-11ea-9c5f-87fe2a97d56c.png)
