### PR TITLE
[Ingest Manager] Remove Data sources link from integration details page

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/side_nav_links.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/side_nav_links.tsx
@@ -3,10 +3,10 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-
-import { EuiButtonEmpty, EuiButtonEmptyProps } from '@elastic/eui';
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
+import { i18n } from '@kbn/i18n';
+import { EuiButtonEmpty, EuiButtonEmptyProps } from '@elastic/eui';
 import { PackageInfo, entries, DetailViewPanelName, InstallStatus } from '../../../../types';
 import { useLinks, useGetPackageInstallStatus } from '../../hooks';
 
@@ -15,9 +15,15 @@ export type NavLinkProps = Pick<PackageInfo, 'name' | 'version'> & {
 };
 
 const PanelDisplayNames: Record<DetailViewPanelName, string> = {
-  overview: 'Overview',
-  'data-sources': 'Data Sources',
-  settings: 'Settings',
+  overview: i18n.translate('xpack.ingestManager.epm.packageDetailsNav.overviewLinkText', {
+    defaultMessage: 'Overview',
+  }),
+  'data-sources': i18n.translate('xpack.ingestManager.epm.packageDetailsNav.datasourcesLinkText', {
+    defaultMessage: 'Data sources',
+  }),
+  settings: i18n.translate('xpack.ingestManager.epm.packageDetailsNav.settingsLinkText', {
+    defaultMessage: 'Settings',
+  }),
 };
 
 export function SideNavLinks({ name, version, active }: NavLinkProps) {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/side_nav_links.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/screens/detail/side_nav_links.tsx
@@ -36,8 +36,12 @@ export function SideNavLinks({ name, version, active }: NavLinkProps) {
               ? p.theme.eui.euiFontWeightSemiBold
               : p.theme.eui.euiFontWeightRegular};
         `;
-        // don't display Data Sources tab if the package is not installed
-        if (packageInstallStatus.status !== InstallStatus.installed && panel === 'data-sources')
+        // Don't display Data Sources tab as we haven't implemented this yet
+        // FIXME: Restore when we implement data sources page
+        if (
+          panel === 'data-sources' &&
+          (true || packageInstallStatus.status !== InstallStatus.installed)
+        )
           return null;
 
         return (


### PR DESCRIPTION
## Summary

This PR removes `Data sources` menu link from integration details page and localizes all the menu items.