### PR TITLE
[TSVB] Allows the user to change the tooltip mode

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/timeseries.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/timeseries.js
@@ -61,6 +61,7 @@ class TimeseriesPanelConfigUi extends Component {
       axis_min: '',
       legend_position: 'right',
       show_grid: 1,
+      tooltip_mode: 'show_all',
     };
     const model = { ...defaults, ...this.props.model };
     const { selectedTab } = this.state;
@@ -83,6 +84,22 @@ class TimeseriesPanelConfigUi extends Component {
           defaultMessage: 'Left',
         }),
         value: 'left',
+      },
+    ];
+    const tooltipModeOptions = [
+      {
+        label: intl.formatMessage({
+          id: 'visTypeTimeseries.timeseries.tooltipOptions.showAll',
+          defaultMessage: 'Show all values',
+        }),
+        value: 'show_all',
+      },
+      {
+        label: intl.formatMessage({
+          id: 'visTypeTimeseries.timeseries.tooltipOptions.showFocused',
+          defaultMessage: 'Show single value',
+        }),
+        value: 'show_focused',
       },
     ];
     const selectedPositionOption = positionOptions.find((option) => {
@@ -132,6 +149,10 @@ class TimeseriesPanelConfigUi extends Component {
     ];
     const selectedLegendPosOption = legendPositionOptions.find((option) => {
       return model.legend_position === option.value;
+    });
+
+    const selectedTooltipMode = tooltipModeOptions.find((option) => {
+      return model.tooltip_mode === option.value;
     });
 
     let view;
@@ -355,6 +376,24 @@ class TimeseriesPanelConfigUi extends Component {
               </EuiFlexItem>
               <EuiFlexItem>
                 <YesNo value={model.show_grid} name="show_grid" onChange={this.props.onChange} />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFormLabel>
+                  <FormattedMessage
+                    id="visTypeTimeseries.timeseries.optionsTab.tooltipMode"
+                    defaultMessage="Tooltip"
+                  />
+                </EuiFormLabel>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiComboBox
+                  isClearable={false}
+                  id={htmlId('tooltipMode')}
+                  options={tooltipModeOptions}
+                  selectedOptions={selectedTooltipMode ? [selectedTooltipMode] : []}
+                  onChange={handleSelectChange('tooltip_mode')}
+                  singleSelection={{ asPlainText: true }}
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/timeseries.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/timeseries.js
@@ -97,7 +97,7 @@ class TimeseriesPanelConfigUi extends Component {
       {
         label: intl.formatMessage({
           id: 'visTypeTimeseries.timeseries.tooltipOptions.showFocused',
-          defaultMessage: 'Show single value',
+          defaultMessage: 'Show focused values',
         }),
         value: 'show_focused',
       },

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/vis.js
@@ -250,6 +250,7 @@ export class TimeseriesVisualization extends Component {
           showGrid={Boolean(model.show_grid)}
           legend={Boolean(model.show_legend)}
           legendPosition={model.legend_position}
+          tooltipMode={model.tooltip_mode}
           xAxisLabel={getAxisLabelString(interval)}
           xAxisFormatter={this.xAxisFormatter(interval)}
           annotations={this.prepareAnnotations()}

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
@@ -61,6 +61,7 @@ export const TimeSeries = ({
   showGrid,
   legend,
   legendPosition,
+  tooltipMode,
   xAxisLabel,
   series,
   yAxis,
@@ -131,7 +132,7 @@ export const TimeSeries = ({
         baseTheme={theme}
         tooltip={{
           snap: true,
-          type: TooltipType.VerticalCursor,
+          type: tooltipMode === 'show_all' ? TooltipType.VerticalCursor : TooltipType.Follow,
           headerFormatter: tooltipFormatter,
         }}
       />

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
@@ -132,7 +132,7 @@ export const TimeSeries = ({
         baseTheme={theme}
         tooltip={{
           snap: true,
-          type: tooltipMode === 'show_all' ? TooltipType.VerticalCursor : TooltipType.Follow,
+          type: tooltipMode === 'show_focused' ? TooltipType.Follow : TooltipType.VerticalCursor,
           headerFormatter: tooltipFormatter,
         }}
       />

--- a/src/plugins/vis_type_timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_type.ts
@@ -69,6 +69,7 @@ export const metricsVisDefinition = {
       axis_scale: 'normal',
       show_legend: 1,
       show_grid: 1,
+      tooltip_mode: 'show_all',
     },
     component: VisEditor,
   },

--- a/src/plugins/vis_type_timeseries/server/routes/post_vis_schema.ts
+++ b/src/plugins/vis_type_timeseries/server/routes/post_vis_schema.ts
@@ -247,6 +247,9 @@ export const visPayloadSchema = schema.object({
       series: schema.arrayOf(seriesItems),
       show_grid: numberIntegerRequired,
       show_legend: numberIntegerRequired,
+      tooltip_mode: schema.maybe(
+        schema.oneOf([schema.literal('show_all'), schema.literal('show_focused')])
+      ),
       time_field: stringOptionalNullable,
       time_range_mode: stringOptionalNullable,
       type: stringRequired,


### PR DESCRIPTION
## Summary

Fixes #60013. We added a dropdown to the panel options of TSVB in order the user to be able to toggle the tooltip mode. So now the user can also see in the tooltip only the values of the selected datapoint.

<img width="511" alt="Screenshot 2020-05-29 at 6 03 43 PM" src="https://user-images.githubusercontent.com/17003240/83274694-c5b0e800-a1d6-11ea-84d2-2f38749b232c.png">

On the following video we can see the new functionality
![Toggle_Tooltip_Mode_TSVB](https://user-images.githubusercontent.com/17003240/83275225-8fc03380-a1d7-11ea-825a-9152337bfa9b.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [x] This was checked for cross-browser compatibility, (https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)