### PR TITLE
[SIEM][Detections] Updates edit exception text save button

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -198,7 +198,7 @@ export const EditExceptionModal = memo(function EditExceptionModal({
     <EuiOverlayMask>
       <Modal onClose={onCancel} data-test-subj="add-exception-modal">
         <ModalHeader>
-          <EuiModalHeaderTitle>{i18n.EDIT_EXCEPTION}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>{i18n.EDIT_EXCEPTION_TITLE}</EuiModalHeaderTitle>
           <ModalHeaderSubtitle className="eui-textTruncate" title={ruleName}>
             {ruleName}
           </ModalHeaderSubtitle>
@@ -260,7 +260,7 @@ export const EditExceptionModal = memo(function EditExceptionModal({
           <EuiButtonEmpty onClick={onCancel}>{i18n.CANCEL}</EuiButtonEmpty>
 
           <EuiButton onClick={onEditExceptionConfirm} isLoading={addExceptionIsLoading} fill>
-            {i18n.EDIT_EXCEPTION}
+            {i18n.EDIT_EXCEPTION_SAVE_BUTTON}
           </EuiButton>
         </EuiModalFooter>
       </Modal>

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/translations.ts
@@ -10,8 +10,15 @@ export const CANCEL = i18n.translate('xpack.securitySolution.exceptions.editExce
   defaultMessage: 'Cancel',
 });
 
-export const EDIT_EXCEPTION = i18n.translate(
-  'xpack.securitySolution.exceptions.editException.editException',
+export const EDIT_EXCEPTION_SAVE_BUTTON = i18n.translate(
+  'xpack.securitySolution.exceptions.editException.editExceptionSaveButton',
+  {
+    defaultMessage: 'Save',
+  }
+);
+
+export const EDIT_EXCEPTION_TITLE = i18n.translate(
+  'xpack.securitySolution.exceptions.editException.editExceptionTitle',
   {
     defaultMessage: 'Edit Exception',
   }


### PR DESCRIPTION
## Summary

In this PR we are updating the text for the "Edit Exception" modal that saves the changes as agreed with @MikePaquette.

![Screenshot 2020-07-14 at 17 55 58](https://user-images.githubusercontent.com/17427073/87448274-e8b72000-c5fb-11ea-9897-e1f4fcdb720c.png)


