### PR TITLE
[7.x] [APM] Run API tests as restricted user (#70050)

### DIFF
--- a/x-pack/plugins/apm/readme.md
+++ b/x-pack/plugins/apm/readme.md
@@ -80,19 +80,38 @@ For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
 
 ### API integration tests
 
+Our tests are separated in two suites: one suite runs with a basic license, and the other
+with a trial license (the equivalent of gold+). This requires separate test servers and test runs.
+
 **Start server**
 
+Basic:
+
 ```
-node scripts/functional_tests_server --config x-pack/test/api_integration/config.ts
+node scripts/functional_tests_server --config x-pack/test/apm_api_integration/basic/config.ts
+```
+
+Trial:
+
+```
+node scripts/functional_tests_server --config x-pack/test/apm_api_integration/trial/config.ts
 ```
 
 **Run tests**
 
+Basic:
+
 ```
-node scripts/functional_test_runner --config x-pack/test/api_integration/config.ts --grep='APM specs'
+node scripts/functional_test_runner --config x-pack/test/apm_api_integration/basic/config.ts
 ```
 
-APM tests are located in `x-pack/test/api_integration/apis/apm`.
+Trial:
+
+```
+node scripts/functional_test_runner --config x-pack/test/apm_api_integration/trial/config.ts
+```
+
+APM tests are located in `x-pack/test/apm_api_integration`.
 For debugging access Elasticsearch on http://localhost:9220` (elastic/changeme)
 
 ### Linting

--- a/x-pack/test/apm_api_integration/basic/tests/agent_configuration.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/agent_configuration.ts
@@ -10,11 +10,12 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function agentConfigurationTests({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
+  const supertestRead = getService('supertestAsApmReadUser');
+  const supertestWrite = getService('supertestAsApmWriteUser');
   const log = getService('log');
 
   function searchConfigurations(configuration: any) {
-    return supertest
+    return supertestRead
       .post(`/api/apm/settings/agent-configuration/search`)
       .send(configuration)
       .set('kbn-xsrf', 'foo');
@@ -22,7 +23,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
 
   async function createConfiguration(config: AgentConfigurationIntake) {
     log.debug('creating configuration', config.service);
-    const res = await supertest
+    const res = await supertestWrite
       .put(`/api/apm/settings/agent-configuration`)
       .send(config)
       .set('kbn-xsrf', 'foo');
@@ -34,7 +35,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
 
   async function updateConfiguration(config: AgentConfigurationIntake) {
     log.debug('updating configuration', config.service);
-    const res = await supertest
+    const res = await supertestWrite
       .put(`/api/apm/settings/agent-configuration?overwrite=true`)
       .send(config)
       .set('kbn-xsrf', 'foo');
@@ -46,7 +47,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
 
   async function deleteConfiguration({ service }: AgentConfigurationIntake) {
     log.debug('deleting configuration', service);
-    const res = await supertest
+    const res = await supertestWrite
       .delete(`/api/apm/settings/agent-configuration`)
       .send({ service })
       .set('kbn-xsrf', 'foo');

--- a/x-pack/test/apm_api_integration/basic/tests/annotations.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/annotations.ts
@@ -10,15 +10,15 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function annotationApiTests({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
+  const supertestWrite = getService('supertestAsApmAnnotationsWriteUser');
 
   function request({ method, url, data }: { method: string; url: string; data?: JsonObject }) {
     switch (method.toLowerCase()) {
       case 'post':
-        return supertest.post(url).send(data).set('kbn-xsrf', 'foo');
+        return supertestWrite.post(url).send(data).set('kbn-xsrf', 'foo');
 
       default:
-        throw new Error(`Unsupported methoed ${method}`);
+        throw new Error(`Unsupported method ${method}`);
     }
   }
 

--- a/x-pack/test/apm_api_integration/basic/tests/custom_link.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/custom_link.ts
@@ -10,7 +10,8 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function customLinksTests({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
+  const supertestRead = getService('supertestAsApmReadUser');
+  const supertestWrite = getService('supertestAsApmWriteUser');
   const log = getService('log');
 
   function searchCustomLinks(filters?: any) {
@@ -18,12 +19,12 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
       pathname: `/api/apm/settings/custom_links`,
       query: filters,
     });
-    return supertest.get(path).set('kbn-xsrf', 'foo');
+    return supertestRead.get(path).set('kbn-xsrf', 'foo');
   }
 
   async function createCustomLink(customLink: CustomLink) {
     log.debug('creating configuration', customLink);
-    const res = await supertest
+    const res = await supertestWrite
       .post(`/api/apm/settings/custom_links`)
       .send(customLink)
       .set('kbn-xsrf', 'foo');
@@ -35,7 +36,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
 
   async function updateCustomLink(id: string, customLink: CustomLink) {
     log.debug('updating configuration', id, customLink);
-    const res = await supertest
+    const res = await supertestWrite
       .put(`/api/apm/settings/custom_links/${id}`)
       .send(customLink)
       .set('kbn-xsrf', 'foo');
@@ -47,7 +48,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
 
   async function deleteCustomLink(id: string) {
     log.debug('deleting configuration', id);
-    const res = await supertest
+    const res = await supertestWrite
       .delete(`/api/apm/settings/custom_links/${id}`)
       .set('kbn-xsrf', 'foo');
 

--- a/x-pack/test/apm_api_integration/basic/tests/feature_controls.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/feature_controls.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function featureControlsTests({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
+  const supertest = getService('supertestAsApmWriteUser');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
   const spaces = getService('spaces');

--- a/x-pack/test/apm_api_integration/common/authentication.ts
+++ b/x-pack/test/apm_api_integration/common/authentication.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { PromiseReturnType } from '../../../plugins/apm/typings/common';
+import { SecurityServiceProvider } from '../../../../test/common/services/security';
+
+type SecurityService = PromiseReturnType<typeof SecurityServiceProvider>;
+
+export enum ApmUser {
+  apmReadUser = 'apm_read_user',
+  apmWriteUser = 'apm_write_user',
+  apmAnnotationsWriteUser = 'apm_annotations_write_user',
+}
+
+const roles = {
+  [ApmUser.apmReadUser]: {
+    elasticsearch: {
+      cluster: [],
+      indices: [
+        { names: ['observability-annotations'], privileges: ['read', 'view_index_metadata'] },
+      ],
+    },
+    kibana: [
+      {
+        base: [],
+        feature: {
+          apm: ['read'],
+        },
+        spaces: ['*'],
+      },
+    ],
+  },
+  [ApmUser.apmWriteUser]: {
+    elasticsearch: {
+      cluster: [],
+      indices: [
+        { names: ['observability-annotations'], privileges: ['read', 'view_index_metadata'] },
+      ],
+    },
+    kibana: [
+      {
+        base: [],
+        feature: {
+          apm: ['all'],
+        },
+        spaces: ['*'],
+      },
+    ],
+  },
+  [ApmUser.apmAnnotationsWriteUser]: {
+    elasticsearch: {
+      cluster: [],
+      indices: [
+        {
+          names: ['observability-annotations'],
+          privileges: [
+            'read',
+            'view_index_metadata',
+            'index',
+            'manage',
+            'create_index',
+            'create_doc',
+          ],
+        },
+      ],
+    },
+  },
+};
+
+const users = {
+  [ApmUser.apmReadUser]: {
+    roles: ['apm_user', ApmUser.apmReadUser],
+  },
+  [ApmUser.apmWriteUser]: {
+    roles: ['apm_user', ApmUser.apmWriteUser],
+  },
+  [ApmUser.apmAnnotationsWriteUser]: {
+    roles: ['apm_user', ApmUser.apmWriteUser, ApmUser.apmAnnotationsWriteUser],
+  },
+};
+
+export async function createApmUser(security: SecurityService, apmUser: ApmUser) {
+  const role = roles[apmUser];
+  const user = users[apmUser];
+
+  if (!role || !user) {
+    throw new Error(`No configuration found for ${apmUser}`);
+  }
+
+  await security.role.create(apmUser, role);
+
+  await security.user.create(apmUser, {
+    full_name: apmUser,
+    password: APM_TEST_PASSWORD,
+    roles: user.roles,
+  });
+}
+
+export const APM_TEST_PASSWORD = 'changeme';

--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -5,12 +5,33 @@
  */
 
 import { FtrConfigProviderContext } from '@kbn/test/types/ftr';
+import supertestAsPromised from 'supertest-as-promised';
+import { format, UrlObject } from 'url';
+import { InheritedFtrProviderContext, InheritedServices } from './ftr_provider_context';
+import { PromiseReturnType } from '../../../plugins/apm/typings/common';
+import { createApmUser, APM_TEST_PASSWORD, ApmUser } from './authentication';
 
 interface Settings {
   license: 'basic' | 'trial';
   testFiles: string[];
   name: string;
 }
+
+const supertestAsApmUser = (kibanaServer: UrlObject, apmUser: ApmUser) => async (
+  context: InheritedFtrProviderContext
+) => {
+  const security = context.getService('security');
+  await security.init();
+
+  await createApmUser(security, apmUser);
+
+  const url = format({
+    ...kibanaServer,
+    auth: `${apmUser}:${APM_TEST_PASSWORD}`,
+  });
+
+  return supertestAsPromised(url);
+};
 
 export function createTestConfig(settings: Settings) {
   const { testFiles, license, name } = settings;
@@ -20,14 +41,27 @@ export function createTestConfig(settings: Settings) {
       require.resolve('../../api_integration/config.ts')
     );
 
+    const services = xPackAPITestsConfig.get('services') as InheritedServices;
+    const servers = xPackAPITestsConfig.get('servers');
+
+    const supertestAsApmReadUser = supertestAsApmUser(servers.kibana, ApmUser.apmReadUser);
+
     return {
       testFiles,
-      servers: xPackAPITestsConfig.get('servers'),
-      services: xPackAPITestsConfig.get('services'),
+      servers,
+      services: {
+        ...services,
+        supertest: supertestAsApmReadUser,
+        supertestAsApmReadUser,
+        supertestAsApmWriteUser: supertestAsApmUser(servers.kibana, ApmUser.apmWriteUser),
+        supertestAsApmAnnotationsWriteUser: supertestAsApmUser(
+          servers.kibana,
+          ApmUser.apmAnnotationsWriteUser
+        ),
+      },
       junit: {
         reportName: name,
       },
-
       esTestCluster: {
         ...xPackAPITestsConfig.get('esTestCluster'),
         license,
@@ -36,3 +70,5 @@ export function createTestConfig(settings: Settings) {
     };
   };
 }
+
+export type ApmServices = PromiseReturnType<ReturnType<typeof createTestConfig>>['services'];

--- a/x-pack/test/apm_api_integration/common/ftr_provider_context.ts
+++ b/x-pack/test/apm_api_integration/common/ftr_provider_context.ts
@@ -4,4 +4,16 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export { FtrProviderContext } from '../../api_integration/ftr_provider_context';
+import { GenericFtrProviderContext } from '@kbn/test/types/ftr';
+import { FtrProviderContext as InheritedFtrProviderContext } from '../../api_integration/ftr_provider_context';
+import { ApmServices } from './config';
+
+export type InheritedServices = InheritedFtrProviderContext extends GenericFtrProviderContext<
+  infer TServices,
+  {}
+>
+  ? TServices
+  : {};
+
+export { InheritedFtrProviderContext };
+export type FtrProviderContext = GenericFtrProviderContext<ApmServices, {}>;

--- a/x-pack/test/apm_api_integration/trial/tests/annotations.ts
+++ b/x-pack/test/apm_api_integration/trial/tests/annotations.ts
@@ -13,7 +13,8 @@ const DEFAULT_INDEX_NAME = 'observability-annotations';
 
 // eslint-disable-next-line import/no-default-export
 export default function annotationApiTests({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
+  const supertestRead = getService('supertestAsApmReadUser');
+  const supertestWrite = getService('supertestAsApmAnnotationsWriteUser');
   const es = getService('es');
 
   function expectContainsObj(source: JsonObject, expected: JsonObject) {
@@ -30,13 +31,13 @@ export default function annotationApiTests({ getService }: FtrProviderContext) {
   function request({ method, url, data }: { method: string; url: string; data?: JsonObject }) {
     switch (method.toLowerCase()) {
       case 'get':
-        return supertest.get(url).set('kbn-xsrf', 'foo');
+        return supertestRead.get(url).set('kbn-xsrf', 'foo');
 
       case 'post':
-        return supertest.post(url).send(data).set('kbn-xsrf', 'foo');
+        return supertestWrite.post(url).send(data).set('kbn-xsrf', 'foo');
 
       default:
-        throw new Error(`Unsupported methoed ${method}`);
+        throw new Error(`Unsupported method ${method}`);
     }
   }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [APM] Run API tests as restricted user (#70050)