### PR TITLE
[Lens] Unskip Lens smokescreen test

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -314,11 +314,11 @@ describe('IndexPatternDimensionEditorPanel', () => {
       const items: EuiListGroupItemProps[] = wrapper.find(EuiListGroup).prop('listItems') || [];
 
       expect(items.find(({ label }) => label === 'Minimum')!['data-test-subj']).not.toContain(
-        'Incompatible'
+        'incompatible'
       );
 
       expect(items.find(({ label }) => label === 'Date histogram')!['data-test-subj']).toContain(
-        'Incompatible'
+        'incompatible'
       );
     });
 
@@ -601,7 +601,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
 
         act(() => {
           wrapper
-            .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-terms"]')
+            .find('button[data-test-subj="lns-indexPatternDimension-terms incompatible"]')
             .simulate('click');
         });
 
@@ -612,7 +612,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
         wrapper = mount(<IndexPatternDimensionEditorComponent {...defaultProps} />);
 
         wrapper
-          .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-terms"]')
+          .find('button[data-test-subj="lns-indexPatternDimension-terms incompatible"]')
           .simulate('click');
 
         expect(wrapper.find('[data-test-subj="indexPattern-invalid-operation"]')).not.toHaveLength(
@@ -626,7 +626,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
         wrapper = mount(<IndexPatternDimensionEditorComponent {...defaultProps} />);
 
         wrapper
-          .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-terms"]')
+          .find('button[data-test-subj="lns-indexPatternDimension-terms incompatible"]')
           .simulate('click');
 
         wrapper
@@ -640,7 +640,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
         wrapper = mount(<IndexPatternDimensionEditorComponent {...defaultProps} />);
 
         wrapper
-          .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-terms"]')
+          .find('button[data-test-subj="lns-indexPatternDimension-terms incompatible"]')
           .simulate('click');
 
         const options = wrapper
@@ -722,7 +722,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
         );
 
         wrapper
-          .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-count"]')
+          .find('button[data-test-subj="lns-indexPatternDimension-count incompatible"]')
           .simulate('click');
 
         const newColumnState = setState.mock.calls[0][0].layers.first.columns.col2;
@@ -758,7 +758,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
         );
 
         wrapper
-          .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-terms"]')
+          .find('button[data-test-subj="lns-indexPatternDimension-terms incompatible"]')
           .simulate('click');
 
         const options = wrapper
@@ -781,7 +781,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
 
         act(() => {
           wrapper
-            .find('button[data-test-subj="lns-indexPatternDimensionIncompatible-terms"]')
+            .find('button[data-test-subj="lns-indexPatternDimension-terms incompatible"]')
             .simulate('click');
         });
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/popover_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/popover_editor.tsx
@@ -156,9 +156,9 @@ export function PopoverEditor(props: PopoverEditorProps) {
         isActive,
         size: 's',
         className: 'lnsIndexPatternDimensionEditor__operation',
-        'data-test-subj': `lns-indexPatternDimension${
-          compatibleWithCurrentField ? '' : 'Incompatible'
-        }-${operationType}`,
+        'data-test-subj': `lns-indexPatternDimension-${operationType}${
+          compatibleWithCurrentField ? '' : ' incompatible'
+        }`,
         onClick() {
           if (!selectedColumn || !compatibleWithCurrentField) {
             const possibleFields = fieldByOperation[operationType] || [];

--- a/x-pack/test/functional/apps/dashboard_mode/dashboard_empty_screen.js
+++ b/x-pack/test/functional/apps/dashboard_mode/dashboard_empty_screen.js
@@ -36,22 +36,19 @@ export default function ({ getPageObjects, getService }) {
       await PageObjects.visualize.clickLensWidget();
       await PageObjects.lens.goToTimeRange();
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_xDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
         operation: 'date_histogram',
         field: '@timestamp',
       });
 
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_yDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
         operation: 'avg',
         field: 'bytes',
       });
 
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_splitDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
         operation: 'terms',
         field: 'ip',
       });

--- a/x-pack/test/functional/apps/lens/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/smokescreen.ts
@@ -64,8 +64,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await browser.getActions().move({ x: 5, y: 5, origin: el._webElement }).click().perform();
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/71304
-  describe.skip('lens smokescreen tests', () => {
+  describe('lens smokescreen tests', () => {
     it('should allow editing saved visualizations', async () => {
       await PageObjects.visualize.gotoVisualizationLandingPage();
       await listingTable.searchForItemWithName('Artistpreviouslyknownaslens');
@@ -112,9 +111,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.clickVisualizeListItemTitle('Artistpreviouslyknownaslens');
       await PageObjects.lens.goToTimeRange();
       await assertExpectedMetric();
-      await PageObjects.lens.switchToVisualization('lnsChartSwitchPopover_lnsDatatable');
+      await PageObjects.lens.switchToVisualization('lnsDatatable');
       await assertExpectedTable();
-      await PageObjects.lens.switchToVisualization('lnsChartSwitchPopover_lnsMetric');
+      await PageObjects.lens.switchToVisualization('lnsMetric');
       await assertExpectedMetric();
     });
 
@@ -124,33 +123,29 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.goToTimeRange();
 
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_xDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
         operation: 'date_histogram',
         field: '@timestamp',
       });
 
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_yDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
         operation: 'avg',
         field: 'bytes',
       });
 
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_splitDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
         operation: 'terms',
         field: '@message.raw',
       });
 
-      await PageObjects.lens.switchToVisualization('lnsChartSwitchPopover_lnsDatatable');
+      await PageObjects.lens.switchToVisualization('lnsDatatable');
       await PageObjects.lens.removeDimension('lnsDatatable_column');
-      await PageObjects.lens.switchToVisualization('lnsChartSwitchPopover_bar_stacked');
+      await PageObjects.lens.switchToVisualization('bar_stacked');
 
       await PageObjects.lens.configureDimension({
-        dimension:
-          '[data-test-subj="lnsXY_splitDimensionPanel"] [data-test-subj="lns-empty-dimension"]',
+        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
         operation: 'terms',
         field: 'ip',
       });


### PR DESCRIPTION
This fixes the flakiness in the Lens smokescreen test in two places:

* Opening the chart switcher
* Clicking dimensions

By adding a retry to work around this issue. https://github.com/elastic/kibana/issues/71256

I ran 42 successful tests in the flaky test runner: https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/592/

Fixes https://github.com/elastic/kibana/issues/71304
