### PR TITLE
[Security] Remove scroll onBeforeCapture

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/drag_and_drop/drag_drop_context_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/drag_and_drop/drag_drop_context_wrapper.tsx
@@ -168,18 +168,6 @@ export const DragDropContextWrapper = connector(DragDropContextWrapperComponent)
 DragDropContextWrapper.displayName = 'DragDropContextWrapper';
 
 const onBeforeCapture = (before: BeforeCapture) => {
-  const x =
-    window.pageXOffset !== undefined
-      ? window.pageXOffset
-      : (document.documentElement || document.body.parentNode || document.body).scrollLeft;
-
-  const y =
-    window.pageYOffset !== undefined
-      ? window.pageYOffset
-      : (document.documentElement || document.body.parentNode || document.body).scrollTop;
-
-  window.onscroll = () => window.scrollTo(x, y);
-
   if (!draggableIsField(before)) {
     document.body.classList.add(IS_DRAGGING_CLASS_NAME);
   }


### PR DESCRIPTION
## Summary

This code was introduced when we have a full drop area in the timeline to allow drag and drop functionality when you were scrolling on the page and/or the timeline. Since the drop area of the timeline changed, this code is not needed and introduced a weird bug that you need to scroll to get the drag register inside of the drop area.

```
Fixes an issue where, when the timeline is closed, the drag area remains "stuck" after a drag and drop until the view is scrolled.

To reproduce:
1. Drag a hostname from the Hosts tab to the Timeline while the Timeline is closed

Expected result:
- After the drop completes, the hostname is added to the Timeline

Actual result:
- The preview of the Timeline drop area remains "stuck" until the view is scrolled
```



