### PR TITLE
[Lens] performance improvement for dragging field Items 

### DIFF
--- a/x-pack/plugins/lens/public/drag_drop/drag_drop.test.tsx
+++ b/x-pack/plugins/lens/public/drag_drop/drag_drop.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { render, shallow, mount } from 'enzyme';
+import { render, mount } from 'enzyme';
 import { DragDrop } from './drag_drop';
 import { ChildDragDropProvider } from './providers';
 
@@ -24,7 +24,7 @@ describe('DragDrop', () => {
 
   test('dragover calls preventDefault if droppable is true', () => {
     const preventDefault = jest.fn();
-    const component = shallow(<DragDrop droppable>Hello!</DragDrop>);
+    const component = mount(<DragDrop droppable>Hello!</DragDrop>);
 
     component.find('[data-test-subj="lnsDragDrop"]').simulate('dragover', { preventDefault });
 
@@ -33,7 +33,7 @@ describe('DragDrop', () => {
 
   test('dragover does not call preventDefault if droppable is false', () => {
     const preventDefault = jest.fn();
-    const component = shallow(<DragDrop>Hello!</DragDrop>);
+    const component = mount(<DragDrop>Hello!</DragDrop>);
 
     component.find('[data-test-subj="lnsDragDrop"]').simulate('dragover', { preventDefault });
 

--- a/x-pack/plugins/lens/public/drag_drop/drag_drop.tsx
+++ b/x-pack/plugins/lens/public/drag_drop/drag_drop.tsx
@@ -88,11 +88,39 @@ type Props = DraggableProps | NonDraggableProps;
  *
  * @param props
  */
-export function DragDrop(props: Props) {
+
+export const DragDrop = (props: Props) => {
   const { dragging, setDragging } = useContext(DragContext);
+  const { value, draggable, droppable } = props;
+  return (
+    <DragDropInner
+      {...props}
+      dragging={droppable ? dragging : undefined}
+      isDragging={!!(draggable && value === dragging)}
+      setDragging={setDragging}
+    />
+  );
+};
+
+const DragDropInner = React.memo(function DragDropInner(
+  props: Props & {
+    dragging: unknown;
+    setDragging: (dragging: unknown) => void;
+    isDragging: boolean;
+  }
+) {
   const [state, setState] = useState({ isActive: false });
-  const { className, onDrop, value, children, droppable, draggable } = props;
-  const isDragging = draggable && value === dragging;
+  const {
+    className,
+    onDrop,
+    value,
+    children,
+    droppable,
+    draggable,
+    dragging,
+    setDragging,
+    isDragging,
+  } = props;
 
   const classes = classNames('lnsDragDrop', className, {
     'lnsDragDrop-isDropTarget': droppable,
@@ -166,4 +194,4 @@ export function DragDrop(props: Props) {
       {children}
     </div>
   );
-}
+});

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -78,7 +78,7 @@ function wrapOnDot(str?: string) {
   return str ? str.replace(/\./g, '.\u200B') : '';
 }
 
-export function FieldItem(props: FieldItemProps) {
+export const FieldItem = React.memo(function FieldItem(props: FieldItemProps) {
   const {
     core,
     field,
@@ -170,6 +170,10 @@ export function FieldItem(props: FieldItemProps) {
     }
   }
 
+  const value = React.useMemo(() => ({ field, indexPatternId: indexPattern.id } as DraggedField), [
+    field,
+    indexPattern.id,
+  ]);
   return (
     <EuiPopover
       id="lnsFieldListPanel__field"
@@ -179,7 +183,7 @@ export function FieldItem(props: FieldItemProps) {
       button={
         <DragDrop
           label={field.name}
-          value={{ field, indexPatternId: indexPattern.id } as DraggedField}
+          value={value}
           data-test-subj="lnsFieldListPanelField"
           draggable
           className={`lnsFieldItem lnsFieldItem--${field.type} lnsFieldItem--${
@@ -235,7 +239,7 @@ export function FieldItem(props: FieldItemProps) {
       <FieldItemPopoverContents {...state} {...props} />
     </EuiPopover>
   );
-}
+});
 
 function FieldItemPopoverContents(props: State & FieldItemProps) {
   const {


### PR DESCRIPTION
## Summary

When testing 7.8 for big datasets, I noticed that when I have the option `Only show fields with data` unchecked and try to drag and drop one field item, there's a visible lag (especially in Safari). That's because we pass the context to the each `FieldItem` with the information about which field is being dragged (`dragging`) - it causes the unnecessary re-render of all the `FieldItem`s. If at some point we decide we'll be showing all the fields by default, this has to be fixed. This PR solves the issue by creating memoized inner `DragDropInner` component of `DragDrop`. 
We're only passing the information about `dragging` to `DragDropInner` for the currently dragged field and for all the droppables. (Droppables have to know what's being dragged) - this way we can skip rerenders of all FieldItems except for the active one.

Here's the snapshots from the profiler:
![image](https://user-images.githubusercontent.com/4283304/83011428-21824200-a01a-11ea-8c62-95e10dcd839c.png)
![image](https://user-images.githubusercontent.com/4283304/83011431-234c0580-a01a-11ea-88fc-ebafad7f74e9.png)

And videos of dropping the element for an index of 520 fields. 
https://drive.google.com/open?id=1wgMbrvuM9XWMo7PD3ycMeB5Y4DHdaLre
https://drive.google.com/open?id=1f8jxrOWCSS5g17YtT-Vf_JWjuM3f8s_4

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
