### PR TITLE
[7.x] index pattern(s) take dependencies as object (#69055)

### DIFF
--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpattern._constructor_.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpattern._constructor_.md
@@ -9,7 +9,7 @@ Constructs a new instance of the `IndexPattern` class
 <b>Signature:</b>
 
 ```typescript
-constructor(id: string | undefined, getConfig: any, savedObjectsClient: SavedObjectsClientContract, apiClient: IIndexPatternsApiClient, patternCache: PatternCache, fieldFormats: FieldFormatsStartCommon, onNotification: OnNotification, onError: OnError, onUnsupportedTimePattern: OnUnsupportedTimePattern);
+constructor(id: string | undefined, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern, }: IndexPatternDeps);
 ```
 
 ## Parameters
@@ -17,12 +17,5 @@ constructor(id: string | undefined, getConfig: any, savedObjectsClient: SavedObj
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  id | <code>string &#124; undefined</code> |  |
-|  getConfig | <code>any</code> |  |
-|  savedObjectsClient | <code>SavedObjectsClientContract</code> |  |
-|  apiClient | <code>IIndexPatternsApiClient</code> |  |
-|  patternCache | <code>PatternCache</code> |  |
-|  fieldFormats | <code>FieldFormatsStartCommon</code> |  |
-|  onNotification | <code>OnNotification</code> |  |
-|  onError | <code>OnError</code> |  |
-|  onUnsupportedTimePattern | <code>OnUnsupportedTimePattern</code> |  |
+|  { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern, } | <code>IndexPatternDeps</code> |  |
 

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpattern.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpattern.md
@@ -14,7 +14,7 @@ export declare class IndexPattern implements IIndexPattern
 
 |  Constructor | Modifiers | Description |
 |  --- | --- | --- |
-|  [(constructor)(id, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern,})](./kibana-plugin-plugins-data-public.indexpattern._constructor_.md) |  | Constructs a new instance of the <code>IndexPattern</code> class |
+|  [(constructor)(id, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern, })](./kibana-plugin-plugins-data-public.indexpattern._constructor_.md) |  | Constructs a new instance of the <code>IndexPattern</code> class |
 
 ## Properties
 

--- a/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpattern.md
+++ b/docs/development/plugins/data/public/kibana-plugin-plugins-data-public.indexpattern.md
@@ -14,7 +14,7 @@ export declare class IndexPattern implements IIndexPattern
 
 |  Constructor | Modifiers | Description |
 |  --- | --- | --- |
-|  [(constructor)(id, getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern)](./kibana-plugin-plugins-data-public.indexpattern._constructor_.md) |  | Constructs a new instance of the <code>IndexPattern</code> class |
+|  [(constructor)(id, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern,})](./kibana-plugin-plugins-data-public.indexpattern._constructor_.md) |  | Constructs a new instance of the <code>IndexPattern</code> class |
 
 ## Properties
 

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.test.ts
@@ -28,7 +28,7 @@ import mockLogStashFields from '../../../../../fixtures/logstash_fields';
 import { stubbedSavedObjectIndexPattern } from '../../../../../fixtures/stubbed_saved_object_index_pattern';
 import { Field } from '../fields';
 
-import { FieldFormatsStartCommon } from '../../field_formats';
+import { fieldFormatsMock } from '../../field_formats/mocks';
 
 jest.mock('../../field_mapping', () => {
   const originalModule = jest.requireActual('../../field_mapping');
@@ -97,17 +97,16 @@ const apiClient = {
 
 // helper function to create index patterns
 function create(id: string, payload?: any): Promise<IndexPattern> {
-  const indexPattern = new IndexPattern(
-    id,
-    (cfg: any) => config.get(cfg),
-    savedObjectsClient as any,
+  const indexPattern = new IndexPattern(id, {
+    getConfig: (cfg: any) => config.get(cfg),
+    savedObjectsClient: savedObjectsClient as any,
     apiClient,
     patternCache,
-    ({ getDefaultInstance: () => {}, getType: () => {} } as unknown) as FieldFormatsStartCommon,
-    () => {},
-    () => {},
-    () => {}
-  );
+    fieldFormats: fieldFormatsMock,
+    onNotification: () => {},
+    onError: () => {},
+    onUnsupportedTimePattern: () => {},
+  });
 
   setDocsourcePayload(id, payload);
 
@@ -364,33 +363,31 @@ describe('IndexPattern', () => {
       },
     });
     // Create a normal index pattern
-    const pattern = new IndexPattern(
-      'foo',
-      (cfg: any) => config.get(cfg),
-      savedObjectsClient as any,
+    const pattern = new IndexPattern('foo', {
+      getConfig: (cfg: any) => config.get(cfg),
+      savedObjectsClient: savedObjectsClient as any,
       apiClient,
       patternCache,
-      ({ getDefaultInstance: () => {}, getType: () => {} } as unknown) as FieldFormatsStartCommon,
-      () => {},
-      () => {},
-      () => {}
-    );
+      fieldFormats: fieldFormatsMock,
+      onNotification: () => {},
+      onError: () => {},
+      onUnsupportedTimePattern: () => {},
+    });
     await pattern.init();
 
     expect(get(pattern, 'version')).toBe('fooa');
 
     // Create the same one - we're going to handle concurrency
-    const samePattern = new IndexPattern(
-      'foo',
-      (cfg: any) => config.get(cfg),
-      savedObjectsClient as any,
+    const samePattern = new IndexPattern('foo', {
+      getConfig: (cfg: any) => config.get(cfg),
+      savedObjectsClient: savedObjectsClient as any,
       apiClient,
       patternCache,
-      ({ getDefaultInstance: () => {}, getType: () => {} } as unknown) as FieldFormatsStartCommon,
-      () => {},
-      () => {},
-      () => {}
-    );
+      fieldFormats: fieldFormatsMock,
+      onNotification: () => {},
+      onError: () => {},
+      onUnsupportedTimePattern: () => {},
+    });
     await samePattern.init();
 
     expect(get(samePattern, 'version')).toBe('fooaa');

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -46,6 +46,17 @@ import { expandShorthand, FieldMappingSpec, MappingObject } from '../../field_ma
 const MAX_ATTEMPTS_TO_RESOLVE_CONFLICTS = 3;
 const type = 'index-pattern';
 
+interface IndexPatternDeps {
+  getConfig: any;
+  savedObjectsClient: SavedObjectsClientContract;
+  apiClient: IIndexPatternsApiClient;
+  patternCache: PatternCache;
+  fieldFormats: FieldFormatsStartCommon;
+  onNotification: OnNotification;
+  onError: OnError;
+  onUnsupportedTimePattern: OnUnsupportedTimePattern;
+}
+
 export class IndexPattern implements IIndexPattern {
   [key: string]: any;
 
@@ -100,14 +111,16 @@ export class IndexPattern implements IIndexPattern {
 
   constructor(
     id: string | undefined,
-    getConfig: any,
-    savedObjectsClient: SavedObjectsClientContract,
-    apiClient: IIndexPatternsApiClient,
-    patternCache: PatternCache,
-    fieldFormats: FieldFormatsStartCommon,
-    onNotification: OnNotification,
-    onError: OnError,
-    onUnsupportedTimePattern: OnUnsupportedTimePattern
+    {
+      getConfig,
+      savedObjectsClient,
+      apiClient,
+      patternCache,
+      fieldFormats,
+      onNotification,
+      onError,
+      onUnsupportedTimePattern,
+    }: IndexPatternDeps
   ) {
     this.id = id;
     this.savedObjectsClient = savedObjectsClient;
@@ -449,17 +462,16 @@ export class IndexPattern implements IIndexPattern {
   async create(allowOverride: boolean = false) {
     const _create = async (duplicateId?: string) => {
       if (duplicateId) {
-        const duplicatePattern = new IndexPattern(
-          duplicateId,
-          this.getConfig,
-          this.savedObjectsClient,
-          this.apiClient,
-          this.patternCache,
-          this.fieldFormats,
-          this.onNotification,
-          this.onError,
-          this.onUnsupportedTimePattern
-        );
+        const duplicatePattern = new IndexPattern(duplicateId, {
+          getConfig: this.getConfig,
+          savedObjectsClient: this.savedObjectsClient,
+          apiClient: this.apiClient,
+          patternCache: this.patternCache,
+          fieldFormats: this.fieldFormats,
+          onNotification: this.onNotification,
+          onError: this.onError,
+          onUnsupportedTimePattern: this.this.onUnsupportedTimePattern,
+        });
 
         await duplicatePattern.destroy();
       }
@@ -503,17 +515,16 @@ export class IndexPattern implements IIndexPattern {
           _.get(err, 'res.status') === 409 &&
           saveAttempts++ < MAX_ATTEMPTS_TO_RESOLVE_CONFLICTS
         ) {
-          const samePattern = new IndexPattern(
-            this.id,
-            this.getConfig,
-            this.savedObjectsClient,
-            this.apiClient,
-            this.patternCache,
-            this.fieldFormats,
-            this.onNotification,
-            this.onError,
-            this.onUnsupportedTimePattern
-          );
+          const samePattern = new IndexPattern(this.id, {
+            getConfig: this.getConfig,
+            savedObjectsClient: this.savedObjectsClient,
+            apiClient: this.apiClient,
+            patternCache: this.patternCache,
+            fieldFormats: this.fieldFormats,
+            onNotification: this.onNotification,
+            onError: this.onError,
+            onUnsupportedTimePattern: this.this.onUnsupportedTimePattern,
+          });
           return samePattern.init().then(() => {
             // What keys changed from now and what the server returned
             const updatedBody = samePattern.prepBody();

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -470,7 +470,7 @@ export class IndexPattern implements IIndexPattern {
           fieldFormats: this.fieldFormats,
           onNotification: this.onNotification,
           onError: this.onError,
-          onUnsupportedTimePattern: this.this.onUnsupportedTimePattern,
+          onUnsupportedTimePattern: this.onUnsupportedTimePattern,
         });
 
         await duplicatePattern.destroy();
@@ -523,7 +523,7 @@ export class IndexPattern implements IIndexPattern {
             fieldFormats: this.fieldFormats,
             onNotification: this.onNotification,
             onError: this.onError,
-            onUnsupportedTimePattern: this.this.onUnsupportedTimePattern,
+            onUnsupportedTimePattern: this.onUnsupportedTimePattern,
           });
           return samePattern.init().then(() => {
             // What keys changed from now and what the server returned

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
@@ -62,16 +62,16 @@ describe('IndexPatterns', () => {
         }) as Promise<SavedObjectsFindResponsePublic<any>>
     );
 
-    indexPatterns = new IndexPatternsService(
-      core.uiSettings,
+    indexPatterns = new IndexPatternsService({
+      uiSettings: core.uiSettings,
       savedObjectsClient,
       http,
       fieldFormats,
-      () => {},
-      () => {},
-      () => {},
-      () => {}
-    );
+      onNotification: () => {},
+      onError: () => {},
+      onRedirectNoIndexPattern: () => {},
+      onUnsupportedTimePattern: () => {},
+    });
   });
 
   test('does cache gets for the same id', async () => {

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -49,6 +49,17 @@ export interface IndexPatternSavedObjectAttrs {
   title: string;
 }
 
+interface IndexPatternsServiceDeps {
+  uiSettings: CoreStart['uiSettings'];
+  savedObjectsClient: SavedObjectsClientContract;
+  http: HttpStart;
+  fieldFormats: FieldFormatsStartCommon;
+  onNotification: OnNotification;
+  onError: OnError;
+  onRedirectNoIndexPattern: () => void;
+  onUnsupportedTimePattern: OnUnsupportedTimePattern;
+}
+
 export class IndexPatternsService {
   private config: IUiSettingsClient;
   private savedObjectsClient: SavedObjectsClientContract;
@@ -66,16 +77,16 @@ export class IndexPatternsService {
     shortDotsEnable: boolean
   ) => Field;
 
-  constructor(
-    uiSettings: CoreStart['uiSettings'],
-    savedObjectsClient: SavedObjectsClientContract,
-    http: HttpStart,
-    fieldFormats: FieldFormatsStartCommon,
-    onNotification: OnNotification,
-    onError: OnError,
-    onRedirectNoIndexPattern: () => void,
-    onUnsupportedTimePattern: OnUnsupportedTimePattern
-  ) {
+  constructor({
+    uiSettings,
+    savedObjectsClient,
+    http,
+    fieldFormats,
+    onNotification,
+    onError,
+    onRedirectNoIndexPattern,
+    onUnsupportedTimePattern,
+  }: IndexPatternsServiceDeps) {
     this.apiClient = new IndexPatternsApiClient(http);
     this.config = uiSettings;
     this.savedObjectsClient = savedObjectsClient;
@@ -189,17 +200,16 @@ export class IndexPatternsService {
   };
 
   make = (id?: string): Promise<IndexPattern> => {
-    const indexPattern = new IndexPattern(
-      id,
-      (cfg: any) => this.config.get(cfg),
-      this.savedObjectsClient,
-      this.apiClient,
-      indexPatternCache,
-      this.fieldFormats,
-      this.onNotification,
-      this.onError,
-      this.onUnsupportedTimePattern
-    );
+    const indexPattern = new IndexPattern(id, {
+      getConfig: (cfg: any) => this.config.get(cfg),
+      savedObjectsClient: this.savedObjectsClient,
+      apiClient: this.apiClient,
+      patternCache: indexPatternCache,
+      fieldFormats: this.fieldFormats,
+      onNotification: this.onNotification,
+      onError: this.onError,
+      onUnsupportedTimePattern: this.onUnsupportedTimePattern,
+    });
 
     return indexPattern.init();
   };

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -168,18 +168,25 @@ export class DataPublicPlugin implements Plugin<DataPublicPluginSetup, DataPubli
     const fieldFormats = this.fieldFormatsService.start();
     setFieldFormats(fieldFormats);
 
-    const indexPatterns = new IndexPatternsService(
+    const indexPatterns = new IndexPatternsService({
       uiSettings,
-      savedObjects.client,
+      savedObjectsClient: savedObjects.client,
       http,
       fieldFormats,
-      (toastInputFields) => {
+      onNotification: (toastInputFields) => {
         notifications.toasts.add(toastInputFields);
       },
-      notifications.toasts.addError,
-      onRedirectNoIndexPattern(application.capabilities, application.navigateToApp, overlays),
-      onUnsupportedTimePattern(notifications.toasts, application.navigateToApp)
-    );
+      onError: notifications.toasts.addError,
+      onRedirectNoIndexPattern: onRedirectNoIndexPattern(
+        application.capabilities,
+        application.navigateToApp,
+        overlays
+      ),
+      onUnsupportedTimePattern: onUnsupportedTimePattern(
+        notifications.toasts,
+        application.navigateToApp
+      ),
+    });
     setIndexPatterns(indexPatterns);
 
     const query = this.queryService.start(savedObjects);

--- a/src/plugins/data/public/public.api.md
+++ b/src/plugins/data/public/public.api.md
@@ -979,15 +979,9 @@ export type IMetricAggType = MetricAggType;
 // Warning: (ae-missing-release-tag) "IndexPattern" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export class IndexPattern implements IIndexPattern {
-    // Warning: (ae-forgotten-export) The symbol "IIndexPatternsApiClient" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "PatternCache" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "FieldFormatsStartCommon" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "OnNotification" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "OnError" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "OnUnsupportedTimePattern" needs to be exported by the entry point index.d.ts
-    constructor(id: string | undefined, getConfig: any, savedObjectsClient: SavedObjectsClientContract, apiClient: IIndexPatternsApiClient, patternCache: PatternCache, fieldFormats: FieldFormatsStartCommon, onNotification: OnNotification, onError: OnError, onUnsupportedTimePattern: OnUnsupportedTimePattern);
-    // (undocumented)
+export class IndexPattern implements IIndexPattern {s
+    // Warning: (ae-forgotten-export) The symbol "IndexPatternDeps" needs to be exported by the entry point index.d.ts
+    constructor(id: string | undefined, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern,}: IndexPatternDeps);
     [key: string]: any;
     // (undocumented)
     addScriptedField(name: string, script: string, fieldType: string | undefined, lang: string): Promise<void>;

--- a/src/plugins/data/public/public.api.md
+++ b/src/plugins/data/public/public.api.md
@@ -979,9 +979,10 @@ export type IMetricAggType = MetricAggType;
 // Warning: (ae-missing-release-tag) "IndexPattern" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export class IndexPattern implements IIndexPattern {s
+export class IndexPattern implements IIndexPattern {
     // Warning: (ae-forgotten-export) The symbol "IndexPatternDeps" needs to be exported by the entry point index.d.ts
-    constructor(id: string | undefined, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern,}: IndexPatternDeps);
+    constructor(id: string | undefined, { getConfig, savedObjectsClient, apiClient, patternCache, fieldFormats, onNotification, onError, onUnsupportedTimePattern, }: IndexPatternDeps);
+    // (undocumented)
     [key: string]: any;
     // (undocumented)
     addScriptedField(name: string, script: string, fieldType: string | undefined, lang: string): Promise<void>;


### PR DESCRIPTION
Backports the following commits to 7.x:
  - index pattern(s) take dependencies as object (#69055)