### PR TITLE
[SIEM][Detection Engine] Fixes 7.8 upgrade issue within rules where you can get the error "params invalid: [lists]: definition for this key is missing"

### DIFF
--- a/x-pack/plugins/siem/server/lib/detection_engine/routes/rules/import_rules_route.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/routes/rules/import_rules_route.ts
@@ -229,7 +229,6 @@ export const importRulesRoute = (router: IRouter, config: ConfigType, ml: SetupP
                         references,
                         note,
                         version,
-                        exceptions_list,
                         anomalyThreshold,
                         machineLearningJobId,
                       });

--- a/x-pack/plugins/siem/server/lib/detection_engine/rules/patch_rules.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/rules/patch_rules.ts
@@ -76,7 +76,6 @@ export const patchRules = async ({
     references,
     version,
     note,
-    exceptions_list,
     anomalyThreshold,
     machineLearningJobId,
   });

--- a/x-pack/plugins/siem/server/lib/detection_engine/rules/patch_rules.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/rules/patch_rules.ts
@@ -76,6 +76,7 @@ export const patchRules = async ({
     references,
     version,
     note,
+    exceptions_list,
     anomalyThreshold,
     machineLearningJobId,
   });
@@ -107,7 +108,6 @@ export const patchRules = async ({
       references,
       note,
       version: calculatedVersion,
-      exceptions_list,
       anomalyThreshold,
       machineLearningJobId,
     }

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.mock.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.mock.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const getSignalParamsSchemaMock = () => ({
+  description: 'Detecting root and admin users',
+  query: 'user.name: root or user.name: admin',
+  severity: 'high',
+  type: 'query',
+  riskScore: 55,
+  language: 'kuery',
+  ruleId: 'rule-1',
+  from: 'now-6m',
+  to: 'now',
+});
+
+export const getSignalParamsSchemaDecodedMock = () => ({
+  description: 'Detecting root and admin users',
+  falsePositives: [],
+  filters: null,
+  from: 'now-6m',
+  immutable: false,
+  index: null,
+  language: 'kuery',
+  maxSignals: 100,
+  meta: null,
+  note: null,
+  outputIndex: null,
+  query: 'user.name: root or user.name: admin',
+  references: [],
+  riskScore: 55,
+  ruleId: 'rule-1',
+  savedId: null,
+  severity: 'high',
+  threat: null,
+  timelineId: null,
+  timelineTitle: null,
+  to: 'now',
+  type: 'query',
+  version: 1,
+});

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.test.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { signalParamsSchema } from './signal_params_schema';
+import {
+  getSignalParamsSchemaDecodedMock,
+  getSignalParamsSchemaMock,
+} from './signal_params_schema.mock';
+import { DEFAULT_MAX_SIGNALS } from '../../../../common/constants';
+
+describe('signal_params_schema', () => {
+  test('it works with expected basic mock data set', () => {
+    const schema = signalParamsSchema();
+    expect(schema.validate(getSignalParamsSchemaMock())).toEqual(
+      getSignalParamsSchemaDecodedMock()
+    );
+  });
+
+  test('it works on older lists data structures if they exist as an empty array', () => {
+    const schema = signalParamsSchema();
+    const mock = { lists: [], ...getSignalParamsSchemaMock() };
+    const expected = {
+      lists: [],
+      ...getSignalParamsSchemaDecodedMock(),
+    };
+    expect(schema.validate(mock)).toEqual(expected);
+  });
+
+  test('it works on older exceptions_list data structures if they exist as an empty array', () => {
+    const schema = signalParamsSchema();
+    const mock = {
+      exceptions_list: [],
+      ...getSignalParamsSchemaMock(),
+    };
+    const expected = {
+      exceptions_list: [],
+      ...getSignalParamsSchemaDecodedMock(),
+    };
+    expect(schema.validate(mock)).toEqual(expected);
+  });
+
+  test('it throws if given an invalid value', () => {
+    const schema = signalParamsSchema();
+    const mock = {
+      madeUpValue: 'something',
+      ...getSignalParamsSchemaMock(),
+    };
+    expect(() => schema.validate(mock)).toThrow(
+      '[madeUpValue]: definition for this key is missing'
+    );
+  });
+
+  test('if risk score is a string then it will be converted into a number before being inserted as data', () => {
+    const schema = signalParamsSchema();
+    const mock = {
+      ...getSignalParamsSchemaMock(),
+      riskScore: '5',
+    };
+    expect(schema.validate(mock).riskScore).toEqual(5);
+    expect(typeof schema.validate(mock).riskScore).toEqual('number');
+  });
+
+  test('if risk score is a number then it will work as a number', () => {
+    const schema = signalParamsSchema();
+    const mock = {
+      ...getSignalParamsSchemaMock(),
+      riskScore: 5,
+    };
+    expect(schema.validate(mock).riskScore).toEqual(5);
+    expect(typeof schema.validate(mock).riskScore).toEqual('number');
+  });
+
+  test('maxSignals will default to "DEFAULT_MAX_SIGNALS" if not set', () => {
+    const schema = signalParamsSchema();
+    // mock data already does not have it on it
+    const withoutMockData = getSignalParamsSchemaMock();
+    expect(schema.validate(withoutMockData).maxSignals).toEqual(DEFAULT_MAX_SIGNALS);
+  });
+
+  test('version will default to "1" if not set', () => {
+    const schema = signalParamsSchema();
+    // mock data already does not have it on it
+    const withoutVersion = getSignalParamsSchemaMock();
+    expect(schema.validate(withoutVersion).version).toEqual(1);
+  });
+
+  test('references will default to an empty array if not set', () => {
+    const schema = signalParamsSchema();
+    // mock data already does not have it on it
+    const withoutReferences = getSignalParamsSchemaMock();
+    expect(schema.validate(withoutReferences).references).toEqual([]);
+  });
+
+  test('immutable will default to false if not set', () => {
+    const schema = signalParamsSchema();
+    // mock data already does not have it on it
+    const withoutImmutable = getSignalParamsSchemaMock();
+    expect(schema.validate(withoutImmutable).immutable).toEqual(false);
+  });
+
+  test('falsePositives will default to an empty array if not set', () => {
+    const schema = signalParamsSchema();
+    // mock data already does not have it on it
+    const withoutFalsePositives = getSignalParamsSchemaMock();
+    expect(schema.validate(withoutFalsePositives).falsePositives).toEqual([]);
+  });
+});

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.ts
@@ -39,5 +39,7 @@ export const signalParamsSchema = () =>
     type: schema.string(),
     references: schema.arrayOf(schema.string(), { defaultValue: [] }),
     version: schema.number({ defaultValue: 1 }),
+    // For backwards compatibility with customers that had a data bug in 7.7. Once we use a migration script please remove this.
+    lists: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
     exceptions_list: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
   });

--- a/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.ts
+++ b/x-pack/plugins/siem/server/lib/detection_engine/signals/signal_params_schema.ts
@@ -39,7 +39,6 @@ export const signalParamsSchema = () =>
     type: schema.string(),
     references: schema.arrayOf(schema.string(), { defaultValue: [] }),
     version: schema.number({ defaultValue: 1 }),
-    // For backwards compatibility with customers that had a data bug in 7.7. Once we use a migration script please remove this.
-    lists: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
+    lists: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))), // For backwards compatibility with customers that had a data bug in 7.7. Once we use a migration script please remove this.
     exceptions_list: schema.maybe(schema.arrayOf(schema.object({}, { unknowns: 'allow' }))),
   });


### PR DESCRIPTION
## Summary
* https://github.com/elastic/kibana/issues/69463

This fixes a bug where if you import rules and set your overwrite to `true` multiple times in a row within 7.7 you can end up with a lists array. When upgrading to 7.8, we change the name of `lists` to `exceptions_lists` and suddenly when you enable/disable a rule you can get the following error below:

![image](https://user-images.githubusercontent.com/1151048/84945824-fa60e280-b0a4-11ea-8e05-bffdec2e4765.png)

The fix is to allow the lists array still if it is present within saved objects to avoid seeing this error screen and being tolerant. We also fix the area of code that is causing the data bug so it cannot happen again with `exceptions_list` which is what the name of lists was renamed to causing this problem.

### Checklist

* Manually tested the fix within Elastic Cloud. No unit tests as in 7.9 we are going to remove the feature flag altogether and just have exception lists and not worry about older data structures.
