### PR TITLE
APM TypeScript improvements

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -103,7 +103,7 @@ const ErrorGroupList: React.FC<Props> = (props) => {
         }),
         field: 'type',
         sortable: false,
-        render: (type: string, item: ErrorGroupListAPIResponse[0]) => {
+        render: (type: string) => {
           return (
             <ErrorLink
               title={type}

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/SettingsPage/SettingsPage.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/SettingsPage/SettingsPage.tsx
@@ -39,7 +39,7 @@ import { getOptionLabel } from '../../../../../../../common/agent_configuration/
 
 function removeEmpty<T>(obj: T): T {
   return Object.fromEntries(
-    Object.entries(obj).filter(([k, v]) => v != null && v !== '')
+    Object.entries(obj).filter(([_, v]) => v != null && v !== '')
   );
 }
 

--- a/x-pack/plugins/apm/public/components/shared/ErrorRateAlertTrigger/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ErrorRateAlertTrigger/index.stories.tsx
@@ -8,7 +8,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { ErrorRateAlertTrigger } from '.';
 
-storiesOf('app/ErrorRateAlertTrigger', module).add('example', (props) => {
+storiesOf('app/ErrorRateAlertTrigger', module).add('example', () => {
   const params = {
     threshold: 2,
     window: '5m',

--- a/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/StickyProperties/index.tsx
@@ -69,7 +69,6 @@ function getPropertyLabel({ fieldName, label }: Partial<IStickyProperty>) {
 
 function getPropertyValue({
   val,
-  fieldName,
   truncated = false,
 }: Partial<IStickyProperty>) {
   if (truncated) {

--- a/x-pack/plugins/apm/public/components/shared/TransactionDurationAlertTrigger/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionDurationAlertTrigger/index.stories.tsx
@@ -14,37 +14,34 @@ import {
 import { MockUrlParamsContextProvider } from '../../../context/UrlParamsContext/MockUrlParamsContextProvider';
 import { ApmPluginContextValue } from '../../../context/ApmPluginContext';
 
-storiesOf('app/TransactionDurationAlertTrigger', module).add(
-  'example',
-  (context) => {
-    const params = {
-      threshold: 1500,
-      aggregationType: 'avg' as const,
-      window: '5m',
-    };
+storiesOf('app/TransactionDurationAlertTrigger', module).add('example', () => {
+  const params = {
+    threshold: 1500,
+    aggregationType: 'avg' as const,
+    window: '5m',
+  };
 
-    const contextMock = (merge(cloneDeep(mockApmPluginContextValue), {
-      core: {
-        http: {
-          get: () => {
-            return Promise.resolve({ transactionTypes: ['request'] });
-          },
+  const contextMock = (merge(cloneDeep(mockApmPluginContextValue), {
+    core: {
+      http: {
+        get: () => {
+          return Promise.resolve({ transactionTypes: ['request'] });
         },
       },
-    }) as unknown) as ApmPluginContextValue;
+    },
+  }) as unknown) as ApmPluginContextValue;
 
-    return (
-      <div style={{ width: 400 }}>
-        <MockApmPluginContextWrapper value={contextMock}>
-          <MockUrlParamsContextProvider>
-            <TransactionDurationAlertTrigger
-              alertParams={params as any}
-              setAlertParams={() => undefined}
-              setAlertProperty={() => undefined}
-            />
-          </MockUrlParamsContextProvider>
-        </MockApmPluginContextWrapper>
-      </div>
-    );
-  }
-);
+  return (
+    <div style={{ width: 400 }}>
+      <MockApmPluginContextWrapper value={contextMock}>
+        <MockUrlParamsContextProvider>
+          <TransactionDurationAlertTrigger
+            alertParams={params as any}
+            setAlertParams={() => undefined}
+            setAlertProperty={() => undefined}
+          />
+        </MockUrlParamsContextProvider>
+      </MockApmPluginContextWrapper>
+    </div>
+  );
+});

--- a/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/ChoroplethMap/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/TransactionCharts/ChoroplethMap/index.tsx
@@ -137,7 +137,7 @@ export const ChoroplethMap: React.FC<Props> = (props) => {
   }, [map, items, tooltipState]);
 
   const updateTooltipStateOnMousemoveRef = useRef(
-    (event: mapboxgl.MapMouseEvent & mapboxgl.EventData) => {}
+    (_event: mapboxgl.MapMouseEvent & mapboxgl.EventData) => {}
   );
 
   // initialization side effect, only runs once

--- a/x-pack/plugins/apm/public/context/LoadingIndicatorContext.tsx
+++ b/x-pack/plugins/apm/public/context/LoadingIndicatorContext.tsx
@@ -10,7 +10,7 @@ import { useDelayedVisibility } from '../components/shared/useDelayedVisibility'
 
 export const LoadingIndicatorContext = React.createContext({
   statuses: {},
-  dispatchStatus: (action: Action) => {},
+  dispatchStatus: (_action: Action) => {},
 });
 
 interface State {

--- a/x-pack/plugins/apm/public/context/UrlParamsContext/index.tsx
+++ b/x-pack/plugins/apm/public/context/UrlParamsContext/index.tsx
@@ -40,7 +40,7 @@ function useUiFilters(params: IUrlParams): UIFilters {
   return useDeepObjectIdentity({ kuery, environment, ...localUiFilters });
 }
 
-const defaultRefresh = (time: TimeRange) => {};
+const defaultRefresh = (_time: TimeRange) => {};
 
 const UrlParamsContext = createContext({
   urlParams: {} as IUrlParams,

--- a/x-pack/plugins/apm/public/services/rest/ml.ts
+++ b/x-pack/plugins/apm/public/services/rest/ml.ts
@@ -36,7 +36,7 @@ interface StartedMLJobApiResponse {
   jobs: MlResponseItem[];
 }
 
-async function getTransactionIndices(http: HttpSetup) {
+async function getTransactionIndices() {
   const indices = await callApmApi({
     method: 'GET',
     pathname: `/api/apm/settings/apm-indices`,
@@ -53,7 +53,7 @@ export async function startMLJob({
   transactionType: string;
   http: HttpSetup;
 }) {
-  const transactionIndices = await getTransactionIndices(http);
+  const transactionIndices = await getTransactionIndices();
   const groups = [
     'apm',
     encodeForMlApi(serviceName),

--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
@@ -4,8 +4,8 @@
     "./plugins/observability/**/*",
     "./typings/**/*"
   ],
-  "exclude": [
-    "**/__fixtures__/**/*",
-    "./plugins/apm/e2e/cypress/**/*"
-  ]
+  "exclude": ["**/__fixtures__/**/*", "./plugins/apm/e2e/cypress/**/*"],
+  "compilerOptions": {
+    "noErrorTruncation": true
+  }
 }

--- a/x-pack/plugins/apm/scripts/upload-telemetry-data/generate-sample-documents.ts
+++ b/x-pack/plugins/apm/scripts/upload-telemetry-data/generate-sample-documents.ts
@@ -78,7 +78,7 @@ export async function generateSampleDocuments(
   const dateOfScriptExecution = new Date();
 
   return flatten(
-    range(0, opts.instances).map((instanceNo) => {
+    range(0, opts.instances).map(() => {
       const instanceId = uuid.v4();
       const defaults = {
         cluster_uuid: instanceId,

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
@@ -120,7 +120,7 @@ export async function createApmTelemetry({
 
   usageCollector.registerCollector(collector);
 
-  core.getStartServices().then(([coreStart, pluginsStart]) => {
+  core.getStartServices().then(([_coreStart, pluginsStart]) => {
     const { taskManager: taskManagerStart } = pluginsStart as {
       taskManager: TaskManagerStartContract;
     };

--- a/x-pack/plugins/apm/server/lib/service_map/get_service_map_from_trace_ids.ts
+++ b/x-pack/plugins/apm/server/lib/service_map/get_service_map_from_trace_ids.ts
@@ -270,7 +270,7 @@ export async function getServiceMapFromTraceIds({
         return conns;
       }, [] as Connection[]);
     }, [] as Connection[]),
-    (value, index, array) => {
+    (value, _index, array) => {
       return find(array, value);
     }
   );

--- a/x-pack/plugins/apm/server/lib/services/annotations/index.ts
+++ b/x-pack/plugins/apm/server/lib/services/annotations/index.ts
@@ -41,7 +41,7 @@ export async function getServiceAnnotations({
     : [];
 
   if (storedAnnotations.length) {
-    derivedAnnotationsPromise.catch((error) => {
+    derivedAnnotationsPromise.catch(() => {
       // handle error silently to prevent Kibana from crashing
     });
     return { annotations: storedAnnotations };

--- a/x-pack/plugins/apm/server/lib/settings/apm_indices/save_apm_indices.ts
+++ b/x-pack/plugins/apm/server/lib/settings/apm_indices/save_apm_indices.ts
@@ -28,6 +28,6 @@ export async function saveApmIndices(
 function removeEmpty(apmIndices: Partial<ApmIndicesConfig>) {
   return Object.entries(apmIndices)
     .map(([key, value]) => [key, value?.trim()])
-    .filter(([key, value]) => !!value)
+    .filter(([_, value]) => !!value)
     .reduce((obj, [key, value]) => ({ ...obj, [key as string]: value }), {});
 }

--- a/x-pack/plugins/apm/server/routes/errors.ts
+++ b/x-pack/plugins/apm/server/routes/errors.ts
@@ -12,7 +12,7 @@ import { getErrorGroups } from '../lib/errors/get_error_groups';
 import { setupRequest } from '../lib/helpers/setup_request';
 import { uiFiltersRt, rangeRt } from './default_api_types';
 
-export const errorsRoute = createRoute((core) => ({
+export const errorsRoute = createRoute(() => ({
   path: '/api/apm/services/{serviceName}/errors',
   params: {
     path: t.type({

--- a/x-pack/plugins/apm/server/routes/service_nodes.ts
+++ b/x-pack/plugins/apm/server/routes/service_nodes.ts
@@ -9,7 +9,7 @@ import { setupRequest } from '../lib/helpers/setup_request';
 import { getServiceNodes } from '../lib/service_nodes';
 import { rangeRt, uiFiltersRt } from './default_api_types';
 
-export const serviceNodesRoute = createRoute((core) => ({
+export const serviceNodesRoute = createRoute(() => ({
   path: '/api/apm/services/{serviceName}/serviceNodes',
   params: {
     path: t.type({

--- a/x-pack/plugins/apm/server/routes/services.ts
+++ b/x-pack/plugins/apm/server/routes/services.ts
@@ -17,7 +17,7 @@ import { uiFiltersRt, rangeRt } from './default_api_types';
 import { getServiceAnnotations } from '../lib/services/annotations';
 import { dateAsStringRt } from '../../common/runtime_types/date_as_string_rt';
 
-export const servicesRoute = createRoute((core) => ({
+export const servicesRoute = createRoute(() => ({
   path: '/api/apm/services',
   params: {
     query: t.intersection([uiFiltersRt, rangeRt]),

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration.ts
@@ -24,7 +24,7 @@ import {
 import { jsonRt } from '../../../common/runtime_types/json_rt';
 
 // get list of configurations
-export const agentConfigurationRoute = createRoute((core) => ({
+export const agentConfigurationRoute = createRoute(() => ({
   path: '/api/apm/settings/agent-configuration',
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
@@ -137,7 +137,7 @@ export const createOrUpdateAgentConfigurationRoute = createRoute(() => ({
 }));
 
 // Lookup single configuration (used by APM Server)
-export const agentConfigurationSearchRoute = createRoute((core) => ({
+export const agentConfigurationSearchRoute = createRoute(() => ({
   method: 'POST',
   path: '/api/apm/settings/agent-configuration/search',
   params: {

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
@@ -34,7 +34,7 @@ export const apmIndicesRoute = createRoute(() => ({
 }));
 
 // save ui indices
-export const saveApmIndicesRoute = createRoute((core) => ({
+export const saveApmIndicesRoute = createRoute(() => ({
   method: 'POST',
   path: '/api/apm/settings/apm-indices/save',
   options: {
@@ -50,7 +50,7 @@ export const saveApmIndicesRoute = createRoute((core) => ({
       'apm_oss.metricsIndices': t.string,
     }),
   },
-  handler: async ({ context, request }) => {
+  handler: async ({ context }) => {
     const { body } = context.params;
     const savedObjectsClient = context.core.savedObjects.client;
     return await saveApmIndices(savedObjectsClient, body);

--- a/x-pack/plugins/apm/server/routes/settings/custom_link.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link.ts
@@ -17,7 +17,7 @@ import { getTransaction } from '../../lib/settings/custom_link/get_transaction';
 import { listCustomLinks } from '../../lib/settings/custom_link/list_custom_links';
 import { createRoute } from '../create_route';
 
-export const customLinkTransactionRoute = createRoute((core) => ({
+export const customLinkTransactionRoute = createRoute(() => ({
   path: '/api/apm/settings/custom_links/transaction',
   params: {
     query: filterOptionsRt,
@@ -31,7 +31,7 @@ export const customLinkTransactionRoute = createRoute((core) => ({
   },
 }));
 
-export const listCustomLinksRoute = createRoute((core) => ({
+export const listCustomLinksRoute = createRoute(() => ({
   path: '/api/apm/settings/custom_links',
   params: {
     query: filterOptionsRt,


### PR DESCRIPTION
* Add `compilerOptions.noErrorTrunctation` to the tsconfig template
* Remove unused parameters

Not adding `noUnusedParamaters` to the tsconfig since we get too many hits from dependencies when running `tsc`. These do show up in the editor as warnings, though.
