### PR TITLE
[code coverage] ingest correct coveredFilePath for mocha

### DIFF
--- a/src/dev/code_coverage/shell_scripts/ingest_coverage.sh
+++ b/src/dev/code_coverage/shell_scripts/ingest_coverage.sh
@@ -17,13 +17,19 @@ export ES_HOST
 STATIC_SITE_URL_BASE='https://kibana-coverage.elastic.dev'
 export STATIC_SITE_URL_BASE
 
-for x in jest functional mocha; do
+for x in jest functional; do
   echo "### Ingesting coverage for ${x}"
 
   COVERAGE_SUMMARY_FILE=target/kibana-coverage/${x}-combined/coverage-summary.json
 
   node scripts/ingest_coverage.js --verbose --path ${COVERAGE_SUMMARY_FILE} --vcsInfoPath ./VCS_INFO.txt
 done
+
+# Need to override COVERAGE_INGESTION_KIBANA_ROOT since mocha json file has original intake worker path
+COVERAGE_SUMMARY_FILE=target/kibana-coverage/mocha-combined/coverage-summary.json
+COVERAGE_INGESTION_KIBANA_ROOT=/dev/shm/workspace/kibana
+
+node scripts/ingest_coverage.js --verbose --path ${COVERAGE_SUMMARY_FILE} --vcsInfoPath ./VCS_INFO.txt
 
 echo "###  Ingesting Code Coverage - Complete"
 echo ""

--- a/src/dev/code_coverage/shell_scripts/ingest_coverage.sh
+++ b/src/dev/code_coverage/shell_scripts/ingest_coverage.sh
@@ -27,7 +27,7 @@ done
 
 # Need to override COVERAGE_INGESTION_KIBANA_ROOT since mocha json file has original intake worker path
 COVERAGE_SUMMARY_FILE=target/kibana-coverage/mocha-combined/coverage-summary.json
-COVERAGE_INGESTION_KIBANA_ROOT=/dev/shm/workspace/kibana
+export COVERAGE_INGESTION_KIBANA_ROOT=/dev/shm/workspace/kibana
 
 node scripts/ingest_coverage.js --verbose --path ${COVERAGE_SUMMARY_FILE} --vcsInfoPath ./VCS_INFO.txt
 


### PR DESCRIPTION
## Summary

Fixing coveredFilePath for mocha: we ingest wrong value because we do not merge mocha, it is executed under oss-intake and coverage report contains original root path. As for jest and functional we do merge it in other worker, and we later use COVERAGE_INGESTION_KIBANA_ROOT value to clean path.

For mocha we need to override COVERAGE_INGESTION_KIBANA_ROOT with original worker path: `/dev/shm/workspace/kibana`

<img width="939" alt="Discover - Elastic 2020-06-29 17-00-26" src="https://user-images.githubusercontent.com/10977896/86022192-507d4080-ba2a-11ea-9634-524691718011.png">

job: https://kibana-ci.elastic.co/job/elastic+kibana+code-coverage/862/

Fixed:

<img width="880" alt="Discover - Elastic 2020-06-30 01-25-46" src="https://user-images.githubusercontent.com/10977896/86065738-af65a880-ba70-11ea-8f18-088d9f2dc25e.png">
