### PR TITLE
[Ingest Manager] install default packages in parallel

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
@@ -52,22 +52,22 @@ export async function ensureInstalledDefaultPackages(
   const installations = [];
   for (const pkgName in DefaultPackages) {
     if (!DefaultPackages.hasOwnProperty(pkgName)) continue;
-    const installation = await ensureInstalledPackage({
+    const installation = ensureInstalledPackage({
       savedObjectsClient,
       pkgName,
       callCluster,
     });
-    if (installation) installations.push(installation);
+    installations.push(installation);
   }
 
-  return installations;
+  return Promise.all(installations);
 }
 
 export async function ensureInstalledPackage(options: {
   savedObjectsClient: SavedObjectsClientContract;
   pkgName: string;
   callCluster: CallESAsCurrentUser;
-}): Promise<Installation | undefined> {
+}): Promise<Installation> {
   const { savedObjectsClient, pkgName, callCluster } = options;
   const installedPackage = await getInstallation({ savedObjectsClient, pkgName });
   if (installedPackage) {
@@ -79,7 +79,9 @@ export async function ensureInstalledPackage(options: {
     pkgName,
     callCluster,
   });
-  return await getInstallation({ savedObjectsClient, pkgName });
+  const installation = await getInstallation({ savedObjectsClient, pkgName });
+  if (!installation) throw new Error(`could not get installation ${pkgName}`);
+  return installation;
 }
 
 export async function installPackage(options: {


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/66125
In cloud, /setup is taking so long that it times out.  We should continue to try and make more optimizations but this was an obvious one.

- Changes the installation of default packages in setup to be parallel

To test try these changes on master and compare to this branch:
- Restart elasticsearch so no packages are installed
- Refresh Kibana in the browser with devtools open and see the /setup request
- The initial setup requests takes about 9-10 seconds on master and about 6-7 with these changes

Before:
<img width="2560" alt="Screen Shot 2020-06-01 at 3 00 13 PM" src="https://user-images.githubusercontent.com/1676003/83444142-ef595180-a418-11ea-8106-e43cae8df2a0.png">

After:
<img width="2558" alt="Screen Shot 2020-06-01 at 2 48 34 PM" src="https://user-images.githubusercontent.com/1676003/83444145-eff1e800-a418-11ea-8898-fceef08c1ff2.png">

Note: In the screenshots, /setup gets gets called twice in Ingest Manager, so the larger number is the one to look at which happens first