### PR TITLE
[Resolver] Remove `currentPanelView` selector

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/store/actions.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/actions.ts
@@ -25,17 +25,6 @@ interface UserBroughtProcessIntoView {
 }
 
 /**
- * Dispatched to notify state that a different panel needs to be displayed
- */
-interface AppDisplayedDifferentPanel {
-  readonly type: 'appDisplayedDifferentPanel';
-  /**
-   * The name of the panel to display
-   */
-  readonly payload: string;
-}
-
-/**
  * When an examination of query params in the UI indicates that state needs to
  * be updated to reflect the new selection
  */
@@ -130,5 +119,4 @@ export type ResolverAction =
   | UserRequestedRelatedEventData
   | UserSelectedRelatedEventCategory
   | AppDetectedNewIdFromQueryParams
-  | AppDisplayedDifferentPanel
   | AppDetectedMissingEventData;

--- a/x-pack/plugins/security_solution/public/resolver/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/reducer.ts
@@ -24,7 +24,6 @@ const uiReducer: Reducer<ResolverUIState, ResolverAction> = (
     activeDescendantId: null,
     selectedDescendantId: null,
     processEntityIdOfSelectedDescendant: null,
-    panelToDisplay: null,
   },
   action
 ) => {
@@ -38,11 +37,6 @@ const uiReducer: Reducer<ResolverUIState, ResolverAction> = (
       ...uiState,
       selectedDescendantId: action.payload.nodeId,
       processEntityIdOfSelectedDescendant: action.payload.selectedProcessId,
-    };
-  } else if (action.type === 'appDisplayedDifferentPanel') {
-    return {
-      ...uiState,
-      panelToDisplay: action.payload,
     };
   } else if (
     action.type === 'userBroughtProcessIntoView' ||

--- a/x-pack/plugins/security_solution/public/resolver/store/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/selectors.ts
@@ -128,11 +128,6 @@ export const uiSelectedDescendantProcessId = composeSelectors(
 );
 
 /**
- * The current panel to display
- */
-export const currentPanelView = composeSelectors(uiStateSelector, uiSelectors.currentPanelView);
-
-/**
  * Returns the camera state from within ResolverState
  */
 function cameraStateSelector(state: ResolverState) {

--- a/x-pack/plugins/security_solution/public/resolver/store/ui/selectors.ts
+++ b/x-pack/plugins/security_solution/public/resolver/store/ui/selectors.ts
@@ -39,8 +39,3 @@ export const selectedDescendantProcessId = createSelector(
     return processEntityIdOfSelectedDescendant;
   }
 );
-
-// Select the current panel to be displayed
-export const currentPanelView = (uiState: ResolverUIState) => {
-  return uiState.panelToDisplay;
-};

--- a/x-pack/plugins/security_solution/public/resolver/types.ts
+++ b/x-pack/plugins/security_solution/public/resolver/types.ts
@@ -45,10 +45,6 @@ export interface ResolverUIState {
    * The entity_id of the process for the resolver's currently selected descendant.
    */
   readonly processEntityIdOfSelectedDescendant: string | null;
-  /**
-   * Which panel the ui should display
-   */
-  readonly panelToDisplay: string | null;
 }
 
 /**

--- a/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panel.tsx
@@ -4,15 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, {
-  memo,
-  useCallback,
-  useMemo,
-  useContext,
-  useLayoutEffect,
-  useState,
-  useEffect,
-} from 'react';
+import React, { memo, useCallback, useMemo, useContext, useLayoutEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 // eslint-disable-next-line import/no-nodejs-modules
@@ -205,21 +197,12 @@ const PanelContent = memo(function PanelContent() {
     return 'processListWithCounts';
   }, [uiSelectedEvent, crumbEvent, crumbId, graphableProcessEntityIds]);
 
-  useEffect(() => {
-    // dispatch `appDisplayedDifferentPanel` to sync state with which panel gets displayed
-    dispatch({
-      type: 'appDisplayedDifferentPanel',
-      payload: panelToShow,
-    });
-  }, [panelToShow, dispatch]);
-
-  const currentPanelView = useSelector(selectors.currentPanelView);
   const terminatedProcesses = useSelector(selectors.terminatedProcesses);
   const processEntityId = uiSelectedEvent ? event.entityId(uiSelectedEvent) : undefined;
   const isProcessTerminated = processEntityId ? terminatedProcesses.has(processEntityId) : false;
 
   const panelInstance = useMemo(() => {
-    if (currentPanelView === 'processDetails') {
+    if (panelToShow === 'processDetails') {
       return (
         <ProcessDetails
           processEvent={uiSelectedEvent!}
@@ -230,7 +213,7 @@ const PanelContent = memo(function PanelContent() {
       );
     }
 
-    if (currentPanelView === 'eventCountsForProcess') {
+    if (panelToShow === 'eventCountsForProcess') {
       return (
         <EventCountsForProcess
           processEvent={uiSelectedEvent!}
@@ -240,7 +223,7 @@ const PanelContent = memo(function PanelContent() {
       );
     }
 
-    if (currentPanelView === 'processEventListNarrowedByType') {
+    if (panelToShow === 'processEventListNarrowedByType') {
       return (
         <ProcessEventListNarrowedByType
           processEvent={uiSelectedEvent!}
@@ -251,7 +234,7 @@ const PanelContent = memo(function PanelContent() {
       );
     }
 
-    if (currentPanelView === 'relatedEventDetail') {
+    if (panelToShow === 'relatedEventDetail') {
       const parentCount: number = Object.values(
         relatedStatsForIdFromParams?.events.byCategory || {}
       ).reduce((sum, val) => sum + val, 0);
@@ -278,7 +261,7 @@ const PanelContent = memo(function PanelContent() {
     crumbId,
     pushToQueryParams,
     relatedStatsForIdFromParams,
-    currentPanelView,
+    panelToShow,
     isProcessTerminated,
   ]);
 

--- a/x-pack/plugins/security_solution/public/resolver/view/panels/panel_content_utilities.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/panel_content_utilities.tsx
@@ -82,10 +82,13 @@ const invalidDateText = i18n.translate(
   }
 );
 /**
- * @param {ConstructorParameters<typeof Date>[0]} timestamp To be passed through Date->Intl.DateTimeFormat
  * @returns {string} A nicely formatted string for a date
  */
-export function formatDate(timestamp: ConstructorParameters<typeof Date>[0]) {
+export function formatDate(
+  /** To be passed through Date->Intl.DateTimeFormat */ timestamp: ConstructorParameters<
+    typeof Date
+  >[0]
+): string {
   const date = new Date(timestamp);
   if (isFinite(date.getTime())) {
     return formatter.format(date);


### PR DESCRIPTION
The `currentPanelView` selector returns a value that's out of sync
with the component that uses it.

Remove the faulty selector, piece of state, and action.

## Summary

![fix_panels mov](https://user-images.githubusercontent.com/35559/86969519-ef492180-c13b-11ea-85cd-fcc12cad90fa.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
