### PR TITLE
Resolver: tweak API limits

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/schema/resolver.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/schema/resolver.ts
@@ -12,10 +12,10 @@ import { schema } from '@kbn/config-schema';
 export const validateTree = {
   params: schema.object({ id: schema.string() }),
   query: schema.object({
-    children: schema.number({ defaultValue: 10, min: 0, max: 100 }),
-    ancestors: schema.number({ defaultValue: 3, min: 0, max: 5 }),
-    events: schema.number({ defaultValue: 100, min: 0, max: 1000 }),
-    alerts: schema.number({ defaultValue: 100, min: 0, max: 1000 }),
+    children: schema.number({ defaultValue: 200, min: 0, max: 10000 }),
+    ancestors: schema.number({ defaultValue: 200, min: 0, max: 10000 }),
+    events: schema.number({ defaultValue: 1000, min: 0, max: 10000 }),
+    alerts: schema.number({ defaultValue: 1000, min: 0, max: 10000 }),
     afterEvent: schema.maybe(schema.string()),
     afterAlert: schema.maybe(schema.string()),
     afterChild: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

Set the Resolver API limits higher

* The defaults are high enough for most use cases
* The max values are high enough to let us test the server code in production by passing various params in the request


### Checklist


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
