### PR TITLE
[Security Solution] [Detections] Fixes bug for determining when we hit max signals after filtering with lists

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
@@ -31,7 +31,6 @@ export const filterEventsAgainstList = async ({
   buildRuleMessage,
 }: FilterEventsAgainstList): Promise<SignalSearchResponse> => {
   try {
-    // logger.debug(buildRuleMessage(`exceptionsList: ${JSON.stringify(exceptionsList, null, 2)}`));
     if (exceptionsList == null || exceptionsList.length === 0) {
       logger.debug(buildRuleMessage('about to return original search result'));
       return eventSearchResult;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/filter_events_with_list.ts
@@ -31,7 +31,7 @@ export const filterEventsAgainstList = async ({
   buildRuleMessage,
 }: FilterEventsAgainstList): Promise<SignalSearchResponse> => {
   try {
-    logger.debug(buildRuleMessage(`exceptionsList: ${JSON.stringify(exceptionsList, null, 2)}`));
+    // logger.debug(buildRuleMessage(`exceptionsList: ${JSON.stringify(exceptionsList, null, 2)}`));
     if (exceptionsList == null || exceptionsList.length === 0) {
       logger.debug(buildRuleMessage('about to return original search result'));
       return eventSearchResult;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -91,7 +91,7 @@ export const searchAfterAndBulkCreate = async ({
   };
 
   let sortId; // tells us where to start our next search_after query
-  let searchResultSize = 0;
+  let signalsCreatedCount = 0;
 
   /*
     The purpose of `maxResults` is to ensure we do not perform
@@ -127,8 +127,8 @@ export const searchAfterAndBulkCreate = async ({
       toReturn.success = false;
       return toReturn;
     }
-    searchResultSize = 0;
-    while (searchResultSize < tuple.maxSignals) {
+    signalsCreatedCount = 0;
+    while (signalsCreatedCount < tuple.maxSignals) {
       try {
         logger.debug(buildRuleMessage(`sortIds: ${sortId}`));
         const {
@@ -187,12 +187,12 @@ export const searchAfterAndBulkCreate = async ({
 
         // make sure we are not going to create more signals than maxSignals allows
         if (
-          searchResultSize != null &&
-          searchResultSize + filteredEvents.hits.hits.length > tuple.maxSignals
+          signalsCreatedCount != null &&
+          signalsCreatedCount + filteredEvents.hits.hits.length > tuple.maxSignals
         ) {
           filteredEvents.hits.hits = filteredEvents.hits.hits.slice(
             0,
-            tuple.maxSignals - searchResultSize
+            tuple.maxSignals - signalsCreatedCount
           );
         }
 
@@ -220,7 +220,7 @@ export const searchAfterAndBulkCreate = async ({
         });
         logger.debug(buildRuleMessage(`created ${createdCount} signals`));
         toReturn.createdSignalsCount += createdCount;
-        searchResultSize += createdCount;
+        signalsCreatedCount += createdCount;
         if (bulkDuration) {
           toReturn.bulkCreateTimes.push(bulkDuration);
         }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -186,10 +186,7 @@ export const searchAfterAndBulkCreate = async ({
         }
 
         // make sure we are not going to create more signals than maxSignals allows
-        if (
-          signalsCreatedCount != null &&
-          signalsCreatedCount + filteredEvents.hits.hits.length > tuple.maxSignals
-        ) {
+        if (signalsCreatedCount + filteredEvents.hits.hits.length > tuple.maxSignals) {
           filteredEvents.hits.hits = filteredEvents.hits.hits.slice(
             0,
             tuple.maxSignals - signalsCreatedCount

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -179,7 +179,6 @@ export const searchAfterAndBulkCreate = async ({
                 buildRuleMessage,
               })
             : searchResult;
-        // searchResultSize += filteredEvents.hits.hits.length;
         if (filteredEvents.hits.total === 0 || filteredEvents.hits.hits.length === 0) {
           // everything in the events were allowed, so no need to generate signals
           toReturn.success = true;
@@ -242,11 +241,6 @@ export const searchAfterAndBulkCreate = async ({
             ? filteredEvents.hits.hits[0].sort[0]
             : undefined;
         }
-        logger.debug(
-          `is searchResultSize (${searchResultSize}) > maxSignals (${tuple.maxSignals})?: ${
-            searchResultSize > tuple.maxSignals
-          }`
-        );
       } catch (exc) {
         logger.error(buildRuleMessage(`[-] search_after and bulk threw an error ${exc}`));
         toReturn.success = false;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/search_after_bulk_create.ts
@@ -218,7 +218,6 @@ export const searchAfterAndBulkCreate = async ({
           refresh,
           tags,
           throttle,
-          searchResultSize,
         });
         logger.debug(buildRuleMessage(`created ${createdCount} signals`));
         toReturn.createdSignalsCount += createdCount;


### PR DESCRIPTION
## Summary

Before exceptions were introduced, we were determining when we hit max signals by checking how many events were searched, as those events were being sent straight to bulk create and would be indexed as signals.

Now with exceptions, each search result from the rule query doesn't necessarily mean we are going to index it as a signal, so we need to increment our counter for max signals by the count returned from bulk create (which does the indexing into the signals index), not the count returned from the search.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
