### PR TITLE
[SIEM][Detections] Fix typo on lists index route

### DIFF
--- a/x-pack/plugins/lists/server/routes/read_list_index_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_list_index_route.ts
@@ -31,7 +31,7 @@ export const readListIndexRoute = (router: IRouter): void => {
 
         if (listIndexExists || listItemIndexExists) {
           const [validated, errors] = validate(
-            { list_index: listIndexExists, lists_item_index: listItemIndexExists },
+            { list_index: listIndexExists, list_item_index: listItemIndexExists },
             listItemIndexExistSchema
           );
           if (errors != null) {


### PR DESCRIPTION
A typo here caused the response to fail validation (and thus return a 500).

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
