### PR TITLE
[Ingest Manager] Fix limited packages incorrect response

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
@@ -69,7 +69,7 @@ export async function getLimitedPackages(options: {
       });
     })
   );
-  return installedPackagesInfo.filter((pkgInfo) => isPackageLimited).map((pkgInfo) => pkgInfo.name);
+  return installedPackagesInfo.filter(isPackageLimited).map((pkgInfo) => pkgInfo.name);
 }
 
 export async function getPackageSavedObjects(savedObjectsClient: SavedObjectsClientContract) {

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/list.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/list.ts
@@ -34,5 +34,21 @@ export default function ({ getService }: FtrProviderContext) {
         warnAndSkipTest(this, log);
       }
     });
+
+    it('lists all limited packages from the registry', async function () {
+      if (server.enabled) {
+        const fetchLimitedPackageList = async () => {
+          const response = await supertest
+            .get('/api/ingest_manager/epm/packages/limited')
+            .set('kbn-xsrf', 'xxx')
+            .expect(200);
+          return response.body;
+        };
+        const listResponse = await fetchLimitedPackageList();
+        expect(listResponse.response).to.eql(['endpoint']);
+      } else {
+        warnAndSkipTest(this, log);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary

API for getting list of limited packages erroneously returned all package names due to typo made during addressing review feedback in the original PR: https://github.com/elastic/kibana/pull/70542/commits/b4e522f6959a53a6aac744b2be923caef1184ca0#diff-ee4f3d8fc618ab9cb7a48e47dcf7e415R72

This PR fixes the issue and adds an integration test for the API endpoint.