### PR TITLE
[CI] GitHub check details link to test reports and errorlevel

### DIFF
--- a/.ci/end2end.groovy
+++ b/.ci/end2end.groovy
@@ -76,7 +76,7 @@ pipeline {
         }
       }
       steps{
-        notifyStatus('Running smoke tests', 'PENDING')
+        notifyTestStatus('Running smoke tests', 'PENDING')
         dir("${BASE_DIR}"){
           sh "${E2E_DIR}/ci/run-e2e.sh"
         }
@@ -95,10 +95,10 @@ pipeline {
           }
         }
         unsuccessful {
-          notifyStatus('Test failures', 'FAILURE')
+          notifyTestStatus('Test failures', 'FAILURE')
         }
         success {
-          notifyStatus('Tests passed', 'SUCCESS')
+          notifyTestStatus('Tests passed', 'SUCCESS')
         }
       }
     }
@@ -113,5 +113,9 @@ pipeline {
 }
 
 def notifyStatus(String description, String status) {
-  withGithubNotify.notify('end2end-for-apm-ui', description, status, getBlueoceanDisplayURL())
+  withGithubNotify.notify('end2end-for-apm-ui', description, status, getBlueoceanTabURL('pipeline'))
+}
+
+def notifyTestStatus(String description, String status) {
+  withGithubNotify.notify('end2end-for-apm-ui', description, status, getBlueoceanTabURL('tests'))
 }

--- a/x-pack/plugins/apm/e2e/run-e2e.sh
+++ b/x-pack/plugins/apm/e2e/run-e2e.sh
@@ -164,6 +164,7 @@ echo "✅ Setup completed successfully. Running tests..."
 # run cypress tests
 ##################################################
 yarn cypress run --config pageLoadTimeout=100000,watchForFileChanges=true
+e2e_status=$?
 
 #
 # Run interactively
@@ -171,3 +172,9 @@ yarn cypress run --config pageLoadTimeout=100000,watchForFileChanges=true
 echo "${bold}If you want to run the test interactively, run:${normal}"
 echo "" # newline
 echo "cd ${E2E_DIR} && yarn cypress open --config pageLoadTimeout=100000,watchForFileChanges=true"
+
+# Report the e2e status at the very end
+if [ $e2e_status -ne 0 ]; then
+    echo "⚠️  Running tests failed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

GitHub check details will link to the test report page in the Jenkins UI, to help with the analysis of test errors. Besides, the script will report the error code.


### Tests

- Prepare Kibana stage (the pre-requirement before running the tests) behaves as used to be:

![image](https://user-images.githubusercontent.com/2871786/84667747-aa561480-af1a-11ea-9a97-935ff755ab5e.png)

- Running the tests stage

![image](https://user-images.githubusercontent.com/2871786/84668474-98c13c80-af1b-11ea-819c-80bf8a33a487.png)
