### PR TITLE
[Ingest Manager] Fix create agent config flyout being covered by bottom bar

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_package_config_page/step_select_config.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_package_config_page/step_select_config.tsx
@@ -148,6 +148,7 @@ export const StepSelectConfig: React.FunctionComponent<{
                 setSelectedConfigId(newAgentConfig.id);
               }
             }}
+            ownFocus={true}
           />
         </EuiPortal>
       ) : null}

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/list_page/components/create_config.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/list_page/components/create_config.tsx
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import {
@@ -17,16 +18,24 @@ import {
   EuiButtonEmpty,
   EuiButton,
   EuiText,
+  EuiFlyoutProps,
 } from '@elastic/eui';
 import { NewAgentConfig, AgentConfig } from '../../../../types';
 import { useCapabilities, useCore, sendCreateAgentConfig } from '../../../../hooks';
 import { AgentConfigForm, agentConfigFormValidation } from '../../components';
 
-interface Props {
+const FlyoutWithHigherZIndex = styled(EuiFlyout)`
+  z-index: ${(props) => props.theme.eui.euiZLevel5};
+`;
+
+interface Props extends EuiFlyoutProps {
   onClose: (createdAgentConfig?: AgentConfig) => void;
 }
 
-export const CreateAgentConfigFlyout: React.FunctionComponent<Props> = ({ onClose }) => {
+export const CreateAgentConfigFlyout: React.FunctionComponent<Props> = ({
+  onClose,
+  ...restOfProps
+}) => {
   const { notifications } = useCore();
   const hasWriteCapabilites = useCapabilities().write;
   const [agentConfig, setAgentConfig] = useState<NewAgentConfig>({
@@ -147,10 +156,10 @@ export const CreateAgentConfigFlyout: React.FunctionComponent<Props> = ({ onClos
   );
 
   return (
-    <EuiFlyout onClose={onClose} size="l" maxWidth={400}>
+    <FlyoutWithHigherZIndex onClose={onClose} size="l" maxWidth={400} {...restOfProps}>
       {header}
       {body}
       {footer}
-    </EuiFlyout>
+    </FlyoutWithHigherZIndex>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #71519. Create agent config flyout was being covered by bottom bar in Step 1 of Add integration due to recent z-index changes in EUI (part of upgrade done in #70243). This PR fixes the overlap issues as adds `ownFocus=true` to the flyout per suggestion from EUI design team.

![image](https://user-images.githubusercontent.com/1965714/87338000-41ea5b00-c4f9-11ea-9ff3-e472f03764cc.png)


