### PR TITLE
[SIEM][Timeline] Reset fields based on timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/alerts/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/alerts/components/alerts_table/index.tsx
@@ -333,6 +333,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
     initializeTimeline({
       id: timelineId,
       documentType: i18n.ALERTS_DOCUMENT_TYPE,
+      defaultModel: alertsDefaultModel,
       footerText: i18n.TOTAL_COUNT_OF_ALERTS,
       loadingText: i18n.LOADING_ALERTS,
       title: i18n.ALERTS_TABLE_TITLE,

--- a/x-pack/plugins/security_solution/public/common/components/alerts_viewer/alerts_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/alerts_viewer/alerts_table.tsx
@@ -75,6 +75,7 @@ const AlertsTableComponent: React.FC<Props> = ({
     initializeTimeline({
       id: timelineId,
       documentType: i18n.ALERTS_DOCUMENT_TYPE,
+      defaultModel: alertsDefaultModel,
       footerText: i18n.TOTAL_COUNT_OF_ALERTS,
       title: i18n.ALERTS_TABLE_TITLE,
       unit: i18n.UNIT,

--- a/x-pack/plugins/security_solution/public/hosts/pages/navigation/events_query_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/navigation/events_query_tab_body.tsx
@@ -17,6 +17,7 @@ import {
 import { MatrixHistogramContainer } from '../../../common/components/matrix_histogram';
 import * as i18n from '../translations';
 import { HistogramType } from '../../../graphql/types';
+import { useManageTimeline } from '../../../timelines/components/manage_timeline';
 
 const EVENTS_HISTOGRAM_ID = 'eventsOverTimeQuery';
 
@@ -55,6 +56,15 @@ export const EventsQueryTabBody = ({
   setQuery,
   startDate,
 }: HostsComponentsQueryProps) => {
+  const { initializeTimeline } = useManageTimeline();
+
+  useEffect(() => {
+    initializeTimeline({
+      id: TimelineId.hostsPageEvents,
+      defaultModel: eventsDefaultModel,
+    });
+  }, [initializeTimeline]);
+
   useEffect(() => {
     return () => {
       if (deleteQuery) {

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.test.tsx
@@ -8,12 +8,8 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { mockBrowserFields } from '../../../common/containers/source/mock';
 import { TestProviders } from '../../../common/mock';
-import { alertsHeaders as alertsDefaultHeaders } from '../../../alerts/components/alerts_table/default_config';
-import { alertsHeaders as commonAlertsDefaultHeaders } from '../../../common/components/alerts_viewer/default_headers';
-import { defaultHeaders as eventsDefaultHeaders } from '../../../common/components/events_viewer/default_headers';
 import { defaultHeaders } from '../timeline/body/column_headers/default_headers';
 import { Header } from './header';
-import { TimelineId } from '../../../../common/types/timeline';
 
 const timelineId = 'test';
 
@@ -76,116 +72,6 @@ describe('Header', () => {
     wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
 
     expect(onUpdateColumns).toBeCalledWith(defaultHeaders);
-  });
-
-  test('it updates the columns correctly for Hosts/Events timeline', () => {
-    const onUpdateColumns = jest.fn();
-
-    const wrapper = mount(
-      <TestProviders>
-        <Header
-          filteredBrowserFields={mockBrowserFields}
-          isSearching={false}
-          onOutsideClick={jest.fn()}
-          onSearchInputChange={jest.fn()}
-          onUpdateColumns={onUpdateColumns}
-          searchInput=""
-          timelineId={TimelineId.hostsPageEvents}
-        />
-      </TestProviders>
-    );
-
-    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
-
-    expect(onUpdateColumns).toBeCalledWith(eventsDefaultHeaders);
-  });
-
-  test('it updates the columns correctly for Hosts/External Alerts timeline', () => {
-    const onUpdateColumns = jest.fn();
-
-    const wrapper = mount(
-      <TestProviders>
-        <Header
-          filteredBrowserFields={mockBrowserFields}
-          isSearching={false}
-          onOutsideClick={jest.fn()}
-          onSearchInputChange={jest.fn()}
-          onUpdateColumns={onUpdateColumns}
-          searchInput=""
-          timelineId={TimelineId.hostsPageExternalAlerts}
-        />
-      </TestProviders>
-    );
-
-    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
-
-    expect(onUpdateColumns).toBeCalledWith(commonAlertsDefaultHeaders);
-  });
-
-  test('it updates the columns correctly for Alerts timeline', () => {
-    const onUpdateColumns = jest.fn();
-
-    const wrapper = mount(
-      <TestProviders>
-        <Header
-          filteredBrowserFields={mockBrowserFields}
-          isSearching={false}
-          onOutsideClick={jest.fn()}
-          onSearchInputChange={jest.fn()}
-          onUpdateColumns={onUpdateColumns}
-          searchInput=""
-          timelineId={TimelineId.alertsPage}
-        />
-      </TestProviders>
-    );
-
-    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
-
-    expect(onUpdateColumns).toBeCalledWith(alertsDefaultHeaders);
-  });
-
-  test('it updates the columns correctly for Alerts/Rule timeline', () => {
-    const onUpdateColumns = jest.fn();
-
-    const wrapper = mount(
-      <TestProviders>
-        <Header
-          filteredBrowserFields={mockBrowserFields}
-          isSearching={false}
-          onOutsideClick={jest.fn()}
-          onSearchInputChange={jest.fn()}
-          onUpdateColumns={onUpdateColumns}
-          searchInput=""
-          timelineId={TimelineId.alertsRulesDetailsPage}
-        />
-      </TestProviders>
-    );
-
-    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
-
-    expect(onUpdateColumns).toBeCalledWith(alertsDefaultHeaders);
-  });
-
-  test('it updates the columns correctly for Network timeline', () => {
-    const onUpdateColumns = jest.fn();
-
-    const wrapper = mount(
-      <TestProviders>
-        <Header
-          filteredBrowserFields={mockBrowserFields}
-          isSearching={false}
-          onOutsideClick={jest.fn()}
-          onSearchInputChange={jest.fn()}
-          onUpdateColumns={onUpdateColumns}
-          searchInput=""
-          timelineId={TimelineId.networkPageExternalAlerts}
-        />
-      </TestProviders>
-    );
-
-    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
-
-    expect(onUpdateColumns).toBeCalledWith(commonAlertsDefaultHeaders);
   });
 
   test('it invokes onOutsideClick when the user clicks the Reset Fields button', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.test.tsx
@@ -8,8 +8,12 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { mockBrowserFields } from '../../../common/containers/source/mock';
 import { TestProviders } from '../../../common/mock';
+import { alertsHeaders as alertsDefaultHeaders } from '../../../alerts/components/alerts_table/default_config';
+import { alertsHeaders as commonAlertsDefaultHeaders } from '../../../common/components/alerts_viewer/default_headers';
+import { defaultHeaders as eventsDefaultHeaders } from '../../../common/components/events_viewer/default_headers';
 import { defaultHeaders } from '../timeline/body/column_headers/default_headers';
 import { Header } from './header';
+import { TimelineId } from '../../../../common/types/timeline';
 
 const timelineId = 'test';
 
@@ -72,6 +76,116 @@ describe('Header', () => {
     wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
 
     expect(onUpdateColumns).toBeCalledWith(defaultHeaders);
+  });
+
+  test('it updates the columns correctly for Hosts/Events timeline', () => {
+    const onUpdateColumns = jest.fn();
+
+    const wrapper = mount(
+      <TestProviders>
+        <Header
+          filteredBrowserFields={mockBrowserFields}
+          isSearching={false}
+          onOutsideClick={jest.fn()}
+          onSearchInputChange={jest.fn()}
+          onUpdateColumns={onUpdateColumns}
+          searchInput=""
+          timelineId={TimelineId.hostsPageEvents}
+        />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
+
+    expect(onUpdateColumns).toBeCalledWith(eventsDefaultHeaders);
+  });
+
+  test('it updates the columns correctly for Hosts/External Alerts timeline', () => {
+    const onUpdateColumns = jest.fn();
+
+    const wrapper = mount(
+      <TestProviders>
+        <Header
+          filteredBrowserFields={mockBrowserFields}
+          isSearching={false}
+          onOutsideClick={jest.fn()}
+          onSearchInputChange={jest.fn()}
+          onUpdateColumns={onUpdateColumns}
+          searchInput=""
+          timelineId={TimelineId.hostsPageExternalAlerts}
+        />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
+
+    expect(onUpdateColumns).toBeCalledWith(commonAlertsDefaultHeaders);
+  });
+
+  test('it updates the columns correctly for Alerts timeline', () => {
+    const onUpdateColumns = jest.fn();
+
+    const wrapper = mount(
+      <TestProviders>
+        <Header
+          filteredBrowserFields={mockBrowserFields}
+          isSearching={false}
+          onOutsideClick={jest.fn()}
+          onSearchInputChange={jest.fn()}
+          onUpdateColumns={onUpdateColumns}
+          searchInput=""
+          timelineId={TimelineId.alertsPage}
+        />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
+
+    expect(onUpdateColumns).toBeCalledWith(alertsDefaultHeaders);
+  });
+
+  test('it updates the columns correctly for Alerts/Rule timeline', () => {
+    const onUpdateColumns = jest.fn();
+
+    const wrapper = mount(
+      <TestProviders>
+        <Header
+          filteredBrowserFields={mockBrowserFields}
+          isSearching={false}
+          onOutsideClick={jest.fn()}
+          onSearchInputChange={jest.fn()}
+          onUpdateColumns={onUpdateColumns}
+          searchInput=""
+          timelineId={TimelineId.alertsRulesDetailsPage}
+        />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
+
+    expect(onUpdateColumns).toBeCalledWith(alertsDefaultHeaders);
+  });
+
+  test('it updates the columns correctly for Network timeline', () => {
+    const onUpdateColumns = jest.fn();
+
+    const wrapper = mount(
+      <TestProviders>
+        <Header
+          filteredBrowserFields={mockBrowserFields}
+          isSearching={false}
+          onOutsideClick={jest.fn()}
+          onSearchInputChange={jest.fn()}
+          onUpdateColumns={onUpdateColumns}
+          searchInput=""
+          timelineId={TimelineId.networkPageExternalAlerts}
+        />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="reset-fields"]').first().simulate('click');
+
+    expect(onUpdateColumns).toBeCalledWith(commonAlertsDefaultHeaders);
   });
 
   test('it invokes onOutsideClick when the user clicks the Reset Fields button', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.tsx
@@ -12,12 +12,13 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
+import { TimelineId } from '../../../../common/types/timeline';
 import { BrowserFields } from '../../../common/containers/source';
-import { alertsHeaders } from '../../../alerts/components/alerts_table/default_config';
-import { alertsHeaders as externalAlertsHeaders } from '../../../common/components/alerts_viewer/default_headers';
+import { alertsHeaders as alertsDefaultHeaders } from '../../../alerts/components/alerts_table/default_config';
+import { alertsHeaders as commonAlertsDefaultHeaders } from '../../../common/components/alerts_viewer/default_headers';
 import { defaultHeaders as eventsDefaultHeaders } from '../../../common/components/events_viewer/default_headers';
 import { defaultHeaders } from '../timeline/body/column_headers/default_headers';
 import { OnUpdateColumns } from '../timeline/events';
@@ -25,7 +26,6 @@ import { OnUpdateColumns } from '../timeline/events';
 import { getFieldBrowserSearchInputClassName, getFieldCount, SEARCH_INPUT_WIDTH } from './helpers';
 
 import * as i18n from './translations';
-import { useManageTimeline } from '../manage_timeline';
 
 const CountsFlexGroup = styled(EuiFlexGroup)`
   margin-top: 5px;
@@ -101,25 +101,21 @@ const TitleRow = React.memo<{
   onOutsideClick: () => void;
   onUpdateColumns: OnUpdateColumns;
 }>(({ id, isEventViewer, onOutsideClick, onUpdateColumns }) => {
-  const { getManageTimelineById } = useManageTimeline();
-  const documentType = useMemo(() => getManageTimelineById(id).documentType, [
-    getManageTimelineById,
-    id,
-  ]);
   const handleResetColumns = useCallback(() => {
     let resetDefaultHeaders = defaultHeaders;
-    if (isEventViewer) {
-      if (documentType.toLocaleLowerCase() === 'externalAlerts') {
-        resetDefaultHeaders = externalAlertsHeaders;
-      } else if (documentType.toLocaleLowerCase() === 'alerts') {
-        resetDefaultHeaders = alertsHeaders;
-      } else {
-        resetDefaultHeaders = eventsDefaultHeaders;
-      }
+    if (id === TimelineId.hostsPageEvents) {
+      resetDefaultHeaders = eventsDefaultHeaders;
+    } else if (
+      id === TimelineId.hostsPageExternalAlerts ||
+      id === TimelineId.networkPageExternalAlerts
+    ) {
+      resetDefaultHeaders = commonAlertsDefaultHeaders;
+    } else if (id === TimelineId.alertsPage || id === TimelineId.alertsRulesDetailsPage) {
+      resetDefaultHeaders = alertsDefaultHeaders;
     }
     onUpdateColumns(resetDefaultHeaders);
     onOutsideClick();
-  }, [isEventViewer, onOutsideClick, onUpdateColumns, documentType]);
+  }, [id, onUpdateColumns, onOutsideClick]);
 
   return (
     <EuiFlexGroup

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/header.tsx
@@ -15,17 +15,13 @@ import {
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
-import { TimelineId } from '../../../../common/types/timeline';
 import { BrowserFields } from '../../../common/containers/source';
-import { alertsHeaders as alertsDefaultHeaders } from '../../../alerts/components/alerts_table/default_config';
-import { alertsHeaders as commonAlertsDefaultHeaders } from '../../../common/components/alerts_viewer/default_headers';
-import { defaultHeaders as eventsDefaultHeaders } from '../../../common/components/events_viewer/default_headers';
-import { defaultHeaders } from '../timeline/body/column_headers/default_headers';
 import { OnUpdateColumns } from '../timeline/events';
 
 import { getFieldBrowserSearchInputClassName, getFieldCount, SEARCH_INPUT_WIDTH } from './helpers';
 
 import * as i18n from './translations';
+import { useManageTimeline } from '../manage_timeline';
 
 const CountsFlexGroup = styled(EuiFlexGroup)`
   margin-top: 5px;
@@ -100,22 +96,13 @@ const TitleRow = React.memo<{
   isEventViewer?: boolean;
   onOutsideClick: () => void;
   onUpdateColumns: OnUpdateColumns;
-}>(({ id, isEventViewer, onOutsideClick, onUpdateColumns }) => {
+}>(({ id, onOutsideClick, onUpdateColumns }) => {
+  const { getManageTimelineById } = useManageTimeline();
   const handleResetColumns = useCallback(() => {
-    let resetDefaultHeaders = defaultHeaders;
-    if (id === TimelineId.hostsPageEvents) {
-      resetDefaultHeaders = eventsDefaultHeaders;
-    } else if (
-      id === TimelineId.hostsPageExternalAlerts ||
-      id === TimelineId.networkPageExternalAlerts
-    ) {
-      resetDefaultHeaders = commonAlertsDefaultHeaders;
-    } else if (id === TimelineId.alertsPage || id === TimelineId.alertsRulesDetailsPage) {
-      resetDefaultHeaders = alertsDefaultHeaders;
-    }
-    onUpdateColumns(resetDefaultHeaders);
+    const timeline = getManageTimelineById(id);
+    onUpdateColumns(timeline.defaultModel.columns);
     onOutsideClick();
-  }, [id, onUpdateColumns, onOutsideClick]);
+  }, [id, onUpdateColumns, onOutsideClick, getManageTimelineById]);
 
   return (
     <EuiFlexGroup

--- a/x-pack/plugins/security_solution/public/timelines/components/manage_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/manage_timeline/index.tsx
@@ -9,11 +9,14 @@ import { noop } from 'lodash/fp';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { FilterManager } from '../../../../../../../src/plugins/data/public/query/filter_manager';
 import { TimelineRowAction } from '../timeline/body/actions';
+import { SubsetTimelineModel } from '../../store/timeline/model';
 import * as i18n from '../../../common/components/events_viewer/translations';
 import * as i18nF from '../timeline/footer/translations';
+import { timelineDefaults as timelineDefaultModel } from '../../store/timeline/defaults';
 
 interface ManageTimelineInit {
   documentType?: string;
+  defaultModel?: SubsetTimelineModel;
   footerText?: string;
   id: string;
   indexToAdd?: string[] | null;
@@ -25,6 +28,7 @@ interface ManageTimelineInit {
 
 interface ManageTimeline {
   documentType: string;
+  defaultModel: SubsetTimelineModel;
   filterManager?: FilterManager;
   footerText: string;
   id: string;
@@ -66,6 +70,7 @@ type ActionManageTimeline =
 
 export const timelineDefaults = {
   indexToAdd: null,
+  defaultModel: timelineDefaultModel,
   loadingText: i18n.LOADING_EVENTS,
   footerText: i18nF.TOTAL_COUNT_OF_EVENTS,
   documentType: i18nF.TOTAL_COUNT_OF_EVENTS,


### PR DESCRIPTION
## Summary

This PR fixes a bug when resetting the fields of a timeline. Specifically, when the user presses the reset fields button the fields are being reset to the defaults of each timeline based on its id.

Fixes: https://github.com/elastic/kibana/issues/70172

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
