### PR TITLE
Use correct text color in metric vis on dark background

### DIFF
--- a/src/plugins/vis_type_metric/public/components/metric_vis_component.tsx
+++ b/src/plugins/vis_type_metric/public/components/metric_vis_component.tsx
@@ -93,7 +93,7 @@ export class MetricVisComponent extends Component<MetricVisComponentProps> {
       return false;
     }
 
-    const [red, green, blue] = colors.slice(1).map(parseInt);
+    const [red, green, blue] = colors.slice(1).map((c) => parseInt(c, 10));
     return isColorDark(red, green, blue);
   }
 


### PR DESCRIPTION
…s dark

## Summary
Fixes #67445 

The metric visualization should change the text color to a lighter theme when the background is dark. The bug here is that it doesn't have the expected behaviour. While the background was set to a dark theme, the label remained also dark and the visualization was unreadable.

The problem here is that the map(parseInt) didn't return an array of integers. The radix parameter was not passed correctly from the map function so parseInt didn't return an integer. Map function added as radix the array index and for this reason the resulting elements were either NaN or a wrong integer number.

The solution is to add the default radix (10) on the parseInt function in order to avoid using the array index instead.

### Checklist
- [x] This was checked for cross-browser compatibility, (https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)