### PR TITLE
[Ingest Manager] Make Ingest Manager link higher in Management nav category

### DIFF
--- a/src/plugins/dev_tools/public/plugin.ts
+++ b/src/plugins/dev_tools/public/plugin.ts
@@ -61,7 +61,7 @@ export class DevToolsPlugin implements Plugin<DevToolsSetup, void> {
       }),
       updater$: this.appStateUpdater,
       euiIconType: 'devToolsApp',
-      order: 9001,
+      order: 9010,
       category: DEFAULT_APP_CATEGORIES.management,
       mount: async (params: AppMountParameters) => {
         const { element, history } = params;

--- a/src/plugins/management/public/plugin.ts
+++ b/src/plugins/management/public/plugin.ts
@@ -65,7 +65,7 @@ export class ManagementPlugin implements Plugin<ManagementSetup, ManagementStart
       title: i18n.translate('management.stackManagement.title', {
         defaultMessage: 'Stack Management',
       }),
-      order: 9003,
+      order: 9040,
       euiIconType: 'managementApp',
       category: DEFAULT_APP_CATEGORIES.management,
       async mount(params: AppMountParameters) {

--- a/x-pack/plugins/ingest_manager/public/plugin.ts
+++ b/x-pack/plugins/ingest_manager/public/plugin.ts
@@ -72,6 +72,7 @@ export class IngestManagerPlugin
       id: PLUGIN_ID,
       category: DEFAULT_APP_CATEGORIES.management,
       title: i18n.translate('xpack.ingestManager.appTitle', { defaultMessage: 'Ingest Manager' }),
+      order: 9020,
       euiIconType: 'savedObjectsApp',
       async mount(params: AppMountParameters) {
         const [coreStart, startDeps] = (await core.getStartServices()) as [

--- a/x-pack/plugins/monitoring/public/plugin.ts
+++ b/x-pack/plugins/monitoring/public/plugin.ts
@@ -74,7 +74,7 @@ export class MonitoringPlugin
     const app: App = {
       id,
       title,
-      order: 9002,
+      order: 9030,
       euiIconType: icon,
       category: DEFAULT_APP_CATEGORIES.management,
       mount: async (params: AppMountParameters) => {


### PR DESCRIPTION
## Summary

Resolves #69570. Makes Ingest Manager app link higher, to be below Dev Tools.

I adjusted the `order` of all apps registered to Management category so that the integers are more spaced apart, allowing for more flexible ordering for future apps without having to modify all other apps.

![image](https://user-images.githubusercontent.com/1965714/87591401-1c965200-c69d-11ea-8fa8-7ce80a01c5a6.png)