### PR TITLE
[7.8] [services/testSubjects] reduce retry usage, add waitForEnabled (#66538)

### DIFF
--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -53,8 +53,7 @@ export function HomePageProvider({ getService, getPageObjects }: FtrProviderCont
 
     async removeSampleDataSet(id: string) {
       // looks like overkill but we're hitting flaky cases where we click but it doesn't remove
-      await testSubjects.isDisplayed(`removeSampleDataSet${id}`);
-      await testSubjects.isEnabled(`removeSampleDataSet${id}`);
+      await testSubjects.waitForEnabled(`removeSampleDataSet${id}`);
       await testSubjects.click(`removeSampleDataSet${id}`);
       await this._waitForSampleDataLoadingAction(id);
     }

--- a/test/functional/services/common/test_subjects.ts
+++ b/test/functional/services/common/test_subjects.ts
@@ -97,12 +97,10 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
     }
 
     public async append(selector: string, text: string): Promise<void> {
-      return await retry.try(async () => {
-        log.debug(`TestSubjects.append(${selector}, ${text})`);
-        const input = await this.find(selector);
-        await input.click();
-        await input.type(text);
-      });
+      log.debug(`TestSubjects.append(${selector}, ${text})`);
+      const input = await this.find(selector);
+      await input.click();
+      await input.type(text);
     }
 
     public async clickWhenNotDisabled(
@@ -119,12 +117,10 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
     }
 
     public async doubleClick(selector: string, timeout: number = FIND_TIME): Promise<void> {
-      return await retry.try(async () => {
-        log.debug(`TestSubjects.doubleClick(${selector})`);
-        const element = await this.find(selector, timeout);
-        await element.moveMouseTo();
-        await element.doubleClick();
-      });
+      log.debug(`TestSubjects.doubleClick(${selector})`);
+      const element = await this.find(selector, timeout);
+      await element.moveMouseTo();
+      await element.doubleClick();
     }
 
     async descendantExists(selector: string, parentElement: WebElementWrapper): Promise<boolean> {
@@ -206,27 +202,21 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
     }
 
     public async isEnabled(selector: string): Promise<boolean> {
-      return await retry.try(async () => {
-        log.debug(`TestSubjects.isEnabled(${selector})`);
-        const element = await this.find(selector);
-        return await element.isEnabled();
-      });
+      log.debug(`TestSubjects.isEnabled(${selector})`);
+      const element = await this.find(selector);
+      return await element.isEnabled();
     }
 
     public async isDisplayed(selector: string): Promise<boolean> {
-      return await retry.try(async () => {
-        log.debug(`TestSubjects.isDisplayed(${selector})`);
-        const element = await this.find(selector);
-        return await element.isDisplayed();
-      });
+      log.debug(`TestSubjects.isDisplayed(${selector})`);
+      const element = await this.find(selector);
+      return await element.isDisplayed();
     }
 
     public async isSelected(selector: string): Promise<boolean> {
-      return await retry.try(async () => {
-        log.debug(`TestSubjects.isSelected(${selector})`);
-        const element = await this.find(selector);
-        return await element.isSelected();
-      });
+      log.debug(`TestSubjects.isSelected(${selector})`);
+      const element = await this.find(selector);
+      return await element.isSelected();
     }
 
     public async isSelectedAll(selectorAll: string): Promise<boolean[]> {
@@ -237,11 +227,9 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
     }
 
     public async getVisibleText(selector: string): Promise<string> {
-      return await retry.try(async () => {
-        log.debug(`TestSubjects.getVisibleText(${selector})`);
-        const element = await this.find(selector);
-        return await element.getVisibleText();
-      });
+      log.debug(`TestSubjects.getVisibleText(${selector})`);
+      const element = await this.find(selector);
+      return await element.getVisibleText();
     }
 
     async getVisibleTextAll(selectorAll: string): Promise<string[]> {
@@ -292,6 +280,13 @@ export function TestSubjectsProvider({ getService }: FtrProviderContext) {
       log.debug(`TestSubjects.waitForHidden(${selector})`);
       const element = await this.find(selector);
       await find.waitForElementHidden(element, timeout);
+    }
+
+    public async waitForEnabled(selector: string, timeout: number = TRY_TIME): Promise<void> {
+      await retry.tryForTime(timeout, async () => {
+        const element = await this.find(selector);
+        return (await element.isDisplayed()) && (await element.isEnabled());
+      });
     }
 
     public getCssSelector(selector: string): string {


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [services/testSubjects] reduce retry usage, add waitForEnabled (#66538)