### PR TITLE
[Ingest Manager] Copy changes

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_package_config_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_package_config_page/index.tsx
@@ -314,7 +314,7 @@ export const CreatePackageConfigPage: React.FunctionComponent = () => {
       title: i18n.translate(
         'xpack.ingestManager.createPackageConfig.stepDefinePackageConfigTitle',
         {
-          defaultMessage: 'Define your integration',
+          defaultMessage: 'Configure integration',
         }
       ),
       status: !packageInfo || !agentConfig ? 'disabled' : undefined,

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/package_configs/package_configs_table.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/package_configs/package_configs_table.tsx
@@ -10,7 +10,6 @@ import {
   EuiInMemoryTable,
   EuiInMemoryTableProps,
   EuiBadge,
-  EuiTextColor,
   EuiContextMenuItem,
   EuiButton,
   EuiFlexGroup,

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/package_configs/package_configs_table.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/details_page/components/package_configs/package_configs_table.tsx
@@ -23,7 +23,6 @@ import { useCapabilities, useLink } from '../../../../../hooks';
 import { useConfigRefresh } from '../../hooks';
 
 interface InMemoryPackageConfig extends PackageConfig {
-  streams: { total: number; enabled: number };
   inputTypes: string[];
   packageName?: string;
   packageTitle?: string;
@@ -72,30 +71,11 @@ export const PackageConfigsTable: React.FunctionComponent<Props> = ({
         }
 
         const dsInputTypes: string[] = [];
-        const streams = packageConfig.inputs.reduce(
-          (streamSummary, input) => {
-            if (!inputTypesValues.includes(input.type)) {
-              inputTypesValues.push(input.type);
-            }
-            if (!dsInputTypes.includes(input.type)) {
-              dsInputTypes.push(input.type);
-            }
-
-            streamSummary.total += input.streams.length;
-            streamSummary.enabled += input.enabled
-              ? input.streams.filter((stream) => stream.enabled).length
-              : 0;
-
-            return streamSummary;
-          },
-          { total: 0, enabled: 0 }
-        );
 
         dsInputTypes.sort(stringSortAscending);
 
         return {
           ...packageConfig,
-          streams,
           inputTypes: dsInputTypes,
           packageName: packageConfig.package?.name ?? '',
           packageTitle: packageConfig.package?.title ?? '',
@@ -173,23 +153,6 @@ export const PackageConfigsTable: React.FunctionComponent<Props> = ({
         ),
         render: (namespace: InMemoryPackageConfig['namespace']) => {
           return namespace ? <EuiBadge color="hollow">{namespace}</EuiBadge> : '';
-        },
-      },
-      {
-        field: 'streams',
-        name: i18n.translate(
-          'xpack.ingestManager.configDetails.packageConfigsTable.streamsCountColumnTitle',
-          {
-            defaultMessage: 'Streams',
-          }
-        ),
-        render: (streams: InMemoryPackageConfig['streams']) => {
-          return (
-            <>
-              <EuiTextColor>{streams.enabled}</EuiTextColor>
-              <EuiTextColor color="subdued">&nbsp;/ {streams.total}</EuiTextColor>
-            </>
-          );
         },
       },
       {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
@@ -245,7 +245,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
     {
       field: 'config_id',
       name: i18n.translate('xpack.ingestManager.agentList.configColumnTitle', {
-        defaultMessage: 'Configuration',
+        defaultMessage: 'Agent config',
       }),
       render: (configId: string, agent: Agent) => {
         const configName = agentConfigs.find((p) => p.id === configId)?.name;
@@ -445,7 +445,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
                     >
                       <FormattedMessage
                         id="xpack.ingestManager.agentList.configFilterText"
-                        defaultMessage="Configs"
+                        defaultMessage="Agent config"
                       />
                     </EuiFilterButton>
                   }

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/enrollment_token_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/enrollment_token_list_page/index.tsx
@@ -175,7 +175,7 @@ export const EnrollmentTokenListPage: React.FunctionComponent<{}> = () => {
     {
       field: 'config_id',
       name: i18n.translate('xpack.ingestManager.enrollmentTokensList.configTitle', {
-        defaultMessage: 'Config',
+        defaultMessage: 'Agent config',
       }),
       render: (configId: string) => {
         const config = agentConfigs.find((c) => c.id === configId);

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/configuration_section.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/configuration_section.tsx
@@ -36,7 +36,7 @@ export const OverviewConfigurationSection: React.FC<{ agentConfigs: AgentConfig[
             <h2>
               <FormattedMessage
                 id="xpack.ingestManager.overviewPageConfigurationsPanelTitle"
-                defaultMessage="Configurations"
+                defaultMessage="Agent configurations"
               />
             </h2>
           </EuiTitle>
@@ -55,7 +55,7 @@ export const OverviewConfigurationSection: React.FC<{ agentConfigs: AgentConfig[
               <EuiDescriptionListTitle>
                 <FormattedMessage
                   id="xpack.ingestManager.overviewConfigTotalTitle"
-                  defaultMessage="Total configs"
+                  defaultMessage="Total available"
                 />
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription>
@@ -64,7 +64,7 @@ export const OverviewConfigurationSection: React.FC<{ agentConfigs: AgentConfig[
               <EuiDescriptionListTitle>
                 <FormattedMessage
                   id="xpack.ingestManager.overviewPackageConfigTitle"
-                  defaultMessage="Total integrations used"
+                  defaultMessage="Configured integrations"
                 />
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -8156,7 +8156,6 @@
     "xpack.ingestManager.configDetails.packageConfigsTable.nameColumnTitle": "データソース",
     "xpack.ingestManager.configDetails.packageConfigsTable.namespaceColumnTitle": "名前空間",
     "xpack.ingestManager.configDetails.packageConfigsTable.packageNameColumnTitle": "統合",
-    "xpack.ingestManager.configDetails.packageConfigsTable.streamsCountColumnTitle": "ストリーム",
     "xpack.ingestManager.configDetails.subTabs.packageConfigsTabText": "データソース",
     "xpack.ingestManager.configDetails.subTabs.settingsTabText": "設定",
     "xpack.ingestManager.configDetails.summary.lastUpdated": "最終更新日:",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -8160,7 +8160,6 @@
     "xpack.ingestManager.configDetails.packageConfigsTable.nameColumnTitle": "数据源",
     "xpack.ingestManager.configDetails.packageConfigsTable.namespaceColumnTitle": "命名空间",
     "xpack.ingestManager.configDetails.packageConfigsTable.packageNameColumnTitle": "集成",
-    "xpack.ingestManager.configDetails.packageConfigsTable.streamsCountColumnTitle": "流计数",
     "xpack.ingestManager.configDetails.subTabs.packageConfigsTabText": "数据源",
     "xpack.ingestManager.configDetails.subTabs.settingsTabText": "设置",
     "xpack.ingestManager.configDetails.summary.lastUpdated": "最后更新时间",


### PR DESCRIPTION
Some copy changes from issue https://github.com/elastic/kibana/issues/70024.  These are simple changes I thought could go in one PR.

## Overview page
| Where | What changed? |
| :- | :- |
| Configuration panel | Change panel header to say "Agent configurations". Change "Data sources" (incorrectly changed to total integrations used) to say "Configured integrations" |

## Agent configurations
| Where | What changed? |
| :- | :- |
| Detail page | Remove "Streams" column |
| Add integration - step 2 | Change "Define your data source"  (incorrectly changed to Define your integration) to "Configure integration" |

## Fleet
| Where | What changed? |
| :- | :- | 
| Agent table | Change "Configuration" column header to "Agent config" |
| Agent filter option | Change "Configs" to "Agent config" |
| Enrollment token table | Change "Config" to "Agent config" |