### PR TITLE
[Ingest Manager] Fix agent config out of date display

### DIFF
--- a/x-pack/plugins/ingest_manager/common/openapi/spec_oas3.json
+++ b/x-pack/plugins/ingest_manager/common/openapi/spec_oas3.json
@@ -4146,9 +4146,6 @@
           "config_revision": {
             "type": ["number", "null"]
           },
-          "config_newest_revision": {
-            "type": "number"
-          },
           "last_checkin": {
             "type": "string"
           },

--- a/x-pack/plugins/ingest_manager/common/types/models/agent.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/agent.ts
@@ -81,7 +81,6 @@ interface AgentBase {
   default_api_key_id?: string;
   config_id?: string;
   config_revision?: number | null;
-  config_newest_revision?: number;
   last_checkin?: string;
   user_provided_metadata: AgentMetadata;
   local_metadata: AgentMetadata;

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   EuiBasicTable,
   EuiButton,
@@ -25,7 +25,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedRelative } from '@kbn/i18n/react';
 import { CSSProperties } from 'styled-components';
 import { AgentEnrollmentFlyout } from '../components';
-import { Agent } from '../../../types';
+import { Agent, AgentConfig } from '../../../types';
 import {
   usePagination,
   useCapabilities,
@@ -220,6 +220,13 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   });
 
   const agentConfigs = agentConfigsRequest.data ? agentConfigsRequest.data.items : [];
+  const agentConfigsIndexedById = useMemo(() => {
+    return agentConfigs.reduce((acc, config) => {
+      acc[config.id] = config;
+
+      return acc;
+    }, {} as { [k: string]: AgentConfig });
+  }, [agentConfigs]);
   const { isLoading: isAgentConfigsLoading } = agentConfigsRequest;
 
   const columns = [
@@ -271,9 +278,10 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
                 </EuiText>
               </EuiFlexItem>
             )}
-            {agent.config_revision &&
-              agent.config_newest_revision &&
-              agent.config_newest_revision > agent.config_revision && (
+            {agent.config_id &&
+              agent.config_revision &&
+              agentConfigsIndexedById[agent.config_id] &&
+              agentConfigsIndexedById[agent.config_id].revision > agent.config_revision && (
                 <EuiFlexItem grow={false}>
                   <EuiText color="subdued" size="xs" className="eui-textNoWrap">
                     <EuiIcon size="m" type="alert" color="warning" />

--- a/x-pack/plugins/ingest_manager/server/saved_objects/index.ts
+++ b/x-pack/plugins/ingest_manager/server/saved_objects/index.ts
@@ -64,7 +64,6 @@ const savedObjectTypes: { [key: string]: SavedObjectsType } = {
         last_updated: { type: 'date' },
         last_checkin: { type: 'date' },
         config_revision: { type: 'integer' },
-        config_newest_revision: { type: 'integer' },
         default_api_key_id: { type: 'keyword' },
         default_api_key: { type: 'binary', index: false },
         updated_at: { type: 'date' },

--- a/x-pack/plugins/ingest_manager/server/services/agent_config_update.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_config_update.ts
@@ -6,7 +6,7 @@
 
 import { SavedObjectsClientContract } from 'src/core/server';
 import { generateEnrollmentAPIKey, deleteEnrollmentApiKeyForConfigId } from './api_keys';
-import { updateAgentsForConfigId, unenrollForConfigId } from './agents';
+import { unenrollForConfigId } from './agents';
 import { outputService } from './output';
 
 export async function agentConfigUpdateEventHandler(
@@ -24,10 +24,6 @@ export async function agentConfigUpdateEventHandler(
     await generateEnrollmentAPIKey(soClient, {
       configId,
     });
-  }
-
-  if (action === 'updated') {
-    await updateAgentsForConfigId(soClient, configId);
   }
 
   if (action === 'deleted') {

--- a/x-pack/plugins/ingest_manager/server/services/agents/reassign.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/reassign.ts
@@ -23,6 +23,5 @@ export async function reassignAgent(
   await soClient.update<AgentSOAttributes>(AGENT_SAVED_OBJECT_TYPE, agentId, {
     config_id: newConfigId,
     config_revision: null,
-    config_newest_revision: config.revision,
   });
 }

--- a/x-pack/plugins/ingest_manager/server/services/agents/update.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/update.ts
@@ -8,38 +8,6 @@ import { SavedObjectsClientContract } from 'src/core/server';
 import { listAgents } from './crud';
 import { AGENT_SAVED_OBJECT_TYPE } from '../../constants';
 import { unenrollAgent } from './unenroll';
-import { agentConfigService } from '../agent_config';
-
-export async function updateAgentsForConfigId(
-  soClient: SavedObjectsClientContract,
-  configId: string
-) {
-  const config = await agentConfigService.get(soClient, configId);
-  if (!config) {
-    throw new Error('Config not found');
-  }
-  let hasMore = true;
-  let page = 1;
-  while (hasMore) {
-    const { agents } = await listAgents(soClient, {
-      kuery: `${AGENT_SAVED_OBJECT_TYPE}.config_id:"${configId}"`,
-      page: page++,
-      perPage: 1000,
-      showInactive: true,
-    });
-    if (agents.length === 0) {
-      hasMore = false;
-      break;
-    }
-    const agentUpdate = agents.map((agent) => ({
-      id: agent.id,
-      type: AGENT_SAVED_OBJECT_TYPE,
-      attributes: { config_newest_revision: config.revision },
-    }));
-
-    await soClient.bulkUpdate(agentUpdate);
-  }
-}
 
 export async function unenrollForConfigId(soClient: SavedObjectsClientContract, configId: string) {
   let hasMore = true;


### PR DESCRIPTION
## Summary

While moving agent checkin to long polling we removed the usage of `config_newest_revision` field on the agent SO.
This PR clean the code, and fix the display of the out of date label in the agent listing.

<img width="1246" alt="Screen Shot 2020-07-08 at 10 56 53 AM" src="https://user-images.githubusercontent.com/1336873/86934596-e3dd0280-c109-11ea-923f-2e185316e699.png">
