### PR TITLE
[Discover] set minBarHeight for high cardinality

### DIFF
--- a/src/plugins/discover/public/application/angular/directives/histogram.tsx
+++ b/src/plugins/discover/public/application/angular/directives/histogram.tsx
@@ -323,7 +323,7 @@ export class DiscoverHistogram extends Component<DiscoverHistogramProps, Discove
         />
         <HistogramBarSeries
           id="discover-histogram"
-          minBarHeight={1}
+          minBarHeight={2}
           xScaleType={ScaleType.Time}
           yScaleType={ScaleType.Linear}
           xAccessor="x"

--- a/src/plugins/discover/public/application/angular/directives/histogram.tsx
+++ b/src/plugins/discover/public/application/angular/directives/histogram.tsx
@@ -323,6 +323,7 @@ export class DiscoverHistogram extends Component<DiscoverHistogramProps, Discove
         />
         <HistogramBarSeries
           id="discover-histogram"
+          minBarHeight={1}
           xScaleType={ScaleType.Time}
           yScaleType={ScaleType.Linear}
           xAccessor="x"


### PR DESCRIPTION
## Summary

Closes #68436

Set `minBarHeight` on discover histogram to always show min bar height of `1px` for non-zero values in high cardinality datasets.

<img width="1207" alt="Image 2020-06-25 at 12 45 50 PM" src="https://user-images.githubusercontent.com/19007109/85771752-d6735180-b6e1-11ea-982b-e4b6f40feea6.png">
