### PR TITLE
[APM] Settings - Agent configuration: Change the unsaved changes text color

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/SettingsPage/SettingsPage.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/SettingsPage/SettingsPage.tsx
@@ -223,7 +223,7 @@ export function SettingsPage({
               }}
             >
               <EuiHealth color="warning" />
-              <EuiText>
+              <EuiText color="ghost">
                 {i18n.translate('xpack.apm.unsavedChanges', {
                   defaultMessage:
                     '{unsavedChangesCount, plural, =0{0 unsaved changes} one {1 unsaved change} other {# unsaved changes}} ',


### PR DESCRIPTION
## Summary

Fixes dark mode issue where the text would render dark on a dark background. Related issue https://github.com/elastic/kibana/issues/30048

**Before**

<img width="1693" alt="Screenshot 2020-06-18 at 09 54 24" src="https://user-images.githubusercontent.com/4104278/85012704-b385f200-b163-11ea-89c6-1422e2b308ba.png">

**After**

<img width="1689" alt="Screenshot 2020-06-18 at 13 01 01" src="https://user-images.githubusercontent.com/4104278/85012755-c7315880-b163-11ea-97a2-05fe42eaf9d2.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
- [ ] ~~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
- [ ] ~~This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~~
