### PR TITLE
[7.8] FTR: move basic services under common folder (#66563)

### DIFF
--- a/test/common/services/security/test_user.ts
+++ b/test/common/services/security/test_user.ts
@@ -19,8 +19,8 @@
 import { Role } from './role';
 import { User } from './user';
 import { FtrProviderContext } from '../../ftr_provider_context';
-import { Browser } from '../../../functional/services/browser';
-import { TestSubjects } from '../../../functional/services/test_subjects';
+import { Browser } from '../../../functional/services/common';
+import { TestSubjects } from '../../../functional/services/common';
 
 export async function createTestUserService(
   role: Role,

--- a/test/functional/services/common/browser.ts
+++ b/test/functional/services/common/browser.ts
@@ -24,10 +24,10 @@ import { LegacyActionSequence } from 'selenium-webdriver/lib/actions';
 import { ProvidedType } from '@kbn/test/types/ftr';
 
 import Jimp from 'jimp';
-import { modifyUrl } from '../../../src/core/utils';
-import { WebElementWrapper } from './lib/web_element_wrapper';
-import { FtrProviderContext } from '../ftr_provider_context';
-import { Browsers } from './remote/browsers';
+import { modifyUrl } from '../../../../src/core/utils';
+import { WebElementWrapper } from '../lib/web_element_wrapper';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { Browsers } from '../remote/browsers';
 
 export type Browser = ProvidedType<typeof BrowserProvider>;
 export async function BrowserProvider({ getService }: FtrProviderContext) {

--- a/test/functional/services/common/failure_debugging.ts
+++ b/test/functional/services/common/failure_debugging.ts
@@ -22,7 +22,7 @@ import { writeFile, mkdir } from 'fs';
 import { promisify } from 'util';
 
 import del from 'del';
-import { FtrProviderContext } from '../ftr_provider_context';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
 interface Test {
   fullTitle(): string;

--- a/test/functional/services/common/find.ts
+++ b/test/functional/services/common/find.ts
@@ -18,8 +18,8 @@
  */
 
 import { WebDriver, WebElement, By, until } from 'selenium-webdriver';
-import { FtrProviderContext } from '../ftr_provider_context';
-import { WebElementWrapper } from './lib/web_element_wrapper';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { WebElementWrapper } from '../lib/web_element_wrapper';
 
 export async function FindProvider({ getService }: FtrProviderContext) {
   const log = getService('log');

--- a/test/functional/services/common/index.ts
+++ b/test/functional/services/common/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { BrowserProvider, Browser } from './browser';
+export { FailureDebuggingProvider } from './failure_debugging';
+export { FindProvider } from './find';
+export { ScreenshotsProvider } from './screenshots';
+export { SnapshotsProvider } from './snapshots';
+export { TestSubjectsProvider, TestSubjects } from './test_subjects';

--- a/test/functional/services/common/screenshots.ts
+++ b/test/functional/services/common/screenshots.ts
@@ -23,9 +23,9 @@ import { promisify } from 'util';
 
 import del from 'del';
 
-import { comparePngs } from './lib/compare_pngs';
-import { FtrProviderContext } from '../ftr_provider_context';
-import { WebElementWrapper } from './lib/web_element_wrapper';
+import { comparePngs } from '../lib/compare_pngs';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { WebElementWrapper } from '../lib/web_element_wrapper';
 
 const mkdirAsync = promisify(mkdir);
 const writeFileAsync = promisify(writeFile);

--- a/test/functional/services/common/snapshots.ts
+++ b/test/functional/services/common/snapshots.ts
@@ -23,7 +23,7 @@ import { promisify } from 'util';
 
 import expect from '@kbn/expect';
 import del from 'del';
-import { FtrProviderContext } from '../ftr_provider_context';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
 const mkdirAsync = promisify(mkdir);
 const writeFileAsync = promisify(writeFile);

--- a/test/functional/services/common/test_subjects.ts
+++ b/test/functional/services/common/test_subjects.ts
@@ -20,8 +20,8 @@
 import testSubjSelector from '@kbn/test-subj-selector';
 import { map as mapAsync } from 'bluebird';
 import { ProvidedType } from '@kbn/test/types/ftr';
-import { WebElementWrapper } from './lib/web_element_wrapper';
-import { FtrProviderContext } from '../ftr_provider_context';
+import { WebElementWrapper } from '../lib/web_element_wrapper';
+import { FtrProviderContext } from '../../ftr_provider_context';
 
 interface ExistsOptions {
   timeout?: number;

--- a/test/functional/services/index.ts
+++ b/test/functional/services/index.ts
@@ -20,7 +20,14 @@
 import { services as commonServiceProviders } from '../../common/services';
 
 import { AppsMenuProvider } from './apps_menu';
-import { BrowserProvider } from './browser';
+import {
+  BrowserProvider,
+  FailureDebuggingProvider,
+  FindProvider,
+  ScreenshotsProvider,
+  SnapshotsProvider,
+  TestSubjectsProvider,
+} from './common';
 import { ComboBoxProvider } from './combo_box';
 import {
   DashboardAddPanelProvider,
@@ -33,19 +40,14 @@ import {
 import { DocTableProvider } from './doc_table';
 import { ElasticChartProvider } from './elastic_chart';
 import { EmbeddingProvider } from './embedding';
-import { FailureDebuggingProvider } from './failure_debugging';
 import { FilterBarProvider } from './filter_bar';
-import { FindProvider } from './find';
 import { FlyoutProvider } from './flyout';
 import { GlobalNavProvider } from './global_nav';
 import { InspectorProvider } from './inspector';
 import { QueryBarProvider } from './query_bar';
 import { RemoteProvider } from './remote';
 import { RenderableProvider } from './renderable';
-import { ScreenshotsProvider } from './screenshots';
-import { SnapshotsProvider } from './snapshots';
 import { TableProvider } from './table';
-import { TestSubjectsProvider } from './test_subjects';
 import { ToastsProvider } from './toasts';
 // @ts-ignore not TS yet
 import { PieChartProvider } from './visualizations';


### PR DESCRIPTION
Backports the following commits to 7.8:
 - FTR: move basic services under common folder (#66563)