### PR TITLE
[APM] Add `name` to `Observer` type

### DIFF
--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/observer.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/observer.ts
@@ -5,6 +5,7 @@
  */
 
 export interface Observer {
+  name?: string;
   version: string;
   version_major: number;
 }


### PR DESCRIPTION
Backport #72078 is failing because of the type check because `observer.name` is not defined. Not sure why this wasn't a problem on master, but adding it here so I can include it.
