### PR TITLE
[7.x] [APM] Use licensing from context (#70118)

### DIFF
--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -4,46 +4,42 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { i18n } from '@kbn/i18n';
+import { combineLatest, Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
 import {
-  PluginInitializerContext,
-  Plugin,
   CoreSetup,
   CoreStart,
   Logger,
+  Plugin,
+  PluginInitializerContext,
 } from 'src/core/server';
-import { Observable, combineLatest } from 'rxjs';
-import { map, take } from 'rxjs/operators';
+import { APMConfig, APMXPackConfig, mergeConfigs } from '.';
+import { APMOSSPluginSetup } from '../../../../src/plugins/apm_oss/server';
+import { HomeServerPluginSetup } from '../../../../src/plugins/home/server';
+import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/server';
+import { ActionsPlugin } from '../../actions/server';
+import { AlertingPlugin } from '../../alerts/server';
+import { CloudSetup } from '../../cloud/server';
+import { PluginSetupContract as FeaturesPluginSetup } from '../../features/server';
+import { LicensingPluginSetup } from '../../licensing/server';
+import { MlPluginSetup } from '../../ml/server';
 import { ObservabilityPluginSetup } from '../../observability/server';
 import { SecurityPluginSetup } from '../../security/server';
-import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/server';
 import { TaskManagerSetupContract } from '../../task_manager/server';
-import { AlertingPlugin } from '../../alerts/server';
-import { ActionsPlugin } from '../../actions/server';
-import { APMOSSPluginSetup } from '../../../../src/plugins/apm_oss/server';
-import { createApmAgentConfigurationIndex } from './lib/settings/agent_configuration/create_agent_config_index';
-import { createApmCustomLinkIndex } from './lib/settings/custom_link/create_custom_link_index';
-import { createApmApi } from './routes/create_apm_api';
-import { getApmIndices } from './lib/settings/apm_indices/get_apm_indices';
-import { APMConfig, mergeConfigs, APMXPackConfig } from '.';
-import { HomeServerPluginSetup } from '../../../../src/plugins/home/server';
-import { CloudSetup } from '../../cloud/server';
-import { getInternalSavedObjectsClient } from './lib/helpers/get_internal_saved_objects_client';
-import {
-  LicensingPluginSetup,
-  LicensingPluginStart,
-} from '../../licensing/server';
-import { registerApmAlerts } from './lib/alerts/register_apm_alerts';
-import { createApmTelemetry } from './lib/apm_telemetry';
-
-import { PluginSetupContract as FeaturesPluginSetup } from '../../features/server';
 import {
   APM_FEATURE,
   APM_SERVICE_MAPS_FEATURE_NAME,
   APM_SERVICE_MAPS_LICENSE_TYPE,
 } from './feature';
+import { registerApmAlerts } from './lib/alerts/register_apm_alerts';
+import { createApmTelemetry } from './lib/apm_telemetry';
+import { getInternalSavedObjectsClient } from './lib/helpers/get_internal_saved_objects_client';
+import { createApmAgentConfigurationIndex } from './lib/settings/agent_configuration/create_agent_config_index';
+import { getApmIndices } from './lib/settings/apm_indices/get_apm_indices';
+import { createApmCustomLinkIndex } from './lib/settings/custom_link/create_custom_link_index';
+import { createApmApi } from './routes/create_apm_api';
 import { apmIndices, apmTelemetry } from './saved_objects';
 import { createElasticCloudInstructions } from './tutorial/elastic_cloud';
-import { MlPluginSetup } from '../../ml/server';
 
 export interface APMPluginSetup {
   config$: Observable<APMConfig>;
@@ -135,18 +131,14 @@ export class APMPlugin implements Plugin<APMPluginSetup> {
       APM_SERVICE_MAPS_LICENSE_TYPE
     );
 
-    core.getStartServices().then(([_coreStart, pluginsStart]) => {
-      createApmApi().init(core, {
-        config$: mergedConfig$,
-        logger: this.logger!,
-        plugins: {
-          licensing: (pluginsStart as { licensing: LicensingPluginStart })
-            .licensing,
-          observability: plugins.observability,
-          security: plugins.security,
-          ml: plugins.ml,
-        },
-      });
+    createApmApi().init(core, {
+      config$: mergedConfig$,
+      logger: this.logger!,
+      plugins: {
+        observability: plugins.observability,
+        security: plugins.security,
+        ml: plugins.ml,
+      },
     });
 
     return {

--- a/x-pack/plugins/apm/server/routes/create_api/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/create_api/index.test.ts
@@ -9,7 +9,6 @@ import { CoreSetup, Logger } from 'src/core/server';
 import { Params } from '../typings';
 import { BehaviorSubject } from 'rxjs';
 import { APMConfig } from '../..';
-import { LicensingPluginStart } from '../../../../licensing/server';
 
 const getCoreMock = () => {
   const get = jest.fn();
@@ -41,7 +40,7 @@ const getCoreMock = () => {
       logger: ({
         error: jest.fn(),
       } as unknown) as Logger,
-      plugins: { licensing: {} as LicensingPluginStart },
+      plugins: {},
     },
   };
 };

--- a/x-pack/plugins/apm/server/routes/service_map.ts
+++ b/x-pack/plugins/apm/server/routes/service_map.ts
@@ -35,10 +35,7 @@ export const serviceMapRoute = createRoute(() => ({
     if (!isValidPlatinumLicense(context.licensing.license)) {
       throw Boom.forbidden(invalidLicenseMessage);
     }
-
-    context.plugins.licensing.featureUsage.notifyUsage(
-      APM_SERVICE_MAPS_FEATURE_NAME
-    );
+    context.licensing.featureUsage.notifyUsage(APM_SERVICE_MAPS_FEATURE_NAME);
 
     const setup = await setupRequest(context, request);
     const {

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -14,7 +14,6 @@ import {
 import { PickByValue, Optional } from 'utility-types';
 import { Observable } from 'rxjs';
 import { Server } from 'hapi';
-import { LicensingPluginStart } from '../../../licensing/server';
 import { ObservabilityPluginSetup } from '../../../observability/server';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { FetchOptions } from '../../public/services/rest/callApi';
@@ -67,7 +66,6 @@ export type APMRequestHandlerContext<
   config: APMConfig;
   logger: Logger;
   plugins: {
-    licensing: LicensingPluginStart;
     observability?: ObservabilityPluginSetup;
     security?: SecurityPluginSetup;
     ml?: MlPluginSetup;
@@ -116,7 +114,6 @@ export interface ServerAPI<TRouteState extends RouteState> {
       config$: Observable<APMConfig>;
       logger: Logger;
       plugins: {
-        licensing: LicensingPluginStart;
         observability?: ObservabilityPluginSetup;
         security?: SecurityPluginSetup;
         ml?: MlPluginSetup;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Use licensing from context (#70118)