### PR TITLE
[7.x] [Metrics UI] Handle event.target properly for Legend Controls (#68029)

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/legend_controls.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/legend_controls.tsx
@@ -141,14 +141,16 @@ export const LegendControls = ({
 
   const handleStepsChange = useCallback(
     (e) => {
-      setLegendOptions((previous) => ({ ...previous, steps: parseInt(e.target.value, 10) }));
+      const steps = parseInt(e.target.value, 10);
+      setLegendOptions((previous) => ({ ...previous, steps }));
     },
     [setLegendOptions]
   );
 
   const handlePaletteChange = useCallback(
     (e) => {
-      setLegendOptions((previous) => ({ ...previous, palette: e.target.value }));
+      const palette = e.target.value;
+      setLegendOptions((previous) => ({ ...previous, palette }));
     },
     [setLegendOptions]
   );


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Handle event.target properly for Legend Controls (#68029)