### PR TITLE
[Monitoring] Fix issue with singular host config

### DIFF
--- a/x-pack/plugins/monitoring/server/es_client/__tests__/instantiate_client.js
+++ b/x-pack/plugins/monitoring/server/es_client/__tests__/instantiate_client.js
@@ -38,6 +38,21 @@ const serverWithUrl = {
     },
   },
 };
+const serverWithUrlAndSingleHost = {
+  monitoring: {
+    ui: {
+      elasticsearch: {
+        hosts: 'http://monitoring-cluster.test:9200',
+        username: 'monitoring-user-internal-test',
+        password: 'monitoring-p@ssw0rd!-internal-test',
+        ssl: {},
+        customHeaders: {
+          'x-custom-headers-test': 'connection-monitoring',
+        },
+      },
+    },
+  },
+};
 
 const createClient = sinon.stub();
 const log = { info: sinon.stub() };
@@ -102,6 +117,18 @@ describe('Instantiate Client', () => {
   describe('Use a connection to monitoring cluster', () => {
     it('exposes an authenticated client using monitoring host settings', () => {
       instantiateClient(serverWithUrl.monitoring.ui.elasticsearch, log, createClient);
+      const createClusterCall = createClient.getCall(0);
+      const createClientOptions = createClusterCall.args[1];
+
+      sinon.assert.calledOnce(createClient);
+      expect(createClusterCall.args[0]).to.be('monitoring');
+      expect(createClientOptions.hosts[0]).to.eql('http://monitoring-cluster.test:9200');
+      expect(createClientOptions.username).to.eql('monitoring-user-internal-test');
+      expect(createClientOptions.password).to.eql('monitoring-p@ssw0rd!-internal-test');
+    });
+
+    it('should always use an array', () => {
+      instantiateClient(serverWithUrlAndSingleHost.monitoring.ui.elasticsearch, log, createClient);
       const createClusterCall = createClient.getCall(0);
       const createClientOptions = createClusterCall.args[1];
 

--- a/x-pack/plugins/monitoring/server/es_client/instantiate_client.ts
+++ b/x-pack/plugins/monitoring/server/es_client/instantiate_client.ts
@@ -24,6 +24,10 @@ export function instantiateClient(
   ) => ICustomClusterClient
 ) {
   const isMonitoringCluster = hasMonitoringCluster(elasticsearchConfig);
+  // elasticsearch_client_config seems to assume we need an array here
+  if (isMonitoringCluster && !Array.isArray(elasticsearchConfig.hosts)) {
+    elasticsearchConfig.hosts = [elasticsearchConfig.hosts];
+  }
   const cluster = createClient('monitoring', {
     ...(isMonitoringCluster ? elasticsearchConfig : {}),
     plugins: [monitoringBulk],


### PR DESCRIPTION
Fixes #67373
Fixes #67668

The setup is something like this in your config:
```
monitoring.ui.elasticsearch.hosts: https://localhost:8200
```

If an array structure is not used, [this code is not executed](https://github.com/elastic/kibana/blob/master/src/core/server/elasticsearch/elasticsearch_client_config.ts#L118) meaning the connection will use the default `localhost:9200`.

This seems like a bug with NP, but it also sounds like something we went through in the NP upgrade but I can't recall what came of that.

cc @restrry 