### PR TITLE
[Ingest Manager] Update index pattern to remove group fields with no child fields

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/__snapshots__/install.test.ts.snap
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/__snapshots__/install.test.ts.snap
@@ -611,7 +611,7 @@ exports[`creating index patterns from yaml fields createIndexPatternFields funct
 }
 `;
 
-exports[`creating index patterns from yaml fields flattenFields function flattens recursively and handles copying alias fields: flattenFields 1`] = `
+exports[`creating index patterns from yaml fields flattenFields function flattens recursively and handles copying alias fields flattenFields matches snapshot: flattenFields 1`] = `
 [
   {
     "name": "coredns.id",

--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.test.ts
@@ -56,9 +56,15 @@ describe('creating index patterns from yaml fields', () => {
     expect(indexPattern).toMatchSnapshot('createIndexPattern');
   });
 
-  test('flattenFields function flattens recursively and handles copying alias fields', () => {
-    const flattened = flattenFields(fields);
-    expect(flattened).toMatchSnapshot('flattenFields');
+  describe('flattenFields function flattens recursively and handles copying alias fields', () => {
+    test('a field of type group with no nested fields is skipped', () => {
+      const flattened = flattenFields([{ name: 'nginx', type: 'group' }]);
+      expect(flattened.length).toBe(0);
+    });
+    test('flattenFields matches snapshot', () => {
+      const flattened = flattenFields(fields);
+      expect(flattened).toMatchSnapshot('flattenFields');
+    });
   });
 
   describe('dedupFields', () => {

--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
@@ -307,6 +307,10 @@ export const transformField = (field: Field, i: number, fields: Fields): IndexPa
 export const flattenFields = (allFields: Fields): Fields => {
   const flatten = (fields: Fields): Fields =>
     fields.reduce<Field[]>((acc, field) => {
+      // if this is a group fields with no fields, skip the field
+      if (field.type === 'group' && !field.fields?.length) {
+        return acc;
+      }
       // recurse through nested fields
       if (field.type === 'group' && field.fields?.length) {
         // skip if field.enabled is not explicitly set to false

--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/tests/nginx.fields.yml
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/tests/nginx.fields.yml
@@ -116,3 +116,5 @@
       type: keyword
     - name: text
       type: text
+- name: nginx
+  type: group


### PR DESCRIPTION
Datasets in a package have a package-fields file which sometimes consists of just the name of the package as a field of type group with no child fields.  Such as:
```
- name: system
  type: group
```
Index pattern logic should have not included this field as part of the index pattern.  The bug exists that when a group field has a fields property those fields are added but not the actual group field, but when the group field does not have a fields list it was not handled and defaulted to being added as a field.  System with no type should not be here:
<img width="1081" alt="Screen Shot 2020-06-17 at 6 13 09 PM" src="https://user-images.githubusercontent.com/1676003/84955973-3bb5ba00-b0c6-11ea-89ce-7aaf485910ab.png">

 This causes some apps in Kibana to interpret the fields incorrectly where everything was nested under this incorrect field.  aws example:
<img width="1225" alt="83775943-cddcad80-a644-11ea-8485-1864ebc5bc0b" src="https://user-images.githubusercontent.com/1676003/84957166-a10aaa80-b0c8-11ea-8654-e15825f5a865.png">

After the fix it it shows up correctly:

<img width="2559" alt="84934893-f2557280-b0a5-11ea-8b60-d8640d658c73" src="https://user-images.githubusercontent.com/1676003/84957211-bbdd1f00-b0c8-11ea-99e3-18cdfa10a0c4.png">

To test 
- using the `system` package, run the agent with the default settings 
- go to Kibana -> Discover and select the metrics-* pattern from the dropdown
- there should be many system fields after this fix whereas before there is only one

<img width="1555" alt="Screen Shot 2020-06-17 at 6 15 13 PM" src="https://user-images.githubusercontent.com/1676003/84957396-1aa29880-b0c9-11ea-9e0f-1d77a8d833da.png">
