### PR TITLE
Update create.asciidoc

### DIFF
--- a/docs/api/saved-objects/create.asciidoc
+++ b/docs/api/saved-objects/create.asciidoc
@@ -13,7 +13,7 @@ experimental[] Create {kib} saved objects.
 
 `POST <kibana host>:<port>/api/saved_objects/<type>/<id>`
 
-`POST <kibana host>:<port>/s/<space_id>/saved_objects/<type>`
+`POST <kibana host>:<port>/s/<space_id>/api/saved_objects/<type>`
 
 [[saved-objects-api-create-path-params]]
 ==== Path parameters


### PR DESCRIPTION
Add "/api/" to "POST \<kibana host\>:\<port\>/s/\<space_id\>/saved_objects/\<type\>"
The correct way:
"POST \<kibana host\>:\<port\>/s/\<space_id\>/api/saved_objects/\<type\>"

## Summary

Updated the url to create saved object on a given space:
Added /api/ 
So that the url becomes : "POST \<kibana host\>:\<port\>/s/\<space_id\>/api/saved_objects/\<type\>"

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials

