### PR TITLE
[EPM] Use higher priority than default templates

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`tests loading base.yml: base.yml 1`] = `
 {
-  "priority": 1,
+  "priority": 200,
   "index_patterns": [
     "foo-*"
   ],
@@ -105,7 +105,7 @@ exports[`tests loading base.yml: base.yml 1`] = `
 
 exports[`tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
 {
-  "priority": 1,
+  "priority": 200,
   "index_patterns": [
     "foo-*"
   ],
@@ -208,7 +208,7 @@ exports[`tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
 
 exports[`tests loading system.yml: system.yml 1`] = `
 {
-  "priority": 1,
+  "priority": 200,
   "index_patterns": [
     "whatsthis-*"
   ],

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -247,8 +247,11 @@ function getBaseTemplate(
   packageName: string
 ): IndexTemplate {
   return {
-    // This takes precedence over all index templates installed with the 'base' package
-    priority: 1,
+    // This takes precedence over all index templates installed by ES by default (logs-*-* and metrics-*-*)
+    // if this number is lower than the ES value (which is 100) this template will never be applied when a data stream
+    // is created. I'm using 200 here to give some room for users to create their own template and fit it between the
+    // default and the one the ingest manager uses.
+    priority: 200,
     // To be completed with the correct index patterns
     index_patterns: [`${templateName}-*`],
     template: {


### PR DESCRIPTION
## Summary

This PR sets the templates that the ingest manager creates to be higher priority than the default ES `logs` and `metrics` templates (`100`)

https://github.com/elastic/elasticsearch/pull/57629#discussion_r449225186

![image](https://user-images.githubusercontent.com/56361221/86402580-10140180-bc7a-11ea-8c85-d3c29831c6c4.png)
