### PR TITLE
Form lib demo

### DIFF
--- a/x-pack/plugins/index_management/public/application/app.tsx
+++ b/x-pack/plugins/index_management/public/application/app.tsx
@@ -11,6 +11,7 @@ import { IndexManagementHome } from './sections/home';
 import { TemplateCreate } from './sections/template_create';
 import { TemplateClone } from './sections/template_clone';
 import { TemplateEdit } from './sections/template_edit';
+import { FormLibDemo } from './sections/form_lib_demo/form_lib_demo';
 
 import { useServices } from './app_context';
 
@@ -28,6 +29,7 @@ export const App = () => {
 // Export this so we can test it with a different router.
 export const AppWithoutRouter = () => (
   <Switch>
+    <Route exact path={`${BASE_PATH}form-lib-demo`} component={FormLibDemo} />
     <Route exact path={`${BASE_PATH}create_template`} component={TemplateCreate} />
     <Route exact path={`${BASE_PATH}clone_template/:name*`} component={TemplateClone} />
     <Route exact path={`${BASE_PATH}edit_template/:name*`} component={TemplateEdit} />

--- a/x-pack/plugins/index_management/public/application/sections/form_lib_demo/form_lib_demo.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/form_lib_demo/form_lib_demo.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React from 'react';
+import { EuiTitle, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { FormWithoutLib } from './form_without_lib';
+import { FormWithFormLib } from './form_with_lib';
+
+export const FormLibDemo = () => {
+  return (
+    <div>
+      <EuiTitle>
+        <h1>Form lib demo</h1>
+      </EuiTitle>
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false} style={{ width: '400px' }}>
+          <EuiTitle>
+            <h2>Form without form lib</h2>
+          </EuiTitle>
+          <EuiSpacer />
+          <FormWithoutLib />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false} style={{ width: '400px' }}>
+          <EuiTitle>
+            <h2>Form with form lib</h2>
+          </EuiTitle>
+          <EuiSpacer />
+          <FormWithFormLib />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/x-pack/plugins/index_management/public/application/sections/form_lib_demo/form_with_lib.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/form_lib_demo/form_with_lib.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React from 'react';
+
+import { EuiSpacer, EuiButton } from '@elastic/eui';
+
+import {
+  Form,
+  useForm,
+  UseField,
+  TextField,
+  JsonEditorField,
+  ComboBoxField,
+  FormSchema,
+  fieldValidators,
+  VALIDATION_TYPES,
+} from '../../../shared_imports';
+
+const { emptyField, isJsonField, startsWithField } = fieldValidators;
+
+interface MyForm {
+  fields: {
+    name: string;
+    type: string;
+  };
+  seeds: Array<{ label: string }>;
+  _meta: string;
+}
+
+const formSchema: FormSchema<MyForm> = {
+  fields: {
+    name: {
+      label: 'Field name',
+      helpText: 'Some help text',
+      validations: [
+        {
+          validator: emptyField('The field cannot be empty'),
+        },
+      ],
+    },
+    type: {
+      label: 'Field type',
+      helpText: 'Some help text',
+      validations: [
+        {
+          validator: emptyField('The field cannot be empty'),
+        },
+      ],
+    },
+  },
+  seeds: {
+    label: 'Seeds',
+    helpText: 'Add an item with a dot (.) to see validation',
+    defaultValue: [],
+    validations: [
+      {
+        validator: emptyField('The field cannot be empty'),
+      },
+      {
+        validator: startsWithField({ message: 'Cannot start with a period.', char: '.' }),
+        type: VALIDATION_TYPES.ARRAY_ITEM,
+      },
+    ],
+  },
+  _meta: {
+    label: 'Meta',
+    helpText: 'Some help text',
+    validations: [
+      {
+        validator: isJsonField('The JSON is invalid.'),
+      },
+    ],
+    // There is a current issue in the lib that I will fix,
+    // we should be able to simply do:
+    // serializer: JSON.parse,
+    serializer: (value: string) => {
+      try {
+        const serialized = JSON.parse(value);
+        return serialized;
+      } catch (e) {
+        return value;
+      }
+    },
+  },
+};
+
+export const FormWithFormLib = () => {
+  const { form } = useForm<MyForm>({ schema: formSchema });
+
+  const submitForm = async () => {
+    const { isValid, data } = await form.submit();
+    if (!isValid) {
+      console.log('Form is invalid!'); // eslint-disable-line
+      return;
+    }
+    console.log(data);  // eslint-disable-line
+  };
+
+  return (
+    <Form form={form}>
+      <UseField path="fields.name" component={TextField} />
+      <EuiSpacer />
+      <UseField path="fields.type" component={TextField} />
+      <EuiSpacer />
+      <UseField
+        path="seeds"
+        component={ComboBoxField}
+        componentProps={{ euiFieldProps: { placeholder: 'host:port' } }}
+      />
+      <EuiSpacer />
+      <UseField
+        path="_meta"
+        component={JsonEditorField}
+        componentProps={{
+          euiCodeEditorProps: {
+            height: '250px',
+          },
+        }}
+      />
+      <EuiSpacer />
+      <EuiButton
+        fill
+        color="secondary"
+        iconType="check"
+        onClick={submitForm}
+        disabled={form.isSubmitted && !form.isValid}
+      >
+        Save
+      </EuiButton>
+    </Form>
+  );
+};

--- a/x-pack/plugins/index_management/public/application/sections/form_lib_demo/form_without_lib.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/form_lib_demo/form_without_lib.tsx
@@ -1,0 +1,303 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React, { useState, useEffect } from 'react';
+
+import {
+  EuiFormRow,
+  EuiFieldText,
+  EuiComboBox,
+  EuiCodeEditor,
+  EuiButton,
+  EuiSpacer,
+  EuiForm,
+} from '@elastic/eui';
+
+interface MyForm {
+  fields: {
+    name: string;
+    type: string;
+  };
+  seeds: Array<{ label: string }>;
+  _meta: string; // string is the **internal** state, we probably want a JSON object out of the form
+}
+
+interface FormErrors {
+  fields: {
+    name: string | null;
+    type: string | null;
+  };
+  seeds: string | null;
+  _meta: string | null;
+}
+
+const defaultValue: MyForm = {
+  fields: {
+    name: '',
+    type: '',
+  },
+  seeds: [],
+  _meta: '',
+};
+
+const defaultErrors = {
+  fields: {
+    name: null,
+    type: null,
+  },
+  seeds: null,
+  _meta: null,
+};
+
+const validateFields = ({ fields, seeds, _meta }: MyForm): FormErrors => {
+  // As you can see, we are validating ALL the fields on each keystroke. Very inefficient.
+  const errors: FormErrors = {
+    fields: {
+      name: null,
+      type: null,
+    },
+    seeds: null,
+    _meta: null,
+  };
+
+  if (fields.name.trim() === '') {
+    errors.fields.name = 'The field cannot be empty';
+  }
+
+  if (fields.type.trim() === '') {
+    errors.fields.type = 'The field cannot be empty';
+  }
+
+  if (seeds.length === 0) {
+    errors.seeds = 'The field cannot be empty';
+  }
+
+  try {
+    JSON.parse(_meta);
+  } catch (e) {
+    errors._meta = 'The JSON is invalid';
+  }
+
+  return errors;
+};
+
+export const FormWithoutLib = () => {
+  const [formState, setFormState] = useState<MyForm>(defaultValue);
+  const [formErrors, setFormErrors] = useState<FormErrors>(defaultErrors);
+  const [localSeedErrors, setLocalSeedErrors] = useState<string | null>(null);
+  const [areErrorsVisible, setAreErrorsVisible] = useState(false);
+
+  const onFieldChange = (fieldName: string, fieldValue: unknown) => {
+    if (fieldName === 'fieldName') {
+      setFormState(prev => {
+        return {
+          ...prev,
+          fields: {
+            ...prev.fields,
+            name: fieldValue as string,
+          },
+        };
+      });
+    } else if (fieldName === 'fieldType') {
+      setFormState(prev => {
+        return {
+          ...prev,
+          fields: {
+            ...prev.fields,
+            type: fieldValue as string,
+          },
+        };
+      });
+    } else {
+      setFormState(prev => {
+        return {
+          ...prev,
+          [fieldName]: fieldValue,
+        };
+      });
+    }
+  };
+
+  const isFormValid = (): boolean => {
+    for (const key of Object.keys(formErrors)) {
+      if (key === 'fields') {
+        if (formErrors.fields.name !== null || formErrors.fields.type !== null) {
+          return false;
+        }
+      } else {
+        if ((formErrors as any)[key] !== null) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  const getFormData = () => {
+    // We now need to "serialize" our internal state (ComboBox, Json string)
+    // to output the format we actually want.
+    const output: any = {
+      ...formState,
+      fields: {
+        ...formState.fields,
+      },
+    };
+
+    output.seeds = output.seeds.map((seed: any) => seed.label);
+    output._meta = JSON.parse(output._meta);
+
+    return output;
+  };
+
+  const submitForm = () => {
+    setAreErrorsVisible(true);
+
+    if (!isFormValid()) {
+      console.log('Form is invalid!'); // eslint-disable-line
+      return;
+    }
+    const formData = getFormData();
+    console.log(formData);  // eslint-disable-line
+  };
+
+  // ComboBox required handlers (just for 1 ComboBox....)
+  // Taken from our ccr 'remote_cluster_form.js' (A form of 960 LOC... without the validators)
+  const onCreateSeed = (newSeed: string) => {
+    // If the user just hit enter without typing anything, treat it as a no-op.
+    if (!newSeed) {
+      return;
+    }
+
+    const errors = newSeed.startsWith('.') ? 'Cannot start with a period.' : null;
+
+    if (errors) {
+      setLocalSeedErrors(errors);
+      // Return false to explicitly reject the user's input.
+      return false;
+    }
+
+    const newSeeds = formState.seeds.slice(0);
+    // We received a string, but the ComboBox works with objects, we need to convert
+    newSeeds.push({ label: newSeed.toLowerCase() });
+    onFieldChange('seeds', newSeeds);
+  };
+
+  const onSeedsInputChange = (seedInput: string) => {
+    if (!seedInput) {
+      // If empty seedInput ("") don't do anything. This happens
+      // right after a seed is created.
+      return;
+    }
+
+    setLocalSeedErrors((prev: any) => {
+      // Allow typing to clear the errors, but not to add new ones.
+      return seedInput.startsWith('.') ? prev : null;
+    });
+  };
+
+  const onSeedsChange = (seeds: any) => {
+    onFieldChange('seeds', seeds);
+  };
+
+  useEffect(() => {
+    const errors = validateFields(formState);
+    setFormErrors(errors);
+  }, [formState]);
+
+  const showSeedsErrors = Boolean(areErrorsVisible && formErrors.seeds) || localSeedErrors !== null;
+  const seedsErrors = areErrorsVisible
+    ? [localSeedErrors].concat(formErrors.seeds)
+    : localSeedErrors;
+
+  return (
+    <EuiForm>
+      <EuiFormRow
+        label="Field name"
+        helpText="Some help text"
+        error={formErrors.fields.name}
+        isInvalid={areErrorsVisible && formErrors.fields.name !== null}
+        fullWidth
+      >
+        <EuiFieldText
+          isInvalid={areErrorsVisible && formErrors.fields.name !== null}
+          value={formState.fields.name}
+          onChange={e => onFieldChange('fieldName', e.target.value)}
+          fullWidth
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiFormRow
+        label="Field type"
+        helpText="Some help text"
+        error={formErrors.fields.type}
+        isInvalid={areErrorsVisible && formErrors.fields.type !== null}
+        fullWidth
+      >
+        <EuiFieldText
+          isInvalid={areErrorsVisible && formErrors.fields.type !== null}
+          value={formState.fields.type}
+          onChange={e => onFieldChange('fieldType', e.target.value)}
+          fullWidth
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiFormRow
+        label="Seeds"
+        helpText="Add an item with a dot (.) to see validation"
+        isInvalid={showSeedsErrors}
+        error={seedsErrors}
+        fullWidth
+      >
+        <EuiComboBox
+          noSuggestions
+          placeholder="host:port"
+          selectedOptions={formState.seeds}
+          onCreateOption={onCreateSeed}
+          onChange={onSeedsChange}
+          onSearchChange={onSeedsInputChange}
+          isInvalid={showSeedsErrors}
+          fullWidth
+          data-test-subj="remoteClusterFormSeedsInput"
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiFormRow
+        label="Meta"
+        helpText="Some help texet"
+        isInvalid={areErrorsVisible && formErrors._meta !== null}
+        error={formErrors._meta}
+        fullWidth
+      >
+        <EuiCodeEditor
+          mode="json"
+          theme="textmate"
+          width="100%"
+          height="250px"
+          setOptions={{
+            showLineNumbers: false,
+            tabSize: 2,
+          }}
+          editorProps={{
+            $blockScrolling: Infinity,
+          }}
+          showGutter={false}
+          minLines={6}
+          value={formState._meta}
+          onChange={value => onFieldChange('_meta', value)}
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiButton
+        fill
+        color="secondary"
+        iconType="check"
+        onClick={submitForm}
+        disabled={areErrorsVisible && !isFormValid()}
+      >
+        Save
+      </EuiButton>
+    </EuiForm>
+  );
+};

--- a/x-pack/plugins/index_management/public/shared_imports.ts
+++ b/x-pack/plugins/index_management/public/shared_imports.ts
@@ -20,6 +20,7 @@ export {
   useForm,
   Form,
   getUseField,
+  UseField,
 } from '../../../../src/plugins/es_ui_shared/static/forms/hook_form_lib';
 
 export {
@@ -28,6 +29,12 @@ export {
   serializers,
 } from '../../../../src/plugins/es_ui_shared/static/forms/helpers';
 
-export { getFormRow, Field } from '../../../../src/plugins/es_ui_shared/static/forms/components';
+export {
+  getFormRow,
+  Field,
+  TextField,
+  ComboBoxField,
+  JsonEditorField,
+} from '../../../../src/plugins/es_ui_shared/static/forms/components';
 
 export { isJSON } from '../../../../src/plugins/es_ui_shared/static/validators/string';


### PR DESCRIPTION
As I was asked to explain the pros and cons of the form library I thought it would be good to go through a real-life example and to build **the exact same form** with and without the library.  
You can play with it by launching Kibana and navigate to the `app/kibana#/management/elasticsearch/index_management/form-lib-demo` URL.

<img width="808" alt="Screenshot 2020-05-14 at 14 16 24" src="https://user-images.githubusercontent.com/2854616/81939416-9440f580-95f6-11ea-92b0-b370e7d3436f.png">


This PR contains two commits:

* 1 to set up the stage (https://github.com/elastic/kibana/pull/66545/commits/9aa953a6291706a09684876f4acf2f663754ccd5), not interesting.
* 1 that represents the work required to build the same form with and without the form library (https://github.com/elastic/kibana/pull/66545/commits/169eb02d6cc5c4aa6bd19f65d2c8ade237d8d08b).

## Plan 

My original plan was to have several commits to show the creation of a form + its evolution with additional requirements. This would allow us to clearly see the diff change required for each form. This was my original plan:

1. Create the forms (https://github.com/elastic/kibana/pull/66545/commits/169eb02d6cc5c4aa6bd19f65d2c8ade237d8d08b)
2. Add a second ComboBox to the form, with a different validation for the allowed entry item.
3. Add a dropdown select to swap the fields in the form (e.g. from the 4 fields we currently have to 2 fields. Reproducing what is happening with the mappings editor).

But the **amount of work** that it took me to do the first point already prove the argument of the necesity to have the form lib in our tools: 

### First takeaway: time

* Time to build without the form lib: **More than 2 hours** 
* Time to build with the form lib: **14 minutes**.

We could stop here but let's enumerate the benefits of having **a system** to build forms instead of leaving the freedom to each dev to re-invent the wheel.

I use the word _system_ as what we are really talking about when we say "_The form library_" is 3 pieces of software:

- The hook form lib (**the core**) // It doesn't handle any UI nor wiring to components
- Reusable **fields components** // The EUI form fields wired to the core `field` hook
- Reusable **fields validators** // In our form we are _always_ (95%+ of the time) validating the fields against the same rules. Those validators take care of not re-writing them once more. 

## Pros

Let's now enumerate the benefits of "The form library"

### 1. Don't re-invent the wheel 😊 

This one is clear.

### 2. Consistency 

With each dev building his form slightly differently it means that we don't have consistency on (a) how it is build. Each time I revisit a form I need to understand how it is all wired together, how is validation done. And (b) visually for our users. When should we display the validation? On blur? After a debounce? After the user clicks "Save"? We currently have a version of each of those in our forms.

### 3. Be declarative

You will notice that in the form built with the form lib **there isn't a single line of code** to manage the form. There is a schema, a handler to submit the form and the rest is pure JSX. What is in the JSX is what I get out of the form. No wiring necessary, no state to handle.

### 4. Composition

The form library has component composition built int. This means that

```js
<Form form={form}>
  <UseField path="fields.name" component={TextField} />
  <EuiSpacer />
  <UseField path="fields.type" component={TextField} />
</Form>
```

Is the same as

```js
// form-a.tsx

<Form form={form}>
  <MyComponent />
</Form>

const MyComponent = () => (
  <>
    <UseField path="fields.name" component={TextField} />
    <EuiSpacer />
    <UseField path="fields.type" component={TextField} />
  </>
);
```

And I can build a second form in seconds, reusing some of the fields from `form-a.tsx` above

```js
// form-b.tsx

<Form form={form}>
  <MyComponent />
  <UseField path="someExtraField" component={TextField} />
</Form>
```

### 5. Less lines of code

In this small demo we have 303 LOC for the "old way" and 135 LOC with the library .This means **a reduction of 55%**!  
Less lines of code = less probability of bugs = faster code review time.

### 6. Performance

A lot of care has been put in optimizing for performance with the form library. In the "old way" we validate _all_ the fields on each keystroke (triggering a full form re-render). This does not happen with the form library as each field has its own state.

## Cons

* **Time invested** in building the system
* **Learning curve** for new devs. They will need to get familiar with a few concepts and read the docs :blush:. I'd argue that, once we have passed the small learning curve, going back to _not_ having the library was really hard in my own experience.
* **Maintenance** Care must be taken to not create breaking change in the library.