### PR TITLE
move security test init out of security_page page object

### DIFF
--- a/test/functional/page_objects/login_page.ts
+++ b/test/functional/page_objects/login_page.ts
@@ -21,13 +21,191 @@ import { FtrProviderContext } from '../ftr_provider_context';
 
 export function LoginPageProvider({ getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
+  const log = getService('log');
+  const retry = getService('retry');
+  const find = getService('find');
+  const browser = getService('browser');
+  const config = getService('config');
+
+  interface LoginOptions {
+    expectSpaceSelector?: boolean;
+    expectSuccess?: boolean;
+    expectForbidden?: boolean;
+  }
+
+  type LoginExpectedResult = 'spaceSelector' | 'error' | 'chrome';
 
   class LoginPage {
-    async login(user: string, pwd: string) {
-      await testSubjects.setValue('loginUsername', user);
-      await testSubjects.setValue('loginPassword', pwd);
-      await testSubjects.click('loginSubmit');
+    // async login(user: string, pwd: string) {
+    //   await testSubjects.setValue('loginUsername', user);
+    //   await testSubjects.setValue('loginPassword', pwd);
+    //   await testSubjects.click('loginSubmit');
+    // }
+
+    async waitForLoginPage() {
+      log.debug('Waiting for Login Page to appear.');
+      await retry.waitForWithTimeout('login page', config.get('timeouts.waitFor') * 5, async () => {
+        // As a part of the cleanup flow tests usually try to log users out, but there are cases when
+        // browser/Kibana would like users to confirm that they want to navigate away from the current
+        // page and lose the state (e.g. unsaved changes) via native alert dialog.
+        const alert = await browser.getAlert();
+        if (alert && alert.accept) {
+          await alert.accept();
+        }
+        return await find.existsByDisplayedByCssSelector('.login-form');
+      });
     }
+
+    public async waitForLoginForm() {
+      log.debug('Waiting for Login Form to appear.');
+      await retry.waitForWithTimeout('login form', config.get('timeouts.waitFor') * 5, async () => {
+        return await testSubjects.exists('loginForm');
+      });
+    }
+
+    async waitForLoginSelector() {
+      log.debug('Waiting for Login Selector to appear.');
+      await retry.waitForWithTimeout(
+        'login selector',
+        config.get('timeouts.waitFor') * 5,
+        async () => {
+          return await testSubjects.exists('loginSelector');
+        }
+      );
+    }
+
+    async waitForLoginHelp(helpText: string) {
+      log.debug(`Waiting for Login Help to appear with text: ${helpText}.`);
+      await retry.waitForWithTimeout('login help', config.get('timeouts.waitFor') * 5, async () => {
+        return (await testSubjects.getVisibleText('loginHelp')) === helpText;
+      });
+    }
+
+    async waitForLoginResult(expectedResult?: LoginExpectedResult) {
+      log.debug(`Waiting for login result, expected: ${expectedResult}.`);
+
+      // wait for either space selector, kibanaChrome or loginErrorMessage
+      if (expectedResult === 'spaceSelector') {
+        await retry.try(() => testSubjects.find('kibanaSpaceSelector'));
+        log.debug(
+          `Finished login process, landed on space selector. currentUrl = ${await browser.getCurrentUrl()}`
+        );
+        return;
+      }
+
+      if (expectedResult === 'error') {
+        const rawDataTabLocator = 'a[id=rawdata-tab]';
+        if (await find.existsByCssSelector(rawDataTabLocator)) {
+          // Firefox has 3 tabs and requires navigation to see Raw output
+          await find.clickByCssSelector(rawDataTabLocator);
+        }
+        await retry.try(async () => {
+          if (await find.existsByCssSelector(rawDataTabLocator)) {
+            await find.clickByCssSelector(rawDataTabLocator);
+          }
+          await PageObjects.error.expectForbidden();
+        });
+        log.debug(
+          `Finished login process, found forbidden message. currentUrl = ${await browser.getCurrentUrl()}`
+        );
+        return;
+      }
+
+      if (expectedResult === 'chrome') {
+        await find.byCssSelector(
+          '[data-test-subj="kibanaChrome"] .app-wrapper:not(.hidden-chrome)',
+          20000
+        );
+        log.debug(`Finished login process currentUrl = ${await browser.getCurrentUrl()}`);
+      }
+    }
+
+    // loginPageObject = Object.freeze({
+    async login(username?: string, password?: string, options: LoginOptions = {}) {
+      // await PageObjects.common.navigateToApp('login');
+
+      // await this.loginPage.login(username, password, options);
+
+      // if (options.expectSpaceSelector || options.expectForbidden) {
+      //   return;
+      // }
+
+      // ensure welcome screen won't be shown. This is relevant for environments which don't allow
+      // to use the yml setting, e.g. cloud
+      // await browser.setLocalStorageItem('home:welcome:show', 'false');
+      await this.waitForLoginForm();
+
+      const [superUsername, superPassword] = config.get('servers.elasticsearch.auth').split(':');
+      await testSubjects.setValue('loginUsername', username || superUsername);
+      await testSubjects.setValue('loginPassword', password || superPassword);
+      await testSubjects.click('loginSubmit');
+
+      await this.waitForLoginResult(
+        options.expectSpaceSelector
+          ? 'spaceSelector'
+          : options.expectForbidden
+          ? 'error'
+          : options.expectSuccess
+          ? 'chrome'
+          : undefined
+      );
+      await retry.waitFor('logout button visible', async () => await userMenu.logoutLinkExists());
+    }
+
+    async getErrorMessage() {
+      return await retry.try(async () => {
+        const errorMessageContainer = await retry.try(() => testSubjects.find('loginErrorMessage'));
+        const errorMessageText = await errorMessageContainer.getVisibleText();
+
+        if (!errorMessageText) {
+          throw new Error('Login Error Message not present yet');
+        }
+
+        return errorMessageText;
+      });
+    }
+    // });
+
+    // loginSelector = Object.freeze({
+    //   async login(providerType: string, providerName: string, options?: Record<string, any>) {
+    //     log.debug(`Starting login flow for ${providerType}/${providerName}`);
+
+    //     await this.verifyLoginSelectorIsVisible();
+    //     await this.selectLoginMethod(providerType, providerName);
+
+    //     if (providerType === 'basic' || providerType === 'token') {
+    //       await waitForLoginForm();
+
+    //       const [superUsername, superPassword] = config.get('servers.elasticsearch.auth').split(':');
+    //       await testSubjects.setValue('loginUsername', options?.username ?? superUsername);
+    //       await testSubjects.setValue('loginPassword', options?.password ?? superPassword);
+    //       await testSubjects.click('loginSubmit');
+    //     }
+
+    //     await waitForLoginResult('chrome');
+
+    //     log.debug(`Finished login process currentUrl = ${await browser.getCurrentUrl()}`);
+    //   },
+
+    //   async selectLoginMethod(providerType: string, providerName: string) {
+    //     // Ensure welcome screen won't be shown. This is relevant for environments which don't allow
+    //     // to use the yml setting, e.g. cloud.
+    //     await browser.setLocalStorageItem('home:welcome:show', 'false');
+    //     await testSubjects.click(`loginCard-${providerType}/${providerName}`);
+    //   },
+
+    //   async verifyLoginFormIsVisible() {
+    //     await waitForLoginForm();
+    //   },
+
+    //   async verifyLoginSelectorIsVisible() {
+    //     await waitForLoginSelector();
+    //   },
+
+    //   async verifyLoginHelpIsVisible(helpText: string) {
+    //     await waitForLoginHelp(helpText);
+    //   },
+    // });
   }
 
   return new LoginPage();

--- a/x-pack/test/functional/apps/security/management.js
+++ b/x-pack/test/functional/apps/security/management.js
@@ -17,6 +17,7 @@ export default function({ getService, getPageObjects }) {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
+  const esArchiver = getService('esArchiver');
   const PageObjects = getPageObjects(['security', 'settings', 'common', 'header']);
 
   // FLAKY: https://github.com/elastic/kibana/issues/61173
@@ -24,8 +25,9 @@ export default function({ getService, getPageObjects }) {
     this.tags(['skipFirefox']);
 
     before(async () => {
-      // await PageObjects.security.login('elastic', 'changeme');
-      await PageObjects.security.initTests();
+      await esArchiver.load('empty_kibana');
+      await esArchiver.loadIfNeeded('logstash_functional');
+      await browser.setWindowSize(1600, 1000);
       await kibanaServer.uiSettings.update({
         defaultIndex: 'logstash-*',
       });

--- a/x-pack/test/functional/config_oss.js
+++ b/x-pack/test/functional/config_oss.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { pageObjects } from './page_objects';
+import { services } from './services';
+
+// the default export of config files must be a config provider
+// that returns an object with the projects config values
+export default async function({ readConfigFile }) {
+  const kibanaCommonConfig = await readConfigFile(
+    require.resolve('../../../test/common/config.js')
+  );
+  // const kibanaFunctionalConfig = await readConfigFile(
+  //   require.resolve('../../../test/functional/config.js')
+  // );
+
+  // export default async function({ readConfigFile }) {
+  //   const commonConfig = await readConfigFile(require.resolve('../common/config'));
+
+  return {
+    testFiles: [
+      require.resolve('../../../test/functional/apps/bundles'),
+      require.resolve('../../../test/functional/apps/console'),
+      require.resolve('../../../test/functional/apps/context'),
+      require.resolve('../../../test/functional/apps/dashboard'),
+      require.resolve('../../../test/functional/apps/discover'),
+      require.resolve('../../../test/functional/apps/getting_started'),
+      require.resolve('../../../test/functional/apps/home'),
+      require.resolve('../../../test/functional/apps/management'),
+      require.resolve('../../../test/functional/apps/saved_objects_management'),
+      require.resolve('../../../test/functional/apps/status_page'),
+      require.resolve('../../../test/functional/apps/timelion'),
+      require.resolve('../../../test/functional/apps/visualize'),
+    ],
+    pageObjects,
+    services,
+    servers: kibanaCommonConfig.get('servers'),
+
+    esTestCluster: kibanaCommonConfig.get('esTestCluster'),
+
+    kbnTestServer: {
+      ...kibanaCommonConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...kibanaCommonConfig.get('kbnTestServer.serverArgs'),
+        '--oss',
+        '--telemetry.optIn=false',
+      ],
+    },
+
+    uiSettings: {
+      defaults: {
+        'accessibility:disableAnimations': true,
+        'dateFormat:tz': 'UTC',
+      },
+    },
+
+    apps: {
+      kibana: {
+        pathname: '/app/kibana',
+      },
+      status_page: {
+        pathname: '/status',
+      },
+      discover: {
+        pathname: '/app/discover',
+        hash: '/',
+      },
+      context: {
+        pathname: '/app/discover',
+        hash: '/context',
+      },
+      visualize: {
+        pathname: '/app/visualize',
+        hash: '/',
+      },
+      dashboard: {
+        pathname: '/app/dashboards',
+        hash: '/list',
+      },
+      settings: {
+        pathname: '/app/kibana',
+        hash: '/management',
+      },
+      timelion: {
+        pathname: '/app/timelion',
+      },
+      console: {
+        pathname: '/app/dev_tools',
+        hash: '/console',
+      },
+      home: {
+        pathname: '/app/home',
+        hash: '/',
+      },
+    },
+    junit: {
+      reportName: 'Chrome UI Functional Tests',
+    },
+    browser: {
+      type: 'chrome',
+    },
+
+    security: {
+      roles: {
+        test_logstash_reader: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['logstash*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+        test_shakespeare_reader: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['shakes*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+        test_testhuge_reader: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['testhuge*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+        test_alias_reader: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['alias*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+        //for sample data - can remove but not add sample data.( not ml)- for ml use built in role.
+        kibana_sample_admin: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['kibana_sample*'],
+                privileges: ['read', 'view_index_metadata', 'manage', 'create_index', 'index'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        kibana_date_nanos: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['date-nanos'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        kibana_date_nanos_custom: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['date_nanos_custom_timestamp'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        kibana_date_nanos_mixed: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['date_nanos_mixed', 'timestamp-*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        kibana_large_strings: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['testlargestring'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        long_window_logstash: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['long-window-logstash-*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+
+        animals: {
+          elasticsearch: {
+            cluster: [],
+            indices: [
+              {
+                names: ['animals-*'],
+                privileges: ['read', 'view_index_metadata'],
+                field_security: { grant: ['*'], except: [] },
+              },
+            ],
+            run_as: [],
+          },
+          kibana: [],
+        },
+      },
+      defaultRoles: ['test_logstash_reader', 'kibana_admin'],
+    },
+  };
+}

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -14,7 +14,6 @@ export function SecurityPageProvider({ getService, getPageObjects }: FtrProvider
   const find = getService('find');
   const log = getService('log');
   const testSubjects = getService('testSubjects');
-  const esArchiver = getService('esArchiver');
   const userMenu = getService('userMenu');
   const PageObjects = getPageObjects(['common', 'header', 'settings', 'home', 'error']);
 
@@ -187,13 +186,6 @@ export function SecurityPageProvider({ getService, getPageObjects }: FtrProvider
   class SecurityPage {
     public loginPage = loginPage;
     public loginSelector = loginSelector;
-
-    async initTests() {
-      log.debug('SecurityPage:initTests');
-      await esArchiver.load('empty_kibana');
-      await esArchiver.loadIfNeeded('logstash_functional');
-      await browser.setWindowSize(1600, 1000);
-    }
 
     async login(username?: string, password?: string, options: LoginOptions = {}) {
       await this.loginPage.login(username, password, options);

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -15,177 +15,177 @@ export function SecurityPageProvider({ getService, getPageObjects }: FtrProvider
   const log = getService('log');
   const testSubjects = getService('testSubjects');
   const userMenu = getService('userMenu');
-  const PageObjects = getPageObjects(['common', 'header', 'settings', 'home', 'error']);
+  const PageObjects = getPageObjects(['common', 'header', 'settings', 'home', 'error', 'login']);
 
-  interface LoginOptions {
-    expectSpaceSelector?: boolean;
-    expectSuccess?: boolean;
-    expectForbidden?: boolean;
-  }
+  // interface LoginOptions {
+  //   expectSpaceSelector?: boolean;
+  //   expectSuccess?: boolean;
+  //   expectForbidden?: boolean;
+  // }
 
-  type LoginExpectedResult = 'spaceSelector' | 'error' | 'chrome';
+  // type LoginExpectedResult = 'spaceSelector' | 'error' | 'chrome';
 
-  async function waitForLoginPage() {
-    log.debug('Waiting for Login Page to appear.');
-    await retry.waitForWithTimeout('login page', config.get('timeouts.waitFor') * 5, async () => {
-      // As a part of the cleanup flow tests usually try to log users out, but there are cases when
-      // browser/Kibana would like users to confirm that they want to navigate away from the current
-      // page and lose the state (e.g. unsaved changes) via native alert dialog.
-      const alert = await browser.getAlert();
-      if (alert && alert.accept) {
-        await alert.accept();
-      }
-      return await find.existsByDisplayedByCssSelector('.login-form');
-    });
-  }
+  // async function waitForLoginPage() {
+  //   log.debug('Waiting for Login Page to appear.');
+  //   await retry.waitForWithTimeout('login page', config.get('timeouts.waitFor') * 5, async () => {
+  //     // As a part of the cleanup flow tests usually try to log users out, but there are cases when
+  //     // browser/Kibana would like users to confirm that they want to navigate away from the current
+  //     // page and lose the state (e.g. unsaved changes) via native alert dialog.
+  //     const alert = await browser.getAlert();
+  //     if (alert && alert.accept) {
+  //       await alert.accept();
+  //     }
+  //     return await find.existsByDisplayedByCssSelector('.login-form');
+  //   });
+  // }
 
-  async function waitForLoginForm() {
-    log.debug('Waiting for Login Form to appear.');
-    await retry.waitForWithTimeout('login form', config.get('timeouts.waitFor') * 5, async () => {
-      return await testSubjects.exists('loginForm');
-    });
-  }
+  // async function waitForLoginForm() {
+  //   log.debug('Waiting for Login Form to appear.');
+  //   await retry.waitForWithTimeout('login form', config.get('timeouts.waitFor') * 5, async () => {
+  //     return await testSubjects.exists('loginForm');
+  //   });
+  // }
 
-  async function waitForLoginSelector() {
-    log.debug('Waiting for Login Selector to appear.');
-    await retry.waitForWithTimeout(
-      'login selector',
-      config.get('timeouts.waitFor') * 5,
-      async () => {
-        return await testSubjects.exists('loginSelector');
-      }
-    );
-  }
+  // async function waitForLoginSelector() {
+  //   log.debug('Waiting for Login Selector to appear.');
+  //   await retry.waitForWithTimeout(
+  //     'login selector',
+  //     config.get('timeouts.waitFor') * 5,
+  //     async () => {
+  //       return await testSubjects.exists('loginSelector');
+  //     }
+  //   );
+  // }
 
-  async function waitForLoginHelp(helpText: string) {
-    log.debug(`Waiting for Login Help to appear with text: ${helpText}.`);
-    await retry.waitForWithTimeout('login help', config.get('timeouts.waitFor') * 5, async () => {
-      return (await testSubjects.getVisibleText('loginHelp')) === helpText;
-    });
-  }
+  // async function waitForLoginHelp(helpText: string) {
+  //   log.debug(`Waiting for Login Help to appear with text: ${helpText}.`);
+  //   await retry.waitForWithTimeout('login help', config.get('timeouts.waitFor') * 5, async () => {
+  //     return (await testSubjects.getVisibleText('loginHelp')) === helpText;
+  //   });
+  // }
 
-  async function waitForLoginResult(expectedResult?: LoginExpectedResult) {
-    log.debug(`Waiting for login result, expected: ${expectedResult}.`);
+  // async function waitForLoginResult(expectedResult?: LoginExpectedResult) {
+  //   log.debug(`Waiting for login result, expected: ${expectedResult}.`);
 
-    // wait for either space selector, kibanaChrome or loginErrorMessage
-    if (expectedResult === 'spaceSelector') {
-      await retry.try(() => testSubjects.find('kibanaSpaceSelector'));
-      log.debug(
-        `Finished login process, landed on space selector. currentUrl = ${await browser.getCurrentUrl()}`
-      );
-      return;
-    }
+  //   // wait for either space selector, kibanaChrome or loginErrorMessage
+  //   if (expectedResult === 'spaceSelector') {
+  //     await retry.try(() => testSubjects.find('kibanaSpaceSelector'));
+  //     log.debug(
+  //       `Finished login process, landed on space selector. currentUrl = ${await browser.getCurrentUrl()}`
+  //     );
+  //     return;
+  //   }
 
-    if (expectedResult === 'error') {
-      const rawDataTabLocator = 'a[id=rawdata-tab]';
-      if (await find.existsByCssSelector(rawDataTabLocator)) {
-        // Firefox has 3 tabs and requires navigation to see Raw output
-        await find.clickByCssSelector(rawDataTabLocator);
-      }
-      await retry.try(async () => {
-        if (await find.existsByCssSelector(rawDataTabLocator)) {
-          await find.clickByCssSelector(rawDataTabLocator);
-        }
-        await PageObjects.error.expectForbidden();
-      });
-      log.debug(
-        `Finished login process, found forbidden message. currentUrl = ${await browser.getCurrentUrl()}`
-      );
-      return;
-    }
+  //   if (expectedResult === 'error') {
+  //     const rawDataTabLocator = 'a[id=rawdata-tab]';
+  //     if (await find.existsByCssSelector(rawDataTabLocator)) {
+  //       // Firefox has 3 tabs and requires navigation to see Raw output
+  //       await find.clickByCssSelector(rawDataTabLocator);
+  //     }
+  //     await retry.try(async () => {
+  //       if (await find.existsByCssSelector(rawDataTabLocator)) {
+  //         await find.clickByCssSelector(rawDataTabLocator);
+  //       }
+  //       await PageObjects.error.expectForbidden();
+  //     });
+  //     log.debug(
+  //       `Finished login process, found forbidden message. currentUrl = ${await browser.getCurrentUrl()}`
+  //     );
+  //     return;
+  //   }
 
-    if (expectedResult === 'chrome') {
-      await find.byCssSelector(
-        '[data-test-subj="kibanaChrome"] .app-wrapper:not(.hidden-chrome)',
-        20000
-      );
-      log.debug(`Finished login process currentUrl = ${await browser.getCurrentUrl()}`);
-    }
-  }
+  //   if (expectedResult === 'chrome') {
+  //     await find.byCssSelector(
+  //       '[data-test-subj="kibanaChrome"] .app-wrapper:not(.hidden-chrome)',
+  //       20000
+  //     );
+  //     log.debug(`Finished login process currentUrl = ${await browser.getCurrentUrl()}`);
+  //   }
+  // }
 
-  const loginPage = Object.freeze({
-    async login(username?: string, password?: string, options: LoginOptions = {}) {
-      await PageObjects.common.navigateToApp('login');
+  // const loginPage = Object.freeze({
+  //   async login(username?: string, password?: string, options: LoginOptions = {}) {
+  //     await PageObjects.common.navigateToApp('login');
 
-      // ensure welcome screen won't be shown. This is relevant for environments which don't allow
-      // to use the yml setting, e.g. cloud
-      await browser.setLocalStorageItem('home:welcome:show', 'false');
-      await waitForLoginForm();
+  //     // ensure welcome screen won't be shown. This is relevant for environments which don't allow
+  //     // to use the yml setting, e.g. cloud
+  //     await browser.setLocalStorageItem('home:welcome:show', 'false');
+  //     await waitForLoginForm();
 
-      const [superUsername, superPassword] = config.get('servers.elasticsearch.auth').split(':');
-      await testSubjects.setValue('loginUsername', username || superUsername);
-      await testSubjects.setValue('loginPassword', password || superPassword);
-      await testSubjects.click('loginSubmit');
+  //     const [superUsername, superPassword] = config.get('servers.elasticsearch.auth').split(':');
+  //     await testSubjects.setValue('loginUsername', username || superUsername);
+  //     await testSubjects.setValue('loginPassword', password || superPassword);
+  //     await testSubjects.click('loginSubmit');
 
-      await waitForLoginResult(
-        options.expectSpaceSelector
-          ? 'spaceSelector'
-          : options.expectForbidden
-          ? 'error'
-          : options.expectSuccess
-          ? 'chrome'
-          : undefined
-      );
-    },
+  //     await waitForLoginResult(
+  //       options.expectSpaceSelector
+  //         ? 'spaceSelector'
+  //         : options.expectForbidden
+  //         ? 'error'
+  //         : options.expectSuccess
+  //         ? 'chrome'
+  //         : undefined
+  //     );
+  //   },
 
-    async getErrorMessage() {
-      return await retry.try(async () => {
-        const errorMessageContainer = await retry.try(() => testSubjects.find('loginErrorMessage'));
-        const errorMessageText = await errorMessageContainer.getVisibleText();
+  //   async getErrorMessage() {
+  //     return await retry.try(async () => {
+  //       const errorMessageContainer = await retry.try(() => testSubjects.find('loginErrorMessage'));
+  //       const errorMessageText = await errorMessageContainer.getVisibleText();
 
-        if (!errorMessageText) {
-          throw new Error('Login Error Message not present yet');
-        }
+  //       if (!errorMessageText) {
+  //         throw new Error('Login Error Message not present yet');
+  //       }
 
-        return errorMessageText;
-      });
-    },
-  });
+  //       return errorMessageText;
+  //     });
+  //   },
+  // });
 
-  const loginSelector = Object.freeze({
-    async login(providerType: string, providerName: string, options?: Record<string, any>) {
-      log.debug(`Starting login flow for ${providerType}/${providerName}`);
+  // const loginSelector = Object.freeze({
+  //   async login(providerType: string, providerName: string, options?: Record<string, any>) {
+  //     log.debug(`Starting login flow for ${providerType}/${providerName}`);
 
-      await this.verifyLoginSelectorIsVisible();
-      await this.selectLoginMethod(providerType, providerName);
+  //     await this.verifyLoginSelectorIsVisible();
+  //     await this.selectLoginMethod(providerType, providerName);
 
-      if (providerType === 'basic' || providerType === 'token') {
-        await waitForLoginForm();
+  //     if (providerType === 'basic' || providerType === 'token') {
+  //       await waitForLoginForm();
 
-        const [superUsername, superPassword] = config.get('servers.elasticsearch.auth').split(':');
-        await testSubjects.setValue('loginUsername', options?.username ?? superUsername);
-        await testSubjects.setValue('loginPassword', options?.password ?? superPassword);
-        await testSubjects.click('loginSubmit');
-      }
+  //       const [superUsername, superPassword] = config.get('servers.elasticsearch.auth').split(':');
+  //       await testSubjects.setValue('loginUsername', options?.username ?? superUsername);
+  //       await testSubjects.setValue('loginPassword', options?.password ?? superPassword);
+  //       await testSubjects.click('loginSubmit');
+  //     }
 
-      await waitForLoginResult('chrome');
+  //     await waitForLoginResult('chrome');
 
-      log.debug(`Finished login process currentUrl = ${await browser.getCurrentUrl()}`);
-    },
+  //     log.debug(`Finished login process currentUrl = ${await browser.getCurrentUrl()}`);
+  //   },
 
-    async selectLoginMethod(providerType: string, providerName: string) {
-      // Ensure welcome screen won't be shown. This is relevant for environments which don't allow
-      // to use the yml setting, e.g. cloud.
-      await browser.setLocalStorageItem('home:welcome:show', 'false');
-      await testSubjects.click(`loginCard-${providerType}/${providerName}`);
-    },
+  //   async selectLoginMethod(providerType: string, providerName: string) {
+  //     // Ensure welcome screen won't be shown. This is relevant for environments which don't allow
+  //     // to use the yml setting, e.g. cloud.
+  //     await browser.setLocalStorageItem('home:welcome:show', 'false');
+  //     await testSubjects.click(`loginCard-${providerType}/${providerName}`);
+  //   },
 
-    async verifyLoginFormIsVisible() {
-      await waitForLoginForm();
-    },
+  //   async verifyLoginFormIsVisible() {
+  //     await waitForLoginForm();
+  //   },
 
-    async verifyLoginSelectorIsVisible() {
-      await waitForLoginSelector();
-    },
+  //   async verifyLoginSelectorIsVisible() {
+  //     await waitForLoginSelector();
+  //   },
 
-    async verifyLoginHelpIsVisible(helpText: string) {
-      await waitForLoginHelp(helpText);
-    },
-  });
+  //   async verifyLoginHelpIsVisible(helpText: string) {
+  //     await waitForLoginHelp(helpText);
+  //   },
+  // });
 
   class SecurityPage {
-    public loginPage = loginPage;
-    public loginSelector = loginSelector;
+    public loginPage = PageObjects.login;
+    // public loginSelector = loginSelector;
 
     async login(username?: string, password?: string, options: LoginOptions = {}) {
       await this.loginPage.login(username, password, options);


### PR DESCRIPTION
## Summary

1. test initialization should be in the before methods of tests, or the parent describes (not in page objects).

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
