### PR TITLE
[code coverage] exclude folders: test_helpers, tests_bundle

### DIFF
--- a/src/dev/jest/config.js
+++ b/src/dev/jest/config.js
@@ -43,6 +43,7 @@ export default {
     'src/plugins/**/*.{ts,tsx}',
     '!src/plugins/**/{__test__,__snapshots__,__examples__,mocks,tests}/**/*',
     '!src/plugins/**/*.d.ts',
+    '!src/plugins/**/test_helpers/**',
     'packages/kbn-ui-framework/src/components/**/*.js',
     '!packages/kbn-ui-framework/src/components/index.js',
     '!packages/kbn-ui-framework/src/components/**/*/index.js',
@@ -51,6 +52,7 @@ export default {
     '!packages/kbn-ui-framework/src/services/**/*/index.js',
     'src/legacy/core_plugins/**/*.{js,jsx,ts,tsx}',
     '!src/legacy/core_plugins/**/{__test__,__snapshots__}/**/*',
+    '!src/legacy/core_plugins/tests_bundle/**',
   ],
   moduleNameMapper: {
     '@elastic/eui$': '<rootDir>/node_modules/@elastic/eui/test-env',

--- a/x-pack/dev-tools/jest/create_jest_config.js
+++ b/x-pack/dev-tools/jest/create_jest_config.js
@@ -44,6 +44,7 @@ export function createJestConfig({ kibanaDirectory, rootDir, xPackKibanaDirector
       '!**/mocks/**',
       '!**/plugins/apm/e2e/**',
       '!**/plugins/siem/cypress/**',
+      '!**/plugins/**/test_helpers/**',
     ],
     coveragePathIgnorePatterns: ['.*\\.d\\.ts'],
     coverageDirectory: `${kibanaDirectory}/target/kibana-coverage/jest`,


### PR DESCRIPTION
## Summary

Removing `test_helpers`, `tests_bundle` path from jest coverage report since it is test-related code.

fixed report:
https://kibana-coverage.elastic.dev/2020-06-29T14:29:20Z/jest-combined/index.html