### PR TITLE
Reduce SavedObjects mappings for Application Usage

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/application_usage/saved_objects_types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/application_usage/saved_objects_types.ts
@@ -35,10 +35,12 @@ export function registerMappings(registerType: SavedObjectsServiceSetup['registe
     hidden: false,
     namespaceType: 'agnostic',
     mappings: {
+      dynamic: false,
       properties: {
-        appId: { type: 'keyword' },
-        numberOfClicks: { type: 'long' },
-        minutesOnScreen: { type: 'float' },
+        // Disabled the mapping of these fields since they are not searched and we need to reduce the amount of indexed fields (#43673)
+        // appId: { type: 'keyword' },
+        // numberOfClicks: { type: 'long' },
+        // minutesOnScreen: { type: 'float' },
       },
     },
   });
@@ -48,11 +50,13 @@ export function registerMappings(registerType: SavedObjectsServiceSetup['registe
     hidden: false,
     namespaceType: 'agnostic',
     mappings: {
+      dynamic: false,
       properties: {
         timestamp: { type: 'date' },
-        appId: { type: 'keyword' },
-        numberOfClicks: { type: 'long' },
-        minutesOnScreen: { type: 'float' },
+        // Disabled the mapping of these fields since they are not searched and we need to reduce the amount of indexed fields (#43673)
+        // appId: { type: 'keyword' },
+        // numberOfClicks: { type: 'long' },
+        // minutesOnScreen: { type: 'float' },
       },
     },
   });


### PR DESCRIPTION
## Summary

Remove from the SavedObject mappings the fields that are not used for search/aggregations in Application Usage to help reduce the number of fields in the `.kibana` indices (#43673).

I've manually tested the collection itself + rollups and it keeps working.

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
