### PR TITLE
[Ingest Manager] rename ilm policy to remove -default

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/__snapshots__/template.test.ts.snap
@@ -10,7 +10,7 @@ exports[`tests loading base.yml: base.yml 1`] = `
     "settings": {
       "index": {
         "lifecycle": {
-          "name": "logs-default"
+          "name": "logs"
         },
         "codec": "best_compression",
         "mapping": {
@@ -113,7 +113,7 @@ exports[`tests loading coredns.logs.yml: coredns.logs.yml 1`] = `
     "settings": {
       "index": {
         "lifecycle": {
-          "name": "logs-default"
+          "name": "logs"
         },
         "codec": "best_compression",
         "mapping": {
@@ -216,7 +216,7 @@ exports[`tests loading system.yml: system.yml 1`] = `
     "settings": {
       "index": {
         "lifecycle": {
-          "name": "metrics-default"
+          "name": "metrics"
         },
         "codec": "best_compression",
         "mapping": {

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -262,7 +262,7 @@ function getBaseTemplate(
         index: {
           // ILM Policy must be added here, for now point to the default global ILM policy name
           lifecycle: {
-            name: `${type}-default`,
+            name: type,
           },
           // What should be our default for the compression?
           codec: 'best_compression',


### PR DESCRIPTION
Default ILM policy names were changed after [the change to have them in Elasticsearch by default](https://github.com/elastic/elasticsearch/pull/57629) and not through installing the base package.  Previously they were called `(type)-default` but now they are just `type`.


## Test
- Run the agent with default settings through Ingest Manager
- Run `GET .ds*/_ilm/explain` in the dev console.  Instead of getting ilm policy not found errors for each data stream there should be the policy
<img width="481" alt="Screen Shot 2020-07-15 at 4 23 12 PM" src="https://user-images.githubusercontent.com/1676003/87592214-7f94e280-c6b7-11ea-92ae-5d3d75883602.png">

- Run `GET /_index_template/`.  `template.settings.index.lifecycle` attribute  called `logs` or `metrics` and not `logs-default`
<img width="404" alt="Screen Shot 2020-07-15 at 4 24 09 PM" src="https://user-images.githubusercontent.com/1676003/87592397-c8e53200-c6b7-11ea-9e3e-2c45db8a1bcd.png">
