### PR TITLE
[APM] Fixes e2e testing by matching stack version with kibana

### DIFF
--- a/x-pack/plugins/apm/e2e/run-e2e.sh
+++ b/x-pack/plugins/apm/e2e/run-e2e.sh
@@ -23,6 +23,8 @@ APM_IT_DIR="./tmp/apm-integration-testing"
 
 cd ${E2E_DIR}
 
+KIBANA_VERSION=$(node -p "require('../../../package.json').version")
+
 #
 # Ask user to start Kibana
 ##################################################
@@ -63,7 +65,8 @@ fi
 
 # Start apm-integration-testing
 echo "Starting docker-compose"
-${APM_IT_DIR}/scripts/compose.py start master \
+echo "Using stack version: ${KIBANA_VERSION}"
+${APM_IT_DIR}/scripts/compose.py start $KIBANA_VERSION \
     --no-kibana \
     --elasticsearch-port $ELASTICSEARCH_PORT \
     --apm-server-port=$APM_SERVER_PORT \


### PR DESCRIPTION
Closes #68055 by detecting the local Kibana version and using that as the stack version for e2e tests.