### PR TITLE
[SECURITY SOLUTION] [Detections] Increase lookback when gap is detected

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/__mocks__/es_results.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/__mocks__/es_results.ts
@@ -364,7 +364,7 @@ export const exampleFindRuleStatusResponse: (
   saved_objects: mockStatuses.map((obj) => ({ ...obj, score: 1 })),
 });
 
-export const mockLogger: Logger = loggingSystemMock.createLogger();
+export const mockLogger: ReturnType<typeof loggingServiceMock.createLogger> = loggingServiceMock.createLogger();
 
 export const sampleBulkErrorItem = (
   {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/__mocks__/es_results.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/__mocks__/es_results.ts
@@ -5,8 +5,12 @@
  */
 
 import { SignalSourceHit, SignalSearchResponse, BulkResponse, BulkItem } from '../types';
-import { SavedObject, SavedObjectsFindResponse } from '../../../../../../../../src/core/server';
-import { loggingServiceMock } from '../../../../../../../../src/core/server/mocks';
+import {
+  Logger,
+  SavedObject,
+  SavedObjectsFindResponse,
+} from '../../../../../../../../src/core/server';
+import { loggingSystemMock } from '../../../../../../../../src/core/server/mocks';
 import { RuleTypeParams } from '../../types';
 import { IRuleStatusAttributes } from '../../rules/types';
 import { ruleStatusSavedObjectType } from '../../rules/saved_object_mappings';
@@ -360,7 +364,7 @@ export const exampleFindRuleStatusResponse: (
   saved_objects: mockStatuses.map((obj) => ({ ...obj, score: 1 })),
 });
 
-export const mockLogger: ReturnType<typeof loggingServiceMock.createLogger> = loggingServiceMock.createLogger();
+export const mockLogger: Logger = loggingSystemMock.createLogger();
 
 export const sampleBulkErrorItem = (
   {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/__mocks__/es_results.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/__mocks__/es_results.ts
@@ -5,12 +5,8 @@
  */
 
 import { SignalSourceHit, SignalSearchResponse, BulkResponse, BulkItem } from '../types';
-import {
-  Logger,
-  SavedObject,
-  SavedObjectsFindResponse,
-} from '../../../../../../../../src/core/server';
-import { loggingSystemMock } from '../../../../../../../../src/core/server/mocks';
+import { SavedObject, SavedObjectsFindResponse } from '../../../../../../../../src/core/server';
+import { loggingServiceMock } from '../../../../../../../../src/core/server/mocks';
 import { RuleTypeParams } from '../../types';
 import { IRuleStatusAttributes } from '../../rules/types';
 import { ruleStatusSavedObjectType } from '../../rules/saved_object_mappings';

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_events_query.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_events_query.ts
@@ -84,13 +84,14 @@ export const buildEventsSearchQuery = ({
     },
   };
   if (searchAfterSortId) {
-    return {
+    const thing = {
       ...searchQuery,
       body: {
         ...searchQuery.body,
         search_after: [searchAfterSortId],
       },
     };
+    return thing;
   }
   return searchQuery;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_events_query.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/build_events_query.ts
@@ -84,14 +84,13 @@ export const buildEventsSearchQuery = ({
     },
   };
   if (searchAfterSortId) {
-    const thing = {
+    return {
       ...searchQuery,
       body: {
         ...searchQuery.body,
         search_after: [searchAfterSortId],
       },
     };
-    return thing;
   }
   return searchQuery;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.test.ts
@@ -6,6 +6,7 @@
 
 import uuid from 'uuid';
 import { filterEventsAgainstList } from './filter_events_with_list';
+import { buildRuleMessageFactory } from './rule_messages';
 import { mockLogger, repeatedSearchResultsWithSortId } from './__mocks__/es_results';
 
 import { getExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
@@ -13,7 +14,12 @@ import { getListItemResponseMock } from '../../../../../lists/common/schemas/res
 import { listMock } from '../../../../../lists/server/mocks';
 
 const someGuids = Array.from({ length: 13 }).map((x) => uuid.v4());
-
+const buildRuleMessage = buildRuleMessageFactory({
+  id: 'fake id',
+  ruleId: 'fake rule id',
+  index: 'fakeindex',
+  name: 'fake name',
+});
 describe('filterEventsAgainstList', () => {
   let listClient = listMock.getListClient();
   beforeEach(() => {
@@ -33,6 +39,7 @@ describe('filterEventsAgainstList', () => {
         '3.3.3.3',
         '7.7.7.7',
       ]),
+      buildRuleMessage,
     });
     expect(res.hits.hits.length).toEqual(4);
   });
@@ -57,6 +64,7 @@ describe('filterEventsAgainstList', () => {
         listClient,
         exceptionsList: [exceptionItem],
         eventSearchResult: repeatedSearchResultsWithSortId(4, 4, someGuids.slice(0, 3)),
+        buildRuleMessage,
       });
       expect(res.hits.hits.length).toEqual(4);
     });
@@ -91,6 +99,7 @@ describe('filterEventsAgainstList', () => {
           '3.3.3.3',
           '7.7.7.7',
         ]),
+        buildRuleMessage,
       });
       expect((listClient.getListItemByValues as jest.Mock).mock.calls[0][0].type).toEqual('ip');
       expect((listClient.getListItemByValues as jest.Mock).mock.calls[0][0].listId).toEqual(
@@ -118,6 +127,7 @@ describe('filterEventsAgainstList', () => {
         listClient,
         exceptionsList: [exceptionItem],
         eventSearchResult: repeatedSearchResultsWithSortId(4, 4, someGuids.slice(0, 3)),
+        buildRuleMessage,
       });
       expect(res.hits.hits.length).toEqual(0);
     });
@@ -152,6 +162,7 @@ describe('filterEventsAgainstList', () => {
           '3.3.3.3',
           '7.7.7.7',
         ]),
+        buildRuleMessage,
       });
       expect((listClient.getListItemByValues as jest.Mock).mock.calls[0][0].type).toEqual('ip');
       expect((listClient.getListItemByValues as jest.Mock).mock.calls[0][0].listId).toEqual(

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
@@ -31,7 +31,7 @@ export const filterEventsAgainstList = async ({
   buildRuleMessage,
 }: FilterEventsAgainstList): Promise<SignalSearchResponse> => {
   try {
-    logger.debug(buildRuleMessage(`exceptionsList: ${JSON.stringify(exceptionsList, null, 4)}`));
+    logger.debug(buildRuleMessage(`exceptionsList: ${JSON.stringify(exceptionsList, null, 2)}`));
     if (exceptionsList == null || exceptionsList.length === 0) {
       logger.debug(buildRuleMessage('about to return original search result'));
       return eventSearchResult;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
@@ -28,7 +28,9 @@ export const filterEventsAgainstList = async ({
   eventSearchResult,
 }: FilterEventsAgainstList): Promise<SignalSearchResponse> => {
   try {
+    logger.debug(`exceptionsList: ${JSON.stringify(exceptionsList, null, 4)}`);
     if (exceptionsList == null || exceptionsList.length === 0) {
+      logger.debug('about to return original search result');
       return eventSearchResult;
     }
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
@@ -8,6 +8,7 @@ import { Logger } from 'src/core/server';
 
 import { ListClient } from '../../../../../lists/server';
 import { SignalSearchResponse, SearchTypes } from './types';
+import { BuildRuleMessage } from './rule_messages';
 import {
   entriesList,
   EntryList,
@@ -19,6 +20,7 @@ interface FilterEventsAgainstList {
   exceptionsList: ExceptionListItemSchema[];
   logger: Logger;
   eventSearchResult: SignalSearchResponse;
+  buildRuleMessage: BuildRuleMessage;
 }
 
 export const filterEventsAgainstList = async ({
@@ -26,11 +28,12 @@ export const filterEventsAgainstList = async ({
   exceptionsList,
   logger,
   eventSearchResult,
+  buildRuleMessage,
 }: FilterEventsAgainstList): Promise<SignalSearchResponse> => {
   try {
-    logger.debug(`exceptionsList: ${JSON.stringify(exceptionsList, null, 4)}`);
+    logger.debug(buildRuleMessage(`exceptionsList: ${JSON.stringify(exceptionsList, null, 4)}`));
     if (exceptionsList == null || exceptionsList.length === 0) {
-      logger.debug('about to return original search result');
+      logger.debug(buildRuleMessage('about to return original search result'));
       return eventSearchResult;
     }
 
@@ -88,7 +91,7 @@ export const filterEventsAgainstList = async ({
               return false;
             });
             const diff = eventSearchResult.hits.hits.length - filteredEvents.length;
-            logger.debug(`Lists filtered out ${diff} events`);
+            logger.debug(buildRuleMessage(`Lists filtered out ${diff} events`));
             return filteredEvents;
           });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.test.ts
@@ -223,24 +223,25 @@ describe('searchAfterAndBulkCreate', () => {
         ],
       })
       .mockResolvedValueOnce(sampleDocSearchResultsNoSortIdNoHits());
+
+    const exceptionItem = getExceptionListItemSchemaMock();
+    exceptionItem.entries = [
+      {
+        field: 'source.ip',
+        operator: 'included',
+        type: 'list',
+        list: {
+          id: 'ci-badguys.txt',
+          type: 'ip',
+        },
+      },
+    ];
     const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
       ruleParams: sampleParams,
       gap: moment.duration(2, 'm'),
       previousStartedAt: moment().subtract(10, 'm').toDate(),
       listClient,
-      exceptionsList: [
-        {
-          field: 'source.ip',
-          values_operator: 'included',
-          values_type: 'list',
-          values: [
-            {
-              id: 'ci-badguys.txt',
-              name: 'ip',
-            },
-          ],
-        },
-      ],
+      exceptionsList: [exceptionItem],
       services: mockService,
       logger: mockLogger,
       id: sampleRuleGuid,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.test.ts
@@ -14,12 +14,20 @@ import {
   sampleDocSearchResultsNoSortIdNoHits,
 } from './__mocks__/es_results';
 import { searchAfterAndBulkCreate } from './search_after_bulk_create';
+import { buildRuleMessageFactory } from './rule_messages';
 import { DEFAULT_SIGNALS_INDEX } from '../../../../common/constants';
 import { alertsMock, AlertServicesMock } from '../../../../../alerts/server/mocks';
 import uuid from 'uuid';
 import { getListItemResponseMock } from '../../../../../lists/common/schemas/response/list_item_schema.mock';
 import { listMock } from '../../../../../lists/server/mocks';
 import { getExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
+
+const buildRuleMessage = buildRuleMessageFactory({
+  id: 'fake id',
+  ruleId: 'fake rule id',
+  index: 'fakeindex',
+  name: 'fake name',
+});
 
 describe('searchAfterAndBulkCreate', () => {
   let mockService: AlertServicesMock;
@@ -136,6 +144,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(success).toEqual(true);
     expect(mockService.callCluster).toHaveBeenCalledTimes(9);
@@ -260,6 +269,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(success).toEqual(true);
     expect(mockService.callCluster).toHaveBeenCalledTimes(12);
@@ -338,6 +348,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(success).toEqual(true);
     expect(mockService.callCluster).toHaveBeenCalledTimes(3);
@@ -412,6 +423,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(success).toEqual(true);
     expect(mockService.callCluster).toHaveBeenCalledTimes(3);
@@ -460,6 +472,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(mockLogger.error).toHaveBeenCalled();
     expect(success).toEqual(false);
@@ -514,6 +527,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(success).toEqual(true);
     expect(createdSignalsCount).toEqual(0);
@@ -584,6 +598,7 @@ describe('searchAfterAndBulkCreate', () => {
       refresh: false,
       tags: ['some fake tag 1', 'some fake tag 2'],
       throttle: 'no_actions',
+      buildRuleMessage,
     });
     expect(success).toEqual(false);
     expect(createdSignalsCount).toEqual(0); // should not create signals if search threw error

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -145,19 +145,23 @@ export const searchAfterAndBulkCreate = async ({
           }
         );
         toReturn.searchAfterTimes.push(searchDuration);
-        toReturn.lastLookBackDate =
-          searchResult.hits.hits.length > 0
-            ? new Date(
-                searchResult.hits.hits[searchResult.hits.hits.length - 1]?._source['@timestamp']
-              )
-            : null;
+
         const totalHits =
           typeof searchResult.hits.total === 'number'
             ? searchResult.hits.total
             : searchResult.hits.total.value;
         logger.debug(`totalHits: ${totalHits}`);
         logger.debug(`searchResult.hit.hits.length: ${searchResult.hits.hits.length}`);
-
+        if (totalHits === 0) {
+          toReturn.success = true;
+          break;
+        }
+        toReturn.lastLookBackDate =
+          searchResult.hits.hits.length > 0
+            ? new Date(
+                searchResult.hits.hits[searchResult.hits.hits.length - 1]?._source['@timestamp']
+              )
+            : null;
         searchResultSize += searchResult.hits.hits.length;
 
         // filter out the search results that match with the values found in the list.
@@ -171,7 +175,6 @@ export const searchAfterAndBulkCreate = async ({
                 eventSearchResult: searchResult,
               })
             : searchResult;
-
         if (filteredEvents.hits.total === 0 || filteredEvents.hits.hits.length === 0) {
           // everything in the events were allowed, so no need to generate signals
           toReturn.success = true;
@@ -230,6 +233,5 @@ export const searchAfterAndBulkCreate = async ({
     }
   }
   logger.debug(`[+] completed bulk index of ${toReturn.createdSignalsCount}`);
-  toReturn.success = true;
   return toReturn;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -6,7 +6,6 @@
 /* eslint-disable complexity */
 
 import moment from 'moment';
-import dateMath from '@elastic/datemath';
 
 import { ListAndOrUndefined } from '../../../../common/detection_engine/schemas/common/schemas';
 import { AlertServices } from '../../../../../alerts/server';

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -143,16 +143,15 @@ export const searchAfterAndBulkCreate = async ({
         //  but there is a gap of one minute, then the number of rule executions missed
         // due to the gap are (6 minutes - 5 minutes) / 5 minutes = 0.2 * MAX_SIGNALS = 20 signals allowed.
         // this is to keep our ratio of MAX_SIGNALS : rule intervals equivalent.
-        const gapDiffInSeconds = calculatedFromAsMoment.diff(
+        const gapDiffInUnits = calculatedFromAsMoment.diff(
           dateMath.parse(ruleParams.from),
           shorthandMap[unit].momentString as moment.DurationInputArg2
         );
-        const normalDiffInSeconds = calculatedNowAsMoment.diff(
+        const normalDiffInUnits = calculatedNowAsMoment.diff(
           dateMath.parse(ruleParams.from),
           shorthandMap[unit].momentString as moment.DurationInputArg2
         );
-        const ratio = Math.abs(gapDiffInSeconds / normalDiffInSeconds);
-
+        const ratio = Math.abs(gapDiffInUnits / normalDiffInUnits);
         // maxCatchup is to ensure we are not trying to catch up too far back.
         // This allows for a maximum of 4 consecutive rule execution misses
         // to be included in the number of signals generated.

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -151,7 +151,7 @@ export const searchAfterAndBulkCreate = async ({
           dateMath.parse(ruleParams.from),
           shorthandMap[unit].momentString as moment.DurationInputArg2
         );
-        const ratio = gapDiffInSeconds / normalDiffInSeconds;
+        const ratio = Math.abs(gapDiffInSeconds / normalDiffInSeconds);
 
         // maxCatchup is to ensure we are not trying to catch up too far back.
         // This allows for a maximum of 4 consecutive rule execution misses
@@ -161,7 +161,8 @@ export const searchAfterAndBulkCreate = async ({
         // create a new max results which in the above example equates to
         // 20 signals as the MAX_SIGNALS for the gap duration + our normal MAX_SIGNALS defaulted to 100
         // which comes out to 120 total max signals.
-        maxResults = Math.round(maxCatchup * ruleParams.maxSignals + ruleParams.maxSignals);
+        maxResults = Math.round(maxCatchup * ruleParams.maxSignals) + ruleParams.maxSignals;
+        logger.debug(`new maxResults: ${maxResults}`);
       }
     }
   }
@@ -176,7 +177,7 @@ export const searchAfterAndBulkCreate = async ({
       }: { searchResult: SignalSearchResponse; searchDuration: string } = await singleSearchAfter({
         searchAfterSortId: sortId,
         index: inputIndexPattern,
-        from: ruleParams.from,
+        from: calculatedFrom,
         to: ruleParams.to,
         services,
         logger,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -116,6 +116,7 @@ export const searchAfterAndBulkCreate = async ({
     interval,
   });
   const useSortIds = totalToFromTuples.length <= 1;
+  logger.debug(`totalToFromTuples: ${totalToFromTuples.length}`);
   while (totalToFromTuples.length > 0) {
     const tuple = totalToFromTuples.pop();
     if (tuple == null || tuple.to == null || tuple.from == null) {
@@ -228,10 +229,11 @@ export const searchAfterAndBulkCreate = async ({
       } catch (exc) {
         logger.error(`[-] search_after and bulk threw an error ${exc}`);
         toReturn.success = false;
-        break;
+        return toReturn;
       }
     }
   }
   logger.debug(`[+] completed bulk index of ${toReturn.createdSignalsCount}`);
+  toReturn.success = true;
   return toReturn;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -116,10 +116,6 @@ export const searchAfterAndBulkCreate = async ({
     previousStartedAt,
     interval,
   });
-
-  logger.debug(
-    `${JSON.stringify(totalToFromTuples, (_, value) => (value === 'undefined' ? null : value), 4)}`
-  );
   const useSortIds = totalToFromTuples.length <= 1;
   while (totalToFromTuples.length > 0) {
     const tuple = totalToFromTuples.pop();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -132,12 +132,10 @@ export const searchAfterAndBulkCreate = async ({
       try {
         logger.debug(buildRuleMessage(`sortIds: ${sortId}`));
         const {
-          // @ts-ignore https://github.com/microsoft/TypeScript/issues/35546
           searchResult,
           searchDuration,
         }: { searchResult: SignalSearchResponse; searchDuration: string } = await singleSearchAfter(
           {
-            // @ts-ignore we are using sortId before being assigned but that's ok.
             searchAfterSortId: useSortIds ? sortId : undefined,
             index: inputIndexPattern,
             from: tuple.from.toISOString(),

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -7,7 +7,6 @@
 
 import moment from 'moment';
 
-import { ListAndOrUndefined } from '../../../../common/detection_engine/schemas/common/schemas';
 import { AlertServices } from '../../../../../alerts/server';
 import { ListClient } from '../../../../../lists/server';
 import { RuleAlertAction } from '../../../../common/detection_engine/types';

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -4,6 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import moment from 'moment';
+import dateMath from '@elastic/datemath';
+
+import { ListAndOrUndefined } from '../../../../common/detection_engine/schemas/common/schemas';
 import { AlertServices } from '../../../../../alerts/server';
 import { ListClient } from '../../../../../lists/server';
 import { RuleAlertAction } from '../../../../common/detection_engine/types';
@@ -16,6 +20,8 @@ import { filterEventsAgainstList } from './filter_events_with_list';
 import { ExceptionListItemSchema } from '../../../../../lists/common/schemas';
 
 interface SearchAfterAndBulkCreateParams {
+  gap: moment.Duration | null;
+  previousStartedAt: Date | null | undefined;
   ruleParams: RuleTypeParams;
   services: AlertServices;
   listClient: ListClient | undefined; // TODO: undefined is for temporary development, remove before merged
@@ -49,6 +55,8 @@ export interface SearchAfterAndBulkCreateReturnType {
 
 // search_after through documents and re-index using bulk endpoint.
 export const searchAfterAndBulkCreate = async ({
+  gap,
+  previousStartedAt,
   ruleParams,
   exceptionsList,
   services,
@@ -98,7 +106,65 @@ export const searchAfterAndBulkCreate = async ({
   */
   let maxResults = ruleParams.maxSignals;
 
-  // Get
+  type unitType = 's' | 'm' | 'h';
+  const isValidUnit = (unit: string): unit is unitType => ['s', 'm', 'h'].includes(unit);
+  // add a 'gap' parameter that would add the
+  // 'from' with the 'gap' - need to figure out
+  // how to do datemath with moment.
+  let calculatedFrom = ruleParams.from;
+  if (gap != null && previousStartedAt != null) {
+    const fromUnit = ruleParams.from[ruleParams.from.length - 1];
+    if (isValidUnit(fromUnit)) {
+      const unit = fromUnit; // only seconds (s), minutes (m) or hours (h)
+      const shorthandMap = {
+        s: {
+          momentString: 'seconds',
+          asFn: (duration: moment.Duration) => duration.asSeconds(),
+        },
+        m: {
+          momentString: 'minutes',
+          asFn: (duration: moment.Duration) => duration.asMinutes(),
+        },
+        h: {
+          momentString: 'hours',
+          asFn: (duration: moment.Duration) => duration.asHours(),
+        },
+      };
+      const tempNow = moment();
+      const newFrom = moment.duration(tempNow.diff(previousStartedAt));
+      const parsed = parseInt(shorthandMap[unit].asFn(newFrom).toString(), 10);
+
+      calculatedFrom = `now-${parsed + unit}`;
+      const calculatedFromAsMoment = dateMath.parse(calculatedFrom);
+      const calculatedNowAsMoment = dateMath.parse('now');
+      if (calculatedFromAsMoment != null && calculatedNowAsMoment != null) {
+        // calculate new max signals so that we keep constant max signals per time interval
+        // essentially if the rule is supposed to run every 5 minutes,
+        //  but there is a gap of one minute, then the number of rule executions missed
+        // due to the gap are (6 minutes - 5 minutes) / 5 minutes = 0.2 * MAX_SIGNALS = 20 signals allowed.
+        // this is to keep our ratio of MAX_SIGNALS : rule intervals equivalent.
+        const gapDiffInSeconds = calculatedFromAsMoment.diff(
+          dateMath.parse(ruleParams.from),
+          shorthandMap[unit].momentString as moment.DurationInputArg2
+        );
+        const normalDiffInSeconds = calculatedNowAsMoment.diff(
+          dateMath.parse(ruleParams.from),
+          shorthandMap[unit].momentString as moment.DurationInputArg2
+        );
+        const ratio = gapDiffInSeconds / normalDiffInSeconds;
+
+        // maxCatchup is to ensure we are not trying to catch up too far back.
+        // This allows for a maximum of 4 consecutive rule execution misses
+        // to be included in the number of signals generated.
+        const maxCatchup = ratio < 4 ? ratio : 4;
+
+        // create a new max results which in the above example equates to
+        // 20 signals as the MAX_SIGNALS for the gap duration + our normal MAX_SIGNALS defaulted to 100
+        // which comes out to 120 total max signals.
+        maxResults = Math.round(maxCatchup * ruleParams.maxSignals + ruleParams.maxSignals);
+      }
+    }
+  }
 
   while (searchResultSize < maxResults) {
     try {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -121,6 +121,7 @@ export const signalRulesAlertType = ({
       });
 
       logger.debug(buildRuleMessage('[+] Starting Signal Rule execution'));
+      logger.debug(buildRuleMessage(`interval: ${interval}`));
       await ruleStatusService.goingToRun();
 
       const gap = getGapBetweenRuns({ previousStartedAt, interval, from, to });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -259,6 +259,7 @@ export const signalRulesAlertType = ({
             refresh,
             tags,
             throttle,
+            buildRuleMessage,
           });
         }
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -3,7 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-/* eslint-disable complexity */
 
 /* eslint-disable complexity */
 
@@ -126,7 +125,6 @@ export const signalRulesAlertType = ({
 
       const gap = getGapBetweenRuns({ previousStartedAt, interval, from, to });
       if (gap != null && gap.asMilliseconds() > 0) {
-        // console.log('GAP', gap.humanize());
         const gapString = gap.humanize();
         const gapMessage = buildRuleMessage(
           `${gapString} (${gap.asMilliseconds()}ms) has passed since last rule execution, and signals may have been missed.`,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/single_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/single_bulk_create.ts
@@ -84,6 +84,7 @@ export const singleBulkCreate = async ({
 }: SingleBulkCreateParams): Promise<SingleBulkCreateResponse> => {
   filteredEvents.hits.hits = filterDuplicateRules(id, filteredEvents);
   if (filteredEvents.hits.hits.length === 0) {
+    logger.debug(`all events were duplicates`);
     return { success: true, createdItemsCount: 0 };
   }
   // index documents after creating an ID based on the

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
@@ -33,9 +33,6 @@ import {
   mockLogger,
 } from './__mocks__/es_results';
 
-// @ts-ignore
-const replacer = (_, value) => (value === 'undefined' ? null : value);
-
 describe('utils', () => {
   const anchor = '2020-01-01T06:06:06.666Z';
   const unix = moment(anchor).valueOf();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
@@ -698,6 +698,24 @@ describe('utils', () => {
         expect(moment(item.to).diff(moment(item.from), 's')).toEqual(10);
       });
     });
+
+    // this tests if calculatedFrom in utils.ts:320 parses an int and not a float
+    // if we don't parse as an int, then dateMath.parse will fail
+    // as it doesn't support parsing `now-67.549`, it only supports ints like `now-67`.
+    test('should return five tuples when given a gap with a decimal to ensure no parsing errors', () => {
+      const someTuples = getSignalTimeTuples({
+        logger: mockLogger,
+        gap: moment.duration(67549, 'ms'), // 64 is 5 times the interval + lookback, which will trigger max lookback
+        previousStartedAt: moment().subtract(67549, 'ms').toDate(),
+        interval: '10s',
+        ruleParamsFrom: 'now-13s',
+        ruleParamsTo: 'now',
+        ruleParamsMaxSignals: 20,
+        buildRuleMessage,
+      });
+      expect(someTuples.length).toEqual(5);
+    });
+
     test('should return single tuples when give a negative gap (rule ran sooner than expected)', () => {
       const someTuples = getSignalTimeTuples({
         logger: mockLogger,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { createHash } from 'crypto';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import dateMath from '@elastic/datemath';
 
 import { SavedObjectsClientContract } from '../../../../../../../src/core/server';
@@ -14,6 +14,8 @@ import { EntriesArray, ExceptionListItemSchema } from '../../../../../lists/comm
 import { ListArrayOrUndefined } from '../../../../common/detection_engine/schemas/types/lists';
 import { hasListsFeature } from '../feature_flags';
 import { BulkResponse, BulkResponseErrorAggregation } from './types';
+import { Logger } from '../../../../../../../src/core/server';
+import { RuleTypeParams, RefreshTypes } from '../types';
 
 interface SortExceptionsReturn {
   exceptionsWithValueLists: ExceptionListItemSchema[];
@@ -247,4 +249,191 @@ export const errorAggregator = (
     }
     return accum;
   }, Object.create(null));
+};
+
+export const getSignalTimeTuples = ({
+  logger,
+  ruleParams,
+  gap,
+  previousStartedAt,
+  interval,
+}: // maxResults,
+{
+  logger: Logger;
+  ruleParams: RuleTypeParams;
+  gap: moment.Duration | null;
+  previousStartedAt: Date | null | undefined;
+  interval: string;
+  // maxResults: number;
+}): Array<{
+  to: moment.Moment | undefined;
+  from: moment.Moment | undefined;
+  maxSignals: number;
+}> => {
+  type unitType = 's' | 'm' | 'h';
+  const isValidUnit = (unit: string): unit is unitType => ['s', 'm', 'h'].includes(unit);
+  // add a 'gap' parameter that would add the
+  // 'from' with the 'gap' - need to figure out
+  // how to do datemath with moment.
+  let calculatedFrom = ruleParams.from;
+  let totalToFromTuples: Array<{
+    to: moment.Moment | undefined;
+    from: moment.Moment | undefined;
+    maxSignals: number;
+  }> = [];
+  if (gap != null && previousStartedAt != null) {
+    const fromUnit = ruleParams.from[ruleParams.from.length - 1];
+    if (isValidUnit(fromUnit)) {
+      const unit = fromUnit; // only seconds (s), minutes (m) or hours (h)
+      const shorthandMap = {
+        s: {
+          momentString: 'seconds',
+          asFn: (duration: moment.Duration) => duration.asSeconds(),
+        },
+        m: {
+          momentString: 'minutes',
+          asFn: (duration: moment.Duration) => duration.asMinutes(),
+        },
+        h: {
+          momentString: 'hours',
+          asFn: (duration: moment.Duration) => duration.asHours(),
+        },
+      };
+      const tempNow = moment();
+      // const newFrom = moment.duration(300, 's');
+      const newFrom = moment.duration(tempNow.diff(previousStartedAt));
+      logger.debug(`newFrom: ${newFrom.asSeconds()}`);
+      const parsed = parseInt(shorthandMap[unit].asFn(newFrom).toString(), 10);
+
+      calculatedFrom = `now-${parsed + unit}`;
+      logger.debug(`calculatedFrom: ${calculatedFrom}`);
+      const intervalMoment = moment.duration(parseInt(interval, 10), unit);
+      const calculatedFromAsMoment = dateMath.parse(calculatedFrom);
+      const calculatedNowAsMoment = dateMath.parse('now');
+      if (
+        calculatedFromAsMoment != null &&
+        calculatedNowAsMoment != null &&
+        intervalMoment != null
+      ) {
+        // calculate new max signals so that we keep constant max signals per time interval
+        // essentially if the rule is supposed to run every 5 minutes,
+        //  but there is a gap of one minute, then the number of rule executions missed
+        // due to the gap are (6 minutes - 5 minutes) / 5 minutes = 0.2 * MAX_SIGNALS = 20 signals allowed.
+        // this is to keep our ratio of MAX_SIGNALS : rule intervals equivalent.
+        const dateMathRuleParamsFrom = dateMath.parse(ruleParams.from);
+        const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
+        logger.debug(
+          `calculatedFromAsMoment: ${calculatedFromAsMoment.toISOString()}, calculatedNowAsMoment: ${calculatedNowAsMoment.toISOString()}`
+        );
+        const gapDiffInUnits = calculatedFromAsMoment.diff(dateMathRuleParamsFrom, momentUnit);
+        // I think we can replace this with the interval?
+        const normalDiffInUnits = calculatedNowAsMoment.diff(dateMathRuleParamsFrom, momentUnit);
+
+        logger.debug(`gapDiffInUnits: ${gapDiffInUnits}, normalDiffInUnits: ${normalDiffInUnits}`);
+        // make an array that represents the number of intervals of (to, from) tuples
+        const ratio = Math.abs(gapDiffInUnits / normalDiffInUnits);
+        // maxCatchup is to ensure we are not trying to catch up too far back.
+        // This allows for a maximum of 4 consecutive rule execution misses
+        // to be included in the number of signals generated.
+        const maxCatchup = ratio < 4 ? ratio : 4;
+
+        // take the `xunit` from the `now-xunit` datemath string and append another interval
+        // to the `x`
+        /*
+        basic algorithm will be a recurrence relation such that
+        the end point for one range becomes the start point for
+        the next range. subtract the intervalMoment from the `to` field
+        to get the next `from`, then on the next iteration, set the `to` field
+        to be the `from` field, then subtract intervalMoment from the `to` field to get
+        the next `from` field, then on the next iteration, set the `to` field
+        to be the `from` field, then subtract the intervalMoment from the `to field to get
+        the next `from` field.
+        */
+        // let tempFrom = dateMath.parse(ruleParams.from);
+        // let tempFrom;
+        let tempTo = dateMath.parse(ruleParams.from);
+        if (tempTo == null) {
+          // return an error
+          throw new Error('dateMath parse failed');
+        }
+        // totalToFromTuples.push({ to: tempTo, from: tempFrom });
+        // consider re-writing as a reduce function?
+        // maybe in a separate utils file?
+        // this way it is easier to test?
+        // but then again I'll be testing timestamps which is ANNOYING
+        // UGH
+        // I guess the way I would test this is ensure the returned
+        // length of totalToFromTuples is greater than 0
+        // and all the `to` and `from` values in each tuple
+        // are differentiated by the given `intervalMoment`.
+        // this way I am not strictly checking for timestamps
+        // but the difference between the two.
+        // subtracting 1 from the length because we start out with the
+        // normal interval tuple, so don't include as part of the
+        // maxCatchup.
+        logger.debug(`maxCatchup: ${maxCatchup}`);
+        let beforeMutatedFrom: moment.Moment | undefined;
+        while (totalToFromTuples.length < maxCatchup) {
+          // if maxCatchup is less than 1, we calculate the 'from' differently
+          // and maxSignals becomes some less amount of maxSignals
+          // in order to maintain maxSignals per full rule interval.
+          if (maxCatchup > 0 && maxCatchup < 1) {
+            totalToFromTuples.push({
+              to: moment(tempTo),
+              from: moment(tempTo.subtract(Math.abs(gapDiffInUnits), momentUnit)),
+              maxSignals: ruleParams.maxSignals * maxCatchup,
+            });
+            break;
+          }
+          logger.debug(`tempTo: ${tempTo.toISOString()}`);
+          const beforeMutatedTo = tempTo.clone(); // make a new moment
+          const tempToClone = tempTo.clone();
+          logger.debug(`intervalMoment: ${intervalMoment.asSeconds()}`);
+          beforeMutatedFrom = moment(tempToClone.subtract(intervalMoment, momentUnit));
+          const tuple = {
+            to: beforeMutatedTo,
+            from: beforeMutatedFrom,
+            maxSignals: ruleParams.maxSignals,
+          };
+          logger.debug(
+            `tuple: ${JSON.stringify(
+              tuple,
+              (_, value) => (typeof value === 'undefined' ? null : value),
+              4
+            )}`
+          );
+          totalToFromTuples = [...totalToFromTuples, tuple];
+          logger.debug(
+            `totalToFromTuples: ${JSON.stringify(
+              totalToFromTuples,
+              (_, value) => (typeof value === 'undefined' ? null : value),
+              4
+            )}`
+          );
+          tempTo = beforeMutatedFrom;
+        }
+        totalToFromTuples = [
+          {
+            to: dateMath.parse(ruleParams.to),
+            from: dateMath.parse(ruleParams.from),
+            maxSignals: ruleParams.maxSignals,
+          },
+          ...totalToFromTuples,
+        ];
+
+        // create a new max results which in the above example equates to
+        // 20 signals as the MAX_SIGNALS for the gap duration + our normal MAX_SIGNALS defaulted to 100
+        // which comes out to 120 total max signals.
+        // maxResults = Math.round(maxCatchup * ruleParams.maxSignals) + ruleParams.maxSignals;
+        // logger.debug(`new maxResults: ${maxResults}`);
+      }
+    }
+  } else {
+    totalToFromTuples.push({
+      to: moment(ruleParams.to),
+      from: moment(ruleParams.from),
+      maxSignals: ruleParams.maxSignals,
+    });
+  }
+  return totalToFromTuples;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -289,7 +289,7 @@ export const getSignalTimeTuples = ({
     from: moment.Moment | undefined;
     maxSignals: number;
   }> = [];
-  if (gap != null && gap > 0 && previousStartedAt != null) {
+  if (gap != null && gap.asMilliseconds() > 0 && previousStartedAt != null) {
     const fromUnit = ruleParamsFrom[ruleParamsFrom.length - 1];
     if (isValidUnit(fromUnit)) {
       const unit = fromUnit; // only seconds (s), minutes (m) or hours (h)

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -15,7 +15,6 @@ import { ListArrayOrUndefined } from '../../../../common/detection_engine/schema
 import { hasListsFeature } from '../feature_flags';
 import { BulkResponse, BulkResponseErrorAggregation } from './types';
 import { Logger } from '../../../../../../../src/core/server';
-import { RuleTypeParams } from '../types';
 
 interface SortExceptionsReturn {
   exceptionsWithValueLists: ExceptionListItemSchema[];

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -7,14 +7,13 @@ import { createHash } from 'crypto';
 import moment from 'moment';
 import dateMath from '@elastic/datemath';
 
-import { SavedObjectsClientContract } from '../../../../../../../src/core/server';
+import { Logger, SavedObjectsClientContract } from '../../../../../../../src/core/server';
 import { AlertServices, parseDuration } from '../../../../../alerts/server';
 import { ExceptionListClient, ListClient, ListPluginSetup } from '../../../../../lists/server';
 import { EntriesArray, ExceptionListItemSchema } from '../../../../../lists/common/schemas';
 import { ListArrayOrUndefined } from '../../../../common/detection_engine/schemas/types/lists';
 import { hasListsFeature } from '../feature_flags';
 import { BulkResponse, BulkResponseErrorAggregation } from './types';
-import { Logger } from '../../../../../../../src/core/server';
 
 interface SortExceptionsReturn {
   exceptionsWithValueLists: ExceptionListItemSchema[];

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -289,7 +289,7 @@ export const getSignalTimeTuples = ({
     from: moment.Moment | undefined;
     maxSignals: number;
   }> = [];
-  if (gap != null && previousStartedAt != null) {
+  if (gap != null && gap > 0 && previousStartedAt != null) {
     const fromUnit = ruleParamsFrom[ruleParamsFrom.length - 1];
     if (isValidUnit(fromUnit)) {
       const unit = fromUnit; // only seconds (s), minutes (m) or hours (h)

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -337,9 +337,6 @@ export const getSignalTimeTuples = ({
         // this is to keep our ratio of MAX_SIGNALS : rule intervals equivalent.
         const dateMathRuleParamsFrom = dateMath.parse(ruleParamsFrom);
         const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
-        logger.debug(
-          `calculatedFromAsMoment: ${calculatedFromAsMoment.toISOString()}, calculatedNowAsMoment: ${calculatedNowAsMoment.toISOString()}`
-        );
         const gapDiffInUnits = calculatedFromAsMoment.diff(dateMathRuleParamsFrom, momentUnit);
 
         // make an array that represents the number of intervals of (to, from) tuples


### PR DESCRIPTION
## Summary

Gap detection remediation strategy option 1 from [this discussion](https://docs.google.com/document/d/1rv-cIV4dbP4yAjEQFkrkBTl4Hh3EQ571sTSzIBuYgY8/edit)


When gaps occur in detections we need to make sure that we generate ~~signals~~ alerts during those gaps, if such alerts exist. In order to do this I have added a function to determine how many discrete time periods (not exceeding the rule interval) to search, given a gap duration. We then iterate over these time period 'tuples' to do an exclusive search and bulk create over each gapped rule interval. My hope is this will resolve the issue of not creating alerts during a gap period even if we search over it.


This implementation also caps the number of full rule interval gaps at 4. If a gap equivalent to more than 4 missed rule executions is present, the rule executor will not look at events that occurred more than 4 rule intervals back in search.

For example if a rule runs every 5 minutes, but has not run in the past 25 minutes, we will only look at the last 20 minutes so as to cap how much data we are looking back so we attempt to prevent search timeouts from occurring. Obviously this method is still open to discussion if there are proposals / addendums people think would be good.

Because we are still preventing the executor from searching a gap greater than 4 full rule interval runs, it is still possible even more alerts will be missed. So we are keeping the alert in the "failed" state when a gap is detected in order to alert the analyst of the existence of the gap, despite our attempts at resolving the gap. From there the analyst could determine if task manager is overextended or if they just need to manually adjust their cluster settings.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenario

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
