### PR TITLE
Change the error message on TSVB in order to be more user friendly

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/lib/validate_interval.js
+++ b/src/plugins/vis_type_timeseries/public/application/lib/validate_interval.js
@@ -40,8 +40,7 @@ export function validateInterval(bounds, panel, maxBuckets) {
           'visTypeTimeseries.validateInterval.notifier.maxBucketsExceededErrorMessage',
           {
             defaultMessage:
-              'Max buckets exceeded: {buckets} is greater than {maxBuckets}, try a larger time interval in the panel options.',
-            values: { buckets, maxBuckets },
+              'Your query attempted to fetch too much data. Reducing the time range or changing the interval used usually fixes the issue.',
           }
         )
       );

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -3631,7 +3631,6 @@
     "visTypeTimeseries.unsupportedAgg.aggIsNotSupportedDescription": "{modelType} 集約はサポートされなくなりました。",
     "visTypeTimeseries.unsupportedAgg.aggIsTemporaryUnsupportedDescription": "{modelType} 集約は現在サポートされていません。",
     "visTypeTimeseries.unsupportedSplit.splitIsUnsupportedDescription": "{modelType} による分割はサポートされていません。",
-    "visTypeTimeseries.validateInterval.notifier.maxBucketsExceededErrorMessage": "バケットの最高数を超えました。{buckets} が {maxBuckets} を超えています。パネルオプションでより広い間隔を試してみてください。",
     "visTypeTimeseries.vars.variableNameAriaLabel": "変数名",
     "visTypeTimeseries.vars.variableNamePlaceholder": "変数名",
     "visTypeTimeseries.visEditorVisualization.applyChangesLabel": "変更を適用",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -3632,7 +3632,6 @@
     "visTypeTimeseries.unsupportedAgg.aggIsNotSupportedDescription": "不再支持 {modelType} 聚合。",
     "visTypeTimeseries.unsupportedAgg.aggIsTemporaryUnsupportedDescription": "当前不支持 {modelType} 聚合。",
     "visTypeTimeseries.unsupportedSplit.splitIsUnsupportedDescription": "不支持拆分依据 {modelType}。",
-    "visTypeTimeseries.validateInterval.notifier.maxBucketsExceededErrorMessage": "超过最大桶数：{buckets} 大于 {maxBuckets}，请在面板选项中尝试较大的时间间隔。",
     "visTypeTimeseries.vars.variableNameAriaLabel": "变量名称",
     "visTypeTimeseries.vars.variableNamePlaceholder": "变量名称",
     "visTypeTimeseries.visEditorVisualization.applyChangesLabel": "应用更改",


### PR DESCRIPTION
## Summary

Fixes #57944.

The new error message is:

<img width="381" alt="Screenshot 2020-05-20 at 1 01 52 PM" src="https://user-images.githubusercontent.com/17003240/82433719-87128380-9a9a-11ea-9fd0-7c2360be4129.png">

instead of:

<img width="381" alt="Screenshot 2020-05-20 at 1 01 52 PM" src="https://user-images.githubusercontent.com/17003240/82433745-909beb80-9a9a-11ea-8399-6a009c03617c.png">