### PR TITLE
[Ingest Manager] add meta "managed"  to index templates

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
@@ -99,7 +99,8 @@ exports[`tests loading base.yml: base.yml 1`] = `
     "package": {
       "name": "nginx"
     },
-    "managed_by": "ingest-manager"
+    "managed_by": "ingest-manager",
+    "managed": true
   }
 }
 `;
@@ -203,7 +204,8 @@ exports[`tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
     "package": {
       "name": "coredns"
     },
-    "managed_by": "ingest-manager"
+    "managed_by": "ingest-manager",
+    "managed": true
   }
 }
 `;
@@ -1691,7 +1693,8 @@ exports[`tests loading system.yml: system.yml 1`] = `
     "package": {
       "name": "system"
     },
-    "managed_by": "ingest-manager"
+    "managed_by": "ingest-manager",
+    "managed": true
   }
 }
 `;

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -317,6 +317,7 @@ function getBaseTemplate(
         name: packageName,
       },
       managed_by: 'ingest-manager',
+      managed: true,
     },
   };
 }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-team-planning/issues/80#issuecomment-655562178

Adds the managed attribute to the meta field of index templates.  This is necessary to distinguish which index templates are being managed, in our case by Ingest Manager.

## Test
- Install a package
- Navigate to Stack Management -> Index Management -> Index Templates tab
- All the associated index templates should have the "Managed" badge

Example of index templates after installing the `aws` package:
<img width="1079" alt="Screen Shot 2020-07-08 at 2 07 54 PM" src="https://user-images.githubusercontent.com/1676003/86954727-7f7b6c80-c124-11ea-85fd-de239eacb4ec.png">
