### PR TITLE
[skip-ci][WIP] @kbn/telemetry-tools: Support schema: getSchema()

### DIFF
--- a/.telemetryrc.json
+++ b/.telemetryrc.json
@@ -16,7 +16,6 @@
       "src/plugins/testbed/",
       "src/plugins/kibana_utils/",
       "src/plugins/kibana_usage_collection/server/collectors/kibana/kibana_usage_collector.ts",
-      "src/plugins/kibana_usage_collection/server/collectors/application_usage/telemetry_application_usage_collector.ts",
       "src/plugins/kibana_usage_collection/server/collectors/management/telemetry_management_collector.ts",
       "src/plugins/kibana_usage_collection/server/collectors/ui_metric/telemetry_ui_metric_collector.ts",
       "src/plugins/telemetry/server/collectors/usage/telemetry_usage_collector.ts"

--- a/packages/kbn-telemetry-tools/src/tools/__fixture__/parsed_code_generated_schema.ts
+++ b/packages/kbn-telemetry-tools/src/tools/__fixture__/parsed_code_generated_schema.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SyntaxKind } from 'typescript';
+import { ParsedUsageCollection } from '../ts_parser';
+
+export const parsedCodeGeneratedSchemaCollector: ParsedUsageCollection[] = [
+  [
+    'src/fixtures/telemetry_collectors/code_generated_schema.ts',
+    {
+      collectorName: 'code_generated_schema',
+      schema: {
+        value: {
+          locale: {
+            type: 'keyword',
+          },
+          something: {
+            nested: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+      fetch: {
+        typeName: 'Usage',
+        typeDescriptor: {
+          locale: {
+            kind: SyntaxKind.StringKeyword,
+            type: 'StringKeyword',
+          },
+          something: {
+            nested: {
+              kind: SyntaxKind.BooleanKeyword,
+              type: 'BooleanKeyword',
+            },
+          },
+        },
+      },
+    },
+  ],
+];

--- a/packages/kbn-telemetry-tools/src/tools/ts_parser.test.ts
+++ b/packages/kbn-telemetry-tools/src/tools/ts_parser.test.ts
@@ -25,6 +25,7 @@ import { parsedNestedCollector } from './__fixture__/parsed_nested_collector';
 import { parsedExternallyDefinedCollector } from './__fixture__/parsed_externally_defined_collector';
 import { parsedImportedUsageInterface } from './__fixture__/parsed_imported_usage_interface';
 import { parsedImportedSchemaCollector } from './__fixture__/parsed_imported_schema';
+import { parsedCodeGeneratedSchemaCollector } from './__fixture__/parsed_code_generated_schema';
 
 export function loadFixtureProgram(fixtureName: string) {
   const fixturePath = path.resolve(
@@ -90,5 +91,12 @@ describe('parseUsageCollection', () => {
     const { program, sourceFile } = loadFixtureProgram('file_with_no_collector');
     const result = [...parseUsageCollection(sourceFile, program)];
     expect(result).toEqual([]);
+  });
+
+  // eslint-disable-next-line jest/no-focused-tests,ban/ban
+  it.only('parses code-generated schemas', () => {
+    const { program, sourceFile } = loadFixtureProgram('code_generated_schema');
+    const result = [...parseUsageCollection(sourceFile, program)];
+    expect(result).toEqual(parsedCodeGeneratedSchemaCollector);
   });
 });

--- a/src/fixtures/telemetry_collectors/code_generated_schema.ts
+++ b/src/fixtures/telemetry_collectors/code_generated_schema.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { CollectorSet, MakeSchemaFrom } from '../../plugins/usage_collection/server/collector';
+import { loggerMock } from '../../core/server/logging/logger.mock';
+
+const { makeUsageCollector } = new CollectorSet({
+  logger: loggerMock.create(),
+  maximumWaitTimeForAllCollectorsInS: 0,
+});
+
+interface Usage {
+  locale?: string;
+  something: { nested: boolean };
+}
+
+function getSchema(): MakeSchemaFrom<Required<Usage>> {
+  return {
+    locale: { type: 'keyword' },
+    something: {
+      nested: { type: 'boolean' },
+    },
+  };
+}
+
+// const schemaVal = getSchema();
+
+export const myCollector = makeUsageCollector<Usage>({
+  type: 'code_generated_schema',
+  isReady: () => true,
+  schema: getSchema(),
+  fetch: () => {
+    return {
+      locale: 'en',
+      something: { nested: true },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

Still a WIP! DO NOT MERGE!

Attempt to extract the schema values when returned by a function.

This is useful when we have collectors that will report the schema in a dynamically generated form (by iterating over a known list of keys). i.e.: APM's current implementation or Application Usage.

So far I only got to get the resolved types from getSchema, so can't differentiate between `keyword` or `string`.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
