### PR TITLE
[APM] Catch annotations index permission error and log warning

### DIFF
--- a/x-pack/plugins/apm/server/lib/services/annotations/index.ts
+++ b/x-pack/plugins/apm/server/lib/services/annotations/index.ts
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { APICaller } from 'kibana/server';
+import { APICaller, Logger } from 'kibana/server';
 import { ScopedAnnotationsClient } from '../../../../../observability/server';
 import { getDerivedServiceAnnotations } from './get_derived_service_annotations';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
@@ -15,12 +15,14 @@ export async function getServiceAnnotations({
   environment,
   annotationsClient,
   apiCaller,
+  logger,
 }: {
   serviceName: string;
   environment?: string;
   setup: Setup & SetupTimeRange;
   annotationsClient?: ScopedAnnotationsClient;
   apiCaller: APICaller;
+  logger: Logger;
 }) {
   // start fetching derived annotations (based on transactions), but don't wait on it
   // it will likely be significantly slower than the stored annotations
@@ -37,6 +39,7 @@ export async function getServiceAnnotations({
         environment,
         annotationsClient,
         apiCaller,
+        logger,
       })
     : [];
 

--- a/x-pack/plugins/apm/server/routes/services.ts
+++ b/x-pack/plugins/apm/server/routes/services.ts
@@ -105,6 +105,7 @@ export const serviceAnnotationsRoute = createRoute(() => ({
       environment,
       annotationsClient,
       apiCaller: context.core.elasticsearch.legacy.client.callAsCurrentUser,
+      logger: context.logger,
     });
   },
 }));


### PR DESCRIPTION
Relates to #69642. If the user doesn't have the appropriate privileges for the annotations index, instead of failing with a 500, we now catch the error and log a warning to the console.