### PR TITLE
[APM] License feature tracking for service maps

### DIFF
--- a/x-pack/plugins/apm/server/feature.ts
+++ b/x-pack/plugins/apm/server/feature.ts
@@ -70,3 +70,6 @@ export const APM_FEATURE = {
     },
   },
 };
+
+export const APM_SERVICE_MAPS_FEATURE_NAME = 'APM service maps';
+export const APM_SERVICE_MAPS_LICENSE_TYPE = 'platinum';

--- a/x-pack/plugins/apm/server/routes/create_api/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/create_api/index.test.ts
@@ -9,6 +9,7 @@ import { CoreSetup, Logger } from 'src/core/server';
 import { Params } from '../typings';
 import { BehaviorSubject } from 'rxjs';
 import { APMConfig } from '../..';
+import { LicensingPluginStart } from '../../../../licensing/server';
 
 const getCoreMock = () => {
   const get = jest.fn();
@@ -40,7 +41,7 @@ const getCoreMock = () => {
       logger: ({
         error: jest.fn(),
       } as unknown) as Logger,
-      plugins: {},
+      plugins: { licensing: {} as LicensingPluginStart },
     },
   };
 };

--- a/x-pack/plugins/apm/server/routes/service_map.ts
+++ b/x-pack/plugins/apm/server/routes/service_map.ts
@@ -15,6 +15,7 @@ import { getServiceMap } from '../lib/service_map/get_service_map';
 import { getServiceMapServiceNodeInfo } from '../lib/service_map/get_service_map_service_node_info';
 import { createRoute } from './create_route';
 import { rangeRt } from './default_api_types';
+import { APM_SERVICE_MAPS_FEATURE_NAME } from '../feature';
 
 export const serviceMapRoute = createRoute(() => ({
   path: '/api/apm/service-map',
@@ -34,6 +35,10 @@ export const serviceMapRoute = createRoute(() => ({
     if (!isValidPlatinumLicense(context.licensing.license)) {
       throw Boom.forbidden(invalidLicenseMessage);
     }
+
+    context.plugins.licensing.featureUsage.notifyUsage(
+      APM_SERVICE_MAPS_FEATURE_NAME
+    );
 
     const setup = await setupRequest(context, request);
     const {

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -14,10 +14,11 @@ import {
 import { PickByValue, Optional } from 'utility-types';
 import { Observable } from 'rxjs';
 import { Server } from 'hapi';
+import { LicensingPluginStart } from '../../../licensing/server';
 import { ObservabilityPluginSetup } from '../../../observability/server';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { FetchOptions } from '../../public/services/rest/callApi';
-import { SecurityPluginSetup } from '../../../security/public';
+import { SecurityPluginSetup } from '../../../security/server';
 import { MlPluginSetup } from '../../../ml/server';
 import { APMConfig } from '..';
 
@@ -66,6 +67,7 @@ export type APMRequestHandlerContext<
   config: APMConfig;
   logger: Logger;
   plugins: {
+    licensing: LicensingPluginStart;
     observability?: ObservabilityPluginSetup;
     security?: SecurityPluginSetup;
     ml?: MlPluginSetup;
@@ -114,6 +116,7 @@ export interface ServerAPI<TRouteState extends RouteState> {
       config$: Observable<APMConfig>;
       logger: Logger;
       plugins: {
+        licensing: LicensingPluginStart;
         observability?: ObservabilityPluginSetup;
         security?: SecurityPluginSetup;
         ml?: MlPluginSetup;


### PR DESCRIPTION
Use the license feature API to register the service maps feature and track its usage when the API endpoint is accessed.

Fixes #64850.
