### PR TITLE
[Security Solution][Detections] Skip jest tests that timeout waiting for react

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.test.tsx
@@ -11,7 +11,8 @@ import { TestProviders } from '../../../common/mock';
 import { ValueListsModal } from './modal';
 import { waitForUpdates } from '../../../common/utils/test_utils';
 
-describe('ValueListsModal', () => {
+// TODO: These are occasionally timing out
+describe.skip('ValueListsModal', () => {
   it('renders nothing if showModal is false', () => {
     const container = mount(
       <TestProviders>


### PR DESCRIPTION
These have not yet failed on master so there's no issue to link to, but they inevitably will as I've seen a few PRs go red. This Preemptively unblocking people by skipping them for now.

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
