### PR TITLE
Fix visualize and lens telemetry

### DIFF
--- a/x-pack/plugins/lens/server/usage/task.ts
+++ b/x-pack/plugins/lens/server/usage/task.ts
@@ -6,6 +6,7 @@
 
 import { APICaller, CoreSetup, Logger } from 'kibana/server';
 import { Observable } from 'rxjs';
+import { first } from 'rxjs/operators';
 import moment from 'moment';
 import {
   RunContext,
@@ -191,7 +192,7 @@ export function telemetryTaskRunner(
 
     return {
       async run() {
-        const kibanaIndex = (await config.toPromise()).kibana.index;
+        const kibanaIndex = (await config.pipe(first()).toPromise()).kibana.index;
 
         return Promise.all([
           getDailyEvents(kibanaIndex, callCluster),

--- a/x-pack/plugins/oss_telemetry/server/lib/tasks/visualizations/task_runner.ts
+++ b/x-pack/plugins/oss_telemetry/server/lib/tasks/visualizations/task_runner.ts
@@ -6,6 +6,8 @@
 
 import { Observable } from 'rxjs';
 import _, { countBy, groupBy, mapValues } from 'lodash';
+import { first } from 'rxjs/operators';
+
 import { APICaller, IClusterClient } from 'src/core/server';
 import { getNextMidnight } from '../../get_next_midnight';
 import { TaskInstance } from '../../../../../task_manager/server';
@@ -80,7 +82,7 @@ export function visualizationsTaskRunner(
     let error;
 
     try {
-      const index = (await config.toPromise()).kibana.index;
+      const index = (await config.pipe(first()).toPromise()).kibana.index;
       stats = await getStats((await esClientPromise).callAsInternalUser, index);
     } catch (err) {
       if (err.constructor === Error) {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/67510

Both the code for visualization and Lens telemetry was waiting for the config observable to complete before actually fetching the saved object data. This PR makes sure to just take the current config and executes the task.

## How to test

A simple way to trigger the tasks is to delete all documents in `.kibana_task_manager` and restart the Kibana server.

Then the data should show up in the telemetry payload accessible via "Management > Advanced settings > "See what we collect" link