### PR TITLE
[Reporting] Adds the enabled key to schema

### DIFF
--- a/x-pack/plugins/reporting/server/config/schema.ts
+++ b/x-pack/plugins/reporting/server/config/schema.ts
@@ -162,6 +162,7 @@ const PollSchema = schema.object({
 });
 
 export const ConfigSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: true }),
   kibanaServer: KibanaServerSchema,
   queue: QueueSchema,
   capture: CaptureSchema,


### PR DESCRIPTION
## Summary

Going along with https://github.com/elastic/kibana/pull/60998, Reporting plugin needs the schema to have the `enabled` config option defined. 

Before, having xpack.reporting.enabled: false would cause Kibana startup to fail with an unrecognized config error.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
