### PR TITLE
[Search][BUG] Call wrong search strategy recursively in async search

### DIFF
--- a/src/plugins/data/public/mocks.ts
+++ b/src/plugins/data/public/mocks.ts
@@ -19,7 +19,7 @@
 
 import { Plugin, IndexPatternsContract } from '.';
 import { fieldFormatsServiceMock } from './field_formats/mocks';
-import { searchSetupMock, searchStartMock } from './search/mocks';
+import { searchServiceMock } from './search/mocks';
 import { queryServiceMock } from './query/mocks';
 import { AutocompleteStart, AutocompleteSetup } from './autocomplete';
 
@@ -41,7 +41,7 @@ const createSetupContract = (): Setup => {
   const querySetupMock = queryServiceMock.createSetupContract();
   return {
     autocomplete: automcompleteSetupMock,
-    search: searchSetupMock,
+    search: searchServiceMock.createSetupContract(),
     fieldFormats: fieldFormatsServiceMock.createSetupContract(),
     query: querySetupMock,
   };
@@ -55,7 +55,7 @@ const createStartContract = (): Start => {
       createFiltersFromRangeSelectAction: jest.fn(),
     },
     autocomplete: autocompleteStartMock,
-    search: searchStartMock,
+    search: searchServiceMock.createStartContract(),
     fieldFormats: fieldFormatsServiceMock.createStartContract(),
     query: queryStartMock,
     ui: {

--- a/src/plugins/data/public/search/legacy/default_search_strategy.test.ts
+++ b/src/plugins/data/public/search/legacy/default_search_strategy.test.ts
@@ -19,7 +19,7 @@
 
 import { IUiSettingsClient } from 'kibana/public';
 import { defaultSearchStrategy } from './default_search_strategy';
-import { searchStartMock } from '../mocks';
+import { searchServiceMock } from '../mocks';
 import { SearchStrategySearchParams } from './types';
 import { UI_SETTINGS } from '../../../common';
 
@@ -51,7 +51,7 @@ describe('defaultSearchStrategy', function () {
       searchMockResponse.abort.mockClear();
       searchMock.mockClear();
 
-      const searchService = searchStartMock;
+      const searchService = searchServiceMock.createStartContract();
       searchService.aggs.calculateAutoTimeExpression = jest.fn().mockReturnValue('1d');
       searchService.__LEGACY.esClient.search = searchMock;
       searchService.__LEGACY.esClient.msearch = msearchMock;

--- a/src/plugins/data/public/search/mocks.ts
+++ b/src/plugins/data/public/search/mocks.ts
@@ -23,7 +23,6 @@ import { searchSourceMock, createSearchSourceMock } from './search_source/mocks'
 
 export * from './search_source/mocks';
 
-
 function createSetupContract(): jest.Mocked<ISearchSetup> {
   return {
     aggs: searchAggsSetupMock(),

--- a/src/plugins/data/public/search/mocks.ts
+++ b/src/plugins/data/public/search/mocks.ts
@@ -23,23 +23,33 @@ import { searchSourceMock, createSearchSourceMock } from './search_source/mocks'
 
 export * from './search_source/mocks';
 
-const searchSetupMock: jest.Mocked<ISearchSetup> = {
-  aggs: searchAggsSetupMock(),
-  registerSearchStrategy: jest.fn(),
-};
 
-const searchStartMock: jest.Mocked<ISearchStart> = {
-  aggs: searchAggsStartMock(),
-  setInterceptor: jest.fn(),
-  getSearchStrategy: jest.fn(),
-  search: jest.fn(),
-  searchSource: searchSourceMock,
-  __LEGACY: {
-    esClient: {
-      search: jest.fn(),
-      msearch: jest.fn(),
+function createSetupContract(): jest.Mocked<ISearchSetup> {
+  return {
+    aggs: searchAggsSetupMock(),
+    registerSearchStrategy: jest.fn(),
+  };
+}
+
+function createStartContract(): jest.Mocked<ISearchStart> {
+  return {
+    aggs: searchAggsStartMock(),
+    setInterceptor: jest.fn(),
+    getSearchStrategy: jest.fn(),
+    search: jest.fn(),
+    searchSource: searchSourceMock,
+    __LEGACY: {
+      esClient: {
+        search: jest.fn(),
+        msearch: jest.fn(),
+      },
     },
-  },
+  };
+}
+
+export const searchServiceMock = {
+  createSetupContract,
+  createStartContract,
 };
 
-export { searchSetupMock, searchStartMock, createSearchSourceMock };
+export { createSearchSourceMock };

--- a/src/plugins/vis_type_table/public/table_vis_controller.test.ts
+++ b/src/plugins/vis_type_table/public/table_vis_controller.test.ts
@@ -36,9 +36,9 @@ import { coreMock } from '../../../core/public/mocks';
 import { IAggConfig, search } from '../../data/public';
 // TODO: remove linting disable
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { searchStartMock } from '../../data/public/search/mocks';
+import { searchServiceMock } from '../../data/public/search/mocks';
 
-const { createAggConfigs } = searchStartMock.aggs;
+const { createAggConfigs } = searchServiceMock.createStartContract().aggs;
 
 const { tabifyAggResponse } = search;
 

--- a/x-pack/plugins/data_enhanced/public/search/async_search_strategy.test.ts
+++ b/x-pack/plugins/data_enhanced/public/search/async_search_strategy.test.ts
@@ -92,6 +92,7 @@ describe('Async search strategy', () => {
 
     await asyncSearch.search(mockRequest, mockOptions).toPromise();
 
+    expect(mockDataStart.search.getSearchStrategy).toBeCalledTimes(1);
     expect(mockSearch).toBeCalledTimes(2);
     expect(mockSearch.mock.calls[0][0]).toEqual(mockRequest);
     expect(mockSearch.mock.calls[1][0]).toEqual({ id: 1, serverStrategy: 'foo' });

--- a/x-pack/plugins/data_enhanced/public/search/async_search_strategy.test.ts
+++ b/x-pack/plugins/data_enhanced/public/search/async_search_strategy.test.ts
@@ -24,7 +24,11 @@ describe('Async search strategy', () => {
   beforeEach(() => {
     mockCoreSetup = coreMock.createSetup();
     mockDataStart = dataPluginMock.createStartContract();
-    (mockDataStart.search.getSearchStrategy as jest.Mock).mockReturnValue({ search: mockSearch });
+
+    const getStrategy = mockDataStart.search.getSearchStrategy as jest.Mock;
+    getStrategy.mockReset();
+    getStrategy.mockReturnValue({ search: mockSearch });
+
     mockCoreSetup.getStartServices.mockResolvedValue([
       undefined as any,
       { data: mockDataStart },

--- a/x-pack/plugins/data_enhanced/public/search/async_search_strategy.test.ts
+++ b/x-pack/plugins/data_enhanced/public/search/async_search_strategy.test.ts
@@ -24,10 +24,7 @@ describe('Async search strategy', () => {
   beforeEach(() => {
     mockCoreSetup = coreMock.createSetup();
     mockDataStart = dataPluginMock.createStartContract();
-
-    const getStrategy = mockDataStart.search.getSearchStrategy as jest.Mock;
-    getStrategy.mockReset();
-    getStrategy.mockReturnValue({ search: mockSearch });
+    (mockDataStart.search.getSearchStrategy as jest.Mock).mockReturnValue({ search: mockSearch });
 
     mockCoreSetup.getStartServices.mockResolvedValue([
       undefined as any,

--- a/x-pack/plugins/data_enhanced/public/search/async_search_strategy.ts
+++ b/x-pack/plugins/data_enhanced/public/search/async_search_strategy.ts
@@ -70,7 +70,7 @@ export function asyncSearchStrategyProvider(
             return timer(pollInterval).pipe(
               // Send future requests using just the ID from the response
               mergeMap(() => {
-                return search({ id, serverStrategy }, options);
+                return syncSearch.search({ id, serverStrategy }, options);
               })
             );
           }),


### PR DESCRIPTION
## Summary

Bug was introduced in #60342
This PR fixes calling wrong strategy recursively and adds a test improvement to prevent this in the future.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
