### PR TITLE
[Security Solution] Add hook for reading/writing resolver query params

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/store/data/action.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/action.ts
@@ -75,7 +75,7 @@ interface AppReceivedNewExternalProperties {
      * the `_id` of an ES document. This defines the origin of the Resolver graph.
      */
     databaseDocumentID?: string;
-    documentLocation: string;
+    resolverComponentInstanceID: string;
   };
 }
 

--- a/x-pack/plugins/security_solution/public/resolver/store/data/action.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/action.ts
@@ -75,6 +75,7 @@ interface AppReceivedNewExternalProperties {
      * the `_id` of an ES document. This defines the origin of the Resolver graph.
      */
     databaseDocumentID?: string;
+    documentLocation: string;
   };
 }
 

--- a/x-pack/plugins/security_solution/public/resolver/store/data/reducer.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/reducer.ts
@@ -11,7 +11,7 @@ import { ResolverAction } from '../actions';
 const initialState: DataState = {
   relatedEvents: new Map(),
   relatedEventsReady: new Map(),
-  documentLocation: '',
+  resolverComponentInstanceID: '',
 };
 
 export const dataReducer: Reducer<DataState, ResolverAction> = (state = initialState, action) => {
@@ -19,7 +19,7 @@ export const dataReducer: Reducer<DataState, ResolverAction> = (state = initialS
     const nextState: DataState = {
       ...state,
       databaseDocumentID: action.payload.databaseDocumentID,
-      documentLocation: action.payload.documentLocation,
+      resolverComponentInstanceID: action.payload.resolverComponentInstanceID,
     };
     return nextState;
   } else if (action.type === 'appRequestedResolverData') {

--- a/x-pack/plugins/security_solution/public/resolver/store/data/reducer.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/reducer.ts
@@ -11,7 +11,7 @@ import { ResolverAction } from '../actions';
 const initialState: DataState = {
   relatedEvents: new Map(),
   relatedEventsReady: new Map(),
-  resolverComponentInstanceID: '',
+  resolverComponentInstanceID: undefined,
 };
 
 export const dataReducer: Reducer<DataState, ResolverAction> = (state = initialState, action) => {

--- a/x-pack/plugins/security_solution/public/resolver/store/data/reducer.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/reducer.ts
@@ -11,6 +11,7 @@ import { ResolverAction } from '../actions';
 const initialState: DataState = {
   relatedEvents: new Map(),
   relatedEventsReady: new Map(),
+  documentLocation: '',
 };
 
 export const dataReducer: Reducer<DataState, ResolverAction> = (state = initialState, action) => {
@@ -18,6 +19,7 @@ export const dataReducer: Reducer<DataState, ResolverAction> = (state = initialS
     const nextState: DataState = {
       ...state,
       databaseDocumentID: action.payload.databaseDocumentID,
+      documentLocation: action.payload.documentLocation,
     };
     return nextState;
   } else if (action.type === 'appRequestedResolverData') {

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
@@ -193,13 +193,10 @@ describe('data state', () => {
       expect(selectors.isLoading(state())).toBe(true);
     });
     it('should need to fetch the second databaseDocumentID', () => {
-      expect(selectors.databaseDocumentIDToFetch(state())).toBe(firstDatabaseDocumentID);
+      expect(selectors.databaseDocumentIDToFetch(state())).toBe(secondDatabaseDocumentID);
     });
     it('should need to abort the request for the databaseDocumentID', () => {
       expect(selectors.databaseDocumentIDToFetch(state())).toBe(secondDatabaseDocumentID);
-    });
-    it('should use the correct location for the first resolver', () => {
-      expect(selectors.resolverComponentInstanceID(state())).toBe(resolverComponentInstanceID1);
     });
     it('should use the correct location for the second resolver', () => {
       expect(selectors.resolverComponentInstanceID(state())).toBe(resolverComponentInstanceID2);

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
@@ -53,11 +53,12 @@ describe('data state', () => {
 
   describe('when there is a databaseDocumentID but no pending request', () => {
     const databaseDocumentID = 'databaseDocumentID';
+    const documentLocation = 'location';
     beforeEach(() => {
       actions = [
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID },
+          payload: { databaseDocumentID, documentLocation },
         },
       ];
     });
@@ -104,11 +105,12 @@ describe('data state', () => {
   });
   describe('when there is a pending request for the current databaseDocumentID', () => {
     const databaseDocumentID = 'databaseDocumentID';
+    const documentLocation = 'location';
     beforeEach(() => {
       actions = [
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID },
+          payload: { databaseDocumentID, documentLocation },
         },
         {
           type: 'appRequestedResolverData',
@@ -160,12 +162,14 @@ describe('data state', () => {
   describe('when there is a pending request for a different databaseDocumentID than the current one', () => {
     const firstDatabaseDocumentID = 'first databaseDocumentID';
     const secondDatabaseDocumentID = 'second databaseDocumentID';
+    const firstLocation = 'firstLocation';
+    const secondLocation = 'secondLocation';
     beforeEach(() => {
       actions = [
         // receive the document ID, this would cause the middleware to starts the request
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID: firstDatabaseDocumentID },
+          payload: { databaseDocumentID: firstDatabaseDocumentID, documentLocation: firstLocation },
         },
         // this happens when the middleware starts the request
         {
@@ -175,7 +179,10 @@ describe('data state', () => {
         // receive a different databaseDocumentID. this should cause the middleware to abort the existing request and start a new one
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID: secondDatabaseDocumentID },
+          payload: {
+            databaseDocumentID: secondDatabaseDocumentID,
+            documentLocation: secondLocation,
+          },
         },
       ];
     });
@@ -187,6 +194,12 @@ describe('data state', () => {
     });
     it('should need to abort the request for the databaseDocumentID', () => {
       expect(selectors.databaseDocumentIDToFetch(state())).toBe(secondDatabaseDocumentID);
+    });
+    it('should use the correct location for the first resolver', () => {
+      expect(selectors.documentLocation(state())).toBe(firstLocation);
+    });
+    it('should use the correct location for the second resolver', () => {
+      expect(selectors.documentLocation(state())).toBe(secondLocation);
     });
     it('should not have an error, more children, or more ancestors.', () => {
       expect(viewAsAString(state())).toMatchInlineSnapshot(`

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
@@ -193,7 +193,7 @@ describe('data state', () => {
       expect(selectors.isLoading(state())).toBe(true);
     });
     it('should need to fetch the second databaseDocumentID', () => {
-      expect(selectors.databaseDocumentIDToFetch(state())).toBe(secondDatabaseDocumentID);
+      expect(selectors.databaseDocumentIDToFetch(state())).toBe(firstDatabaseDocumentID);
     });
     it('should need to abort the request for the databaseDocumentID', () => {
       expect(selectors.databaseDocumentIDToFetch(state())).toBe(secondDatabaseDocumentID);

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.test.ts
@@ -53,12 +53,12 @@ describe('data state', () => {
 
   describe('when there is a databaseDocumentID but no pending request', () => {
     const databaseDocumentID = 'databaseDocumentID';
-    const documentLocation = 'location';
+    const resolverComponentInstanceID = 'resolverComponentInstanceID';
     beforeEach(() => {
       actions = [
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID, documentLocation },
+          payload: { databaseDocumentID, resolverComponentInstanceID },
         },
       ];
     });
@@ -105,12 +105,12 @@ describe('data state', () => {
   });
   describe('when there is a pending request for the current databaseDocumentID', () => {
     const databaseDocumentID = 'databaseDocumentID';
-    const documentLocation = 'location';
+    const resolverComponentInstanceID = 'resolverComponentInstanceID';
     beforeEach(() => {
       actions = [
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID, documentLocation },
+          payload: { databaseDocumentID, resolverComponentInstanceID },
         },
         {
           type: 'appRequestedResolverData',
@@ -162,14 +162,17 @@ describe('data state', () => {
   describe('when there is a pending request for a different databaseDocumentID than the current one', () => {
     const firstDatabaseDocumentID = 'first databaseDocumentID';
     const secondDatabaseDocumentID = 'second databaseDocumentID';
-    const firstLocation = 'firstLocation';
-    const secondLocation = 'secondLocation';
+    const resolverComponentInstanceID1 = 'resolverComponentInstanceID1';
+    const resolverComponentInstanceID2 = 'resolverComponentInstanceID2';
     beforeEach(() => {
       actions = [
         // receive the document ID, this would cause the middleware to starts the request
         {
           type: 'appReceivedNewExternalProperties',
-          payload: { databaseDocumentID: firstDatabaseDocumentID, documentLocation: firstLocation },
+          payload: {
+            databaseDocumentID: firstDatabaseDocumentID,
+            resolverComponentInstanceID: resolverComponentInstanceID1,
+          },
         },
         // this happens when the middleware starts the request
         {
@@ -181,7 +184,7 @@ describe('data state', () => {
           type: 'appReceivedNewExternalProperties',
           payload: {
             databaseDocumentID: secondDatabaseDocumentID,
-            documentLocation: secondLocation,
+            resolverComponentInstanceID: resolverComponentInstanceID2,
           },
         },
       ];
@@ -196,10 +199,10 @@ describe('data state', () => {
       expect(selectors.databaseDocumentIDToFetch(state())).toBe(secondDatabaseDocumentID);
     });
     it('should use the correct location for the first resolver', () => {
-      expect(selectors.documentLocation(state())).toBe(firstLocation);
+      expect(selectors.resolverComponentInstanceID(state())).toBe(resolverComponentInstanceID1);
     });
     it('should use the correct location for the second resolver', () => {
-      expect(selectors.documentLocation(state())).toBe(secondLocation);
+      expect(selectors.resolverComponentInstanceID(state())).toBe(resolverComponentInstanceID2);
     });
     it('should not have an error, more children, or more ancestors.', () => {
       expect(viewAsAString(state())).toMatchInlineSnapshot(`

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.ts
@@ -40,6 +40,10 @@ export function isLoading(state: DataState): boolean {
   return state.pendingRequestDatabaseDocumentID !== undefined;
 }
 
+export function documentLocation(state: DataState): string {
+  return state.documentLocation;
+}
+
 /**
  * If a request was made and it threw an error or returned a failure response code.
  */

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.ts
@@ -44,7 +44,7 @@ export function isLoading(state: DataState): boolean {
  * A string for uniquely identifying the instance of resolver within the app.
  */
 export function resolverComponentInstanceID(state: DataState): string {
-  return state.resolverComponentInstanceID;
+  return state.resolverComponentInstanceID ? state.resolverComponentInstanceID : '';
 }
 
 /**

--- a/x-pack/plugins/security_solution/public/resolver/store/data/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/data/selectors.ts
@@ -40,8 +40,11 @@ export function isLoading(state: DataState): boolean {
   return state.pendingRequestDatabaseDocumentID !== undefined;
 }
 
-export function documentLocation(state: DataState): string {
-  return state.documentLocation;
+/**
+ * A string for uniquely identifying the instance of resolver within the app.
+ */
+export function resolverComponentInstanceID(state: DataState): string {
+  return state.resolverComponentInstanceID;
 }
 
 /**

--- a/x-pack/plugins/security_solution/public/resolver/store/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/selectors.ts
@@ -69,7 +69,10 @@ export const databaseDocumentIDToAbort = composeSelectors(
   dataSelectors.databaseDocumentIDToAbort
 );
 
-export const documentLocation = composeSelectors(dataStateSelector, dataSelectors.documentLocation);
+export const resolverComponentInstanceID = composeSelectors(
+  dataStateSelector,
+  dataSelectors.resolverComponentInstanceID
+);
 
 export const processAdjacencies = composeSelectors(
   dataStateSelector,

--- a/x-pack/plugins/security_solution/public/resolver/store/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/selectors.ts
@@ -69,6 +69,8 @@ export const databaseDocumentIDToAbort = composeSelectors(
   dataSelectors.databaseDocumentIDToAbort
 );
 
+export const documentLocation = composeSelectors(dataStateSelector, dataSelectors.documentLocation);
+
 export const processAdjacencies = composeSelectors(
   dataStateSelector,
   dataSelectors.processAdjacencies

--- a/x-pack/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/plugins/security_solution/public/resolver/types.ts
@@ -177,7 +177,7 @@ export interface DataState {
    * The id used for the pending request, if there is one.
    */
   readonly pendingRequestDatabaseDocumentID?: string;
-  readonly documentLocation: string;
+  readonly resolverComponentInstanceID: string;
 
   /**
    * The parameters and response from the last successful request.

--- a/x-pack/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/plugins/security_solution/public/resolver/types.ts
@@ -177,7 +177,7 @@ export interface DataState {
    * The id used for the pending request, if there is one.
    */
   readonly pendingRequestDatabaseDocumentID?: string;
-  readonly resolverComponentInstanceID: string;
+  readonly resolverComponentInstanceID: string | undefined;
 
   /**
    * The parameters and response from the last successful request.

--- a/x-pack/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/plugins/security_solution/public/resolver/types.ts
@@ -177,6 +177,7 @@ export interface DataState {
    * The id used for the pending request, if there is one.
    */
   readonly pendingRequestDatabaseDocumentID?: string;
+  readonly documentLocation: string;
 
   /**
    * The parameters and response from the last successful request.

--- a/x-pack/plugins/security_solution/public/resolver/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/index.tsx
@@ -18,6 +18,7 @@ import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 export const Resolver = React.memo(function ({
   className,
   databaseDocumentID,
+  documentLocation,
 }: {
   /**
    * Used by `styled-components`.
@@ -28,6 +29,11 @@ export const Resolver = React.memo(function ({
    * Used as the origin of the Resolver graph.
    */
   databaseDocumentID?: string;
+  /**
+   * A string literal describing where in the app resolver is located,
+   * used to prevent collisions in things like query params
+   */
+  documentLocation: string;
 }) {
   const context = useKibana<StartServices>();
   const store = useMemo(() => {
@@ -40,7 +46,11 @@ export const Resolver = React.memo(function ({
    */
   return (
     <Provider store={store}>
-      <ResolverMap className={className} databaseDocumentID={databaseDocumentID} />
+      <ResolverMap
+        className={className}
+        databaseDocumentID={databaseDocumentID}
+        documentLocation={documentLocation}
+      />
     </Provider>
   );
 });

--- a/x-pack/plugins/security_solution/public/resolver/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/index.tsx
@@ -18,7 +18,7 @@ import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 export const Resolver = React.memo(function ({
   className,
   databaseDocumentID,
-  documentLocation,
+  resolverComponentInstanceID,
 }: {
   /**
    * Used by `styled-components`.
@@ -33,7 +33,7 @@ export const Resolver = React.memo(function ({
    * A string literal describing where in the app resolver is located,
    * used to prevent collisions in things like query params
    */
-  documentLocation: string;
+  resolverComponentInstanceID: string;
 }) {
   const context = useKibana<StartServices>();
   const store = useMemo(() => {
@@ -49,7 +49,7 @@ export const Resolver = React.memo(function ({
       <ResolverMap
         className={className}
         databaseDocumentID={databaseDocumentID}
-        documentLocation={documentLocation}
+        resolverComponentInstanceID={resolverComponentInstanceID}
       />
     </Provider>
   );

--- a/x-pack/plugins/security_solution/public/resolver/view/map.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/map.tsx
@@ -29,7 +29,7 @@ import { SideEffectContext } from './side_effect_context';
 export const ResolverMap = React.memo(function ({
   className,
   databaseDocumentID,
-  documentLocation,
+  resolverComponentInstanceID,
 }: {
   /**
    * Used by `styled-components`.
@@ -44,13 +44,13 @@ export const ResolverMap = React.memo(function ({
    * A string literal describing where in the app resolver is located,
    * used to prevent collisions in things like query params
    */
-  documentLocation: string;
+  resolverComponentInstanceID: string;
 }) {
   /**
    * This is responsible for dispatching actions that include any external data.
    * `databaseDocumentID`
    */
-  useStateSyncingActions({ databaseDocumentID, documentLocation });
+  useStateSyncingActions({ databaseDocumentID, resolverComponentInstanceID });
 
   const { timestamp } = useContext(SideEffectContext);
   const { processNodePositions, connectingEdgeLineSegments } = useSelector(

--- a/x-pack/plugins/security_solution/public/resolver/view/map.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/map.tsx
@@ -29,6 +29,7 @@ import { SideEffectContext } from './side_effect_context';
 export const ResolverMap = React.memo(function ({
   className,
   databaseDocumentID,
+  documentLocation,
 }: {
   /**
    * Used by `styled-components`.
@@ -39,6 +40,7 @@ export const ResolverMap = React.memo(function ({
    * Used as the origin of the Resolver graph.
    */
   databaseDocumentID?: string;
+  documentLocation: string;
 }) {
   /**
    * This is responsible for dispatching actions that include any external data.
@@ -111,13 +113,14 @@ export const ResolverMap = React.memo(function ({
                   relatedEventsStats ? relatedEventsStats.get(entityId(processEvent)) : undefined
                 }
                 isProcessTerminated={terminatedProcesses.has(processEntityId)}
+                documentLocation={documentLocation}
                 isProcessOrigin={false}
               />
             );
           })}
         </GraphContainer>
       )}
-      <StyledPanel />
+      <StyledPanel documentLocation={documentLocation} />
       <GraphControls />
       <SymbolDefinitions />
     </StyledMapContainer>

--- a/x-pack/plugins/security_solution/public/resolver/view/map.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/map.tsx
@@ -40,13 +40,17 @@ export const ResolverMap = React.memo(function ({
    * Used as the origin of the Resolver graph.
    */
   databaseDocumentID?: string;
+  /**
+   * A string literal describing where in the app resolver is located,
+   * used to prevent collisions in things like query params
+   */
   documentLocation: string;
 }) {
   /**
    * This is responsible for dispatching actions that include any external data.
    * `databaseDocumentID`
    */
-  useStateSyncingActions({ databaseDocumentID });
+  useStateSyncingActions({ databaseDocumentID, documentLocation });
 
   const { timestamp } = useContext(SideEffectContext);
   const { processNodePositions, connectingEdgeLineSegments } = useSelector(
@@ -113,14 +117,13 @@ export const ResolverMap = React.memo(function ({
                   relatedEventsStats ? relatedEventsStats.get(entityId(processEvent)) : undefined
                 }
                 isProcessTerminated={terminatedProcesses.has(processEntityId)}
-                documentLocation={documentLocation}
                 isProcessOrigin={false}
               />
             );
           })}
         </GraphContainer>
       )}
-      <StyledPanel documentLocation={documentLocation} />
+      <StyledPanel />
       <GraphControls />
       <SymbolDefinitions />
     </StyledMapContainer>

--- a/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
@@ -35,16 +35,12 @@ import { useResolverQueryParams } from './use_resolver_query_params';
  *
  * @returns {JSX.Element} The "right" table content to show based on the query params as described above
  */
-const PanelContent = memo(function PanelContent({
-  documentLocation,
-}: {
-  documentLocation: string;
-}) {
+const PanelContent = memo(function PanelContent() {
   const dispatch = useResolverDispatch();
 
   const { timestamp } = useContext(SideEffectContext);
 
-  const { pushToQueryParams, queryParams } = useResolverQueryParams(documentLocation);
+  const { pushToQueryParams, queryParams } = useResolverQueryParams();
 
   const graphableProcesses = useSelector(selectors.graphableProcesses);
   const graphableProcessEntityIds = useMemo(() => {
@@ -238,16 +234,10 @@ const PanelContent = memo(function PanelContent({
 });
 PanelContent.displayName = 'PanelContent';
 
-export const Panel = memo(function Event({
-  className,
-  documentLocation,
-}: {
-  className?: string;
-  documentLocation: string;
-}) {
+export const Panel = memo(function Event({ className }: { className?: string }) {
   return (
     <EuiPanel className={className}>
-      <PanelContent documentLocation={documentLocation} />
+      <PanelContent />
     </EuiPanel>
   );
 });

--- a/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
@@ -4,11 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { memo, useCallback, useMemo, useContext, useLayoutEffect, useState } from 'react';
+import React, { memo, useMemo, useContext, useLayoutEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
-// eslint-disable-next-line import/no-nodejs-modules
-import querystring from 'querystring';
 import { EuiPanel } from '@elastic/eui';
 import { displayNameRecord } from './process_event_dot';
 import * as selectors from '../store/selectors';
@@ -21,7 +18,7 @@ import { EventCountsForProcess } from './panels/panel_content_related_counts';
 import { ProcessDetails } from './panels/panel_content_process_detail';
 import { ProcessListWithCounts } from './panels/panel_content_process_list';
 import { RelatedEventDetail } from './panels/panel_content_related_detail';
-import { CrumbInfo } from './panels/panel_content_utilities';
+import { useResolverQueryParams } from './use_resolver_query_params';
 
 /**
  * The team decided to use this table to determine which breadcrumbs/view to display:
@@ -38,15 +35,16 @@ import { CrumbInfo } from './panels/panel_content_utilities';
  *
  * @returns {JSX.Element} The "right" table content to show based on the query params as described above
  */
-const PanelContent = memo(function PanelContent() {
-  const history = useHistory();
-  const urlSearch = useLocation().search;
+const PanelContent = memo(function PanelContent({
+  documentLocation,
+}: {
+  documentLocation: string;
+}) {
   const dispatch = useResolverDispatch();
 
   const { timestamp } = useContext(SideEffectContext);
-  const queryParams: CrumbInfo = useMemo(() => {
-    return { crumbId: '', crumbEvent: '', ...querystring.parse(urlSearch.slice(1)) };
-  }, [urlSearch]);
+
+  const { pushToQueryParams, queryParams } = useResolverQueryParams(documentLocation);
 
   const graphableProcesses = useSelector(selectors.graphableProcesses);
   const graphableProcessEntityIds = useMemo(() => {
@@ -103,35 +101,6 @@ const PanelContent = memo(function PanelContent() {
       });
     }
   }, [dispatch, uiSelectedEvent, paramsSelectedEvent, lastUpdatedProcess, timestamp]);
-
-  /**
-   * This updates the breadcrumb nav and the panel view. It's supplied to each
-   * panel content view to allow them to dispatch transitions to each other.
-   */
-  const pushToQueryParams = useCallback(
-    (newCrumbs: CrumbInfo) => {
-      // Construct a new set of params from the current set (minus empty params)
-      // by assigning the new set of params provided in `newCrumbs`
-      const crumbsToPass = {
-        ...querystring.parse(urlSearch.slice(1)),
-        ...newCrumbs,
-      };
-
-      // If either was passed in as empty, remove it from the record
-      if (crumbsToPass.crumbId === '') {
-        delete crumbsToPass.crumbId;
-      }
-      if (crumbsToPass.crumbEvent === '') {
-        delete crumbsToPass.crumbEvent;
-      }
-
-      const relativeURL = { search: querystring.stringify(crumbsToPass) };
-      // We probably don't want to nuke the user's history with a huge
-      // trail of these, thus `.replace` instead of `.push`
-      return history.replace(relativeURL);
-    },
-    [history, urlSearch]
-  );
 
   const relatedEventStats = useSelector(selectors.relatedEventsStats);
   const { crumbId, crumbEvent } = queryParams;
@@ -269,10 +238,16 @@ const PanelContent = memo(function PanelContent() {
 });
 PanelContent.displayName = 'PanelContent';
 
-export const Panel = memo(function Event({ className }: { className?: string }) {
+export const Panel = memo(function Event({
+  className,
+  documentLocation,
+}: {
+  className?: string;
+  documentLocation: string;
+}) {
   return (
     <EuiPanel className={className}>
-      <PanelContent />
+      <PanelContent documentLocation={documentLocation} />
     </EuiPanel>
   );
 });

--- a/x-pack/plugins/security_solution/public/resolver/view/panels/panel_content_utilities.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/panel_content_utilities.tsx
@@ -27,8 +27,7 @@ const BetaHeader = styled(`header`)`
  * The two query parameters we read/write on to control which view the table presents:
  */
 export interface CrumbInfo {
-  readonly crumbId: string;
-  readonly crumbEvent: string;
+  readonly [x: string]: string;
 }
 
 const ThemedBreadcrumbs = styled(EuiBreadcrumbs)<{ background: string; text: string }>`

--- a/x-pack/plugins/security_solution/public/resolver/view/panels/panel_content_utilities.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/panel_content_utilities.tsx
@@ -27,7 +27,8 @@ const BetaHeader = styled(`header`)`
  * The two query parameters we read/write on to control which view the table presents:
  */
 export interface CrumbInfo {
-  readonly [x: string]: string;
+  crumbId: string;
+  crumbEvent: string;
 }
 
 const ThemedBreadcrumbs = styled(EuiBreadcrumbs)<{ background: string; text: string }>`

--- a/x-pack/plugins/security_solution/public/resolver/view/process_event_dot.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/process_event_dot.tsx
@@ -241,7 +241,6 @@ const UnstyledProcessEventDot = React.memo(
     isProcessTerminated,
     isProcessOrigin,
     relatedEventsStatsForProcess,
-    documentLocation,
   }: {
     /**
      * A `className` string provided by `styled`
@@ -277,7 +276,6 @@ const UnstyledProcessEventDot = React.memo(
      * Statistics for the number of related events and alerts for this process node
      */
     relatedEventsStatsForProcess?: ResolverNodeStats;
-    documentLocation: string;
   }) => {
     /**
      * Convert the position, which is in 'world' coordinates, to screen coordinates.
@@ -402,7 +400,7 @@ const UnstyledProcessEventDot = React.memo(
       });
     }, [dispatch, selfId]);
 
-    const { pushToQueryParams } = useResolverQueryParams(documentLocation);
+    const { pushToQueryParams } = useResolverQueryParams();
 
     const handleClick = useCallback(() => {
       if (animationTarget.current !== null) {

--- a/x-pack/plugins/security_solution/public/resolver/view/process_event_dot.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/process_event_dot.tsx
@@ -10,9 +10,6 @@ import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import { htmlIdGenerator, EuiButton, EuiI18nNumber, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { useHistory } from 'react-router-dom';
-// eslint-disable-next-line import/no-nodejs-modules
-import querystring from 'querystring';
 import { useSelector } from 'react-redux';
 import { NodeSubMenu, subMenuAssets } from './submenu';
 import { applyMatrix3 } from '../models/vector2';
@@ -22,7 +19,7 @@ import { ResolverEvent, ResolverNodeStats } from '../../../common/endpoint/types
 import { useResolverDispatch } from './use_resolver_dispatch';
 import * as eventModel from '../../../common/endpoint/models/event';
 import * as selectors from '../store/selectors';
-import { CrumbInfo } from './panels/panel_content_utilities';
+import { useResolverQueryParams } from './use_resolver_query_params';
 
 /**
  * A record of all known event types (in schema format) to translations
@@ -244,6 +241,7 @@ const UnstyledProcessEventDot = React.memo(
     isProcessTerminated,
     isProcessOrigin,
     relatedEventsStatsForProcess,
+    documentLocation,
   }: {
     /**
      * A `className` string provided by `styled`
@@ -279,6 +277,7 @@ const UnstyledProcessEventDot = React.memo(
      * Statistics for the number of related events and alerts for this process node
      */
     relatedEventsStatsForProcess?: ResolverNodeStats;
+    documentLocation: string;
   }) => {
     /**
      * Convert the position, which is in 'world' coordinates, to screen coordinates.
@@ -403,35 +402,7 @@ const UnstyledProcessEventDot = React.memo(
       });
     }, [dispatch, selfId]);
 
-    const history = useHistory();
-    const urlSearch = history.location.search;
-
-    /**
-     * This updates the breadcrumb nav, the table view
-     */
-    const pushToQueryParams = useCallback(
-      (newCrumbs: CrumbInfo) => {
-        // Construct a new set of params from the current set (minus empty params)
-        // by assigning the new set of params provided in `newCrumbs`
-        const crumbsToPass = {
-          ...querystring.parse(urlSearch.slice(1)),
-          ...newCrumbs,
-        };
-
-        // If either was passed in as empty, remove it from the record
-        if (crumbsToPass.crumbId === '') {
-          delete crumbsToPass.crumbId;
-        }
-        if (crumbsToPass.crumbEvent === '') {
-          delete crumbsToPass.crumbEvent;
-        }
-
-        const relativeURL = { search: querystring.stringify(crumbsToPass) };
-
-        return history.replace(relativeURL);
-      },
-      [history, urlSearch]
-    );
+    const { pushToQueryParams } = useResolverQueryParams(documentLocation);
 
     const handleClick = useCallback(() => {
       if (animationTarget.current !== null) {

--- a/x-pack/plugins/security_solution/public/resolver/view/use_resolver_query_params.ts
+++ b/x-pack/plugins/security_solution/public/resolver/view/use_resolver_query_params.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { useCallback, useMemo } from 'react';
+// eslint-disable-next-line import/no-nodejs-modules
+import querystring from 'querystring';
+import { useHistory, useLocation } from 'react-router-dom';
+import { CrumbInfo } from './panels/panel_content_utilities';
+
+export function useResolverQueryParams(documentLocation: string) {
+  /**
+   * This updates the breadcrumb nav and the panel view. It's supplied to each
+   * panel content view to allow them to dispatch transitions to each other.
+   */
+  const history = useHistory();
+  const urlSearch = useLocation().search;
+  const uniqueCrumbIdKey = `${documentLocation}CrumbId`;
+  const uniqueCrumbEventKey = `${documentLocation}CrumbEvent`;
+  const pushToQueryParams = useCallback(
+    (newCrumbs: CrumbInfo) => {
+      // Construct a new set of params from the current set (minus empty params)
+      // by assigning the new set of params provided in `newCrumbs`
+      const crumbsToPass = {
+        ...querystring.parse(urlSearch.slice(1)),
+        [uniqueCrumbIdKey]: newCrumbs.crumbId,
+        [uniqueCrumbEventKey]: newCrumbs.crumbEvent,
+      };
+
+      // If either was passed in as empty, remove it from the record
+      if (crumbsToPass.uniqueCrumbIdKey === '') {
+        delete crumbsToPass.uniqueCrumbIdKey;
+      }
+      if (crumbsToPass.uniqueCrumbEventKey === '') {
+        delete crumbsToPass.uniqueCrumbEventKey;
+      }
+
+      const relativeURL = { search: querystring.stringify(crumbsToPass) };
+      // We probably don't want to nuke the user's history with a huge
+      // trail of these, thus `.replace` instead of `.push`
+      return history.replace(relativeURL);
+    },
+    [history, urlSearch, uniqueCrumbIdKey, uniqueCrumbEventKey]
+  );
+  const queryParams: CrumbInfo = useMemo(() => {
+    const newParams = {
+      [uniqueCrumbIdKey]: '',
+      [uniqueCrumbEventKey]: '',
+      ...querystring.parse(urlSearch.slice(1)),
+    };
+    newParams.crumbId = newParams[uniqueCrumbIdKey];
+    newParams.crumbEvent = newParams[uniqueCrumbEventKey];
+    return newParams;
+  }, [urlSearch, uniqueCrumbIdKey, uniqueCrumbEventKey]);
+
+  return {
+    pushToQueryParams,
+    queryParams,
+  };
+}

--- a/x-pack/plugins/security_solution/public/resolver/view/use_resolver_query_params.ts
+++ b/x-pack/plugins/security_solution/public/resolver/view/use_resolver_query_params.ts
@@ -19,9 +19,9 @@ export function useResolverQueryParams() {
    */
   const history = useHistory();
   const urlSearch = useLocation().search;
-  const documentLocation = useSelector(selectors.documentLocation);
-  const uniqueCrumbIdKey: string = `${documentLocation}CrumbId`;
-  const uniqueCrumbEventKey: string = `${documentLocation}CrumbEvent`;
+  const resolverComponentInstanceID = useSelector(selectors.resolverComponentInstanceID);
+  const uniqueCrumbIdKey: string = `${resolverComponentInstanceID}CrumbId`;
+  const uniqueCrumbEventKey: string = `${resolverComponentInstanceID}CrumbEvent`;
   const pushToQueryParams = useCallback(
     (newCrumbs: CrumbInfo) => {
       // Construct a new set of params from the current set (minus empty params)

--- a/x-pack/plugins/security_solution/public/resolver/view/use_state_syncing_actions.ts
+++ b/x-pack/plugins/security_solution/public/resolver/view/use_state_syncing_actions.ts
@@ -13,19 +13,19 @@ import { useResolverDispatch } from './use_resolver_dispatch';
  */
 export function useStateSyncingActions({
   databaseDocumentID,
-  documentLocation,
+  resolverComponentInstanceID,
 }: {
   /**
    * The `_id` of an event in ES. Used to determine the origin of the Resolver graph.
    */
   databaseDocumentID?: string;
-  documentLocation: string;
+  resolverComponentInstanceID: string;
 }) {
   const dispatch = useResolverDispatch();
   useLayoutEffect(() => {
     dispatch({
       type: 'appReceivedNewExternalProperties',
-      payload: { databaseDocumentID, documentLocation },
+      payload: { databaseDocumentID, resolverComponentInstanceID },
     });
-  }, [dispatch, databaseDocumentID, documentLocation]);
+  }, [dispatch, databaseDocumentID, resolverComponentInstanceID]);
 }

--- a/x-pack/plugins/security_solution/public/resolver/view/use_state_syncing_actions.ts
+++ b/x-pack/plugins/security_solution/public/resolver/view/use_state_syncing_actions.ts
@@ -13,17 +13,19 @@ import { useResolverDispatch } from './use_resolver_dispatch';
  */
 export function useStateSyncingActions({
   databaseDocumentID,
+  documentLocation,
 }: {
   /**
    * The `_id` of an event in ES. Used to determine the origin of the Resolver graph.
    */
   databaseDocumentID?: string;
+  documentLocation: string;
 }) {
   const dispatch = useResolverDispatch();
   useLayoutEffect(() => {
     dispatch({
       type: 'appReceivedNewExternalProperties',
-      payload: { databaseDocumentID },
+      payload: { databaseDocumentID, documentLocation },
     });
-  }, [dispatch, databaseDocumentID]);
+  }, [dispatch, databaseDocumentID, documentLocation]);
 }

--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -118,7 +118,10 @@ const GraphOverlayComponent = ({
       </EuiFlexGroup>
 
       <EuiHorizontalRule margin="none" />
-      <StyledResolver databaseDocumentID={graphEventId} documentLocation={currentTimeline.id} />
+      <StyledResolver
+        databaseDocumentID={graphEventId}
+        resolverComponentInstanceID={currentTimeline.id}
+      />
       <AllCasesModal
         onCloseCaseModal={onCloseCaseModal}
         showCaseModal={showCaseModal}

--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -118,7 +118,7 @@ const GraphOverlayComponent = ({
       </EuiFlexGroup>
 
       <EuiHorizontalRule margin="none" />
-      <StyledResolver databaseDocumentID={graphEventId} />
+      <StyledResolver databaseDocumentID={graphEventId} documentLocation={currentTimeline.id} />
       <AllCasesModal
         onCloseCaseModal={onCloseCaseModal}
         showCaseModal={showCaseModal}


### PR DESCRIPTION
## Summary

This pr adds a hook for use in resolver components that requires a unique key, at this point timeline.Id from siem code, to read and write to url query params without colliding if more than one instance of resolver is on the page at once. 

![2_resolvers](https://user-images.githubusercontent.com/56408403/87332728-073cee80-c50a-11ea-8c88-887281f7c0a2.gif)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
