### PR TITLE
[Security Solution] fix panel links

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
@@ -14,7 +14,7 @@ import React, {
   useEffect,
 } from 'react';
 import { useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 // eslint-disable-next-line import/no-nodejs-modules
 import querystring from 'querystring';
 import { EuiPanel } from '@elastic/eui';
@@ -48,7 +48,7 @@ import { CrumbInfo } from './panels/panel_content_utilities';
  */
 const PanelContent = memo(function PanelContent() {
   const history = useHistory();
-  const urlSearch = history.location.search;
+  const urlSearch = useLocation().search;
   const dispatch = useResolverDispatch();
 
   const { timestamp } = useContext(SideEffectContext);


### PR DESCRIPTION
panel.tsx was relying on `useHistory` to cause a re-render but it
doesn't. `useLocation` does.

## Summary

![links_work_at_least mov](https://user-images.githubusercontent.com/35559/86968705-9c229f00-c13a-11ea-9138-d6e4dc11126f.gif)


### Checklist

- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
