### PR TITLE
[Ingest Manager] Fix datasource validation for streams without vars

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/services/validate_datasource.test.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/services/validate_datasource.test.ts
@@ -184,7 +184,7 @@ describe('Ingest Manager - validateDatasource()', () => {
             vars: { 'var-name': { value: undefined, type: 'text' } },
           },
           {
-            id: 'with-disabled-streams-disabled2',
+            id: 'with-disabled-streams-disabled-without-vars',
             dataset: 'disabled2',
             enabled: false,
           },
@@ -271,7 +271,7 @@ describe('Ingest Manager - validateDatasource()', () => {
             },
           },
           {
-            id: 'with-disabled-streams-disabled2',
+            id: 'with-disabled-streams-disabled-without-vars',
             dataset: 'disabled2',
             enabled: false,
           },
@@ -318,7 +318,7 @@ describe('Ingest Manager - validateDatasource()', () => {
           'with-disabled-streams-disabled': {
             vars: { 'var-name': null },
           },
-          'with-disabled-streams-disabled2': {},
+          'with-disabled-streams-disabled-without-vars': {},
         },
       },
       'with-no-stream-vars': {
@@ -360,7 +360,7 @@ describe('Ingest Manager - validateDatasource()', () => {
         'with-disabled-streams': {
           streams: {
             'with-disabled-streams-disabled': { vars: { 'var-name': null } },
-            'with-disabled-streams-disabled2': {},
+            'with-disabled-streams-disabled-without-vars': {},
           },
         },
         'with-no-stream-vars': {
@@ -418,7 +418,7 @@ describe('Ingest Manager - validateDatasource()', () => {
             'with-disabled-streams-disabled': {
               vars: { 'var-name': null },
             },
-            'with-disabled-streams-disabled2': {},
+            'with-disabled-streams-disabled-without-vars': {},
           },
         },
         'with-no-stream-vars': {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/services/validate_datasource.test.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/services/validate_datasource.test.ts
@@ -106,6 +106,18 @@ describe('Ingest Manager - validateDatasource()', () => {
               { dataset: 'disabled2', input: 'disabled2', title: 'Disabled 2', enabled: false },
             ],
           },
+          {
+            type: 'with-no-stream-vars',
+            enabled: true,
+            vars: [{ required: true, name: 'var-name', type: 'text' }],
+            streams: [
+              {
+                id: 'with-no-stream-vars-bar',
+                dataset: 'bar',
+                enabled: true,
+              },
+            ],
+          },
         ],
       },
     ],
@@ -175,6 +187,20 @@ describe('Ingest Manager - validateDatasource()', () => {
             id: 'with-disabled-streams-disabled2',
             dataset: 'disabled2',
             enabled: false,
+          },
+        ],
+      },
+      {
+        type: 'with-no-stream-vars',
+        enabled: true,
+        vars: {
+          'var-name': { value: 'test', type: 'text' },
+        },
+        streams: [
+          {
+            id: 'with-no-stream-vars-bar',
+            dataset: 'bar',
+            enabled: true,
           },
         ],
       },
@@ -251,6 +277,20 @@ describe('Ingest Manager - validateDatasource()', () => {
           },
         ],
       },
+      {
+        type: 'with-no-stream-vars',
+        enabled: true,
+        vars: {
+          'var-name': { value: undefined, type: 'text' },
+        },
+        streams: [
+          {
+            id: 'with-no-stream-vars-bar',
+            dataset: 'bar',
+            enabled: true,
+          },
+        ],
+      },
     ],
   };
 
@@ -274,7 +314,18 @@ describe('Ingest Manager - validateDatasource()', () => {
         },
       },
       'with-disabled-streams': {
-        streams: { 'with-disabled-streams-disabled': { vars: { 'var-name': null } } },
+        streams: {
+          'with-disabled-streams-disabled': {
+            vars: { 'var-name': null },
+          },
+          'with-disabled-streams-disabled2': {},
+        },
+      },
+      'with-no-stream-vars': {
+        streams: {
+          'with-no-stream-vars-bar': {},
+        },
+        vars: { 'var-name': null },
       },
     },
   };
@@ -307,7 +358,16 @@ describe('Ingest Manager - validateDatasource()', () => {
           },
         },
         'with-disabled-streams': {
-          streams: { 'with-disabled-streams-disabled': { vars: { 'var-name': null } } },
+          streams: {
+            'with-disabled-streams-disabled': { vars: { 'var-name': null } },
+            'with-disabled-streams-disabled2': {},
+          },
+        },
+        'with-no-stream-vars': {
+          vars: {
+            'var-name': ['var-name is required'],
+          },
+          streams: { 'with-no-stream-vars-bar': {} },
         },
       },
     });
@@ -354,7 +414,18 @@ describe('Ingest Manager - validateDatasource()', () => {
           },
         },
         'with-disabled-streams': {
-          streams: { 'with-disabled-streams-disabled': { vars: { 'var-name': null } } },
+          streams: {
+            'with-disabled-streams-disabled': {
+              vars: { 'var-name': null },
+            },
+            'with-disabled-streams-disabled2': {},
+          },
+        },
+        'with-no-stream-vars': {
+          vars: {
+            'var-name': ['var-name is required'],
+          },
+          streams: { 'with-no-stream-vars-bar': {} },
         },
       },
     });

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/services/validate_datasource.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/services/validate_datasource.ts
@@ -110,36 +110,31 @@ export const validateDatasource = (
     // Validate each input stream with config fields
     if (input.streams.length) {
       input.streams.forEach((stream) => {
-        if (!stream.vars) {
-          return;
-        }
-
-        const streamValidationResults: DatasourceConfigValidationResults = {
-          vars: undefined,
-        };
-
-        const streamVarsByName = (
-          (
-            registryInputsByType[input.type].streams.find(
-              (registryStream) => registryStream.dataset === stream.dataset
-            ) || {}
-          ).vars || []
-        ).reduce((vars, registryVar) => {
-          vars[registryVar.name] = registryVar;
-          return vars;
-        }, {} as Record<string, RegistryVarsEntry>);
+        const streamValidationResults: DatasourceConfigValidationResults = {};
 
         // Validate stream-level config fields
-        streamValidationResults.vars = Object.entries(stream.vars).reduce(
-          (results, [name, configEntry]) => {
-            results[name] =
-              input.enabled && stream.enabled
-                ? validateDatasourceConfig(configEntry, streamVarsByName[name])
-                : null;
-            return results;
-          },
-          {} as ValidationEntry
-        );
+        if (stream.vars) {
+          const streamVarsByName = (
+            (
+              registryInputsByType[input.type].streams.find(
+                (registryStream) => registryStream.dataset === stream.dataset
+              ) || {}
+            ).vars || []
+          ).reduce((vars, registryVar) => {
+            vars[registryVar.name] = registryVar;
+            return vars;
+          }, {} as Record<string, RegistryVarsEntry>);
+          streamValidationResults.vars = Object.entries(stream.vars).reduce(
+            (results, [name, configEntry]) => {
+              results[name] =
+                input.enabled && stream.enabled
+                  ? validateDatasourceConfig(configEntry, streamVarsByName[name])
+                  : null;
+              return results;
+            },
+            {} as ValidationEntry
+          );
+        }
 
         inputValidationResults.streams![stream.id] = streamValidationResults;
       });
@@ -228,5 +223,6 @@ export const validationHasErrors = (
     | DatasourceConfigValidationResults
 ) => {
   const flattenedValidation = getFlattenedObject(validationResults);
+
   return !!Object.entries(flattenedValidation).find(([, value]) => !!value);
 };


### PR DESCRIPTION
## Summary

Resolve #67938 

Fix a type error when we validate a datasource with input variables but no stream variables.
How I fixed this? I added the stream to the validation results even if there is no variables for that stream.

<img width="916" alt="Screen Shot 2020-06-02 at 9 51 30 AM" src="https://user-images.githubusercontent.com/1336873/83528164-c5ef0300-a4b6-11ea-8196-1434a858cc88.png">


How to test this?

You can try to add|edit the datasource AWS, if you do not put a Queue URL you should have an error otherwise it should work.



