### PR TITLE
[Obs] Update Observability landing page text

### DIFF
--- a/x-pack/plugins/observability/public/pages/home/index.tsx
+++ b/x-pack/plugins/observability/public/pages/home/index.tsx
@@ -92,7 +92,7 @@ export const Home = () => {
             <EuiTitle size="s">
               <h2>
                 {i18n.translate('xpack.observability.home.sectionTitle', {
-                  defaultMessage: 'Observability built on the Elastic Stack',
+                  defaultMessage: 'Unified visibility across your entire ecosystem',
                 })}
               </h2>
             </EuiTitle>
@@ -100,7 +100,7 @@ export const Home = () => {
             <EuiText size="s" color="subdued">
               {i18n.translate('xpack.observability.home.sectionsubtitle', {
                 defaultMessage:
-                  'Bring your logs, metrics, and APM traces together at scale in a single stack so you can monitor and react to events happening anywhere in your environment.',
+                  'Monitor, analyze, and react to events happening anywhere in your environment by bringing logs, metrics, and traces together at scale in a single stack.',
               })}
             </EuiText>
           </EuiFlexItem>

--- a/x-pack/plugins/observability/public/pages/home/section.ts
+++ b/x-pack/plugins/observability/public/pages/home/section.ts
@@ -34,7 +34,7 @@ export const appsSection: ISection[] = [
     icon: 'logoAPM',
     description: i18n.translate('xpack.observability.section.apps.apm.description', {
       defaultMessage:
-        "Trace transactions through a distributed architecture and map your services’ interactions to easily spot performance bottlenecks.",
+        'Trace transactions through a distributed architecture and map your services’ interactions to easily spot performance bottlenecks.',
     }),
   },
   {

--- a/x-pack/plugins/observability/public/pages/home/section.ts
+++ b/x-pack/plugins/observability/public/pages/home/section.ts
@@ -34,7 +34,7 @@ export const appsSection: ISection[] = [
     icon: 'logoAPM',
     description: i18n.translate('xpack.observability.section.apps.apm.description', {
       defaultMessage:
-        'Trace transactions through a distributed architecture and map your service\'s interactions to easily spot performance bottlenecks.',
+        "Trace transactions through a distributed architecture and map your service's interactions to easily spot performance bottlenecks.",
     }),
   },
   {

--- a/x-pack/plugins/observability/public/pages/home/section.ts
+++ b/x-pack/plugins/observability/public/pages/home/section.ts
@@ -23,7 +23,7 @@ export const appsSection: ISection[] = [
     icon: 'logoLogging',
     description: i18n.translate('xpack.observability.section.apps.logs.description', {
       defaultMessage:
-        'The Elastic Stack (sometimes known as the ELK Stack) is the most popular open source logging platform.',
+        'Centralize logs from any source. Search, tail, automate anomaly detection, and visualize trends so you can take action quicker.',
     }),
   },
   {
@@ -34,7 +34,7 @@ export const appsSection: ISection[] = [
     icon: 'logoAPM',
     description: i18n.translate('xpack.observability.section.apps.apm.description', {
       defaultMessage:
-        'See exactly where your application is spending time so you can quickly fix issues and feel good about the code you push.',
+        'Trace transactions through a distributed architecture and map your service\'s interactions to easily spot performance bottlenecks.',
     }),
   },
   {
@@ -45,7 +45,7 @@ export const appsSection: ISection[] = [
     icon: 'logoMetrics',
     description: i18n.translate('xpack.observability.section.apps.metrics.description', {
       defaultMessage:
-        'Already using the Elastic Stack for logs? Add metrics in just a few steps and correlate metrics and logs in one place.',
+        'Analyze metrics from your infrastructure, apps, and services. Discover trends, forecast behavior, get alerts on anomalies, and more.',
     }),
   },
   {
@@ -56,7 +56,7 @@ export const appsSection: ISection[] = [
     icon: 'logoUptime',
     description: i18n.translate('xpack.observability.section.apps.uptime.description', {
       defaultMessage:
-        'React to availability issues across your apps and services before they affect users.',
+        'Proactively monitor the availability of your sites and services. Receive alerts and resolve issues faster to optimize your users’ experience.',
     }),
   },
 ];

--- a/x-pack/plugins/observability/public/pages/home/section.ts
+++ b/x-pack/plugins/observability/public/pages/home/section.ts
@@ -34,7 +34,7 @@ export const appsSection: ISection[] = [
     icon: 'logoAPM',
     description: i18n.translate('xpack.observability.section.apps.apm.description', {
       defaultMessage:
-        "Trace transactions through a distributed architecture and map your service's interactions to easily spot performance bottlenecks.",
+        "Trace transactions through a distributed architecture and map your services’ interactions to easily spot performance bottlenecks.",
     }),
   },
   {


### PR DESCRIPTION
## Summary

This PR updates the Observability landing page text as discussed in https://github.com/elastic/kibana/issues/69130.

@renuhermon, can you please take a look? I had to shorten some of the text to keep it to four lines. I'd appreciate any feedback.

## Screenshot

<img width="1443" alt="Screen Shot 2020-06-23 at 10 49 45 AM" src="https://user-images.githubusercontent.com/5618806/85437718-e7845d00-b53f-11ea-9f00-83a03bada8a4.png">


Closes https://github.com/elastic/kibana/issues/69130
