### PR TITLE
[Ingest Manager] Rename agent config updated_on => updated_at

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/agent_config.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/agent_config.ts
@@ -28,7 +28,7 @@ export interface AgentConfig extends NewAgentConfig {
   id: string;
   status: AgentConfigStatus;
   datasources: string[] | Datasource[];
-  updated_on: string;
+  updated_at: string;
   updated_by: string;
   revision: number;
 }

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/index.tsx
@@ -152,7 +152,7 @@ export const AgentConfigDetailsLayout: React.FunctionComponent = () => {
             content:
               (agentConfig && (
                 <FormattedDate
-                  value={agentConfig?.updated_on}
+                  value={agentConfig?.updated_at}
                   year="numeric"
                   month="short"
                   day="2-digit"

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/list_page/index.tsx
@@ -207,11 +207,11 @@ export const AgentConfigListPage: React.FunctionComponent<{}> = () => {
         ),
       },
       {
-        field: 'updated_on',
+        field: 'updated_at',
         name: i18n.translate('xpack.ingestManager.agentConfigList.updatedOnColumnTitle', {
           defaultMessage: 'Last updated on',
         }),
-        render: (date: AgentConfig['updated_on']) => (
+        render: (date: AgentConfig['updated_at']) => (
           <FormattedDate value={date} year="numeric" month="short" day="2-digit" />
         ),
       },

--- a/x-pack/plugins/ingest_manager/server/saved_objects/index.ts
+++ b/x-pack/plugins/ingest_manager/server/saved_objects/index.ts
@@ -18,7 +18,7 @@ import {
   GLOBAL_SETTINGS_SAVED_OBJET_TYPE,
 } from '../constants';
 import { migrateDatasourcesToV790 } from './migrations/datasources_v790';
-
+import { migrateAgentConfigToV790 } from './migrations/agent_config_v790';
 /*
  * Saved object types and mappings
  *
@@ -126,11 +126,14 @@ const savedObjectTypes: { [key: string]: SavedObjectsType } = {
         description: { type: 'text' },
         status: { type: 'keyword' },
         datasources: { type: 'keyword' },
-        updated_on: { type: 'keyword' },
+        updated_at: { type: 'date' },
         updated_by: { type: 'keyword' },
         revision: { type: 'integer' },
         monitoring_enabled: { type: 'keyword' },
       },
+    },
+    migrations: {
+      '7.9.0': migrateAgentConfigToV790,
     },
   },
   [ENROLLMENT_API_KEYS_SAVED_OBJECT_TYPE]: {

--- a/x-pack/plugins/ingest_manager/server/saved_objects/migrations/agent_config_v790.ts
+++ b/x-pack/plugins/ingest_manager/server/saved_objects/migrations/agent_config_v790.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { SavedObjectMigrationFn } from 'kibana/server';
+import { cloneDeep } from 'lodash';
+import { AgentConfig } from '../../types';
+
+type Pre790AgentConfig = Exclude<AgentConfig, 'updated_at'> & {
+  updated_on: string;
+};
+
+export const migrateAgentConfigToV790: SavedObjectMigrationFn<
+  Pre790AgentConfig,
+  AgentConfig
+> = doc => {
+  const updatedAgentConfig = cloneDeep(doc);
+
+  updatedAgentConfig.attributes.updated_at = doc.attributes.updated_on;
+  delete updatedAgentConfig.attributes.updated_on;
+
+  return updatedAgentConfig;
+};

--- a/x-pack/plugins/ingest_manager/server/services/agent_config.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_config.ts
@@ -60,7 +60,7 @@ class AgentConfigService {
     await soClient.update<AgentConfig>(SAVED_OBJECT_TYPE, id, {
       ...agentConfig,
       revision: oldAgentConfig.revision + 1,
-      updated_on: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
       updated_by: user ? user.username : 'system',
     });
 
@@ -99,7 +99,7 @@ class AgentConfigService {
       {
         ...agentConfig,
         revision: 1,
-        updated_on: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
         updated_by: options?.user?.username || 'system',
       } as AgentConfig,
       options

--- a/x-pack/plugins/ingest_manager/server/types/models/agent_config.ts
+++ b/x-pack/plugins/ingest_manager/server/types/models/agent_config.ts
@@ -28,6 +28,6 @@ export const AgentConfigSchema = schema.object({
     schema.literal(AgentConfigStatus.Inactive),
   ]),
   datasources: schema.oneOf([schema.arrayOf(schema.string()), schema.arrayOf(DatasourceSchema)]),
-  updated_on: schema.string(),
+  updated_at: schema.string(),
   updated_by: schema.string(),
 });


### PR DESCRIPTION
## Summary

Resolve #66286 
The agent config timestamp for updated was not consistent with the rest of the code. I renamed it from `updated_on` -> `updated_at`