### PR TITLE
[Reporting] Fix Reporting Disabled should not block Kibana startup

### DIFF
--- a/x-pack/legacy/plugins/reporting/server/legacy.ts
+++ b/x-pack/legacy/plugins/reporting/server/legacy.ts
@@ -32,6 +32,11 @@ export const legacyInit = async (
   server: Legacy.Server,
   reportingLegacyPlugin: ReportingPluginSpecOptions
 ) => {
+  if (server.newPlatform.setup.plugins.reporting == null) {
+    // reporting plugin is disabled
+    return;
+  }
+
   const { core: coreSetup } = server.newPlatform.setup;
   const { config$ } = (server.newPlatform.setup.plugins.reporting as PluginsSetup).__legacy;
   const reportingConfig = await config$.pipe(take(1)).toPromise();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/71167

This issue is specific to 7.8, where the Reporting plugin is not fully migrated to the New Platform.

Release note: Fix an issue where disabling the Reporting plugin stops Kibana from starting up.