### PR TITLE
[Ingest Manager] Remove `epm` config options

### DIFF
--- a/docs/settings/ingest-manager-settings.asciidoc
+++ b/docs/settings/ingest-manager-settings.asciidoc
@@ -20,8 +20,6 @@ See the {ingest-guide}/index.html[Ingest Management] docs for more information.
 |===
 | `xpack.ingestManager.enabled` {ess-icon}
   | Set to `true` to enable {ingest-manager}. 
-| `xpack.ingestManager.epm.enabled` {ess-icon}
-  | Set to `true` (default) to enable {package-manager}. 
 | `xpack.ingestManager.fleet.enabled` {ess-icon}
   | Set to `true` (default) to enable {fleet}. 
 |===
@@ -32,7 +30,7 @@ See the {ingest-guide}/index.html[Ingest Management] docs for more information.
 
 [cols="2*<"]
 |===
-| `xpack.ingestManager.epm.registryUrl`
+| `xpack.ingestManager.registryUrl`
   | The address to use to reach {package-manager} registry.
 |===
 

--- a/x-pack/plugins/ingest_manager/README.md
+++ b/x-pack/plugins/ingest_manager/README.md
@@ -4,11 +4,11 @@
 
 - The plugin is disabled by default. See the TypeScript type for the [the available plugin configuration options](https://github.com/elastic/kibana/blob/master/x-pack/plugins/ingest_manager/common/types/index.ts#L9-L27)
 - Setting `xpack.ingestManager.enabled=true` enables the plugin including the EPM and Fleet features. It also adds the `PACKAGE_CONFIG_API_ROUTES` and `AGENT_CONFIG_API_ROUTES` values in [`common/constants/routes.ts`](./common/constants/routes.ts)
-- Adding `--xpack.ingestManager.epm.enabled=false` will disable the EPM API & UI
 - Adding `--xpack.ingestManager.fleet.enabled=false` will disable the Fleet API & UI
   - [code for adding the routes](https://github.com/elastic/kibana/blob/1f27d349533b1c2865c10c45b2cf705d7416fb36/x-pack/plugins/ingest_manager/server/plugin.ts#L115-L133)
   - [Integration tests](server/integration_tests/router.test.ts)
 - Both EPM and Fleet require `ingestManager` be enabled. They are not standalone features.
+- For Gold+ license, a custom package registry URL can be used by setting `xpack.ingestManager.registryUrl=http://localhost:8080`
 
 ## Fleet Requirements
 

--- a/x-pack/plugins/ingest_manager/common/types/index.ts
+++ b/x-pack/plugins/ingest_manager/common/types/index.ts
@@ -8,10 +8,7 @@ export * from './rest_spec';
 
 export interface IngestManagerConfigType {
   enabled: boolean;
-  epm: {
-    enabled: boolean;
-    registryUrl?: string;
-  };
+  registryUrl?: string;
   fleet: {
     enabled: boolean;
     tlsCheckDisabled: boolean;

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/index.tsx
@@ -59,7 +59,7 @@ const ErrorLayout = ({ children }: { children: JSX.Element }) => (
 
 const IngestManagerRoutes = memo<{ history: AppMountParameters['history']; basepath: string }>(
   ({ history, ...rest }) => {
-    const { epm, fleet } = useConfig();
+    const { fleet } = useConfig();
     const { notifications } = useCore();
 
     const [isPermissionsLoading, setIsPermissionsLoading] = useState<boolean>(false);
@@ -186,11 +186,11 @@ const IngestManagerRoutes = memo<{ history: AppMountParameters['history']; basep
             <Router {...rest}>
               <PackageInstallProvider notifications={notifications}>
                 <Switch>
-                  <ProtectedRoute path={PAGE_ROUTING_PATHS.integrations} isAllowed={epm.enabled}>
+                  <Route path={PAGE_ROUTING_PATHS.integrations}>
                     <DefaultLayout section="epm">
                       <EPMApp />
                     </DefaultLayout>
-                  </ProtectedRoute>
+                  </Route>
                   <Route path={PAGE_ROUTING_PATHS.configurations}>
                     <DefaultLayout section="agent_config">
                       <AgentConfigApp />

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
@@ -41,7 +41,7 @@ export const DefaultLayout: React.FunctionComponent<Props> = ({
   children,
 }) => {
   const { getHref } = useLink();
-  const { epm, fleet } = useConfig();
+  const { fleet } = useConfig();
   const { uiSettings } = useCore();
   const [isSettingsFlyoutOpen, setIsSettingsFlyoutOpen] = React.useState(false);
 
@@ -71,11 +71,7 @@ export const DefaultLayout: React.FunctionComponent<Props> = ({
                       defaultMessage="Overview"
                     />
                   </EuiTab>
-                  <EuiTab
-                    isSelected={section === 'epm'}
-                    href={getHref('integrations_all')}
-                    disabled={!epm?.enabled}
-                  >
+                  <EuiTab isSelected={section === 'epm'} href={getHref('integrations_all')}>
                     <FormattedMessage
                       id="xpack.ingestManager.appNavigation.epmLinkText"
                       defaultMessage="Integrations"

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/epm/index.tsx
@@ -7,16 +7,15 @@
 import React from 'react';
 import { HashRouter as Router, Switch, Route } from 'react-router-dom';
 import { PAGE_ROUTING_PATHS } from '../../constants';
-import { useConfig, useBreadcrumbs } from '../../hooks';
+import { useBreadcrumbs } from '../../hooks';
 import { CreatePackageConfigPage } from '../agent_config/create_package_config_page';
 import { EPMHomePage } from './screens/home';
 import { Detail } from './screens/detail';
 
 export const EPMApp: React.FunctionComponent = () => {
   useBreadcrumbs('integrations');
-  const { epm } = useConfig();
 
-  return epm.enabled ? (
+  return (
     <Router>
       <Switch>
         <Route path={PAGE_ROUTING_PATHS.add_integration_to_configuration}>
@@ -30,5 +29,5 @@ export const EPMApp: React.FunctionComponent = () => {
         </Route>
       </Switch>
     </Router>
-  ) : null;
+  );
 };

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -21,10 +21,7 @@ export const config = {
   },
   schema: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
-    epm: schema.object({
-      enabled: schema.boolean({ defaultValue: true }),
-      registryUrl: schema.maybe(schema.uri()),
-    }),
+    registryUrl: schema.maybe(schema.uri()),
     fleet: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
       tlsCheckDisabled: schema.boolean({ defaultValue: false }),

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -215,12 +215,9 @@ export class IngestManagerPlugin
       registerOutputRoutes(router);
       registerSettingsRoutes(router);
       registerDataStreamRoutes(router);
+      registerEPMRoutes(router);
 
       // Conditional config routes
-      if (config.epm.enabled) {
-        registerEPMRoutes(router);
-      }
-
       if (config.fleet.enabled) {
         const isESOUsingEphemeralEncryptionKey =
           deps.encryptedSavedObjects.usingEphemeralEncryptionKey;

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
@@ -8,7 +8,7 @@ import { appContextService, licenseService } from '../../';
 
 export const getRegistryUrl = (): string => {
   const license = licenseService.getLicenseInformation();
-  const customUrl = appContextService.getConfig()?.epm.registryUrl;
+  const customUrl = appContextService.getConfig()?.registryUrl;
 
   if (
     customUrl &&

--- a/x-pack/test/ingest_manager_api_integration/config.ts
+++ b/x-pack/test/ingest_manager_api_integration/config.ts
@@ -63,7 +63,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       serverArgs: [
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
         ...(registryPort
-          ? [`--xpack.ingestManager.epm.registryUrl=http://localhost:${registryPort}`]
+          ? [`--xpack.ingestManager.registryUrl=http://localhost:${registryPort}`]
           : []),
       ],
     },

--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -47,7 +47,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         // define custom kibana server args here
         `--elasticsearch.ssl.certificateAuthorities=${CA_CERT_PATH}`,
         '--xpack.ingestManager.enabled=true',
-        '--xpack.ingestManager.epm.enabled=true',
         '--xpack.ingestManager.fleet.enabled=true',
       ],
     },


### PR DESCRIPTION
## Summary

Resolves #68658. This PR removes `xpack.ingestManager.epm.enabled` config option and all references to it in related code and docs. This PR also flattens `xpack.ingestManager.epm.registryUrl` to `xpack.ingestManager.registryUrl` and updates all references.