### PR TITLE
chore: improve support for mjs file extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,63 +64,63 @@ module.exports = {
      * Temporarily disable some react rules for specific plugins, remove in separate PRs
      */
     {
-      files: ['packages/kbn-ui-framework/**/*.{js,ts,tsx}'],
+      files: ['packages/kbn-ui-framework/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'jsx-a11y/no-onchange': 'off',
       },
     },
     {
-      files: ['src/plugins/es_ui_shared/**/*.{js,ts,tsx}'],
+      files: ['src/plugins/es_ui_shared/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
       },
     },
     {
-      files: ['src/plugins/kibana_react/**/*.{js,ts,tsx}'],
+      files: ['src/plugins/kibana_react/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/rules-of-hooks': 'off',
         'react-hooks/exhaustive-deps': 'off',
       },
     },
     {
-      files: ['src/plugins/kibana_utils/**/*.{js,ts,tsx}'],
+      files: ['src/plugins/kibana_utils/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
       },
     },
     {
-      files: ['x-pack/plugins/canvas/**/*.{js,ts,tsx}'],
+      files: ['x-pack/plugins/canvas/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'jsx-a11y/click-events-have-key-events': 'off',
       },
     },
     {
-      files: ['x-pack/plugins/cross_cluster_replication/**/*.{js,ts,tsx}'],
+      files: ['x-pack/plugins/cross_cluster_replication/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'jsx-a11y/click-events-have-key-events': 'off',
       },
     },
     {
-      files: ['x-pack/legacy/plugins/index_management/**/*.{js,ts,tsx}'],
+      files: ['x-pack/legacy/plugins/index_management/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
         'react-hooks/rules-of-hooks': 'off',
       },
     },
     {
-      files: ['x-pack/plugins/lens/**/*.{js,ts,tsx}'],
+      files: ['x-pack/plugins/lens/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
       },
     },
     {
-      files: ['x-pack/plugins/ml/**/*.{js,ts,tsx}'],
+      files: ['x-pack/plugins/ml/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
       },
     },
     {
-      files: ['x-pack/legacy/plugins/snapshot_restore/**/*.{js,ts,tsx}'],
+      files: ['x-pack/legacy/plugins/snapshot_restore/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
       },
@@ -132,7 +132,7 @@ module.exports = {
      * Licence headers
      */
     {
-      files: ['**/*.{js,ts,tsx}', '!plugins/**/*'],
+      files: ['**/*.{js,mjs,ts,tsx}', '!plugins/**/*'],
       rules: {
         '@kbn/eslint/require-license-header': [
           'error',
@@ -153,7 +153,7 @@ module.exports = {
      * New Platform client-side
      */
     {
-      files: ['{src,x-pack}/plugins/*/public/**/*.{js,ts,tsx}'],
+      files: ['{src,x-pack}/plugins/*/public/**/*.{js,mjs,ts,tsx}'],
       rules: {
         'import/no-commonjs': 'error',
       },
@@ -163,7 +163,7 @@ module.exports = {
      * Files that require Elastic license headers instead of Apache 2.0 header
      */
     {
-      files: ['x-pack/**/*.{js,ts,tsx}'],
+      files: ['x-pack/**/*.{js,mjs,ts,tsx}'],
       rules: {
         '@kbn/eslint/require-license-header': [
           'error',
@@ -184,7 +184,7 @@ module.exports = {
      * Restricted paths
      */
     {
-      files: ['**/*.{js,ts,tsx}'],
+      files: ['**/*.{js,mjs,ts,tsx}'],
       rules: {
         '@kbn/eslint/no-restricted-paths': [
           'error',
@@ -251,8 +251,8 @@ module.exports = {
                 ],
                 from: [
                   '(src|x-pack)/plugins/**/(public|server)/**/*',
-                  '!(src|x-pack)/plugins/**/(public|server)/mocks/index.{js,ts}',
-                  '!(src|x-pack)/plugins/**/(public|server)/(index|mocks).{js,ts,tsx}',
+                  '!(src|x-pack)/plugins/**/(public|server)/mocks/index.{js,mjs,ts}',
+                  '!(src|x-pack)/plugins/**/(public|server)/(index|mocks).{js,mjs,ts,tsx}',
                 ],
                 allowSameFolder: true,
                 errorMessage: 'Plugins may only import from top-level public and server modules.',
@@ -264,11 +264,11 @@ module.exports = {
 
                   'src/legacy/core_plugins/**/*',
                   '!src/legacy/core_plugins/**/server/**/*',
-                  '!src/legacy/core_plugins/**/index.{js,ts,tsx}',
+                  '!src/legacy/core_plugins/**/index.{js,mjs,ts,tsx}',
 
                   'x-pack/legacy/plugins/**/*',
                   '!x-pack/legacy/plugins/**/server/**/*',
-                  '!x-pack/legacy/plugins/**/index.{js,ts,tsx}',
+                  '!x-pack/legacy/plugins/**/index.{js,mjs,ts,tsx}',
 
                   'examples/**/*',
                   '!examples/**/server/**/*',
@@ -530,7 +530,7 @@ module.exports = {
      * Jest specific rules
      */
     {
-      files: ['**/*.test.{js,ts,tsx}'],
+      files: ['**/*.test.{js,mjs,ts,tsx}'],
       rules: {
         'jest/valid-describe': 'error',
       },
@@ -595,8 +595,8 @@ module.exports = {
     {
       // front end and common typescript and javascript files only
       files: [
-        'x-pack/plugins/security_solution/public/**/*.{js,ts,tsx}',
-        'x-pack/plugins/security_solution/common/**/*.{js,ts,tsx}',
+        'x-pack/plugins/security_solution/public/**/*.{js,mjs,ts,tsx}',
+        'x-pack/plugins/security_solution/common/**/*.{js,mjs,ts,tsx}',
       ],
       rules: {
         'import/no-nodejs-modules': 'error',
@@ -646,7 +646,7 @@ module.exports = {
     // {
     //   // will introduced after the other warns are fixed
     //   // typescript and javascript for front end react performance
-    //   files: ['x-pack/plugins/security_solution/public/**/!(*.test).{js,ts,tsx}'],
+    //   files: ['x-pack/plugins/security_solution/public/**/!(*.test).{js,mjs,ts,tsx}'],
     //   plugins: ['react-perf'],
     //   rules: {
     //     // 'react-perf/jsx-no-new-object-as-prop': 'error',
@@ -657,7 +657,7 @@ module.exports = {
     // },
     {
       // typescript and javascript for front and back end
-      files: ['x-pack/{,legacy/}plugins/security_solution/**/*.{js,ts,tsx}'],
+      files: ['x-pack/{,legacy/}plugins/security_solution/**/*.{js,mjs,ts,tsx}'],
       plugins: ['eslint-plugin-node', 'react'],
       env: {
         mocha: true,
@@ -776,8 +776,8 @@ module.exports = {
     {
       // front end and common typescript and javascript files only
       files: [
-        'x-pack/plugins/lists/public/**/*.{js,ts,tsx}',
-        'x-pack/plugins/lists/common/**/*.{js,ts,tsx}',
+        'x-pack/plugins/lists/public/**/*.{js,mjs,ts,tsx}',
+        'x-pack/plugins/lists/common/**/*.{js,mjs,ts,tsx}',
       ],
       rules: {
         'import/no-nodejs-modules': 'error',
@@ -792,7 +792,7 @@ module.exports = {
     },
     {
       // typescript and javascript for front and back end
-      files: ['x-pack/plugins/lists/**/*.{js,ts,tsx}'],
+      files: ['x-pack/plugins/lists/**/*.{js,mjs,ts,tsx}'],
       plugins: ['eslint-plugin-node'],
       env: {
         mocha: true,
@@ -1020,8 +1020,8 @@ module.exports = {
      */
     {
       files: [
-        'src/plugins/vis_type_timeseries/**/*.{js,ts,tsx}',
-        'src/legacy/core_plugins/vis_type_timeseries/**/*.{js,ts,tsx}',
+        'src/plugins/vis_type_timeseries/**/*.{js,mjs,ts,tsx}',
+        'src/legacy/core_plugins/vis_type_timeseries/**/*.{js,mjs,ts,tsx}',
       ],
       rules: {
         'import/no-default-export': 'error',

--- a/docs/developer/core/development-unit-tests.asciidoc
+++ b/docs/developer/core/development-unit-tests.asciidoc
@@ -22,7 +22,7 @@ yarn test:mocha
 
 [float]
 ==== Jest
-Jest tests are stored in the same directory as source code files with the `.test.{js,ts,tsx}` suffix.
+Jest tests are stored in the same directory as source code files with the `.test.{js,mjs,ts,tsx}` suffix.
 
 *Running Jest Unit Tests*
 

--- a/packages/eslint-config-kibana/jest.js
+++ b/packages/eslint-config-kibana/jest.js
@@ -2,8 +2,8 @@ module.exports = {
   overrides: [
     {
       files: [
-        '**/*.{test,test.mocks,mock}.{js,ts,tsx}',
-        '**/__mocks__/**/*.{js,ts,tsx}',
+        '**/*.{test,test.mocks,mock}.{js,mjs,ts,tsx}',
+        '**/__mocks__/**/*.{js,mjs,ts,tsx}',
       ],
       plugins: [
         'jest',

--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -49,7 +49,7 @@ export default {
     'packages/kbn-ui-framework/src/services/**/*.js',
     '!packages/kbn-ui-framework/src/services/index.js',
     '!packages/kbn-ui-framework/src/services/**/*/index.js',
-    'src/legacy/core_plugins/**/*.{js,jsx,ts,tsx}',
+    'src/legacy/core_plugins/**/*.{js,mjs,jsx,ts,tsx}',
     '!src/legacy/core_plugins/**/{__test__,__snapshots__}/**/*',
   ],
   moduleNameMapper: {

--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -79,7 +79,7 @@ export default {
   ],
   coverageDirectory: '<rootDir>/target/kibana-coverage/jest',
   coverageReporters: !!process.env.CODE_COVERAGE ? ['json'] : ['html', 'text'],
-  moduleFileExtensions: ['js', 'json', 'ts', 'tsx', 'node'],
+  moduleFileExtensions: ['js', 'mjs', 'json', 'ts', 'tsx', 'node'],
   modulePathIgnorePatterns: ['__fixtures__/', 'target/'],
   testEnvironment: 'jest-environment-jsdom-thirteen',
   testMatch: ['**/*.test.{js,ts,tsx}'],

--- a/src/dev/run_eslint.js
+++ b/src/dev/run_eslint.js
@@ -31,7 +31,7 @@ if (!process.argv.includes('--no-cache')) {
 }
 
 if (!process.argv.includes('--ext')) {
-  process.argv.push('--ext', '.js,.ts,.tsx');
+  process.argv.push('--ext', '.js,.mjs,.ts,.tsx');
 }
 
 // common-js is required so that logic before this executes before loading eslint

--- a/x-pack/dev-tools/jest/create_jest_config.js
+++ b/x-pack/dev-tools/jest/create_jest_config.js
@@ -9,7 +9,7 @@ export function createJestConfig({ kibanaDirectory, rootDir, xPackKibanaDirector
   return {
     rootDir,
     roots: ['<rootDir>/plugins', '<rootDir>/legacy/plugins', '<rootDir>/legacy/server'],
-    moduleFileExtensions: ['js', 'json', 'ts', 'tsx', 'node'],
+    moduleFileExtensions: ['js', 'mjs', 'json', 'ts', 'tsx', 'node'],
     moduleNameMapper: {
       '@elastic/eui$': `${kibanaDirectory}/node_modules/@elastic/eui/test-env`,
       '@elastic/eui/lib/(.*)?': `${kibanaDirectory}/node_modules/@elastic/eui/test-env/$1`,
@@ -32,11 +32,11 @@ export function createJestConfig({ kibanaDirectory, rootDir, xPackKibanaDirector
       '^(!!)?file-loader!': fileMockPath,
     },
     collectCoverageFrom: [
-      'legacy/plugins/**/*.{js,jsx,ts,tsx}',
-      'legacy/server/**/*.{js,jsx,ts,tsx}',
-      'plugins/**/*.{js,jsx,ts,tsx}',
+      'legacy/plugins/**/*.{js,mjs,jsx,ts,tsx}',
+      'legacy/server/**/*.{js,mjs,jsx,ts,tsx}',
+      'plugins/**/*.{js,mjs,jsx,ts,tsx}',
       '!**/{__test__,__snapshots__,__examples__,integration_tests,tests}/**',
-      '!**/*.test.{js,ts,tsx}',
+      '!**/*.test.{js,mjs,ts,tsx}',
       '!**/flot-charts/**',
       '!**/test/**',
       '!**/build/**',
@@ -59,7 +59,7 @@ export function createJestConfig({ kibanaDirectory, rootDir, xPackKibanaDirector
       `${kibanaDirectory}/src/dev/jest/setup/react_testing_library.js`,
     ],
     testEnvironment: 'jest-environment-jsdom-thirteen',
-    testMatch: ['**/*.test.{js,ts,tsx}'],
+    testMatch: ['**/*.test.{js,mjs,ts,tsx}'],
     testRunner: 'jest-circus/runner',
     transform: {
       '^.+\\.(js|tsx?)$': `${kibanaDirectory}/src/dev/jest/babel_transform.js`,

--- a/x-pack/plugins/apm/jest.config.js
+++ b/x-pack/plugins/apm/jest.config.js
@@ -29,10 +29,10 @@ module.exports = {
   roots: [`${rootDir}/common`, `${rootDir}/public`, `${rootDir}/server`],
   collectCoverage: true,
   collectCoverageFrom: [
-    '**/*.{js,jsx,ts,tsx}',
+    '**/*.{js,mjs,jsx,ts,tsx}',
     '!**/{__test__,__snapshots__,__examples__,integration_tests,tests}/**',
-    '!**/*.stories.{js,ts,tsx}',
-    '!**/*.test.{js,ts,tsx}',
+    '!**/*.stories.{js,mjs,ts,tsx}',
+    '!**/*.test.{js,mjs,ts,tsx}',
     '!**/dev_docs/**',
     '!**/e2e/**',
     '!**/scripts/**',

--- a/x-pack/test_utils/jest/config.integration.js
+++ b/x-pack/test_utils/jest/config.integration.js
@@ -10,9 +10,9 @@ import config from './config';
 export default {
   ...config,
   testMatch: [
-    `**/${RESERVED_DIR_JEST_INTEGRATION_TESTS}/**/*.test.{js,ts,tsx}`,
+    `**/${RESERVED_DIR_JEST_INTEGRATION_TESTS}/**/*.test.{js,mjs,ts,tsx}`,
     // Tests within `__jest__` directories should be treated as regular unit tests.
-    `!**/__jest__/${RESERVED_DIR_JEST_INTEGRATION_TESTS}/**/*.test.{js,ts,tsx}`,
+    `!**/__jest__/${RESERVED_DIR_JEST_INTEGRATION_TESTS}/**/*.test.{js,mjs,ts,tsx}`,
   ],
   testPathIgnorePatterns: config.testPathIgnorePatterns.filter(
     (pattern) => !pattern.includes(RESERVED_DIR_JEST_INTEGRATION_TESTS)

--- a/x-pack/test_utils/jest/config.js
+++ b/x-pack/test_utils/jest/config.js
@@ -29,10 +29,10 @@ export default {
   ],
   coverageDirectory: '<rootDir>/../target/kibana-coverage/jest',
   coverageReporters: ['html'],
-  moduleFileExtensions: ['js', 'json', 'ts', 'tsx', 'node'],
+  moduleFileExtensions: ['js', 'mjs', 'json', 'ts', 'tsx', 'node'],
   modulePathIgnorePatterns: ['__fixtures__/', 'target/'],
   testEnvironment: 'jest-environment-jsdom-thirteen',
-  testMatch: ['**/*.test.{js,ts,tsx}'],
+  testMatch: ['**/*.test.{js,mjs,ts,tsx}'],
   testPathIgnorePatterns: [
     '<rootDir>/packages/kbn-ui-framework/(dist|doc_site|generator-kui)/',
     '<rootDir>/packages/kbn-pm/dist/',


### PR DESCRIPTION
At the time of writing, we do not have any mjs files in the Kibana project (besides in some of our dependencies). But to better support this in the future, we might as well add this to our globs now.