### PR TITLE
[SIEM] Fixes screenshots upload

### DIFF
--- a/vars/kibanaPipeline.groovy
+++ b/vars/kibanaPipeline.groovy
@@ -98,7 +98,7 @@ def withGcsArtifactUpload(workerName, closure) {
   def uploadPrefix = "kibana-ci-artifacts/jobs/${env.JOB_NAME}/${BUILD_NUMBER}/${workerName}"
   def ARTIFACT_PATTERNS = [
     'target/kibana-*',
-    'target/kibana-siem/**/*.png',
+    'target/kibana-security-solution/**/*.png',
     'target/junit/**/*',
     'test/**/screenshots/**/*.png',
     'test/functional/failure_debug/html/*.html',


### PR DESCRIPTION
## Summary

With the renaming we broke the screenshots upload. This functionality is really helpful since when a Cypress test fails in Jenkins the screenshot is uploaded to google cloud making the debugging of the test easier.

In this PR we are fixing the problem :)