### PR TITLE
[7.x] [Metrics UI] Set includeTimeseries on Observability fetchData request (#70735)

### DIFF
--- a/x-pack/plugins/infra/public/metrics_overview_fetchers.test.ts
+++ b/x-pack/plugins/infra/public/metrics_overview_fetchers.test.ts
@@ -76,6 +76,7 @@ describe('Metrics UI Observability Homepage Functions', () => {
           metrics: [{ type: 'cpu' }, { type: 'memory' }, { type: 'rx' }, { type: 'tx' }],
           groupBy: [],
           nodeType: 'host',
+          includeTimeseries: true,
           timerange: {
             from: startTime.valueOf(),
             to: endTime.valueOf(),

--- a/x-pack/plugins/infra/public/metrics_overview_fetchers.ts
+++ b/x-pack/plugins/infra/public/metrics_overview_fetchers.ts
@@ -88,6 +88,7 @@ export const createMetricsFetchData = (
     metrics: ['cpu', 'memory', 'rx', 'tx'].map((type) => ({ type })) as SnapshotMetricInput[],
     groupBy: [],
     nodeType: 'host',
+    includeTimeseries: true,
     timerange: {
       from: moment(startTime).valueOf(),
       to: moment(endTime).valueOf(),


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Set includeTimeseries on Observability fetchData request (#70735)