### PR TITLE
Remove the base package from the default packages

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/epm.ts
@@ -253,7 +253,6 @@ export enum IngestAssetType {
 }
 
 export enum DefaultPackages {
-  base = 'base',
   system = 'system',
   endpoint = 'endpoint',
 }


### PR DESCRIPTION
As the base assets will be shipped by ES directly, the base package is not needed anymore. https://github.com/elastic/elasticsearch/pull/57629

In the future we might reintroduce it to update the installed assets.