### PR TITLE
[APM] Ensure loading indicator stops in Safari

### DIFF
--- a/x-pack/plugins/apm/public/context/LoadingIndicatorContext.tsx
+++ b/x-pack/plugins/apm/public/context/LoadingIndicatorContext.tsx
@@ -4,12 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { EuiPortal, EuiProgress } from '@elastic/eui';
+import { pick } from 'lodash';
 import React, { Fragment, useMemo, useReducer } from 'react';
 import { useDelayedVisibility } from '../components/shared/useDelayedVisibility';
 
 export const LoadingIndicatorContext = React.createContext({
   statuses: {},
-  dispatchStatus: (action: Action) => undefined as void,
+  dispatchStatus: (action: Action) => {},
 });
 
 interface State {
@@ -22,14 +23,13 @@ interface Action {
 }
 
 function reducer(statuses: State, action: Action) {
-  // add loading status
-  if (action.isLoading) {
-    return { ...statuses, [action.id]: true };
-  }
-
-  // remove loading status
-  const { [action.id]: statusToRemove, ...restStatuses } = statuses;
-  return restStatuses;
+  // Return an object with only the ids with `true` as their value, so that ids
+  // that previously had `false` are removed and do not remain hanging around in
+  // the object.
+  return pick(
+    { ...statuses, [action.id.toString()]: action.isLoading },
+    Boolean
+  );
 }
 
 function getIsAnyLoading(statuses: State) {


### PR DESCRIPTION
The combination of using object destructuring and numeric object keys in the reducer for LoadingIndicatorContext caused it so the loading indicator would not disappear in 7.8 in Safari even though there were no more loading statuses.

Optimization changes between 7.8 and master may be why this is only appears on 7.8.

Update this reducer to stringify the key and `lodash.pick` only the true values so the only pairs in the object are ones with `true` as the value.

Fixes #67334.