### PR TITLE
[kbn/optimizer] implement "requiredBundles" property of KP plugins

### DIFF
--- a/examples/bfetch_explorer/kibana.json
+++ b/examples/bfetch_explorer/kibana.json
@@ -5,5 +5,8 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["bfetch", "developerExamples"],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": [
+    "kibanaReact"
+  ]
 }

--- a/examples/dashboard_embeddable_examples/kibana.json
+++ b/examples/dashboard_embeddable_examples/kibana.json
@@ -5,5 +5,8 @@
   "server": false,
   "ui": true,
   "requiredPlugins": ["embeddable", "embeddableExamples", "dashboard", "developerExamples"],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": [
+    "esUiShared"
+  ]
 }

--- a/examples/demo_search/kibana.json
+++ b/examples/demo_search/kibana.json
@@ -6,5 +6,8 @@
   "ui": true,
   "requiredPlugins": ["data"],
   "optionalPlugins": [],
-  "extraPublicDirs": ["common"]
+  "extraPublicDirs": ["common"],
+  "requiredBundles": [
+    "dataEnhanced"
+  ]
 }

--- a/examples/embeddable_examples/kibana.json
+++ b/examples/embeddable_examples/kibana.json
@@ -6,5 +6,6 @@
   "ui": true,
   "requiredPlugins": ["embeddable"],
   "optionalPlugins": [],
-  "extraPublicDirs": ["public/todo", "public/hello_world", "public/todo/todo_ref_embeddable"]
+  "extraPublicDirs": ["public/todo", "public/hello_world", "public/todo/todo_ref_embeddable"],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/examples/state_containers_examples/kibana.json
+++ b/examples/state_containers_examples/kibana.json
@@ -5,5 +5,6 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation", "data", "developerExamples"],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/examples/ui_action_examples/kibana.json
+++ b/examples/ui_action_examples/kibana.json
@@ -5,5 +5,6 @@
   "server": false,
   "ui": true,
   "requiredPlugins": ["uiActions"],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/examples/ui_actions_explorer/kibana.json
+++ b/examples/ui_actions_explorer/kibana.json
@@ -5,5 +5,6 @@
   "server": false,
   "ui": true,
   "requiredPlugins": ["uiActions", "uiActionsExamples", "developerExamples"],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/bar/kibana.json
+++ b/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/bar/kibana.json
@@ -1,4 +1,5 @@
 {
   "id": "bar",
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["foo"]
 }

--- a/packages/kbn-optimizer/src/common/bundle.test.ts
+++ b/packages/kbn-optimizer/src/common/bundle.test.ts
@@ -50,6 +50,7 @@ it('creates cache keys', () => {
       "spec": Object {
         "contextDir": "/foo/bar",
         "id": "bar",
+        "manifestPath": undefined,
         "outputDir": "/foo/bar/target",
         "publicDirNames": Array [
           "public",
@@ -85,6 +86,7 @@ it('parses bundles from JSON specs', () => {
         },
         "contextDir": "/foo/bar",
         "id": "bar",
+        "manifestPath": undefined,
         "outputDir": "/foo/bar/target",
         "publicDirNames": Array [
           "public",

--- a/packages/kbn-optimizer/src/common/bundle.ts
+++ b/packages/kbn-optimizer/src/common/bundle.ts
@@ -18,12 +18,18 @@
  */
 
 import Path from 'path';
+import Fs from 'fs';
 
 import { BundleCache } from './bundle_cache';
 import { UnknownVals } from './ts_helpers';
 import { includes, ascending, entriesToObject } from './array_helpers';
 
 const VALID_BUNDLE_TYPES = ['plugin' as const, 'entry' as const];
+
+const DEFAULT_IMPLICIT_BUNDLE_DEPS = ['core'];
+
+const isStringArray = (input: any): input is string[] =>
+  Array.isArray(input) && input.every((x) => typeof x === 'string');
 
 export interface BundleSpec {
   readonly type: typeof VALID_BUNDLE_TYPES[0];
@@ -37,6 +43,8 @@ export interface BundleSpec {
   readonly sourceRoot: string;
   /** Absolute path to the directory where output should be written */
   readonly outputDir: string;
+  /** Absolute path to a kibana.json manifest file, if omitted we assume there are not dependenices */
+  readonly manifestPath?: string;
 }
 
 export class Bundle {
@@ -56,6 +64,12 @@ export class Bundle {
   public readonly sourceRoot: BundleSpec['sourceRoot'];
   /** Absolute path to the output directory for this bundle */
   public readonly outputDir: BundleSpec['outputDir'];
+  /**
+   * Absolute path to a manifest file with "requiredBundles" which will be
+   * used to allow bundleRefs from this bundle to the exports of another bundle.
+   * Every bundle mentioned in the `requiredBundles` must be built together.
+   */
+  public readonly manifestPath: BundleSpec['manifestPath'];
 
   public readonly cache: BundleCache;
 
@@ -66,6 +80,7 @@ export class Bundle {
     this.contextDir = spec.contextDir;
     this.sourceRoot = spec.sourceRoot;
     this.outputDir = spec.outputDir;
+    this.manifestPath = spec.manifestPath;
 
     this.cache = new BundleCache(Path.resolve(this.outputDir, '.kbn-optimizer-cache'));
   }
@@ -96,7 +111,53 @@ export class Bundle {
       contextDir: this.contextDir,
       sourceRoot: this.sourceRoot,
       outputDir: this.outputDir,
+      manifestPath: this.manifestPath,
     };
+  }
+
+  readBundleDeps(): { implicit: string[]; explicit: string[] } {
+    if (!this.manifestPath) {
+      return {
+        implicit: [...DEFAULT_IMPLICIT_BUNDLE_DEPS],
+        explicit: [],
+      };
+    }
+
+    let json: string;
+    try {
+      json = Fs.readFileSync(this.manifestPath, 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+
+      json = '{}';
+    }
+
+    let parsedManifest: { requiredPlugins?: string[]; requiredBundles?: string[] };
+    try {
+      parsedManifest = JSON.parse(json);
+    } catch (error) {
+      throw new Error(
+        `unable to parse manifest at [${this.manifestPath}], error: [${error.message}]`
+      );
+    }
+
+    if (typeof parsedManifest === 'object' && parsedManifest) {
+      const explicit = parsedManifest.requiredBundles || [];
+      const implicit = [...DEFAULT_IMPLICIT_BUNDLE_DEPS, ...(parsedManifest.requiredPlugins || [])];
+
+      if (isStringArray(explicit) && isStringArray(implicit)) {
+        return {
+          explicit,
+          implicit,
+        };
+      }
+    }
+
+    throw new Error(
+      `Expected "requiredBundles" and "requiredPlugins" in manifest file [${this.manifestPath}] to be arrays of strings`
+    );
   }
 }
 
@@ -152,6 +213,13 @@ export function parseBundles(json: string) {
           throw new Error('`bundles[]` must have an absolute path `outputDir` property');
         }
 
+        const { manifestPath } = spec;
+        if (manifestPath !== undefined) {
+          if (!(typeof manifestPath === 'string' && Path.isAbsolute(manifestPath))) {
+            throw new Error('`bundles[]` must have an absolute path `manifestPath` property');
+          }
+        }
+
         return new Bundle({
           type,
           id,
@@ -159,6 +227,7 @@ export function parseBundles(json: string) {
           contextDir,
           sourceRoot,
           outputDir,
+          manifestPath,
         });
       }
     );

--- a/packages/kbn-optimizer/src/common/bundle_refs.ts
+++ b/packages/kbn-optimizer/src/common/bundle_refs.ts
@@ -114,6 +114,10 @@ export class BundleRefs {
 
   constructor(private readonly refs: BundleRef[]) {}
 
+  public forBundleIds(bundleIds: string[]) {
+    return this.refs.filter((r) => bundleIds.includes(r.bundleId));
+  }
+
   public filterByExportIds(exportIds: string[]) {
     return this.refs.filter((r) => exportIds.includes(r.exportId));
   }

--- a/packages/kbn-optimizer/src/optimizer/get_plugin_bundles.test.ts
+++ b/packages/kbn-optimizer/src/optimizer/get_plugin_bundles.test.ts
@@ -53,6 +53,7 @@ it('returns a bundle for core and each plugin', () => {
       Object {
         "contextDir": <absolute path>/plugins/foo,
         "id": "foo",
+        "manifestPath": undefined,
         "outputDir": <absolute path>/plugins/foo/target/public,
         "publicDirNames": Array [
           "public",
@@ -63,6 +64,7 @@ it('returns a bundle for core and each plugin', () => {
       Object {
         "contextDir": "/outside/of/repo/plugins/baz",
         "id": "baz",
+        "manifestPath": undefined,
         "outputDir": "/outside/of/repo/plugins/baz/target/public",
         "publicDirNames": Array [
           "public",

--- a/packages/kbn-optimizer/src/optimizer/get_plugin_bundles.ts
+++ b/packages/kbn-optimizer/src/optimizer/get_plugin_bundles.ts
@@ -35,6 +35,7 @@ export function getPluginBundles(plugins: KibanaPlatformPlugin[], repoRoot: stri
           sourceRoot: repoRoot,
           contextDir: p.directory,
           outputDir: Path.resolve(p.directory, 'target/public'),
+          manifestPath: p.manifestPath,
         })
     );
 }

--- a/packages/kbn-optimizer/src/optimizer/kibana_platform_plugins.test.ts
+++ b/packages/kbn-optimizer/src/optimizer/kibana_platform_plugins.test.ts
@@ -40,24 +40,28 @@ it('parses kibana.json files of plugins found in pluginDirs', () => {
         "extraPublicDirs": Array [],
         "id": "bar",
         "isUiPlugin": true,
+        "manifestPath": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/bar/kibana.json,
       },
       Object {
         "directory": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/foo,
         "extraPublicDirs": Array [],
         "id": "foo",
         "isUiPlugin": true,
+        "manifestPath": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/foo/kibana.json,
       },
       Object {
         "directory": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/nested/baz,
         "extraPublicDirs": Array [],
         "id": "baz",
         "isUiPlugin": false,
+        "manifestPath": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/plugins/nested/baz/kibana.json,
       },
       Object {
         "directory": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/test_plugins/test_baz,
         "extraPublicDirs": Array [],
         "id": "test_baz",
         "isUiPlugin": false,
+        "manifestPath": <absolute path>/packages/kbn-optimizer/src/__fixtures__/mock_repo/test_plugins/test_baz/kibana.json,
       },
     ]
   `);

--- a/packages/kbn-optimizer/src/optimizer/kibana_platform_plugins.ts
+++ b/packages/kbn-optimizer/src/optimizer/kibana_platform_plugins.ts
@@ -24,6 +24,7 @@ import loadJsonFile from 'load-json-file';
 
 export interface KibanaPlatformPlugin {
   readonly directory: string;
+  readonly manifestPath: string;
   readonly id: string;
   readonly isUiPlugin: boolean;
   readonly extraPublicDirs: string[];
@@ -92,6 +93,7 @@ function readKibanaPlatformPlugin(manifestPath: string): KibanaPlatformPlugin {
 
   return {
     directory: Path.dirname(manifestPath),
+    manifestPath,
     id: manifest.id,
     isUiPlugin: !!manifest.ui,
     extraPublicDirs: extraPublicDirs || [],

--- a/packages/kbn-optimizer/src/worker/bundle_ref_module.ts
+++ b/packages/kbn-optimizer/src/worker/bundle_ref_module.ts
@@ -10,6 +10,7 @@
 
 // @ts-ignore not typed by @types/webpack
 import Module from 'webpack/lib/Module';
+import { BundleRef } from '../common';
 
 export class BundleRefModule extends Module {
   public built = false;
@@ -17,12 +18,12 @@ export class BundleRefModule extends Module {
   public buildInfo?: any;
   public exportsArgument = '__webpack_exports__';
 
-  constructor(public readonly exportId: string) {
+  constructor(public readonly ref: BundleRef) {
     super('kbn/bundleRef', null);
   }
 
   libIdent() {
-    return this.exportId;
+    return this.ref.exportId;
   }
 
   chunkCondition(chunk: any) {
@@ -30,7 +31,7 @@ export class BundleRefModule extends Module {
   }
 
   identifier() {
-    return '@kbn/bundleRef ' + JSON.stringify(this.exportId);
+    return '@kbn/bundleRef ' + JSON.stringify(this.ref.exportId);
   }
 
   readableIdentifier() {
@@ -51,7 +52,7 @@ export class BundleRefModule extends Module {
   source() {
     return `
       __webpack_require__.r(__webpack_exports__);
-      var ns = __kbnBundles__.get('${this.exportId}');
+      var ns = __kbnBundles__.get('${this.ref.exportId}');
       Object.defineProperties(__webpack_exports__, Object.getOwnPropertyDescriptors(ns))
     `;
   }

--- a/packages/kbn-optimizer/src/worker/run_compilers.ts
+++ b/packages/kbn-optimizer/src/worker/run_compilers.ts
@@ -36,6 +36,7 @@ import {
   ascending,
   parseFilePath,
   BundleRefs,
+  BundleRef,
 } from '../common';
 import { BundleRefModule } from './bundle_ref_module';
 import { getWebpackConfig } from './webpack.config';
@@ -99,7 +100,7 @@ const observeCompiler = (
         });
       }
 
-      const bundleRefExportIds: string[] = [];
+      const bundleRefs: BundleRef[] = [];
       const referencedFiles = new Set<string>();
       let normalModuleCount = 0;
 
@@ -127,7 +128,7 @@ const observeCompiler = (
         }
 
         if (module instanceof BundleRefModule) {
-          bundleRefExportIds.push(module.exportId);
+          bundleRefs.push(module.ref);
           continue;
         }
 
@@ -154,7 +155,7 @@ const observeCompiler = (
       );
 
       bundle.cache.set({
-        bundleRefExportIds,
+        bundleRefExportIds: bundleRefs.map((ref) => ref.exportId),
         optimizerCacheKey: workerConfig.optimizerCacheKey,
         cacheKey: bundle.createCacheKey(files, mtimes),
         moduleCount: normalModuleCount,

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.test.ts
@@ -302,6 +302,7 @@ test('set defaults for all missing optional fields', async () => {
     kibanaVersion: '7.0.0',
     optionalPlugins: [],
     requiredPlugins: [],
+    requiredBundles: [],
     server: true,
     ui: false,
   });
@@ -331,6 +332,7 @@ test('return all set optional fields as they are in manifest', async () => {
     version: 'some-version',
     kibanaVersion: '7.0.0',
     optionalPlugins: ['some-optional-plugin'],
+    requiredBundles: [],
     requiredPlugins: ['some-required-plugin', 'some-required-plugin-2'],
     server: false,
     ui: true,
@@ -361,6 +363,7 @@ test('return manifest when plugin expected Kibana version matches actual version
     kibanaVersion: '7.0.0-alpha2',
     optionalPlugins: [],
     requiredPlugins: ['some-required-plugin'],
+    requiredBundles: [],
     server: true,
     ui: false,
   });
@@ -390,6 +393,7 @@ test('return manifest when plugin expected Kibana version is `kibana`', async ()
     kibanaVersion: 'kibana',
     optionalPlugins: [],
     requiredPlugins: ['some-required-plugin'],
+    requiredBundles: [],
     server: true,
     ui: true,
   });

--- a/src/core/server/plugins/discovery/plugin_manifest_parser.ts
+++ b/src/core/server/plugins/discovery/plugin_manifest_parser.ts
@@ -58,6 +58,7 @@ const KNOWN_MANIFEST_FIELDS = (() => {
     ui: true,
     server: true,
     extraPublicDirs: true,
+    requiredBundles: true,
   };
 
   return new Set(Object.keys(manifestFields));
@@ -191,6 +192,7 @@ export async function parseManifest(
     configPath: manifest.configPath || snakeCase(manifest.id),
     requiredPlugins: Array.isArray(manifest.requiredPlugins) ? manifest.requiredPlugins : [],
     optionalPlugins: Array.isArray(manifest.optionalPlugins) ? manifest.optionalPlugins : [],
+    requiredBundles: Array.isArray(manifest.requiredBundles) ? manifest.requiredBundles : [],
     ui: includesUiPlugin,
     server: includesServerPlugin,
     extraPublicDirs: manifest.extraPublicDirs,

--- a/src/core/server/plugins/integration_tests/plugins_service.test.ts
+++ b/src/core/server/plugins/integration_tests/plugins_service.test.ts
@@ -43,6 +43,7 @@ describe('PluginsService', () => {
       disabled = false,
       version = 'some-version',
       requiredPlugins = [],
+      requiredBundles = [],
       optionalPlugins = [],
       kibanaVersion = '7.0.0',
       configPath = [path],
@@ -53,6 +54,7 @@ describe('PluginsService', () => {
       disabled?: boolean;
       version?: string;
       requiredPlugins?: string[];
+      requiredBundles?: string[];
       optionalPlugins?: string[];
       kibanaVersion?: string;
       configPath?: ConfigPath;
@@ -68,6 +70,7 @@ describe('PluginsService', () => {
         configPath: `${configPath}${disabled ? '-disabled' : ''}`,
         kibanaVersion,
         requiredPlugins,
+        requiredBundles,
         optionalPlugins,
         server,
         ui,

--- a/src/core/server/plugins/plugin.test.ts
+++ b/src/core/server/plugins/plugin.test.ts
@@ -54,6 +54,7 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     kibanaVersion: '7.0.0',
     requiredPlugins: ['some-required-dep'],
     optionalPlugins: ['some-optional-dep'],
+    requiredBundles: [],
     server: true,
     ui: true,
     ...manifestProps,

--- a/src/core/server/plugins/plugin.ts
+++ b/src/core/server/plugins/plugin.ts
@@ -53,6 +53,7 @@ export class PluginWrapper<
   public readonly configPath: PluginManifest['configPath'];
   public readonly requiredPlugins: PluginManifest['requiredPlugins'];
   public readonly optionalPlugins: PluginManifest['optionalPlugins'];
+  public readonly requiredBundles: PluginManifest['requiredBundles'];
   public readonly includesServerPlugin: PluginManifest['server'];
   public readonly includesUiPlugin: PluginManifest['ui'];
 
@@ -81,6 +82,7 @@ export class PluginWrapper<
     this.configPath = params.manifest.configPath;
     this.requiredPlugins = params.manifest.requiredPlugins;
     this.optionalPlugins = params.manifest.optionalPlugins;
+    this.requiredBundles = params.manifest.requiredBundles;
     this.includesServerPlugin = params.manifest.server;
     this.includesUiPlugin = params.manifest.ui;
   }

--- a/src/core/server/plugins/plugin_context.test.ts
+++ b/src/core/server/plugins/plugin_context.test.ts
@@ -43,6 +43,7 @@ function createPluginManifest(manifestProps: Partial<PluginManifest> = {}): Plug
     configPath: 'path',
     kibanaVersion: '7.0.0',
     requiredPlugins: ['some-required-dep'],
+    requiredBundles: [],
     optionalPlugins: ['some-optional-dep'],
     server: true,
     ui: true,

--- a/src/core/server/plugins/plugins_service.test.ts
+++ b/src/core/server/plugins/plugins_service.test.ts
@@ -64,6 +64,7 @@ const createPlugin = (
     disabled = false,
     version = 'some-version',
     requiredPlugins = [],
+    requiredBundles = [],
     optionalPlugins = [],
     kibanaVersion = '7.0.0',
     configPath = [path],
@@ -74,6 +75,7 @@ const createPlugin = (
     disabled?: boolean;
     version?: string;
     requiredPlugins?: string[];
+    requiredBundles?: string[];
     optionalPlugins?: string[];
     kibanaVersion?: string;
     configPath?: ConfigPath;
@@ -89,6 +91,7 @@ const createPlugin = (
       configPath: `${configPath}${disabled ? '-disabled' : ''}`,
       kibanaVersion,
       requiredPlugins,
+      requiredBundles,
       optionalPlugins,
       server,
       ui,
@@ -460,6 +463,7 @@ describe('PluginsService', () => {
         id: plugin.name,
         configPath: plugin.manifest.configPath,
         requiredPlugins: [],
+        requiredBundles: [],
         optionalPlugins: [],
       },
     ];
@@ -563,10 +567,12 @@ describe('PluginsService', () => {
             "plugin-1" => Object {
               "publicAssetsDir": <absolute path>/path-1/public/assets,
               "publicTargetDir": <absolute path>/path-1/target/public,
+              "requiredBundles": Array [],
             },
             "plugin-2" => Object {
               "publicAssetsDir": <absolute path>/path-2/public/assets,
               "publicTargetDir": <absolute path>/path-2/target/public,
+              "requiredBundles": Array [],
             },
           }
         `);

--- a/src/core/server/plugins/plugins_service.ts
+++ b/src/core/server/plugins/plugins_service.ts
@@ -228,6 +228,7 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
 
           if (plugin.includesUiPlugin) {
             this.uiPluginInternalInfo.set(plugin.name, {
+              requiredBundles: plugin.requiredBundles,
               publicTargetDir: Path.resolve(plugin.path, 'target/public'),
               publicAssetsDir: Path.resolve(plugin.path, 'public/assets'),
             });
@@ -239,6 +240,21 @@ export class PluginsService implements CoreService<PluginsServiceSetup, PluginsS
       .toPromise();
 
     for (const [pluginName, { plugin, isEnabled }] of pluginEnableStatuses) {
+      // validate that `requiredBundles` ids point to discovered plugins which `includesUiPlugins`
+      for (const requiredBundleId of plugin.requiredBundles) {
+        if (!pluginEnableStatuses.has(requiredBundleId)) {
+          throw new Error(
+            `Plugin bundle with id "${requiredBundleId}" is required by plugin "${pluginName}" but it is missing.`
+          );
+        }
+
+        if (!pluginEnableStatuses.get(requiredBundleId)!.plugin.includesUiPlugin) {
+          throw new Error(
+            `Plugin bundle with id "${requiredBundleId}" is required by plugin "${pluginName}" but it doesn't have a UI bundle.`
+          );
+        }
+      }
+
       const pluginEnablement = this.shouldEnablePlugin(pluginName, pluginEnableStatuses);
 
       if (pluginEnablement.enabled) {

--- a/src/core/server/plugins/plugins_system.ts
+++ b/src/core/server/plugins/plugins_system.ts
@@ -178,6 +178,7 @@ export class PluginsSystem {
             optionalPlugins: plugin.manifest.optionalPlugins.filter((p) =>
               uiPluginNames.includes(p)
             ),
+            requiredBundles: plugin.manifest.requiredBundles,
           },
         ];
       })

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -137,6 +137,15 @@ export interface PluginManifest {
   readonly requiredPlugins: readonly PluginName[];
 
   /**
+   * An optional list of the other plugins which are imported by the UI bundles
+   * of this plugin. If the plugins listed here are disabled their bundles will
+   * still be loaded into the browser. Required by the @kbn/optimizer to allow
+   * cross plugin imports. "core" and plugins listed in "requiredPlugins" do not
+   * need to be listed here.
+   */
+  readonly requiredBundles: readonly string[];
+
+  /**
    * An optional list of the other plugins that if installed and enabled **may be**
    * leveraged by this plugin for some additional functionality but otherwise are
    * not required for this plugin to work properly.
@@ -191,12 +200,25 @@ export interface DiscoveredPlugin {
    * not required for this plugin to work properly.
    */
   readonly optionalPlugins: readonly PluginName[];
+
+  /**
+   * An optional list of the other plugins which are imported by the UI bundles
+   * of this plugin. If the plugins listed here are disabled their bundles will
+   * still be loaded into the browser. Required by the @kbn/optimizer to allow
+   * cross plugin imports. "core" and plugins listed in "requiredPlugins" do not
+   * need to be listed here.
+   */
+  readonly requiredBundles: readonly PluginName[];
 }
 
 /**
  * @internal
  */
 export interface InternalPluginInfo {
+  /**
+   * Bundles that must be loaded for this plugoin
+   */
+  readonly requiredBundles: readonly string[];
   /**
    * Path to the target/public directory of the plugin which should be
    * served

--- a/src/legacy/ui/ui_render/ui_render_mixin.js
+++ b/src/legacy/ui/ui_render/ui_render_mixin.js
@@ -150,7 +150,23 @@ export function uiRenderMixin(kbnServer, server, config) {
               ]),
         ];
 
-        const kpPluginIds = Array.from(kbnServer.newPlatform.__internals.uiPlugins.public.keys());
+        const kpUiPlugins = kbnServer.newPlatform.__internals.uiPlugins;
+        const kpPluginPublicPaths = new Map();
+        const kpPluginBundlePaths = new Set();
+
+        // recursively iterate over the kpUiPlugin ids and their required bundles
+        // to populate kpPluginPublicPaths and kpPluginBundlePaths
+        (function readKpPlugins(ids) {
+          for (const id of ids) {
+            if (kpPluginPublicPaths.has(id)) {
+              continue;
+            }
+
+            kpPluginPublicPaths.set(id, `${regularBundlePath}/plugin/${id}/`);
+            kpPluginBundlePaths.add(`${regularBundlePath}/plugin/${id}/${id}.plugin.js`);
+            readKpPlugins(kpUiPlugins.internal.get(id).requiredBundles);
+          }
+        })(kpUiPlugins.public.keys());
 
         const jsDependencyPaths = [
           ...UiSharedDeps.jsDepFilenames.map(
@@ -160,9 +176,7 @@ export function uiRenderMixin(kbnServer, server, config) {
           ...(isCore ? [] : [`${dllBundlePath}/vendors_runtime.bundle.dll.js`, ...dllJsChunks]),
 
           `${regularBundlePath}/core/core.entry.js`,
-          ...kpPluginIds.map(
-            (pluginId) => `${regularBundlePath}/plugin/${pluginId}/${pluginId}.plugin.js`
-          ),
+          ...kpPluginBundlePaths,
         ];
 
         // These paths should align with the bundle routes configured in
@@ -170,13 +184,7 @@ export function uiRenderMixin(kbnServer, server, config) {
         const publicPathMap = JSON.stringify({
           core: `${regularBundlePath}/core/`,
           'kbn-ui-shared-deps': `${regularBundlePath}/kbn-ui-shared-deps/`,
-          ...kpPluginIds.reduce(
-            (acc, pluginId) => ({
-              ...acc,
-              [pluginId]: `${regularBundlePath}/plugin/${pluginId}/`,
-            }),
-            {}
-          ),
+          ...Object.fromEntries(kpPluginPublicPaths),
         });
 
         const bootstrap = new AppBootstrap({

--- a/src/plugins/advanced_settings/kibana.json
+++ b/src/plugins/advanced_settings/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["management"]
+  "requiredPlugins": ["management"],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/src/plugins/bfetch/kibana.json
+++ b/src/plugins/bfetch/kibana.json
@@ -2,5 +2,6 @@
   "id": "bfetch",
   "version": "kibana",
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaUtils"]
 }

--- a/src/plugins/charts/kibana.json
+++ b/src/plugins/charts/kibana.json
@@ -2,5 +2,6 @@
   "id": "charts",
   "version": "kibana",
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaUtils", "kibanaReact", "data"]
 }

--- a/src/plugins/console/kibana.json
+++ b/src/plugins/console/kibana.json
@@ -4,5 +4,6 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["devTools", "home"],
-  "optionalPlugins": ["usageCollection"]
+  "optionalPlugins": ["usageCollection"],
+  "requiredBundles": ["esUiShared", "kibanaReact", "kibanaUtils"]
 }

--- a/src/plugins/dashboard/kibana.json
+++ b/src/plugins/dashboard/kibana.json
@@ -12,5 +12,6 @@
   ],
   "optionalPlugins": ["home", "share", "usageCollection"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaUtils", "kibanaReact", "home"]
 }

--- a/src/plugins/data/kibana.json
+++ b/src/plugins/data/kibana.json
@@ -8,5 +8,11 @@
     "uiActions"
   ],
   "optionalPlugins": ["usageCollection"],
-  "extraPublicDirs": ["common", "common/utils/abort_utils"]
+  "extraPublicDirs": ["common", "common/utils/abort_utils"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "kibanaLegacy",
+    "inspector"
+  ]
 }

--- a/src/plugins/discover/kibana.json
+++ b/src/plugins/discover/kibana.json
@@ -1,7 +1,6 @@
 {
   "id": "discover",
   "version": "kibana",
-  "optionalPlugins": ["share"],
   "server": true,
   "ui": true,
   "requiredPlugins": [
@@ -14,5 +13,11 @@
     "uiActions",
     "visualizations"
   ],
-  "optionalPlugins": ["home", "share"]
+  "optionalPlugins": ["home", "share"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "home",
+    "savedObjects",
+    "kibanaReact"
+  ]
 }

--- a/src/plugins/embeddable/kibana.json
+++ b/src/plugins/embeddable/kibana.json
@@ -10,5 +10,9 @@
   ],
   "extraPublicDirs": [
     "public/lib/test_samples"
+  ],
+  "requiredBundles": [
+    "savedObjects",
+    "kibanaReact"
   ]
 }

--- a/src/plugins/es_ui_shared/kibana.json
+++ b/src/plugins/es_ui_shared/kibana.json
@@ -10,5 +10,8 @@
     "static/forms/helpers",
     "static/forms/components",
     "static/forms/helpers/field_validators/types"
+  ],
+  "requiredBundles": [
+    "data"
   ]
 }

--- a/src/plugins/expressions/kibana.json
+++ b/src/plugins/expressions/kibana.json
@@ -6,5 +6,10 @@
   "requiredPlugins": [
     "bfetch"
   ],
-  "extraPublicDirs": ["common", "common/fonts"]
+  "extraPublicDirs": ["common", "common/fonts"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "inspector",
+    "data"
+  ]
 }

--- a/src/plugins/home/kibana.json
+++ b/src/plugins/home/kibana.json
@@ -4,5 +4,8 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["data", "kibanaLegacy"],
-  "optionalPlugins": ["usageCollection", "telemetry"]
+  "optionalPlugins": ["usageCollection", "telemetry"],
+  "requiredBundles": [
+    "kibanaReact"
+  ]
 }

--- a/src/plugins/index_pattern_management/kibana.json
+++ b/src/plugins/index_pattern_management/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "server": false,
   "ui": true,
-  "requiredPlugins": ["management", "data", "kibanaLegacy"]
+  "requiredPlugins": ["management", "data", "kibanaLegacy"],
+  "requiredBundles": ["kibanaReact", "kibanaUtils"]
 }

--- a/src/plugins/input_control_vis/kibana.json
+++ b/src/plugins/input_control_vis/kibana.json
@@ -4,5 +4,6 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data", "expressions", "visualizations"]
+  "requiredPlugins": ["data", "expressions", "visualizations"],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/src/plugins/inspector/kibana.json
+++ b/src/plugins/inspector/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "server": false,
   "ui": true,
-  "extraPublicDirs": ["common", "common/adapters/request"]
+  "extraPublicDirs": ["common", "common/adapters/request"],
+  "requiredBundles": ["kibanaReact", "share"]
 }

--- a/src/plugins/kibana_react/kibana.json
+++ b/src/plugins/kibana_react/kibana.json
@@ -1,5 +1,6 @@
 {
   "id": "kibanaReact",
   "version": "kibana",
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaUtils"]
 }

--- a/src/plugins/management/kibana.json
+++ b/src/plugins/management/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["kibanaLegacy", "home"]
+  "requiredPlugins": ["kibanaLegacy", "home"],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/src/plugins/maps_legacy/kibana.json
+++ b/src/plugins/maps_legacy/kibana.json
@@ -4,5 +4,6 @@
   "kibanaVersion": "kibana",
   "configPath": ["map"],
   "ui": true,
-  "server": true
+  "server": true,
+  "requiredBundles": ["kibanaReact", "charts"]
 }

--- a/src/plugins/region_map/kibana.json
+++ b/src/plugins/region_map/kibana.json
@@ -11,5 +11,10 @@
     "mapsLegacy",
     "kibanaLegacy",
     "data"
+  ],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "charts"
   ]
 }

--- a/src/plugins/saved_objects/kibana.json
+++ b/src/plugins/saved_objects/kibana.json
@@ -3,5 +3,9 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data"]
+  "requiredPlugins": ["data"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact"
+  ]
 }

--- a/src/plugins/saved_objects_management/kibana.json
+++ b/src/plugins/saved_objects_management/kibana.json
@@ -5,5 +5,6 @@
   "ui": true,
   "requiredPlugins": ["home", "management", "data"],
   "optionalPlugins": ["dashboard", "visualizations", "discover"],
-  "extraPublicDirs": ["public/lib"]
+  "extraPublicDirs": ["public/lib"],
+  "requiredBundles": ["kibanaReact"]
 }

--- a/src/plugins/share/kibana.json
+++ b/src/plugins/share/kibana.json
@@ -2,5 +2,6 @@
   "id": "share",
   "version": "kibana",
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaUtils"]
 }

--- a/src/plugins/telemetry/kibana.json
+++ b/src/plugins/telemetry/kibana.json
@@ -9,5 +9,9 @@
   ],
   "extraPublicDirs": [
     "common/constants"
+  ],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact"
   ]
 }

--- a/src/plugins/tile_map/kibana.json
+++ b/src/plugins/tile_map/kibana.json
@@ -11,5 +11,10 @@
     "mapsLegacy",
     "kibanaLegacy",
     "data"
+  ],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "charts"
   ]
 }

--- a/src/plugins/ui_actions/kibana.json
+++ b/src/plugins/ui_actions/kibana.json
@@ -5,5 +5,8 @@
   "ui": true,
   "extraPublicDirs": [
     "public/tests/test_samples"
+  ],
+  "requiredBundles": [
+    "kibanaReact"
   ]
 }

--- a/src/plugins/usage_collection/kibana.json
+++ b/src/plugins/usage_collection/kibana.json
@@ -3,5 +3,8 @@
   "configPath": ["usageCollection"],
   "version": "kibana",
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "kibanaUtils"
+  ]
 }

--- a/src/plugins/vis_type_markdown/kibana.json
+++ b/src/plugins/vis_type_markdown/kibana.json
@@ -3,5 +3,6 @@
     "version": "kibana",
     "ui": true,
     "server": true,
-    "requiredPlugins": ["expressions", "visualizations"]
+    "requiredPlugins": ["expressions", "visualizations"],
+    "requiredBundles": ["kibanaUtils", "kibanaReact", "data", "charts"]
 }

--- a/src/plugins/vis_type_metric/kibana.json
+++ b/src/plugins/vis_type_metric/kibana.json
@@ -4,5 +4,6 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data", "visualizations", "charts","expressions"]
+  "requiredPlugins": ["data", "visualizations", "charts","expressions"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/src/plugins/vis_type_table/kibana.json
+++ b/src/plugins/vis_type_table/kibana.json
@@ -8,5 +8,11 @@
     "visualizations",
     "data",
     "kibanaLegacy"
+  ],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "share",
+    "charts"
   ]
 }

--- a/src/plugins/vis_type_tagcloud/kibana.json
+++ b/src/plugins/vis_type_tagcloud/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "ui": true,
   "server": true,
-  "requiredPlugins": ["data", "expressions", "visualizations", "charts"]
+  "requiredPlugins": ["data", "expressions", "visualizations", "charts"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/src/plugins/vis_type_timelion/kibana.json
+++ b/src/plugins/vis_type_timelion/kibana.json
@@ -4,5 +4,6 @@
   "kibanaVersion": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["visualizations", "data", "expressions"]
+  "requiredPlugins": ["visualizations", "data", "expressions"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/src/plugins/vis_type_timeseries/kibana.json
+++ b/src/plugins/vis_type_timeseries/kibana.json
@@ -5,5 +5,6 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["charts", "data", "expressions", "visualizations"],
-  "optionalPlugins": ["usageCollection"]
+  "optionalPlugins": ["usageCollection"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/src/plugins/vis_type_vega/kibana.json
+++ b/src/plugins/vis_type_vega/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data", "visualizations", "mapsLegacy", "expressions"]
+  "requiredPlugins": ["data", "visualizations", "mapsLegacy", "expressions"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/src/plugins/vis_type_vislib/kibana.json
+++ b/src/plugins/vis_type_vislib/kibana.json
@@ -4,5 +4,6 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["charts", "data", "expressions", "visualizations", "kibanaLegacy"],
-  "optionalPlugins": ["visTypeXy"]
+  "optionalPlugins": ["visTypeXy"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact"]
 }

--- a/src/plugins/visualizations/kibana.json
+++ b/src/plugins/visualizations/kibana.json
@@ -3,5 +3,6 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["data", "expressions", "uiActions", "embeddable", "usageCollection", "inspector"]
+  "requiredPlugins": ["data", "expressions", "uiActions", "embeddable", "usageCollection", "inspector"],
+  "requiredBundles": ["kibanaUtils", "discover", "savedObjects"]
 }

--- a/src/plugins/visualize/kibana.json
+++ b/src/plugins/visualize/kibana.json
@@ -11,5 +11,11 @@
     "visualizations",
     "embeddable"
   ],
-  "optionalPlugins": ["home", "share"]
+  "optionalPlugins": ["home", "share"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "home",
+    "discover"
+  ]
 }

--- a/x-pack/examples/ui_actions_enhanced_examples/kibana.json
+++ b/x-pack/examples/ui_actions_enhanced_examples/kibana.json
@@ -6,5 +6,9 @@
   "server": false,
   "ui": true,
   "requiredPlugins": ["uiActionsEnhanced", "data", "discover"],
-  "optionalPlugins": []
+  "optionalPlugins": [],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/apm/kibana.json
+++ b/x-pack/plugins/apm/kibana.json
@@ -28,5 +28,10 @@
   ],
   "extraPublicDirs": [
     "public/style/variables"
+  ],
+  "requiredBundles": [
+    "kibanaReact",
+    "observability",
+    "kibanaUtils"
   ]
 }

--- a/x-pack/plugins/canvas/kibana.json
+++ b/x-pack/plugins/canvas/kibana.json
@@ -6,5 +6,6 @@
     "server": true,
     "ui": true,
     "requiredPlugins": ["data", "embeddable", "expressions", "features", "home", "inspector", "uiActions"],
-    "optionalPlugins": ["usageCollection"]
+    "optionalPlugins": ["usageCollection"],
+    "requiredBundles": ["kibanaReact", "maps", "lens", "visualizations", "kibanaUtils", "kibanaLegacy", "discover", "savedObjects", "reporting"]
   }

--- a/x-pack/plugins/cross_cluster_replication/kibana.json
+++ b/x-pack/plugins/cross_cluster_replication/kibana.json
@@ -13,5 +13,10 @@
   "optionalPlugins": [
     "usageCollection"
   ],
-  "configPath": ["xpack", "ccr"]
+  "configPath": ["xpack", "ccr"],
+  "requiredBundles": [
+    "kibanaReact",
+    "esUiShared",
+    "data"
+  ]
 }

--- a/x-pack/plugins/dashboard_enhanced/kibana.json
+++ b/x-pack/plugins/dashboard_enhanced/kibana.json
@@ -4,5 +4,10 @@
   "server": false,
   "ui": true,
   "requiredPlugins": ["data", "uiActionsEnhanced", "embeddable", "dashboard", "share"],
-  "configPath": ["xpack", "dashboardEnhanced"]
+  "configPath": ["xpack", "dashboardEnhanced"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "embeddableEnhanced",
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/data_enhanced/kibana.json
+++ b/x-pack/plugins/data_enhanced/kibana.json
@@ -10,5 +10,6 @@
   ],
   "optionalPlugins": ["kibanaReact", "kibanaUtils"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaReact", "kibanaUtils"]
 }

--- a/x-pack/plugins/discover_enhanced/kibana.json
+++ b/x-pack/plugins/discover_enhanced/kibana.json
@@ -6,5 +6,6 @@
   "ui": true,
   "requiredPlugins": ["uiActions", "embeddable", "discover"],
   "optionalPlugins": ["share"],
-  "configPath": ["xpack", "discoverEnhanced"]
+  "configPath": ["xpack", "discoverEnhanced"],
+  "requiredBundles": ["kibanaUtils", "data"]
 }

--- a/x-pack/plugins/graph/kibana.json
+++ b/x-pack/plugins/graph/kibana.json
@@ -6,5 +6,6 @@
   "ui": true,
   "requiredPlugins": ["licensing", "data", "navigation", "savedObjects", "kibanaLegacy"],
   "optionalPlugins": ["home", "features"],
-  "configPath": ["xpack", "graph"]
+  "configPath": ["xpack", "graph"],
+  "requiredBundles": ["kibanaUtils", "kibanaReact", "home"]
 }

--- a/x-pack/plugins/grokdebugger/kibana.json
+++ b/x-pack/plugins/grokdebugger/kibana.json
@@ -9,5 +9,8 @@
   ],
   "server": true,
   "ui": true,
-  "configPath": ["xpack", "grokdebugger"]
+  "configPath": ["xpack", "grokdebugger"],
+  "requiredBundles": [
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/index_lifecycle_management/kibana.json
+++ b/x-pack/plugins/index_lifecycle_management/kibana.json
@@ -12,5 +12,9 @@
     "usageCollection",
     "indexManagement"
   ],
-  "configPath": ["xpack", "ilm"]
+  "configPath": ["xpack", "ilm"],
+  "requiredBundles": [
+    "indexManagement",
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/index_management/kibana.json
+++ b/x-pack/plugins/index_management/kibana.json
@@ -13,5 +13,9 @@
     "usageCollection",
     "ingestManager"
   ],
-  "configPath": ["xpack", "index_management"]
+  "configPath": ["xpack", "index_management"],
+  "requiredBundles": [
+    "kibanaReact",
+    "esUiShared"
+  ]
 }

--- a/x-pack/plugins/infra/kibana.json
+++ b/x-pack/plugins/infra/kibana.json
@@ -16,5 +16,12 @@
   "optionalPlugins": ["ml", "observability"],
   "server": true,
   "ui": true,
-  "configPath": ["xpack", "infra"]
+  "configPath": ["xpack", "infra"],
+  "requiredBundles": [
+    "observability",
+    "licenseManagement",
+    "kibanaUtils",
+    "kibanaReact",
+    "apm"
+  ]
 }

--- a/x-pack/plugins/ingest_manager/kibana.json
+++ b/x-pack/plugins/ingest_manager/kibana.json
@@ -6,5 +6,6 @@
   "configPath": ["xpack", "ingestManager"],
   "requiredPlugins": ["licensing", "data", "encryptedSavedObjects"],
   "optionalPlugins": ["security", "features", "cloud"],
-  "extraPublicDirs": ["common"]
+  "extraPublicDirs": ["common"],
+  "requiredBundles": ["kibanaReact", "esUiShared"]
 }

--- a/x-pack/plugins/ingest_pipelines/kibana.json
+++ b/x-pack/plugins/ingest_pipelines/kibana.json
@@ -5,5 +5,6 @@
   "ui": true,
   "requiredPlugins": ["licensing", "management"],
   "optionalPlugins": ["security", "usageCollection"],
-  "configPath": ["xpack", "ingest_pipelines"]
+  "configPath": ["xpack", "ingest_pipelines"],
+  "requiredBundles": ["esUiShared", "kibanaReact"]
 }

--- a/x-pack/plugins/lens/kibana.json
+++ b/x-pack/plugins/lens/kibana.json
@@ -15,5 +15,6 @@
   ],
   "optionalPlugins": ["embeddable", "usageCollection", "taskManager", "uiActions"],
   "configPath": ["xpack", "lens"],
-  "extraPublicDirs": ["common/constants"]
+  "extraPublicDirs": ["common/constants"],
+  "requiredBundles": ["savedObjects", "kibanaUtils", "kibanaReact", "embeddable"]
 }

--- a/x-pack/plugins/license_management/kibana.json
+++ b/x-pack/plugins/license_management/kibana.json
@@ -6,5 +6,9 @@
   "requiredPlugins": ["home", "licensing", "management"],
   "optionalPlugins": ["telemetry"],
   "configPath": ["xpack", "license_management"],
-  "extraPublicDirs": ["common/constants"]
+  "extraPublicDirs": ["common/constants"],
+  "requiredBundles": [
+    "telemetryManagementSection",
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/licensing/kibana.json
+++ b/x-pack/plugins/licensing/kibana.json
@@ -4,5 +4,6 @@
   "kibanaVersion": "kibana",
   "configPath": ["xpack", "licensing"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaReact"]
 }

--- a/x-pack/plugins/logstash/kibana.json
+++ b/x-pack/plugins/logstash/kibana.json
@@ -13,5 +13,6 @@
     "security"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["home"]
 }

--- a/x-pack/plugins/maps/kibana.json
+++ b/x-pack/plugins/maps/kibana.json
@@ -19,5 +19,11 @@
   ],
   "ui": true,
   "server": true,
-  "extraPublicDirs": ["common/constants"]
+  "extraPublicDirs": ["common/constants"],
+  "requiredBundles": [
+    "charts",
+    "kibanaReact",
+    "kibanaUtils",
+    "savedObjects"
+  ]
 }

--- a/x-pack/plugins/ml/kibana.json
+++ b/x-pack/plugins/ml/kibana.json
@@ -25,5 +25,13 @@
     "licenseManagement"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "esUiShared",
+    "kibanaUtils",
+    "kibanaReact",
+    "management",
+    "dashboard",
+    "savedObjects"
+  ]
 }

--- a/x-pack/plugins/monitoring/kibana.json
+++ b/x-pack/plugins/monitoring/kibana.json
@@ -6,5 +6,6 @@
   "requiredPlugins": ["licensing", "features", "data", "navigation", "kibanaLegacy"],
   "optionalPlugins": ["alerts", "actions", "infra", "telemetryCollectionManager", "usageCollection", "home", "cloud"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["kibanaUtils", "home", "alerts", "kibanaReact", "licenseManagement"]
 }

--- a/x-pack/plugins/observability/kibana.json
+++ b/x-pack/plugins/observability/kibana.json
@@ -10,5 +10,8 @@
     "licensing"
   ],
   "ui": true,
-  "server": true
+  "server": true,
+  "requiredBundles": [
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/painless_lab/kibana.json
+++ b/x-pack/plugins/painless_lab/kibana.json
@@ -12,5 +12,8 @@
     "painless_lab"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/remote_clusters/kibana.json
+++ b/x-pack/plugins/remote_clusters/kibana.json
@@ -15,5 +15,8 @@
     "cloud"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/reporting/kibana.json
+++ b/x-pack/plugins/reporting/kibana.json
@@ -17,5 +17,9 @@
     "share"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "kibanaReact",
+    "discover"
+  ]
 }

--- a/x-pack/plugins/rollup/kibana.json
+++ b/x-pack/plugins/rollup/kibana.json
@@ -15,5 +15,12 @@
     "usageCollection",
     "visTypeTimeseries"
   ],
-  "configPath": ["xpack", "rollup"]
+  "configPath": ["xpack", "rollup"],
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "home",
+    "esUiShared",
+    "data"
+  ]
 }

--- a/x-pack/plugins/searchprofiler/kibana.json
+++ b/x-pack/plugins/searchprofiler/kibana.json
@@ -5,5 +5,6 @@
   "requiredPlugins": ["devTools", "home", "licensing"],
   "configPath": ["xpack", "searchprofiler"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": ["esUiShared"]
 }

--- a/x-pack/plugins/security/kibana.json
+++ b/x-pack/plugins/security/kibana.json
@@ -6,5 +6,13 @@
   "requiredPlugins": ["data", "features", "licensing"],
   "optionalPlugins": ["home", "management"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "home",
+    "management",
+    "kibanaReact",
+    "spaces",
+    "esUiShared",
+    "management"
+  ]
 }

--- a/x-pack/plugins/security_solution/kibana.json
+++ b/x-pack/plugins/security_solution/kibana.json
@@ -29,5 +29,10 @@
     "lists"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "kibanaUtils",
+    "esUiShared",
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/snapshot_restore/kibana.json
+++ b/x-pack/plugins/snapshot_restore/kibana.json
@@ -13,5 +13,9 @@
     "security",
     "cloud"
   ],
-  "configPath": ["xpack", "snapshot_restore"]
+  "configPath": ["xpack", "snapshot_restore"],
+  "requiredBundles": [
+    "esUiShared",
+    "kibanaReact"
+  ]
 }

--- a/x-pack/plugins/spaces/kibana.json
+++ b/x-pack/plugins/spaces/kibana.json
@@ -14,5 +14,11 @@
   ],
   "server": true,
   "ui": true,
-  "extraPublicDirs": ["common"]
+  "extraPublicDirs": ["common"],
+  "requiredBundles": [
+    "kibanaReact",
+    "savedObjectsManagement",
+    "management",
+    "home"
+  ]
 }

--- a/x-pack/plugins/transform/kibana.json
+++ b/x-pack/plugins/transform/kibana.json
@@ -13,5 +13,13 @@
     "security",
     "usageCollection"
   ],
-  "configPath": ["xpack", "transform"]
+  "configPath": ["xpack", "transform"],
+  "requiredBundles": [
+    "ml",
+    "esUiShared",
+    "discover",
+    "kibanaUtils",
+    "kibanaReact",
+    "savedObjects"
+  ]
 }

--- a/x-pack/plugins/triggers_actions_ui/kibana.json
+++ b/x-pack/plugins/triggers_actions_ui/kibana.json
@@ -6,5 +6,6 @@
   "optionalPlugins": ["alerts", "alertingBuiltins"],
   "requiredPlugins": ["management", "charts", "data"],
   "configPath": ["xpack", "trigger_actions_ui"],
-  "extraPublicDirs": ["public/common", "public/common/constants"]
+  "extraPublicDirs": ["public/common", "public/common/constants"],
+  "requiredBundles": ["alerts", "esUiShared"]
 }

--- a/x-pack/plugins/ui_actions_enhanced/kibana.json
+++ b/x-pack/plugins/ui_actions_enhanced/kibana.json
@@ -8,5 +8,10 @@
     "licensing"
   ],
   "server": false,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "kibanaUtils",
+    "kibanaReact",
+    "data"
+  ]
 }

--- a/x-pack/plugins/upgrade_assistant/kibana.json
+++ b/x-pack/plugins/upgrade_assistant/kibana.json
@@ -5,5 +5,6 @@
   "ui": true,
   "configPath": ["xpack", "upgrade_assistant"],
   "requiredPlugins": ["management", "licensing"],
-  "optionalPlugins": ["cloud", "usageCollection"]
+  "optionalPlugins": ["cloud", "usageCollection"],
+  "requiredBundles": ["management"]
 }

--- a/x-pack/plugins/uptime/kibana.json
+++ b/x-pack/plugins/uptime/kibana.json
@@ -13,5 +13,14 @@
   ],
   "server": true,
   "ui": true,
-  "version": "8.0.0"
+  "version": "8.0.0",
+  "requiredBundles": [
+    "observability",
+    "kibanaReact",
+    "home",
+    "data",
+    "ml",
+    "apm",
+    "maps"
+  ]
 }

--- a/x-pack/plugins/watcher/kibana.json
+++ b/x-pack/plugins/watcher/kibana.json
@@ -10,5 +10,9 @@
     "data"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "requiredBundles": [
+    "esUiShared",
+    "kibanaReact"
+  ]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/69458

This PR requires that plugin define the bundles which they import from, so that when the bundle for that plugin is loaded we can be certain that the imported-from bundles are loaded even when those plugins are disabled.

When a plugin tries to import from another bundle but the bundle is not mentioned in the `kibana.json` file the following error will be logged:

```
import [../../../../../src/plugins/kibana_react/public] references a public export of the [kibanaReact] bundle, but that bundle is not in the "requiredPlugins" or "requiredBundles" list in the plugin manifest [{path to}/kibana.json]
```

When users fix this problem while running in `--watch` mode, webpack will notice the change to the kibana.json and rebuild, adapting to changes in kibana.json at runtime without needing to restart the optimizer.

```
```