### PR TITLE
[SECURITY SOLUTION] [Detections] Fixes bug where rule failed to run on first execution

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_bulk_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_bulk_route.ts
@@ -118,7 +118,7 @@ export const createRulesBulkRoute = (router: IRouter, ml: SetupPlugins['ml']) =>
                 alertsClient,
                 anomalyThreshold,
                 description,
-                enabled,
+                enabled: false,
                 falsePositives,
                 from,
                 immutable: false,
@@ -158,6 +158,8 @@ export const createRulesBulkRoute = (router: IRouter, ml: SetupPlugins['ml']) =>
                 throttle,
                 name,
               });
+
+              await alertsClient.enable({ id: createdRule.id });
 
               return transformValidateBulkError(ruleIdOrUuid, createdRule, ruleActions);
             } catch (err) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_bulk_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_bulk_route.ts
@@ -160,6 +160,7 @@ export const createRulesBulkRoute = (router: IRouter, ml: SetupPlugins['ml']) =>
               });
 
               await alertsClient.enable({ id: createdRule.id });
+              createdRule.enabled = true;
 
               return transformValidateBulkError(ruleIdOrUuid, createdRule, ruleActions);
             } catch (err) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
@@ -144,6 +144,7 @@ export const createRulesRoute = (router: IRouter, ml: SetupPlugins['ml']): void 
 
         // enable rule here.
         await alertsClient.enable({ id: createdRule.id });
+        createdRule.enabled = true;
 
         const ruleStatuses = await ruleStatusSavedObjectsClientFactory(savedObjectsClient).find({
           perPage: 1,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
@@ -101,7 +101,7 @@ export const createRulesRoute = (router: IRouter, ml: SetupPlugins['ml']): void 
           alertsClient,
           anomalyThreshold,
           description,
-          enabled,
+          enabled: false, // enable the rule down the line, so it doesn't start running until after notifications / actions have had api keys updated
           falsePositives,
           from,
           immutable: false,
@@ -141,6 +141,9 @@ export const createRulesRoute = (router: IRouter, ml: SetupPlugins['ml']): void 
           throttle,
           name,
         });
+
+        // enable rule here.
+        await alertsClient.enable({ id: createdRule.id });
 
         const ruleStatuses = await ruleStatusSavedObjectsClientFactory(savedObjectsClient).find({
           perPage: 1,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules_notifications.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules_notifications.ts
@@ -46,7 +46,7 @@ export const updateRulesNotifications = async ({
   });
 
   // TODO: Workaround for https://github.com/elastic/kibana/issues/67290
-  // await alertsClient.updateApiKey({ id: ruleAlertId });
+  await alertsClient.updateApiKey({ id: ruleAlertId });
 
   return ruleActions;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules_notifications.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules_notifications.ts
@@ -45,8 +45,5 @@ export const updateRulesNotifications = async ({
     interval: ruleActions.alertThrottle,
   });
 
-  // TODO: Workaround for https://github.com/elastic/kibana/issues/67290
-  await alertsClient.updateApiKey({ id: ruleAlertId });
-
   return ruleActions;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules_notifications.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rules/update_rules_notifications.ts
@@ -45,5 +45,8 @@ export const updateRulesNotifications = async ({
     interval: ruleActions.alertThrottle,
   });
 
+  // TODO: Workaround for https://github.com/elastic/kibana/issues/67290
+  // await alertsClient.updateApiKey({ id: ruleAlertId });
+
   return ruleActions;
 };

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/create_rules.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import uuid from 'uuid';
 import expect from '@kbn/expect';
 
 import {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/find_statuses.ts
@@ -60,8 +60,8 @@ export default ({ getService }: FtrProviderContext): void => {
         .send({ ids: [resBody.id] })
         .expect(200);
 
-      // expected result for status should be 'going to run' or 'succeeded
-      expect(['succeeded', 'going to run']).to.contain(body[resBody.id].current_status.status);
+      // expected result for status should be 'succeeded
+      expect(body[resBody.id].current_status.status).to.eql('succeeded');
     });
   });
 };


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/siem-team/issues/697

Source of the error was the addition of `updateApiKey` https://github.com/elastic/kibana/pull/67364 which would invalidate the api key of the rule as it was running or before it could start running which would yield the errors displayed in the above issue.

The fix involves creating the rule as disabled first, so that the task manager does not pick it up until after the actions are updated inside of https://github.com/patrykkopycinski/kibana/blob/f7e8c597b16756b2af15e81dfa0695d3d890c619/x-pack/plugins/siem/server/lib/detection_engine/rules/update_rules_notifications.ts

and the call to `updateApiKey` is executed. After this, we enable the rule which will allow task manager to pick up the rule and begin executing, this time with a new api key.

I have an idea that this PR may actually allow us to remove the `updateApiKey` call inside of https://github.com/patrykkopycinski/kibana/blob/f7e8c597b16756b2af15e81dfa0695d3d890c619/x-pack/plugins/siem/server/lib/detection_engine/rules/update_rules_notifications.ts since it will generate a new api key when it enables the rule. I will test that out later. Wanted to get feedback on this method first before changing anything further.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
