### PR TITLE
[DOCS] Update links to Beats documentation

### DIFF
--- a/docs/management/index-lifecycle-policies/example-index-lifecycle-policy.asciidoc
+++ b/docs/management/index-lifecycle-policies/example-index-lifecycle-policy.asciidoc
@@ -50,7 +50,7 @@ node.attr.data: "warm"
 --------------------------------------------------------------------------------
 
 * A server with {filebeat} installed and configured to send logs to the `elasticsearch`
-output as described in {filebeat-ref}/filebeat-getting-started.html[Getting Started with {filebeat}].
+output as described in {filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start].
 
 [discrete]
 [[example-using-index-lifecycle-policy-view-fb-ilm-policy]]

--- a/docs/management/watcher-ui/index.asciidoc
+++ b/docs/management/watcher-ui/index.asciidoc
@@ -59,7 +59,7 @@ The following example walks you through creating a threshold alert. The alert
 is triggered when the maximum total CPU usage on a machine goes above a
 certain percentage. The example uses https://www.elastic.co/products/beats/metricbeat[Metricbeat]
 to collect metrics from your systems and services.
-{metricbeat-ref}/metricbeat-installation.html[Learn more] on how to install
+{metricbeat-ref}/metricbeat-installation-configuration.html[Learn more] on how to install
 and get started with Metricbeat.
 
 [float]

--- a/docs/uptime-guide/install.asciidoc
+++ b/docs/uptime-guide/install.asciidoc
@@ -51,7 +51,7 @@ Uptime requires the setup of monitors in Heartbeat.
 These monitors provide the data you'll be visualizing in the {kibana-ref}/xpack-uptime.html[Uptime app].
 
 For instructions on installing and configuring Heartbeat, see the *Setup Instructions* in {kib}.
-Additional information is available in {heartbeat-ref}/heartbeat-configuration.html[Configure Heartbeat].
+Additional information is available in {heartbeat-ref}/configuring-howto-heartbeat.html[Configure Heartbeat].
 
 [role="screenshot"]
 image::images/uptime-setup.png[Installation instructions on the Uptime page in Kibana]

--- a/docs/user/monitoring/monitoring-metricbeat.asciidoc
+++ b/docs/user/monitoring/monitoring-metricbeat.asciidoc
@@ -82,7 +82,7 @@ For more information, see {ref}/monitoring-settings.html[Monitoring settings in 
 and {ref}/cluster-update-settings.html[Cluster update settings].
 --
 
-. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the
+. {metricbeat-ref}/metricbeat-installation-configuration.html[Install {metricbeat}] on the
 same server as {kib}.
 
 . Enable the {kib} {xpack} module in {metricbeat}. +

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -41,8 +41,8 @@ export class DocLinksService {
         },
         filebeat: {
           base: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}`,
-          installation: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation.html`,
-          configuration: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-configuration.html`,
+          installation: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation-configuration.html`,
+          configuration: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/configuring-howto-filebeat.html`,
           elasticsearchOutput: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/elasticsearch-output.html`,
           startup: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-starting.html`,
           exportedFields: `${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/exported-fields.html`,

--- a/src/plugins/home/server/tutorials/cloudwatch_logs/index.ts
+++ b/src/plugins/home/server/tutorials/cloudwatch_logs/index.ts
@@ -45,7 +45,7 @@ export function cloudwatchLogsSpecProvider(context: TutorialContext): TutorialSc
         an AWS Lambda function. \
         [Learn more]({learnMoreLink}).',
       values: {
-        learnMoreLink: '{config.docs.beats.functionbeat}/functionbeat-getting-started.html',
+        learnMoreLink: '{config.docs.beats.functionbeat}/functionbeat-installation-configuration.html',
       },
     }),
     euiIconType: 'logoAWS',

--- a/src/plugins/home/server/tutorials/instructions/auditbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/auditbeat_instructions.ts
@@ -31,9 +31,9 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Auditbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.auditbeatInstructions.install.osxTextPre', {
-        defaultMessage: 'First time using Auditbeat? See the [Getting Started Guide]({linkUrl}).',
+        defaultMessage: 'First time using Auditbeat? See the [Quick Start]({linkUrl}).',
         values: {
-          linkUrl: '{config.docs.beats.auditbeat}/auditbeat-getting-started.html',
+          linkUrl: '{config.docs.beats.auditbeat}/auditbeat-installation-configuration.html',
         },
       }),
       commands: [
@@ -47,9 +47,9 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Auditbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.auditbeatInstructions.install.debTextPre', {
-        defaultMessage: 'First time using Auditbeat? See the [Getting Started Guide]({linkUrl}).',
+        defaultMessage: 'First time using Auditbeat? See the [Quick Start]({linkUrl}).',
         values: {
-          linkUrl: '{config.docs.beats.auditbeat}/auditbeat-getting-started.html',
+          linkUrl: '{config.docs.beats.auditbeat}/auditbeat-installation-configuration.html',
         },
       }),
       commands: [
@@ -68,9 +68,9 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Auditbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.auditbeatInstructions.install.rpmTextPre', {
-        defaultMessage: 'First time using Auditbeat? See the [Getting Started Guide]({linkUrl}).',
+        defaultMessage: 'First time using Auditbeat? See the [Quick Start]({linkUrl}).',
         values: {
-          linkUrl: '{config.docs.beats.auditbeat}/auditbeat-getting-started.html',
+          linkUrl: '{config.docs.beats.auditbeat}/auditbeat-installation-configuration.html',
         },
       }),
       commands: [
@@ -92,7 +92,7 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
         'home.tutorials.common.auditbeatInstructions.install.windowsTextPre',
         {
           defaultMessage:
-            'First time using Auditbeat? See the [Getting Started Guide]({guideLinkUrl}).\n\
+            'First time using Auditbeat? See the [Quick Start]({guideLinkUrl}).\n\
  1. Download the Auditbeat Windows zip file from the [Download]({auditbeatLinkUrl}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the `{directoryName}` directory to `Auditbeat`.\n\
@@ -101,7 +101,7 @@ export const createAuditbeatInstructions = (context?: TutorialContext) => ({
  5. From the PowerShell prompt, run the following commands to install Auditbeat as a Windows service.',
           values: {
             folderPath: '`C:\\Program Files`',
-            guideLinkUrl: '{config.docs.beats.auditbeat}/auditbeat-getting-started.html',
+            guideLinkUrl: '{config.docs.beats.auditbeat}/auditbeat-installation-configuration.html',
             auditbeatLinkUrl: 'https://www.elastic.co/downloads/beats/auditbeat',
             directoryName: 'auditbeat-{config.kibana.version}-windows',
           },

--- a/src/plugins/home/server/tutorials/instructions/filebeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/filebeat_instructions.ts
@@ -31,9 +31,9 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Filebeat',
       }),
       textPre: i18n.translate('home.tutorials.common.filebeatInstructions.install.osxTextPre', {
-        defaultMessage: 'First time using Filebeat? See the [Getting Started Guide]({linkUrl}).',
+        defaultMessage: 'First time using Filebeat? See the [Quick Start]({linkUrl}).',
         values: {
-          linkUrl: '{config.docs.beats.filebeat}/filebeat-getting-started.html',
+          linkUrl: '{config.docs.beats.filebeat}/filebeat-installation-configuration.html',
         },
       }),
       commands: [
@@ -47,9 +47,9 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Filebeat',
       }),
       textPre: i18n.translate('home.tutorials.common.filebeatInstructions.install.debTextPre', {
-        defaultMessage: 'First time using Filebeat? See the [Getting Started Guide]({linkUrl}).',
+        defaultMessage: 'First time using Filebeat? See the [Quick Start]({linkUrl}).',
         values: {
-          linkUrl: '{config.docs.beats.filebeat}/filebeat-getting-started.html',
+          linkUrl: '{config.docs.beats.filebeat}/filebeat-installation-configuration.html',
         },
       }),
       commands: [
@@ -68,9 +68,9 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Filebeat',
       }),
       textPre: i18n.translate('home.tutorials.common.filebeatInstructions.install.rpmTextPre', {
-        defaultMessage: 'First time using Filebeat? See the [Getting Started Guide]({linkUrl}).',
+        defaultMessage: 'First time using Filebeat? See the [Quick Start]({linkUrl}).',
         values: {
-          linkUrl: '{config.docs.beats.filebeat}/filebeat-getting-started.html',
+          linkUrl: '{config.docs.beats.filebeat}/filebeat-installation-configuration.html',
         },
       }),
       commands: [
@@ -90,7 +90,7 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
       }),
       textPre: i18n.translate('home.tutorials.common.filebeatInstructions.install.windowsTextPre', {
         defaultMessage:
-          'First time using Filebeat? See the [Getting Started Guide]({guideLinkUrl}).\n\
+          'First time using Filebeat? See the [Quick Start]({guideLinkUrl}).\n\
  1. Download the Filebeat Windows zip file from the [Download]({filebeatLinkUrl}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the `{directoryName}` directory to `Filebeat`.\n\
@@ -99,7 +99,7 @@ export const createFilebeatInstructions = (context?: TutorialContext) => ({
  5. From the PowerShell prompt, run the following commands to install Filebeat as a Windows service.',
         values: {
           folderPath: '`C:\\Program Files`',
-          guideLinkUrl: '{config.docs.beats.filebeat}/filebeat-getting-started.html',
+          guideLinkUrl: '{config.docs.beats.filebeat}/filebeat-installation-configuration.html',
           filebeatLinkUrl: 'https://www.elastic.co/downloads/beats/filebeat',
           directoryName: 'filebeat-{config.kibana.version}-windows',
         },

--- a/src/plugins/home/server/tutorials/instructions/functionbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/functionbeat_instructions.ts
@@ -31,8 +31,8 @@ export const createFunctionbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Functionbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.functionbeatInstructions.install.osxTextPre', {
-        defaultMessage: 'First time using Functionbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.functionbeat}/functionbeat-getting-started.html' },
+        defaultMessage: 'First time using Functionbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.functionbeat}/functionbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
@@ -47,8 +47,8 @@ export const createFunctionbeatInstructions = (context?: TutorialContext) => ({
       textPre: i18n.translate(
         'home.tutorials.common.functionbeatInstructions.install.linuxTextPre',
         {
-          defaultMessage: 'First time using Functionbeat? See the [Getting Started Guide]({link}).',
-          values: { link: '{config.docs.beats.functionbeat}/functionbeat-getting-started.html' },
+          defaultMessage: 'First time using Functionbeat? See the [Quick Start]({link}).',
+          values: { link: '{config.docs.beats.functionbeat}/functionbeat-installation-configuration.html' },
         }
       ),
       commands: [
@@ -65,7 +65,7 @@ export const createFunctionbeatInstructions = (context?: TutorialContext) => ({
         'home.tutorials.common.functionbeatInstructions.install.windowsTextPre',
         {
           defaultMessage:
-            'First time using Functionbeat? See the [Getting Started Guide]({functionbeatLink}).\n\
+            'First time using Functionbeat? See the [Quick Start]({functionbeatLink}).\n\
  1. Download the Functionbeat Windows zip file from the [Download]({elasticLink}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the {directoryName} directory to `Functionbeat`.\n\
@@ -75,7 +75,7 @@ export const createFunctionbeatInstructions = (context?: TutorialContext) => ({
           values: {
             directoryName: '`functionbeat-{config.kibana.version}-windows`',
             folderPath: '`C:\\Program Files`',
-            functionbeatLink: '{config.docs.beats.functionbeat}/functionbeat-getting-started.html',
+            functionbeatLink: '{config.docs.beats.functionbeat}/functionbeat-installation-configuration.html',
             elasticLink: 'https://www.elastic.co/downloads/beats/functionbeat',
           },
         }

--- a/src/plugins/home/server/tutorials/instructions/heartbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/heartbeat_instructions.ts
@@ -31,8 +31,8 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Heartbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.heartbeatInstructions.install.osxTextPre', {
-        defaultMessage: 'First time using Heartbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.heartbeat}/heartbeat-getting-started.html' },
+        defaultMessage: 'First time using Heartbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
@@ -45,8 +45,8 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Heartbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.heartbeatInstructions.install.debTextPre', {
-        defaultMessage: 'First time using Heartbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.heartbeat}/heartbeat-getting-started.html' },
+        defaultMessage: 'First time using Heartbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{config.kibana.version}-amd64.deb',
@@ -62,8 +62,8 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Heartbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.heartbeatInstructions.install.rpmTextPre', {
-        defaultMessage: 'First time using Heartbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.heartbeat}/heartbeat-getting-started.html' },
+        defaultMessage: 'First time using Heartbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{config.kibana.version}-x86_64.rpm',
@@ -82,7 +82,7 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
         'home.tutorials.common.heartbeatInstructions.install.windowsTextPre',
         {
           defaultMessage:
-            'First time using Heartbeat? See the [Getting Started Guide]({heartbeatLink}).\n\
+            'First time using Heartbeat? See the [Quick Start]({heartbeatLink}).\n\
  1. Download the Heartbeat Windows zip file from the [Download]({elasticLink}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the {directoryName} directory to `Heartbeat`.\n\
@@ -92,7 +92,7 @@ export const createHeartbeatInstructions = (context?: TutorialContext) => ({
           values: {
             directoryName: '`heartbeat-{config.kibana.version}-windows`',
             folderPath: '`C:\\Program Files`',
-            heartbeatLink: '{config.docs.beats.heartbeat}/heartbeat-getting-started.html',
+            heartbeatLink: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html',
             elasticLink: 'https://www.elastic.co/downloads/beats/heartbeat',
           },
         }
@@ -357,7 +357,7 @@ export function heartbeatEnableInstructionsOnPrem() {
         'Where {hostTemplate} is your monitored URL, For more details on how to configure Monitors in \
       Heartbeat, read the [Heartbeat configuration docs.]({configureLink})',
       values: {
-        configureLink: '{config.docs.beats.heartbeat}/heartbeat-configuration.html',
+        configureLink: '{config.docs.beats.heartbeat}/configuring-howto-heartbeat.html',
         hostTemplate: '`<http://localhost:9200>`',
       },
     }
@@ -428,7 +428,7 @@ export function heartbeatEnableInstructionsCloud() {
     {
       defaultMessage:
         'For more details on how to configure Monitors in Heartbeat, read the [Heartbeat configuration docs.]({configureLink})',
-      values: { configureLink: '{config.docs.beats.heartbeat}/heartbeat-configuration.html' },
+      values: { configureLink: '{config.docs.beats.heartbeat}/configuring-howto-heartbeat.html' },
     }
   );
   return {

--- a/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
@@ -31,8 +31,8 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Metricbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.install.osxTextPre', {
-        defaultMessage: 'First time using Metricbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.metricbeat}/metricbeat-getting-started.html' },
+        defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
@@ -45,8 +45,8 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Metricbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.install.debTextPre', {
-        defaultMessage: 'First time using Metricbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.metricbeat}/metricbeat-getting-started.html' },
+        defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-amd64.deb',
@@ -62,8 +62,8 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
         defaultMessage: 'Download and install Metricbeat',
       }),
       textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.install.rpmTextPre', {
-        defaultMessage: 'First time using Metricbeat? See the [Getting Started Guide]({link}).',
-        values: { link: '{config.docs.beats.metricbeat}/metricbeat-getting-started.html' },
+        defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
+        values: { link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html' },
       }),
       commands: [
         'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-x86_64.rpm',
@@ -82,7 +82,7 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
         'home.tutorials.common.metricbeatInstructions.install.windowsTextPre',
         {
           defaultMessage:
-            'First time using Metricbeat? See the [Getting Started Guide]({metricbeatLink}).\n\
+            'First time using Metricbeat? See the [Quick Start]({metricbeatLink}).\n\
  1. Download the Metricbeat Windows zip file from the [Download]({elasticLink}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the {directoryName} directory to `Metricbeat`.\n\
@@ -92,7 +92,7 @@ export const createMetricbeatInstructions = (context?: TutorialContext) => ({
           values: {
             directoryName: '`metricbeat-{config.kibana.version}-windows`',
             folderPath: '`C:\\Program Files`',
-            metricbeatLink: '{config.docs.beats.metricbeat}/metricbeat-getting-started.html',
+            metricbeatLink: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
             elasticLink: 'https://www.elastic.co/downloads/beats/metricbeat',
           },
         }

--- a/src/plugins/home/server/tutorials/instructions/winlogbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/winlogbeat_instructions.ts
@@ -34,7 +34,7 @@ export const createWinlogbeatInstructions = (context?: TutorialContext) => ({
         'home.tutorials.common.winlogbeatInstructions.install.windowsTextPre',
         {
           defaultMessage:
-            'First time using Winlogbeat? See the [Getting Started Guide]({winlogbeatLink}).\n\
+            'First time using Winlogbeat? See the [Quick Start]({winlogbeatLink}).\n\
  1. Download the Winlogbeat Windows zip file from the [Download]({elasticLink}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the {directoryName} directory to `Winlogbeat`.\n\
@@ -44,7 +44,7 @@ export const createWinlogbeatInstructions = (context?: TutorialContext) => ({
           values: {
             directoryName: '`winlogbeat-{config.kibana.version}-windows`',
             folderPath: '`C:\\Program Files`',
-            winlogbeatLink: '{config.docs.beats.winlogbeat}/winlogbeat-getting-started.html',
+            winlogbeatLink: '{config.docs.beats.winlogbeat}/winlogbeat-installation-configuration.html',
             elasticLink: 'https://www.elastic.co/downloads/beats/winlogbeat',
           },
         }

--- a/src/plugins/home/server/tutorials/uptime_monitors/index.ts
+++ b/src/plugins/home/server/tutorials/uptime_monitors/index.ts
@@ -45,7 +45,7 @@ export function uptimeMonitorsSpecProvider(context: TutorialContext): TutorialSc
         Given a list of URLs, Heartbeat asks the simple question: Are you alive? \
         [Learn more]({learnMoreLink}).',
       values: {
-        learnMoreLink: '{config.docs.beats.heartbeat}/heartbeat-getting-started.html',
+        learnMoreLink: '{config.docs.beats.heartbeat}/heartbeat-installation-configuration.html',
       },
     }),
     euiIconType: 'uptimeApp',

--- a/x-pack/plugins/monitoring/public/components/logs/reason.js
+++ b/x-pack/plugins/monitoring/public/components/logs/reason.js
@@ -24,7 +24,7 @@ export const Reason = ({ reason }) => {
         link: (
           <EuiLink
             target="_blank"
-            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation.html`}
+            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation-configuration.html`}
           >
             <FormattedMessage
               id="xpack.monitoring.logs.reason.defaultMessageLink"
@@ -48,7 +48,7 @@ export const Reason = ({ reason }) => {
           link: (
             <EuiLink
               target="_blank"
-              href={`${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation.html`}
+              href={`${ELASTIC_WEBSITE_URL}guide/en/beats/filebeat/${DOC_LINK_VERSION}/filebeat-installation-configuration.html`}
             >
               {i18n.translate('xpack.monitoring.logs.reason.noIndexPatternLink', {
                 defaultMessage: 'Filebeat',

--- a/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/apm/enable_metricbeat_instructions.js
+++ b/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/apm/enable_metricbeat_instructions.js
@@ -14,7 +14,7 @@ import { getMigrationStatusStep, getSecurityStep } from '../common_instructions'
 export function getApmInstructionsForEnablingMetricbeat(product, _meta, { esMonitoringUrl }) {
   const { ELASTIC_WEBSITE_URL, DOC_LINK_VERSION } = Legacy.shims.docLinks;
   const securitySetup = getSecurityStep(
-    `${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-configuration.html`
+    `${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/configuring-howto-metricbeat.html`
   );
 
   const installMetricbeatStep = {
@@ -28,7 +28,7 @@ export function getApmInstructionsForEnablingMetricbeat(product, _meta, { esMoni
       <EuiText>
         <p>
           <EuiLink
-            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation.html`}
+            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation-configuration.html`}
             target="_blank"
           >
             <FormattedMessage

--- a/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/beats/enable_metricbeat_instructions.js
+++ b/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/beats/enable_metricbeat_instructions.js
@@ -16,7 +16,7 @@ export function getBeatsInstructionsForEnablingMetricbeat(product, _meta, { esMo
   const { ELASTIC_WEBSITE_URL, DOC_LINK_VERSION } = Legacy.shims.docLinks;
   const beatType = product.beatType;
   const securitySetup = getSecurityStep(
-    `${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-configuration.html`
+    `${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/configuring-howto-metricbeat.html`
   );
 
   const installMetricbeatStep = {
@@ -33,7 +33,7 @@ export function getBeatsInstructionsForEnablingMetricbeat(product, _meta, { esMo
       <EuiText>
         <p>
           <EuiLink
-            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation.html`}
+            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation-configuration.html`}
             target="_blank"
           >
             <FormattedMessage

--- a/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/elasticsearch/enable_metricbeat_instructions.js
+++ b/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/elasticsearch/enable_metricbeat_instructions.js
@@ -32,7 +32,7 @@ export function getElasticsearchInstructionsForEnablingMetricbeat(
       <EuiText>
         <p>
           <EuiLink
-            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation.html`}
+            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation-configuration.html`}
             target="_blank"
           >
             <FormattedMessage

--- a/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/kibana/enable_metricbeat_instructions.js
+++ b/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/kibana/enable_metricbeat_instructions.js
@@ -28,7 +28,7 @@ export function getKibanaInstructionsForEnablingMetricbeat(product, _meta, { esM
       <EuiText>
         <p>
           <EuiLink
-            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation.html`}
+            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation-configuration.html`}
             target="_blank"
           >
             <FormattedMessage

--- a/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/logstash/enable_metricbeat_instructions.js
+++ b/x-pack/plugins/monitoring/public/components/metricbeat_migration/instruction_steps/logstash/enable_metricbeat_instructions.js
@@ -28,7 +28,7 @@ export function getLogstashInstructionsForEnablingMetricbeat(product, _meta, { e
       <EuiText>
         <p>
           <EuiLink
-            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation.html`}
+            href={`${ELASTIC_WEBSITE_URL}guide/en/beats/metricbeat/${DOC_LINK_VERSION}/metricbeat-installation-configuration.html`}
             target="_blank"
           >
             <FormattedMessage


### PR DESCRIPTION
## Summary

Replaced by https://github.com/elastic/kibana/pull/70380.

Starting in 7.9, the Beats getting started guides are refactored and reduced to a single page. This PR updates all Kibana links that point to the Beats getting started guides.

Follow-up to https://github.com/elastic/beats/pull/19302.
