### PR TITLE
[QA] Code coverage: fix flaky tests

### DIFF
--- a/test/functional/apps/dashboard/dashboard_filter_bar.js
+++ b/test/functional/apps/dashboard/dashboard_filter_bar.js
@@ -170,6 +170,8 @@ export default function ({ getService, getPageObjects }) {
     });
 
     describe('saved search filtering', function () {
+      // https://github.com/elastic/kibana/issues/47286#issuecomment-644687577
+      this.tags('skipCoverage');
       before(async () => {
         await filterBar.ensureFieldEditorModalIsClosed();
         await PageObjects.dashboard.gotoDashboardLandingPage();

--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -409,7 +409,7 @@ export function CommonPageProvider({ getService, getPageObjects }: FtrProviderCo
     async closeToastIfExists() {
       const toastShown = await find.existsByCssSelector('.euiToast');
       if (toastShown) {
-        await this.closeToast();
+        await find.clickByCssSelector('.euiToast__closeButton');
       }
     }
 


### PR DESCRIPTION
## Summary

Addressing 2 failures for code coverage runs:

• test/functional/apps/dashboard/dashboard_snapshots·js.dashboard app using current data dashboard snapshots compare TSVB snapshot:
    - updating `closeToastIfExists`
• test/functional/apps/dashboard/dashboard_filter_bar·js.dashboard app using current data dashboard filter bar saved search filtering are added when a cell magnifying glass is clicked :     -     
    - skipping test since magnifying glass is not rendered when Kibana is started from source (still works fine from snapshot)

Tested with:
https://kibana-ci.elastic.co/job/elastic+kibana+qa-research/8/
https://kibana-ci.elastic.co/job/elastic+kibana+qa-research/9/