### PR TITLE
[SECURITY] Updates mappings and re-enables tests

### DIFF
--- a/test/scripts/jenkins_security_solution_cypress.sh
+++ b/test/scripts/jenkins_security_solution_cypress.sh
@@ -11,16 +11,11 @@ export KIBANA_INSTALL_DIR="$destDir"
 echo " -> Running security solution cypress tests"
 cd "$XPACK_DIR"
 
-# Failures across multiple suites, skipping all
-# https://github.com/elastic/kibana/issues/69847
-# https://github.com/elastic/kibana/issues/69848
-# https://github.com/elastic/kibana/issues/69849
-
-# checks-reporter-with-killswitch "Security solution Cypress Tests" \
-#   node scripts/functional_tests \
-#     --debug --bail \
-#     --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-#     --config test/security_solution_cypress/config.ts
+checks-reporter-with-killswitch "Security solution Cypress Tests" \
+  node scripts/functional_tests \
+    --debug --bail \
+    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+    --config test/security_solution_cypress/config.ts
 
 echo ""
 echo ""

--- a/x-pack/plugins/security_solution/public/index.ts
+++ b/x-pack/plugins/security_solution/public/index.ts
@@ -11,3 +11,5 @@ import { PluginSetup, PluginStart } from './types';
 export const plugin = (context: PluginInitializerContext): Plugin => new Plugin(context);
 
 export { Plugin, PluginSetup, PluginStart };
+
+// NOOP


### PR DESCRIPTION
The provided mappings were resulting in > 1k mapping fields after a migration. This updates them so there aren't any dangling fields so the tests can be re-enabled.

We probably want to wait until https://github.com/elastic/kibana/pull/69871 is merged and update the mappings here again.

Closes https://github.com/elastic/kibana/issues/69848
Blocked on https://github.com/elastic/kibana/pull/69871