### PR TITLE
[Ingest Manager] Fix agent stream to support optionnal yaml root values

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.test.ts
@@ -83,4 +83,22 @@ foo: bar
       custom: { foo: 'bar' },
     });
   });
+
+  it('should support optionnal yaml values ar root level', () => {
+    const streamTemplate = `
+input: logs
+{{custom}}
+    `;
+    const vars = {
+      custom: {
+        type: 'yaml',
+        value: null,
+      },
+    };
+
+    const output = createStream(vars, streamTemplate);
+    expect(output).toEqual({
+      input: 'logs',
+    });
+  });
 });

--- a/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.test.ts
@@ -84,7 +84,7 @@ foo: bar
     });
   });
 
-  it('should support optionnal yaml values ar root level', () => {
+  it('should support optional yaml values at root level', () => {
     const streamTemplate = `
 input: logs
 {{custom}}

--- a/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.ts
@@ -94,7 +94,10 @@ function replaceRootLevelYamlVariables(yamlVariables: { [k: string]: any }, yaml
 
   let patchedTemplate = yamlTemplate;
   Object.entries(yamlVariables).forEach(([key, val]) => {
-    patchedTemplate = patchedTemplate.replace(new RegExp(`^"${key}"`, 'gm'), safeDump(val));
+    patchedTemplate = patchedTemplate.replace(
+      new RegExp(`^"${key}"`, 'gm'),
+      val ? safeDump(val) : ''
+    );
   });
 
   return patchedTemplate;


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/integrations/issues/58

This allow to support yaml template like this (where custom could be optionnal)
```yaml
type: logs
{{custom}}
```

@ruflin You can also have this template working without this PR  if you write it like this:
```yaml
type: logs
{{#if custom}}
{{custom}}
{{/if}
```
But I think we should try to be the more robust possible in kibana.
