### PR TITLE
[APM] Fix obscured service map connections

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -80,7 +80,7 @@ function getLayoutOptions(
     roots: selectedRoots.length ? selectedRoots : undefined,
     fit: true,
     padding: nodeHeight,
-    spacingFactor: 0.85,
+    spacingFactor: 1.2,
     // @ts-ignore
     // Rotate nodes counter-clockwise to transform layout from top→bottom to left→right.
     // The extra 5° achieves the effect of separating overlapping taxi-styled edges.

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
@@ -117,7 +117,7 @@ const style: cytoscape.Stylesheet[] = [
       // theme.euiFontFamily doesn't work here for some reason, so we're just
       // specifying a subset of the fonts for the label text.
       'font-family': 'Inter UI, Segoe UI, Helvetica, Arial, sans-serif',
-      'font-size': theme.euiFontSizeXS,
+      'font-size': theme.euiFontSizeS,
       ghost: 'yes',
       'ghost-offset-x': 0,
       'ghost-offset-y': 2,
@@ -127,7 +127,7 @@ const style: cytoscape.Stylesheet[] = [
         isService(el)
           ? el.data(SERVICE_NAME)
           : el.data(SPAN_DESTINATION_SERVICE_RESOURCE),
-      'min-zoomed-font-size': parseInt(theme.euiSizeL, 10),
+      'min-zoomed-font-size': parseInt(theme.euiSizeS, 10),
       'overlay-opacity': 0,
       shape: (el: cytoscape.NodeSingular) =>
         isService(el) ? (isIE11 ? 'rectangle' : 'ellipse') : 'diamond',


### PR DESCRIPTION
Closes #67126 by increasing `spacingFactor` in the Cytoscape layout from 0.85 -> 1.2

After (`spacingFactor: 1.2`):
![Screen Shot 2020-05-20 at 4 59 12 PM](https://user-images.githubusercontent.com/1967266/82509027-9eae3400-9abb-11ea-9294-5a1787b5b7ee.png)


Before (`spacingFactor: 0.85`):
![Screen Shot 2020-05-20 at 1 46 09 PM](https://user-images.githubusercontent.com/1967266/82498160-58010f80-9aa4-11ea-8aa3-6124452a98fa.png)
