### PR TITLE
[APM] Increase `xpack.apm.ui.transactionGroupBucketSize`

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -47,7 +47,7 @@ Changing these settings may disable features of the APM App.
   | Set to `false` to hide the APM app from the menu. Defaults to `true`.
 
 | `xpack.apm.ui.transactionGroupBucketSize`
-  | Number of top transaction groups displayed in the APM app. Defaults to `100`.
+  | Number of top transaction groups displayed in the APM app. Defaults to `1000`.
 
 | `xpack.apm.ui.maxTraceItems` {ess-icon}
   | Maximum number of child items displayed when viewing trace details. Defaults to `1000`.

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -27,7 +27,7 @@ export const config = {
     autocreateApmIndexPattern: schema.boolean({ defaultValue: true }),
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
-      transactionGroupBucketSize: schema.number({ defaultValue: 100 }),
+      transactionGroupBucketSize: schema.number({ defaultValue: 1000 }),
       maxTraceItems: schema.number({ defaultValue: 1000 }),
     }),
     telemetryCollectionEnabled: schema.boolean({ defaultValue: true }),

--- a/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/fetcher.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/fetcher.test.ts.snap
@@ -46,7 +46,7 @@ Array [
               },
             },
             "composite": Object {
-              "size": 101,
+              "size": 10000,
               "sources": Array [
                 Object {
                   "service": Object {

--- a/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/__snapshots__/queries.test.ts.snap
@@ -44,7 +44,7 @@ Object {
           },
         },
         "composite": Object {
-          "size": 101,
+          "size": 10000,
           "sources": Array [
             Object {
               "service": Object {

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -72,7 +72,9 @@ export async function transactionGroupsFetcher(
       aggs: {
         transaction_groups: {
           composite: {
-            size: bucketSize + 1, // 1 extra bucket is added to check whether the total number of buckets exceed the specified bucket size.
+            // traces overview is hardcoded to 10000
+            // transactions overview: 1 extra bucket is added to check whether the total number of buckets exceed the specified bucket size.
+            size: isTopTraces ? 10000 : bucketSize + 1,
             sources: [
               ...(isTopTraces
                 ? [{ service: { terms: { field: SERVICE_NAME } } }]

--- a/x-pack/test/apm_api_integration/basic/tests/services/transactions/top_transaction_groups.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/services/transactions/top_transaction_groups.ts
@@ -25,7 +25,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         );
 
         expect(response.status).to.be(200);
-        expect(response.body).to.eql({ items: [], isAggregationAccurate: true, bucketSize: 100 });
+        expect(response.body).to.eql({ items: [], isAggregationAccurate: true, bucketSize: 1000 });
       });
     });
 

--- a/x-pack/test/apm_api_integration/basic/tests/traces/top_traces.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/traces/top_traces.ts
@@ -24,7 +24,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         );
 
         expect(response.status).to.be(200);
-        expect(response.body).to.eql({ items: [], isAggregationAccurate: true, bucketSize: 100 });
+        expect(response.body).to.eql({ items: [], isAggregationAccurate: true, bucketSize: 1000 });
       });
     });
 


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/issues/67273 which reduced `xpack.apm.ui.transactionGroupBucketSize` to 100.

This increases the limit to 1000 which means fewer people will see a warning.