### PR TITLE
[Ingest Manager] Fleet require encrypted saved object encryption key …

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/rest_spec/fleet_setup.ts
+++ b/x-pack/plugins/ingest_manager/common/types/rest_spec/fleet_setup.ts
@@ -10,5 +10,10 @@ export interface CreateFleetSetupResponse {
 
 export interface GetFleetStatusResponse {
   isReady: boolean;
-  missing_requirements: Array<'tls_required' | 'api_keys' | 'fleet_admin_user'>;
+  missing_requirements: Array<
+    | 'tls_required'
+    | 'api_keys'
+    | 'fleet_admin_user'
+    | 'encrypted_saved_object_encryption_key_required'
+  >;
 }

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -39,7 +39,9 @@ export const SetupPage: React.FunctionComponent<{
   };
 
   const content =
-    missingRequirements.includes('tls_required') || missingRequirements.includes('api_keys') ? (
+    missingRequirements.includes('tls_required') ||
+    missingRequirements.includes('api_keys') ||
+    missingRequirements.includes('encrypted_saved_object_encryption_key_required') ? (
       <>
         <EuiSpacer size="m" />
         <EuiIcon type="lock" color="subdued" size="xl" />
@@ -53,12 +55,13 @@ export const SetupPage: React.FunctionComponent<{
           </h2>
         </EuiTitle>
         <EuiSpacer size="xl" />
-        <EuiText color="subdued">
+        <EuiText color="subdued" textAlign={'left'}>
           <FormattedMessage
             id="xpack.ingestManager.setupPage.missingRequirementsDescription"
             defaultMessage="To use Fleet, you must enable the following features:
           {space}- Enable Elasticsearch API keys.
           {space}- Enable TLS to secure the communication between Agents and Kibana.
+          {space}- Set the encryption key for encrypted saved objects.
           "
             values={{
               space: <EuiSpacer size="m" />,

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -67,7 +67,8 @@ export interface IngestManagerSetupDeps {
 export type IngestManagerStartDeps = object;
 
 export interface IngestManagerAppContext {
-  encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
+  encryptedSavedObjectsStart: EncryptedSavedObjectsPluginStart;
+  encryptedSavedObjectsSetup?: EncryptedSavedObjectsPluginSetup;
   security?: SecurityPluginSetup;
   config$?: Observable<IngestManagerConfigType>;
   savedObjects: SavedObjectsServiceStart;
@@ -115,6 +116,7 @@ export class IngestManagerPlugin
   private isProductionMode: boolean;
   private kibanaVersion: string;
   private httpSetup: HttpServiceSetup | undefined;
+  private encryptedSavedObjectsSetup: EncryptedSavedObjectsPluginSetup | undefined;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.config$ = this.initializerContext.config.create<IngestManagerConfigType>();
@@ -129,6 +131,7 @@ export class IngestManagerPlugin
     if (deps.security) {
       this.security = deps.security;
     }
+    this.encryptedSavedObjectsSetup = deps.encryptedSavedObjects;
     this.cloud = deps.cloud;
 
     registerSavedObjects(core.savedObjects);
@@ -187,12 +190,22 @@ export class IngestManagerPlugin
       }
 
       if (config.fleet.enabled) {
-        registerAgentRoutes(router);
-        registerEnrollmentApiKeyRoutes(router);
-        registerInstallScriptRoutes({
-          router,
-          basePath: core.http.basePath,
-        });
+        const isESOUsingEphemeralEncryptionKey =
+          deps.encryptedSavedObjects.usingEphemeralEncryptionKey;
+        if (isESOUsingEphemeralEncryptionKey) {
+          if (this.logger) {
+            this.logger.warn(
+              'Fleet APIs are disabled due to the Encrypted Saved Objects plugin using an ephemeral encryption key. Please set xpack.encryptedSavedObjects.encryptionKey in kibana.yml.'
+            );
+          }
+        } else {
+          registerAgentRoutes(router);
+          registerEnrollmentApiKeyRoutes(router);
+          registerInstallScriptRoutes({
+            router,
+            basePath: core.http.basePath,
+          });
+        }
       }
     }
   }
@@ -204,7 +217,8 @@ export class IngestManagerPlugin
     }
   ) {
     appContextService.start({
-      encryptedSavedObjects: plugins.encryptedSavedObjects,
+      encryptedSavedObjectsStart: plugins.encryptedSavedObjects,
+      encryptedSavedObjectsSetup: this.encryptedSavedObjectsSetup,
       security: this.security,
       config$: this.config$,
       savedObjects: core.savedObjects,

--- a/x-pack/plugins/ingest_manager/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/setup/handlers.ts
@@ -20,6 +20,8 @@ export const getFleetStatusHandler: RequestHandler = async (context, request, re
     const isProductionMode = appContextService.getIsProductionMode();
     const isCloud = appContextService.getCloud()?.isCloudEnabled ?? false;
     const isTLSCheckDisabled = appContextService.getConfig()?.fleet?.tlsCheckDisabled ?? false;
+    const isUsingEphemeralEncryptionKey = appContextService.getEncryptedSavedObjectsSetup()
+      .usingEphemeralEncryptionKey;
 
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
     if (!isAdminUserSetup) {
@@ -30,6 +32,10 @@ export const getFleetStatusHandler: RequestHandler = async (context, request, re
     }
     if (!isTLSCheckDisabled && !isCloud && isProductionMode && !isTLSEnabled) {
       missingRequirements.push('tls_required');
+    }
+
+    if (isUsingEphemeralEncryptionKey) {
+      missingRequirements.push('encrypted_saved_object_encryption_key_required');
     }
 
     const body: GetFleetStatusResponse = {

--- a/x-pack/plugins/ingest_manager/server/services/agents/acks.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/acks.test.ts
@@ -24,7 +24,7 @@ describe('test agent acks services', () => {
     const mockSavedObjectsClient = savedObjectsClientMock.create();
     const mockStartEncryptedSOPlugin = encryptedSavedObjectsMock.createStart();
     appContextService.start(({
-      encryptedSavedObjects: mockStartEncryptedSOPlugin,
+      encryptedSavedObjectsStart: mockStartEncryptedSOPlugin,
     } as unknown) as IngestManagerAppContext);
 
     const [

--- a/x-pack/plugins/ingest_manager/server/services/app_context.ts
+++ b/x-pack/plugins/ingest_manager/server/services/app_context.ts
@@ -6,7 +6,10 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { SavedObjectsServiceStart, HttpServiceSetup, Logger } from 'src/core/server';
-import { EncryptedSavedObjectsClient } from '../../../encrypted_saved_objects/server';
+import {
+  EncryptedSavedObjectsClient,
+  EncryptedSavedObjectsPluginSetup,
+} from '../../../encrypted_saved_objects/server';
 import { SecurityPluginSetup } from '../../../security/server';
 import { IngestManagerConfigType } from '../../common';
 import { IngestManagerAppContext } from '../plugin';
@@ -14,6 +17,7 @@ import { CloudSetup } from '../../../cloud/server';
 
 class AppContextService {
   private encryptedSavedObjects: EncryptedSavedObjectsClient | undefined;
+  private encryptedSavedObjectsSetup: EncryptedSavedObjectsPluginSetup | undefined;
   private security: SecurityPluginSetup | undefined;
   private config$?: Observable<IngestManagerConfigType>;
   private configSubject$?: BehaviorSubject<IngestManagerConfigType>;
@@ -25,7 +29,8 @@ class AppContextService {
   private httpSetup?: HttpServiceSetup;
 
   public async start(appContext: IngestManagerAppContext) {
-    this.encryptedSavedObjects = appContext.encryptedSavedObjects?.getClient();
+    this.encryptedSavedObjects = appContext.encryptedSavedObjectsStart?.getClient();
+    this.encryptedSavedObjectsSetup = appContext.encryptedSavedObjectsSetup;
     this.security = appContext.security;
     this.savedObjects = appContext.savedObjects;
     this.isProductionMode = appContext.isProductionMode;
@@ -93,6 +98,14 @@ class AppContextService {
       throw new Error('HttpServiceSetup not set.');
     }
     return this.httpSetup;
+  }
+
+  public getEncryptedSavedObjectsSetup() {
+    if (!this.encryptedSavedObjectsSetup) {
+      throw new Error('encryptedSavedObjectsSetup is not set');
+    }
+
+    return this.encryptedSavedObjectsSetup;
   }
 
   public getKibanaVersion() {


### PR DESCRIPTION
## Description

Resolve https://github.com/elastic/kibana/issues/68750

To be able to use Fleet correctly an user need to set an encryption key for encrypted saved object(if Kibana is running in production).

This PR enforce the key to be configured by:
* not registering fleet API if the key is not set
* display an error message in the UI

## UI Change

<img width="822" alt="Screen Shot 2020-06-17 at 10 45 34 AM" src="https://user-images.githubusercontent.com/1336873/84913000-0a1dfe00-b088-11ea-8067-c2cd82e7677a.png">

## How to test this?

The easiest way is to hack this line to return true https://github.com/nchaulet/kibana/blob/feature-fleet-require-encryptionkey/x-pack/plugins/encrypted_saved_objects/server/plugin.ts#L72

