### PR TITLE
[Telemetry] fix error and add tests

### DIFF
--- a/src/plugins/telemetry/server/fetcher.test.ts
+++ b/src/plugins/telemetry/server/fetcher.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable dot-notation */
+import { FetcherTask } from './fetcher';
+// import { CoreSetup } from 'src/core/server';
+import { coreMock } from '../../../core/server/mocks';
+
+describe('FetcherTask', () => {
+  describe('sendIfDue', () => {
+    it('returns undefined and warns when it fails to get telemetry configs', async () => {
+      const initializerContext = coreMock.createPluginInitializerContext({});
+      const fetcherTask = new FetcherTask(initializerContext);
+      const mockError = new Error('Some message.');
+      fetcherTask['getCurrentConfigs'] = async () => {
+        throw mockError;
+      };
+      const result = await fetcherTask['sendIfDue']();
+      expect(result).toBe(undefined);
+      expect(fetcherTask['logger'].warn).toBeCalledTimes(1);
+      expect(fetcherTask['logger'].warn).toHaveBeenCalledWith(
+        `Error fetching telemetry configs: ${mockError}`
+      );
+    });
+  });
+});

--- a/src/plugins/telemetry/server/fetcher.test.ts
+++ b/src/plugins/telemetry/server/fetcher.test.ts
@@ -19,7 +19,6 @@
 
 /* eslint-disable dot-notation */
 import { FetcherTask } from './fetcher';
-// import { CoreSetup } from 'src/core/server';
 import { coreMock } from '../../../core/server/mocks';
 
 describe('FetcherTask', () => {

--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -44,6 +44,14 @@ export interface FetcherTaskDepsStart {
   telemetryCollectionManager: TelemetryCollectionManagerPluginStart;
 }
 
+interface TelemetryConfig {
+  telemetryOptIn: boolean | null;
+  telemetrySendUsageFrom: 'server' | 'browser';
+  telemetryUrl: string;
+  failureCount: number;
+  failureVersion: string | undefined;
+}
+
 export class FetcherTask {
   private readonly initialCheckDelayMs = 60 * 1000 * 5;
   private readonly checkIntervalMs = 60 * 1000 * 60 * 12;
@@ -90,8 +98,16 @@ export class FetcherTask {
     if (this.isSending) {
       return;
     }
-    const telemetryConfig = await this.getCurrentConfigs();
-    if (!this.shouldSendReport(telemetryConfig)) {
+    let telemetryConfig: TelemetryConfig | undefined;
+
+    try {
+      telemetryConfig = await this.getCurrentConfigs();
+    } catch (err) {
+      this.logger.warn(`Error fetching telemetry configs: ${err}`);
+      return;
+    }
+
+    if (!telemetryConfig || !this.shouldSendReport(telemetryConfig)) {
       return;
     }
 
@@ -112,7 +128,7 @@ export class FetcherTask {
     this.isSending = false;
   }
 
-  private async getCurrentConfigs() {
+  private async getCurrentConfigs(): Promise<TelemetryConfig> {
     const telemetrySavedObject = await getTelemetrySavedObject(this.internalRepository!);
     const config = await this.config$.pipe(take(1)).toPromise();
     const currentKibanaVersion = this.currentKibanaVersion;


### PR DESCRIPTION
Fixes a bug and adds tests for the case when ES goes down and goes up again the telemetry server fetcher throws an uncaught error trying to fetch the telemetry configs.


```
Unhandled Promise rejection detected:
{ Error: [security_exception] unable to authenticate user [kibana_system] for REST request [/.kibana/_doc/telemetry%3Atelemetry], with { header={ WWW-Authenticate={ 0="Bearer realm=\"security\"" & 1="ApiKey" & 2="Basic realm=\"security\" charset=\"UTF-8\"" } } }
    at respond (/projects/elastic/master/kibana/node_modules/elasticsearch/src/lib/transport.js:349:15)
    at checkRespForFailure (/projects/elastic/master/kibana/node_modules/elasticsearch/src/lib/transport.js:306:7)
    at HttpConnector.<anonymous> (/projects/elastic/master/kibana/node_modules/elasticsearch/src/lib/connectors/http.js:173:7)
    at IncomingMessage.wrapper (/projects/elastic/master/kibana/node_modules/elasticsearch/node_modules/lodash/lodash.js:4929:19)
    at IncomingMessage.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
  status: 401,
  displayName: 'AuthenticationException',
  message:
   '[security_exception] unable to authenticate user [kibana_system] for REST request [/.kibana/_doc/telemetry%3Atelemetry], with { header={ WWW-Authenticate={ 0="Bearer realm=\\"security\\"" & 1="ApiKey" & 2="Basic realm=\\"security\\" charset=\\"UTF-8\\"" } } }',
  path: '/.kibana/_doc/telemetry%3Atelemetry',
  query: {},
  body:
   { error:
      { root_cause: [Array],
        type: 'security_exception',
        reason:
         'unable to authenticate user [kibana_system] for REST request [/.kibana/_doc/telemetry%3Atelemetry]',
        header: [Object] },
     status: 401 },
  statusCode: 401,
  response:
   '{"error":{"root_cause":[{"type":"security_exception","reason":"unable to authenticate user [kibana_system] for REST request [/.kibana/_doc/telemetry%3Atelemetry]","header":{"WWW-Authenticate":["Bearer realm=\\"security\\"","ApiKey","Basic realm=\\"security\\" charset=\\"UTF-8\\""]}}],"type":"security_exception","reason":"unable to authenticate user [kibana_system] for REST request [/.kibana/_doc/telemetry%3Atelemetry]","header":{"WWW-Authenticate":["Bearer realm=\\"security\\"","ApiKey","Basic realm=\\"security\\" charset=\\"UTF-8\\""]}},"status":401}',
  wwwAuthenticateDirective:
   'Bearer realm="security", ApiKey, Basic realm="security" charset="UTF-8"',
  toString: [Function],
  toJSON: [Function],
  isBoom: true,
  isServer: false,
  data: null,
  output:
   { statusCode: 401,
     payload:
      { statusCode: 401,
        error: 'Unauthorized',
        message:
         '[security_exception] unable to authenticate user [kibana_system] for REST request [/.kibana/_doc/telemetry%3Atelemetry], with { header={ WWW-Authenticate={ 0="Bearer realm=\\"security\\"" & 1="ApiKey" & 2="Basic realm=\\"security\\" charset=\\"UTF-8\\"" } } }' },
     headers: { 'WWW-Authenticate': [Array] } },
  reformat: [Function],
  [Symbol(ElasticsearchError)]: 'Elasticsearch/notAuthorized',
  [Symbol(SavedObjectsClientErrorCode)]: 'SavedObjectsClient/notAuthorized' }
Terminating process...
 server crashed  with status code 1
```

CC @azasypkin 