### PR TITLE
[RUM] E2e test improve timeout

### DIFF
--- a/x-pack/plugins/apm/e2e/cypress/support/step_definitions/rum/rum_dashboard.ts
+++ b/x-pack/plugins/apm/e2e/cypress/support/step_definitions/rum/rum_dashboard.ts
@@ -61,7 +61,10 @@ Then(`should display chart legend`, () => {
   cy.get('kbnLoadingIndicator').should('not.be.visible');
   cy.get('.euiLoadingChart').should('not.be.visible');
 
-  cy.get(chartLegend).eq(0).invoke('text').snapshot();
+  cy.get(chartLegend, { timeout: DEFAULT_TIMEOUT })
+    .eq(0)
+    .invoke('text')
+    .snapshot();
 });
 
 Then(`should display tooltip on hover`, () => {
@@ -73,7 +76,7 @@ Then(`should display tooltip on hover`, () => {
   cy.get('kbnLoadingIndicator').should('not.be.visible');
   cy.get('.euiLoadingChart').should('not.be.visible');
 
-  const marker = cy.get(pMarkers).eq(0);
+  const marker = cy.get(pMarkers, { timeout: DEFAULT_TIMEOUT }).eq(0);
   marker.invoke('show');
   marker.trigger('mouseover', { force: true });
   cy.get('span[data-cy=percentileTooltipTitle]').should('be.visible');


### PR DESCRIPTION
## Summary

Added timeout in rum apm e2e tests for cypress get statement. 