### PR TITLE
[APM] Make service map empty message link to service maps docs

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/EmptyBanner.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/EmptyBanner.tsx
@@ -65,7 +65,10 @@ export function EmptyBanner() {
           defaultMessage:
             "We will map out connected services and external requests if we can detect them. Please make sure you're running the latest version of the APM agent."
         })}{' '}
-        <ElasticDocsLink section="/apm/get-started" path="/agents.html">
+        <ElasticDocsLink
+          section="/kibana"
+          path="/service-maps.html#service-maps-supported"
+        >
           {i18n.translate('xpack.apm.serviceMap.emptyBanner.docsLink', {
             defaultMessage: 'Learn more in the docs'
           })}


### PR DESCRIPTION
Fixes #62812.
