### PR TITLE
[Security Solution][Detections] Associate Endpoint Exceptions List to Rule during rule creation/update

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_histogram_panel/index.tsx
@@ -83,7 +83,7 @@ const NO_LEGEND_DATA: LegendItem[] = [];
 export const AlertsHistogramPanel = memo<AlertsHistogramPanelProps>(
   ({
     chartHeight,
-    defaultStackByOption = alertsHistogramOptions[0],
+    defaultStackByOption = alertsHistogramOptions[8], // signal.rule.name
     deleteQuery,
     filters,
     headerChildren,

--- a/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/ml_card_description.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/ml_card_description.tsx
@@ -5,7 +5,8 @@
  */
 
 import { FormattedMessage } from '@kbn/i18n/react';
-import { EuiText, EuiLink } from '@elastic/eui';
+import { EuiLink } from '@elastic/eui';
+import styled from 'styled-components';
 import React from 'react';
 
 import { ML_TYPE_DESCRIPTION } from './translations';
@@ -15,11 +16,15 @@ interface MlCardDescriptionProps {
   hasValidLicense?: boolean;
 }
 
+const SmallText = styled.span`
+  font-size: ${({ theme }) => theme.eui.euiFontSizeS};
+`;
+
 const MlCardDescriptionComponent: React.FC<MlCardDescriptionProps> = ({
   subscriptionUrl,
   hasValidLicense = false,
 }) => (
-  <EuiText size="s">
+  <SmallText>
     {hasValidLicense ? (
       ML_TYPE_DESCRIPTION
     ) : (
@@ -38,7 +43,7 @@ const MlCardDescriptionComponent: React.FC<MlCardDescriptionProps> = ({
         }}
       />
     )}
-  </EuiText>
+  </SmallText>
 );
 
 MlCardDescriptionComponent.displayName = 'MlCardDescriptionComponent';

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/default_value.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/default_value.ts
@@ -18,6 +18,7 @@ export const stepAboutDefaultValue: AboutStepRule = {
   author: [],
   name: '',
   description: '',
+  isAssociatedToEndpointList: false,
   isBuildingBlock: false,
   isNew: true,
   severity: { value: 'low', mapping: [] },

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.test.tsx
@@ -165,6 +165,7 @@ describe('StepAboutRuleComponent', () => {
     await wait();
     const expected: Omit<AboutStepRule, 'isNew'> = {
       author: [],
+      isAssociatedToEndpointList: false,
       isBuildingBlock: false,
       license: '',
       ruleNameOverride: '',
@@ -223,6 +224,7 @@ describe('StepAboutRuleComponent', () => {
     await wait();
     const expected: Omit<AboutStepRule, 'isNew'> = {
       author: [],
+      isAssociatedToEndpointList: false,
       isBuildingBlock: false,
       license: '',
       ruleNameOverride: '',

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
@@ -282,7 +282,20 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
               }}
             />
             <EuiSpacer size="l" />
-            <EuiFormRow label={I18n.BUILDING_BLOCK} isInvalid={false} fullWidth>
+            <EuiFormRow label={I18n.GLOBAL_ENDPOINT_EXCEPTION_LIST} fullWidth>
+              <CommonUseField
+                path="isAssociatedToEndpointList"
+                componentProps={{
+                  idAria: 'detectionEngineStepAboutRuleAssociatedToEndpointList',
+                  'data-test-subj': 'detectionEngineStepAboutRuleAssociatedToEndpointList',
+                  euiFieldProps: {
+                    fullWidth: true,
+                    isDisabled: isLoading,
+                  },
+                }}
+              />
+            </EuiFormRow>
+            <EuiFormRow label={I18n.BUILDING_BLOCK} fullWidth>
               <CommonUseField
                 path="isBuildingBlock"
                 componentProps={{
@@ -291,7 +304,6 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
                   euiFieldProps: {
                     fullWidth: true,
                     isDisabled: isLoading,
-                    placeholder: '',
                   },
                 }}
               />

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/schema.tsx
@@ -91,6 +91,16 @@ export const schema: FormSchema = {
     ),
     labelAppend: OptionalFieldLabel,
   },
+  isAssociatedToEndpointList: {
+    type: FIELD_TYPES.CHECKBOX,
+    label: i18n.translate(
+      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.fieldAssociatedToEndpointListLabel',
+      {
+        defaultMessage: 'Associate rule to Global Endpoint Exception List',
+      }
+    ),
+    labelAppend: OptionalFieldLabel,
+  },
   severity: {
     value: {
       type: FIELD_TYPES.SUPER_SELECT,

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/translations.ts
@@ -26,6 +26,14 @@ export const ADD_FALSE_POSITIVE = i18n.translate(
     defaultMessage: 'Add false positive example',
   }
 );
+
+export const GLOBAL_ENDPOINT_EXCEPTION_LIST = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepAboutRuleForm.endpointExceptionListLabel',
+  {
+    defaultMessage: 'Global endpoint exception list',
+  }
+);
+
 export const BUILDING_BLOCK = i18n.translate(
   'xpack.securitySolution.detectionEngine.createRule.stepAboutRuleForm.buildingBlockLabel',
   {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/__mocks__/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/__mocks__/mock.ts
@@ -167,6 +167,7 @@ export const mockRuleWithEverything = (id: string): Rule => ({
 export const mockAboutStepRule = (isNew = false): AboutStepRule => ({
   isNew,
   author: ['Elastic'],
+  isAssociatedToEndpointList: false,
   isBuildingBlock: false,
   timestampOverride: '',
   ruleNameOverride: '',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
@@ -153,6 +153,7 @@ export const formatAboutStepData = (aboutStepData: AboutStepRule): AboutStepRule
     riskScore,
     severity,
     threat,
+    isAssociatedToEndpointList,
     isBuildingBlock,
     isNew,
     note,
@@ -163,6 +164,13 @@ export const formatAboutStepData = (aboutStepData: AboutStepRule): AboutStepRule
   const resp = {
     author: author.filter((item) => !isEmpty(item)),
     ...(isBuildingBlock ? { building_block_type: 'default' } : {}),
+    ...(isAssociatedToEndpointList
+      ? {
+          exceptions_list: [
+            { id: 'endpoint_list', namespace_type: 'agnostic', type: 'endpoint' },
+          ] as AboutStepRuleJson['exceptions_list'],
+        }
+      : {}),
     false_positives: falsePositives.filter((item) => !isEmpty(item)),
     references: references.filter((item) => !isEmpty(item)),
     risk_score: riskScore.value,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
@@ -83,10 +83,12 @@ describe('rule helpers', () => {
           title: 'Titled timeline',
         },
       };
-      const aboutRuleStepData = {
+
+      const aboutRuleStepData: AboutStepRule = {
         author: [],
         description: '24/7',
         falsePositives: ['test'],
+        isAssociatedToEndpointList: false,
         isBuildingBlock: false,
         isNew: false,
         license: 'Elastic License',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
@@ -122,6 +122,7 @@ export const getAboutStepsData = (rule: Rule, detailsView: boolean): AboutStepRu
   const {
     author,
     building_block_type: buildingBlockType,
+    exceptions_list: exceptionsList,
     license,
     risk_score_mapping: riskScoreMapping,
     rule_name_override: ruleNameOverride,
@@ -138,6 +139,7 @@ export const getAboutStepsData = (rule: Rule, detailsView: boolean): AboutStepRu
   return {
     isNew: false,
     author,
+    isAssociatedToEndpointList: exceptionsList?.some(({ id }) => id === 'endpoint_list') ?? false,
     isBuildingBlock: buildingBlockType !== undefined,
     license: license ?? '',
     ruleNameOverride: ruleNameOverride ?? '',

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
@@ -20,6 +20,7 @@ import {
   SeverityMapping,
   TimestampOverride,
 } from '../../../../../common/detection_engine/schemas/common/schemas';
+import { List } from '../../../../../common/detection_engine/schemas/types';
 
 export interface EuiBasicTableSortTypes {
   field: string;
@@ -65,6 +66,7 @@ export interface AboutStepRule extends StepRuleData {
   author: string[];
   name: string;
   description: string;
+  isAssociatedToEndpointList: boolean;
   isBuildingBlock: boolean;
   severity: AboutStepSeverity;
   riskScore: AboutStepRiskScore;
@@ -136,6 +138,7 @@ export interface DefineStepRuleJson {
 export interface AboutStepRuleJson {
   author: Author;
   building_block_type?: BuildingBlockType;
+  exceptions_list?: List[];
   name: string;
   description: string;
   license: License;


### PR DESCRIPTION
## Summary

This adds the following:

* Checkbox to associate/dissociate a given rule with the global exceptions list on create/edit
* Changes default stacking of the Alerts Histogram to be `signal.rule.name`
* Fixes a react warning on the rule creation form(s)

## TODO

* [x] verify against https://github.com/elastic/kibana/pull/71792

## Followup Actions:
* replace magic strings (`'endpoint_list'`) with common constant from https://github.com/elastic/kibana/pull/71792
* disable checkbox for ML and threshold rules


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
