### PR TITLE
[Lens] Last used Index pattern is saved to and retrieved from local storage

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.tsx
@@ -125,6 +125,7 @@ export function getIndexPatternDatasource({
         state,
         savedObjectsClient: await savedObjectsClient,
         defaultIndexPatternId: core.uiSettings.get('defaultIndex'),
+        storage,
       });
     },
 
@@ -207,6 +208,7 @@ export function getIndexPatternDatasource({
                 setState,
                 savedObjectsClient,
                 onError: onIndexPatternLoadError,
+                storage,
               });
             }}
             data={data}
@@ -290,6 +292,7 @@ export function getIndexPatternDatasource({
               layerId: props.layerId,
               onError: onIndexPatternLoadError,
               replaceIfPossible: true,
+              storage,
             });
           }}
           {...props}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
@@ -105,12 +105,13 @@ export async function loadInitialState({
   );
 
   const currentIndexPatternId = requiredPatterns[0];
+  setLastUsedIndexPatternId(storage, currentIndexPatternId);
+
   const indexPatterns = await loadIndexPatterns({
     savedObjectsClient,
     cache: {},
     patterns: requiredPatterns,
   });
-
   if (state) {
     return {
       ...state,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
@@ -25,7 +25,7 @@ import {
   IFieldType,
   IndexPatternTypeMeta,
 } from '../../../../../src/plugins/data/public';
-import { readFromStorage, writeToStorage } from '../../settings_storage';
+import { readFromStorage, writeToStorage } from '../settings_storage';
 
 interface SavedIndexPatternAttributes extends SavedObjectAttributes {
   title: string;
@@ -74,12 +74,12 @@ const getLastUsedIndexPatternId = (
   storage: IStorageWrapper,
   indexPatternRefs: IndexPatternRef[]
 ) => {
-  const indexPattern = readFromStorage(storage, 'indexPattern');
+  const indexPattern = readFromStorage(storage, 'indexPatternId');
   return indexPattern && indexPatternRefs.find((i) => i.id === indexPattern)?.id;
 };
 
 const setLastUsedIndexPatternId = (storage: IStorageWrapper, value: string) => {
-  writeToStorage(storage, 'indexPattern', value);
+  writeToStorage(storage, 'indexPatternId', value);
 };
 
 export async function loadInitialState({

--- a/x-pack/plugins/lens/public/settings_storage.tsx
+++ b/x-pack/plugins/lens/public/settings_storage.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+const STORAGE_KEY = 'lens-settings';
+
+export const readFromStorage = (storage: IStorageWrapper, key: string) => {
+  const data = storage.get(STORAGE_KEY);
+  return data && data[key];
+};
+export const writeToStorage = (storage: IStorageWrapper, key: string, value: string) => {
+  storage.set(STORAGE_KEY, { [key]: value });
+};

--- a/x-pack/plugins/lens/public/settings_storage.tsx
+++ b/x-pack/plugins/lens/public/settings_storage.tsx
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { IStorageWrapper } from 'src/plugins/kibana_utils/public';
+
 const STORAGE_KEY = 'lens-settings';
 
 export const readFromStorage = (storage: IStorageWrapper, key: string) => {


### PR DESCRIPTION
## Summary

1. When opening the saved object, the first index pattern from the is the active one. It is set as the `indexPatternId` in local storage.
2. When opening the new lens vis:
   2.1. If the last used index pattern is found in local storage and it still exists in kibana, it is set as active.
   2.2. If the last used index pattern is found in storage but doesn't exist in kibana, the default one is set as active. The default one is set as the `indexPatternId` in local storage.
   2.3. If there's no index pattern in storage, the default one is set as active. The default one is set as the `indexPatternId` in local storage. 

3. When changing the index pattern in layer or in datasource panel, it is set as the `indexPatternId` in local storage.

Fixes https://github.com/elastic/kibana/issues/61757

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
