### PR TITLE
[Ingest Manager] Better display of Fleet requirements

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import {
   EuiPageBody,
@@ -14,10 +15,38 @@ import {
   EuiTitle,
   EuiSpacer,
   EuiIcon,
+  EuiCallOut,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiCode,
+  EuiCodeBlock,
+  EuiLink,
 } from '@elastic/eui';
 import { useCore, sendPostFleetSetup } from '../../../hooks';
 import { WithoutHeaderLayout } from '../../../layouts';
 import { GetFleetStatusResponse } from '../../../types';
+
+export const RequirementItem: React.FunctionComponent<{ isMissing: boolean }> = ({
+  isMissing,
+  children,
+}) => {
+  return (
+    <EuiFlexGroup gutterSize="s" alignItems="flexStart">
+      <EuiFlexItem grow={false}>
+        <EuiText>
+          {isMissing ? (
+            <EuiIcon type="crossInACircleFilled" color="danger" />
+          ) : (
+            <EuiIcon type="checkInCircleFilled" color="success" />
+          )}
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText>{children}</EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
 
 export const SetupPage: React.FunctionComponent<{
   refresh: () => Promise<void>;
@@ -38,84 +67,154 @@ export const SetupPage: React.FunctionComponent<{
     }
   };
 
-  const content =
-    missingRequirements.includes('tls_required') ||
-    missingRequirements.includes('api_keys') ||
-    missingRequirements.includes('encrypted_saved_object_encryption_key_required') ? (
-      <>
-        <EuiSpacer size="m" />
-        <EuiIcon type="lock" color="subdued" size="xl" />
-        <EuiSpacer size="m" />
-        <EuiTitle size="l">
-          <h2>
-            <FormattedMessage
-              id="xpack.ingestManager.setupPage.missingRequirementsTitle"
-              defaultMessage="Missing requirements"
-            />
-          </h2>
-        </EuiTitle>
-        <EuiSpacer size="xl" />
-        <EuiText color="subdued" textAlign={'left'}>
-          <FormattedMessage
-            id="xpack.ingestManager.setupPage.missingRequirementsDescription"
-            defaultMessage="To use Fleet, you must enable the following features:
-          {space}- Enable Elasticsearch API keys.
-          {space}- Enable TLS to secure the communication between Agents and Kibana.
-          {space}- Set the encryption key for encrypted saved objects.
-          "
-            values={{
-              space: <EuiSpacer size="m" />,
-            }}
-          />
-        </EuiText>
-        <EuiSpacer size="l" />
-      </>
-    ) : (
-      <>
-        <EuiSpacer size="m" />
-        <EuiIcon type="lock" color="subdued" size="xl" />
-        <EuiSpacer size="m" />
-        <EuiTitle size="l">
-          <h2>
-            <FormattedMessage
-              id="xpack.ingestManager.setupPage.enableTitle"
-              defaultMessage="Enable Fleet"
-            />
-          </h2>
-        </EuiTitle>
-        <EuiSpacer size="xl" />
-        <EuiText color="subdued">
-          <FormattedMessage
-            id="xpack.ingestManager.setupPage.enableText"
-            defaultMessage="In order to use Fleet, you must create an Elastic user. This user can create API keys
-        and write to logs-* and metrics-*."
-          />
-        </EuiText>
-        <EuiSpacer size="l" />
-        <EuiForm>
-          <form onSubmit={onSubmit}>
-            <EuiButton fill isLoading={isFormLoading} type="submit">
+  if (
+    !missingRequirements.includes('tls_required') &&
+    !missingRequirements.includes('api_keys') &&
+    !missingRequirements.includes('encrypted_saved_object_encryption_key_required')
+  ) {
+    return (
+      <WithoutHeaderLayout>
+        <EuiPageBody restrictWidth={548}>
+          <EuiPageContent
+            verticalPosition="center"
+            horizontalPosition="center"
+            className="eui-textCenter"
+            paddingSize="l"
+          >
+            <EuiSpacer size="m" />
+            <EuiIcon type="lock" color="subdued" size="xl" />
+            <EuiSpacer size="m" />
+            <EuiTitle size="l">
+              <h2>
+                <FormattedMessage
+                  id="xpack.ingestManager.setupPage.enableTitle"
+                  defaultMessage="Enable Fleet"
+                />
+              </h2>
+            </EuiTitle>
+            <EuiSpacer size="xl" />
+            <EuiText color="subdued">
               <FormattedMessage
-                id="xpack.ingestManager.setupPage.enableFleet"
-                defaultMessage="Create user and enable Fleet"
+                id="xpack.ingestManager.setupPage.enableText"
+                defaultMessage="In order to use Fleet, you must create an Elastic user. This user can create API keys
+        and write to logs-* and metrics-*."
               />
-            </EuiButton>
-          </form>
-        </EuiForm>
-        <EuiSpacer size="m" />
-      </>
+            </EuiText>
+            <EuiSpacer size="l" />
+            <EuiForm>
+              <form onSubmit={onSubmit}>
+                <EuiButton fill isLoading={isFormLoading} type="submit">
+                  <FormattedMessage
+                    id="xpack.ingestManager.setupPage.enableFleet"
+                    defaultMessage="Create user and enable Fleet"
+                  />
+                </EuiButton>
+              </form>
+            </EuiForm>
+            <EuiSpacer size="m" />
+          </EuiPageContent>
+        </EuiPageBody>
+      </WithoutHeaderLayout>
     );
+  }
 
   return (
     <WithoutHeaderLayout>
-      <EuiPageBody restrictWidth={548}>
-        <EuiPageContent
-          verticalPosition="center"
-          horizontalPosition="center"
-          className="eui-textCenter"
-          paddingSize="l"
-        >
-          {content}
+      <EuiPageBody restrictWidth={820}>
+        <EuiPageContent>
+          <EuiCallOut
+            title={i18n.translate('xpack.ingestManager.setupPage.missingRequirementsCalloutTitle', {
+              defaultMessage: 'Missing security requirements',
+            })}
+            color="warning"
+            iconType="alert"
+          >
+            <FormattedMessage
+              id="xpack.ingestManager.setupPage.missingRequirementsCalloutDescription"
+              defaultMessage="In order to use Fleet, you must enable the following Elasticsearch and Kibana security features."
+            />
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+          <FormattedMessage
+            id="xpack.ingestManager.setupPage.missingRequirementsElasticsearchTitle"
+            defaultMessage="In your Elasticsearch configuration, enable:"
+          />
+          <EuiSpacer size="l" />
+          <RequirementItem isMissing={false}>
+            <FormattedMessage
+              id="xpack.ingestManager.setupPage.elasticsearchSecurityFlagText"
+              defaultMessage="Elasticsearch security. Set {securityFlag} to {true} ."
+              values={{
+                securityFlag: <EuiCode>xpack.security.enabled</EuiCode>,
+                true: <EuiCode>true</EuiCode>,
+              }}
+            />
+          </RequirementItem>
+          <EuiSpacer size="s" />
+          <RequirementItem isMissing={missingRequirements.includes('api_keys')}>
+            <FormattedMessage
+              id="xpack.ingestManager.setupPage.elasticsearchApiKeyFlagText"
+              defaultMessage="API key service. Set {apiKeyFlag} to {true} ."
+              values={{
+                apiKeyFlag: <EuiCode>xpack.security.authc.api_key.enabled</EuiCode>,
+                true: <EuiCode>true</EuiCode>,
+              }}
+            />
+          </RequirementItem>
+          <EuiSpacer size="m" />
+          <EuiCodeBlock isCopyable={true}>
+            {`xpack.security.enabled: true
+xpack.security.authc.api_key.enabled: true`}
+          </EuiCodeBlock>
+          <EuiSpacer size="l" />
+          <FormattedMessage
+            id="xpack.ingestManager.setupPage.missingRequirementsKibanaTitle"
+            defaultMessage="In your Kibana configuration, enable:"
+          />
+          <EuiSpacer size="l" />
+          <RequirementItem isMissing={missingRequirements.includes('tls_required')}>
+            <FormattedMessage
+              id="xpack.ingestManager.setupPage.tlsFlagText"
+              defaultMessage="Kibana security. Set. Set {securityFlag} to {true}. For development purposes, you can disable TLS by setting {tlsFlag} to {true} as an unsafe alternative."
+              values={{
+                securityFlag: <EuiCode>xpack.security.enabled</EuiCode>,
+                tlsFlag: <EuiCode>xpack.ingestManager.fleet.tlsCheckDisabled</EuiCode>,
+                true: <EuiCode>true</EuiCode>,
+              }}
+            />
+          </RequirementItem>
+          <EuiSpacer size="m" />
+          <RequirementItem
+            isMissing={missingRequirements.includes(
+              'encrypted_saved_object_encryption_key_required'
+            )}
+          >
+            <FormattedMessage
+              id="xpack.ingestManager.setupPage.encryptionKeyFlagText"
+              defaultMessage="Encryption key. Set {keyFlag} to use a secret key."
+              values={{
+                keyFlag: <EuiCode>xpack.reporting.encryptionKey</EuiCode>,
+              }}
+            />
+          </RequirementItem>
+          <EuiSpacer size="l" />
+          <FormattedMessage
+            id="xpack.ingestManager.setupPage.gettingStartedText"
+            defaultMessage="For more information, read our {link}."
+            values={{
+              link: (
+                <EuiLink
+                  href="https://www.elastic.co/guide/en/ingest-management/current/index.html"
+                  target="_blank"
+                >
+                  <FormattedMessage
+                    id="xpack.ingestManager.setupPage.gettingStartedLink"
+                    defaultMessage="Getting Started"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
         </EuiPageContent>
       </EuiPageBody>
     </WithoutHeaderLayout>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -55,8 +55,7 @@ export const SetupPage: React.FunctionComponent<{
   const [isFormLoading, setIsFormLoading] = useState<boolean>(false);
   const core = useCore();
 
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const onSubmit = async () => {
     setIsFormLoading(true);
     try {
       await sendPostFleetSetup({ forceRecreate: true });
@@ -102,14 +101,12 @@ export const SetupPage: React.FunctionComponent<{
             </EuiText>
             <EuiSpacer size="l" />
             <EuiForm>
-              <form onSubmit={onSubmit}>
-                <EuiButton fill isLoading={isFormLoading} type="submit">
-                  <FormattedMessage
-                    id="xpack.ingestManager.setupPage.enableFleet"
-                    defaultMessage="Create user and enable Fleet"
-                  />
-                </EuiButton>
-              </form>
+              <EuiButton onClick={onSubmit} fill isLoading={isFormLoading} type="submit">
+                <FormattedMessage
+                  id="xpack.ingestManager.setupPage.enableFleet"
+                  defaultMessage="Create user and enable Fleet"
+                />
+              </EuiButton>
             </EuiForm>
             <EuiSpacer size="m" />
           </EuiPageContent>
@@ -149,6 +146,7 @@ export const SetupPage: React.FunctionComponent<{
                   <EuiLink
                     href="https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html"
                     target="_blank"
+                    external
                   >
                     <FormattedMessage
                       id="xpack.ingestManager.setupPage.elasticsearchSecurityLink"
@@ -173,6 +171,7 @@ export const SetupPage: React.FunctionComponent<{
                   <EuiLink
                     href="https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#api-key-service-settings"
                     target="_blank"
+                    external
                   >
                     <FormattedMessage
                       id="xpack.ingestManager.setupPage.apiKeyServiceLink"
@@ -203,6 +202,7 @@ xpack.security.authc.api_key.enabled: true`}
                   <EuiLink
                     href="https://www.elastic.co/guide/en/kibana/current/using-kibana-with-security.html"
                     target="_blank"
+                    external
                   >
                     <FormattedMessage
                       id="xpack.ingestManager.setupPage.kibanaSecurityLink"
@@ -215,6 +215,7 @@ xpack.security.authc.api_key.enabled: true`}
                   <EuiLink
                     href="https://www.elastic.co/guide/en/kibana/current/configuring-tls.html"
                     target="_blank"
+                    external
                   >
                     <FormattedMessage
                       id="xpack.ingestManager.setupPage.tlsLink"
@@ -227,7 +228,7 @@ xpack.security.authc.api_key.enabled: true`}
               }}
             />
           </RequirementItem>
-          <EuiSpacer size="m" />
+          <EuiSpacer size="s" />
           <RequirementItem
             isMissing={missingRequirements.includes(
               'encrypted_saved_object_encryption_key_required'
@@ -235,12 +236,29 @@ xpack.security.authc.api_key.enabled: true`}
           >
             <FormattedMessage
               id="xpack.ingestManager.setupPage.encryptionKeyFlagText"
-              defaultMessage="Encryption key. Set {keyFlag} to use a secret key."
+              defaultMessage="{encryptionKeyLink}. Set {keyFlag} to any alphanumeric value of at least 32 characters."
               values={{
-                keyFlag: <EuiCode>xpack.reporting.encryptionKey</EuiCode>,
+                encryptionKeyLink: (
+                  <EuiLink
+                    href="https://www.elastic.co/guide/en/kibana/current/ingest-manager-settings-kb.html"
+                    target="_blank"
+                    external
+                  >
+                    <FormattedMessage
+                      id="xpack.ingestManager.setupPage.kibanaEncryptionLink"
+                      defaultMessage="Kibana encryption key"
+                    />
+                  </EuiLink>
+                ),
+                keyFlag: <EuiCode>xpack.encryptedSavedObjects.encryptionKey</EuiCode>,
               }}
             />
           </RequirementItem>
+          <EuiSpacer size="m" />
+          <EuiCodeBlock isCopyable={true}>
+            {`xpack.security.enabled: true
+xpack.encryptedSavedObjects.encryptionKey: "something_at_least_32_characters"`}
+          </EuiCodeBlock>
           <EuiSpacer size="l" />
           <FormattedMessage
             id="xpack.ingestManager.setupPage.gettingStartedText"
@@ -250,6 +268,7 @@ xpack.security.authc.api_key.enabled: true`}
                 <EuiLink
                   href="https://www.elastic.co/guide/en/ingest-management/current/index.html"
                   target="_blank"
+                  external
                 >
                   <FormattedMessage
                     id="xpack.ingestManager.setupPage.gettingStartedLink"

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -175,7 +175,7 @@ xpack.security.authc.api_key.enabled: true`}
           <RequirementItem isMissing={missingRequirements.includes('tls_required')}>
             <FormattedMessage
               id="xpack.ingestManager.setupPage.tlsFlagText"
-              defaultMessage="Kibana security. Set. Set {securityFlag} to {true}. For development purposes, you can disable TLS by setting {tlsFlag} to {true} as an unsafe alternative."
+              defaultMessage="Kibana security. Set {securityFlag} to {true}. For development purposes, you can disable TLS by setting {tlsFlag} to {true} as an unsafe alternative."
               values={{
                 securityFlag: <EuiCode>xpack.security.enabled</EuiCode>,
                 tlsFlag: <EuiCode>xpack.ingestManager.fleet.tlsCheckDisabled</EuiCode>,
@@ -200,7 +200,7 @@ xpack.security.authc.api_key.enabled: true`}
           <EuiSpacer size="l" />
           <FormattedMessage
             id="xpack.ingestManager.setupPage.gettingStartedText"
-            defaultMessage="For more information, read our {link}."
+            defaultMessage="For more information, read our {link} guide."
             values={{
               link: (
                 <EuiLink

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -143,8 +143,19 @@ export const SetupPage: React.FunctionComponent<{
           <RequirementItem isMissing={false}>
             <FormattedMessage
               id="xpack.ingestManager.setupPage.elasticsearchSecurityFlagText"
-              defaultMessage="Elasticsearch security. Set {securityFlag} to {true} ."
+              defaultMessage="{esSecurityLink}. Set {securityFlag} to {true} ."
               values={{
+                esSecurityLink: (
+                  <EuiLink
+                    href="https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html"
+                    target="_blank"
+                  >
+                    <FormattedMessage
+                      id="xpack.ingestManager.setupPage.elasticsearchSecurityLink"
+                      defaultMessage="Elasticsearch security"
+                    />
+                  </EuiLink>
+                ),
                 securityFlag: <EuiCode>xpack.security.enabled</EuiCode>,
                 true: <EuiCode>true</EuiCode>,
               }}
@@ -154,10 +165,21 @@ export const SetupPage: React.FunctionComponent<{
           <RequirementItem isMissing={missingRequirements.includes('api_keys')}>
             <FormattedMessage
               id="xpack.ingestManager.setupPage.elasticsearchApiKeyFlagText"
-              defaultMessage="API key service. Set {apiKeyFlag} to {true} ."
+              defaultMessage="{apiKeyLink}. Set {apiKeyFlag} to {true} ."
               values={{
                 apiKeyFlag: <EuiCode>xpack.security.authc.api_key.enabled</EuiCode>,
                 true: <EuiCode>true</EuiCode>,
+                apiKeyLink: (
+                  <EuiLink
+                    href="https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#api-key-service-settings"
+                    target="_blank"
+                  >
+                    <FormattedMessage
+                      id="xpack.ingestManager.setupPage.apiKeyServiceLink"
+                      defaultMessage="API key service"
+                    />
+                  </EuiLink>
+                ),
               }}
             />
           </RequirementItem>
@@ -175,9 +197,31 @@ xpack.security.authc.api_key.enabled: true`}
           <RequirementItem isMissing={missingRequirements.includes('tls_required')}>
             <FormattedMessage
               id="xpack.ingestManager.setupPage.tlsFlagText"
-              defaultMessage="Kibana security. Set {securityFlag} to {true}. For development purposes, you can disable TLS by setting {tlsFlag} to {true} as an unsafe alternative."
+              defaultMessage="{kibanaSecurityLink}. Set {securityFlag} to {true}. For development purposes, you can disable {tlsLink} by setting {tlsFlag} to {true} as an unsafe alternative."
               values={{
+                kibanaSecurityLink: (
+                  <EuiLink
+                    href="https://www.elastic.co/guide/en/kibana/current/using-kibana-with-security.html"
+                    target="_blank"
+                  >
+                    <FormattedMessage
+                      id="xpack.ingestManager.setupPage.kibanaSecurityLink"
+                      defaultMessage="Kibana security"
+                    />
+                  </EuiLink>
+                ),
                 securityFlag: <EuiCode>xpack.security.enabled</EuiCode>,
+                tlsLink: (
+                  <EuiLink
+                    href="https://www.elastic.co/guide/en/kibana/current/configuring-tls.html"
+                    target="_blank"
+                  >
+                    <FormattedMessage
+                      id="xpack.ingestManager.setupPage.tlsLink"
+                      defaultMessage="TLS"
+                    />
+                  </EuiLink>
+                ),
                 tlsFlag: <EuiCode>xpack.ingestManager.fleet.tlsCheckDisabled</EuiCode>,
                 true: <EuiCode>true</EuiCode>,
               }}

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -8375,8 +8375,6 @@
     "xpack.ingestManager.setupPage.enableFleet": "ユーザーを作成してフリートを有効にます",
     "xpack.ingestManager.setupPage.enableText": "フリートを使用するには、Elasticユーザーを作成する必要があります。このユーザーは、APIキーを作成して、logs-*およびmetrics-*に書き込むことができます。",
     "xpack.ingestManager.setupPage.enableTitle": "フリートを有効にする",
-    "xpack.ingestManager.setupPage.missingRequirementsDescription": "Fleetを使用するには、次の機能を有効にする必要があります。{space}- Elasticsearch APIキーを有効にします。{space}- TLSを有効にして、エージェントKibanaの間の通信を保護します。 ",
-    "xpack.ingestManager.setupPage.missingRequirementsTitle": "見つからない要件",
     "xpack.ingestManager.unenrollAgents.confirmModal.cancelButtonLabel": "キャンセル",
     "xpack.ingestManager.unenrollAgents.confirmModal.confirmButtonLabel": "登録解除",
     "xpack.ingestManager.unenrollAgents.confirmModal.deleteMultipleTitle": "{count, plural, one {# エージェント} other {# エージェント}}の登録を解除しますか？",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -8380,8 +8380,6 @@
     "xpack.ingestManager.setupPage.enableFleet": "创建用户并启用 Fleet",
     "xpack.ingestManager.setupPage.enableText": "要使用 Fleet，必须创建 Elastic 用户。此用户可以创建 API 密钥并写入到 logs-* and metrics-*。",
     "xpack.ingestManager.setupPage.enableTitle": "启用 Fleet",
-    "xpack.ingestManager.setupPage.missingRequirementsDescription": "要使用 Fleet，必须启用以下功能：{space}- 启用 Elasticsearch API 密钥。{space}- 启用 TLS 以保护代理和 Kibana 之间的通信。 ",
-    "xpack.ingestManager.setupPage.missingRequirementsTitle": "缺失的要求",
     "xpack.ingestManager.unenrollAgents.confirmModal.cancelButtonLabel": "取消",
     "xpack.ingestManager.unenrollAgents.confirmModal.confirmButtonLabel": "取消注册",
     "xpack.ingestManager.unenrollAgents.confirmModal.deleteMultipleTitle": "取消注册 {count, plural, one {# 个代理} other {# 个代理}}？",


### PR DESCRIPTION
## Summary

Resolve #70034

Better display of Fleet requirements

## UI Change

<img width="1155" alt="Screen Shot 2020-07-14 at 3 14 50 PM" src="https://user-images.githubusercontent.com/1336873/87468391-8bb16f00-c5e7-11ea-8dae-7072e7519c92.png">



## How to tests

Try to run Elasticsearch without the API key flag