### PR TITLE
[Security Solution][Detections] Disable exceptions for Threshold and ML rules

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/utils.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/utils.ts
@@ -5,6 +5,7 @@
  */
 
 import { EntriesArray } from '../shared_imports';
+import { RuleType } from './types';
 
 export const hasLargeValueList = (entries: EntriesArray): boolean => {
   const found = entries.filter(({ type }) => type === 'list');
@@ -15,3 +16,5 @@ export const hasNestedEntry = (entries: EntriesArray): boolean => {
   const found = entries.filter(({ type }) => type === 'nested');
   return found.length > 0;
 };
+
+export const isThresholdRule = (ruleType: RuleType) => ruleType === 'threshold';

--- a/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/select_rule_type/index.tsx
@@ -8,13 +8,12 @@ import React, { useCallback, useMemo } from 'react';
 import { EuiCard, EuiFlexGrid, EuiFlexItem, EuiFormRow, EuiIcon } from '@elastic/eui';
 
 import { isMlRule } from '../../../../../common/machine_learning/helpers';
+import { isThresholdRule } from '../../../../../common/detection_engine/utils';
 import { RuleType } from '../../../../../common/detection_engine/types';
 import { FieldHook } from '../../../../shared_imports';
 import { useKibana } from '../../../../common/lib/kibana';
 import * as i18n from './translations';
 import { MlCardDescription } from './ml_card_description';
-
-const isThresholdRule = (ruleType: RuleType) => ruleType === 'threshold';
 
 interface SelectRuleTypeProps {
   describedByIds?: string[];

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
@@ -8,6 +8,8 @@ import { EuiAccordion, EuiFlexItem, EuiSpacer, EuiButtonEmpty, EuiFormRow } from
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { isMlRule } from '../../../../../common/machine_learning/helpers';
+import { isThresholdRule } from '../../../../../common/detection_engine/utils';
 import {
   RuleStepProps,
   RuleStep,
@@ -94,6 +96,9 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
   const [{ isLoading: indexPatternLoading, indexPatterns }] = useFetchIndexPatterns(
     defineRuleData?.index ?? []
   );
+  const exceptionsDisabledForRule =
+    defineRuleData?.ruleType &&
+    (isMlRule(defineRuleData.ruleType) || isThresholdRule(defineRuleData.ruleType));
 
   const { form } = useForm({
     defaultValue: initialState,
@@ -274,8 +279,7 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
                   idAria: 'detectionEngineStepAboutRuleAssociatedToEndpointList',
                   'data-test-subj': 'detectionEngineStepAboutRuleAssociatedToEndpointList',
                   euiFieldProps: {
-                    fullWidth: true,
-                    isDisabled: isLoading,
+                    disabled: isLoading || exceptionsDisabledForRule,
                   },
                 }}
               />
@@ -287,8 +291,7 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
                   idAria: 'detectionEngineStepAboutRuleBuildingBlock',
                   'data-test-subj': 'detectionEngineStepAboutRuleBuildingBlock',
                   euiFieldProps: {
-                    fullWidth: true,
-                    isDisabled: isLoading,
+                    disabled: isLoading,
                   },
                 }}
               />

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiAccordion, EuiFlexItem, EuiSpacer, EuiButtonEmpty, EuiFormRow } from '@elastic/eui';
+import { EuiAccordion, EuiFlexItem, EuiSpacer, EuiFormRow } from '@elastic/eui';
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
@@ -60,26 +60,6 @@ const TagContainer = styled.div`
 
 TagContainer.displayName = 'TagContainer';
 
-const AdvancedSettingsAccordion = styled(EuiAccordion)`
-  .euiAccordion__iconWrapper {
-    display: none;
-  }
-
-  .euiAccordion__childWrapper {
-    transition-duration: 1ms; /* hack to fire Step accordion to set proper content's height */
-  }
-
-  &.euiAccordion-isOpen .euiButtonEmpty__content > svg {
-    transform: rotate(90deg);
-  }
-`;
-
-const AdvancedSettingsAccordionButton = (
-  <EuiButtonEmpty flush="left" size="s" iconType="arrowRight">
-    {I18n.ADVANCED_SETTINGS}
-  </EuiButtonEmpty>
-);
-
 const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
   addPadding = false,
   defaultValues,
@@ -198,10 +178,10 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
             />
           </TagContainer>
           <EuiSpacer size="l" />
-          <AdvancedSettingsAccordion
+          <EuiAccordion
             data-test-subj="advancedSettings"
             id="advancedSettingsAccordion"
-            buttonContent={AdvancedSettingsAccordionButton}
+            buttonContent={I18n.ADVANCED_SETTINGS}
           >
             <EuiSpacer size="l" />
             <UseField
@@ -322,7 +302,7 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
                 placeholder: '',
               }}
             />
-          </AdvancedSettingsAccordion>
+          </EuiAccordion>
           <FormDataProvider pathsToWatch="severity">
             {({ severity }) => {
               const newRiskScore = defaultRiskScoreBySeverity[severity as SeverityValue];

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
@@ -76,9 +76,10 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
   const [{ isLoading: indexPatternLoading, indexPatterns }] = useFetchIndexPatterns(
     defineRuleData?.index ?? []
   );
-  const exceptionsDisabledForRule =
+  const canUseExceptions =
     defineRuleData?.ruleType &&
-    (isMlRule(defineRuleData.ruleType) || isThresholdRule(defineRuleData.ruleType));
+    !isMlRule(defineRuleData.ruleType) &&
+    !isThresholdRule(defineRuleData.ruleType);
 
   const { form } = useForm({
     defaultValue: initialState,
@@ -259,7 +260,7 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
                   idAria: 'detectionEngineStepAboutRuleAssociatedToEndpointList',
                   'data-test-subj': 'detectionEngineStepAboutRuleAssociatedToEndpointList',
                   euiFieldProps: {
-                    disabled: isLoading || exceptionsDisabledForRule,
+                    disabled: isLoading || !canUseExceptions,
                   },
                 }}
               />

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -37,7 +37,7 @@ import {
 } from '../../../../../common/components/link_to/redirect_to_detection_engine';
 import { SiemSearchBar } from '../../../../../common/components/search_bar';
 import { WrapperPage } from '../../../../../common/components/wrapper_page';
-import { useRule } from '../../../../containers/detection_engine/rules';
+import { useRule, Rule } from '../../../../containers/detection_engine/rules';
 import { useListsConfig } from '../../../../containers/detection_engine/lists/use_lists_config';
 
 import { useWithSource } from '../../../../../common/containers/source';
@@ -90,6 +90,8 @@ import {
   MIN_EVENTS_VIEWER_BODY_HEIGHT,
 } from '../../../../../timelines/components/timeline/body/helpers';
 import { footerHeight } from '../../../../../timelines/components/timeline/footer';
+import { isMlRule } from '../../../../../../common/machine_learning/helpers';
+import { isThresholdRule } from '../../../../../../common/detection_engine/utils';
 
 enum RuleDetailTabs {
   alerts = 'alerts',
@@ -97,23 +99,26 @@ enum RuleDetailTabs {
   exceptions = 'exceptions',
 }
 
-const ruleDetailTabs = [
-  {
-    id: RuleDetailTabs.alerts,
-    name: detectionI18n.ALERT,
-    disabled: false,
-  },
-  {
-    id: RuleDetailTabs.exceptions,
-    name: i18n.EXCEPTIONS_TAB,
-    disabled: false,
-  },
-  {
-    id: RuleDetailTabs.failures,
-    name: i18n.FAILURE_HISTORY_TAB,
-    disabled: false,
-  },
-];
+const getRuleDetailsTabs = (rule: Rule | null) => {
+  const canUseExceptions = rule && !isMlRule(rule.type) && !isThresholdRule(rule.type);
+  return [
+    {
+      id: RuleDetailTabs.alerts,
+      name: detectionI18n.ALERT,
+      disabled: false,
+    },
+    {
+      id: RuleDetailTabs.exceptions,
+      name: i18n.EXCEPTIONS_TAB,
+      disabled: !canUseExceptions,
+    },
+    {
+      id: RuleDetailTabs.failures,
+      name: i18n.FAILURE_HISTORY_TAB,
+      disabled: false,
+    },
+  ];
+};
 
 export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
   filters,
@@ -160,6 +165,7 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
   // TODO: Refactor license check + hasMlAdminPermissions to common check
   const hasMlPermissions =
     mlCapabilities.isPlatinumOrTrialLicense && hasMlAdminPermissions(mlCapabilities);
+  const ruleDetailTabs = getRuleDetailsTabs(rule);
 
   const title = isLoading === true || rule === null ? <EuiLoadingSpinner size="m" /> : rule.name;
   const subTitle = useMemo(


### PR DESCRIPTION
## Summary

This restricts the UI; I believe the backend still needs similar guards.

* #### On Rule Creation and Rule Update, the 'Associate to Global Endpoint Exceptions List' checkbox is disabled
    <img width="812" alt="b7510536-6db9-45a4-bf39-5247df589e14_-_Kibana" src="https://user-images.githubusercontent.com/657252/87711949-9b5ac000-c76d-11ea-912b-bbd22b7f3d65.png">
* #### On Rule Details, the Endpoints tab is disabled
    <img width="977" alt="b7510536-6db9-45a4-bf39-5247df589e14_-_Kibana" src="https://user-images.githubusercontent.com/657252/87711853-7b2b0100-c76d-11ea-8009-5a2b3fbe3d2c.png">

#### Notes:

* We could alternately disable the 'Add Exception' button instead of the entire Exceptions tab


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
