### PR TITLE
[Ingest Manager] Update registry URL to point to snapshot registry

### DIFF
--- a/x-pack/plugins/ingest_manager/common/constants/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/constants/epm.ts
@@ -6,5 +6,5 @@
 
 export const PACKAGES_SAVED_OBJECT_TYPE = 'epm-packages';
 export const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
-export const DEFAULT_REGISTRY_URL = 'https://epr.elastic.co';
+export const DEFAULT_REGISTRY_URL = 'https://epr-snapshot.ea-web.elastic.dev';
 export const INDEX_PATTERN_PLACEHOLDER_SUFFIX = '-index_pattern_placeholder';


### PR DESCRIPTION
With https://github.com/elastic/package-storage/issues/86 we have now 3 registries available: production, staging, snapshot. Our current master snapshot build should point to the snapshot registry. The 7.x and 7.8 branch both should point to the production registry. It means, if someone runs the master snapshot builds, he always has the most recent packages available.

This also ensures, we don't accidentally ship with the production registry. The only time we need to be careful, is when we will branch of 8.x from master. At this stage, we need to switch over the registry in 8.x to prod again.

The registry URL used is: https://epr-snapshot.ea-web.elastic.dev The reasons is that the CDN URL is not deployed yet. As soon as the CDN is available, we should switch it over to : https://epr-snapshot.elastic.co The reason I'm already switching over is to make sure we can use the snapshot branch as soon as possible.
