### PR TITLE
[Ingest Manager] Fix edit data source not working

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/components/custom_configure_datasource.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/components/custom_configure_datasource.tsx
@@ -12,7 +12,8 @@ import { CreateDatasourceFrom } from '../types';
 export interface CustomConfigureDatasourceProps {
   packageName: string;
   from: CreateDatasourceFrom;
-  datasource: NewDatasource | (NewDatasource & { id: string });
+  datasource: NewDatasource;
+  datasourceId?: string;
 }
 
 /**

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/step_configure_datasource.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_datasource_page/step_configure_datasource.tsx
@@ -16,7 +16,8 @@ import { CreateDatasourceFrom } from './types';
 export const StepConfigureDatasource: React.FunctionComponent<{
   from?: CreateDatasourceFrom;
   packageInfo: PackageInfo;
-  datasource: NewDatasource | (NewDatasource & { id: string });
+  datasource: NewDatasource;
+  datasourceId?: string;
   updateDatasource: (fields: Partial<NewDatasource>) => void;
   validationResults: DatasourceValidationResults;
   submitAttempted: boolean;
@@ -24,6 +25,7 @@ export const StepConfigureDatasource: React.FunctionComponent<{
   from = 'config',
   packageInfo,
   datasource,
+  datasourceId,
   updateDatasource,
   validationResults,
   submitAttempted,
@@ -70,9 +72,10 @@ export const StepConfigureDatasource: React.FunctionComponent<{
     ) : (
       <EuiPanel>
         <CustomConfigureDatasource
+          from={from}
           packageName={packageInfo.name}
           datasource={datasource}
-          from={from}
+          datasourceId={datasourceId}
         />
       </EuiPanel>
     );

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/edit_datasource_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/edit_datasource_page/index.tsx
@@ -69,8 +69,7 @@ export const EditDatasourcePage: React.FunctionComponent = () => {
   const [loadingError, setLoadingError] = useState<Error>();
   const [agentConfig, setAgentConfig] = useState<AgentConfig>();
   const [packageInfo, setPackageInfo] = useState<PackageInfo>();
-  const [datasource, setDatasource] = useState<NewDatasource & { id: string }>({
-    id: '',
+  const [datasource, setDatasource] = useState<NewDatasource>({
     name: '',
     description: '',
     config_id: '',
@@ -94,6 +93,7 @@ export const EditDatasourcePage: React.FunctionComponent = () => {
         }
         if (datasourceData?.item) {
           const {
+            id,
             revision,
             inputs,
             created_by,
@@ -302,6 +302,7 @@ export const EditDatasourcePage: React.FunctionComponent = () => {
                     from={'edit'}
                     packageInfo={packageInfo}
                     datasource={datasource}
+                    datasourceId={datasourceId}
                     updateDatasource={updateDatasource}
                     validationResults={validationResults!}
                     submitAttempted={formState === 'INVALID'}

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/configure_datasource.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/configure_datasource.tsx
@@ -12,30 +12,21 @@ import { LinkToApp } from '../../../../../common/components/endpoint/link_to_app
 import {
   CustomConfigureDatasourceContent,
   CustomConfigureDatasourceProps,
-  NewDatasource,
 } from '../../../../../../../ingest_manager/public';
 import { getManagementUrl } from '../../../..';
-
-type DatasourceWithId = NewDatasource & { id: string };
 
 /**
  * Exports Endpoint-specific datasource configuration instructions
  * for use in the Ingest app create / edit datasource config
  */
 export const ConfigureEndpointDatasource = memo<CustomConfigureDatasourceContent>(
-  ({
-    from,
-    datasource,
-  }: {
-    from: string;
-    datasource: CustomConfigureDatasourceProps['datasource'];
-  }) => {
+  ({ from, datasourceId }: CustomConfigureDatasourceProps) => {
     const { services } = useKibana();
     let policyUrl = '';
-    if (from === 'edit') {
+    if (from === 'edit' && datasourceId) {
       policyUrl = getManagementUrl({
         name: 'policyDetails',
-        policyId: (datasource as DatasourceWithId).id,
+        policyId: datasourceId,
       });
     }
 


### PR DESCRIPTION
## Summary

Part of the changes in #67234 broke edit data source due to passing `id` as part of the update data source endpoint payload. That endpoint does not accept `id` part of the data source payload, causing a Bad Request to be returned in the UI when user attempts to edit any data source. This PR fixes that by passing `datasourceId` as a separate prop to the custom config components instead of passing it with the `datasource` object.