### PR TITLE
[Ingest Manager] update index pattern and privileges for Fleet user and api key

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
@@ -24,7 +24,7 @@ export async function generateOutputApiKey(
       cluster: ['monitor'],
       index: [
         {
-          names: ['.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          names: ['logs-*', 'metrics-*', 'events-*', '.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
@@ -24,8 +24,8 @@ export async function generateOutputApiKey(
       cluster: ['monitor'],
       index: [
         {
-          names: ['logs-*', 'metrics-*', 'events-*'],
-          privileges: ['write', 'create_index'],
+          names: ['.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],
     },

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -111,8 +111,8 @@ export async function setupFleet(
       cluster: ['monitor', 'manage_api_key'],
       indices: [
         {
-          names: ['logs-*', 'metrics-*', 'events-*'],
-          privileges: ['write', 'create_index'],
+          names: ['.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],
     },

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -111,7 +111,7 @@ export async function setupFleet(
       cluster: ['monitor', 'manage_api_key'],
       indices: [
         {
-          names: ['.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          names: ['logs-*', 'metrics-*', 'events-*', '.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/test/api_integration/apis/fleet/setup.ts
+++ b/x-pack/test/api_integration/apis/fleet/setup.ts
@@ -57,7 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
         indices: [
           {
             names: ['logs-*', 'metrics-*', 'events-*'],
-            privileges: ['write', 'create_index'],
+            privileges: ['write', 'create_index', 'indices:admin/auto_create'],
             allow_restricted_indices: false,
           },
         ],

--- a/x-pack/test/api_integration/apis/fleet/setup.ts
+++ b/x-pack/test/api_integration/apis/fleet/setup.ts
@@ -56,7 +56,14 @@ export default function ({ getService }: FtrProviderContext) {
         cluster: ['monitor', 'manage_api_key'],
         indices: [
           {
-            names: ['logs-*', 'metrics-*', 'events-*'],
+            names: [
+              'logs-*',
+              'metrics-*',
+              'events-*',
+              '.ds-logs-*',
+              '.ds-metrics-*',
+              '.ds-events-*',
+            ],
             privileges: ['write', 'create_index', 'indices:admin/auto_create'],
             allow_restricted_indices: false,
           },


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/68775

Backing indices were changed for data streams and prepended with a `.ds-`, though security has not been updated for the backing indices that match the data stream. This is temporary change until https://github.com/elastic/elasticsearch/issues/57934 is complete, then we can undo having to specify the backing index pattern and may or may not be able to remove `indices:admin/auto_create`.  

> the data stream names will still need to be specified. whether the indices:admin/auto_create action can be removed is TBD. if we include that action in an existing privilege, then it could be removed. we're still figuring that out