### PR TITLE
[Security][Network] Exclude glob-only (*) Index Pattern from map layers

### DIFF
--- a/x-pack/plugins/security_solution/public/network/components/embeddables/__mocks__/mock.ts
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/__mocks__/mock.ts
@@ -475,3 +475,12 @@ export const mockGlobIndexPattern: IndexPatternSavedObject = {
     title: '*',
   },
 };
+
+export const mockCCSGlobIndexPattern: IndexPatternSavedObject = {
+  id: '*:*',
+  type: 'index-pattern',
+  _version: 'abc',
+  attributes: {
+    title: '*:*',
+  },
+};

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.test.tsx
@@ -14,6 +14,7 @@ import {
   mockAuditbeatIndexPattern,
   mockFilebeatIndexPattern,
   mockGlobIndexPattern,
+  mockCCSGlobIndexPattern,
 } from './__mocks__/mock';
 
 const mockEmbeddable = embeddablePluginMock.createStartContract();
@@ -109,6 +110,14 @@ describe('embedded_map_helpers', () => {
     test('excludes glob-only index patterns', () => {
       const matchingIndexPatterns = findMatchingIndexPatterns({
         kibanaIndexPatterns: [mockGlobIndexPattern, mockFilebeatIndexPattern],
+        siemDefaultIndices,
+      });
+      expect(matchingIndexPatterns).toEqual([mockFilebeatIndexPattern]);
+    });
+
+    test('excludes glob-only CCS index patterns', () => {
+      const matchingIndexPatterns = findMatchingIndexPatterns({
+        kibanaIndexPatterns: [mockCCSGlobIndexPattern, mockFilebeatIndexPattern],
         siemDefaultIndices,
       });
       expect(matchingIndexPatterns).toEqual([mockFilebeatIndexPattern]);

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.test.tsx
@@ -106,12 +106,12 @@ describe('embedded_map_helpers', () => {
       ]);
     });
 
-    test('finds glob-only index patterns ', () => {
+    test('excludes glob-only index patterns', () => {
       const matchingIndexPatterns = findMatchingIndexPatterns({
         kibanaIndexPatterns: [mockGlobIndexPattern, mockFilebeatIndexPattern],
         siemDefaultIndices,
       });
-      expect(matchingIndexPatterns).toEqual([mockGlobIndexPattern, mockFilebeatIndexPattern]);
+      expect(matchingIndexPatterns).toEqual([mockFilebeatIndexPattern]);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.tsx
@@ -142,9 +142,10 @@ export const findMatchingIndexPatterns = ({
   siemDefaultIndices: string[];
 }): IndexPatternSavedObject[] => {
   try {
-    return kibanaIndexPatterns.filter((kip) =>
-      siemDefaultIndices.some((sdi) => minimatch(sdi, kip.attributes.title))
-    );
+    return kibanaIndexPatterns.filter((kip) => {
+      const pattern = kip.attributes.title;
+      return pattern !== '*' && siemDefaultIndices.some((sdi) => minimatch(sdi, pattern));
+    });
   } catch {
     return [];
   }

--- a/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/network/components/embeddables/embedded_map_helpers.tsx
@@ -128,6 +128,9 @@ export const createEmbeddable = async (
   return embeddableObject;
 };
 
+// These patterns are overly greedy and must be excluded when matching against Security indexes.
+const ignoredIndexPatterns = ['*', '*:*'];
+
 /**
  * Returns kibanaIndexPatterns that wildcard match at least one of siemDefaultIndices
  *
@@ -144,7 +147,10 @@ export const findMatchingIndexPatterns = ({
   try {
     return kibanaIndexPatterns.filter((kip) => {
       const pattern = kip.attributes.title;
-      return pattern !== '*' && siemDefaultIndices.some((sdi) => minimatch(sdi, pattern));
+      return (
+        !ignoredIndexPatterns.includes(pattern) &&
+        siemDefaultIndices.some((sdi) => minimatch(sdi, pattern))
+      );
     });
   } catch {
     return [];


### PR DESCRIPTION
## Summary

This pattern is a special case that our map should ignore, as including it causes all indexes to be queried.
Addresses #69184. 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
