### PR TITLE
[SIEM][Timeline][skip-ci] Improve timeline's type

### DIFF
--- a/x-pack/plugins/security_solution/public/alerts/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/alerts/components/alerts_table/index.tsx
@@ -21,7 +21,6 @@ import { useKibana } from '../../../common/lib/kibana';
 import { inputsSelectors, State, inputsModel } from '../../../common/store';
 import { timelineActions, timelineSelectors } from '../../../timelines/store/timeline';
 import { TimelineModel } from '../../../timelines/store/timeline/model';
-import { timelineDefaults } from '../../../timelines/store/timeline/defaults';
 import { useManageTimeline } from '../../../timelines/components/manage_timeline';
 import { useApolloClient } from '../../../common/utils/apollo_context';
 
@@ -376,7 +375,7 @@ const makeMapStateToProps = () => {
   const getGlobalInputs = inputsSelectors.globalSelector();
   const mapStateToProps = (state: State, ownProps: OwnProps) => {
     const { timelineId } = ownProps;
-    const timeline: TimelineModel = getTimeline(state, timelineId) ?? timelineDefaults;
+    const timeline: TimelineModel = getTimeline(state, timelineId);
     const { deletedEventIds, isSelectAllChecked, loadingEventIds, selectedEventIds } = timeline;
 
     const globalInputs: inputsModel.InputsRange = getGlobalInputs(state);
@@ -394,30 +393,31 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  clearSelected: ({ id }: { id: string }) => dispatch(timelineActions.clearSelected({ id })),
+  clearSelected: ({ id }: { id: TimelineIdLiteral }) =>
+    dispatch(timelineActions.clearSelected({ id })),
   setEventsLoading: ({
     id,
     eventIds,
     isLoading,
   }: {
-    id: string;
+    id: TimelineIdLiteral;
     eventIds: string[];
     isLoading: boolean;
   }) => dispatch(timelineActions.setEventsLoading({ id, eventIds, isLoading })),
-  clearEventsLoading: ({ id }: { id: string }) =>
+  clearEventsLoading: ({ id }: { id: TimelineIdLiteral }) =>
     dispatch(timelineActions.clearEventsLoading({ id })),
   setEventsDeleted: ({
     id,
     eventIds,
     isDeleted,
   }: {
-    id: string;
+    id: TimelineIdLiteral;
     eventIds: string[];
     isDeleted: boolean;
   }) => dispatch(timelineActions.setEventsDeleted({ id, eventIds, isDeleted })),
-  clearEventsDeleted: ({ id }: { id: string }) =>
+  clearEventsDeleted: ({ id }: { id: TimelineIdLiteral }) =>
     dispatch(timelineActions.clearEventsDeleted({ id })),
-  updateTimelineIsLoading: ({ id, isLoading }: { id: string; isLoading: boolean }) =>
+  updateTimelineIsLoading: ({ id, isLoading }: { id: TimelineIdLiteral; isLoading: boolean }) =>
     dispatch(timelineActions.updateIsLoading({ id, isLoading })),
   updateTimeline: dispatchUpdateTimeline(dispatch),
 });

--- a/x-pack/plugins/security_solution/public/alerts/constants.ts
+++ b/x-pack/plugins/security_solution/public/alerts/constants.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
-
-export const ALERTS_RULES_DETAILS_PAGE_TIMELINE_ID = 'alerts-rules-details-page';
-export const ALERTS_TIMELINE_ID = 'alerts-page';

--- a/x-pack/plugins/security_solution/public/cases/components/user_action_tree/user_action_markdown.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/user_action_tree/user_action_markdown.tsx
@@ -9,6 +9,7 @@ import React, { useCallback } from 'react';
 import styled, { css } from 'styled-components';
 
 import { useDispatch } from 'react-redux';
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import * as i18n from '../case_view/translations';
 import { Markdown } from '../../../common/components/markdown';
 import { Form, useForm, UseField } from '../../../shared_imports';
@@ -60,7 +61,7 @@ export const UserActionMarkdown = ({
   }, [id, onChangeEditable]);
 
   const handleTimelineClick = useCallback(
-    (timelineId: string) => {
+    (timelineId: TimelineIdLiteral) => {
       queryTimelineById({
         apolloClient,
         timelineId,
@@ -68,7 +69,7 @@ export const UserActionMarkdown = ({
           id: currentTimelineId,
           isLoading,
         }: {
-          id: string;
+          id: TimelineIdLiteral;
           isLoading: boolean;
         }) => dispatch(dispatchUpdateIsLoading({ id: currentTimelineId, isLoading })),
         updateTimeline: dispatchUpdateTimeline(dispatch),

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useMemo, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { DEFAULT_INDEX_KEY } from '../../../../common/constants';
 import { inputsModel, inputsSelectors, State } from '../../store';
 import { inputsActions } from '../../store/actions';
@@ -28,7 +29,7 @@ export interface OwnProps {
   defaultIndices?: string[];
   defaultModel: SubsetTimelineModel;
   end: number;
-  id: string;
+  id: TimelineIdLiteral;
   start: number;
   headerFilterGroup?: React.ReactNode;
   pageFilters?: Filter[];

--- a/x-pack/plugins/security_solution/public/common/components/markdown/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown/index.tsx
@@ -10,6 +10,7 @@ import { EuiLink, EuiTableRow, EuiTableRowCell, EuiText, EuiToolTip } from '@ela
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled, { css } from 'styled-components';
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import * as i18n from './translations';
 
 const TableHeader = styled.thead`
@@ -38,7 +39,7 @@ const REL_NOREFERRER = 'noreferrer';
 export const Markdown = React.memo<{
   disableLinks?: boolean;
   raw?: string;
-  onClickTimeline?: (timelineId: string) => void;
+  onClickTimeline?: (timelineId: TimelineIdLiteral) => void;
   size?: 'xs' | 's' | 'm';
 }>(({ disableLinks = false, onClickTimeline, raw, size = 's' }) => {
   const markdownRenderers = {
@@ -63,7 +64,8 @@ export const Markdown = React.memo<{
     ),
     link: ({ children, href }: { children: React.ReactNode[]; href?: string }) => {
       if (onClickTimeline != null && href != null && href.indexOf(`timelines?timeline=(id:`) > -1) {
-        const timelineId = href.split('timelines?timeline=(id:')[1].split("'")[1] ?? '';
+        const timelineId = (href.split('timelines?timeline=(id:')[1].split("'")[1] ??
+          '') as TimelineIdLiteral;
         return (
           <EuiToolTip content={i18n.TIMELINE_ID(timelineId)}>
             <EuiLink

--- a/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/search_bar/index.tsx
@@ -22,6 +22,7 @@ import {
 
 import { OnTimeChangeProps } from '@elastic/eui';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { inputsActions } from '../../store/inputs';
 import { InputsRange } from '../../store/inputs/model';
 import { InputsModelId } from '../../store/inputs/constants';
@@ -309,7 +310,7 @@ interface UpdateReduxSearchBar extends OnTimeChangeProps {
   query?: Query;
   savedQuery?: SavedQuery;
   resetSavedQuery?: boolean;
-  timelineId?: string;
+  timelineId?: TimelineIdLiteral;
   updateTime: boolean;
 }
 

--- a/x-pack/plugins/security_solution/public/common/components/super_date_picker/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/super_date_picker/index.tsx
@@ -17,6 +17,7 @@ import React, { useState, useCallback } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Dispatch } from 'redux';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { DEFAULT_TIMEPICKER_QUICK_RANGES } from '../../../../common/constants';
 import { timelineActions } from '../../../timelines/store/timeline';
 import { useUiSetting$ } from '../../lib/kibana';
@@ -48,7 +49,7 @@ interface Range {
 interface UpdateReduxTime extends OnTimeChangeProps {
   id: InputsModelId;
   kql?: inputsModel.GlobalKqlQuery | undefined;
-  timelineId?: string;
+  timelineId?: TimelineIdLiteral;
 }
 
 interface ReturnUpdateReduxTime {
@@ -67,7 +68,7 @@ export type DispatchUpdateReduxTime = ({
 interface OwnProps {
   disabled?: boolean;
   id: InputsModelId;
-  timelineId?: string;
+  timelineId?: TimelineIdLiteral;
 }
 
 export type SuperDatePickerProps = OwnProps & PropsFromRedux;

--- a/x-pack/plugins/security_solution/public/common/components/top_n/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/index.test.tsx
@@ -82,7 +82,7 @@ const state: State = {
     ...mockGlobalState.timeline,
     timelineById: {
       [ACTIVE_TIMELINE_REDUX_ID]: {
-        ...mockGlobalState.timeline.timelineById.test,
+        ...mockGlobalState.timeline.timelineById.test!,
         id: ACTIVE_TIMELINE_REDUX_ID,
         dataProviders: [
           {

--- a/x-pack/plugins/security_solution/public/common/components/top_n/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/index.tsx
@@ -7,6 +7,7 @@
 import React, { useMemo } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
+import { TimelineId } from '../../../../common/types/timeline';
 import { GlobalTime } from '../../containers/global_time';
 import { BrowserFields, WithSource } from '../../containers/source';
 import { useKibana } from '../../lib/kibana';
@@ -23,7 +24,7 @@ import { TopN } from './top_n';
 import { useManageTimeline } from '../../../timelines/components/manage_timeline';
 
 /** The currently active timeline always has this Redux ID */
-export const ACTIVE_TIMELINE_REDUX_ID = 'timeline-1';
+export const ACTIVE_TIMELINE_REDUX_ID = TimelineId.active;
 
 const EMPTY_FILTERS: Filter[] = [];
 const EMPTY_QUERY: Query = { query: '', language: 'kuery' };

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -122,8 +122,8 @@ export const makeMapStateToProps = () => {
 
     const timeline = Object.entries(getTimelines(state)).reduce(
       (obj, [timelineId, timelineObj]) => ({
-        id: timelineObj.savedObjectId != null ? timelineObj.savedObjectId : '',
-        isOpen: timelineObj.show,
+        id: timelineObj?.savedObjectId != null ? timelineObj.savedObjectId : '',
+        isOpen: timelineObj?.show ?? false,
       }),
       { id: '', isOpen: false }
     );

--- a/x-pack/plugins/security_solution/public/common/components/url_state/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/index.tsx
@@ -9,6 +9,7 @@ import { compose, Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { timelineActions } from '../../../timelines/store/timeline';
 import { RouteSpyState } from '../../utils/route/types';
 import { useRouteSpy } from '../../utils/route/use_route_spy';
@@ -29,7 +30,7 @@ export const UrlStateContainer: React.FC<UrlStateContainerPropTypes> = (
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   setInitialStateFromUrl: dispatchSetInitialStateFromUrl(dispatch),
   updateTimeline: dispatchUpdateTimeline(dispatch),
-  updateTimelineIsLoading: ({ id, isLoading }: { id: string; isLoading: boolean }) =>
+  updateTimelineIsLoading: ({ id, isLoading }: { id: TimelineIdLiteral; isLoading: boolean }) =>
     dispatch(timelineActions.updateIsLoading({ id, isLoading })),
 });
 

--- a/x-pack/plugins/security_solution/public/common/utils/kql/use_update_kql.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/kql/use_update_kql.tsx
@@ -8,6 +8,7 @@ import { Dispatch } from 'redux';
 import { IIndexPattern } from 'src/plugins/data/public';
 import deepEqual from 'fast-deep-equal';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { KueryFilterQuery } from '../../store';
 import { applyKqlFilterQuery as dispatchApplyTimelineFilterQuery } from '../../../timelines/store/timeline/actions';
 import { convertKueryToElasticSearchQuery } from '../../lib/keury';
@@ -18,7 +19,7 @@ interface UseUpdateKqlProps {
   kueryFilterQuery: KueryFilterQuery | null;
   kueryFilterQueryDraft: KueryFilterQuery | null;
   storeType: 'timelineType';
-  timelineId?: string;
+  timelineId?: TimelineIdLiteral;
 }
 
 export const useUpdateKql = ({

--- a/x-pack/plugins/security_solution/public/overview/components/recent_timelines/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/recent_timelines/index.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useMemo, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Dispatch } from 'redux';
 
-import { TimelineType } from '../../../../common/types/timeline';
+import { TimelineType, TimelineIdLiteral } from '../../../../common/types/timeline';
 import { useGetAllTimeline } from '../../../timelines/containers/all';
 import { SortFieldTimeline, Direction } from '../../../graphql/types';
 import {
@@ -40,7 +40,7 @@ const PAGE_SIZE = 3;
 const StatefulRecentTimelinesComponent = React.memo<Props>(
   ({ apolloClient, filterBy, updateIsLoading, updateTimeline }) => {
     const onOpenTimeline: OnOpenTimeline = useCallback(
-      ({ duplicate, timelineId }: { duplicate: boolean; timelineId: string }) => {
+      ({ duplicate, timelineId }: { duplicate: boolean; timelineId: TimelineIdLiteral }) => {
         queryTimelineById({
           apolloClient,
           duplicate,
@@ -106,7 +106,7 @@ const StatefulRecentTimelinesComponent = React.memo<Props>(
 StatefulRecentTimelinesComponent.displayName = 'StatefulRecentTimelinesComponent';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  updateIsLoading: ({ id, isLoading }: { id: string; isLoading: boolean }) =>
+  updateIsLoading: ({ id, isLoading }: { id: TimelineIdLiteral; isLoading: boolean }) =>
     dispatch(dispatchUpdateIsLoading({ id, isLoading })),
   updateTimeline: dispatchUpdateTimeline(dispatch),
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -8,6 +8,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { ActionCreator } from 'typescript-fsa';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { mockBrowserFields } from '../../../common/containers/source/mock';
 import { TestProviders } from '../../../common/mock';
 import { ColumnHeaderOptions } from '../../../timelines/store/timeline/model';
@@ -30,13 +31,13 @@ afterAll(() => {
 });
 
 const removeColumnMock = (jest.fn() as unknown) as ActionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   columnId: string;
 }>;
 
 const upsertColumnMock = (jest.fn() as unknown) as ActionCreator<{
   column: ColumnHeaderOptions;
-  id: string;
+  id: TimelineIdLiteral;
   index: number;
 }>;
 

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header/index.tsx
@@ -7,8 +7,9 @@
 import React, { useCallback } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { Dispatch } from 'redux';
-
 import { isEmpty, get } from 'lodash/fp';
+
+import { TimelineIdLiteral } from '../../../../../common/types/timeline';
 import { History } from '../../../../common/lib/history';
 import { Note } from '../../../../common/lib/note';
 import { appSelectors, inputsModel, inputsSelectors, State } from '../../../../common/store';
@@ -22,7 +23,7 @@ import { timelineDefaults } from '../../../../timelines/store/timeline/defaults'
 import { InputsModelId } from '../../../../common/store/inputs/constants';
 
 interface OwnProps {
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
   usersViewing: string[];
 }
 
@@ -119,7 +120,7 @@ const makeMapStateToProps = () => {
 
 const mapDispatchToProps = (dispatch: Dispatch, { timelineId }: OwnProps) => ({
   associateNote: (noteId: string) => dispatch(timelineActions.addNote({ id: timelineId, noteId })),
-  createTimeline: ({ id, show }: { id: string; show?: boolean }) =>
+  createTimeline: ({ id, show }: { id: TimelineIdLiteral; show?: boolean }) =>
     dispatch(
       timelineActions.createTimeline({
         id,
@@ -127,14 +128,14 @@ const mapDispatchToProps = (dispatch: Dispatch, { timelineId }: OwnProps) => ({
         show,
       })
     ),
-  updateDescription: ({ id, description }: { id: string; description: string }) =>
+  updateDescription: ({ id, description }: { id: TimelineIdLiteral; description: string }) =>
     dispatch(timelineActions.updateDescription({ id, description })),
-  updateIsFavorite: ({ id, isFavorite }: { id: string; isFavorite: boolean }) =>
+  updateIsFavorite: ({ id, isFavorite }: { id: TimelineIdLiteral; isFavorite: boolean }) =>
     dispatch(timelineActions.updateIsFavorite({ id, isFavorite })),
-  updateIsLive: ({ id, isLive }: { id: string; isLive: boolean }) =>
+  updateIsLive: ({ id, isLive }: { id: TimelineIdLiteral; isLive: boolean }) =>
     dispatch(timelineActions.updateIsLive({ id, isLive })),
   updateNote: (note: Note) => dispatch(appActions.updateNote({ note })),
-  updateTitle: ({ id, title }: { id: string; title: string }) =>
+  updateTitle: ({ id, title }: { id: TimelineIdLiteral; title: string }) =>
     dispatch(timelineActions.updateTitle({ id, title })),
   toggleLock: ({ linkToId }: { linkToId: InputsModelId }) =>
     dispatch(inputsActions.toggleTimelineLinkTo({ linkToId })),

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header_with_close_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header_with_close_button/index.test.tsx
@@ -7,6 +7,7 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
+import { TimelineId } from '../../../../../common/types/timeline';
 import { TestProviders } from '../../../../common/mock';
 import { FlyoutHeaderWithCloseButton } from '.';
 
@@ -37,7 +38,7 @@ describe('FlyoutHeaderWithCloseButton', () => {
       <TestProviders>
         <FlyoutHeaderWithCloseButton
           onClose={jest.fn()}
-          timelineId={'test'}
+          timelineId={TimelineId.test}
           usersViewing={['elastic']}
         />
       </TestProviders>
@@ -51,7 +52,7 @@ describe('FlyoutHeaderWithCloseButton', () => {
       <TestProviders>
         <FlyoutHeaderWithCloseButton
           onClose={closeMock}
-          timelineId={'test'}
+          timelineId={TimelineId.test}
           usersViewing={['elastic']}
         />
       </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/header_with_close_button/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/header_with_close_button/index.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
 import styled from 'styled-components';
 
+import { TimelineIdLiteral } from '../../../../../common/types/timeline';
 import { FlyoutHeader } from '../header';
 import * as i18n from './translations';
 
@@ -26,7 +27,7 @@ const WrappedCloseButton = styled.div`
 
 const FlyoutHeaderWithCloseButtonComponent: React.FC<{
   onClose: () => void;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
   usersViewing: string[];
 }> = ({ onClose, timelineId, usersViewing }) => (
   <FlyoutHeaderContainer>

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/index.test.tsx
@@ -9,6 +9,7 @@ import { set } from 'lodash/fp';
 import React from 'react';
 import { ActionCreator } from 'typescript-fsa';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import {
   apolloClientObservable,
   mockGlobalState,
@@ -157,7 +158,10 @@ describe('Flyout', () => {
     });
 
     test('should call the onOpen when the mouse is clicked for rendering', () => {
-      const showTimeline = (jest.fn() as unknown) as ActionCreator<{ id: string; show: boolean }>;
+      const showTimeline = (jest.fn() as unknown) as ActionCreator<{
+        id: TimelineIdLiteral;
+        show: boolean;
+      }>;
       const wrapper = mount(
         <TestProviders>
           <FlyoutComponent

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/index.tsx
@@ -9,6 +9,7 @@ import React, { useCallback } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import styled from 'styled-components';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { State } from '../../../common/store';
 import { DataProvider } from '../timeline/data_providers/data_provider';
 import { FlyoutButton } from './button';
@@ -17,6 +18,9 @@ import { timelineActions, timelineSelectors } from '../../store/timeline';
 import { DEFAULT_TIMELINE_WIDTH } from '../timeline/body/constants';
 import { StatefulTimeline } from '../timeline';
 import { TimelineById } from '../../store/timeline/types';
+
+const DEFAULT_DATA_PROVIDERS: DataProvider[] = [];
+const DEFAULT_TIMELINE_BY_ID = {};
 
 export const Badge = (styled(EuiBadge)`
   position: absolute;
@@ -37,7 +41,7 @@ Visible.displayName = 'Visible';
 
 interface OwnProps {
   flyoutHeight: number;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
   usersViewing: string[];
 }
 
@@ -67,7 +71,7 @@ export const FlyoutComponent = React.memo<Props>(
           </Pane>
         </Visible>
         <FlyoutButton
-          dataProviders={dataProviders}
+          dataProviders={dataProviders ?? DEFAULT_DATA_PROVIDERS}
           show={!show}
           timelineId={timelineId}
           onOpen={handleOpen}
@@ -78,9 +82,6 @@ export const FlyoutComponent = React.memo<Props>(
 );
 
 FlyoutComponent.displayName = 'FlyoutComponent';
-
-const DEFAULT_DATA_PROVIDERS: DataProvider[] = [];
-const DEFAULT_TIMELINE_BY_ID = {};
 
 const mapStateToProps = (state: State, { timelineId }: OwnProps) => {
   const timelineById: TimelineById =

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/pane/index.tsx
@@ -10,9 +10,10 @@ import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { Resizable, ResizeCallback } from 're-resizable';
 
-import { TimelineResizeHandle } from './timeline_resize_handle';
+import { TimelineIdLiteral } from '../../../../../common/types/timeline';
 import { EventDetailsWidthProvider } from '../../../../common/components/events_viewer/event_details_width_context';
 
+import { TimelineResizeHandle } from './timeline_resize_handle';
 import * as i18n from './translations';
 import { timelineActions } from '../../../store/timeline';
 
@@ -22,7 +23,7 @@ interface FlyoutPaneComponentProps {
   children: React.ReactNode;
   flyoutHeight: number;
   onClose: () => void;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
   width: number;
 }
 

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.ts
@@ -9,6 +9,7 @@ import { getOr, set, isEmpty } from 'lodash/fp';
 import { Action } from 'typescript-fsa';
 import uuid from 'uuid';
 import { Dispatch } from 'redux';
+import { TimelineIdLiteral, TimelineId } from '../../../../common/types/timeline';
 import { oneTimelineQuery } from '../../containers/one/index.gql_query';
 import { TimelineResult, GetOneTimeline, NoteResult } from '../../../graphql/types';
 import {
@@ -190,14 +191,14 @@ export const formatTimelineResultToModel = (
 export interface QueryTimelineById<TCache> {
   apolloClient: ApolloClient<TCache> | ApolloClient<{}> | undefined;
   duplicate?: boolean;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
   onOpenTimeline?: (timeline: TimelineModel) => void;
   openTimeline?: boolean;
   updateIsLoading: ({
     id,
     isLoading,
   }: {
-    id: string;
+    id: TimelineIdLiteral;
     isLoading: boolean;
   }) => Action<{ id: string; isLoading: boolean }>;
   updateTimeline: DispatchUpdateTimeline;
@@ -212,7 +213,7 @@ export const queryTimelineById = <TCache>({
   updateIsLoading,
   updateTimeline,
 }: QueryTimelineById<TCache>) => {
-  updateIsLoading({ id: 'timeline-1', isLoading: true });
+  updateIsLoading({ id: TimelineId.active, isLoading: true });
   if (apolloClient) {
     apolloClient
       .query<GetOneTimeline.Query, GetOneTimeline.Variables>({
@@ -234,7 +235,7 @@ export const queryTimelineById = <TCache>({
           updateTimeline({
             duplicate,
             from: getOr(from, 'dateRange.start', timeline),
-            id: 'timeline-1',
+            id: TimelineId.active,
             notes,
             timeline: {
               ...timeline,
@@ -245,7 +246,7 @@ export const queryTimelineById = <TCache>({
         }
       })
       .finally(() => {
-        updateIsLoading({ id: 'timeline-1', isLoading: false });
+        updateIsLoading({ id: TimelineId.active, isLoading: false });
       });
   }
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { Dispatch } from 'redux';
+import { TimelineIdLiteral, TimelineId } from '../../../../common/types/timeline';
 import { defaultHeaders } from '../timeline/body/column_headers/default_headers';
 import { deleteTimelineMutation } from '../../containers/delete/persist.gql_query';
 import { useGetAllTimeline } from '../../containers/all';
@@ -155,7 +156,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     const deleteTimelines: DeleteTimelines = useCallback(
       async (timelineIds: string[]) => {
         if (timelineIds.includes(timeline.savedObjectId || '')) {
-          createNewTimeline({ id: 'timeline-1', columns: defaultHeaders, show: false });
+          createNewTimeline({ id: TimelineId.active, columns: defaultHeaders, show: false });
         }
 
         await apolloClient.mutate<
@@ -229,7 +230,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     }, []);
 
     const openTimeline: OnOpenTimeline = useCallback(
-      ({ duplicate, timelineId }: { duplicate: boolean; timelineId: string }) => {
+      ({ duplicate, timelineId }: { duplicate: boolean; timelineId: TimelineIdLiteral }) => {
         if (isModal && closeModalTimeline != null) {
           closeModalTimeline();
         }
@@ -319,7 +320,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
 const makeMapStateToProps = () => {
   const getTimeline = timelineSelectors.getTimelineByIdSelector();
   const mapStateToProps = (state: State) => {
-    const timeline = getTimeline(state, 'timeline-1') ?? timelineDefaults;
+    const timeline = getTimeline(state, TimelineId.active) ?? timelineDefaults;
     return {
       timeline,
     };
@@ -333,11 +334,11 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     columns,
     show,
   }: {
-    id: string;
+    id: TimelineIdLiteral;
     columns: ColumnHeaderOptions[];
     show?: boolean;
   }) => dispatch(dispatchCreateNewTimeline({ id, columns, show })),
-  updateIsLoading: ({ id, isLoading }: { id: string; isLoading: boolean }) =>
+  updateIsLoading: ({ id, isLoading }: { id: TimelineIdLiteral; isLoading: boolean }) =>
     dispatch(dispatchUpdateIsLoading({ id, isLoading })),
   updateTimeline: dispatchUpdateTimeline(dispatch),
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
@@ -8,7 +8,7 @@ import { SetStateAction, Dispatch } from 'react';
 import { AllTimelinesVariables } from '../../containers/all';
 import { TimelineModel } from '../../store/timeline/model';
 import { NoteResult } from '../../../graphql/types';
-import { TimelineTypeLiteral } from '../../../../common/types/timeline';
+import { TimelineTypeLiteral, TimelineIdLiteral } from '../../../../common/types/timeline';
 
 /** The users who added a timeline to favorites */
 export interface FavoriteTimelineResult {
@@ -78,7 +78,7 @@ export type OnOpenTimeline = ({
   timelineId,
 }: {
   duplicate: boolean;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => void;
 
 export type OnOpenDeleteTimelineModal = (selectedItem: OpenTimelineResult) => void;
@@ -172,7 +172,7 @@ export interface OpenTimelineProps {
 
 export interface UpdateTimeline {
   duplicate: boolean;
-  id: string;
+  id: TimelineIdLiteral;
   from: number;
   notes: NoteResult[] | null | undefined;
   timeline: TimelineModel;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/stateful_body.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/stateful_body.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 
+import { TimelineIdLiteral } from '../../../../../common/types/timeline';
 import { BrowserFields } from '../../../../common/containers/source';
 import { TimelineItem } from '../../../../graphql/types';
 import { Note } from '../../../../common/lib/note';
@@ -41,7 +42,7 @@ interface OwnProps {
   browserFields: BrowserFields;
   data: TimelineItem[];
   height?: number;
-  id: string;
+  id: TimelineIdLiteral;
   isEventViewer?: boolean;
   sort: Sort;
   toggleColumn: (column: ColumnHeaderOptions) => void;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/data_providers/helpers.tsx
@@ -8,6 +8,7 @@ import { omit } from 'lodash/fp';
 import { DraggableLocation } from 'react-beautiful-dnd';
 import { Dispatch } from 'redux';
 
+import { TimelineIdLiteral } from '../../../../../common/types/timeline';
 import { updateProviders } from '../../../store/timeline/actions';
 
 import { DataProvider, DataProvidersAnd } from './data_provider';
@@ -89,7 +90,7 @@ export const reArrangeProvidersInSameGroup = ({
   destination: DraggableLocation;
   dispatch: Dispatch;
   source: DraggableLocation;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => {
   const groupIndex = getGroupIndexFromDroppableId(source.droppableId);
 
@@ -149,7 +150,7 @@ export const moveProvidersBetweenGroups = ({
   destination: DraggableLocation;
   dispatch: Dispatch;
   source: DraggableLocation;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => {
   const sourceGroupIndex = getGroupIndexFromDroppableId(source.droppableId);
   const destinationGroupIndex = getGroupIndexFromDroppableId(destination.droppableId);
@@ -206,7 +207,7 @@ export const addProviderToEmptyTimeline = ({
   dispatch: Dispatch;
   onAddedToTimeline: (fieldOrValue: string) => void;
   providerToAdd: DataProvider;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => {
   dispatch(
     updateProviders({
@@ -232,7 +233,7 @@ export const reArrangeProviders = ({
   destination: DraggableLocation | undefined;
   dispatch: Dispatch;
   source: DraggableLocation;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => {
   if (!isValidDestination(destination)) {
     return;
@@ -272,7 +273,7 @@ export const addProviderToGroup = ({
   dispatch: Dispatch;
   onAddedToTimeline: (fieldOrValue: string) => void;
   providerToAdd: DataProvider;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => {
   const dataProviderGroups = [...flattenIntoAndGroups(dataProviders), ...EMPTY_GROUP];
 
@@ -325,7 +326,7 @@ export const addContentToTimeline = ({
   dispatch: Dispatch;
   onAddedToTimeline: (fieldOrValue: string) => void;
   providerToAdd: DataProvider;
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
 }) => {
   if (dataProviders.length === 0) {
     addProviderToEmptyTimeline({ dispatch, onAddedToTimeline, providerToAdd, timelineId });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/fetch_kql_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/fetch_kql_timeline.tsx
@@ -9,13 +9,14 @@ import { connect, ConnectedProps } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import { IIndexPattern } from 'src/plugins/data/public';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { State } from '../../../common/store';
 import { inputsActions } from '../../../common/store/actions';
 import { InputsModelId } from '../../../common/store/inputs/constants';
 import { useUpdateKql } from '../../../common/utils/kql/use_update_kql';
 import { timelineSelectors } from '../../store/timeline';
 export interface TimelineKqlFetchProps {
-  id: string;
+  id: TimelineIdLiteral;
   indexPattern: IIndexPattern;
   inputId: InputsModelId;
 }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useCallback, useMemo } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { NO_ALERT_INDEX } from '../../../../common/constants';
 import { WithSource } from '../../../common/containers/source';
 import { useSignalIndex } from '../../../alerts/containers/detection_engine/alerts/use_signal_index';
@@ -26,7 +27,7 @@ import {
 import { Timeline } from './timeline';
 
 export interface OwnProps {
-  id: string;
+  id: TimelineIdLiteral;
   onClose: () => void;
   usersViewing: string[];
 }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/index.tsx
@@ -8,7 +8,11 @@ import React, { useState, useCallback, useMemo } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { TimelineStatus, TimelineTypeLiteral } from '../../../../../common/types/timeline';
+import {
+  TimelineStatus,
+  TimelineTypeLiteral,
+  TimelineIdLiteral,
+} from '../../../../../common/types/timeline';
 import { useThrottledResizeObserver } from '../../../../common/components/utils';
 import { Note } from '../../../../common/lib/note';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
@@ -30,13 +34,29 @@ type CreateTimeline = ({
   show,
   timelineType,
 }: {
-  id: string;
+  id: TimelineIdLiteral;
   show?: boolean;
   timelineType?: TimelineTypeLiteral;
 }) => void;
-type UpdateIsFavorite = ({ id, isFavorite }: { id: string; isFavorite: boolean }) => void;
-type UpdateTitle = ({ id, title }: { id: string; title: string }) => void;
-type UpdateDescription = ({ id, description }: { id: string; description: string }) => void;
+
+type UpdateIsFavorite = ({
+  id,
+  isFavorite,
+}: {
+  id: TimelineIdLiteral;
+  isFavorite: boolean;
+}) => void;
+
+type UpdateTitle = ({ id, title }: { id: TimelineIdLiteral; title: string }) => void;
+
+type UpdateDescription = ({
+  id,
+  description,
+}: {
+  id: TimelineIdLiteral;
+  description: string;
+}) => void;
+
 type ToggleLock = ({ linkToId }: { linkToId: InputsModelId }) => void;
 
 interface Props {

--- a/x-pack/plugins/security_solution/public/timelines/containers/local_storage/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/local_storage/index.tsx
@@ -9,11 +9,10 @@ import { TimelinesStorage } from './types';
 import { useKibana } from '../../../common/lib/kibana';
 import { TimelineModel } from '../../store/timeline/model';
 import { TimelineIdLiteral } from '../../../../common/types/timeline';
+import { TimelineById } from '../../store/timeline/types';
 
 export const LOCAL_STORAGE_TIMELINE_KEY = 'timelines';
-const EMPTY_TIMELINE = {} as {
-  [K in TimelineIdLiteral]: TimelineModel;
-};
+const EMPTY_TIMELINE = {} as TimelineById;
 
 export const getTimelinesInStorageByIds = (storage: Storage, timelineIds: TimelineIdLiteral[]) => {
   const allTimelines = storage.get(LOCAL_STORAGE_TIMELINE_KEY);
@@ -34,7 +33,7 @@ export const getTimelinesInStorageByIds = (storage: Storage, timelineIds: Timeli
       ...acc,
       [timelineId]: timelineModel,
     };
-  }, {} as { [K in TimelineIdLiteral]: TimelineModel });
+  }, {} as TimelineById);
 };
 
 export const getAllTimelinesInStorage = (storage: Storage) =>

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/actions.ts
@@ -16,29 +16,35 @@ import { KueryFilterQuery, SerializedFilterQuery } from '../../../common/store/t
 
 import { EventType, KqlMode, TimelineModel, ColumnHeaderOptions } from './model';
 import { TimelineNonEcsData } from '../../../graphql/types';
-import { TimelineTypeLiteral } from '../../../../common/types/timeline';
+import { TimelineTypeLiteral, TimelineIdLiteral } from '../../../../common/types/timeline';
 import { InsertTimeline } from './types';
 
 const actionCreator = actionCreatorFactory('x-pack/security_solution/local/timeline');
 
-export const addHistory = actionCreator<{ id: string; historyId: string }>('ADD_HISTORY');
-
-export const addNote = actionCreator<{ id: string; noteId: string }>('ADD_NOTE');
-
-export const addNoteToEvent = actionCreator<{ id: string; noteId: string; eventId: string }>(
-  'ADD_NOTE_TO_EVENT'
+export const addHistory = actionCreator<{ id: TimelineIdLiteral; historyId: string }>(
+  'ADD_HISTORY'
 );
+
+export const addNote = actionCreator<{ id: TimelineIdLiteral; noteId: string }>('ADD_NOTE');
+
+export const addNoteToEvent = actionCreator<{
+  id: TimelineIdLiteral;
+  noteId: string;
+  eventId: string;
+}>('ADD_NOTE_TO_EVENT');
 
 export const upsertColumn = actionCreator<{
   column: ColumnHeaderOptions;
-  id: string;
+  id: TimelineIdLiteral;
   index: number;
 }>('UPSERT_COLUMN');
 
-export const addProvider = actionCreator<{ id: string; provider: DataProvider }>('ADD_PROVIDER');
+export const addProvider = actionCreator<{ id: TimelineIdLiteral; provider: DataProvider }>(
+  'ADD_PROVIDER'
+);
 
 export const applyDeltaToWidth = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   delta: number;
   bodyClientWidthPixels: number;
   minWidthPixels: number;
@@ -46,13 +52,13 @@ export const applyDeltaToWidth = actionCreator<{
 }>('APPLY_DELTA_TO_WIDTH');
 
 export const applyDeltaToColumnWidth = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   columnId: string;
   delta: number;
 }>('APPLY_DELTA_TO_COLUMN_WIDTH');
 
 export const createTimeline = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   dataProviders?: DataProvider[];
   dateRange?: {
     start: number;
@@ -72,62 +78,64 @@ export const createTimeline = actionCreator<{
   timelineType?: TimelineTypeLiteral;
 }>('CREATE_TIMELINE');
 
-export const pinEvent = actionCreator<{ id: string; eventId: string }>('PIN_EVENT');
+export const pinEvent = actionCreator<{ id: TimelineIdLiteral; eventId: string }>('PIN_EVENT');
 
 export const removeColumn = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   columnId: string;
 }>('REMOVE_COLUMN');
 
 export const removeProvider = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
   andProviderId?: string;
 }>('REMOVE_PROVIDER');
 
-export const showTimeline = actionCreator<{ id: string; show: boolean }>('SHOW_TIMELINE');
+export const showTimeline = actionCreator<{ id: TimelineIdLiteral; show: boolean }>(
+  'SHOW_TIMELINE'
+);
 
-export const unPinEvent = actionCreator<{ id: string; eventId: string }>('UN_PIN_EVENT');
+export const unPinEvent = actionCreator<{ id: TimelineIdLiteral; eventId: string }>('UN_PIN_EVENT');
 
 export const updateTimeline = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   timeline: TimelineModel;
 }>('UPDATE_TIMELINE');
 
 export const addTimeline = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   timeline: TimelineModel;
 }>('ADD_TIMELINE');
 
 export const setInsertTimeline = actionCreator<InsertTimeline | null>('SET_INSERT_TIMELINE');
 
 export const startTimelineSaving = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
 }>('START_TIMELINE_SAVING');
 
 export const endTimelineSaving = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
 }>('END_TIMELINE_SAVING');
 
 export const updateIsLoading = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   isLoading: boolean;
 }>('UPDATE_LOADING');
 
 export const updateColumns = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   columns: ColumnHeaderOptions[];
 }>('UPDATE_COLUMNS');
 
 export const updateDataProviderEnabled = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   enabled: boolean;
   providerId: string;
   andProviderId?: string;
 }>('TOGGLE_PROVIDER_ENABLED');
 
 export const updateDataProviderExcluded = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   excluded: boolean;
   providerId: string;
   andProviderId?: string;
@@ -137,118 +145,122 @@ export const dataProviderEdited = actionCreator<{
   andProviderId?: string;
   excluded: boolean;
   field: string;
-  id: string;
+  id: TimelineIdLiteral;
   operator: QueryOperator;
   providerId: string;
   value: string | number;
 }>('DATA_PROVIDER_EDITED');
 
 export const updateDataProviderKqlQuery = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   kqlQuery: string;
   providerId: string;
 }>('PROVIDER_EDIT_KQL_QUERY');
 
 export const updateHighlightedDropAndProviderId = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
 }>('UPDATE_DROP_AND_PROVIDER');
 
-export const updateDescription = actionCreator<{ id: string; description: string }>(
+export const updateDescription = actionCreator<{ id: TimelineIdLiteral; description: string }>(
   'UPDATE_DESCRIPTION'
 );
 
-export const updateKqlMode = actionCreator<{ id: string; kqlMode: KqlMode }>('UPDATE_KQL_MODE');
+export const updateKqlMode = actionCreator<{ id: TimelineIdLiteral; kqlMode: KqlMode }>(
+  'UPDATE_KQL_MODE'
+);
 
 export const setKqlFilterQueryDraft = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   filterQueryDraft: KueryFilterQuery;
 }>('SET_KQL_FILTER_QUERY_DRAFT');
 
 export const applyKqlFilterQuery = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   filterQuery: SerializedFilterQuery;
 }>('APPLY_KQL_FILTER_QUERY');
 
-export const updateIsFavorite = actionCreator<{ id: string; isFavorite: boolean }>(
+export const updateIsFavorite = actionCreator<{ id: TimelineIdLiteral; isFavorite: boolean }>(
   'UPDATE_IS_FAVORITE'
 );
 
-export const updateIsLive = actionCreator<{ id: string; isLive: boolean }>('UPDATE_IS_LIVE');
+export const updateIsLive = actionCreator<{ id: TimelineIdLiteral; isLive: boolean }>(
+  'UPDATE_IS_LIVE'
+);
 
-export const updateItemsPerPage = actionCreator<{ id: string; itemsPerPage: number }>(
+export const updateItemsPerPage = actionCreator<{ id: TimelineIdLiteral; itemsPerPage: number }>(
   'UPDATE_ITEMS_PER_PAGE'
 );
 
 export const updateItemsPerPageOptions = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   itemsPerPageOptions: number[];
 }>('UPDATE_ITEMS_PER_PAGE_OPTIONS');
 
-export const updateTitle = actionCreator<{ id: string; title: string }>('UPDATE_TITLE');
+export const updateTitle = actionCreator<{ id: TimelineIdLiteral; title: string }>('UPDATE_TITLE');
 
-export const updatePageIndex = actionCreator<{ id: string; activePage: number }>(
+export const updatePageIndex = actionCreator<{ id: TimelineIdLiteral; activePage: number }>(
   'UPDATE_PAGE_INDEX'
 );
 
-export const updateProviders = actionCreator<{ id: string; providers: DataProvider[] }>(
+export const updateProviders = actionCreator<{ id: TimelineIdLiteral; providers: DataProvider[] }>(
   'UPDATE_PROVIDERS'
 );
 
-export const updateRange = actionCreator<{ id: string; start: number; end: number }>(
+export const updateRange = actionCreator<{ id: TimelineIdLiteral; start: number; end: number }>(
   'UPDATE_RANGE'
 );
 
-export const updateSort = actionCreator<{ id: string; sort: Sort }>('UPDATE_SORT');
+export const updateSort = actionCreator<{ id: TimelineIdLiteral; sort: Sort }>('UPDATE_SORT');
 
 export const updateAutoSaveMsg = actionCreator<{
-  timelineId: string | null;
+  timelineId: TimelineIdLiteral | null;
   newTimelineModel: TimelineModel | null;
 }>('UPDATE_AUTO_SAVE');
 
 export const showCallOutUnauthorizedMsg = actionCreator('SHOW_CALL_OUT_UNAUTHORIZED_MSG');
 
 export const setSavedQueryId = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   savedQueryId: string | null;
 }>('SET_TIMELINE_SAVED_QUERY');
 
 export const setFilters = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   filters: Filter[];
 }>('SET_TIMELINE_FILTERS');
 
 export const setSelected = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   eventIds: Readonly<Record<string, TimelineNonEcsData[]>>;
   isSelected: boolean;
   isSelectAllChecked: boolean;
 }>('SET_TIMELINE_SELECTED');
 
 export const clearSelected = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
 }>('CLEAR_TIMELINE_SELECTED');
 
 export const setEventsLoading = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   eventIds: string[];
   isLoading: boolean;
 }>('SET_TIMELINE_EVENTS_LOADING');
 
 export const clearEventsLoading = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
 }>('CLEAR_TIMELINE_EVENTS_LOADING');
 
 export const setEventsDeleted = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
   eventIds: string[];
   isDeleted: boolean;
 }>('SET_TIMELINE_EVENTS_DELETED');
 
 export const clearEventsDeleted = actionCreator<{
-  id: string;
+  id: TimelineIdLiteral;
 }>('CLEAR_TIMELINE_EVENTS_DELETED');
 
-export const updateEventType = actionCreator<{ id: string; eventType: EventType }>(
+export const updateEventType = actionCreator<{ id: TimelineIdLiteral; eventType: EventType }>(
   'UPDATE_EVENT_TYPE'
 );

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../timelines/components/timeline/data_providers/data_provider';
 import { KueryFilterQuery, SerializedFilterQuery } from '../../../common/store/model';
 import { TimelineNonEcsData } from '../../../graphql/types';
-import { TimelineTypeLiteral } from '../../../../common/types/timeline';
+import { TimelineTypeLiteral, TimelineIdLiteral } from '../../../../common/types/timeline';
 
 import { timelineDefaults } from './defaults';
 import { ColumnHeaderOptions, KqlMode, TimelineModel, EventType } from './model';
@@ -27,8 +27,13 @@ import { TimelineById } from './types';
 
 export const isNotNull = <T>(value: T | null): value is T => value !== null;
 
+export const getTimeline = (
+  timelineById: TimelineById,
+  timelineId: TimelineIdLiteral
+): TimelineModel => timelineById[timelineId] ?? { ...timelineDefaults, id: timelineId };
+
 interface AddTimelineHistoryParams {
-  id: string;
+  id: TimelineIdLiteral;
   historyId: string;
   timelineById: TimelineById;
 }
@@ -38,7 +43,7 @@ export const addTimelineHistory = ({
   historyId,
   timelineById,
 }: AddTimelineHistoryParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   return {
     ...timelineById,
@@ -50,7 +55,7 @@ export const addTimelineHistory = ({
 };
 
 interface AddTimelineNoteParams {
-  id: string;
+  id: TimelineIdLiteral;
   noteId: string;
   timelineById: TimelineById;
 }
@@ -60,7 +65,7 @@ export const addTimelineNote = ({
   noteId,
   timelineById,
 }: AddTimelineNoteParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   return {
     ...timelineById,
@@ -72,7 +77,7 @@ export const addTimelineNote = ({
 };
 
 interface AddTimelineNoteToEventParams {
-  id: string;
+  id: TimelineIdLiteral;
   noteId: string;
   eventId: string;
   timelineById: TimelineById;
@@ -84,7 +89,7 @@ export const addTimelineNoteToEvent = ({
   eventId,
   timelineById,
 }: AddTimelineNoteToEventParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   const existingNoteIds = getOr([], `eventIdToNoteIds.${eventId}`, timeline);
 
   return {
@@ -100,7 +105,7 @@ export const addTimelineNoteToEvent = ({
 };
 
 interface AddTimelineParams {
-  id: string;
+  id: TimelineIdLiteral;
   timeline: TimelineModel;
   timelineById: TimelineById;
 }
@@ -117,7 +122,7 @@ export const addTimelineToStore = ({
   ...timelineById,
   [id]: {
     ...timeline,
-    isLoading: timelineById[id].isLoading,
+    isLoading: getTimeline(timelineById, id).isLoading,
   },
 });
 
@@ -129,7 +134,7 @@ interface AddNewTimelineParams {
     end: number;
   };
   filters?: Filter[];
-  id: string;
+  id: TimelineIdLiteral;
   itemsPerPage?: number;
   kqlQuery?: {
     filterQuery: SerializedFilterQuery | null;
@@ -182,7 +187,7 @@ export const addNewTimeline = ({
 });
 
 interface PinTimelineEventParams {
-  id: string;
+  id: TimelineIdLiteral;
   eventId: string;
   timelineById: TimelineById;
 }
@@ -192,7 +197,7 @@ export const pinTimelineEvent = ({
   eventId,
   timelineById,
 }: PinTimelineEventParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   return {
     ...timelineById,
@@ -207,7 +212,7 @@ export const pinTimelineEvent = ({
 };
 
 interface UpdateShowTimelineProps {
-  id: string;
+  id: TimelineIdLiteral;
   show: boolean;
   timelineById: TimelineById;
 }
@@ -229,7 +234,7 @@ export const updateTimelineShowTimeline = ({
 };
 
 interface ApplyDeltaToCurrentWidthParams {
-  id: string;
+  id: TimelineIdLiteral;
   delta: number;
   bodyClientWidthPixels: number;
   minWidthPixels: number;
@@ -245,7 +250,7 @@ export const applyDeltaToCurrentWidth = ({
   maxWidthPercent,
   timelineById,
 }: ApplyDeltaToCurrentWidthParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   const requestedWidth = timeline.width + delta * -1; // raw change in width
   const maxWidthPixels = (maxWidthPercent / 100) * bodyClientWidthPixels;
@@ -350,7 +355,7 @@ const addProviderToTimeline = (
 
 interface AddTimelineColumnParams {
   column: ColumnHeaderOptions;
-  id: string;
+  id: TimelineIdLiteral;
   index: number;
   timelineById: TimelineById;
 }
@@ -365,7 +370,7 @@ export const upsertTimelineColumn = ({
   index,
   timelineById,
 }: AddTimelineColumnParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   const alreadyExistsAtIndex = timeline.columns.findIndex((c) => c.id === column.id);
 
   if (alreadyExistsAtIndex !== -1) {
@@ -396,7 +401,7 @@ export const upsertTimelineColumn = ({
 };
 
 interface RemoveTimelineColumnParams {
-  id: string;
+  id: TimelineIdLiteral;
   columnId: string;
   timelineById: TimelineById;
 }
@@ -406,7 +411,7 @@ export const removeTimelineColumn = ({
   columnId,
   timelineById,
 }: RemoveTimelineColumnParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   const columns = timeline.columns.filter((c) => c.id !== columnId);
 
@@ -420,7 +425,7 @@ export const removeTimelineColumn = ({
 };
 
 interface ApplyDeltaToTimelineColumnWidth {
-  id: string;
+  id: TimelineIdLiteral;
   columnId: string;
   delta: number;
   timelineById: TimelineById;
@@ -432,7 +437,7 @@ export const applyDeltaToTimelineColumnWidth = ({
   delta,
   timelineById,
 }: ApplyDeltaToTimelineColumnWidth): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   const columnIndex = timeline.columns.findIndex((c) => c.id === columnId);
   if (columnIndex === -1) {
@@ -469,7 +474,7 @@ export const applyDeltaToTimelineColumnWidth = ({
 };
 
 interface AddTimelineProviderParams {
-  id: string;
+  id: TimelineIdLiteral;
   provider: DataProvider;
   timelineById: TimelineById;
 }
@@ -479,7 +484,7 @@ export const addTimelineProvider = ({
   provider,
   timelineById,
 }: AddTimelineProviderParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   if (timeline.highlightedDropAndProviderId !== '') {
     return addAndToProviderInTimeline(id, provider, timeline, timelineById);
@@ -489,7 +494,7 @@ export const addTimelineProvider = ({
 };
 
 interface ApplyKqlFilterQueryDraftParams {
-  id: string;
+  id: TimelineIdLiteral;
   filterQuery: SerializedFilterQuery;
   timelineById: TimelineById;
 }
@@ -499,7 +504,7 @@ export const applyKqlFilterQueryDraft = ({
   filterQuery,
   timelineById,
 }: ApplyKqlFilterQueryDraftParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   return {
     ...timelineById,
@@ -514,7 +519,7 @@ export const applyKqlFilterQueryDraft = ({
 };
 
 interface UpdateTimelineKqlModeParams {
-  id: string;
+  id: TimelineIdLiteral;
   kqlMode: KqlMode;
   timelineById: TimelineById;
 }
@@ -536,7 +541,7 @@ export const updateTimelineKqlMode = ({
 };
 
 interface UpdateKqlFilterQueryDraftParams {
-  id: string;
+  id: TimelineIdLiteral;
   filterQueryDraft: KueryFilterQuery;
   timelineById: TimelineById;
 }
@@ -546,7 +551,7 @@ export const updateKqlFilterQueryDraft = ({
   filterQueryDraft,
   timelineById,
 }: UpdateKqlFilterQueryDraftParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   return {
     ...timelineById,
@@ -561,7 +566,7 @@ export const updateKqlFilterQueryDraft = ({
 };
 
 interface UpdateTimelineColumnsParams {
-  id: string;
+  id: TimelineIdLiteral;
   columns: ColumnHeaderOptions[];
   timelineById: TimelineById;
 }
@@ -583,7 +588,7 @@ export const updateTimelineColumns = ({
 };
 
 interface UpdateTimelineDescriptionParams {
-  id: string;
+  id: TimelineIdLiteral;
   description: string;
   timelineById: TimelineById;
 }
@@ -605,7 +610,7 @@ export const updateTimelineDescription = ({
 };
 
 interface UpdateTimelineTitleParams {
-  id: string;
+  id: TimelineIdLiteral;
   title: string;
   timelineById: TimelineById;
 }
@@ -627,7 +632,7 @@ export const updateTimelineTitle = ({
 };
 
 interface UpdateTimelineEventTypeParams {
-  id: string;
+  id: TimelineIdLiteral;
   eventType: EventType;
   timelineById: TimelineById;
 }
@@ -649,7 +654,7 @@ export const updateTimelineEventType = ({
 };
 
 interface UpdateTimelineIsFavoriteParams {
-  id: string;
+  id: TimelineIdLiteral;
   isFavorite: boolean;
   timelineById: TimelineById;
 }
@@ -671,7 +676,7 @@ export const updateTimelineIsFavorite = ({
 };
 
 interface UpdateTimelineIsLiveParams {
-  id: string;
+  id: TimelineIdLiteral;
   isLive: boolean;
   timelineById: TimelineById;
 }
@@ -693,7 +698,7 @@ export const updateTimelineIsLive = ({
 };
 
 interface UpdateTimelineProvidersParams {
-  id: string;
+  id: TimelineIdLiteral;
   providers: DataProvider[];
   timelineById: TimelineById;
 }
@@ -715,7 +720,7 @@ export const updateTimelineProviders = ({
 };
 
 interface UpdateTimelineRangeParams {
-  id: string;
+  id: TimelineIdLiteral;
   start: number;
   end: number;
   timelineById: TimelineById;
@@ -741,7 +746,7 @@ export const updateTimelineRange = ({
 };
 
 interface UpdateTimelineSortParams {
-  id: string;
+  id: TimelineIdLiteral;
   sort: Sort;
   timelineById: TimelineById;
 }
@@ -789,7 +794,7 @@ const updateEnabledProvider = (enabled: boolean, providerId: string, timeline: T
   );
 
 interface UpdateTimelineProviderEnabledParams {
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
   enabled: boolean;
   timelineById: TimelineById;
@@ -803,7 +808,7 @@ export const updateTimelineProviderEnabled = ({
   timelineById,
   andProviderId,
 }: UpdateTimelineProviderEnabledParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   return {
     ...timelineById,
     [id]: {
@@ -843,7 +848,7 @@ const updateExcludedProvider = (excluded: boolean, providerId: string, timeline:
   );
 
 interface UpdateTimelineProviderExcludedParams {
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
   excluded: boolean;
   timelineById: TimelineById;
@@ -857,7 +862,7 @@ export const updateTimelineProviderExcluded = ({
   timelineById,
   andProviderId,
 }: UpdateTimelineProviderExcludedParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   return {
     ...timelineById,
     [id]: {
@@ -946,7 +951,7 @@ interface UpdateTimelineProviderEditPropertiesParams {
   andProviderId?: string;
   excluded: boolean;
   field: string;
-  id: string;
+  id: TimelineIdLiteral;
   operator: QueryOperator;
   providerId: string;
   timelineById: TimelineById;
@@ -963,7 +968,7 @@ export const updateTimelineProviderProperties = ({
   timelineById,
   value,
 }: UpdateTimelineProviderEditPropertiesParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   return {
     ...timelineById,
     [id]: {
@@ -991,7 +996,7 @@ export const updateTimelineProviderProperties = ({
 };
 
 interface UpdateTimelineProviderKqlQueryParams {
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
   kqlQuery: string;
   timelineById: TimelineById;
@@ -1003,7 +1008,7 @@ export const updateTimelineProviderKqlQuery = ({
   kqlQuery,
   timelineById,
 }: UpdateTimelineProviderKqlQueryParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   return {
     ...timelineById,
     [id]: {
@@ -1016,7 +1021,7 @@ export const updateTimelineProviderKqlQuery = ({
 };
 
 interface UpdateTimelineItemsPerPageParams {
-  id: string;
+  id: TimelineIdLiteral;
   itemsPerPage: number;
   timelineById: TimelineById;
 }
@@ -1037,7 +1042,7 @@ export const updateTimelineItemsPerPage = ({
 };
 
 interface UpdateTimelinePageIndexParams {
-  id: string;
+  id: TimelineIdLiteral;
   activePage: number;
   timelineById: TimelineById;
 }
@@ -1058,7 +1063,7 @@ export const updateTimelinePageIndex = ({
 };
 
 interface UpdateTimelinePerPageOptionsParams {
-  id: string;
+  id: TimelineIdLiteral;
   itemsPerPageOptions: number[];
   timelineById: TimelineById;
 }
@@ -1113,7 +1118,7 @@ const removeProvider = (providerId: string, timeline: TimelineModel) => {
 };
 
 interface RemoveTimelineProviderParams {
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
   timelineById: TimelineById;
   andProviderId?: string;
@@ -1125,7 +1130,7 @@ export const removeTimelineProvider = ({
   timelineById,
   andProviderId,
 }: RemoveTimelineProviderParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   return {
     ...timelineById,
@@ -1139,7 +1144,7 @@ export const removeTimelineProvider = ({
 };
 
 interface SetDeletedTimelineEventsParams {
-  id: string;
+  id: TimelineIdLiteral;
   eventIds: string[];
   isDeleted: boolean;
   timelineById: TimelineById;
@@ -1151,7 +1156,7 @@ export const setDeletedTimelineEvents = ({
   isDeleted,
   timelineById,
 }: SetDeletedTimelineEventsParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   const deletedEventIds = isDeleted
     ? union(timeline.deletedEventIds, eventIds)
@@ -1178,7 +1183,7 @@ export const setDeletedTimelineEvents = ({
 };
 
 interface SetLoadingTimelineEventsParams {
-  id: string;
+  id: TimelineIdLiteral;
   eventIds: string[];
   isLoading: boolean;
   timelineById: TimelineById;
@@ -1190,7 +1195,7 @@ export const setLoadingTimelineEvents = ({
   isLoading,
   timelineById,
 }: SetLoadingTimelineEventsParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   const loadingEventIds = isLoading
     ? union(timeline.loadingEventIds, eventIds)
@@ -1206,7 +1211,7 @@ export const setLoadingTimelineEvents = ({
 };
 
 interface SetSelectedTimelineEventsParams {
-  id: string;
+  id: TimelineIdLiteral;
   eventIds: Record<string, TimelineNonEcsData[]>;
   isSelectAllChecked: boolean;
   isSelected: boolean;
@@ -1220,7 +1225,7 @@ export const setSelectedTimelineEvents = ({
   isSelected,
   timelineById,
 }: SetSelectedTimelineEventsParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
 
   const selectedEventIds = isSelected
     ? { ...timeline.selectedEventIds, ...eventIds }
@@ -1237,7 +1242,7 @@ export const setSelectedTimelineEvents = ({
 };
 
 interface UnPinTimelineEventParams {
-  id: string;
+  id: TimelineIdLiteral;
   eventId: string;
   timelineById: TimelineById;
 }
@@ -1247,7 +1252,7 @@ export const unPinTimelineEvent = ({
   eventId,
   timelineById,
 }: UnPinTimelineEventParams): TimelineById => {
-  const timeline = timelineById[id];
+  const timeline = getTimeline(timelineById, id);
   return {
     ...timelineById,
     [id]: {
@@ -1258,7 +1263,7 @@ export const unPinTimelineEvent = ({
 };
 
 interface UpdateHighlightedDropAndProviderIdParams {
-  id: string;
+  id: TimelineIdLiteral;
   providerId: string;
   timelineById: TimelineById;
 }
@@ -1280,7 +1285,7 @@ export const updateHighlightedDropAndProvider = ({
 };
 
 interface UpdateSavedQueryParams {
-  id: string;
+  id: TimelineIdLiteral;
   savedQueryId: string | null;
   timelineById: TimelineById;
 }
@@ -1302,7 +1307,7 @@ export const updateSavedQuery = ({
 };
 
 interface UpdateFiltersParams {
-  id: string;
+  id: TimelineIdLiteral;
   filters: Filter[];
   timelineById: TimelineById;
 }

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/reducer.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/reducer.test.ts
@@ -6,7 +6,7 @@
 
 import { cloneDeep, set } from 'lodash/fp';
 
-import { TimelineType, TimelineStatus } from '../../../../common/types/timeline';
+import { TimelineType, TimelineStatus, TimelineId } from '../../../../common/types/timeline';
 
 import {
   IS_OPERATOR,
@@ -47,7 +47,7 @@ import { timelineDefaults } from './defaults';
 import { TimelineById } from './types';
 
 const timelineByIdMock: TimelineById = {
-  foo: {
+  test: {
     dataProviders: [
       {
         and: [],
@@ -70,7 +70,7 @@ const timelineByIdMock: TimelineById = {
     eventIdToNoteIds: {},
     highlightedDropAndProviderId: '',
     historyIds: [],
-    id: 'foo',
+    id: TimelineId.test,
     savedObjectId: null,
     isFavorite: false,
     isLive: false,
@@ -117,16 +117,16 @@ describe('Timeline', () => {
   describe('#add saved object Timeline to store ', () => {
     test('should return a timelineModel with default value and not just a timelineResult ', () => {
       const update = addTimelineToStore({
-        id: 'foo',
+        id: TimelineId.test,
         timeline: {
-          ...timelineByIdMock.foo,
+          ...timelineByIdMock.test!,
         },
         timelineById: timelineByIdMock,
       });
 
       expect(update).toEqual({
         foo: {
-          ...timelineByIdMock.foo,
+          ...timelineByIdMock.test!,
           show: true,
         },
       });
@@ -136,7 +136,7 @@ describe('Timeline', () => {
   describe('#addNewTimeline', () => {
     test('should return a new reference and not the same reference', () => {
       const update = addNewTimeline({
-        id: 'bar',
+        id: TimelineId.test,
         columns: defaultHeaders,
         timelineById: timelineByIdMock,
         timelineType: TimelineType.default,
@@ -146,13 +146,13 @@ describe('Timeline', () => {
 
     test('should add a new timeline', () => {
       const update = addNewTimeline({
-        id: 'bar',
+        id: TimelineId.test,
         columns: timelineDefaults.columns,
         timelineById: timelineByIdMock,
         timelineType: TimelineType.default,
       });
       expect(update).toEqual({
-        foo: timelineByIdMock.foo,
+        foo: timelineByIdMock.test!,
         bar: set('id', 'bar', timelineDefaults),
       });
     });
@@ -162,13 +162,13 @@ describe('Timeline', () => {
       const barWithPopulatedColumns = set('columns', defaultHeaders, barWithEmptyColumns);
 
       const update = addNewTimeline({
-        id: 'bar',
+        id: TimelineId.test,
         columns: defaultHeaders,
         timelineById: timelineByIdMock,
         timelineType: TimelineType.default,
       });
       expect(update).toEqual({
-        foo: timelineByIdMock.foo,
+        foo: timelineByIdMock.test!,
         bar: barWithPopulatedColumns,
       });
     });
@@ -177,7 +177,7 @@ describe('Timeline', () => {
   describe('#updateTimelineShowTimeline', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineShowTimeline({
-        id: 'foo',
+        id: TimelineId.test,
         show: false,
         timelineById: timelineByIdMock,
       });
@@ -186,7 +186,7 @@ describe('Timeline', () => {
 
     test('should change show from true to false', () => {
       const update = updateTimelineShowTimeline({
-        id: 'foo',
+        id: TimelineId.test,
         show: false, // value we are changing from true to false
         timelineById: timelineByIdMock,
       });
@@ -218,7 +218,7 @@ describe('Timeline', () => {
     test('should return a new reference and not the same reference', () => {
       const update = upsertTimelineColumn({
         column: columnToAdd,
-        id: 'foo',
+        id: TimelineId.test,
         index: 0,
         timelineById,
       });
@@ -230,7 +230,7 @@ describe('Timeline', () => {
       const expectedColumns = [columnToAdd];
       const update = upsertTimelineColumn({
         column: columnToAdd,
-        id: 'foo',
+        id: TimelineId.test,
         index: 0,
         timelineById,
       });
@@ -244,7 +244,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columnToAdd,
-        id: 'foo',
+        id: TimelineId.test,
         index: 0,
         timelineById: mockWithExistingColumns,
       });
@@ -258,7 +258,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columnToAdd,
-        id: 'foo',
+        id: TimelineId.test,
         index: 1,
         timelineById: mockWithExistingColumns,
       });
@@ -272,7 +272,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columnToAdd,
-        id: 'foo',
+        id: TimelineId.test,
         index: expectedColumns.length - 1,
         timelineById: mockWithExistingColumns,
       });
@@ -286,7 +286,7 @@ describe('Timeline', () => {
 
         const update = upsertTimelineColumn({
           column,
-          id: 'foo',
+          id: TimelineId.test,
           index: i,
           timelineById: mockWithExistingColumns,
         });
@@ -301,7 +301,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columns[0],
-        id: 'foo',
+        id: TimelineId.test,
         index: 1,
         timelineById: mockWithExistingColumns,
       });
@@ -315,7 +315,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columns[0],
-        id: 'foo',
+        id: TimelineId.test,
         index: 2,
         timelineById: mockWithExistingColumns,
       });
@@ -329,7 +329,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columns[1],
-        id: 'foo',
+        id: TimelineId.test,
         index: 0,
         timelineById: mockWithExistingColumns,
       });
@@ -343,7 +343,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columns[1],
-        id: 'foo',
+        id: TimelineId.test,
         index: 2,
         timelineById: mockWithExistingColumns,
       });
@@ -357,7 +357,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columns[2],
-        id: 'foo',
+        id: TimelineId.test,
         index: 0,
         timelineById: mockWithExistingColumns,
       });
@@ -371,7 +371,7 @@ describe('Timeline', () => {
 
       const update = upsertTimelineColumn({
         column: columns[2],
-        id: 'foo',
+        id: TimelineId.test,
         index: 1,
         timelineById: mockWithExistingColumns,
       });
@@ -383,7 +383,7 @@ describe('Timeline', () => {
   describe('#addTimelineProvider', () => {
     test('should return a new reference and not the same reference', () => {
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: {
           and: [],
           id: '567',
@@ -419,11 +419,11 @@ describe('Timeline', () => {
         kqlQuery: '',
       };
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
-      const addedDataProvider = timelineByIdMock.foo.dataProviders.concat(providerToAdd);
+      const addedDataProvider = timelineByIdMock.test!.dataProviders.concat(providerToAdd);
       expect(update).toEqual(set('foo.dataProviders', addedDataProvider, timelineByIdMock));
     });
 
@@ -443,7 +443,7 @@ describe('Timeline', () => {
         kqlQuery: '',
       };
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
@@ -452,7 +452,7 @@ describe('Timeline', () => {
 
     test('should add a new timeline provider if it already exists and the attributes "and" is NOT empty', () => {
       const myMockTimelineByIdMock = cloneDeep(timelineByIdMock);
-      myMockTimelineByIdMock.foo.dataProviders[0].and = [
+      myMockTimelineByIdMock.test!.dataProviders[0].and = [
         {
           id: '456',
           name: 'and data provider 1',
@@ -481,7 +481,7 @@ describe('Timeline', () => {
         kqlQuery: '',
       };
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: myMockTimelineByIdMock,
       });
@@ -503,7 +503,7 @@ describe('Timeline', () => {
         kqlQuery: '',
       };
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
@@ -517,7 +517,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = removeTimelineColumn({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: columnsMock[0].id,
         timelineById: mockWithExistingColumns,
       });
@@ -532,7 +532,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = removeTimelineColumn({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: columnsMock[0].id,
         timelineById: mockWithExistingColumns,
       });
@@ -547,7 +547,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = removeTimelineColumn({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: columnsMock[2].id,
         timelineById: mockWithExistingColumns,
       });
@@ -562,7 +562,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = removeTimelineColumn({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: columnsMock[1].id,
         timelineById: mockWithExistingColumns,
       });
@@ -577,7 +577,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = removeTimelineColumn({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: 'does.not.exist',
         timelineById: mockWithExistingColumns,
       });
@@ -593,7 +593,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: columnsMock[0].id,
         delta,
         timelineById: mockWithExistingColumns,
@@ -615,7 +615,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: aDateColumn.id,
         delta,
         timelineById: mockWithExistingColumns,
@@ -637,7 +637,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: aDateColumn.id,
         delta,
         timelineById: mockWithExistingColumns,
@@ -659,7 +659,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: aNonDateColumn.id,
         delta,
         timelineById: mockWithExistingColumns,
@@ -681,7 +681,7 @@ describe('Timeline', () => {
       const mockWithExistingColumns = set('foo.columns', columnsMock, timelineByIdMock);
 
       const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
+        id: TimelineId.test,
         columnId: aNonDateColumn.id,
         delta,
         timelineById: mockWithExistingColumns,
@@ -708,12 +708,12 @@ describe('Timeline', () => {
       };
 
       const newTimeline = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
 
-      newTimeline.foo.highlightedDropAndProviderId = '567';
+      newTimeline.test!.highlightedDropAndProviderId = '567';
 
       const andProviderToAdd: DataProvider = {
         and: [],
@@ -731,15 +731,15 @@ describe('Timeline', () => {
       };
 
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: andProviderToAdd,
         timelineById: newTimeline,
       });
-      const indexProvider = update.foo.dataProviders.findIndex((i) => i.id === '567');
-      const addedAndDataProvider = update.foo.dataProviders[indexProvider].and[0];
+      const indexProvider = update.test!.dataProviders.findIndex((i) => i.id === '567');
+      const addedAndDataProvider = update.test!.dataProviders[indexProvider].and[0];
       const { and, ...expectedResult } = andProviderToAdd;
       expect(addedAndDataProvider).toEqual(expectedResult);
-      newTimeline.foo.highlightedDropAndProviderId = '';
+      update.test!.highlightedDropAndProviderId = '';
     });
 
     test('should add another and provider because it is not a duplicate', () => {
@@ -771,12 +771,12 @@ describe('Timeline', () => {
       };
 
       const newTimeline = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
 
-      newTimeline.foo.highlightedDropAndProviderId = '567';
+      newTimeline.test!.highlightedDropAndProviderId = '567';
 
       const andProviderToAdd: DataProvider = {
         and: [],
@@ -795,13 +795,13 @@ describe('Timeline', () => {
       // that's bigger a refactor than just fixing a bug
       delete andProviderToAdd.and;
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: andProviderToAdd,
         timelineById: newTimeline,
       });
 
       expect(update).toEqual(set('foo.dataProviders[1].and[1]', andProviderToAdd, newTimeline));
-      newTimeline.foo.highlightedDropAndProviderId = '';
+      update.test!.highlightedDropAndProviderId = '';
     });
 
     test('should NOT add another and provider because it is a duplicate', () => {
@@ -833,12 +833,12 @@ describe('Timeline', () => {
       };
 
       const newTimeline = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
 
-      newTimeline.foo.highlightedDropAndProviderId = '567';
+      newTimeline.test!.highlightedDropAndProviderId = '567';
 
       const andProviderToAdd: DataProvider = {
         and: [],
@@ -854,20 +854,20 @@ describe('Timeline', () => {
         kqlQuery: '',
       };
       const update = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: andProviderToAdd,
         timelineById: newTimeline,
       });
 
       expect(update).toEqual(newTimeline);
-      newTimeline.foo.highlightedDropAndProviderId = '';
+      update.test!.highlightedDropAndProviderId = '';
     });
   });
 
   describe('#updateTimelineColumns', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineColumns({
-        id: 'foo',
+        id: TimelineId.test,
         columns: columnsMock,
         timelineById: timelineByIdMock,
       });
@@ -876,7 +876,7 @@ describe('Timeline', () => {
 
     test('should update a timeline with new columns', () => {
       const update = updateTimelineColumns({
-        id: 'foo',
+        id: TimelineId.test,
         columns: columnsMock,
         timelineById: timelineByIdMock,
       });
@@ -889,7 +889,7 @@ describe('Timeline', () => {
 
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineDescription({
-        id: 'foo',
+        id: TimelineId.test,
         description: newDescription,
         timelineById: timelineByIdMock,
       });
@@ -898,7 +898,7 @@ describe('Timeline', () => {
 
     test('should update the timeline description', () => {
       const update = updateTimelineDescription({
-        id: 'foo',
+        id: TimelineId.test,
         description: newDescription,
         timelineById: timelineByIdMock,
       });
@@ -907,7 +907,7 @@ describe('Timeline', () => {
 
     test('should always trim all leading whitespace and allow only one trailing space', () => {
       const update = updateTimelineDescription({
-        id: 'foo',
+        id: TimelineId.test,
         description: '      breathing room      ',
         timelineById: timelineByIdMock,
       });
@@ -920,7 +920,7 @@ describe('Timeline', () => {
 
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineTitle({
-        id: 'foo',
+        id: TimelineId.test,
         title: newTitle,
         timelineById: timelineByIdMock,
       });
@@ -929,7 +929,7 @@ describe('Timeline', () => {
 
     test('should update the timeline title', () => {
       const update = updateTimelineTitle({
-        id: 'foo',
+        id: TimelineId.test,
         title: newTitle,
         timelineById: timelineByIdMock,
       });
@@ -938,7 +938,7 @@ describe('Timeline', () => {
 
     test('should always trim all leading whitespace and allow only one trailing space', () => {
       const update = updateTimelineTitle({
-        id: 'foo',
+        id: TimelineId.test,
         title: '      room at the back      ',
         timelineById: timelineByIdMock,
       });
@@ -949,7 +949,7 @@ describe('Timeline', () => {
   describe('#updateTimelineProviders', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineProviders({
-        id: 'foo',
+        id: TimelineId.test,
         providers: [
           {
             and: [],
@@ -987,7 +987,7 @@ describe('Timeline', () => {
         kqlQuery: '',
       };
       const update = updateTimelineProviders({
-        id: 'foo',
+        id: TimelineId.test,
         providers: [providerToAdd],
         timelineById: timelineByIdMock,
       });
@@ -998,7 +998,7 @@ describe('Timeline', () => {
   describe('#updateTimelineRange', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineRange({
-        id: 'foo',
+        id: TimelineId.test,
         start: 23,
         end: 33,
         timelineById: timelineByIdMock,
@@ -1008,7 +1008,7 @@ describe('Timeline', () => {
 
     test('should update the timeline range', () => {
       const update = updateTimelineRange({
-        id: 'foo',
+        id: TimelineId.test,
         start: 23,
         end: 33,
         timelineById: timelineByIdMock,
@@ -1029,7 +1029,7 @@ describe('Timeline', () => {
   describe('#updateTimelineSort', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineSort({
-        id: 'foo',
+        id: TimelineId.test,
         sort: {
           columnId: 'some column',
           sortDirection: Direction.desc,
@@ -1041,7 +1041,7 @@ describe('Timeline', () => {
 
     test('should update the timeline range', () => {
       const update = updateTimelineSort({
-        id: 'foo',
+        id: TimelineId.test,
         sort: {
           columnId: 'some column',
           sortDirection: Direction.desc,
@@ -1061,7 +1061,7 @@ describe('Timeline', () => {
   describe('#updateTimelineProviderEnabled', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         enabled: false, // value we are updating from true to false
         timelineById: timelineByIdMock,
@@ -1071,24 +1071,24 @@ describe('Timeline', () => {
 
     test('should return a new reference for data provider and not the same reference of data provider', () => {
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         enabled: false, // value we are updating from true to false
         timelineById: timelineByIdMock,
       });
-      expect(update.foo.dataProviders).not.toBe(timelineByIdMock.foo.dataProviders);
+      expect(update.test!.dataProviders).not.toBe(timelineByIdMock.test!.dataProviders);
     });
 
     test('should update the timeline provider enabled from true to false', () => {
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         enabled: false, // value we are updating from true to false
         timelineById: timelineByIdMock,
       });
       const expected: TimelineById = {
-        foo: {
-          id: 'foo',
+        test: {
+          id: TimelineId.test,
           savedObjectId: null,
           columns: [],
           dataProviders: [
@@ -1149,7 +1149,7 @@ describe('Timeline', () => {
     });
 
     test('should update only one data provider and not two data providers', () => {
-      const multiDataProvider = timelineByIdMock.foo.dataProviders.concat({
+      const multiDataProvider = timelineByIdMock.test!.dataProviders.concat({
         and: [],
         id: '456',
         name: 'data provider 1',
@@ -1164,14 +1164,14 @@ describe('Timeline', () => {
       });
       const multiDataProviderMock = set('foo.dataProviders', multiDataProvider, timelineByIdMock);
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         enabled: false, // value we are updating from true to false
         timelineById: multiDataProviderMock,
       });
       const expected: TimelineById = {
-        foo: {
-          id: 'foo',
+        test: {
+          id: TimelineId.test,
           savedObjectId: null,
           columns: [],
           dataProviders: [
@@ -1278,7 +1278,7 @@ describe('Timeline', () => {
       };
 
       timelineByIdwithAndMock = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
@@ -1286,7 +1286,7 @@ describe('Timeline', () => {
 
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         enabled: false, // value we are updating from true to false
         timelineById: timelineByIdwithAndMock,
@@ -1297,32 +1297,32 @@ describe('Timeline', () => {
 
     test('should return a new reference for and data provider and not the same reference of data and provider', () => {
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         enabled: false, // value we are updating from true to false
         timelineById: timelineByIdwithAndMock,
         andProviderId: '568',
       });
-      expect(update.foo.dataProviders).not.toBe(timelineByIdMock.foo.dataProviders);
+      expect(update.test!.dataProviders).not.toBe(timelineByIdMock.test!.dataProviders);
     });
 
     test('should update the timeline and provider enabled from true to false', () => {
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         enabled: false, // value we are updating from true to false
         timelineById: timelineByIdwithAndMock,
         andProviderId: '568',
       });
-      const indexProvider = update.foo.dataProviders.findIndex((i) => i.id === '567');
-      expect(update.foo.dataProviders[indexProvider].and[0].enabled).toEqual(false);
+      const indexProvider = update.test!.dataProviders.findIndex((i) => i.id === '567');
+      expect(update.test!.dataProviders[indexProvider].and[0].enabled).toEqual(false);
     });
 
     test('should update only one and data provider and not two and data providers', () => {
-      const indexProvider = timelineByIdwithAndMock.foo.dataProviders.findIndex(
+      const indexProvider = timelineByIdwithAndMock.test!.dataProviders.findIndex(
         (i) => i.id === '567'
       );
-      const multiAndDataProvider = timelineByIdwithAndMock.foo.dataProviders[
+      const multiAndDataProvider = timelineByIdwithAndMock.test!.dataProviders[
         indexProvider
       ].and.concat({
         id: '456',
@@ -1343,16 +1343,16 @@ describe('Timeline', () => {
         timelineByIdwithAndMock
       );
       const update = updateTimelineProviderEnabled({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         enabled: false, // value we are updating from true to false
         timelineById: multiAndDataProviderMock,
         andProviderId: '568',
       });
-      const oldAndProvider = update.foo.dataProviders[indexProvider].and.find(
+      const oldAndProvider = update.test!.dataProviders[indexProvider].and.find(
         (i) => i.id === '568'
       );
-      const newAndProvider = update.foo.dataProviders[indexProvider].and.find(
+      const newAndProvider = update.test!.dataProviders[indexProvider].and.find(
         (i) => i.id === '456'
       );
       expect(oldAndProvider!.enabled).toEqual(false);
@@ -1363,7 +1363,7 @@ describe('Timeline', () => {
   describe('#updateTimelineProviderExcluded', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         excluded: true, // value we are updating from false to true
         timelineById: timelineByIdMock,
@@ -1373,24 +1373,24 @@ describe('Timeline', () => {
 
     test('should return a new reference for data provider and not the same reference of data provider', () => {
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         excluded: true, // value we are updating from false to true
         timelineById: timelineByIdMock,
       });
-      expect(update.foo.dataProviders).not.toBe(timelineByIdMock.foo.dataProviders);
+      expect(update.test!.dataProviders).not.toBe(timelineByIdMock.test!.dataProviders);
     });
 
     test('should update the timeline provider excluded from true to false', () => {
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         excluded: true, // value we are updating from false to true
         timelineById: timelineByIdMock,
       });
       const expected: TimelineById = {
-        foo: {
-          id: 'foo',
+        test: {
+          id: TimelineId.test,
           savedObjectId: null,
           columns: [],
           dataProviders: [
@@ -1451,7 +1451,7 @@ describe('Timeline', () => {
     });
 
     test('should update only one data provider and not two data providers', () => {
-      const multiDataProvider = timelineByIdMock.foo.dataProviders.concat({
+      const multiDataProvider = timelineByIdMock.test!.dataProviders.concat({
         and: [],
         id: '456',
         name: 'data provider 1',
@@ -1466,14 +1466,14 @@ describe('Timeline', () => {
       });
       const multiDataProviderMock = set('foo.dataProviders', multiDataProvider, timelineByIdMock);
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         excluded: true, // value we are updating from false to true
         timelineById: multiDataProviderMock,
       });
       const expected: TimelineById = {
-        foo: {
-          id: 'foo',
+        test: {
+          id: TimelineId.test,
           savedObjectId: null,
           columns: [],
           dataProviders: [
@@ -1580,7 +1580,7 @@ describe('Timeline', () => {
       };
 
       timelineByIdwithAndMock = addTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         provider: providerToAdd,
         timelineById: timelineByIdMock,
       });
@@ -1588,7 +1588,7 @@ describe('Timeline', () => {
 
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         excluded: true, // value we are updating from true to false
         timelineById: timelineByIdwithAndMock,
@@ -1599,32 +1599,32 @@ describe('Timeline', () => {
 
     test('should return a new reference for and data provider and not the same reference of data and provider', () => {
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         excluded: true, // value we are updating from false to true
         timelineById: timelineByIdwithAndMock,
         andProviderId: '568',
       });
-      expect(update.foo.dataProviders).not.toBe(timelineByIdMock.foo.dataProviders);
+      expect(update.test!.dataProviders).not.toBe(timelineByIdMock.test!.dataProviders);
     });
 
     test('should update the timeline and provider excluded from true to false', () => {
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         excluded: true, // value we are updating from true to false
         timelineById: timelineByIdwithAndMock,
         andProviderId: '568',
       });
-      const indexProvider = update.foo.dataProviders.findIndex((i) => i.id === '567');
-      expect(update.foo.dataProviders[indexProvider].and[0].enabled).toEqual(true);
+      const indexProvider = update.test!.dataProviders.findIndex((i) => i.id === '567');
+      expect(update.test!.dataProviders[indexProvider].and[0].enabled).toEqual(true);
     });
 
     test('should update only one and data provider and not two and data providers', () => {
-      const indexProvider = timelineByIdwithAndMock.foo.dataProviders.findIndex(
+      const indexProvider = timelineByIdwithAndMock.test!.dataProviders.findIndex(
         (i) => i.id === '567'
       );
-      const multiAndDataProvider = timelineByIdwithAndMock.foo.dataProviders[
+      const multiAndDataProvider = timelineByIdwithAndMock.test!.dataProviders[
         indexProvider
       ].and.concat({
         id: '456',
@@ -1645,16 +1645,16 @@ describe('Timeline', () => {
         timelineByIdwithAndMock
       );
       const update = updateTimelineProviderExcluded({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '567',
         excluded: true, // value we are updating from true to false
         timelineById: multiAndDataProviderMock,
         andProviderId: '568',
       });
-      const oldAndProvider = update.foo.dataProviders[indexProvider].and.find(
+      const oldAndProvider = update.test!.dataProviders[indexProvider].and.find(
         (i) => i.id === '568'
       );
-      const newAndProvider = update.foo.dataProviders[indexProvider].and.find(
+      const newAndProvider = update.test!.dataProviders[indexProvider].and.find(
         (i) => i.id === '456'
       );
       expect(oldAndProvider!.excluded).toEqual(true);
@@ -1665,7 +1665,7 @@ describe('Timeline', () => {
   describe('#updateTimelineItemsPerPage', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelineItemsPerPage({
-        id: 'foo',
+        id: TimelineId.test,
         itemsPerPage: 10, // value we are updating from 5 to 10
         timelineById: timelineByIdMock,
       });
@@ -1674,13 +1674,13 @@ describe('Timeline', () => {
 
     test('should update the items per page from 25 to 50', () => {
       const update = updateTimelineItemsPerPage({
-        id: 'foo',
+        id: TimelineId.test,
         itemsPerPage: 50, // value we are updating from 25 to 50
         timelineById: timelineByIdMock,
       });
       const expected: TimelineById = {
-        foo: {
-          id: 'foo',
+        test: {
+          id: TimelineId.test,
           savedObjectId: null,
           columns: [],
           dataProviders: [
@@ -1745,7 +1745,7 @@ describe('Timeline', () => {
   describe('#updateTimelinePerPageOptions', () => {
     test('should return a new reference and not the same reference', () => {
       const update = updateTimelinePerPageOptions({
-        id: 'foo',
+        id: TimelineId.test,
         itemsPerPageOptions: [100, 200, 300], // value we are updating from [5, 10, 20]
         timelineById: timelineByIdMock,
       });
@@ -1754,12 +1754,12 @@ describe('Timeline', () => {
 
     test('should update the items per page options from [10, 25, 50] to [100, 200, 300]', () => {
       const update = updateTimelinePerPageOptions({
-        id: 'foo',
+        id: TimelineId.test,
         itemsPerPageOptions: [100, 200, 300], // value we are updating from [10, 25, 50]
         timelineById: timelineByIdMock,
       });
       const expected: TimelineById = {
-        foo: {
+        test: {
           columns: [],
           dataProviders: [
             {
@@ -1786,7 +1786,7 @@ describe('Timeline', () => {
           isLive: false,
           isSelectAllChecked: false,
           isLoading: false,
-          id: 'foo',
+          id: TimelineId.test,
           savedObjectId: null,
           kqlMode: 'filter',
           kqlQuery: { filterQuery: null, filterQueryDraft: null },
@@ -1825,7 +1825,7 @@ describe('Timeline', () => {
   describe('#removeTimelineProvider', () => {
     test('should return a new reference and not the same reference', () => {
       const update = removeTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         timelineById: timelineByIdMock,
       });
@@ -1834,7 +1834,7 @@ describe('Timeline', () => {
 
     test('should remove a timeline provider', () => {
       const update = removeTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         timelineById: timelineByIdMock,
       });
@@ -1842,7 +1842,7 @@ describe('Timeline', () => {
     });
 
     test('should remove only one data provider and not two data providers', () => {
-      const multiDataProvider = timelineByIdMock.foo.dataProviders.concat({
+      const multiDataProvider = timelineByIdMock.test!.dataProviders.concat({
         and: [],
         id: '456',
         name: 'data provider 2',
@@ -1858,12 +1858,12 @@ describe('Timeline', () => {
       });
       const multiDataProviderMock = set('foo.dataProviders', multiDataProvider, timelineByIdMock);
       const update = removeTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '123',
         timelineById: multiDataProviderMock,
       });
       const expected: TimelineById = {
-        foo: {
+        test: {
           columns: [],
           dataProviders: [
             {
@@ -1886,7 +1886,7 @@ describe('Timeline', () => {
           eventIdToNoteIds: {},
           highlightedDropAndProviderId: '',
           historyIds: [],
-          id: 'foo',
+          id: TimelineId.test,
           savedObjectId: null,
           isFavorite: false,
           isLive: false,
@@ -1994,7 +1994,7 @@ describe('Timeline', () => {
       );
 
       const update = removeTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: '222',
         timelineById: nestedMultiAndDataProviderMock,
       });
@@ -2002,9 +2002,9 @@ describe('Timeline', () => {
         set(
           'foo.dataProviders',
           [
-            nestedMultiAndDataProviderMock.foo.dataProviders[0],
+            nestedMultiAndDataProviderMock.test!.dataProviders[0],
             { ...andDataProvider, and: [] },
-            nestedMultiAndDataProviderMock.foo.dataProviders[2],
+            nestedMultiAndDataProviderMock.test!.dataProviders[2],
           ],
           timelineByIdMock
         )
@@ -2056,7 +2056,7 @@ describe('Timeline', () => {
       const multiDataProviderMock = set('foo.dataProviders', multiDataProvider, timelineByIdMock);
 
       const update = removeTimelineProvider({
-        id: 'foo',
+        id: TimelineId.test,
         providerId: 'hosts-table-hostName-suricata-iowa',
         timelineById: multiDataProviderMock,
       });
@@ -2142,7 +2142,7 @@ describe('Timeline', () => {
 
       const update = removeTimelineProvider({
         andProviderId: 'socket_closed-MSoH7GoB9v5HJNSHRYj1-user_name-root',
-        id: 'foo',
+        id: TimelineId.test,
         providerId: 'hosts-table-hostName-suricata-iowa',
         timelineById: multiDataProviderMock,
       });
@@ -2229,7 +2229,7 @@ describe('Timeline', () => {
 
       const update = removeTimelineProvider({
         andProviderId: 'executed-yioH7GoB9v5HJNSHKnp5-auditd_result-success',
-        id: 'foo',
+        id: TimelineId.test,
         providerId: 'hosts-table-hostName-suricata-iowa',
         timelineById: multiDataProviderMock,
       });

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/selectors.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/selectors.ts
@@ -6,10 +6,12 @@
 
 import { createSelector } from 'reselect';
 
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { isFromKueryExpressionValid } from '../../../common/lib/keury';
 import { State } from '../../../common/store/types';
 
 import { TimelineModel } from './model';
+import { timelineDefaults } from './defaults';
 import { AutoSavedWarningMsg, InsertTimeline, TimelineById } from './types';
 
 const selectTimelineById = (state: State): TimelineById => state.timeline.timelineById;
@@ -19,8 +21,8 @@ const selectAutoSaveMsg = (state: State): AutoSavedWarningMsg => state.timeline.
 const selectCallOutUnauthorizedMsg = (state: State): boolean =>
   state.timeline.showCallOutUnauthorizedMsg;
 
-export const selectTimeline = (state: State, timelineId: string): TimelineModel =>
-  state.timeline.timelineById[timelineId];
+export const selectTimeline = (state: State, timelineId: TimelineIdLiteral): TimelineModel =>
+  state.timeline.timelineById[timelineId] ?? { ...timelineDefaults, id: timelineId };
 
 export const selectInsertTimeline = (state: State): InsertTimeline | null =>
   state.timeline.insertTimeline;

--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/types.ts
@@ -7,23 +7,24 @@ import { Action } from 'redux';
 import { Observable } from 'rxjs';
 
 import { Storage } from '../../../../../../../src/plugins/kibana_utils/public';
+import { TimelineIdLiteral } from '../../../../common/types/timeline';
 import { AppApolloClient } from '../../../common/lib/lib';
 import { inputsModel } from '../../../common/store/inputs';
 import { NotesById } from '../../../common/store/app/model';
 import { TimelineModel } from './model';
 
 export interface AutoSavedWarningMsg {
-  timelineId: string | null;
+  timelineId: TimelineIdLiteral | null;
   newTimelineModel: TimelineModel | null;
 }
 
 /** A map of id to timeline  */
-export interface TimelineById {
-  [id: string]: TimelineModel;
-}
+export type TimelineById = {
+  [id in TimelineIdLiteral]?: TimelineModel;
+};
 
 export interface InsertTimeline {
-  timelineId: string;
+  timelineId: TimelineIdLiteral;
   timelineSavedObjectId: string | null;
   timelineTitle: string;
 }


### PR DESCRIPTION
## Summary

This PR improves the `TimelineById` type. Specifically, the type allowed any string as a key for the object. The PR limits the keys to only the allowed timeline ids and specifically to the ids that were introduced by https://github.com/elastic/kibana/pull/67156

### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
