### PR TITLE
[ENDPOINT] Initial version of new page layout.

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/index.tsx
@@ -7,6 +7,7 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useThrottledResizeObserver } from '../../common/components/utils';
 import { DragDropContextWrapper } from '../../common/components/drag_and_drop/drag_drop_context_wrapper';
 import { Flyout } from '../../timelines/components/flyout';
@@ -20,7 +21,7 @@ import { navTabs } from './home_navigations';
 import { useSignalIndex } from '../../detections/containers/detection_engine/alerts/use_signal_index';
 
 const WrappedByAutoSizer = styled.div`
-  height: 100%;
+  min-height: calc(100vh - 48px);
 `;
 WrappedByAutoSizer.displayName = 'WrappedByAutoSizer';
 
@@ -69,10 +70,17 @@ export const HomePage: React.FC<HomePageProps> = ({ children }) => {
   const { browserFields, indexPattern, indicesExist } = useWithSource('default', indexToAdd);
 
   return (
-    <WrappedByAutoSizer data-test-subj="wrapped-by-auto-sizer" ref={measureRef}>
-      <HeaderGlobal />
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="none"
+      data-test-subj="wrapped-by-auto-sizer"
+      style={{ minHeight: 'calc(100vh - 48px)' }}
+    >
+      <EuiFlexItem grow={false}>
+        <HeaderGlobal className="euiFlexItem" />
+      </EuiFlexItem>
 
-      <Main data-test-subj="pageContainer">
+      <EuiFlexItem data-test-subj="pageContainer">
         <DragDropContextWrapper browserFields={browserFields}>
           <UseUrlState indexPattern={indexPattern} navTabs={navTabs} />
           {indicesExist && showTimeline && (
@@ -88,10 +96,10 @@ export const HomePage: React.FC<HomePageProps> = ({ children }) => {
 
           {children}
         </DragDropContextWrapper>
-      </Main>
+      </EuiFlexItem>
 
       <HelpMenu />
-    </WrappedByAutoSizer>
+    </EuiFlexGroup>
   );
 };
 

--- a/x-pack/plugins/security_solution/public/common/components/endpoint/page_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/page_view.tsx
@@ -25,15 +25,17 @@ import { EuiTabProps } from '@elastic/eui/src/components/tabs/tab';
 
 const StyledEuiPage = styled(EuiPage)`
   &.endpoint--isListView {
-    padding: 0 ${(props) => props.theme.eui.euiSizeL};
+    padding: 0;
+    flex: 1 1 100%;
 
     .endpoint-header {
       padding: ${(props) => props.theme.eui.euiSizeL};
       margin-bottom: 0;
     }
     .endpoint-page-content {
-      border-left: none;
-      border-right: none;
+      border: none;
+      box-shadow: none;
+      border-radius: 0;
     }
   }
   &.endpoint--isDetailsView {
@@ -44,7 +46,7 @@ const StyledEuiPage = styled(EuiPage)`
     }
   }
   .endpoint-navTabs {
-    margin-left: ${(props) => props.theme.eui.euiSizeM};
+    padding-left: ${(props) => props.theme.eui.euiSizeM};
   }
   .endpoint-header-leftSection {
     overflow: hidden;


### PR DESCRIPTION
## Summary

Attempt to implement new list page layout. Done based on the same approach used in Observability -> Overview and Ingest Manager views.

New layout:
<img width="1605" alt="new layout" src="https://user-images.githubusercontent.com/1155504/87449463-8a8b3c80-c5fd-11ea-8071-6b3094d123a8.png">
