### PR TITLE
[Ingest Manager] change user facing text "Data streams" to "datasets"

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/constants/page_paths.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/constants/page_paths.ts
@@ -53,7 +53,7 @@ export const PAGE_ROUTING_PATHS = {
   fleet_agent_details_events: '/fleet/agents/:agentId',
   fleet_agent_details_details: '/fleet/agents/:agentId/details',
   fleet_enrollment_tokens: '/fleet/enrollment-tokens',
-  data_streams: '/data-streams',
+  data_streams: '/datasets',
 };
 
 export const pagePathGetters: {
@@ -80,5 +80,5 @@ export const pagePathGetters: {
   fleet_agent_details: ({ agentId, tabId }) =>
     `/fleet/agents/${agentId}${tabId ? `/${tabId}` : ''}`,
   fleet_enrollment_tokens: () => '/fleet/enrollment-tokens',
-  data_streams: () => '/data-streams',
+  data_streams: () => '/datasets',
 };

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/hooks/use_breadcrumbs.tsx
@@ -207,7 +207,7 @@ const breadcrumbGetters: {
     BASE_BREADCRUMB,
     {
       text: i18n.translate('xpack.ingestManager.breadcrumbs.datastreamsPageTitle', {
-        defaultMessage: 'Data streams',
+        defaultMessage: 'Datasets',
       }),
     },
   ],

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
@@ -103,7 +103,7 @@ export const DefaultLayout: React.FunctionComponent<Props> = ({
                   <EuiTab isSelected={section === 'data_stream'} href={getHref('data_streams')}>
                     <FormattedMessage
                       id="xpack.ingestManager.appNavigation.dataStreamsLinkText"
-                      defaultMessage="Data streams"
+                      defaultMessage="Datasets"
                     />
                   </EuiTab>
                 </EuiTabs>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/data_stream/list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/data_stream/list_page/index.tsx
@@ -32,7 +32,7 @@ const DataStreamListPageLayout: React.FunctionComponent = ({ children }) => (
             <h1>
               <FormattedMessage
                 id="xpack.ingestManager.dataStreamList.pageTitle"
-                defaultMessage="Data streams"
+                defaultMessage="Datasets"
               />
             </h1>
           </EuiText>
@@ -177,7 +177,7 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
           <h2>
             <FormattedMessage
               id="xpack.ingestManager.dataStreamList.noDataStreamsPrompt"
-              defaultMessage="No data streams"
+              defaultMessage="No datasets"
             />
           </h2>
         }
@@ -220,14 +220,14 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
           isLoading ? (
             <FormattedMessage
               id="xpack.ingestManager.dataStreamList.loadingDataStreamsMessage"
-              defaultMessage="Loading data streams…"
+              defaultMessage="Loading datasets…"
             />
           ) : dataStreamsData && !dataStreamsData.data_streams.length ? (
             emptyPrompt
           ) : (
             <FormattedMessage
               id="xpack.ingestManager.dataStreamList.noFilteredDataStreamsMessage"
-              defaultMessage="No matching data streams found"
+              defaultMessage="No matching datasets found"
             />
           )
         }
@@ -257,7 +257,7 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
             placeholder: i18n.translate(
               'xpack.ingestManager.dataStreamList.searchPlaceholderTitle',
               {
-                defaultMessage: 'Filter data streams',
+                defaultMessage: 'Filter datasets',
               }
             ),
             incremental: true,

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/datastream_section.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/datastream_section.tsx
@@ -51,14 +51,14 @@ export const OverviewDatastreamSection: React.FC = () => {
             <h2>
               <FormattedMessage
                 id="xpack.ingestManager.overviewPageDataStreamsPanelTitle"
-                defaultMessage="Data streams"
+                defaultMessage="Datasets"
               />
             </h2>
           </EuiTitle>
           <EuiButtonEmpty size="xs" flush="right" href={getHref('data_streams')}>
             <FormattedMessage
               id="xpack.ingestManager.overviewPageDataStreamsPanelAction"
-              defaultMessage="View data streams"
+              defaultMessage="View datasets"
             />
           </EuiButtonEmpty>
         </header>
@@ -70,7 +70,7 @@ export const OverviewDatastreamSection: React.FC = () => {
               <EuiDescriptionListTitle>
                 <FormattedMessage
                   id="xpack.ingestManager.overviewDatastreamTotalTitle"
-                  defaultMessage="Data streams"
+                  defaultMessage="Datasets"
                 />
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription>


### PR DESCRIPTION
From https://github.com/elastic/kibana/issues/70024

This PR only changes the user facing text from Data Streams to Datasets as well as the route as I think from a developer perspective we think of them as [Data streams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html).  There is also already a [Dataset model](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ingest_manager/common/types/models/epm.ts#L169) that EPM uses to handle datasets from packages.
If there is a feeling we should change all the code from "data streams" to "dataset" because it would be confusing to the developer, we could discuss renaming the epm dataset model to something else.

<img width="1799" alt="Screen Shot 2020-07-06 at 1 42 26 PM" src="https://user-images.githubusercontent.com/1676003/86622851-97b98300-bf8e-11ea-8816-36c7edc743fb.png">

To test:
In the Ingest Manager app, navigate to the Datasets app.  There should be no mention of "Data streams" and the route should be `dataset` and not `data-stream`
