### PR TITLE
[APM] Don't show annotations on charts with no data

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/CustomPlot.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/CustomPlot.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+// @ts-ignore
+import CustomPlot from './';
+
+storiesOf('shared/charts/CustomPlot', module).add(
+  'with annotations but no data',
+  () => {
+    const annotations = [
+      {
+        type: 'version',
+        id: '2020-06-10 04:36:31',
+        '@timestamp': 1591763925012,
+        text: '2020-06-10 04:36:31',
+      },
+      {
+        type: 'version',
+        id: '2020-06-10 15:23:01',
+        '@timestamp': 1591802689233,
+        text: '2020-06-10 15:23:01',
+      },
+    ];
+    return <CustomPlot annotations={annotations} series={[]} />;
+  },
+  {
+    info: {
+      source: false,
+      text:
+        "When a chart has no data but does have annotations, the annotations shouldn't show up at all.",
+    },
+  }
+);

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/index.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/index.js
@@ -168,7 +168,7 @@ export class InnerCustomPlot extends PureComponent {
             tickFormatX={this.props.tickFormatX}
           />
 
-          {this.state.showAnnotations && !isEmpty(annotations) && (
+          {this.state.showAnnotations && !isEmpty(annotations) && !noHits && (
             <AnnotationsPlot
               plotValues={plotValues}
               width={width}
@@ -202,7 +202,7 @@ export class InnerCustomPlot extends PureComponent {
           hiddenSeriesCount={hiddenSeriesCount}
           clickLegend={this.clickLegend}
           seriesEnabledState={this.state.seriesEnabledState}
-          hasAnnotations={!isEmpty(annotations)}
+          hasAnnotations={!isEmpty(annotations) && !noHits}
           showAnnotations={this.state.showAnnotations}
           onAnnotationsToggle={() => {
             this.setState(({ showAnnotations }) => ({

--- a/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
+++ b/x-pack/plugins/apm/public/components/shared/charts/CustomPlot/test/CustomPlot.test.js
@@ -255,12 +255,28 @@ describe('when response has no data', () => {
   const onHover = jest.fn();
   const onMouseLeave = jest.fn();
   const onSelectionEnd = jest.fn();
+  const annotations = [
+    {
+      type: 'version',
+      id: '2020-06-10 04:36:31',
+      '@timestamp': 1591763925012,
+      text: '2020-06-10 04:36:31',
+    },
+    {
+      type: 'version',
+      id: '2020-06-10 15:23:01',
+      '@timestamp': 1591802689233,
+      text: '2020-06-10 15:23:01',
+    },
+  ];
+
   let wrapper;
   beforeEach(() => {
     const series = getEmptySeries(1451606400000, 1451610000000);
 
     wrapper = mount(
       <InnerCustomPlot
+        annotations={annotations}
         series={series}
         onHover={onHover}
         onMouseLeave={onMouseLeave}
@@ -292,6 +308,10 @@ describe('when response has no data', () => {
 
     it('should not display tooltip', () => {
       expect(wrapper.find('Tooltip').length).toEqual(0);
+    });
+
+    it('should not show annotations', () => {
+      expect(wrapper.find('AnnotationsPlot')).toHaveLength(0);
     });
 
     it('should have correct markup', () => {


### PR DESCRIPTION
Hide the annotations plot and legend when a chart has annotations but doesn't have any values in the series.

Before:

<img width="712" alt="before" src="https://user-images.githubusercontent.com/9912/84324059-963a9d80-ab3d-11ea-91f3-413b12b7cb9a.png">

After:

<img width="711" alt="after" src="https://user-images.githubusercontent.com/9912/84324073-9b97e800-ab3d-11ea-9048-811dcb1db72a.png">

Fixes #66981.
