### PR TITLE
[SIEM][Exceptions] Add success/error toast component on alert state change

### DIFF
--- a/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
@@ -43,11 +43,11 @@ export const getUpdateSignalsQuery = (eventIds: Readonly<string[]>) => {
 export const getFilterAndRuleBounds = (
   data: TimelineNonEcsData[][]
 ): [string[], number, number] => {
-  const stringFilter = data?.[0].filter((d) => d.field === 'signal.rule.filters')?.[0]?.value ?? [];
+  const stringFilter = data?.[0].filter(d => d.field === 'signal.rule.filters')?.[0]?.value ?? [];
 
   const eventTimes = data
-    .flatMap((signal) => signal.filter((d) => d.field === 'signal.original_time')?.[0]?.value ?? [])
-    .map((d) => moment(d));
+    .flatMap(signal => signal.filter(d => d.field === 'signal.original_time')?.[0]?.value ?? [])
+    .map(d => moment(d));
 
   return [stringFilter, moment.min(eventTimes).valueOf(), moment.max(eventTimes).valueOf()];
 };

--- a/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
@@ -43,11 +43,11 @@ export const getUpdateSignalsQuery = (eventIds: Readonly<string[]>) => {
 export const getFilterAndRuleBounds = (
   data: TimelineNonEcsData[][]
 ): [string[], number, number] => {
-  const stringFilter = data?.[0].filter(d => d.field === 'signal.rule.filters')?.[0]?.value ?? [];
+  const stringFilter = data?.[0].filter((d) => d.field === 'signal.rule.filters')?.[0]?.value ?? [];
 
   const eventTimes = data
-    .flatMap(signal => signal.filter(d => d.field === 'signal.original_time')?.[0]?.value ?? [])
-    .map(d => moment(d));
+    .flatMap((signal) => signal.filter((d) => d.field === 'signal.original_time')?.[0]?.value ?? [])
+    .map((d) => moment(d));
 
   return [stringFilter, moment.min(eventTimes).valueOf(), moment.max(eventTimes).valueOf()];
 };

--- a/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
@@ -23,7 +23,7 @@ import {
   replaceTemplateFieldFromMatchFilters,
   replaceTemplateFieldFromDataProviders,
 } from './helpers';
-import { displaySuccessToast } from '../../../common/components/toasters';
+import { displaySuccessToast, displayErrorToast } from '../../../common/components/toasters';
 import * as i18n from './translations';
 
 export const getUpdateSignalsQuery = (eventIds: Readonly<string[]>) => {
@@ -69,14 +69,18 @@ export const updateSignalStatusAction = async ({
     // TODO: Only delete those that were successfully updated from updatedRules
     setEventsDeleted({ eventIds: signalIds, isDeleted: true });
 
-    const statusMessage =
+    const successTitle =
       status === 'closed'
-        ? i18n.CLOSED_ALERT_TOAST(signalIds.length)
-        : i18n.OPENED_ALERT_TOAST(signalIds.length);
+        ? i18n.CLOSED_ALERT_SUCCESS_TOAST(signalIds.length)
+        : i18n.OPENED_ALERT_SUCCESS_TOAST(signalIds.length);
 
-    displaySuccessToast(statusMessage, dispatchToaster);
+    displaySuccessToast(successTitle, dispatchToaster);
   } catch (e) {
-    // TODO: Show error toasts
+    const errorTitle =
+      status === 'closed'
+        ? i18n.CLOSED_ALERT_FAILED_TOAST(signalIds.length)
+        : i18n.OPENED_ALERT_FAILED_TOAST(signalIds.length);
+    displayErrorToast(errorTitle, [e.message], dispatchToaster);
   } finally {
     setEventsLoading({ eventIds: signalIds, isLoading: false });
   }

--- a/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/actions.tsx
@@ -23,6 +23,8 @@ import {
   replaceTemplateFieldFromMatchFilters,
   replaceTemplateFieldFromDataProviders,
 } from './helpers';
+import { displaySuccessToast } from '../../../common/components/toasters';
+import * as i18n from './translations';
 
 export const getUpdateSignalsQuery = (eventIds: Readonly<string[]>) => {
   return {
@@ -56,6 +58,7 @@ export const updateSignalStatusAction = async ({
   status,
   setEventsLoading,
   setEventsDeleted,
+  dispatchToaster,
 }: UpdateSignalStatusActionProps) => {
   try {
     setEventsLoading({ eventIds: signalIds, isLoading: true });
@@ -65,6 +68,13 @@ export const updateSignalStatusAction = async ({
     await updateSignalStatus({ query: queryObject, status });
     // TODO: Only delete those that were successfully updated from updatedRules
     setEventsDeleted({ eventIds: signalIds, isDeleted: true });
+
+    const statusMessage =
+      status === 'closed'
+        ? i18n.CLOSED_ALERT_TOAST(signalIds.length)
+        : i18n.OPENED_ALERT_TOAST(signalIds.length);
+
+    displaySuccessToast(statusMessage, dispatchToaster);
   } catch (e) {
     // TODO: Show error toasts
   } finally {

--- a/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
@@ -19,6 +19,7 @@ import {
 import { mockEcsDataWithSignal } from '../../../common/mock/mock_ecs';
 import { sendSignalToTimelineAction, updateSignalStatusAction } from './actions';
 import * as i18n from './translations';
+import { ActionToaster } from '../../../common/components/toasters';
 
 jest.mock('./actions');
 
@@ -53,12 +54,14 @@ describe('signals default_config', () => {
     let setEventsDeleted: ({ eventIds, isDeleted }: SetEventsDeletedProps) => void;
     let createTimeline: CreateTimeline;
     let updateTimelineIsLoading: UpdateTimelineLoading;
+    let dispatchToaster: React.Dispatch<ActionToaster>;
 
     beforeEach(() => {
       setEventsLoading = jest.fn();
       setEventsDeleted = jest.fn();
       createTimeline = jest.fn();
       updateTimelineIsLoading = jest.fn();
+      dispatchToaster = jest.fn();
     });
 
     describe('timeline tooltip', () => {
@@ -71,6 +74,7 @@ describe('signals default_config', () => {
           createTimeline,
           status: 'open',
           updateTimelineIsLoading,
+          dispatchToaster,
         });
         const timelineAction = signalsActions[0].getAction({
           eventId: 'even-id',
@@ -97,6 +101,7 @@ describe('signals default_config', () => {
           createTimeline,
           status: 'open',
           updateTimelineIsLoading,
+          dispatchToaster,
         });
 
         signalOpenAction = signalsActions[1].getAction({
@@ -151,6 +156,7 @@ describe('signals default_config', () => {
           createTimeline,
           status: 'closed',
           updateTimelineIsLoading,
+          dispatchToaster,
         });
 
         signalCloseAction = signalsActions[1].getAction({

--- a/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
@@ -129,6 +129,7 @@ describe('signals default_config', () => {
           setEventsLoading,
           setEventsDeleted,
           onAlertStatusUpdateSuccess,
+          onAlertStatusUpdateFailure,
         });
       });
 
@@ -186,6 +187,7 @@ describe('signals default_config', () => {
           setEventsLoading,
           setEventsDeleted,
           onAlertStatusUpdateSuccess,
+          onAlertStatusUpdateFailure,
         });
       });
 

--- a/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
@@ -19,7 +19,6 @@ import {
 import { mockEcsDataWithSignal } from '../../../common/mock/mock_ecs';
 import { sendSignalToTimelineAction, updateSignalStatusAction } from './actions';
 import * as i18n from './translations';
-import { ActionToaster } from '../../../common/components/toasters';
 
 jest.mock('./actions');
 
@@ -54,14 +53,17 @@ describe('signals default_config', () => {
     let setEventsDeleted: ({ eventIds, isDeleted }: SetEventsDeletedProps) => void;
     let createTimeline: CreateTimeline;
     let updateTimelineIsLoading: UpdateTimelineLoading;
-    let dispatchToaster: React.Dispatch<ActionToaster>;
+
+    let onAlertStatusUpdateSuccess: (count: number, status: string) => void;
+    let onAlertStatusUpdateFailure: (status: string, error: Error) => void;
 
     beforeEach(() => {
       setEventsLoading = jest.fn();
       setEventsDeleted = jest.fn();
       createTimeline = jest.fn();
       updateTimelineIsLoading = jest.fn();
-      dispatchToaster = jest.fn();
+      onAlertStatusUpdateSuccess = jest.fn();
+      onAlertStatusUpdateFailure = jest.fn();
     });
 
     describe('timeline tooltip', () => {
@@ -74,7 +76,8 @@ describe('signals default_config', () => {
           createTimeline,
           status: 'open',
           updateTimelineIsLoading,
-          dispatchToaster,
+          onAlertStatusUpdateSuccess,
+          onAlertStatusUpdateFailure,
         });
         const timelineAction = signalsActions[0].getAction({
           eventId: 'even-id',
@@ -101,7 +104,8 @@ describe('signals default_config', () => {
           createTimeline,
           status: 'open',
           updateTimelineIsLoading,
-          dispatchToaster,
+          onAlertStatusUpdateSuccess,
+          onAlertStatusUpdateFailure,
         });
 
         signalOpenAction = signalsActions[1].getAction({
@@ -124,7 +128,7 @@ describe('signals default_config', () => {
           status: 'open',
           setEventsLoading,
           setEventsDeleted,
-          dispatchToaster,
+          onAlertStatusUpdateSuccess,
         });
       });
 
@@ -157,7 +161,8 @@ describe('signals default_config', () => {
           createTimeline,
           status: 'closed',
           updateTimelineIsLoading,
-          dispatchToaster,
+          onAlertStatusUpdateSuccess,
+          onAlertStatusUpdateFailure,
         });
 
         signalCloseAction = signalsActions[1].getAction({
@@ -180,7 +185,7 @@ describe('signals default_config', () => {
           status: 'closed',
           setEventsLoading,
           setEventsDeleted,
-          dispatchToaster,
+          onAlertStatusUpdateSuccess,
         });
       });
 

--- a/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/default_config.test.tsx
@@ -124,6 +124,7 @@ describe('signals default_config', () => {
           status: 'open',
           setEventsLoading,
           setEventsDeleted,
+          dispatchToaster,
         });
       });
 
@@ -179,6 +180,7 @@ describe('signals default_config', () => {
           status: 'closed',
           setEventsLoading,
           setEventsDeleted,
+          dispatchToaster,
         });
       });
 

--- a/x-pack/plugins/siem/public/alerts/components/signals/default_config.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/default_config.tsx
@@ -32,7 +32,6 @@ import {
   SetEventsLoadingProps,
   UpdateTimelineLoading,
 } from './types';
-import { ActionToaster } from '../../../common/components/toasters';
 
 export const signalsOpenFilters: Filter[] = [
   {
@@ -199,7 +198,8 @@ export const getSignalsActions = ({
   createTimeline,
   status,
   updateTimelineIsLoading,
-  dispatchToaster,
+  onAlertStatusUpdateSuccess,
+  onAlertStatusUpdateFailure,
 }: {
   apolloClient?: ApolloClient<{}>;
   canUserCRUD: boolean;
@@ -209,7 +209,8 @@ export const getSignalsActions = ({
   createTimeline: CreateTimeline;
   status: 'open' | 'closed';
   updateTimelineIsLoading: UpdateTimelineLoading;
-  dispatchToaster: React.Dispatch<ActionToaster>;
+  onAlertStatusUpdateSuccess: (count: number, status: string) => void;
+  onAlertStatusUpdateFailure: (status: string, error: Error) => void;
 }): TimelineAction[] => [
   {
     getAction: ({ ecsData }: TimelineActionProps): JSX.Element => (
@@ -249,7 +250,8 @@ export const getSignalsActions = ({
               status,
               setEventsLoading,
               setEventsDeleted,
-              dispatchToaster,
+              onAlertStatusUpdateSuccess,
+              onAlertStatusUpdateFailure,
             })
           }
           isDisabled={!canUserCRUD || !hasIndexWrite}

--- a/x-pack/plugins/siem/public/alerts/components/signals/default_config.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/default_config.tsx
@@ -32,6 +32,7 @@ import {
   SetEventsLoadingProps,
   UpdateTimelineLoading,
 } from './types';
+import { ActionToaster } from '../../../common/components/toasters';
 
 export const signalsOpenFilters: Filter[] = [
   {
@@ -198,6 +199,7 @@ export const getSignalsActions = ({
   createTimeline,
   status,
   updateTimelineIsLoading,
+  dispatchToaster,
 }: {
   apolloClient?: ApolloClient<{}>;
   canUserCRUD: boolean;
@@ -207,6 +209,7 @@ export const getSignalsActions = ({
   createTimeline: CreateTimeline;
   status: 'open' | 'closed';
   updateTimelineIsLoading: UpdateTimelineLoading;
+  dispatchToaster: React.Dispatch<ActionToaster>;
 }): TimelineAction[] => [
   {
     getAction: ({ ecsData }: TimelineActionProps): JSX.Element => (
@@ -246,6 +249,7 @@ export const getSignalsActions = ({
               status,
               setEventsLoading,
               setEventsDeleted,
+              dispatchToaster,
             })
           }
           isDisabled={!canUserCRUD || !hasIndexWrite}

--- a/x-pack/plugins/siem/public/alerts/components/signals/index.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/index.tsx
@@ -46,6 +46,7 @@ import {
   UpdateSignalsStatusProps,
 } from './types';
 import { dispatchUpdateTimeline } from '../../../timelines/components/open_timeline/helpers';
+import { useStateToaster } from '../../../common/components/toasters';
 
 export const SIGNALS_PAGE_TIMELINE_ID = 'signals-page';
 
@@ -91,6 +92,7 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
     signalsIndex !== '' ? [signalsIndex] : []
   );
   const kibana = useKibana();
+  const [, dispatchToaster] = useStateToaster();
 
   const getGlobalQuery = useCallback(() => {
     if (browserFields != null && indexPatterns != null) {
@@ -189,6 +191,7 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
         status,
         setEventsDeleted: setEventsDeletedCallback,
         setEventsLoading: setEventsLoadingCallback,
+        dispatchToaster,
       });
       refetchQuery();
     },
@@ -198,6 +201,7 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
       setEventsDeletedCallback,
       setEventsLoadingCallback,
       showClearSelectionAction,
+      dispatchToaster,
     ]
   );
 
@@ -244,6 +248,7 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
         setEventsDeleted: setEventsDeletedCallback,
         status: filterGroup === FILTER_OPEN ? FILTER_CLOSED : FILTER_OPEN,
         updateTimelineIsLoading,
+        dispatchToaster,
       }),
     [
       apolloClient,
@@ -254,6 +259,7 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
       setEventsLoadingCallback,
       setEventsDeletedCallback,
       updateTimelineIsLoading,
+      dispatchToaster,
     ]
   );
 

--- a/x-pack/plugins/siem/public/alerts/components/signals/index.tsx
+++ b/x-pack/plugins/siem/public/alerts/components/signals/index.tsx
@@ -46,7 +46,11 @@ import {
   UpdateSignalsStatusProps,
 } from './types';
 import { dispatchUpdateTimeline } from '../../../timelines/components/open_timeline/helpers';
-import { useStateToaster } from '../../../common/components/toasters';
+import {
+  useStateToaster,
+  displaySuccessToast,
+  displayErrorToast,
+} from '../../../common/components/toasters';
 
 export const SIGNALS_PAGE_TIMELINE_ID = 'signals-page';
 
@@ -148,6 +152,27 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
     [setEventsDeleted, SIGNALS_PAGE_TIMELINE_ID]
   );
 
+  const onAlertStatusUpdateSuccess = useCallback(
+    (count: number, status: string) => {
+      const title =
+        status === 'closed'
+          ? i18n.CLOSED_ALERT_SUCCESS_TOAST(count)
+          : i18n.OPENED_ALERT_SUCCESS_TOAST(count);
+
+      displaySuccessToast(title, dispatchToaster);
+    },
+    [dispatchToaster]
+  );
+
+  const onAlertStatusUpdateFailure = useCallback(
+    (status: string, error: Error) => {
+      const title =
+        status === 'closed' ? i18n.CLOSED_ALERT_FAILED_TOAST : i18n.OPENED_ALERT_FAILED_TOAST;
+      displayErrorToast(title, [error.message], dispatchToaster);
+    },
+    [dispatchToaster]
+  );
+
   // Catches state change isSelectAllChecked->false upon user selection change to reset utility bar
   useEffect(() => {
     if (!isSelectAllChecked) {
@@ -191,7 +216,8 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
         status,
         setEventsDeleted: setEventsDeletedCallback,
         setEventsLoading: setEventsLoadingCallback,
-        dispatchToaster,
+        onAlertStatusUpdateSuccess,
+        onAlertStatusUpdateFailure,
       });
       refetchQuery();
     },
@@ -201,7 +227,8 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
       setEventsDeletedCallback,
       setEventsLoadingCallback,
       showClearSelectionAction,
-      dispatchToaster,
+      onAlertStatusUpdateSuccess,
+      onAlertStatusUpdateFailure,
     ]
   );
 
@@ -248,7 +275,8 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
         setEventsDeleted: setEventsDeletedCallback,
         status: filterGroup === FILTER_OPEN ? FILTER_CLOSED : FILTER_OPEN,
         updateTimelineIsLoading,
-        dispatchToaster,
+        onAlertStatusUpdateSuccess,
+        onAlertStatusUpdateFailure,
       }),
     [
       apolloClient,
@@ -259,7 +287,8 @@ export const SignalsTableComponent: React.FC<SignalsTableComponentProps> = ({
       setEventsLoadingCallback,
       setEventsDeletedCallback,
       updateTimelineIsLoading,
-      dispatchToaster,
+      onAlertStatusUpdateSuccess,
+      onAlertStatusUpdateFailure,
     ]
   );
 

--- a/x-pack/plugins/siem/public/alerts/components/signals/translations.ts
+++ b/x-pack/plugins/siem/public/alerts/components/signals/translations.ts
@@ -101,3 +101,17 @@ export const ACTION_INVESTIGATE_IN_TIMELINE = i18n.translate(
     defaultMessage: 'Investigate in timeline',
   }
 );
+
+export const CLOSED_ALERT_TOAST = (totalAlerts: number) =>
+  i18n.translate('xpack.siem.detectionEngine.signals.closedAlertToastMessage', {
+    values: { totalAlerts },
+    defaultMessage:
+      'Successfully Closed {totalAlerts} {totalAlerts, plural, =1 {Alert} other {Alerts}}.',
+  });
+
+export const OPENED_ALERT_TOAST = (totalAlerts: number) =>
+  i18n.translate('xpack.siem.detectionEngine.signals.openedAlertToastMessage', {
+    values: { totalAlerts },
+    defaultMessage:
+      'Successfully Opened {totalAlerts} {totalAlerts, plural, =1 {Alert} other {Alerts}}.',
+  });

--- a/x-pack/plugins/siem/public/alerts/components/signals/translations.ts
+++ b/x-pack/plugins/siem/public/alerts/components/signals/translations.ts
@@ -102,16 +102,30 @@ export const ACTION_INVESTIGATE_IN_TIMELINE = i18n.translate(
   }
 );
 
-export const CLOSED_ALERT_TOAST = (totalAlerts: number) =>
-  i18n.translate('xpack.siem.detectionEngine.signals.closedAlertToastMessage', {
+export const CLOSED_ALERT_SUCCESS_TOAST = (totalAlerts: number) =>
+  i18n.translate('xpack.siem.detectionEngine.signals.closedAlertSuccessToastMessage', {
     values: { totalAlerts },
     defaultMessage:
-      'Successfully Closed {totalAlerts} {totalAlerts, plural, =1 {Alert} other {Alerts}}.',
+      'Successfully closed {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
   });
 
-export const OPENED_ALERT_TOAST = (totalAlerts: number) =>
-  i18n.translate('xpack.siem.detectionEngine.signals.openedAlertToastMessage', {
+export const OPENED_ALERT_SUCCESS_TOAST = (totalAlerts: number) =>
+  i18n.translate('xpack.siem.detectionEngine.signals.openedAlertSuccessToastMessage', {
     values: { totalAlerts },
     defaultMessage:
-      'Successfully Opened {totalAlerts} {totalAlerts, plural, =1 {Alert} other {Alerts}}.',
+      'Successfully opened {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
+  });
+
+export const CLOSED_ALERT_FAILED_TOAST = (totalAlerts: number) =>
+  i18n.translate('xpack.siem.detectionEngine.signals.closedAlertFailedToastMessage', {
+    values: { totalAlerts },
+    defaultMessage:
+      'Failed to close {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
+  });
+
+export const OPENED_ALERT_FAILED_TOAST = (totalAlerts: number) =>
+  i18n.translate('xpack.siem.detectionEngine.signals.openedAlertFailedToastMessage', {
+    values: { totalAlerts },
+    defaultMessage:
+      'Failed to open {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
   });

--- a/x-pack/plugins/siem/public/alerts/components/signals/translations.ts
+++ b/x-pack/plugins/siem/public/alerts/components/signals/translations.ts
@@ -116,16 +116,16 @@ export const OPENED_ALERT_SUCCESS_TOAST = (totalAlerts: number) =>
       'Successfully opened {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
   });
 
-export const CLOSED_ALERT_FAILED_TOAST = (totalAlerts: number) =>
-  i18n.translate('xpack.siem.detectionEngine.signals.closedAlertFailedToastMessage', {
-    values: { totalAlerts },
-    defaultMessage:
-      'Failed to close {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
-  });
+export const CLOSED_ALERT_FAILED_TOAST = i18n.translate(
+  'xpack.siem.detectionEngine.signals.closedAlertFailedToastMessage',
+  {
+    defaultMessage: 'Failed to close alert(s).',
+  }
+);
 
-export const OPENED_ALERT_FAILED_TOAST = (totalAlerts: number) =>
-  i18n.translate('xpack.siem.detectionEngine.signals.openedAlertFailedToastMessage', {
-    values: { totalAlerts },
-    defaultMessage:
-      'Failed to open {totalAlerts} {totalAlerts, plural, =1 {alert} other {alerts}}.',
-  });
+export const OPENED_ALERT_FAILED_TOAST = i18n.translate(
+  'xpack.siem.detectionEngine.signals.openedAlertFailedToastMessage',
+  {
+    defaultMessage: 'Failed to open alert(s)',
+  }
+);

--- a/x-pack/plugins/siem/public/alerts/components/signals/types.ts
+++ b/x-pack/plugins/siem/public/alerts/components/signals/types.ts
@@ -9,6 +9,7 @@ import ApolloClient from 'apollo-client';
 import { Ecs } from '../../../graphql/types';
 import { TimelineModel } from '../../../timelines/store/timeline/model';
 import { inputsModel } from '../../../common/store';
+import { ActionToaster } from '../../../common/components/toasters';
 
 export interface SetEventsLoadingProps {
   eventIds: string[];
@@ -37,6 +38,7 @@ export interface UpdateSignalStatusActionProps {
   status: 'open' | 'closed';
   setEventsLoading: ({ eventIds, isLoading }: SetEventsLoadingProps) => void;
   setEventsDeleted: ({ eventIds, isDeleted }: SetEventsDeletedProps) => void;
+  dispatchToaster: React.Dispatch<ActionToaster>;
 }
 
 export type SendSignalsToTimeline = () => void;

--- a/x-pack/plugins/siem/public/alerts/components/signals/types.ts
+++ b/x-pack/plugins/siem/public/alerts/components/signals/types.ts
@@ -9,7 +9,6 @@ import ApolloClient from 'apollo-client';
 import { Ecs } from '../../../graphql/types';
 import { TimelineModel } from '../../../timelines/store/timeline/model';
 import { inputsModel } from '../../../common/store';
-import { ActionToaster } from '../../../common/components/toasters';
 
 export interface SetEventsLoadingProps {
   eventIds: string[];
@@ -38,7 +37,8 @@ export interface UpdateSignalStatusActionProps {
   status: 'open' | 'closed';
   setEventsLoading: ({ eventIds, isLoading }: SetEventsLoadingProps) => void;
   setEventsDeleted: ({ eventIds, isDeleted }: SetEventsDeletedProps) => void;
-  dispatchToaster: React.Dispatch<ActionToaster>;
+  onAlertStatusUpdateSuccess: (count: number, status: string) => void;
+  onAlertStatusUpdateFailure: (status: string, error: Error) => void;
 }
 
 export type SendSignalsToTimeline = () => void;

--- a/x-pack/plugins/siem/public/alerts/containers/detection_engine/signals/api.ts
+++ b/x-pack/plugins/siem/public/alerts/containers/detection_engine/signals/api.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { ReindexResponse } from 'elasticsearch';
 import {
   DETECTION_ENGINE_QUERY_SIGNALS_URL,
   DETECTION_ENGINE_SIGNALS_STATUS_URL,
@@ -54,7 +55,7 @@ export const updateSignalStatus = async ({
   query,
   status,
   signal,
-}: UpdateSignalStatusProps): Promise<unknown> =>
+}: UpdateSignalStatusProps): Promise<ReindexResponse> =>
   KibanaServices.get().http.fetch(DETECTION_ENGINE_SIGNALS_STATUS_URL, {
     method: 'POST',
     body: JSON.stringify({ status, ...query }),

--- a/x-pack/plugins/siem/scripts/endpoint/resolver_generator.ts
+++ b/x-pack/plugins/siem/scripts/endpoint/resolver_generator.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import * as yargs from 'yargs';
-import fs from 'fs';
 import seedrandom from 'seedrandom';
 import { Client, ClientOptions } from '@elastic/elasticsearch';
 import { ResponseError } from '@elastic/elasticsearch/lib/errors';
@@ -163,9 +162,6 @@ async function main() {
   eventMapping.settings.index.default_pipeline = pipelineName;
   const clientOptions: ClientOptions = {
     node: argv.node,
-    ssl: {
-      ca: fs.readFileSync('../../../packages/kbn-dev-utils/certs/ca.crt'),
-    },
   };
   if (argv.auth) {
     const [username, password]: string[] = argv.auth.split(':', 2);

--- a/x-pack/plugins/siem/scripts/endpoint/resolver_generator.ts
+++ b/x-pack/plugins/siem/scripts/endpoint/resolver_generator.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import * as yargs from 'yargs';
+import fs from 'fs';
 import seedrandom from 'seedrandom';
 import { Client, ClientOptions } from '@elastic/elasticsearch';
 import { ResponseError } from '@elastic/elasticsearch/lib/errors';
@@ -162,6 +163,9 @@ async function main() {
   eventMapping.settings.index.default_pipeline = pipelineName;
   const clientOptions: ClientOptions = {
     node: argv.node,
+    ssl: {
+      ca: fs.readFileSync('../../../packages/kbn-dev-utils/certs/ca.crt'),
+    },
   };
   if (argv.auth) {
     const [username, password]: string[] = argv.auth.split(':', 2);


### PR DESCRIPTION
## Summary

Adds a success and error toast on open or close of alert(s). #65947

<img width="1035" alt="Screen Shot 2020-05-26 at 2 28 57 PM" src="https://user-images.githubusercontent.com/56367316/82947446-5086ae00-9f5d-11ea-848a-9edae48c47dc.png">

<img width="1022" alt="Screen Shot 2020-05-28 at 12 01 03 PM" src="https://user-images.githubusercontent.com/56367316/83176760-3f63ab80-a0db-11ea-9f4d-7b745d0b4bf0.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
