### PR TITLE
[APM] agent config 'profiling_inferred_spans_min_duration' default value is '0ms' but the min value in the field is '1ms'

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
@@ -84,7 +84,7 @@ Array [
   },
   Object {
     "key": "profiling_inferred_spans_min_duration",
-    "min": "1ms",
+    "min": "0ms",
     "type": "duration",
     "units": Array [
       "ms",

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/java_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/java_settings.ts
@@ -197,7 +197,8 @@ export const javaSettings: RawSettingDefinition[] = [
           'The minimum duration of an inferred span. Note that the min duration is also implicitly set by the sampling interval. However, increasing the sampling interval also decreases the accuracy of the duration of inferred spans.'
       }
     ),
-    includeAgents: ['java']
+    includeAgents: ['java'],
+    min: '0ms'
   },
   {
     key: 'profiling_inferred_spans_included_classes',


### PR DESCRIPTION
closes #66885

before:
<img width="1764" alt="Screenshot 2020-05-18 at 13 51 02" src="https://user-images.githubusercontent.com/55978943/82212774-64a22e00-9913-11ea-8a81-7fc70cdb012e.png">

after:
<img width="1809" alt="Screenshot 2020-05-18 at 14 02 39" src="https://user-images.githubusercontent.com/55978943/82212785-6966e200-9913-11ea-945b-fd7c0a629267.png">

