### PR TITLE
[APM] Service maps: Minor style fixes for the node strokes

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
@@ -58,9 +58,9 @@ const getBorderWidth = (el: cytoscape.NodeSingular) => {
   if (nodeSeverity === severity.minor || nodeSeverity === severity.major) {
     return 4;
   } else if (nodeSeverity === severity.critical) {
-    return 12;
+    return 8;
   } else {
-    return 2;
+    return 4;
   }
 };
 


### PR DESCRIPTION
## Summary

In order to improve visibility on larger zoom levels, we’re changing the stroke widths slightly. Additionally, there was a problem with the critical state where the concentric strokes would squash the icon within the node. This changes the stroke to a smaller width which doesn't choke the node icon.

<img width="1134" alt="Screenshot 2020-05-14 at 16 36 37" src="https://user-images.githubusercontent.com/4104278/81949342-0d464a00-9603-11ea-95e4-04693f009706.png">

<img width="414" alt="Screenshot 2020-05-14 at 16 36 51" src="https://user-images.githubusercontent.com/4104278/81949351-10413a80-9603-11ea-84f5-aa6f9070ed08.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
- [ ] ~~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
