### PR TITLE
[SIEM][Detections] Allow rules to be created with timeline-populated queries in the UI

### DIFF
--- a/x-pack/plugins/siem/public/alerts/components/rules/query_bar/index.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/rules/query_bar/index.tsx
@@ -208,7 +208,7 @@ export const QueryBarDefineRule = ({
             ? [...newFilters, getDataProviderFilter(dataProvidersDsl)]
             : newFilters,
         query: newQuery,
-        saved_id: '',
+        saved_id: undefined,
       });
     },
     [browserFields, field, indexPattern]


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/67336.

This is a UI bug; the API behaves as expected because the API simply receives a `query` field.

NB that for both saved queries and "import query from timeline" we copy the query during rule creation; if the saved query or timeline change, the rule's query remains the same. NB also that we do not currently persist the timeline's id on the rule, so the previously-mentioned functionality wasn't/isn't currently possible.

Commit message:

> When importing a query from a timeline, the saved_id field was being
> populated with an empty string. This value was previously ignored by the
> encompassing form, but a refactor removed that filtering logic.
> 
> Rather than setting and filtering a misleading field, we now leave it
> undefined in this situation.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
