### PR TITLE
[Lens] Fix filter filtering out falsy values

### DIFF
--- a/x-pack/plugins/lens/public/xy_visualization/xy_expression.test.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_expression.test.tsx
@@ -1283,6 +1283,65 @@ describe('xy_expression', () => {
       expect(series.prop('data')).toEqual([{ a: 1, b: 5, c: 'J', d: 'Row 2' }]);
     });
 
+    test('it should not remove rows with falsy but non-undefined values', () => {
+      const data: LensMultiTable = {
+        type: 'lens_multitable',
+        tables: {
+          first: {
+            type: 'kibana_datatable',
+            columns: [
+              { id: 'a', name: 'a' },
+              { id: 'b', name: 'b' },
+              { id: 'c', name: 'c' },
+            ],
+            rows: [
+              { a: 0, b: 2, c: 5 },
+              { a: 1, b: 0, c: 7 },
+            ],
+          },
+        },
+      };
+
+      const args: XYArgs = {
+        xTitle: '',
+        yTitle: '',
+        legend: { type: 'lens_xy_legendConfig', isVisible: false, position: Position.Top },
+        layers: [
+          {
+            layerId: 'first',
+            seriesType: 'line',
+            xAccessor: 'a',
+            accessors: ['c'],
+            splitAccessor: 'b',
+            columnToLabel: '',
+            xScaleType: 'ordinal',
+            yScaleType: 'linear',
+            isHistogram: false,
+          },
+        ],
+      };
+
+      const component = shallow(
+        <XYChart
+          data={data}
+          args={args}
+          formatFactory={getFormatSpy}
+          timeZone="UTC"
+          chartTheme={{}}
+          histogramBarTarget={50}
+          onClickValue={onClickValue}
+          onSelectRange={onSelectRange}
+        />
+      );
+
+      const series = component.find(LineSeries);
+
+      expect(series.prop('data')).toEqual([
+        { a: 0, b: 2, c: 5 },
+        { a: 1, b: 0, c: 7 },
+      ]);
+    });
+
     test('it should show legend for split series, even with one row', () => {
       const data: LensMultiTable = {
         type: 'lens_multitable',

--- a/x-pack/plugins/lens/public/xy_visualization/xy_expression.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_expression.tsx
@@ -402,8 +402,12 @@ export function XYChart({
           const rows = table.rows.filter(
             row =>
               xAccessor &&
-              row[xAccessor] &&
-              !(splitAccessor && !row[splitAccessor] && accessors.every(accessor => !row[accessor]))
+              typeof row[xAccessor] !== 'undefined' &&
+              !(
+                splitAccessor &&
+                typeof row[splitAccessor] === 'undefined' &&
+                accessors.every(accessor => typeof row[accessor] === 'undefined')
+              )
           );
 
           const seriesProps: SeriesSpec = {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/66865

## Summary

In the xy chart rows were filtered out if the x axis accessor had a falsy value. This PR changes the check to `typeof val === 'undefined'`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
