### PR TITLE
[7.x] [ftr] use typed chromeOptions object, adding TEST_BROWSER_BINARY_PATH (#71279)

### DIFF
--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -47,6 +47,7 @@ import { Browsers } from './browsers';
 
 const throttleOption: string = process.env.TEST_THROTTLE_NETWORK as string;
 const headlessBrowser: string = process.env.TEST_BROWSER_HEADLESS as string;
+const browserBinaryPath: string = process.env.TEST_BROWSER_BINARY_PATH as string;
 const remoteDebug: string = process.env.TEST_REMOTE_DEBUG as string;
 const certValidation: string = process.env.NODE_TLS_REJECT_UNAUTHORIZED as string;
 const SECOND = 1000;
@@ -54,10 +55,8 @@ const MINUTE = 60 * SECOND;
 const NO_QUEUE_COMMANDS = ['getLog', 'getStatus', 'newSession', 'quit'];
 const downloadDir = resolve(REPO_ROOT, 'target/functional-tests/downloads');
 const chromiumDownloadPrefs = {
-  prefs: {
-    'download.default_directory': downloadDir,
-    'download.prompt_for_download': false,
-  },
+  'download.default_directory': downloadDir,
+  'download.prompt_for_download': false,
 };
 
 /**
@@ -93,8 +92,8 @@ async function attemptToCreateCommand(
   const buildDriverInstance = async () => {
     switch (browserType) {
       case 'chrome': {
-        const chromeCapabilities = Capabilities.chrome();
-        const chromeOptions = [
+        const chromeOptions = new chrome.Options();
+        chromeOptions.addArguments(
           // Disables the sandbox for all process types that are normally sandboxed.
           'no-sandbox',
           // Launches URL in new browser window.
@@ -104,47 +103,55 @@ async function attemptToCreateCommand(
           // Use fake device for Media Stream to replace actual camera and microphone.
           'use-fake-device-for-media-stream',
           // Bypass the media stream infobar by selecting the default device for media streams (e.g. WebRTC). Works with --use-fake-device-for-media-stream.
-          'use-fake-ui-for-media-stream',
-        ];
+          'use-fake-ui-for-media-stream'
+        );
+
         if (process.platform === 'linux') {
           // The /dev/shm partition is too small in certain VM environments, causing
           // Chrome to fail or crash. Use this flag to work-around this issue
           // (a temporary directory will always be used to create anonymous shared memory files).
-          chromeOptions.push('disable-dev-shm-usage');
+          chromeOptions.addArguments('disable-dev-shm-usage');
         }
+
         if (headlessBrowser === '1') {
           // Use --disable-gpu to avoid an error from a missing Mesa library, as per
           // See: https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
-          chromeOptions.push('headless', 'disable-gpu');
+          chromeOptions.headless();
+          chromeOptions.addArguments('disable-gpu');
         }
+
         if (certValidation === '0') {
-          chromeOptions.push('ignore-certificate-errors');
+          chromeOptions.addArguments('ignore-certificate-errors');
         }
 
         if (remoteDebug === '1') {
           // Visit chrome://inspect in chrome to remotely view/debug
-          chromeOptions.push('headless', 'disable-gpu', 'remote-debugging-port=9222');
+          chromeOptions.headless();
+          chromeOptions.addArguments('disable-gpu', 'remote-debugging-port=9222');
         }
-        chromeCapabilities.set('goog:chromeOptions', {
-          w3c: true,
-          args: chromeOptions,
-          ...chromiumDownloadPrefs,
-        });
-        chromeCapabilities.set('unexpectedAlertBehaviour', 'accept');
-        chromeCapabilities.set('goog:loggingPrefs', { browser: 'ALL' });
-        chromeCapabilities.setAcceptInsecureCerts(config.acceptInsecureCerts);
+
+        if (browserBinaryPath) {
+          chromeOptions.setChromeBinaryPath(browserBinaryPath);
+        }
+
+        const prefs = new logging.Preferences();
+        prefs.setLevel(logging.Type.BROWSER, logging.Level.ALL);
+        chromeOptions.setUserPreferences(chromiumDownloadPrefs);
+        chromeOptions.setLoggingPrefs(prefs);
+        chromeOptions.set('unexpectedAlertBehaviour', 'accept');
+        chromeOptions.setAcceptInsecureCerts(config.acceptInsecureCerts);
 
         let session;
         if (remoteSessionUrl) {
           session = await new Builder()
             .forBrowser(browserType)
-            .withCapabilities(chromeCapabilities)
+            .setChromeOptions(chromeOptions)
             .usingServer(remoteSessionUrl)
             .build();
         } else {
           session = await new Builder()
             .forBrowser(browserType)
-            .withCapabilities(chromeCapabilities)
+            .setChromeOptions(chromeOptions)
             .setChromeService(new chrome.ServiceBuilder(chromeDriver.path).enableVerboseLogging())
             .build();
         }
@@ -174,7 +181,7 @@ async function attemptToCreateCommand(
           edgeOptions.setBinaryPath(edgePaths.browserPath);
           const options = edgeOptions.get('ms:edgeOptions');
           // overriding options to include preferences
-          Object.assign(options, chromiumDownloadPrefs);
+          Object.assign(options, { prefs: chromiumDownloadPrefs });
           edgeOptions.set('ms:edgeOptions', options);
           const session = await new Builder()
             .forBrowser('MicrosoftEdge')


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ftr] use typed chromeOptions object, adding TEST_BROWSER_BINARY_PATH (#71279)