### PR TITLE
[SIEM] Unskips 'Events columns' Cypress test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/events_viewer.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/events_viewer.spec.ts
@@ -153,7 +153,7 @@ describe('Events Viewer', () => {
     });
   });
 
-  context.skip('Events columns', () => {
+  context('Events columns', () => {
     before(() => {
       loginAndWaitForPage(HOSTS_PAGE);
       openEvents();


### PR DESCRIPTION
## Summary

This test has been executed 10 times in a row and passed in the local machine emulating the CI.

In this PR we are removing the skip.  