### PR TITLE
[Ingest Manager] Add usage collector for telemetry.

### DIFF
--- a/x-pack/.telemetryrc.json
+++ b/x-pack/.telemetryrc.json
@@ -7,6 +7,7 @@
     "plugins/apm/server/lib/apm_telemetry/index.ts",
     "plugins/canvas/server/collectors/collector.ts",
     "plugins/infra/server/usage/usage_collector.ts",
+    "plugins/ingest_manager/server/collectors/register.ts",
     "plugins/lens/server/usage/collectors.ts",
     "plugins/reporting/server/usage/reporting_usage_collector.ts",
     "plugins/maps/server/maps_telemetry/collectors/register.ts"

--- a/x-pack/plugins/ingest_manager/common/constants/plugin.ts
+++ b/x-pack/plugins/ingest_manager/common/constants/plugin.ts
@@ -4,4 +4,3 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 export const PLUGIN_ID = 'ingestManager';
-export const USAGE_TYPE = 'ingest_manager';

--- a/x-pack/plugins/ingest_manager/common/constants/plugin.ts
+++ b/x-pack/plugins/ingest_manager/common/constants/plugin.ts
@@ -4,3 +4,4 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 export const PLUGIN_ID = 'ingestManager';
+export const USAGE_TYPE = 'ingest_manager';

--- a/x-pack/plugins/ingest_manager/kibana.json
+++ b/x-pack/plugins/ingest_manager/kibana.json
@@ -5,6 +5,6 @@
   "ui": true,
   "configPath": ["xpack", "ingestManager"],
   "requiredPlugins": ["licensing", "data", "encryptedSavedObjects"],
-  "optionalPlugins": ["security", "features", "cloud"],
+  "optionalPlugins": ["security", "features", "cloud", "usageCollection"],
   "extraPublicDirs": ["common"]
 }

--- a/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
@@ -8,7 +8,6 @@
 import { SavedObjectsClient } from 'src/core/server/saved_objects';
 import * as AgentService from '../services/agents';
 export interface AgentUsage {
-  events: number;
   total: number;
   online: number;
   error: number;
@@ -19,12 +18,20 @@ export const getAgentUsage = async (soClient?: SavedObjectsClient): Promise<Agen
   // TODO: unsure if this case is possible at all.
   if (!soClient) {
     return {
-      events: 0,
       total: 0,
       online: 0,
       error: 0,
       offline: 0,
     };
   }
-  return AgentService.getAgentStatusForConfig(soClient, undefined);
+  const { total, online, error, offline } = await AgentService.getAgentStatusForConfig(
+    soClient,
+    undefined
+  );
+  return {
+    total,
+    online,
+    error,
+    offline,
+  };
 };

--- a/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { SavedObjectsClient } from 'src/core/server/saved_objects';
+import * as AgentService from '../services/agents';
+export interface AgentUsage {
+  events: number;
+  total: number;
+  online: number;
+  error: number;
+  offline: number;
+}
+
+export const getAgentUsage = async (soClient?: SavedObjectsClient): Promise<AgentUsage> => {
+  // TODO: unsure if this case is possible at all.
+  if (!soClient) {
+    return {
+      events: 0,
+      total: 0,
+      online: 0,
+      error: 0,
+      offline: 0,
+    };
+  }
+  return AgentService.getAgentStatusForConfig(soClient, undefined);
+};

--- a/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
@@ -23,10 +23,7 @@ export const getAgentUsage = async (soClient?: SavedObjectsClient): Promise<Agen
       offline: 0,
     };
   }
-  const { total, online, error, offline } = await AgentService.getAgentStatusForConfig(
-    soClient,
-    undefined
-  );
+  const { total, online, error, offline } = await AgentService.getAgentStatusForConfig(soClient);
   return {
     total,
     online,

--- a/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/agent_collectors.ts
@@ -4,8 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { SavedObjectsClient } from 'src/core/server/saved_objects';
+import { SavedObjectsClient } from 'kibana/server';
 import * as AgentService from '../services/agents';
 export interface AgentUsage {
   total: number;

--- a/x-pack/plugins/ingest_manager/server/collectors/config_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/config_collectors.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { IngestManagerConfigType } from '..';
+
+export const getIsFleetEnabled = (config: IngestManagerConfigType) => {
+  return config.fleet.enabled;
+};

--- a/x-pack/plugins/ingest_manager/server/collectors/helpers.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/helpers.ts
@@ -4,11 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { CoreSetup, SavedObjectsClient } from 'kibana/server';
+import { CoreSetup } from 'kibana/server';
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { SavedObjectsClient } from '../../../../../src/core/server/saved_objects/service/saved_objects_client';
 
 export async function getInternalSavedObjectsClient(core: CoreSetup) {
   return core.getStartServices().then(async ([coreStart]) => {
-    // TODO: is this safe?
-    return (coreStart.savedObjects.createInternalRepository() as unknown) as SavedObjectsClient;
+    const savedObjectsRepo = coreStart.savedObjects.createInternalRepository();
+    return new SavedObjectsClient(savedObjectsRepo);
   });
 }

--- a/x-pack/plugins/ingest_manager/server/collectors/helpers.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/helpers.ts
@@ -5,8 +5,7 @@
  */
 
 import { CoreSetup } from 'kibana/server';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { SavedObjectsClient } from '../../../../../src/core/server/saved_objects/service/saved_objects_client';
+import { SavedObjectsClient } from '../../../../../src/core/server';
 
 export async function getInternalSavedObjectsClient(core: CoreSetup) {
   return core.getStartServices().then(async ([coreStart]) => {

--- a/x-pack/plugins/ingest_manager/server/collectors/helpers.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/helpers.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { CoreSetup, SavedObjectsClient } from 'kibana/server';
+
+export async function getInternalSavedObjectsClient(core: CoreSetup) {
+  return core.getStartServices().then(async ([coreStart]) => {
+    // TODO: is this safe?
+    return (coreStart.savedObjects.createInternalRepository() as unknown) as SavedObjectsClient;
+  });
+}

--- a/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { SavedObjectsClient } from 'kibana/server';
+import { getPackageSavedObjects } from '../services/epm/packages/get';
+
+export interface PackageUsage {
+  name: string;
+  version: string;
+}
+
+export const getPackageUsage = async (soClient?: SavedObjectsClient): Promise<PackageUsage[]> => {
+  if (!soClient) {
+    return [];
+  }
+  const packagesSavedObjects = await getPackageSavedObjects(soClient);
+  // console.log('packages is ', JSON.stringify(packagesSave, null, 2));
+  return packagesSavedObjects.saved_objects.map((p) => {
+    return {
+      name: p.attributes.name,
+      version: p.attributes.version,
+    };
+  });
+};

--- a/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
@@ -30,13 +30,11 @@ export const getPackageUsage = async (soClient?: SavedObjectsClient): Promise<Pa
   // to the (then to be created) agent config collector, so we only query and loop over these
   // objects once.
 
-  // I couldn't convince TS that no undefined will end up in this string[][], so let it be any
-  const packagesInConfigs: any[][] = [];
-  agentConfigs.items.forEach((agentConfig) => {
+  const packagesInConfigs = agentConfigs.items.map((agentConfig) => {
     const packageConfigs: NewPackageConfig[] = agentConfig.package_configs as NewPackageConfig[];
-    packagesInConfigs.push(
-      packageConfigs.map((pc) => pc.package?.name).filter((pn) => pn !== undefined)
-    );
+    return packageConfigs
+      .map((pc) => pc.package?.name)
+      .filter((pn): pn is string => pn !== undefined);
   });
 
   const enabledPackages = _.uniq(_.flatten(packagesInConfigs));

--- a/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
@@ -43,7 +43,7 @@ export const getPackageUsage = async (soClient?: SavedObjectsClient): Promise<Pa
     return {
       name: p.attributes.name,
       version: p.attributes.version,
-      enabled: p.attributes.name in enabledPackages,
+      enabled: enabledPackages.includes(p.attributes.name),
     };
   });
 };

--- a/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/package_collectors.ts
@@ -33,8 +33,8 @@ export const getPackageUsage = async (soClient?: SavedObjectsClient): Promise<Pa
   const packagesInConfigs = agentConfigs.items.map((agentConfig) => {
     const packageConfigs: NewPackageConfig[] = agentConfig.package_configs as NewPackageConfig[];
     return packageConfigs
-      .map((pc) => pc.package?.name)
-      .filter((pn): pn is string => pn !== undefined);
+      .map((packageConfig) => packageConfig.package?.name)
+      .filter((packageName): packageName is string => packageName !== undefined);
   });
 
   const enabledPackages = _.uniq(_.flatten(packagesInConfigs));

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -11,11 +11,11 @@ interface Usage {
   agents: {
     enrolled: number;
   };
-  packages: {
+  packages: Array<{
     name: string;
     version: string;
     enabled: boolean;
-  };
+  }>;
 }
 
 export function registerIngestManagerUsageCollector(usageCollection?: UsageCollectionSetup): void {

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -34,9 +34,6 @@ export function registerIngestManagerUsageCollector(
     type: 'ingest_manager',
     isReady: () => true,
     fetch: async () => {
-      // query ES and get some data
-      // summarize the data into a model
-      // return the modeled object that includes whatever you want to track
       const soClient = await getInternalSavedObjectsClient(core);
       return {
         fleet_enabled: getIsFleetEnabled(config),
@@ -55,6 +52,7 @@ export function registerIngestManagerUsageCollector(
     //   packages: {
     //     name: { type: 'keyword' },
     //     version: { type: 'keyword' },
+    //     enabled: { type: boolean },
     //   },
     // },
   });

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -56,7 +56,6 @@ export function registerIngestManagerUsageCollector(
     // schema: { // temporarily disabled because of type errors
     //   fleet_enabled: { type: 'boolean' },
     //   agents: {
-    //    events: { type: 'number' },
     //    total: { type: 'number' },
     //    online: { type: 'number' },
     //    error: { type: 'number' },

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -46,17 +46,17 @@ export function registerIngestManagerUsageCollector(usageCollection?: UsageColle
         ],
       };
     },
-    schema: {
-      fleet_enabled: { type: 'boolean' },
-      agents: {
-        enrolled: { type: 'number' },
-      },
-      packages: {
-        name: { type: 'keyword' },
-        version: { type: 'keyword' },
-        enabled: { type: 'boolean' },
-      },
-    },
+    // schema: { // temporarily disabled because of type errors
+    //   fleet_enabled: { type: 'boolean' },
+    //   agents: {
+    //     enrolled: { type: 'number' },
+    //   },
+    //   packages: {
+    //     name: { type: 'keyword' },
+    //     version: { type: 'keyword' },
+    //     enabled: { type: 'boolean' },
+    //   },
+    // },
   });
 
   // register usage collector

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
+import { APICaller } from 'kibana/server';
+import { USAGE_TYPE } from '../../common';
+
+export function registerIngestManagerUsageCollector(usageCollection?: UsageCollectionSetup): void {
+  // usageCollection is an optional dependency, so make sure to return if it is not registered.
+  if (!usageCollection) {
+    return;
+  }
+
+  // create usage collector
+  const ingestManagerCollector = usageCollection.makeUsageCollector({
+    type: USAGE_TYPE,
+    isReady: () => true,
+    fetch: async (callCluster: APICaller) => {
+      // query ES and get some data
+      // summarize the data into a model
+      // return the modeled object that includes whatever you want to track
+
+      return {
+        packages_installed: [
+          {
+            name: 'system',
+            version: '0.0.1',
+          },
+          {
+            name: 'endpoint',
+            version: '1.0.0',
+          },
+        ],
+        agents_enrolled: 42,
+        agent_configs_present: 23,
+        fleet_enabled: true,
+      };
+    },
+  });
+
+  // register usage collector
+  usageCollection.registerCollector(ingestManagerCollector);
+}

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -9,16 +9,13 @@ import { CoreSetup } from 'kibana/server';
 import { getIsFleetEnabled } from './config_collectors';
 import { AgentUsage, getAgentUsage } from './agent_collectors';
 import { getInternalSavedObjectsClient } from './helpers';
+import { PackageUsage, getPackageUsage } from './package_collectors';
 import { IngestManagerConfigType } from '..';
 
 interface Usage {
   fleet_enabled: boolean;
   agents: AgentUsage;
-  packages: Array<{
-    name: string;
-    version: string;
-    enabled: boolean;
-  }>;
+  packages: PackageUsage[];
 }
 
 export function registerIngestManagerUsageCollector(
@@ -44,13 +41,7 @@ export function registerIngestManagerUsageCollector(
       return {
         fleet_enabled: getIsFleetEnabled(config),
         agents: await getAgentUsage(soClient),
-        packages: [
-          {
-            name: 'system',
-            version: '0.0.1',
-            enabled: true,
-          },
-        ],
+        packages: await getPackageUsage(soClient),
       };
     },
     // schema: { // temporarily disabled because of type errors
@@ -64,7 +55,6 @@ export function registerIngestManagerUsageCollector(
     //   packages: {
     //     name: { type: 'keyword' },
     //     version: { type: 'keyword' },
-    //     enabled: { type: 'boolean' },
     //   },
     // },
   });

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -8,6 +8,14 @@ import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 
 interface Usage {
   fleet_enabled: boolean;
+  agents: {
+    enrolled: number;
+  };
+  packages: {
+    name: string;
+    version: string;
+    enabled: boolean;
+  };
 }
 
 export function registerIngestManagerUsageCollector(usageCollection?: UsageCollectionSetup): void {
@@ -26,10 +34,28 @@ export function registerIngestManagerUsageCollector(usageCollection?: UsageColle
       // return the modeled object that includes whatever you want to track
       return {
         fleet_enabled: true,
+        agents: {
+          enrolled: 42,
+        },
+        packages: [
+          {
+            name: 'system',
+            version: '0.0.1',
+            enabled: true,
+          },
+        ],
       };
     },
     schema: {
       fleet_enabled: { type: 'boolean' },
+      agents: {
+        enrolled: { type: 'number' },
+      },
+      packages: {
+        name: { type: 'keyword' },
+        version: { type: 'keyword' },
+        enabled: { type: 'boolean' },
+      },
     },
   });
 

--- a/x-pack/plugins/ingest_manager/server/collectors/register.ts
+++ b/x-pack/plugins/ingest_manager/server/collectors/register.ts
@@ -5,8 +5,10 @@
  */
 
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
-import { APICaller } from 'kibana/server';
-import { USAGE_TYPE } from '../../common';
+
+interface Usage {
+  fleet_enabled: boolean;
+}
 
 export function registerIngestManagerUsageCollector(usageCollection?: UsageCollectionSetup): void {
   // usageCollection is an optional dependency, so make sure to return if it is not registered.
@@ -15,29 +17,19 @@ export function registerIngestManagerUsageCollector(usageCollection?: UsageColle
   }
 
   // create usage collector
-  const ingestManagerCollector = usageCollection.makeUsageCollector({
-    type: USAGE_TYPE,
+  const ingestManagerCollector = usageCollection.makeUsageCollector<Usage>({
+    type: 'ingest_manager',
     isReady: () => true,
-    fetch: async (callCluster: APICaller) => {
+    fetch: async () => {
       // query ES and get some data
       // summarize the data into a model
       // return the modeled object that includes whatever you want to track
-
       return {
-        packages_installed: [
-          {
-            name: 'system',
-            version: '0.0.1',
-          },
-          {
-            name: 'endpoint',
-            version: '1.0.0',
-          },
-        ],
-        agents_enrolled: 42,
-        agent_configs_present: 23,
         fleet_enabled: true,
       };
+    },
+    schema: {
+      fleet_enabled: { type: 'boolean' },
     },
   });
 

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -14,6 +14,7 @@ import {
   SavedObjectsServiceStart,
   HttpServiceSetup,
 } from 'kibana/server';
+import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 import { LicensingPluginSetup, ILicense } from '../../licensing/server';
 import {
   EncryptedSavedObjectsPluginStart,
@@ -69,6 +70,7 @@ export interface IngestManagerSetupDeps {
   features?: FeaturesPluginSetup;
   encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
   cloud?: CloudSetup;
+  usageCollection?: UsageCollectionSetup;
 }
 
 export type IngestManagerStartDeps = object;

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -166,9 +166,6 @@ export class IngestManagerPlugin
     registerSavedObjects(core.savedObjects);
     registerEncryptedSavedObjects(deps.encryptedSavedObjects);
 
-    // Register usage collection
-    registerIngestManagerUsageCollector(deps.usageCollection);
-
     // Register feature
     // TODO: Flesh out privileges
     if (deps.features) {
@@ -203,6 +200,9 @@ export class IngestManagerPlugin
 
     const router = core.http.createRouter();
     const config = await this.config$.pipe(first()).toPromise();
+
+    // Register usage collection
+    registerIngestManagerUsageCollector(core, config, deps.usageCollection);
 
     // Always register app routes for permissions checking
     registerAppRoutes(router);

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -63,6 +63,7 @@ import {
 } from './services/agents';
 import { CloudSetup } from '../../cloud/server';
 import { agentCheckinState } from './services/agents/checkin/state';
+import { registerIngestManagerUsageCollector } from './collectors/register';
 
 export interface IngestManagerSetupDeps {
   licensing: LicensingPluginSetup;
@@ -164,6 +165,9 @@ export class IngestManagerPlugin
 
     registerSavedObjects(core.savedObjects);
     registerEncryptedSavedObjects(deps.encryptedSavedObjects);
+
+    // Register usage collection
+    registerIngestManagerUsageCollector(deps.usageCollection);
 
     // Register feature
     // TODO: Flesh out privileges

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -14,6 +14,13 @@
         }
       }
     },
+    "ingest_manager": {
+      "properties": {
+        "fleet_enabled": {
+          "type": "boolean"
+        }
+      }
+    },
     "mlTelemetry": {
       "properties": {
         "file_data_visualizer": {

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -14,13 +14,6 @@
         }
       }
     },
-    "ingest_manager": {
-      "properties": {
-        "fleet_enabled": {
-          "type": "boolean"
-        }
-      }
-    },
     "mlTelemetry": {
       "properties": {
         "file_data_visualizer": {


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/69282

This adds and registers a `usageCollector` for the Ingest Manager plugin according to the telemetry documentation at 

* https://github.com/elastic/kibana/blob/master/src/plugins/usage_collection/README.md#new-platform
* https://github.com/elastic/kibana-team/blob/master/telemetry.md#the-hitchhikers-guide-to-telemetry

## How to test this

Run a local setup with Ingest Manager enabled and log in to Kibana once, so that the initial setup of Ingest Manager has been performed.

Trigger a telemetry collection by visiting http://localhost:5601/api/stats?extended=true . In the output, find the `ingest_manager` key. All telemetry reported by this PR appears in the JSON object belonging to this key. (Some way to pretty-format JSON output is probably helpful, I'm using [JSNView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc?hl=de) for Chrome.)

* Disable fleet by setting `xpack.ingestManager.fleet.enabled: false` in `kibana.dev.yml` or any other means of configuring Kibana. This should result in `fleet_enabled: false` in the telemetry output. Enable fleet again and verify that you now see `fleet_enabled: true`
* With fleet enabled again, enroll one or more agents. The numbers in the `agents` part of the response should go up correspondingly.
* When only the default agent config is used, the `packages` part of the response should list the `system` package with `enabled: true` and the `endpoint` package with `enabled: false`.
* Creating more agent configurations and installing more integrations should be reflected in the telemetry output as well.

## Known issues

* ~I had to do some wild typecasting in https://github.com/elastic/kibana/pull/69294/files#diff-02006980a036f05fecfa9277bb5a1c01R12 in order to use our existing methods to query saved objects. The issue is that according to the existing example code, accessing saved objects from the telemetry collector is done with the return value of `core.savedObjects.createInternalRepository()`, which for all practical purposes behaves like a `SavedObjectsClient`, but the types don't match up.~ SOLVED, see discussion.

* Accesses to saved objects aren't paginated right now. This code catches and analyses the first `1000` agent configs and the first `20` packages, mirroring what we do elsewhere in Ingest Manager. This is probably instantaneous tech debt -- I can amend this but wanted to open the PR for review now.

