### PR TITLE
[APM] Update RUM documentation link in Add data tutorial

### DIFF
--- a/x-pack/plugins/apm/server/tutorial/instructions/apm_agent_instructions.ts
+++ b/x-pack/plugins/apm/server/tutorial/instructions/apm_agent_instructions.ts
@@ -507,7 +507,7 @@ var apm = initApm({curlyOpen}
 See the [integration documentation]({docLink}) for more information.',
         values: {
           docLink:
-            '{config.docs.base_url}guide/en/apm/agent/rum-js/{config.docs.version}/framework-integrations.html'
+            '{config.docs.base_url}guide/en/apm/agent/rum-js/current/framework-integrations.html'
         }
       }
     )


### PR DESCRIPTION
This PR fixes a broken link in the RUM Add data tutorial.

The original link used `{config.docs.version}` to generate a link to the relevant version of the Agent documentation. Because agents are versioned separately from the stack, this resulted in a 404:

<img width="1202" alt="Screen Shot 2020-05-19 at 9 56 27 AM" src="https://user-images.githubusercontent.com/5618806/82355621-51e13500-99b7-11ea-8400-bd81df387736.png">

This PR hardcodes the documentation link to current. It's not the ideal solution, but it's better than a 404.  

