### PR TITLE
[SIEM][Timeline] Updates all events text timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/search_or_filter/translations.ts
@@ -73,7 +73,7 @@ export const FILTER_OR_SEARCH_WITH_KQL = i18n.translate(
 export const ALL_EVENT = i18n.translate(
   'xpack.securitySolution.timeline.searchOrFilter.eventTypeAllEvent',
   {
-    defaultMessage: 'All events',
+    defaultMessage: 'All',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/timeline.test.tsx
@@ -167,7 +167,7 @@ describe('Timeline', () => {
       expect(wrapper.find('[data-test-subj="table-pagination"]').exists()).toEqual(false);
     });
 
-    test('it defaults to showing `All events`', () => {
+    test('it defaults to showing `All`', () => {
       const wrapper = mount(
         <TestProviders>
           <MockedProvider mocks={mocks}>
@@ -177,7 +177,7 @@ describe('Timeline', () => {
       );
 
       expect(wrapper.find('[data-test-subj="pick-event-type"] button').text()).toEqual(
-        'All events'
+        'All'
       );
     });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/timeline.test.tsx
@@ -176,9 +176,7 @@ describe('Timeline', () => {
         </TestProviders>
       );
 
-      expect(wrapper.find('[data-test-subj="pick-event-type"] button').text()).toEqual(
-        'All'
-      );
+      expect(wrapper.find('[data-test-subj="pick-event-type"] button').text()).toEqual('All');
     });
 
     it('it shows the timeline footer', () => {


### PR DESCRIPTION
## Summary

Following @MikePaquette suggestion the default text "All events" has been modified to "All".

### Suggestion

![image (12)](https://user-images.githubusercontent.com/17427073/87453686-2d928500-c603-11ea-8481-8d1ee7839838.png)

### Final Result

![Screenshot 2020-07-14 at 19 03 37](https://user-images.githubusercontent.com/17427073/87454829-d2619200-c604-11ea-916f-99db73d66f94.png)


 