### PR TITLE
[Security Solution][Detections] Fix UI race condition with lists index creation

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
@@ -19,17 +19,20 @@ export interface UseListsConfigReturn {
 }
 
 export const useListsConfig = (): UseListsConfigReturn => {
-  const { createIndex, indexExists, loading: indexLoading } = useListsIndex();
+  const { createIndex, createIndexError, indexExists, loading: indexLoading } = useListsIndex();
   const { canManageIndex, canWriteIndex, loading: privilegesLoading } = useListsPrivileges();
   const { lists } = useKibana().services;
 
   const enabled = lists != null;
   const loading = indexLoading || privilegesLoading;
   const needsIndex = indexExists === false;
-  const needsConfiguration = !enabled || needsIndex || canWriteIndex === false;
+  const indexCreationFailed = createIndexError != null;
+  const needsIndexConfiguration =
+    needsIndex && (canManageIndex === false || (canManageIndex === true && indexCreationFailed));
+  const needsConfiguration = !enabled || canWriteIndex === false || needsIndexConfiguration;
 
   useEffect(() => {
-    if (canManageIndex && needsIndex) {
+    if (needsIndex && canManageIndex) {
       createIndex();
     }
   }, [canManageIndex, createIndex, needsIndex]);

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
@@ -18,6 +18,8 @@ export interface UseListsIndexState {
 export interface UseListsIndexReturn extends UseListsIndexState {
   loading: boolean;
   createIndex: () => void;
+  createIndexError: unknown;
+  createIndexResult: { acknowledged: boolean } | undefined;
 }
 
 export const useListsIndex = (): UseListsIndexReturn => {
@@ -96,5 +98,11 @@ export const useListsIndex = (): UseListsIndexReturn => {
     }
   }, [createListIndexState.error, toasts]);
 
-  return { loading, createIndex, ...state };
+  return {
+    loading,
+    createIndex,
+    createIndexError: createListIndexState.error,
+    createIndexResult: createListIndexState.result,
+    ...state,
+  };
 };


### PR DESCRIPTION
## Summary

The errant behavior here was that you'd be redirected to detections from wherever you were, with no warning/indication. This would only happen once as the creation would succeed.

When we knew we needed an index, and that we could create one, `needsConfiguration` was incorrectly true during the time between realizing this fact and creating the index. That intermediate state is now captured in `needsIndexConfiguration`, which is true if we either can't create the index or we failed our attempt to do so.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
