### PR TITLE
[APM] Lowercase agent names so icons work

### DIFF
--- a/x-pack/plugins/apm/common/agent_name.ts
+++ b/x-pack/plugins/apm/common/agent_name.ts
@@ -41,3 +41,16 @@ export function isJavaAgentName(
 ): agentName is 'java' {
   return agentName === 'java';
 }
+
+/**
+ * "Normalizes" and agent name by:
+ *
+ * * Converting to lowercase
+ * * Converting "rum-js" to "js-base"
+ *
+ * This helps dealing with some older agent versions
+ */
+export function getNormalizedAgentName(agentName?: string) {
+  const lowercased = agentName && agentName.toLowerCase();
+  return isRumAgentName(lowercased) ? 'js-base' : lowercased;
+}

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.stories.tsx
@@ -188,6 +188,13 @@ storiesOf('app/ServiceMap/Cytoscape', module)
         },
         {
           data: {
+            id: 'dotNet',
+            'service.name': 'dotNet service',
+            'agent.name': 'dotNet'
+          }
+        },
+        {
+          data: {
             id: 'go',
             'service.name': 'go service',
             'agent.name': 'go'

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/icons.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/icons.ts
@@ -5,7 +5,7 @@
  */
 
 import cytoscape from 'cytoscape';
-import { isRumAgentName } from '../../../../common/agent_name';
+import { getNormalizedAgentName } from '../../../../common/agent_name';
 import {
   AGENT_NAME,
   SPAN_SUBTYPE,
@@ -87,9 +87,8 @@ const agentIcons: { [key: string]: string } = {
 };
 
 function getAgentIcon(agentName?: string) {
-  // RUM can have multiple names. Normalize it
-  const normalizedAgentName = isRumAgentName(agentName) ? 'js-base' : agentName;
-  return normalizedAgentName && agentIcons[normalizedAgentName.toLowerCase()];
+  const normalizedAgentName = getNormalizedAgentName(agentName);
+  return normalizedAgentName && agentIcons[normalizedAgentName];
 }
 
 function getSpanIcon(type?: string, subtype?: string) {

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/icons.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/icons.ts
@@ -89,7 +89,7 @@ const agentIcons: { [key: string]: string } = {
 function getAgentIcon(agentName?: string) {
   // RUM can have multiple names. Normalize it
   const normalizedAgentName = isRumAgentName(agentName) ? 'js-base' : agentName;
-  return normalizedAgentName && agentIcons[normalizedAgentName];
+  return normalizedAgentName && agentIcons[normalizedAgentName.toLowerCase()];
 }
 
 function getSpanIcon(type?: string, subtype?: string) {


### PR DESCRIPTION
.NET agent name can be reported as "dotNet" instead of "dotnet". Lowercase the key so either one will work.
