### PR TITLE
[Security Solution][Exceptions] Exception modal bulk close alerts that match exception attributes

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.test.ts
@@ -22,10 +22,82 @@ import {
   EntryMatch,
   EntryMatchAny,
   EntriesArray,
+  Operator,
 } from '../../../lists/common/schemas';
 import { getExceptionListItemSchemaMock } from '../../../lists/common/schemas/response/exception_list_item_schema.mock';
 
 describe('build_exceptions_query', () => {
+  let exclude: boolean;
+  const makeMatchEntry = ({
+    field,
+    value = 'value-1',
+    operator = 'included',
+  }: {
+    field: string;
+    value?: string;
+    operator?: Operator;
+  }): EntryMatch => {
+    return {
+      field,
+      operator,
+      type: 'match',
+      value,
+    };
+  };
+  const makeMatchAnyEntry = ({
+    field,
+    operator = 'included',
+    value = ['value-1', 'value-2'],
+  }: {
+    field: string;
+    operator?: Operator;
+    value?: string[];
+  }): EntryMatchAny => {
+    return {
+      field,
+      operator,
+      value,
+      type: 'match_any',
+    };
+  };
+  const makeExistsEntry = ({
+    field,
+    operator = 'included',
+  }: {
+    field: string;
+    operator?: Operator;
+  }): EntryExists => {
+    return {
+      field,
+      operator,
+      type: 'exists',
+    };
+  };
+  const matchEntryWithIncluded: EntryMatch = makeMatchEntry({
+    field: 'host.name',
+    value: 'suricata',
+  });
+  const matchEntryWithExcluded: EntryMatch = makeMatchEntry({
+    field: 'host.name',
+    value: 'suricata',
+    operator: 'excluded',
+  });
+  const matchAnyEntryWithIncludedAndTwoValues: EntryMatchAny = makeMatchAnyEntry({
+    field: 'host.name',
+    value: ['suricata', 'auditd'],
+  });
+  const existsEntryWithIncluded: EntryExists = makeExistsEntry({
+    field: 'host.name',
+  });
+  const existsEntryWithExcluded: EntryExists = makeExistsEntry({
+    field: 'host.name',
+    operator: 'excluded',
+  });
+
+  beforeEach(() => {
+    exclude = true;
+  });
+
   describe('getLanguageBooleanOperator', () => {
     test('it returns value as uppercase if language is "lucene"', () => {
       const result = getLanguageBooleanOperator({ language: 'lucene', value: 'not' });
@@ -41,239 +113,376 @@ describe('build_exceptions_query', () => {
   });
 
   describe('operatorBuilder', () => {
-    describe('kuery', () => {
-      test('it returns "not " when operator is "included"', () => {
-        const operator = operatorBuilder({ operator: 'included', language: 'kuery' });
-
-        expect(operator).toEqual('not ');
+    describe("when 'exclude' is true", () => {
+      describe('and langauge is kuery', () => {
+        test('it returns "not " when operator is "included"', () => {
+          const operator = operatorBuilder({ operator: 'included', language: 'kuery', exclude });
+          expect(operator).toEqual('not ');
+        });
+        test('it returns empty string when operator is "excluded"', () => {
+          const operator = operatorBuilder({ operator: 'excluded', language: 'kuery', exclude });
+          expect(operator).toEqual('');
+        });
       });
 
-      test('it returns empty string when operator is "excluded"', () => {
-        const operator = operatorBuilder({ operator: 'excluded', language: 'kuery' });
-
-        expect(operator).toEqual('');
+      describe('and language is lucene', () => {
+        test('it returns "NOT " when operator is "included"', () => {
+          const operator = operatorBuilder({ operator: 'included', language: 'lucene', exclude });
+          expect(operator).toEqual('NOT ');
+        });
+        test('it returns empty string when operator is "excluded"', () => {
+          const operator = operatorBuilder({ operator: 'excluded', language: 'lucene', exclude });
+          expect(operator).toEqual('');
+        });
       });
     });
-
-    describe('lucene', () => {
-      test('it returns "NOT " when operator is "included"', () => {
-        const operator = operatorBuilder({ operator: 'included', language: 'lucene' });
-
-        expect(operator).toEqual('NOT ');
+    describe("when 'exclude' is false", () => {
+      beforeEach(() => {
+        exclude = false;
       });
 
-      test('it returns empty string when operator is "excluded"', () => {
-        const operator = operatorBuilder({ operator: 'excluded', language: 'lucene' });
+      describe('and language is kuery', () => {
+        test('it returns empty string when operator is "included"', () => {
+          const operator = operatorBuilder({ operator: 'included', language: 'kuery', exclude });
+          expect(operator).toEqual('');
+        });
+        test('it returns "not " when operator is "excluded"', () => {
+          const operator = operatorBuilder({ operator: 'excluded', language: 'kuery', exclude });
+          expect(operator).toEqual('not ');
+        });
+      });
 
-        expect(operator).toEqual('');
+      describe('and language is lucene', () => {
+        test('it returns empty string when operator is "included"', () => {
+          const operator = operatorBuilder({ operator: 'included', language: 'lucene', exclude });
+          expect(operator).toEqual('');
+        });
+        test('it returns "NOT " when operator is "excluded"', () => {
+          const operator = operatorBuilder({ operator: 'excluded', language: 'lucene', exclude });
+          expect(operator).toEqual('NOT ');
+        });
       });
     });
   });
 
   describe('buildExists', () => {
-    describe('kuery', () => {
-      test('it returns formatted wildcard string when operator is "excluded"', () => {
-        const query = buildExists({
-          item: { type: 'exists', operator: 'excluded', field: 'host.name' },
-          language: 'kuery',
+    describe("when 'exclude' is true", () => {
+      describe('kuery', () => {
+        test('it returns formatted wildcard string when operator is "excluded"', () => {
+          const query = buildExists({
+            item: existsEntryWithExcluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('host.name:*');
         });
-
-        expect(query).toEqual('host.name:*');
+        test('it returns formatted wildcard string when operator is "included"', () => {
+          const query = buildExists({
+            item: existsEntryWithIncluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('not host.name:*');
+        });
       });
 
-      test('it returns formatted wildcard string when operator is "included"', () => {
-        const query = buildExists({
-          item: { type: 'exists', operator: 'included', field: 'host.name' },
-          language: 'kuery',
+      describe('lucene', () => {
+        test('it returns formatted wildcard string when operator is "excluded"', () => {
+          const query = buildExists({
+            item: existsEntryWithExcluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('_exists_host.name');
         });
-
-        expect(query).toEqual('not host.name:*');
+        test('it returns formatted wildcard string when operator is "included"', () => {
+          const query = buildExists({
+            item: existsEntryWithIncluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('NOT _exists_host.name');
+        });
       });
     });
 
-    describe('lucene', () => {
-      test('it returns formatted wildcard string when operator is "excluded"', () => {
-        const query = buildExists({
-          item: { type: 'exists', operator: 'excluded', field: 'host.name' },
-          language: 'lucene',
-        });
-
-        expect(query).toEqual('_exists_host.name');
+    describe("when 'exclude' is false", () => {
+      beforeEach(() => {
+        exclude = false;
       });
 
-      test('it returns formatted wildcard string when operator is "included"', () => {
-        const query = buildExists({
-          item: { type: 'exists', operator: 'included', field: 'host.name' },
-          language: 'lucene',
+      describe('kuery', () => {
+        test('it returns formatted wildcard string when operator is "excluded"', () => {
+          const query = buildExists({
+            item: existsEntryWithExcluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('not host.name:*');
         });
+        test('it returns formatted wildcard string when operator is "included"', () => {
+          const query = buildExists({
+            item: existsEntryWithIncluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('host.name:*');
+        });
+      });
 
-        expect(query).toEqual('NOT _exists_host.name');
+      describe('lucene', () => {
+        test('it returns formatted wildcard string when operator is "excluded"', () => {
+          const query = buildExists({
+            item: existsEntryWithExcluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('NOT _exists_host.name');
+        });
+        test('it returns formatted wildcard string when operator is "included"', () => {
+          const query = buildExists({
+            item: existsEntryWithIncluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('_exists_host.name');
+        });
       });
     });
   });
 
   describe('buildMatch', () => {
-    describe('kuery', () => {
-      test('it returns formatted string when operator is "included"', () => {
-        const query = buildMatch({
-          item: {
-            type: 'match',
-            operator: 'included',
-            field: 'host.name',
-            value: 'suricata',
-          },
-          language: 'kuery',
+    describe("when 'exclude' is true", () => {
+      describe('kuery', () => {
+        test('it returns formatted string when operator is "included"', () => {
+          const query = buildMatch({
+            item: matchEntryWithIncluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('not host.name:suricata');
         });
-
-        expect(query).toEqual('not host.name:suricata');
+        test('it returns formatted string when operator is "excluded"', () => {
+          const query = buildMatch({
+            item: matchEntryWithExcluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('host.name:suricata');
+        });
       });
 
-      test('it returns formatted string when operator is "excluded"', () => {
-        const query = buildMatch({
-          item: {
-            type: 'match',
-            operator: 'excluded',
-            field: 'host.name',
-            value: 'suricata',
-          },
-          language: 'kuery',
+      describe('lucene', () => {
+        test('it returns formatted string when operator is "included"', () => {
+          const query = buildMatch({
+            item: matchEntryWithIncluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('NOT host.name:suricata');
         });
-
-        expect(query).toEqual('host.name:suricata');
+        test('it returns formatted string when operator is "excluded"', () => {
+          const query = buildMatch({
+            item: matchEntryWithExcluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('host.name:suricata');
+        });
       });
     });
 
-    describe('lucene', () => {
-      test('it returns formatted string when operator is "included"', () => {
-        const query = buildMatch({
-          item: {
-            type: 'match',
-            operator: 'included',
-            field: 'host.name',
-            value: 'suricata',
-          },
-          language: 'lucene',
-        });
-
-        expect(query).toEqual('NOT host.name:suricata');
+    describe("when 'exclude' is false", () => {
+      beforeEach(() => {
+        exclude = false;
       });
 
-      test('it returns formatted string when operator is "excluded"', () => {
-        const query = buildMatch({
-          item: {
-            type: 'match',
-            operator: 'excluded',
-            field: 'host.name',
-            value: 'suricata',
-          },
-          language: 'lucene',
+      describe('kuery', () => {
+        test('it returns formatted string when operator is "included"', () => {
+          const query = buildMatch({
+            item: matchEntryWithIncluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('host.name:suricata');
         });
+        test('it returns formatted string when operator is "excluded"', () => {
+          const query = buildMatch({
+            item: matchEntryWithExcluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(query).toEqual('not host.name:suricata');
+        });
+      });
 
-        expect(query).toEqual('host.name:suricata');
+      describe('lucene', () => {
+        test('it returns formatted string when operator is "included"', () => {
+          const query = buildMatch({
+            item: matchEntryWithIncluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('host.name:suricata');
+        });
+        test('it returns formatted string when operator is "excluded"', () => {
+          const query = buildMatch({
+            item: matchEntryWithExcluded,
+            language: 'lucene',
+            exclude,
+          });
+          expect(query).toEqual('NOT host.name:suricata');
+        });
       });
     });
   });
 
   describe('buildMatchAny', () => {
-    describe('kuery', () => {
-      test('it returns empty string if given an empty array for "values"', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'included',
-            field: 'host.name',
-            value: [],
-            type: 'match_any',
-          },
-          language: 'kuery',
+    const entryWithIncludedAndNoValues: EntryMatchAny = makeMatchAnyEntry({
+      field: 'host.name',
+      value: [],
+    });
+    const entryWithIncludedAndOneValue: EntryMatchAny = makeMatchAnyEntry({
+      field: 'host.name',
+      value: ['suricata'],
+    });
+    const entryWithExcludedAndTwoValues: EntryMatchAny = makeMatchAnyEntry({
+      field: 'host.name',
+      value: ['suricata', 'auditd'],
+      operator: 'excluded',
+    });
+
+    describe("when 'exclude' is true", () => {
+      describe('kuery', () => {
+        test('it returns empty string if given an empty array for "values"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithIncludedAndNoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('');
+        });
+        test('it returns formatted string when "values" includes only one item', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithIncludedAndOneValue,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('not host.name:(suricata)');
+        });
+        test('it returns formatted string when operator is "included"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: matchAnyEntryWithIncludedAndTwoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('not host.name:(suricata or auditd)');
         });
 
-        expect(exceptionSegment).toEqual('');
+        test('it returns formatted string when operator is "excluded"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithExcludedAndTwoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('host.name:(suricata or auditd)');
+        });
       });
 
-      test('it returns formatted string when "values" includes only one item', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'included',
-            field: 'host.name',
-            value: ['suricata'],
-            type: 'match_any',
-          },
-          language: 'kuery',
+      describe('lucene', () => {
+        test('it returns formatted string when operator is "included"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: matchAnyEntryWithIncludedAndTwoValues,
+            language: 'lucene',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('NOT host.name:(suricata OR auditd)');
         });
-
-        expect(exceptionSegment).toEqual('not host.name:(suricata)');
-      });
-
-      test('it returns formatted string when operator is "included"', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'included',
-            field: 'host.name',
-            value: ['suricata', 'auditd'],
-            type: 'match_any',
-          },
-          language: 'kuery',
+        test('it returns formatted string when operator is "excluded"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithExcludedAndTwoValues,
+            language: 'lucene',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('host.name:(suricata OR auditd)');
         });
-
-        expect(exceptionSegment).toEqual('not host.name:(suricata or auditd)');
-      });
-
-      test('it returns formatted string when operator is "excluded"', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'excluded',
-            field: 'host.name',
-            value: ['suricata', 'auditd'],
-            type: 'match_any',
-          },
-          language: 'kuery',
+        test('it returns formatted string when "values" includes only one item', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithIncludedAndOneValue,
+            language: 'lucene',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('NOT host.name:(suricata)');
         });
-
-        expect(exceptionSegment).toEqual('host.name:(suricata or auditd)');
       });
     });
 
-    describe('lucene', () => {
-      test('it returns formatted string when operator is "included"', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'included',
-            field: 'host.name',
-            value: ['suricata', 'auditd'],
-            type: 'match_any',
-          },
-          language: 'lucene',
-        });
-
-        expect(exceptionSegment).toEqual('NOT host.name:(suricata OR auditd)');
+    describe("when 'exclude' is false", () => {
+      beforeEach(() => {
+        exclude = false;
       });
 
-      test('it returns formatted string when operator is "excluded"', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'excluded',
-            field: 'host.name',
-            value: ['suricata', 'auditd'],
-            type: 'match_any',
-          },
-          language: 'lucene',
+      describe('kuery', () => {
+        test('it returns empty string if given an empty array for "values"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithIncludedAndNoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('');
+        });
+        test('it returns formatted string when "values" includes only one item', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithIncludedAndOneValue,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('host.name:(suricata)');
+        });
+        test('it returns formatted string when operator is "included"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: matchAnyEntryWithIncludedAndTwoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('host.name:(suricata or auditd)');
         });
 
-        expect(exceptionSegment).toEqual('host.name:(suricata OR auditd)');
+        test('it returns formatted string when operator is "excluded"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithExcludedAndTwoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('not host.name:(suricata or auditd)');
+        });
       });
 
-      test('it returns formatted string when "values" includes only one item', () => {
-        const exceptionSegment = buildMatchAny({
-          item: {
-            operator: 'included',
-            field: 'host.name',
-            value: ['suricata'],
-            type: 'match_any',
-          },
-          language: 'lucene',
+      describe('lucene', () => {
+        test('it returns formatted string when operator is "included"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: matchAnyEntryWithIncludedAndTwoValues,
+            language: 'lucene',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('host.name:(suricata OR auditd)');
         });
-
-        expect(exceptionSegment).toEqual('NOT host.name:(suricata)');
+        test('it returns formatted string when operator is "excluded"', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithExcludedAndTwoValues,
+            language: 'lucene',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('NOT host.name:(suricata OR auditd)');
+        });
+        test('it returns formatted string when "values" includes only one item', () => {
+          const exceptionSegment = buildMatchAny({
+            item: entryWithIncludedAndOneValue,
+            language: 'lucene',
+            exclude,
+          });
+          expect(exceptionSegment).toEqual('host.name:(suricata)');
+        });
       });
     });
   });
@@ -284,18 +493,11 @@ describe('build_exceptions_query', () => {
         const item: EntryNested = {
           field: 'parent',
           type: 'nested',
-          entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
-          ],
+          entries: [makeMatchEntry({ field: 'nestedField', operator: 'excluded' })],
         };
         const result = buildNested({ item, language: 'kuery' });
 
-        expect(result).toEqual('parent:{ nestedField:value-3 }');
+        expect(result).toEqual('parent:{ nestedField:value-1 }');
       });
 
       test('it returns formatted query when multiple items in nested entry', () => {
@@ -303,23 +505,13 @@ describe('build_exceptions_query', () => {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
-            {
-              field: 'nestedFieldB',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-4',
-            },
+            makeMatchEntry({ field: 'nestedField', operator: 'excluded' }),
+            makeMatchEntry({ field: 'nestedFieldB', operator: 'excluded', value: 'value-2' }),
           ],
         };
         const result = buildNested({ item, language: 'kuery' });
 
-        expect(result).toEqual('parent:{ nestedField:value-3 and nestedFieldB:value-4 }');
+        expect(result).toEqual('parent:{ nestedField:value-1 and nestedFieldB:value-2 }');
       });
     });
 
@@ -329,18 +521,11 @@ describe('build_exceptions_query', () => {
         const item: EntryNested = {
           field: 'parent',
           type: 'nested',
-          entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
-          ],
+          entries: [makeMatchEntry({ field: 'nestedField', operator: 'excluded' })],
         };
         const result = buildNested({ item, language: 'lucene' });
 
-        expect(result).toEqual('parent:{ nestedField:value-3 }');
+        expect(result).toEqual('parent:{ nestedField:value-1 }');
       });
 
       test('it returns formatted query when multiple items in nested entry', () => {
@@ -348,129 +533,157 @@ describe('build_exceptions_query', () => {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
-            {
-              field: 'nestedFieldB',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-4',
-            },
+            makeMatchEntry({ field: 'nestedField', operator: 'excluded' }),
+            makeMatchEntry({ field: 'nestedFieldB', operator: 'excluded', value: 'value-2' }),
           ],
         };
         const result = buildNested({ item, language: 'lucene' });
 
-        expect(result).toEqual('parent:{ nestedField:value-3 AND nestedFieldB:value-4 }');
+        expect(result).toEqual('parent:{ nestedField:value-1 AND nestedFieldB:value-2 }');
       });
     });
   });
 
   describe('evaluateValues', () => {
-    describe('kuery', () => {
-      test('it returns formatted wildcard string when "type" is "exists"', () => {
-        const list: EntryExists = {
-          operator: 'included',
-          type: 'exists',
-          field: 'host.name',
-        };
-        const result = evaluateValues({
-          item: list,
-          language: 'kuery',
+    describe("when 'exclude' is true", () => {
+      describe('kuery', () => {
+        test('it returns formatted wildcard string when "type" is "exists"', () => {
+          const result = evaluateValues({
+            item: existsEntryWithIncluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(result).toEqual('not host.name:*');
         });
-
-        expect(result).toEqual('not host.name:*');
+        test('it returns formatted string when "type" is "match"', () => {
+          const result = evaluateValues({
+            item: matchEntryWithIncluded,
+            language: 'kuery',
+            exclude,
+          });
+          expect(result).toEqual('not host.name:suricata');
+        });
+        test('it returns formatted string when "type" is "match_any"', () => {
+          const result = evaluateValues({
+            item: matchAnyEntryWithIncludedAndTwoValues,
+            language: 'kuery',
+            exclude,
+          });
+          expect(result).toEqual('not host.name:(suricata or auditd)');
+        });
       });
 
-      test('it returns formatted string when "type" is "match"', () => {
-        const list: EntryMatch = {
-          operator: 'included',
-          type: 'match',
-          field: 'host.name',
-          value: 'suricata',
-        };
-        const result = evaluateValues({
-          item: list,
-          language: 'kuery',
+      describe('lucene', () => {
+        describe('kuery', () => {
+          test('it returns formatted wildcard string when "type" is "exists"', () => {
+            const result = evaluateValues({
+              item: existsEntryWithIncluded,
+              language: 'lucene',
+              exclude,
+            });
+            expect(result).toEqual('NOT _exists_host.name');
+          });
+          test('it returns formatted string when "type" is "match"', () => {
+            const result = evaluateValues({
+              item: matchEntryWithIncluded,
+              language: 'lucene',
+              exclude,
+            });
+            expect(result).toEqual('NOT host.name:suricata');
+          });
+          test('it returns formatted string when "type" is "match_any"', () => {
+            const result = evaluateValues({
+              item: matchAnyEntryWithIncludedAndTwoValues,
+              language: 'lucene',
+              exclude,
+            });
+            expect(result).toEqual('NOT host.name:(suricata OR auditd)');
+          });
         });
-
-        expect(result).toEqual('not host.name:suricata');
-      });
-
-      test('it returns formatted string when "type" is "match_any"', () => {
-        const list: EntryMatchAny = {
-          operator: 'included',
-          type: 'match_any',
-          field: 'host.name',
-          value: ['suricata', 'auditd'],
-        };
-
-        const result = evaluateValues({
-          item: list,
-          language: 'kuery',
-        });
-
-        expect(result).toEqual('not host.name:(suricata or auditd)');
       });
     });
 
-    describe('lucene', () => {
+    describe("when 'exclude' is false", () => {
+      beforeEach(() => {
+        exclude = false;
+      });
+
       describe('kuery', () => {
         test('it returns formatted wildcard string when "type" is "exists"', () => {
-          const list: EntryExists = {
-            operator: 'included',
-            type: 'exists',
-            field: 'host.name',
-          };
           const result = evaluateValues({
-            item: list,
-            language: 'lucene',
+            item: existsEntryWithIncluded,
+            language: 'kuery',
+            exclude,
           });
-
-          expect(result).toEqual('NOT _exists_host.name');
+          expect(result).toEqual('host.name:*');
         });
-
         test('it returns formatted string when "type" is "match"', () => {
-          const list: EntryMatch = {
-            operator: 'included',
-            type: 'match',
-            field: 'host.name',
-            value: 'suricata',
-          };
           const result = evaluateValues({
-            item: list,
-            language: 'lucene',
+            item: matchEntryWithIncluded,
+            language: 'kuery',
+            exclude,
           });
-
-          expect(result).toEqual('NOT host.name:suricata');
+          expect(result).toEqual('host.name:suricata');
         });
-
         test('it returns formatted string when "type" is "match_any"', () => {
-          const list: EntryMatchAny = {
-            operator: 'included',
-            type: 'match_any',
-            field: 'host.name',
-            value: ['suricata', 'auditd'],
-          };
-
           const result = evaluateValues({
-            item: list,
-            language: 'lucene',
+            item: matchAnyEntryWithIncludedAndTwoValues,
+            language: 'kuery',
+            exclude,
           });
+          expect(result).toEqual('host.name:(suricata or auditd)');
+        });
+      });
 
-          expect(result).toEqual('NOT host.name:(suricata OR auditd)');
+      describe('lucene', () => {
+        describe('kuery', () => {
+          test('it returns formatted wildcard string when "type" is "exists"', () => {
+            const result = evaluateValues({
+              item: existsEntryWithIncluded,
+              language: 'lucene',
+              exclude,
+            });
+            expect(result).toEqual('_exists_host.name');
+          });
+          test('it returns formatted string when "type" is "match"', () => {
+            const result = evaluateValues({
+              item: matchEntryWithIncluded,
+              language: 'lucene',
+              exclude,
+            });
+            expect(result).toEqual('host.name:suricata');
+          });
+          test('it returns formatted string when "type" is "match_any"', () => {
+            const result = evaluateValues({
+              item: matchAnyEntryWithIncludedAndTwoValues,
+              language: 'lucene',
+              exclude,
+            });
+            expect(result).toEqual('host.name:(suricata OR auditd)');
+          });
         });
       });
     });
   });
 
   describe('formatQuery', () => {
+    describe('when query is empty string', () => {
+      test('it returns query if "exceptions" is empty array', () => {
+        const formattedQuery = formatQuery({ exceptions: [], query: '', language: 'kuery' });
+        expect(formattedQuery).toEqual('');
+      });
+      test('it returns expected query string when single exception in array', () => {
+        const formattedQuery = formatQuery({
+          exceptions: ['b:(value-1 or value-2) and not c:*'],
+          query: '',
+          language: 'kuery',
+        });
+        expect(formattedQuery).toEqual('(b:(value-1 or value-2) and not c:*)');
+      });
+    });
+
     test('it returns query if "exceptions" is empty array', () => {
       const formattedQuery = formatQuery({ exceptions: [], query: 'a:*', language: 'kuery' });
-
       expect(formattedQuery).toEqual('a:*');
     });
 
@@ -480,7 +693,6 @@ describe('build_exceptions_query', () => {
         query: 'a:*',
         language: 'kuery',
       });
-
       expect(formattedQuery).toEqual('(a:* and b:(value-1 or value-2) and not c:*)');
     });
 
@@ -490,7 +702,6 @@ describe('build_exceptions_query', () => {
         query: 'a:*',
         language: 'kuery',
       });
-
       expect(formattedQuery).toEqual(
         '(a:* and b:(value-1 or value-2) and not c:*) or (a:* and not d:*)'
       );
@@ -502,6 +713,7 @@ describe('build_exceptions_query', () => {
       const query = buildExceptionItemEntries({
         language: 'kuery',
         lists: [],
+        exclude,
       });
 
       expect(query).toEqual('');
@@ -511,22 +723,13 @@ describe('build_exceptions_query', () => {
       // Equal to query && !(b && !c) -> (query AND NOT b) OR (query AND c)
       // https://www.dcode.fr/boolean-expressions-calculator
       const payload: EntriesArray = [
-        {
-          field: 'b',
-          operator: 'included',
-          type: 'match_any',
-          value: ['value-1', 'value-2'],
-        },
-        {
-          field: 'c',
-          operator: 'excluded',
-          type: 'match',
-          value: 'value-3',
-        },
+        makeMatchAnyEntry({ field: 'b' }),
+        makeMatchEntry({ field: 'c', operator: 'excluded', value: 'value-3' }),
       ];
       const query = buildExceptionItemEntries({
         language: 'kuery',
         lists: payload,
+        exclude,
       });
       const expectedQuery = 'not b:(value-1 or value-2) and c:value-3';
 
@@ -537,28 +740,19 @@ describe('build_exceptions_query', () => {
       // Equal to query && !(b || !c) -> (query AND NOT b AND c)
       // https://www.dcode.fr/boolean-expressions-calculator
       const lists: EntriesArray = [
-        {
-          field: 'b',
-          operator: 'included',
-          type: 'match_any',
-          value: ['value-1', 'value-2'],
-        },
+        makeMatchAnyEntry({ field: 'b' }),
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
+            makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
           ],
         },
       ];
       const query = buildExceptionItemEntries({
         language: 'kuery',
         lists,
+        exclude,
       });
       const expectedQuery = 'not b:(value-1 or value-2) and parent:{ nestedField:value-3 }';
 
@@ -569,33 +763,20 @@ describe('build_exceptions_query', () => {
       // Equal to query && !((b || !c) && d) -> (query AND NOT b AND c) OR (query AND NOT d)
       // https://www.dcode.fr/boolean-expressions-calculator
       const lists: EntriesArray = [
-        {
-          field: 'b',
-          operator: 'included',
-          type: 'match_any',
-          value: ['value-1', 'value-2'],
-        },
+        makeMatchAnyEntry({ field: 'b' }),
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
+            makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
           ],
         },
-        {
-          field: 'd',
-          operator: 'included',
-          type: 'exists',
-        },
+        makeExistsEntry({ field: 'd' }),
       ];
       const query = buildExceptionItemEntries({
         language: 'kuery',
         lists,
+        exclude,
       });
       const expectedQuery =
         'not b:(value-1 or value-2) and parent:{ nestedField:value-3 } and not d:*';
@@ -606,53 +787,137 @@ describe('build_exceptions_query', () => {
       // Equal to query && !((b || !c) && !d) -> (query AND NOT b AND c) OR (query AND d)
       // https://www.dcode.fr/boolean-expressions-calculator
       const lists: EntriesArray = [
-        {
-          field: 'b',
-          operator: 'included',
-          type: 'match_any',
-          value: ['value-1', 'value-2'],
-        },
+        makeMatchAnyEntry({ field: 'b' }),
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'nestedField',
-              operator: 'excluded',
-              type: 'match',
-              value: 'value-3',
-            },
+            makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
           ],
         },
-        {
-          field: 'e',
-          operator: 'excluded',
-          type: 'exists',
-        },
+        makeExistsEntry({ field: 'e', operator: 'excluded' }),
       ];
       const query = buildExceptionItemEntries({
         language: 'lucene',
         lists,
+        exclude,
       });
       const expectedQuery =
         'NOT b:(value-1 OR value-2) AND parent:{ nestedField:value-3 } AND _exists_e';
       expect(query).toEqual(expectedQuery);
     });
 
-    describe('exists', () => {
-      test('it returns expected query when list includes single list item with operator of "included"', () => {
-        // Equal to query && !(b) -> (query AND NOT b)
+    describe('when "exclude" is false', () => {
+      beforeEach(() => {
+        exclude = false;
+      });
+
+      test('it returns empty string if empty lists array passed in', () => {
+        const query = buildExceptionItemEntries({
+          language: 'kuery',
+          lists: [],
+          exclude,
+        });
+
+        expect(query).toEqual('');
+      });
+      test('it returns expected query when more than one item in list', () => {
+        // Equal to query && !(b && !c) -> (query AND NOT b) OR (query AND c)
+        // https://www.dcode.fr/boolean-expressions-calculator
+        const payload: EntriesArray = [
+          makeMatchAnyEntry({ field: 'b' }),
+          makeMatchEntry({ field: 'c', operator: 'excluded', value: 'value-3' }),
+        ];
+        const query = buildExceptionItemEntries({
+          language: 'kuery',
+          lists: payload,
+          exclude,
+        });
+        const expectedQuery = 'b:(value-1 or value-2) and not c:value-3';
+
+        expect(query).toEqual(expectedQuery);
+      });
+
+      test('it returns expected query when list item includes nested value', () => {
+        // Equal to query && !(b || !c) -> (query AND NOT b AND c)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
+          makeMatchAnyEntry({ field: 'b' }),
           {
-            field: 'b',
-            operator: 'included',
-            type: 'exists',
+            field: 'parent',
+            type: 'nested',
+            entries: [
+              makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
+            ],
           },
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
+        });
+        const expectedQuery = 'b:(value-1 or value-2) and parent:{ nestedField:value-3 }';
+
+        expect(query).toEqual(expectedQuery);
+      });
+
+      test('it returns expected query when list includes multiple items and nested "and" values', () => {
+        // Equal to query && !((b || !c) && d) -> (query AND NOT b AND c) OR (query AND NOT d)
+        // https://www.dcode.fr/boolean-expressions-calculator
+        const lists: EntriesArray = [
+          makeMatchAnyEntry({ field: 'b' }),
+          {
+            field: 'parent',
+            type: 'nested',
+            entries: [
+              makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
+            ],
+          },
+          makeExistsEntry({ field: 'd' }),
+        ];
+        const query = buildExceptionItemEntries({
+          language: 'kuery',
+          lists,
+          exclude,
+        });
+        const expectedQuery = 'b:(value-1 or value-2) and parent:{ nestedField:value-3 } and d:*';
+        expect(query).toEqual(expectedQuery);
+      });
+
+      test('it returns expected query when language is "lucene"', () => {
+        // Equal to query && !((b || !c) && !d) -> (query AND NOT b AND c) OR (query AND d)
+        // https://www.dcode.fr/boolean-expressions-calculator
+        const lists: EntriesArray = [
+          makeMatchAnyEntry({ field: 'b' }),
+          {
+            field: 'parent',
+            type: 'nested',
+            entries: [
+              makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
+            ],
+          },
+          makeExistsEntry({ field: 'e', operator: 'excluded' }),
+        ];
+        const query = buildExceptionItemEntries({
+          language: 'lucene',
+          lists,
+          exclude,
+        });
+        const expectedQuery =
+          'b:(value-1 OR value-2) AND parent:{ nestedField:value-3 } AND NOT _exists_e';
+        expect(query).toEqual(expectedQuery);
+      });
+    });
+
+    describe('exists', () => {
+      test('it returns expected query when list includes single list item with operator of "included"', () => {
+        // Equal to query && !(b) -> (query AND NOT b)
+        // https://www.dcode.fr/boolean-expressions-calculator
+        const lists: EntriesArray = [makeExistsEntry({ field: 'b' })];
+        const query = buildExceptionItemEntries({
+          language: 'kuery',
+          lists,
+          exclude,
         });
         const expectedQuery = 'not b:*';
 
@@ -662,16 +927,11 @@ describe('build_exceptions_query', () => {
       test('it returns expected query when list includes single list item with operator of "excluded"', () => {
         // Equal to query && !(!b) -> (query AND b)
         // https://www.dcode.fr/boolean-expressions-calculator
-        const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'excluded',
-            type: 'exists',
-          },
-        ];
+        const lists: EntriesArray = [makeExistsEntry({ field: 'b', operator: 'excluded' })];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
         const expectedQuery = 'b:*';
 
@@ -682,27 +942,17 @@ describe('build_exceptions_query', () => {
         // Equal to query && !(!b || !c) -> (query AND b AND c)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'excluded',
-            type: 'exists',
-          },
+          makeExistsEntry({ field: 'b', operator: 'excluded' }),
           {
             field: 'parent',
             type: 'nested',
-            entries: [
-              {
-                field: 'c',
-                operator: 'excluded',
-                type: 'match',
-                value: 'value-1',
-              },
-            ],
+            entries: [makeMatchEntry({ field: 'c', operator: 'excluded', value: 'value-1' })],
           },
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
         const expectedQuery = 'b:* and parent:{ c:value-1 }';
 
@@ -713,38 +963,21 @@ describe('build_exceptions_query', () => {
         // Equal to query && !((b || !c || d) && e) -> (query AND NOT b AND c AND NOT d) OR (query AND NOT e)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'included',
-            type: 'exists',
-          },
+          makeExistsEntry({ field: 'b' }),
           {
             field: 'parent',
             type: 'nested',
             entries: [
-              {
-                field: 'c',
-                operator: 'excluded',
-                type: 'match',
-                value: 'value-1',
-              },
-              {
-                field: 'd',
-                operator: 'included',
-                type: 'match',
-                value: 'value-2',
-              },
+              makeMatchEntry({ field: 'c', operator: 'excluded', value: 'value-1' }),
+              makeMatchEntry({ field: 'd', value: 'value-2' }),
             ],
           },
-          {
-            field: 'e',
-            operator: 'included',
-            type: 'exists',
-          },
+          makeExistsEntry({ field: 'e' }),
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
         const expectedQuery = 'not b:* and parent:{ c:value-1 and d:value-2 } and not e:*';
 
@@ -756,17 +989,11 @@ describe('build_exceptions_query', () => {
       test('it returns expected query when list includes single list item with operator of "included"', () => {
         // Equal to query && !(b) -> (query AND NOT b)
         // https://www.dcode.fr/boolean-expressions-calculator
-        const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'included',
-            type: 'match',
-            value: 'value',
-          },
-        ];
+        const lists: EntriesArray = [makeMatchEntry({ field: 'b', value: 'value' })];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
         const expectedQuery = 'not b:value';
 
@@ -777,16 +1004,12 @@ describe('build_exceptions_query', () => {
         // Equal to query && !(!b) -> (query AND b)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'excluded',
-            type: 'match',
-            value: 'value',
-          },
+          makeMatchEntry({ field: 'b', operator: 'excluded', value: 'value' }),
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
         const expectedQuery = 'b:value';
 
@@ -797,28 +1020,17 @@ describe('build_exceptions_query', () => {
         // Equal to query && !(!b || !c) -> (query AND b AND c)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'excluded',
-            type: 'match',
-            value: 'value',
-          },
+          makeMatchEntry({ field: 'b', operator: 'excluded', value: 'value' }),
           {
             field: 'parent',
             type: 'nested',
-            entries: [
-              {
-                field: 'c',
-                operator: 'excluded',
-                type: 'match',
-                value: 'valueC',
-              },
-            ],
+            entries: [makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' })],
           },
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
         const expectedQuery = 'b:value and parent:{ c:valueC }';
 
@@ -829,42 +1041,23 @@ describe('build_exceptions_query', () => {
         // Equal to query && !((b || !c || d) && e) -> (query AND NOT b AND c AND NOT d) OR (query AND NOT e)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'included',
-            type: 'match',
-            value: 'value',
-          },
+          makeMatchEntry({ field: 'b', value: 'value' }),
           {
             field: 'parent',
             type: 'nested',
             entries: [
-              {
-                field: 'c',
-                operator: 'excluded',
-                type: 'match',
-                value: 'valueC',
-              },
-              {
-                field: 'd',
-                operator: 'excluded',
-                type: 'match',
-                value: 'valueC',
-              },
+              makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
+              makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
             ],
           },
-          {
-            field: 'e',
-            operator: 'included',
-            type: 'match',
-            value: 'valueC',
-          },
+          makeMatchEntry({ field: 'e', value: 'valueE' }),
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
-        const expectedQuery = 'not b:value and parent:{ c:valueC and d:valueC } and not e:valueC';
+        const expectedQuery = 'not b:value and parent:{ c:valueC and d:valueD } and not e:valueE';
 
         expect(query).toEqual(expectedQuery);
       });
@@ -874,19 +1067,13 @@ describe('build_exceptions_query', () => {
       test('it returns expected query when list includes single list item with operator of "included"', () => {
         // Equal to query && !(b) -> (query AND NOT b)
         // https://www.dcode.fr/boolean-expressions-calculator
-        const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'included',
-            type: 'match_any',
-            value: ['value', 'value-1'],
-          },
-        ];
+        const lists: EntriesArray = [makeMatchAnyEntry({ field: 'b' })];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
-        const expectedQuery = 'not b:(value or value-1)';
+        const expectedQuery = 'not b:(value-1 or value-2)';
 
         expect(query).toEqual(expectedQuery);
       });
@@ -894,19 +1081,13 @@ describe('build_exceptions_query', () => {
       test('it returns expected query when list includes single list item with operator of "excluded"', () => {
         // Equal to query && !(!b) -> (query AND b)
         // https://www.dcode.fr/boolean-expressions-calculator
-        const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'excluded',
-            type: 'match_any',
-            value: ['value', 'value-1'],
-          },
-        ];
+        const lists: EntriesArray = [makeMatchAnyEntry({ field: 'b', operator: 'excluded' })];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
-        const expectedQuery = 'b:(value or value-1)';
+        const expectedQuery = 'b:(value-1 or value-2)';
 
         expect(query).toEqual(expectedQuery);
       });
@@ -915,30 +1096,19 @@ describe('build_exceptions_query', () => {
         // Equal to query && !(!b || c) -> (query AND b AND NOT c)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'excluded',
-            type: 'match_any',
-            value: ['value', 'value-1'],
-          },
+          makeMatchAnyEntry({ field: 'b', operator: 'excluded' }),
           {
             field: 'parent',
             type: 'nested',
-            entries: [
-              {
-                field: 'c',
-                operator: 'excluded',
-                type: 'match',
-                value: 'valueC',
-              },
-            ],
+            entries: [makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' })],
           },
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
-        const expectedQuery = 'b:(value or value-1) and parent:{ c:valueC }';
+        const expectedQuery = 'b:(value-1 or value-2) and parent:{ c:valueC }';
 
         expect(query).toEqual(expectedQuery);
       });
@@ -947,24 +1117,15 @@ describe('build_exceptions_query', () => {
         // Equal to query && !((b || !c || d) && e) -> ((query AND NOT b AND c AND NOT d) OR (query AND NOT e)
         // https://www.dcode.fr/boolean-expressions-calculator
         const lists: EntriesArray = [
-          {
-            field: 'b',
-            operator: 'included',
-            type: 'match_any',
-            value: ['value', 'value-1'],
-          },
-          {
-            field: 'e',
-            operator: 'included',
-            type: 'match_any',
-            value: ['valueE', 'value-4'],
-          },
+          makeMatchAnyEntry({ field: 'b' }),
+          makeMatchAnyEntry({ field: 'c' }),
         ];
         const query = buildExceptionItemEntries({
           language: 'kuery',
           lists,
+          exclude,
         });
-        const expectedQuery = 'not b:(value or value-1) and not e:(valueE or value-4)';
+        const expectedQuery = 'not b:(value-1 or value-2) and not c:(value-1 or value-2)';
 
         expect(query).toEqual(expectedQuery);
       });
@@ -985,36 +1146,16 @@ describe('build_exceptions_query', () => {
       const payload = getExceptionListItemSchemaMock();
       const payload2 = getExceptionListItemSchemaMock();
       payload2.entries = [
-        {
-          field: 'b',
-          operator: 'included',
-          type: 'match_any',
-          value: ['value', 'value-1'],
-        },
+        makeMatchAnyEntry({ field: 'b' }),
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'c',
-              operator: 'excluded',
-              type: 'match',
-              value: 'valueC',
-            },
-            {
-              field: 'd',
-              operator: 'excluded',
-              type: 'match',
-              value: 'valueD',
-            },
+            makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
+            makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
           ],
         },
-        {
-          field: 'e',
-          operator: 'included',
-          type: 'match_any',
-          value: ['valueE', 'value-4'],
-        },
+        makeMatchAnyEntry({ field: 'e' }),
       ];
       const query = buildQueryExceptions({
         query: 'a:*',
@@ -1022,7 +1163,7 @@ describe('build_exceptions_query', () => {
         lists: [payload, payload2],
       });
       const expectedQuery =
-        '(a:* and some.parentField:{ nested.field:some value } and not some.not.nested.field:some value) or (a:* and not b:(value or value-1) and parent:{ c:valueC and d:valueD } and not e:(valueE or value-4))';
+        '(a:* and some.parentField:{ nested.field:some value } and not some.not.nested.field:some value) or (a:* and not b:(value-1 or value-2) and parent:{ c:valueC and d:valueD } and not e:(value-1 or value-2))';
 
       expect(query).toEqual([{ query: expectedQuery, language: 'kuery' }]);
     });
@@ -1033,36 +1174,16 @@ describe('build_exceptions_query', () => {
       const payload = getExceptionListItemSchemaMock();
       const payload2 = getExceptionListItemSchemaMock();
       payload2.entries = [
-        {
-          field: 'b',
-          operator: 'included',
-          type: 'match_any',
-          value: ['value', 'value-1'],
-        },
+        makeMatchAnyEntry({ field: 'b' }),
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            {
-              field: 'c',
-              operator: 'excluded',
-              type: 'match',
-              value: 'valueC',
-            },
-            {
-              field: 'd',
-              operator: 'excluded',
-              type: 'match',
-              value: 'valueD',
-            },
+            makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
+            makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
           ],
         },
-        {
-          field: 'e',
-          operator: 'included',
-          type: 'match_any',
-          value: ['valueE', 'value-4'],
-        },
+        makeMatchAnyEntry({ field: 'e' }),
       ];
       const query = buildQueryExceptions({
         query: 'a:*',
@@ -1070,9 +1191,85 @@ describe('build_exceptions_query', () => {
         lists: [payload, payload2],
       });
       const expectedQuery =
-        '(a:* AND some.parentField:{ nested.field:some value } AND NOT some.not.nested.field:some value) OR (a:* AND NOT b:(value OR value-1) AND parent:{ c:valueC AND d:valueD } AND NOT e:(valueE OR value-4))';
+        '(a:* AND some.parentField:{ nested.field:some value } AND NOT some.not.nested.field:some value) OR (a:* AND NOT b:(value-1 OR value-2) AND parent:{ c:valueC AND d:valueD } AND NOT e:(value-1 OR value-2))';
 
       expect(query).toEqual([{ query: expectedQuery, language: 'lucene' }]);
+    });
+
+    describe('when "exclude" is false', () => {
+      beforeEach(() => {
+        exclude = false;
+      });
+
+      test('it returns original query if lists is empty array', () => {
+        const query = buildQueryExceptions({
+          query: 'host.name: *',
+          language: 'kuery',
+          lists: [],
+          exclude,
+        });
+        const expectedQuery = 'host.name: *';
+
+        expect(query).toEqual([{ query: expectedQuery, language: 'kuery' }]);
+      });
+
+      test('it returns expected query when lists exist and language is "kuery"', () => {
+        // Equal to query && !((b || !c || d) && e) -> ((query AND NOT b AND c AND NOT d) OR (query AND NOT e)
+        // https://www.dcode.fr/boolean-expressions-calculator
+        const payload = getExceptionListItemSchemaMock();
+        const payload2 = getExceptionListItemSchemaMock();
+        payload2.entries = [
+          makeMatchAnyEntry({ field: 'b' }),
+          {
+            field: 'parent',
+            type: 'nested',
+            entries: [
+              makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
+              makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
+            ],
+          },
+          makeMatchAnyEntry({ field: 'e' }),
+        ];
+        const query = buildQueryExceptions({
+          query: 'a:*',
+          language: 'kuery',
+          lists: [payload, payload2],
+          exclude,
+        });
+        const expectedQuery =
+          '(a:* and some.parentField:{ nested.field:some value } and some.not.nested.field:some value) or (a:* and b:(value-1 or value-2) and parent:{ c:valueC and d:valueD } and e:(value-1 or value-2))';
+
+        expect(query).toEqual([{ query: expectedQuery, language: 'kuery' }]);
+      });
+
+      test('it returns expected query when lists exist and language is "lucene"', () => {
+        // Equal to query && !((b || !c || d) && e) -> ((query AND NOT b AND c AND NOT d) OR (query AND NOT e)
+        // https://www.dcode.fr/boolean-expressions-calculator
+        const payload = getExceptionListItemSchemaMock();
+        const payload2 = getExceptionListItemSchemaMock();
+        payload2.entries = [
+          makeMatchAnyEntry({ field: 'b' }),
+          {
+            field: 'parent',
+            type: 'nested',
+            entries: [
+              makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
+              makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
+            ],
+          },
+          makeMatchAnyEntry({ field: 'e' }),
+        ];
+        const query = buildQueryExceptions({
+          query: 'a:*',
+          language: 'lucene',
+          lists: [payload, payload2],
+          exclude,
+        });
+        const expectedQuery =
+          '(a:* AND some.parentField:{ nested.field:some value } AND some.not.nested.field:some value) OR (a:* AND b:(value-1 OR value-2) AND parent:{ c:valueC AND d:valueD } AND e:(value-1 OR value-2))';
+
+        expect(query).toEqual([{ query: expectedQuery, language: 'lucene' }]);
+      });
     });
   });
 });

--- a/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.ts
@@ -218,14 +218,14 @@ export const buildQueryExceptions = ({
   exclude?: boolean;
 }): DataQuery[] => {
   if (lists != null) {
-    const exceptions = lists.reduce((acc, exceptionItem) => {
+    const exceptions = lists.reduce<string[]>((acc, exceptionItem) => {
       return [
         ...acc,
         ...(exceptionItem.entries !== undefined
           ? [buildExceptionItemEntries({ lists: exceptionItem.entries, language, exclude })]
           : []),
       ];
-    }, [] as string[]);
+    }, []);
     const formattedQuery = formatQuery({ exceptions, language, query });
     return [
       {

--- a/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.ts
@@ -17,6 +17,7 @@ import {
   entriesMatch,
   entriesNested,
   ExceptionListItemSchema,
+  CreateExceptionListItemSchema,
 } from '../shared_imports';
 import { Language, Query } from './schemas/common/schemas';
 
@@ -45,32 +46,35 @@ export const getLanguageBooleanOperator = ({
 export const operatorBuilder = ({
   operator,
   language,
+  exclude,
 }: {
   operator: Operator;
   language: Language;
+  exclude: boolean;
 }): string => {
   const not = getLanguageBooleanOperator({
     language,
     value: 'not',
   });
 
-  switch (operator) {
-    case 'included':
-      return `${not} `;
-    default:
-      return '';
+  if ((exclude && operator === 'included') || (!exclude && operator === 'excluded')) {
+    return `${not} `;
+  } else {
+    return '';
   }
 };
 
 export const buildExists = ({
   item,
   language,
+  exclude,
 }: {
   item: EntryExists;
   language: Language;
+  exclude: boolean;
 }): string => {
   const { operator, field } = item;
-  const exceptionOperator = operatorBuilder({ operator, language });
+  const exceptionOperator = operatorBuilder({ operator, language, exclude });
 
   switch (language) {
     case 'kuery':
@@ -85,12 +89,14 @@ export const buildExists = ({
 export const buildMatch = ({
   item,
   language,
+  exclude,
 }: {
   item: EntryMatch;
   language: Language;
+  exclude: boolean;
 }): string => {
   const { value, operator, field } = item;
-  const exceptionOperator = operatorBuilder({ operator, language });
+  const exceptionOperator = operatorBuilder({ operator, language, exclude });
 
   return `${exceptionOperator}${field}:${value}`;
 };
@@ -98,9 +104,11 @@ export const buildMatch = ({
 export const buildMatchAny = ({
   item,
   language,
+  exclude,
 }: {
   item: EntryMatchAny;
   language: Language;
+  exclude: boolean;
 }): string => {
   const { value, operator, field } = item;
 
@@ -109,7 +117,7 @@ export const buildMatchAny = ({
       return '';
     default:
       const or = getLanguageBooleanOperator({ language, value: 'or' });
-      const exceptionOperator = operatorBuilder({ operator, language });
+      const exceptionOperator = operatorBuilder({ operator, language, exclude });
       const matchAnyValues = value.map((v) => v);
 
       return `${exceptionOperator}${field}:(${matchAnyValues.join(` ${or} `)})`;
@@ -133,16 +141,18 @@ export const buildNested = ({
 export const evaluateValues = ({
   item,
   language,
+  exclude,
 }: {
   item: Entry | EntryNested;
   language: Language;
+  exclude: boolean;
 }): string => {
   if (entriesExists.is(item)) {
-    return buildExists({ item, language });
+    return buildExists({ item, language, exclude });
   } else if (entriesMatch.is(item)) {
-    return buildMatch({ item, language });
+    return buildMatch({ item, language, exclude });
   } else if (entriesMatchAny.is(item)) {
-    return buildMatchAny({ item, language });
+    return buildMatchAny({ item, language, exclude });
   } else if (entriesNested.is(item)) {
     return buildNested({ item, language });
   } else {
@@ -163,7 +173,11 @@ export const formatQuery = ({
     const or = getLanguageBooleanOperator({ language, value: 'or' });
     const and = getLanguageBooleanOperator({ language, value: 'and' });
     const formattedExceptions = exceptions.map((exception) => {
-      return `(${query} ${and} ${exception})`;
+      if (query === '') {
+        return `(${exception})`;
+      } else {
+        return `(${query} ${and} ${exception})`;
+      }
     });
 
     return formattedExceptions.join(` ${or} `);
@@ -175,15 +189,17 @@ export const formatQuery = ({
 export const buildExceptionItemEntries = ({
   lists,
   language,
+  exclude,
 }: {
   lists: EntriesArray;
   language: Language;
+  exclude: boolean;
 }): string => {
   const and = getLanguageBooleanOperator({ language, value: 'and' });
   const exceptionItem = lists
     .filter(({ type }) => type !== 'list')
     .reduce<string[]>((accum, listItem) => {
-      const exceptionSegment = evaluateValues({ item: listItem, language });
+      const exceptionSegment = evaluateValues({ item: listItem, language, exclude });
       return [...accum, exceptionSegment];
     }, []);
 
@@ -194,15 +210,22 @@ export const buildQueryExceptions = ({
   query,
   language,
   lists,
+  exclude = true,
 }: {
   query: Query;
   language: Language;
-  lists: ExceptionListItemSchema[] | undefined;
+  lists: Array<ExceptionListItemSchema | CreateExceptionListItemSchema> | undefined;
+  exclude?: boolean;
 }): DataQuery[] => {
   if (lists != null) {
-    const exceptions = lists.map((exceptionItem) =>
-      buildExceptionItemEntries({ lists: exceptionItem.entries, language })
-    );
+    const exceptions = lists.reduce((acc, exceptionItem) => {
+      return [
+        ...acc,
+        ...(exceptionItem.entries !== undefined
+          ? [buildExceptionItemEntries({ lists: exceptionItem.entries, language, exclude })]
+          : []),
+      ];
+    }, [] as string[]);
     const formattedQuery = formatQuery({ exceptions, language, query });
     return [
       {

--- a/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.ts
@@ -11,7 +11,10 @@ import {
   buildEsQuery,
   Query as DataQuery,
 } from '../../../../../src/plugins/data/common';
-import { ExceptionListItemSchema } from '../../../lists/common/schemas';
+import {
+  ExceptionListItemSchema,
+  CreateExceptionListItemSchema,
+} from '../../../lists/common/schemas';
 import { buildQueryExceptions } from './build_exceptions_query';
 import { Query, Language, Index } from './schemas/common/schemas';
 
@@ -20,14 +23,20 @@ export const getQueryFilter = (
   language: Language,
   filters: Array<Partial<Filter>>,
   index: Index,
-  lists: ExceptionListItemSchema[]
+  lists: Array<ExceptionListItemSchema | CreateExceptionListItemSchema>,
+  excludeExceptions: boolean = true
 ) => {
   const indexPattern: IIndexPattern = {
     fields: [],
     title: index.join(),
   };
 
-  const queries: DataQuery[] = buildQueryExceptions({ query, language, lists });
+  const queries: DataQuery[] = buildQueryExceptions({
+    query,
+    language,
+    lists,
+    exclude: excludeExceptions,
+  });
 
   const config = {
     allowLeadingWildcards: true,

--- a/x-pack/plugins/security_solution/common/shared_imports.ts
+++ b/x-pack/plugins/security_solution/common/shared_imports.ts
@@ -39,5 +39,4 @@ export {
   entriesList,
   namespaceType,
   ExceptionListType,
-  EntryMatch,
 } from '../../lists/common';

--- a/x-pack/plugins/security_solution/common/shared_imports.ts
+++ b/x-pack/plugins/security_solution/common/shared_imports.ts
@@ -39,4 +39,5 @@ export {
   entriesList,
   namespaceType,
   ExceptionListType,
+  EntryMatch,
 } from '../../lists/common';

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -252,12 +252,22 @@ export const AddExceptionModal = memo(function AddExceptionModal({
   const onAddExceptionConfirm = useCallback(() => {
     if (addOrUpdateExceptionItems !== null) {
       if (shouldCloseAlert && alertData) {
-        addOrUpdateExceptionItems(enrichExceptionItems(), alertData.ecsData._id);
+        addOrUpdateExceptionItems(
+          enrichExceptionItems(),
+          alertData.ecsData._id,
+          shouldBulkCloseAlert
+        );
       } else {
-        addOrUpdateExceptionItems(enrichExceptionItems());
+        addOrUpdateExceptionItems(enrichExceptionItems(), undefined, shouldBulkCloseAlert);
       }
     }
-  }, [addOrUpdateExceptionItems, enrichExceptionItems, shouldCloseAlert, alertData]);
+  }, [
+    addOrUpdateExceptionItems,
+    enrichExceptionItems,
+    shouldCloseAlert,
+    shouldBulkCloseAlert,
+    alertData,
+  ]);
 
   const isSubmitButtonDisabled = useCallback(
     () => fetchOrCreateListError || exceptionItemsToAdd.length === 0,

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -251,15 +251,10 @@ export const AddExceptionModal = memo(function AddExceptionModal({
 
   const onAddExceptionConfirm = useCallback(() => {
     if (addOrUpdateExceptionItems !== null) {
-      if (shouldCloseAlert && alertData) {
-        addOrUpdateExceptionItems(
-          enrichExceptionItems(),
-          alertData.ecsData._id,
-          shouldBulkCloseAlert
-        );
-      } else {
-        addOrUpdateExceptionItems(enrichExceptionItems(), undefined, shouldBulkCloseAlert);
-      }
+      const alertIdToClose = shouldCloseAlert && alertData ? alertData.ecsData._id : undefined;
+      const bulkCloseIndex =
+        shouldBulkCloseAlert && signalIndexName !== null ? [signalIndexName] : undefined;
+      addOrUpdateExceptionItems(enrichExceptionItems(), alertIdToClose, bulkCloseIndex);
     }
   }, [
     addOrUpdateExceptionItems,
@@ -267,6 +262,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
     shouldCloseAlert,
     shouldBulkCloseAlert,
     alertData,
+    signalIndexName,
   ]);
 
   const isSubmitButtonDisabled = useCallback(
@@ -340,7 +336,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
               <EuiHorizontalRule />
               <ModalBodySection>
                 {alertData !== undefined && (
-                  <EuiFormRow>
+                  <EuiFormRow fullWidth>
                     <EuiCheckbox
                       id="close-alert-on-add-add-exception-checkbox"
                       label="Close this alert"
@@ -349,10 +345,14 @@ export const AddExceptionModal = memo(function AddExceptionModal({
                     />
                   </EuiFormRow>
                 )}
-                <EuiFormRow>
+                <EuiFormRow fullWidth>
                   <EuiCheckbox
                     id="bulk-close-alert-on-add-add-exception-checkbox"
-                    label={i18n.BULK_CLOSE_LABEL}
+                    label={
+                      shouldDisableBulkClose
+                        ? i18n.BULK_CLOSE_LABEL_DISABLED
+                        : i18n.BULK_CLOSE_LABEL
+                    }
                     checked={shouldBulkCloseAlert}
                     onChange={onBulkCloseAlertCheckboxChange}
                     disabled={shouldDisableBulkClose}

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/translations.ts
@@ -60,6 +60,14 @@ export const BULK_CLOSE_LABEL = i18n.translate(
   }
 );
 
+export const BULK_CLOSE_LABEL_DISABLED = i18n.translate(
+  'xpack.securitySolution.exceptions.addException.bulkCloseLabel.disabled',
+  {
+    defaultMessage:
+      'Close all alerts that match attributes in this exception (Lists and non-ECS fields are not supported)',
+  }
+);
+
 export const EXCEPTION_BUILDER_INFO = i18n.translate(
   'xpack.securitySolution.exceptions.addException.infoLabel',
   {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -181,9 +181,11 @@ export const EditExceptionModal = memo(function EditExceptionModal({
 
   const onEditExceptionConfirm = useCallback(() => {
     if (addOrUpdateExceptionItems !== null) {
-      addOrUpdateExceptionItems(enrichExceptionItems());
+      const bulkCloseIndex =
+        shouldBulkCloseAlert && signalIndexName !== null ? [signalIndexName] : undefined;
+      addOrUpdateExceptionItems(enrichExceptionItems(), undefined, bulkCloseIndex);
     }
-  }, [addOrUpdateExceptionItems, enrichExceptionItems]);
+  }, [addOrUpdateExceptionItems, enrichExceptionItems, shouldBulkCloseAlert, signalIndexName]);
 
   const indexPatternConfig = useCallback(() => {
     if (exceptionListType === 'endpoint') {
@@ -239,10 +241,12 @@ export const EditExceptionModal = memo(function EditExceptionModal({
             </ModalBodySection>
             <EuiHorizontalRule />
             <ModalBodySection>
-              <EuiFormRow>
+              <EuiFormRow fullWidth>
                 <EuiCheckbox
                   id="close-alert-on-add-add-exception-checkbox"
-                  label={i18n.BULK_CLOSE_LABEL}
+                  label={
+                    shouldDisableBulkClose ? i18n.BULK_CLOSE_LABEL_DISABLED : i18n.BULK_CLOSE_LABEL
+                  }
                   checked={shouldBulkCloseAlert}
                   onChange={onBulkCloseAlertCheckboxChange}
                   disabled={shouldDisableBulkClose}

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/translations.ts
@@ -38,6 +38,14 @@ export const BULK_CLOSE_LABEL = i18n.translate(
   }
 );
 
+export const BULK_CLOSE_LABEL_DISABLED = i18n.translate(
+  'xpack.securitySolution.exceptions.editException.bulkCloseLabel.disabled',
+  {
+    defaultMessage:
+      'Close all alerts that match attributes in this exception (Lists and non-ECS fields are not supported)',
+  }
+);
+
 export const ENDPOINT_QUARANTINE_TEXT = i18n.translate(
   'xpack.securitySolution.exceptions.editException.endpointQuarantineText',
   {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
@@ -745,52 +745,5 @@ describe('Exception helpers', () => {
       const result = prepareExceptionItemsForBulkClose(payload);
       expect(result).toEqual(expected);
     });
-
-    test("should update nested entry fields when they start with 'event.'", () => {
-      const payload: ExceptionListItemSchema[] = [
-        {
-          ...getExceptionListItemSchemaMock(),
-          entries: [
-            {
-              ...getEntryNestedMock(),
-              field: 'event.kind',
-            },
-            {
-              ...getEntryNestedMock(),
-              entries: [
-                {
-                  ...getEntryMatchMock(),
-                  field: 'event.module',
-                },
-                getEntryMatchMock(),
-              ],
-            },
-          ],
-        },
-      ];
-      const expected = [
-        {
-          ...getExceptionListItemSchemaMock(),
-          entries: [
-            {
-              ...getEntryNestedMock(),
-              field: 'signal.original_event.kind',
-            },
-            {
-              ...getEntryNestedMock(),
-              entries: [
-                {
-                  ...getEntryMatchMock(),
-                  field: 'signal.original_event.module',
-                },
-                getEntryMatchMock(),
-              ],
-            },
-          ],
-        },
-      ];
-      const result = prepareExceptionItemsForBulkClose(payload);
-      expect(result).toEqual(expected);
-    });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
@@ -45,7 +45,6 @@ import {
   getEntryListMock,
   getEntryMatchMock,
   getEntryMatchAnyMock,
-  getEntryNestedMock,
   getEntriesArrayMock,
 } from '../../../../../lists/common/schemas/types/entries.mock';
 import { getCommentsArrayMock } from '../../../../../lists/common/schemas/types/comments.mock';

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
@@ -36,7 +36,7 @@ import {
   exceptionListItemSchema,
   UpdateExceptionListItemSchema,
   ExceptionListType,
-  EntriesArray,
+  EntryNested,
 } from '../../../lists_plugin_deps';
 import { IFieldType, IIndexPattern } from '../../../../../../../src/plugins/data/common';
 import { TimelineNonEcsData } from '../../../graphql/types';
@@ -392,7 +392,7 @@ export const prepareExceptionItemsForBulkClose = (
 ): Array<ExceptionListItemSchema | CreateExceptionListItemSchema> => {
   return exceptionItems.map((item: ExceptionListItemSchema | CreateExceptionListItemSchema) => {
     if (item.entries !== undefined) {
-      const newEntries = item.entries.map((itemEntry: EntriesArray[0]) => {
+      const newEntries = item.entries.map((itemEntry: Entry | EntryNested) => {
         return {
           ...itemEntry,
           field: itemEntry.field.startsWith('event.')

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
@@ -37,7 +37,6 @@ import {
   UpdateExceptionListItemSchema,
   ExceptionListType,
   EntriesArray,
-  EntryMatch,
 } from '../../../lists_plugin_deps';
 import { IFieldType, IIndexPattern } from '../../../../../../../src/plugins/data/common';
 import { TimelineNonEcsData } from '../../../graphql/types';
@@ -391,33 +390,15 @@ export const formatExceptionItemForUpdate = (
 export const prepareExceptionItemsForBulkClose = (
   exceptionItems: Array<ExceptionListItemSchema | CreateExceptionListItemSchema>
 ): Array<ExceptionListItemSchema | CreateExceptionListItemSchema> => {
-  const replaceField = (fieldToReplace: string) => {
-    return fieldToReplace.startsWith('event.')
-      ? fieldToReplace.replace(/^event./, 'signal.original_event.')
-      : fieldToReplace;
-  };
-
   return exceptionItems.map((item: ExceptionListItemSchema | CreateExceptionListItemSchema) => {
     if (item.entries !== undefined) {
       const newEntries = item.entries.map((itemEntry: EntriesArray[0]) => {
-        if (itemEntry.type === 'nested') {
-          const newNestedEntries = itemEntry.entries.map((nestedEntry: EntryMatch) => {
-            return {
-              ...nestedEntry,
-              field: replaceField(nestedEntry.field),
-            };
-          });
-          return {
-            ...itemEntry,
-            field: replaceField(itemEntry.field),
-            entries: newNestedEntries,
-          };
-        } else {
-          return {
-            ...itemEntry,
-            field: replaceField(itemEntry.field),
-          };
-        }
+        return {
+          ...itemEntry,
+          field: itemEntry.field.startsWith('event.')
+            ? itemEntry.field.replace(/^event./, 'signal.original_event.')
+            : itemEntry.field,
+        };
       });
       return {
         ...item,

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.test.tsx
@@ -9,6 +9,8 @@ import { KibanaServices } from '../../../common/lib/kibana';
 
 import * as alertsApi from '../../../detections/containers/detection_engine/alerts/api';
 import * as listsApi from '../../../../../lists/public/exceptions/api';
+import * as getQueryFilterHelper from '../../../../common/detection_engine/get_query_filter';
+import * as buildAlertStatusFilterHelper from '../../../detections/components/alerts_table/default_config';
 import { getExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
 import { getCreateExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/request/create_exception_list_item_schema.mock';
 import { getUpdateExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/request/update_exception_list_item_schema.mock';
@@ -38,11 +40,16 @@ describe('useAddOrUpdateException', () => {
   let updateExceptionListItem: jest.SpyInstance<ReturnType<
     typeof listsApi.updateExceptionListItem
   >>;
+  let getQueryFilter: jest.SpyInstance<ReturnType<typeof getQueryFilterHelper.getQueryFilter>>;
+  let buildAlertStatusFilter: jest.SpyInstance<ReturnType<
+    typeof buildAlertStatusFilterHelper.buildAlertStatusFilter
+  >>;
   let addOrUpdateItemsArgs: Parameters<AddOrUpdateExceptionItemsFunc>;
   let render: () => RenderHookResult<UseAddOrUpdateExceptionProps, ReturnUseAddOrUpdateException>;
   const onError = jest.fn();
   const onSuccess = jest.fn();
   const alertIdToClose = 'idToClose';
+  const bulkCloseIndex = ['.signals'];
   const itemsToAdd: CreateExceptionListItemSchema[] = [
     {
       ...getCreateExceptionListItemSchemaMock(),
@@ -112,6 +119,10 @@ describe('useAddOrUpdateException', () => {
     updateExceptionListItem = jest
       .spyOn(listsApi, 'updateExceptionListItem')
       .mockResolvedValue(getExceptionListItemSchemaMock());
+
+    getQueryFilter = jest.spyOn(getQueryFilterHelper, 'getQueryFilter');
+
+    buildAlertStatusFilter = jest.spyOn(buildAlertStatusFilterHelper, 'buildAlertStatusFilter');
 
     addOrUpdateItemsArgs = [itemsToAddOrUpdate];
     render = () =>
@@ -193,6 +204,94 @@ describe('useAddOrUpdateException', () => {
   describe('when alertIdToClose is passed in', () => {
     beforeEach(() => {
       addOrUpdateItemsArgs = [itemsToAddOrUpdate, alertIdToClose];
+    });
+    it('should update the alert status', async () => {
+      await act(async () => {
+        const { rerender, result, waitForNextUpdate } = render();
+        const addOrUpdateItems = await waitForAddOrUpdateFunc({
+          rerender,
+          result,
+          waitForNextUpdate,
+        });
+        if (addOrUpdateItems) {
+          addOrUpdateItems(...addOrUpdateItemsArgs);
+        }
+        await waitForNextUpdate();
+        expect(updateAlertStatus).toHaveBeenCalledTimes(1);
+      });
+    });
+    it('creates new items', async () => {
+      await act(async () => {
+        const { rerender, result, waitForNextUpdate } = render();
+        const addOrUpdateItems = await waitForAddOrUpdateFunc({
+          rerender,
+          result,
+          waitForNextUpdate,
+        });
+        if (addOrUpdateItems) {
+          addOrUpdateItems(...addOrUpdateItemsArgs);
+        }
+        await waitForNextUpdate();
+        expect(addExceptionListItem).toHaveBeenCalledTimes(2);
+        expect(addExceptionListItem.mock.calls[1][0].listItem).toEqual(itemsToAdd[1]);
+      });
+    });
+    it('updates existing items', async () => {
+      await act(async () => {
+        const { rerender, result, waitForNextUpdate } = render();
+        const addOrUpdateItems = await waitForAddOrUpdateFunc({
+          rerender,
+          result,
+          waitForNextUpdate,
+        });
+        if (addOrUpdateItems) {
+          addOrUpdateItems(...addOrUpdateItemsArgs);
+        }
+        await waitForNextUpdate();
+        expect(updateExceptionListItem).toHaveBeenCalledTimes(2);
+        expect(updateExceptionListItem.mock.calls[1][0].listItem).toEqual(
+          itemsToUpdateFormatted[1]
+        );
+      });
+    });
+  });
+
+  describe('when bulkCloseIndex is passed in', () => {
+    beforeEach(() => {
+      addOrUpdateItemsArgs = [itemsToAddOrUpdate, undefined, bulkCloseIndex];
+    });
+    it('should update the status of only alerts that are open', async () => {
+      await act(async () => {
+        const { rerender, result, waitForNextUpdate } = render();
+        const addOrUpdateItems = await waitForAddOrUpdateFunc({
+          rerender,
+          result,
+          waitForNextUpdate,
+        });
+        if (addOrUpdateItems) {
+          addOrUpdateItems(...addOrUpdateItemsArgs);
+        }
+        await waitForNextUpdate();
+        expect(buildAlertStatusFilter).toHaveBeenCalledTimes(1);
+        expect(buildAlertStatusFilter.mock.calls[0][0]).toEqual('open');
+      });
+    });
+    it('should generate the query filter using exceptions', async () => {
+      await act(async () => {
+        const { rerender, result, waitForNextUpdate } = render();
+        const addOrUpdateItems = await waitForAddOrUpdateFunc({
+          rerender,
+          result,
+          waitForNextUpdate,
+        });
+        if (addOrUpdateItems) {
+          addOrUpdateItems(...addOrUpdateItemsArgs);
+        }
+        await waitForNextUpdate();
+        expect(getQueryFilter).toHaveBeenCalledTimes(1);
+        expect(getQueryFilter.mock.calls[0][4]).toEqual(itemsToAddOrUpdate);
+        expect(getQueryFilter.mock.calls[0][5]).toEqual(false);
+      });
     });
     it('should update the alert status', async () => {
       await act(async () => {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.tsx
@@ -19,7 +19,7 @@ import { getUpdateAlertsQuery } from '../../../detections/components/alerts_tabl
 import { buildAlertStatusFilter } from '../../../detections/components/alerts_table/default_config';
 import { getQueryFilter } from '../../../../common/detection_engine/get_query_filter';
 import { Index } from '../../../../common/detection_engine/schemas/common/schemas';
-import { formatExceptionItemForUpdate } from './helpers';
+import { formatExceptionItemForUpdate, prepareExceptionItemsForBulkClose } from './helpers';
 
 /**
  * Adds exception items to the list. Also optionally closes alerts.
@@ -123,7 +123,7 @@ export const useAddOrUpdateException = ({
             'kuery',
             buildAlertStatusFilter('open'),
             bulkCloseIndex,
-            exceptionItemsToAddOrUpdate,
+            prepareExceptionItemsForBulkClose(exceptionItemsToAddOrUpdate),
             false
           );
           await updateAlertStatus({

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.tsx
@@ -116,7 +116,6 @@ export const useAddOrUpdateException = ({
           });
         }
 
-        console.log(shouldBulkClose);
         if (shouldBulkClose === true) {
           const filter = getQueryFilter(
             '',
@@ -126,23 +125,15 @@ export const useAddOrUpdateException = ({
             exceptionItemsToAddOrUpdate,
             false
           );
-          const queries = buildQueryExceptions({
-            query: '',
-            language: 'kuery',
-            lists: exceptionItemsToAddOrUpdate,
-            exclude: false,
-          });
-          console.log(queries);
-          console.log(filter);
-          /*
           await updateAlertStatus({
-            query: queries,
+            query: {
+              query: filter,
+            },
             status: 'closed',
           });
-           */
         }
 
-        // await addOrUpdateItems(exceptionItemsToAddOrUpdate);
+        await addOrUpdateItems(exceptionItemsToAddOrUpdate);
 
         if (isSubscribed) {
           setIsLoading(false);

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/use_add_exception.tsx
@@ -16,8 +16,9 @@ import {
 } from '../../../lists_plugin_deps';
 import { updateAlertStatus } from '../../../detections/containers/detection_engine/alerts/api';
 import { getUpdateAlertsQuery } from '../../../detections/components/alerts_table/actions';
-import { buildQueryExceptions } from '../../../../common/detection_engine/build_exceptions_query';
+import { buildAlertStatusFilter } from '../../../detections/components/alerts_table/default_config';
 import { getQueryFilter } from '../../../../common/detection_engine/get_query_filter';
+import { Index } from '../../../../common/detection_engine/schemas/common/schemas';
 import { formatExceptionItemForUpdate } from './helpers';
 
 /**
@@ -25,13 +26,13 @@ import { formatExceptionItemForUpdate } from './helpers';
  *
  * @param exceptionItemsToAddOrUpdate array of ExceptionListItemSchema to add or update
  * @param alertIdToClose - optional string representing alert to close
- * @param shouldBulkClose - optional boolean for whether to close alerts matching the exceptions query
+ * @param bulkCloseIndex - optional index used to create bulk close query
  *
  */
 export type AddOrUpdateExceptionItemsFunc = (
   exceptionItemsToAddOrUpdate: Array<ExceptionListItemSchema | CreateExceptionListItemSchema>,
   alertIdToClose?: string,
-  shouldBulkClose?: boolean
+  bulkCloseIndex?: Index
 ) => Promise<void>;
 
 export type ReturnUseAddOrUpdateException = [
@@ -105,7 +106,7 @@ export const useAddOrUpdateException = ({
     const addOrUpdateExceptionItems: AddOrUpdateExceptionItemsFunc = async (
       exceptionItemsToAddOrUpdate,
       alertIdToClose,
-      shouldBulkClose
+      bulkCloseIndex
     ) => {
       try {
         setIsLoading(true);
@@ -116,12 +117,12 @@ export const useAddOrUpdateException = ({
           });
         }
 
-        if (shouldBulkClose === true) {
+        if (bulkCloseIndex != null) {
           const filter = getQueryFilter(
             '',
             'kuery',
-            [],
-            ['.siem-signals'],
+            buildAlertStatusFilter('open'),
+            bulkCloseIndex,
             exceptionItemsToAddOrUpdate,
             false
           );


### PR DESCRIPTION
## Summary
Adds the bulk close feature to the Exception modal. A couple of items of note:
- Bulk closing will not be supported exceptions that use Value Lists or for exceptions that contain non-ECS fields
- Bulk closing will close alerts in the `.signals` index that match the exception's fields and values included in the Exception Modal


### Bulk close disabled when "is in list" operator is selected
![image](https://user-images.githubusercontent.com/616158/87258415-4cf9a880-c471-11ea-8f2c-2870262a1890.png)

### Bulk closing 4,100 alerts from Edit Modal
![bulk_close_1 mov](https://user-images.githubusercontent.com/616158/87258586-c1811700-c472-11ea-99e3-dd3dbc43e78c.gif)

## Testing
Navigate to the Alerts page, click on the overflow menu and select `Add exception`. After selecting the exception attributes, click the checkbox with text `Close all alerts that match attributes in this exception`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
