### PR TITLE
[Security Solution] [DETECTIONS] Set rule status to failure only on large gaps

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
@@ -10,7 +10,13 @@ import { getResult, getMlResult } from '../routes/__mocks__/request_responses';
 import { signalRulesAlertType } from './signal_rule_alert_type';
 import { alertsMock, AlertServicesMock } from '../../../../../alerts/server/mocks';
 import { ruleStatusServiceFactory } from './rule_status_service';
-import { getGapBetweenRuns, getListsClient, getExceptions, sortExceptionItems } from './utils';
+import {
+  getGapBetweenRuns,
+  getGapMaxCatchupRatio,
+  getListsClient,
+  getExceptions,
+  sortExceptionItems,
+} from './utils';
 import { RuleExecutorOptions } from './types';
 import { searchAfterAndBulkCreate } from './search_after_bulk_create';
 import { scheduleNotificationActions } from '../notifications/schedule_notification_actions';
@@ -97,6 +103,7 @@ describe('rules_notification_alert_type', () => {
       exceptionsWithValueLists: [],
     });
     (searchAfterAndBulkCreate as jest.Mock).mockClear();
+    (getGapMaxCatchupRatio as jestMock).mockClear();
     (searchAfterAndBulkCreate as jest.Mock).mockResolvedValue({
       success: true,
       searchAfterTimes: [],
@@ -126,20 +133,37 @@ describe('rules_notification_alert_type', () => {
   });
 
   describe('executor', () => {
-    it('should warn about the gap between runs', async () => {
-      (getGapBetweenRuns as jest.Mock).mockReturnValue(moment.duration(1000));
+    it('should warn about the gap between runs if gap is very large', async () => {
+      (getGapBetweenRuns as jest.Mock).mockReturnValue(moment.duration(100, 'm'));
+      (getGapMaxCatchupRatio as jest.Mock).mockReturnValue({
+        maxCatchup: 4,
+        ratio: 20,
+        gapDiffInUnits: 95,
+      });
       await alert.executor(payload);
       expect(logger.warn).toHaveBeenCalled();
       expect(logger.warn.mock.calls[0][0]).toContain(
-        'a few seconds (1000ms) has passed since last rule execution, and signals may have been missed.'
+        '2 hours (6000000ms) has passed since last rule execution, and signals may have been missed.'
       );
       expect(ruleStatusService.error).toHaveBeenCalled();
       expect(ruleStatusService.error.mock.calls[0][0]).toContain(
-        'a few seconds (1000ms) has passed since last rule execution, and signals may have been missed.'
+        '2 hours (6000000ms) has passed since last rule execution, and signals may have been missed.'
       );
       expect(ruleStatusService.error.mock.calls[0][1]).toEqual({
-        gap: 'a few seconds',
+        gap: '2 hours',
       });
+    });
+
+    it('should NOT warn about the gap between runs if gap small', async () => {
+      (getGapBetweenRuns as jest.Mock).mockReturnValue(moment.duration(1, 'm'));
+      (getGapMaxCatchupRatio as jest.Mock).mockReturnValue({
+        maxCatchup: 1,
+        ratio: 1,
+        gapDiffInUnits: 1,
+      });
+      await alert.executor(payload);
+      expect(logger.warn).toHaveBeenCalledTimes(0);
+      expect(ruleStatusService.error).toHaveBeenCalledTimes(0);
     });
 
     it("should set refresh to 'wait_for' when actions are present", async () => {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
@@ -103,7 +103,7 @@ describe('rules_notification_alert_type', () => {
       exceptionsWithValueLists: [],
     });
     (searchAfterAndBulkCreate as jest.Mock).mockClear();
-    (getGapMaxCatchupRatio as jestMock).mockClear();
+    (getGapMaxCatchupRatio as jest.Mock).mockClear();
     (searchAfterAndBulkCreate as jest.Mock).mockResolvedValue({
       success: true,
       searchAfterTimes: [],

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/types.ts
@@ -11,6 +11,11 @@ import { RuleAlertAction } from '../../../../common/detection_engine/types';
 import { RuleTypeParams } from '../types';
 import { SearchResponse } from '../../types';
 
+// used for gap detection code
+export type unitType = 's' | 'm' | 'h';
+export const isValidUnit = (unitParam: string): unitParam is unitType =>
+  ['s', 'm', 'h'].includes(unitParam);
+
 export interface SignalsParams {
   signalIds: string[] | undefined | null;
   query: object | undefined | null;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -12,13 +12,99 @@ import { AlertServices, parseDuration } from '../../../../../alerts/server';
 import { ExceptionListClient, ListClient, ListPluginSetup } from '../../../../../lists/server';
 import { EntriesArray, ExceptionListItemSchema } from '../../../../../lists/common/schemas';
 import { ListArrayOrUndefined } from '../../../../common/detection_engine/schemas/types/lists';
-import { BulkResponse, BulkResponseErrorAggregation } from './types';
+import { BulkResponse, BulkResponseErrorAggregation, isValidUnit } from './types';
 import { BuildRuleMessage } from './rule_messages';
 
 interface SortExceptionsReturn {
   exceptionsWithValueLists: ExceptionListItemSchema[];
   exceptionsWithoutValueLists: ExceptionListItemSchema[];
 }
+
+export const MAX_RULE_GAP_RATIO = 4;
+
+export const shorthandMap = {
+  s: {
+    momentString: 'seconds',
+    asFn: (duration: moment.Duration) => duration.asSeconds(),
+  },
+  m: {
+    momentString: 'minutes',
+    asFn: (duration: moment.Duration) => duration.asMinutes(),
+  },
+  h: {
+    momentString: 'hours',
+    asFn: (duration: moment.Duration) => duration.asHours(),
+  },
+};
+
+export const getGapMaxCatchupRatio = ({
+  logger,
+  previousStartedAt,
+  unit,
+  buildRuleMessage,
+  ruleParamsFrom,
+  interval,
+}: {
+  logger: Logger;
+  ruleParamsFrom: string;
+  previousStartedAt: Date | null | undefined;
+  interval: string;
+  buildRuleMessage: BuildRuleMessage;
+  unit: string;
+}): {
+  maxCatchup: number | null;
+  ratio: number | null;
+  gapDiffInUnits: number | null;
+} => {
+  if (previousStartedAt == null) {
+    return {
+      maxCatchup: null,
+      ratio: null,
+      gapDiffInUnits: null,
+    };
+  }
+  if (!isValidUnit(unit)) {
+    throw new Error(`previousStartedAt: ${previousStartedAt} and isValidUnit: ${isValidUnit}`);
+  }
+  /*
+      we need the total duration from now until the last time the rule ran.
+      the next few lines can be summed up as calculating
+      "how many second | minutes | hours have passed since the last time this ran?"
+      */
+  const nowToGapDiff = moment.duration(moment().diff(previousStartedAt));
+  // rule ran early, no gap
+  if (shorthandMap[unit].asFn(nowToGapDiff) < 0) {
+    // rule ran early, no gap
+    return {
+      maxCatchup: null,
+      ratio: null,
+      gapDiffInUnits: null,
+    };
+  }
+  const calculatedFrom = `now-${
+    parseInt(shorthandMap[unit].asFn(nowToGapDiff).toString(), 10) + unit
+  }`;
+  logger.debug(buildRuleMessage(`calculatedFrom: ${calculatedFrom}`));
+
+  const intervalMoment = moment.duration(parseInt(interval, 10), unit);
+  logger.debug(buildRuleMessage(`intervalMoment: ${shorthandMap[unit].asFn(intervalMoment)}`));
+  const calculatedFromAsMoment = dateMath.parse(calculatedFrom);
+  const dateMathRuleParamsFrom = dateMath.parse(ruleParamsFrom);
+  if (dateMathRuleParamsFrom != null && intervalMoment != null) {
+    const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
+    // const gapDiffInUnits = calculatedFromAsMoment.diff(dateMathRuleParamsFrom, momentUnit);
+    const gapDiffInUnits = dateMathRuleParamsFrom.diff(calculatedFromAsMoment, momentUnit);
+
+    const ratio = Math.abs(gapDiffInUnits / shorthandMap[unit].asFn(intervalMoment));
+
+    // maxCatchup is to ensure we are not trying to catch up too far back.
+    // This allows for a maximum of 4 consecutive rule execution misses
+    // to be included in the number of signals generated.
+    const maxCatchup = ratio < MAX_RULE_GAP_RATIO ? ratio : MAX_RULE_GAP_RATIO;
+    return { maxCatchup, ratio, gapDiffInUnits };
+  }
+  throw new Error('failed to parse calculatedFrom and intervalMoment');
+};
 
 export const getListsClient = async ({
   lists,
@@ -294,8 +380,6 @@ export const getSignalTimeTuples = ({
   from: moment.Moment | undefined;
   maxSignals: number;
 }> => {
-  type unitType = 's' | 'm' | 'h';
-  const isValidUnit = (unit: string): unit is unitType => ['s', 'm', 'h'].includes(unit);
   let totalToFromTuples: Array<{
     to: moment.Moment | undefined;
     from: moment.Moment | undefined;
@@ -305,20 +389,6 @@ export const getSignalTimeTuples = ({
     const fromUnit = ruleParamsFrom[ruleParamsFrom.length - 1];
     if (isValidUnit(fromUnit)) {
       const unit = fromUnit; // only seconds (s), minutes (m) or hours (h)
-      const shorthandMap = {
-        s: {
-          momentString: 'seconds',
-          asFn: (duration: moment.Duration) => duration.asSeconds(),
-        },
-        m: {
-          momentString: 'minutes',
-          asFn: (duration: moment.Duration) => duration.asMinutes(),
-        },
-        h: {
-          momentString: 'hours',
-          asFn: (duration: moment.Duration) => duration.asHours(),
-        },
-      };
 
       /*
       we need the total duration from now until the last time the rule ran.
@@ -333,62 +403,63 @@ export const getSignalTimeTuples = ({
 
       const intervalMoment = moment.duration(parseInt(interval, 10), unit);
       logger.debug(buildRuleMessage(`intervalMoment: ${shorthandMap[unit].asFn(intervalMoment)}`));
-      const calculatedFromAsMoment = dateMath.parse(calculatedFrom);
-      if (calculatedFromAsMoment != null && intervalMoment != null) {
-        const dateMathRuleParamsFrom = dateMath.parse(ruleParamsFrom);
-        const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
-        const gapDiffInUnits = calculatedFromAsMoment.diff(dateMathRuleParamsFrom, momentUnit);
-
-        const ratio = Math.abs(gapDiffInUnits / shorthandMap[unit].asFn(intervalMoment));
-
-        // maxCatchup is to ensure we are not trying to catch up too far back.
-        // This allows for a maximum of 4 consecutive rule execution misses
-        // to be included in the number of signals generated.
-        const maxCatchup = ratio < 4 ? ratio : 4;
-        logger.debug(buildRuleMessage(`maxCatchup: ${ratio}`));
-
-        let tempTo = dateMath.parse(ruleParamsFrom);
-        if (tempTo == null) {
-          // return an error
-          throw new Error('dateMath parse failed');
-        }
-
-        let beforeMutatedFrom: moment.Moment | undefined;
-        while (totalToFromTuples.length < maxCatchup) {
-          // if maxCatchup is less than 1, we calculate the 'from' differently
-          // and maxSignals becomes some less amount of maxSignals
-          // in order to maintain maxSignals per full rule interval.
-          if (maxCatchup > 0 && maxCatchup < 1) {
-            totalToFromTuples.push({
-              to: tempTo.clone(),
-              from: tempTo.clone().subtract(Math.abs(gapDiffInUnits), momentUnit),
-              maxSignals: ruleParamsMaxSignals * maxCatchup,
-            });
-            break;
-          }
-          const beforeMutatedTo = tempTo.clone();
-
-          // moment.subtract mutates the moment so we need to clone again..
-          beforeMutatedFrom = tempTo.clone().subtract(intervalMoment, momentUnit);
-          const tuple = {
-            to: beforeMutatedTo,
-            from: beforeMutatedFrom,
-            maxSignals: ruleParamsMaxSignals,
-          };
-          totalToFromTuples = [...totalToFromTuples, tuple];
-          tempTo = beforeMutatedFrom;
-        }
-        totalToFromTuples = [
-          {
-            to: dateMath.parse(ruleParamsTo),
-            from: dateMath.parse(ruleParamsFrom),
-            maxSignals: ruleParamsMaxSignals,
-          },
-          ...totalToFromTuples,
-        ];
-      } else {
-        logger.debug(buildRuleMessage('calculatedFromMoment was null or intervalMoment was null'));
+      const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
+      // maxCatchup is to ensure we are not trying to catch up too far back.
+      // This allows for a maximum of 4 consecutive rule execution misses
+      // to be included in the number of signals generated.
+      const { maxCatchup, ratio, gapDiffInUnits } = getGapMaxCatchupRatio({
+        logger,
+        buildRuleMessage,
+        previousStartedAt,
+        unit,
+        ruleParamsFrom,
+        interval,
+      });
+      logger.debug(buildRuleMessage(`maxCatchup: ${maxCatchup}, ratio: ${ratio}`));
+      if (maxCatchup == null || ratio == null || gapDiffInUnits == null) {
+        throw new Error(
+          buildRuleMessage('failed to calculate maxCatchup, ratio, or gapDiffInUnits')
+        );
       }
+      let tempTo = dateMath.parse(ruleParamsFrom);
+      if (tempTo == null) {
+        // return an error
+        throw new Error(buildRuleMessage('dateMath parse failed'));
+      }
+
+      let beforeMutatedFrom: moment.Moment | undefined;
+      while (totalToFromTuples.length < maxCatchup) {
+        // if maxCatchup is less than 1, we calculate the 'from' differently
+        // and maxSignals becomes some less amount of maxSignals
+        // in order to maintain maxSignals per full rule interval.
+        if (maxCatchup > 0 && maxCatchup < 1) {
+          totalToFromTuples.push({
+            to: tempTo.clone(),
+            from: tempTo.clone().subtract(Math.abs(gapDiffInUnits), momentUnit),
+            maxSignals: ruleParamsMaxSignals * maxCatchup,
+          });
+          break;
+        }
+        const beforeMutatedTo = tempTo.clone();
+
+        // moment.subtract mutates the moment so we need to clone again..
+        beforeMutatedFrom = tempTo.clone().subtract(intervalMoment, momentUnit);
+        const tuple = {
+          to: beforeMutatedTo,
+          from: beforeMutatedFrom,
+          maxSignals: ruleParamsMaxSignals,
+        };
+        totalToFromTuples = [...totalToFromTuples, tuple];
+        tempTo = beforeMutatedFrom;
+      }
+      totalToFromTuples = [
+        {
+          to: dateMath.parse(ruleParamsTo),
+          from: dateMath.parse(ruleParamsFrom),
+          maxSignals: ruleParamsMaxSignals,
+        },
+        ...totalToFromTuples,
+      ];
     }
   } else {
     totalToFromTuples = [

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -64,7 +64,12 @@ export const getGapMaxCatchupRatio = ({
     };
   }
   if (!isValidUnit(unit)) {
-    throw new Error(`previousStartedAt: ${previousStartedAt} and isValidUnit: ${isValidUnit}`);
+    logger.error(buildRuleMessage(`unit: ${unit} failed isValidUnit check`));
+    return {
+      maxCatchup: null,
+      ratio: null,
+      gapDiffInUnits: null,
+    };
   }
   /*
       we need the total duration from now until the last time the rule ran.
@@ -103,7 +108,12 @@ export const getGapMaxCatchupRatio = ({
     const maxCatchup = ratio < MAX_RULE_GAP_RATIO ? ratio : MAX_RULE_GAP_RATIO;
     return { maxCatchup, ratio, gapDiffInUnits };
   }
-  throw new Error('failed to parse calculatedFrom and intervalMoment');
+  logger.error(buildRuleMessage('failed to parse calculatedFrom and intervalMoment'));
+  return {
+    maxCatchup: null,
+    ratio: null,
+    gapDiffInUnits: null,
+  };
 };
 
 export const getListsClient = async ({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -99,7 +99,7 @@ export const getGapMaxCatchupRatio = ({
     const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
     const gapDiffInUnits = dateMathRuleParamsFrom.diff(calculatedFromAsMoment, momentUnit);
 
-    const ratio = Math.abs(gapDiffInUnits / shorthandMap[unit].asFn(intervalMoment));
+    const ratio = gapDiffInUnits / shorthandMap[unit].asFn(intervalMoment);
 
     // maxCatchup is to ensure we are not trying to catch up too far back.
     // This allows for a maximum of 4 consecutive rule execution misses
@@ -444,7 +444,7 @@ export const getSignalTimeTuples = ({
         if (maxCatchup > 0 && maxCatchup < 1) {
           totalToFromTuples.push({
             to: tempTo.clone(),
-            from: tempTo.clone().subtract(Math.abs(gapDiffInUnits), momentUnit),
+            from: tempTo.clone().subtract(gapDiffInUnits, momentUnit),
             maxSignals: ruleParamsMaxSignals * maxCatchup,
           });
           break;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -97,7 +97,6 @@ export const getGapMaxCatchupRatio = ({
   const dateMathRuleParamsFrom = dateMath.parse(ruleParamsFrom);
   if (dateMathRuleParamsFrom != null && intervalMoment != null) {
     const momentUnit = shorthandMap[unit].momentString as moment.DurationInputArg2;
-    // const gapDiffInUnits = calculatedFromAsMoment.diff(dateMathRuleParamsFrom, momentUnit);
     const gapDiffInUnits = dateMathRuleParamsFrom.diff(calculatedFromAsMoment, momentUnit);
 
     const ratio = Math.abs(gapDiffInUnits / shorthandMap[unit].asFn(intervalMoment));


### PR DESCRIPTION
## Summary

This is a follow-on PR to update the UX for when an error appears on the UI when a rule runs into a gap.

Previously, we were writing a failing status for a rule whenever a gap occurred. This PR introduces logic to write a failing rule status only if the calculated gap is very large (equivalent to 4x the rule interval). Otherwise don't write a status until rule execution has completed.

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
