### PR TITLE
[SIEM] Reenabling Cypress tests

### DIFF
--- a/test/scripts/jenkins_security_solution_cypress.sh
+++ b/test/scripts/jenkins_security_solution_cypress.sh
@@ -11,16 +11,11 @@ export KIBANA_INSTALL_DIR="$destDir"
 echo " -> Running security solution cypress tests"
 cd "$XPACK_DIR"
 
-# Failures across multiple suites, skipping all
-# https://github.com/elastic/kibana/issues/69847
-# https://github.com/elastic/kibana/issues/69848
-# https://github.com/elastic/kibana/issues/69849
-
-# checks-reporter-with-killswitch "Security solution Cypress Tests" \
-#   node scripts/functional_tests \
-#     --debug --bail \
-#     --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-#     --config test/security_solution_cypress/config.ts
+checks-reporter-with-killswitch "Security solution Cypress Tests" \
+ node scripts/functional_tests \
+   --debug --bail \
+   --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+   --config test/security_solution_cypress/config.ts
 
 echo ""
 echo ""

--- a/x-pack/plugins/security_solution/cypress/integration/overview.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/overview.spec.ts
@@ -11,7 +11,7 @@ import { loginAndWaitForPage } from '../tasks/login';
 
 import { OVERVIEW_URL } from '../urls/navigation';
 
-describe('Overview Page', () => {
+describe.skip('Overview Page', () => {
   before(() => {
     cy.stubSecurityApi('overview');
     loginAndWaitForPage(OVERVIEW_URL);

--- a/x-pack/plugins/security_solution/cypress/integration/search_bar.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/search_bar.spec.ts
@@ -12,7 +12,7 @@ import { hostIpFilter } from '../objects/filter';
 import { HOSTS_URL } from '../urls/navigation';
 import { waitForAllHostsToBeLoaded } from '../tasks/hosts/all_hosts';
 
-describe('SearchBar', () => {
+describe.skip('SearchBar', () => {
   before(() => {
     loginAndWaitForPage(HOSTS_URL);
     waitForAllHostsToBeLoaded();

--- a/x-pack/plugins/security_solution/cypress/integration/url_state.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/url_state.spec.ts
@@ -234,7 +234,7 @@ describe('url state', () => {
     cy.get(KQL_INPUT).should('have.attr', 'value', 'source.ip: "10.142.0.9"');
   });
 
-  it('sets and reads the url state for timeline by id', () => {
+  it.skip('sets and reads the url state for timeline by id', () => {
     loginAndWaitForPage(HOSTS_URL);
     openTimeline();
     executeTimelineKQL('host.name: *');


### PR DESCRIPTION
Reenabling Cypress tests.

Skips:
- Overview Page
- Search Bar
- Sets and reads the url state for timeline by id'