### PR TITLE
[Ingest Manager] Fix agent version check to work with SNAPSHOT versions

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/agents/enroll.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/enroll.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { validateAgentVersion } from './enroll';
+import { appContextService } from '../app_context';
+import { IngestManagerAppContext } from '../../plugin';
+
+describe('validateAgentVersion', () => {
+  it('should throw with agent > kibana version', () => {
+    appContextService.start(({
+      kibanaVersion: '8.0.0',
+    } as unknown) as IngestManagerAppContext);
+    expect(() =>
+      validateAgentVersion({
+        local: { elastic: { agent: { version: '8.8.0' } } },
+        userProvided: {},
+      })
+    ).toThrowError(/Agent version is not compatible with kibana version/);
+  });
+  it('should work with agent < kibana version', () => {
+    appContextService.start(({
+      kibanaVersion: '8.0.0',
+    } as unknown) as IngestManagerAppContext);
+    validateAgentVersion({ local: { elastic: { agent: { version: '7.8.0' } } }, userProvided: {} });
+  });
+
+  it('should work with agent = kibana version', () => {
+    appContextService.start(({
+      kibanaVersion: '8.0.0',
+    } as unknown) as IngestManagerAppContext);
+    validateAgentVersion({ local: { elastic: { agent: { version: '8.0.0' } } }, userProvided: {} });
+  });
+
+  it('should work with SNAPSHOT version', () => {
+    appContextService.start(({
+      kibanaVersion: '8.0.0-SNAPSHOT',
+    } as unknown) as IngestManagerAppContext);
+    validateAgentVersion({
+      local: { elastic: { agent: { version: '8.0.0-SNAPSHOT' } } },
+      userProvided: {},
+    });
+  });
+
+  it('should work with a agent using SNAPSHOT version', () => {
+    appContextService.start(({
+      kibanaVersion: '7.8.0',
+    } as unknown) as IngestManagerAppContext);
+    validateAgentVersion({
+      local: { elastic: { agent: { version: '7.8.0-SNAPSHOT' } } },
+      userProvided: {},
+    });
+  });
+
+  it('should work with a kibana using SNAPSHOT version', () => {
+    appContextService.start(({
+      kibanaVersion: '7.8.0-SNAPSHOT',
+    } as unknown) as IngestManagerAppContext);
+    validateAgentVersion({
+      local: { elastic: { agent: { version: '7.8.0' } } },
+      userProvided: {},
+    });
+  });
+});

--- a/x-pack/plugins/ingest_manager/server/services/agents/enroll.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/enroll.ts
@@ -90,9 +90,7 @@ async function getAgentBySharedId(soClient: SavedObjectsClientContract, sharedId
 }
 
 export function validateAgentVersion(metadata?: { local: any; userProvided: any }) {
-  const kibanaVersion = semver.parse(appContextService.getKibanaVersion(), {
-    includePrerelease: true,
-  });
+  const kibanaVersion = semver.parse(appContextService.getKibanaVersion());
   if (!kibanaVersion) {
     throw Boom.badRequest('Kibana version is not set');
   }

--- a/x-pack/plugins/ingest_manager/server/services/agents/enroll.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/enroll.ts
@@ -20,11 +20,7 @@ export async function enroll(
   metadata?: { local: any; userProvided: any },
   sharedId?: string
 ): Promise<Agent> {
-  const kibanaVersion = appContextService.getKibanaVersion();
-  const version: string | undefined = metadata?.local?.elastic?.agent?.version;
-  if (!version || semver.compare(version, kibanaVersion) === 1) {
-    throw Boom.badRequest('Agent version is not compatible with kibana version');
-  }
+  validateAgentVersion(metadata);
 
   const existingAgent = sharedId ? await getAgentBySharedId(soClient, sharedId) : null;
 
@@ -91,4 +87,28 @@ async function getAgentBySharedId(soClient: SavedObjectsClientContract, sharedId
   }
 
   return null;
+}
+
+export function validateAgentVersion(metadata?: { local: any; userProvided: any }) {
+  const kibanaVersion = semver.parse(appContextService.getKibanaVersion(), {
+    includePrerelease: true,
+  });
+  if (!kibanaVersion) {
+    throw Boom.badRequest('Kibana version is not set');
+  }
+  const version = semver.parse(metadata?.local?.elastic?.agent?.version);
+  if (!version) {
+    throw Boom.badRequest('Agent version not provided in metadata.');
+  }
+
+  if (!version || !semver.lte(formatVersion(version), formatVersion(kibanaVersion))) {
+    throw Boom.badRequest('Agent version is not compatible with kibana version');
+  }
+}
+
+/**
+ * used to remove prelease from version as includePrerelease in not working as expected
+ */
+function formatVersion(version: semver.SemVer) {
+  return `${version.major}.${version.minor}.${version.patch}`;
 }


### PR DESCRIPTION
## Summary

Fix a bug introduced here https://github.com/elastic/kibana/pull/70339 
Resolved https://github.com/elastic/kibana/issues/70726

During enrollment we check that the kibana version is >= to the agent version, this was not working with prerelease tag.
This PR fix that and add the tests to ensure it's working as expected.

the semver module has an option `includePrerelease: true|false`  but this seems to doesn't work as expected, so I just removed the prelease tag manually.