### PR TITLE
Fix code coverage for jest, upload merged reports

### DIFF
--- a/.ci/Jenkinsfile_coverage
+++ b/.ci/Jenkinsfile_coverage
@@ -23,6 +23,8 @@ def handleIngestion(timestamp) {
   kibanaPipeline.downloadCoverageArtifacts()
   kibanaCoverage.prokLinks("### Process HTML Links")
   kibanaCoverage.collectVcsInfo("### Collect VCS Info")
+  kibanaCoverage.generateReports("### Merge coverage reports")
+  kibanaCoverage.uploadCombinedReports()
   kibanaCoverage.ingest(timestamp, '### Injest && Upload')
   kibanaCoverage.uploadCoverageStaticSite(timestamp)
 }

--- a/src/dev/code_coverage/shell_scripts/fix_html_reports_parallel.sh
+++ b/src/dev/code_coverage/shell_scripts/fix_html_reports_parallel.sh
@@ -7,7 +7,13 @@ COMBINED_EXRACT_DIR=/${EXTRACT_START_DIR}/${EXTRACT_END_DIR}
 PWD=$(pwd)
 du -sh $COMBINED_EXRACT_DIR
 
-echo "### Replacing path in json files"
+echo "### Jest: replacing path in json files"
+for i in coverage-final xpack-coverage-final;  do
+  sed -i "s|/dev/shm/workspace/kibana|${PWD}|g" $COMBINED_EXRACT_DIR/jest/${i}.json &
+done
+wait
+
+echo "### Functional: replacing path in json files"
 for i in {1..9}; do
   sed -i "s|/dev/shm/workspace/kibana|${PWD}|g" $COMBINED_EXRACT_DIR/functional/${i}*.json &
 done


### PR DESCRIPTION
## Summary

With #67676 being merged jest coverage report contains paths with `/dev/shm/workspace/kibana` prefix and we need to replace it with actual path to Kibana sources before running oss/xpack json merge.

To make investigation easier next time, we upload merged reports to build artifacts. If ingestion fails, we can quickly check what were the input files.

Related code coverage job: [768](https://kibana-ci.elastic.co/job/elastic+kibana+code-coverage/768/) passed