### PR TITLE
[expressions] Provide a list of defaulted arguments to the fn

### DIFF
--- a/src/plugins/expressions/common/execution/execution.ts
+++ b/src/plugins/expressions/common/execution/execution.ts
@@ -159,6 +159,7 @@ export class Execution<
     });
 
     this.context = {
+      defaultedArgs: [],
       getInitialInput: () => this.input,
       variables: {},
       types: executor.getTypes(),
@@ -370,6 +371,7 @@ export class Execution<
       (acc: any, argDef: any, argName: any) => {
         if (typeof acc[argName] === 'undefined' && typeof argDef.default !== 'undefined') {
           acc[argName] = [parse(argDef.default, 'argument')];
+          this.context.defaultedArgs.push(argName);
         }
 
         return acc;

--- a/src/plugins/expressions/common/execution/types.ts
+++ b/src/plugins/expressions/common/execution/types.ts
@@ -70,6 +70,11 @@ export interface ExecutionContext<Input = unknown, InspectorAdapters = DefaultIn
     type: string,
     id: string
   ) => Promise<SavedObject<T>>;
+
+  /**
+   * A list of names of arguments which were defaulted in the course of execution.
+   */
+  defaultedArgs: string[];
 }
 
 /**

--- a/src/plugins/expressions/common/mocks.ts
+++ b/src/plugins/expressions/common/mocks.ts
@@ -24,6 +24,7 @@ export const createMockExecutionContext = <ExtraContext extends object = object>
 ): ExecutionContext & ExtraContext => {
   const executionContext: ExecutionContext = {
     getInitialInput: jest.fn(),
+    defaultedArgs: [],
     variables: {},
     types: {},
     abortSignal: {


### PR DESCRIPTION
## Summary

This is a simple but useful change: provide a list of names of arguments that were not specified in the expression and were therefore defaulted.

This has application in Canvas, where we will apply a global color palette/font/etc, but don't want to override what the user may have specified.  We also don't want to remove the defaulting from the spec, because the user should know we're defaulting when they write the expression.

This is a passive change.  If there is a good means of testing this in the current test suite, let me know.
