### PR TITLE
[7.x] [Ingest Manager] Fix agent stream to support optionnal yaml root values (#68272)

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.test.ts
@@ -83,4 +83,22 @@ foo: bar
       custom: { foo: 'bar' },
     });
   });
+
+  it('should support optional yaml values at root level', () => {
+    const streamTemplate = `
+input: logs
+{{custom}}
+    `;
+    const vars = {
+      custom: {
+        type: 'yaml',
+        value: null,
+      },
+    };
+
+    const output = createStream(vars, streamTemplate);
+    expect(output).toEqual({
+      input: 'logs',
+    });
+  });
 });

--- a/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/agent/agent.ts
@@ -94,7 +94,10 @@ function replaceRootLevelYamlVariables(yamlVariables: { [k: string]: any }, yaml
 
   let patchedTemplate = yamlTemplate;
   Object.entries(yamlVariables).forEach(([key, val]) => {
-    patchedTemplate = patchedTemplate.replace(new RegExp(`^"${key}"`, 'gm'), safeDump(val));
+    patchedTemplate = patchedTemplate.replace(
+      new RegExp(`^"${key}"`, 'gm'),
+      val ? safeDump(val) : ''
+    );
   });
 
   return patchedTemplate;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Ingest Manager] Fix agent stream to support optionnal yaml root values (#68272)