### PR TITLE
[Monitoring] Added cloud as an optional dependency

### DIFF
--- a/x-pack/plugins/monitoring/kibana.json
+++ b/x-pack/plugins/monitoring/kibana.json
@@ -4,7 +4,7 @@
   "kibanaVersion": "kibana",
   "configPath": ["monitoring"],
   "requiredPlugins": ["licensing", "features", "data", "navigation", "kibanaLegacy"],
-  "optionalPlugins": ["alerts", "actions", "infra", "telemetryCollectionManager", "usageCollection", "home"],
+  "optionalPlugins": ["alerts", "actions", "infra", "telemetryCollectionManager", "usageCollection", "home", "cloud"],
   "server": true,
   "ui": true
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/68933

We have some `isCloudEnabled` logic that wasn't working simply because we did not include the "cloud" plugin in our kibana.json file
