### PR TITLE
[RUM Dashboard] Update rum title to be consistent with APM

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Home/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Home/index.tsx
@@ -27,7 +27,6 @@ import { ServiceOverview } from '../ServiceOverview';
 import { TraceOverview } from '../TraceOverview';
 import { RumOverview } from '../RumDashboard';
 import { RumOverviewLink } from '../../shared/Links/apm/RumOverviewLink';
-import { I18LABELS } from '../RumDashboard/translations';
 
 function getHomeTabs({
   serviceMapEnabled = true,
@@ -109,11 +108,7 @@ export function Home({ tab }: Props) {
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiTitle size="l">
-              <h1>
-                {selectedTab.name === 'rum-overview'
-                  ? I18LABELS.endUserExperience
-                  : 'APM'}
-              </h1>
+              <h1>APM</h1>
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/RumDashboard.tsx
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/RumDashboard.tsx
@@ -16,50 +16,33 @@ import { ClientMetrics } from './ClientMetrics';
 import { PageViewsTrend } from './PageViewsTrend';
 import { PageLoadDistribution } from './PageLoadDistribution';
 import { I18LABELS } from './translations';
-import { useUrlParams } from '../../../hooks/useUrlParams';
 
 export function RumDashboard() {
-  const { urlParams } = useUrlParams();
-
-  const { environment } = urlParams;
-
-  let environmentLabel = environment || 'all environments';
-
-  if (environment === 'ENVIRONMENT_NOT_DEFINED') {
-    environmentLabel = 'undefined environment';
-  }
-
   return (
-    <>
-      <EuiTitle>
-        <h2>{I18LABELS.getWhatIsGoingOn(environmentLabel)}</h2>
-      </EuiTitle>
-      <EuiSpacer />
-      <EuiFlexGroup direction="column" gutterSize="s">
-        <EuiFlexItem>
-          <EuiPanel>
-            <EuiFlexGroup justifyContent="spaceBetween">
-              <EuiFlexItem grow={1} data-cy={`client-metrics`}>
-                <EuiTitle size="xs">
-                  <h3>{I18LABELS.pageLoadTimes}</h3>
-                </EuiTitle>
-                <EuiSpacer size="s" />
-                <ClientMetrics />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPanel>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiPanel>
-            <EuiFlexGroup justifyContent="spaceBetween">
-              <EuiFlexItem grow={3}>
-                <PageLoadDistribution />
-                <PageViewsTrend />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPanel>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexItem>
+        <EuiPanel>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={1} data-cy={`client-metrics`}>
+              <EuiTitle size="xs">
+                <h3>{I18LABELS.pageLoadTimes}</h3>
+              </EuiTitle>
+              <EuiSpacer size="s" />
+              <ClientMetrics />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiPanel>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={3}>
+              <PageLoadDistribution />
+              <PageViewsTrend />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/RumDashboard/translations.ts
+++ b/x-pack/plugins/apm/public/components/app/RumDashboard/translations.ts
@@ -7,14 +7,6 @@
 import { i18n } from '@kbn/i18n';
 
 export const I18LABELS = {
-  endUserExperience: i18n.translate('xpack.apm.rum.dashboard.title', {
-    defaultMessage: 'End User Experience',
-  }),
-  getWhatIsGoingOn: (environmentVal: string) =>
-    i18n.translate('xpack.apm.rum.dashboard.environment.title', {
-      defaultMessage: `What's going on in {environmentVal}?`,
-      values: { environmentVal },
-    }),
   backEnd: i18n.translate('xpack.apm.rum.dashboard.backend', {
     defaultMessage: 'Backend',
   }),


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/70292

Removed setting rum title to keep it APM, also removed a label 'What's going on in environment' to keep it consistent with other APM tabs, also it looks awkward since most users doesn't set environment value. so it will say undefined environment. 
