### PR TITLE
[Ingest Manager] Remove endpoint enable flag from README

### DIFF
--- a/x-pack/plugins/ingest_manager/README.md
+++ b/x-pack/plugins/ingest_manager/README.md
@@ -28,7 +28,7 @@ One common development workflow is:
   ```
 - Start Kibana in another shell
   ```
-  yarn start --xpack.ingestManager.enabled=true --no-base-path --xpack.endpoint.enabled=true
+  yarn start --xpack.ingestManager.enabled=true --no-base-path
   ```
 
 This plugin follows the `common`, `server`, `public` structure from the [Architecture Style Guide


### PR DESCRIPTION
## Summary

Update the README file to remove the Endpoint enable flag (Endpoint has been merged into SIEM)
