### PR TITLE
[7.8] [Metrics UI] Fixing chart label for ungrouped alerts (#66444)

### DIFF
--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/expression_chart.tsx
@@ -265,8 +265,8 @@ export const ExpressionChart: React.FC<Props> = ({
           <EuiText size="xs" color="subdued">
             <FormattedMessage
               id="xpack.infra.metrics.alerts.dataTimeRangeLabel"
-              defaultMessage="Last 20 {timeLabel}"
-              values={{ timeLabel }}
+              defaultMessage="Last {lookback} {timeLabel}"
+              values={{ timeLabel, lookback: timeSize * 20 }}
             />
           </EuiText>
         )}


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [Metrics UI] Fixing chart label for ungrouped alerts (#66444)