### PR TITLE
Fixes bug on color picker defaults on TSVB

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/color_picker.test.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_picker.test.tsx
@@ -22,6 +22,8 @@ import { ColorPicker, ColorPickerProps } from './color_picker';
 import { mount } from 'enzyme';
 import { ReactWrapper } from 'enzyme';
 import { EuiColorPicker, EuiIconTip } from '@elastic/eui';
+// @ts-ignore
+import { findTestSubject } from '@elastic/eui/lib/test';
 
 describe('ColorPicker', () => {
   const defaultProps: ColorPickerProps = {
@@ -40,6 +42,22 @@ describe('ColorPicker', () => {
   it('should not render the clear button', () => {
     component = mount(<ColorPicker {...defaultProps} />);
     expect(component.find('.tvbColorPicker__clear').length).toBe(0);
+  });
+
+  it('should render the correct value to the input text if the prop value is hex', () => {
+    const props = { ...defaultProps, value: '#68BC00' };
+    component = mount(<ColorPicker {...props} />);
+    component.find('.tvbColorPicker button').simulate('click');
+    const input = findTestSubject(component, 'topColorPickerInput');
+    expect(input.props().value).toBe('#68BC00');
+  });
+
+  it('should render the correct value to the input text if the prop value is rgba', () => {
+    const props = { ...defaultProps, value: 'rgba(85,66,177,1)' };
+    component = mount(<ColorPicker {...props} />);
+    component.find('.tvbColorPicker button').simulate('click');
+    const input = findTestSubject(component, 'topColorPickerInput');
+    expect(input.props().value).toBe('85,66,177,1');
   });
 
   it('should render the correct aria label to the color swatch button', () => {

--- a/src/plugins/vis_type_timeseries/public/application/components/color_picker.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_picker.tsx
@@ -46,7 +46,7 @@ export function ColorPicker({ name, value, disableTrash = false, onChange }: Col
   const initialColorValue = value?.includes('rgba')
     ? value.replace(COMMAS_NUMS_ONLY_RE, '')
     : value;
-  const [color, setColor] = useState(initialColorValue);
+  const [color, setColor] = useState(initialColorValue || '');
 
   const handleColorChange: EuiColorPickerProps['onChange'] = (text: string, { rgba, hex }) => {
     setColor(text);

--- a/src/plugins/vis_type_timeseries/public/application/components/color_picker.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/color_picker.tsx
@@ -43,7 +43,9 @@ export interface ColorPickerProps {
 }
 
 export function ColorPicker({ name, value, disableTrash = false, onChange }: ColorPickerProps) {
-  const initialColorValue = value ? value.replace(COMMAS_NUMS_ONLY_RE, '') : '';
+  const initialColorValue = value?.includes('rgba')
+    ? value.replace(COMMAS_NUMS_ONLY_RE, '')
+    : value;
   const [color, setColor] = useState(initialColorValue);
 
   const handleColorChange: EuiColorPickerProps['onChange'] = (text: string, { rgba, hex }) => {


### PR DESCRIPTION
## Summary

Fixes #69813. There was a problem on initialization of the TSVB picker default color. It was set to #6800 instead of #68BC00, which caused problem when the user tried to change the transparency of the default color. It made the chart disappear (actually it made the color transparent in a transparent background).

Fixed:
![Visualize_-_Elastic](https://user-images.githubusercontent.com/17003240/85681345-dd936300-b6d3-11ea-82c1-5c08aee32f2e.gif)
