### PR TITLE
[Security Solution][Detections] Better toast errors

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -115,7 +115,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
     Array<ExceptionListItemSchema | CreateExceptionListItemSchema>
   >([]);
   const [fetchOrCreateListError, setFetchOrCreateListError] = useState(false);
-  const toasts = useAppToasts();
+  const { addError, addSuccess } = useAppToasts();
   const { loading: isSignalIndexLoading, signalIndexName } = useSignalIndex();
 
   const [{ isLoading: indexPatternLoading, indexPatterns }] = useFetchIndexPatterns(
@@ -124,15 +124,15 @@ export const AddExceptionModal = memo(function AddExceptionModal({
 
   const onError = useCallback(
     (error: Error) => {
-      toasts.addError(error, { title: i18n.ADD_EXCEPTION_ERROR });
+      addError(error, { title: i18n.ADD_EXCEPTION_ERROR });
       onCancel();
     },
-    [onCancel, toasts]
+    [addError, onCancel]
   );
   const onSuccess = useCallback(() => {
-    toasts.addSuccess(i18n.ADD_EXCEPTION_SUCCESS);
+    addSuccess(i18n.ADD_EXCEPTION_SUCCESS);
     onConfirm(shouldCloseAlert);
-  }, [onConfirm, shouldCloseAlert, toasts]);
+  }, [addSuccess, onConfirm, shouldCloseAlert]);
 
   const [{ isLoading: addExceptionIsLoading }, addOrUpdateExceptionItems] = useAddOrUpdateException(
     {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -29,8 +29,8 @@ import {
 } from '../../../../../public/lists_plugin_deps';
 import * as i18n from './translations';
 import { TimelineNonEcsData, Ecs } from '../../../../graphql/types';
+import { useAppToasts } from '../../../hooks/use_app_toasts';
 import { useKibana } from '../../../lib/kibana';
-import { errorToToaster, displaySuccessToast, useStateToaster } from '../../toasters';
 import { ExceptionBuilder } from '../builder';
 import { Loader } from '../../loader';
 import { useAddOrUpdateException } from '../use_add_exception';
@@ -115,7 +115,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
     Array<ExceptionListItemSchema | CreateExceptionListItemSchema>
   >([]);
   const [fetchOrCreateListError, setFetchOrCreateListError] = useState(false);
-  const [, dispatchToaster] = useStateToaster();
+  const toasts = useAppToasts();
   const { loading: isSignalIndexLoading, signalIndexName } = useSignalIndex();
 
   const [{ isLoading: indexPatternLoading, indexPatterns }] = useFetchIndexPatterns(
@@ -124,15 +124,15 @@ export const AddExceptionModal = memo(function AddExceptionModal({
 
   const onError = useCallback(
     (error: Error) => {
-      errorToToaster({ title: i18n.ADD_EXCEPTION_ERROR, error, dispatchToaster });
+      toasts.addError(error, { title: i18n.ADD_EXCEPTION_ERROR });
       onCancel();
     },
-    [dispatchToaster, onCancel]
+    [onCancel, toasts]
   );
   const onSuccess = useCallback(() => {
-    displaySuccessToast(i18n.ADD_EXCEPTION_SUCCESS, dispatchToaster);
+    toasts.addSuccess(i18n.ADD_EXCEPTION_SUCCESS);
     onConfirm(shouldCloseAlert);
-  }, [dispatchToaster, onConfirm, shouldCloseAlert]);
+  }, [onConfirm, shouldCloseAlert, toasts]);
 
   const [{ isLoading: addExceptionIsLoading }, addOrUpdateExceptionItems] = useAddOrUpdateException(
     {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -93,7 +93,7 @@ export const EditExceptionModal = memo(function EditExceptionModal({
   const [exceptionItemsToAdd, setExceptionItemsToAdd] = useState<
     Array<ExceptionListItemSchema | CreateExceptionListItemSchema>
   >([]);
-  const toasts = useAppToasts();
+  const { addError, addSuccess } = useAppToasts();
   const { loading: isSignalIndexLoading, signalIndexName } = useSignalIndex();
 
   const [{ isLoading: indexPatternLoading, indexPatterns }] = useFetchIndexPatterns(
@@ -102,15 +102,15 @@ export const EditExceptionModal = memo(function EditExceptionModal({
 
   const onError = useCallback(
     (error) => {
-      toasts.addError(error, { title: i18n.EDIT_EXCEPTION_ERROR });
+      addError(error, { title: i18n.EDIT_EXCEPTION_ERROR });
       onCancel();
     },
-    [onCancel, toasts]
+    [addError, onCancel]
   );
   const onSuccess = useCallback(() => {
-    toasts.addSuccess(i18n.EDIT_EXCEPTION_SUCCESS);
+    addSuccess(i18n.EDIT_EXCEPTION_SUCCESS);
     onConfirm();
-  }, [onConfirm, toasts]);
+  }, [addSuccess, onConfirm]);
 
   const [{ isLoading: addExceptionIsLoading }, addOrUpdateExceptionItems] = useAddOrUpdateException(
     {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../../../../public/lists_plugin_deps';
 import * as i18n from './translations';
 import { useKibana } from '../../../lib/kibana';
-import { errorToToaster, displaySuccessToast, useStateToaster } from '../../toasters';
+import { useAppToasts } from '../../../hooks/use_app_toasts';
 import { ExceptionBuilder } from '../builder';
 import { useAddOrUpdateException } from '../use_add_exception';
 import { AddExceptionComments } from '../add_exception_comments';
@@ -93,7 +93,7 @@ export const EditExceptionModal = memo(function EditExceptionModal({
   const [exceptionItemsToAdd, setExceptionItemsToAdd] = useState<
     Array<ExceptionListItemSchema | CreateExceptionListItemSchema>
   >([]);
-  const [, dispatchToaster] = useStateToaster();
+  const toasts = useAppToasts();
   const { loading: isSignalIndexLoading, signalIndexName } = useSignalIndex();
 
   const [{ isLoading: indexPatternLoading, indexPatterns }] = useFetchIndexPatterns(
@@ -102,15 +102,15 @@ export const EditExceptionModal = memo(function EditExceptionModal({
 
   const onError = useCallback(
     (error) => {
-      errorToToaster({ title: i18n.EDIT_EXCEPTION_ERROR, error, dispatchToaster });
+      toasts.addError(error, { title: i18n.EDIT_EXCEPTION_ERROR });
       onCancel();
     },
-    [dispatchToaster, onCancel]
+    [onCancel, toasts]
   );
   const onSuccess = useCallback(() => {
-    displaySuccessToast(i18n.EDIT_EXCEPTION_SUCCESS, dispatchToaster);
+    toasts.addSuccess(i18n.EDIT_EXCEPTION_SUCCESS);
     onConfirm();
-  }, [dispatchToaster, onConfirm]);
+  }, [onConfirm, toasts]);
 
   const [{ isLoading: addExceptionIsLoading }, addOrUpdateExceptionItems] = useAddOrUpdateException(
     {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/exception_item/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/exception_item/index.test.tsx
@@ -13,6 +13,8 @@ import { ExceptionItem } from './';
 import { getExceptionListItemSchemaMock } from '../../../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
 import { getCommentsArrayMock } from '../../../../../../../lists/common/schemas/types/comments.mock';
 
+jest.mock('../../../../lib/kibana');
+
 describe('ExceptionItem', () => {
   it('it renders ExceptionDetails and ExceptionEntries', () => {
     const exceptionItem = getExceptionListItemSchemaMock();

--- a/x-pack/plugins/security_solution/public/common/components/toasters/utils.ts
+++ b/x-pack/plugins/security_solution/public/common/components/toasters/utils.ts
@@ -9,7 +9,7 @@ import { isError } from 'lodash/fp';
 
 import { AppToast, ActionToaster } from './';
 import { isToasterError } from './errors';
-import { isApiError } from '../../utils/api';
+import { isAppError } from '../../utils/api';
 
 /**
  * Displays an error toast for the provided title and message
@@ -114,7 +114,7 @@ export const errorToToaster = ({
       iconType,
       errors: error.messages,
     };
-  } else if (isApiError(error)) {
+  } else if (isAppError(error)) {
     toast = {
       id,
       title,

--- a/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.test.ts
@@ -13,11 +13,14 @@ jest.mock('../lib/kibana');
 
 describe('useDeleteList', () => {
   let addErrorMock: jest.Mock;
+  let addSuccessMock: jest.Mock;
 
   beforeEach(() => {
     addErrorMock = jest.fn();
+    addSuccessMock = jest.fn();
     (useToasts as jest.Mock).mockImplementation(() => ({
       addError: addErrorMock,
+      addSuccess: addSuccessMock,
     }));
   });
 

--- a/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useToasts } from '../lib/kibana';
+import { useAppToasts } from './use_app_toasts';
+
+jest.mock('../lib/kibana');
+
+describe('useDeleteList', () => {
+  let addErrorMock: jest.Mock;
+
+  beforeEach(() => {
+    addErrorMock = jest.fn();
+    (useToasts as jest.Mock).mockImplementation(() => ({
+      addError: addErrorMock,
+    }));
+  });
+
+  it('works normally with a regular error', async () => {
+    const error = new Error('regular error');
+    const { result } = renderHook(() => useAppToasts());
+
+    result.current.addError(error, { title: 'title' });
+
+    expect(addErrorMock).toHaveBeenCalledWith(error, { title: 'title' });
+  });
+
+  it("uses a KibanaApiError's body.message as the toastMessage", async () => {
+    const kibanaApiError = {
+      message: 'Not Found',
+      body: { status_code: 404, message: 'Detailed Message' },
+    };
+
+    const { result } = renderHook(() => useAppToasts());
+
+    result.current.addError(kibanaApiError, { title: 'title' });
+
+    expect(addErrorMock).toHaveBeenCalledWith(kibanaApiError, {
+      title: 'title',
+      toastMessage: 'Detailed Message',
+    });
+  });
+
+  it('converts an unknown error to an Error', () => {
+    const unknownError = undefined;
+
+    const { result } = renderHook(() => useAppToasts());
+
+    result.current.addError(unknownError, { title: 'title' });
+
+    expect(addErrorMock).toHaveBeenCalledWith(Error(`${undefined}`), {
+      title: 'title',
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.test.ts
@@ -30,7 +30,7 @@ describe('useDeleteList', () => {
     expect(addErrorMock).toHaveBeenCalledWith(error, { title: 'title' });
   });
 
-  it("uses a KibanaApiError's body.message as the toastMessage", async () => {
+  it("uses a AppError's body.message as the toastMessage", async () => {
     const kibanaApiError = {
       message: 'Not Found',
       body: { status_code: 404, message: 'Detailed Message' },

--- a/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.ts
@@ -8,13 +8,13 @@ import { useCallback } from 'react';
 
 import { ErrorToastOptions } from '../../../../../../src/core/public';
 import { useToasts } from '../lib/kibana';
-import { KibanaApiError, isApiError } from '../utils/api';
+import { isAppError, AppError } from '../utils/api';
 
 export const useAppToasts = () => {
   const toasts = useToasts();
 
-  const addApiError = useCallback(
-    (error: KibanaApiError, options: ErrorToastOptions) => {
+  const addAppError = useCallback(
+    (error: AppError, options: ErrorToastOptions) => {
       toasts.addError(error, {
         ...options,
         toastMessage: error.body.message,
@@ -25,8 +25,8 @@ export const useAppToasts = () => {
 
   const addError = useCallback(
     (error: unknown, options: ErrorToastOptions) => {
-      if (isApiError(error)) {
-        addApiError(error, options);
+      if (isAppError(error)) {
+        addAppError(error, options);
       } else {
         if (error instanceof Error) {
           toasts.addError(error, options);
@@ -35,7 +35,7 @@ export const useAppToasts = () => {
         }
       }
     },
-    [addApiError, toasts]
+    [addAppError, toasts]
   );
 
   return { ...toasts, addError };

--- a/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { useCallback } from 'react';
+
+import { ErrorToastOptions } from '../../../../../../src/core/public';
+import { useToasts } from '../lib/kibana';
+import { KibanaApiError, isApiError } from '../utils/api';
+
+export const useAppToasts = () => {
+  const toasts = useToasts();
+
+  const addApiError = useCallback(
+    (error: KibanaApiError, options: ErrorToastOptions) => {
+      toasts.addError(error, {
+        ...options,
+        toastMessage: error.body.message,
+      });
+    },
+    [toasts]
+  );
+
+  const addError = useCallback(
+    (error: unknown, options: ErrorToastOptions) => {
+      if (isApiError(error)) {
+        addApiError(error, options);
+      } else {
+        if (error instanceof Error) {
+          toasts.addError(error, options);
+        } else {
+          toasts.addError(new Error(String(error)), options);
+        }
+      }
+    },
+    [addApiError, toasts]
+  );
+
+  return { ...toasts, addError };
+};

--- a/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_app_toasts.ts
@@ -4,39 +4,45 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
-import { ErrorToastOptions } from '../../../../../../src/core/public';
+import { ErrorToastOptions, ToastsStart, Toast } from '../../../../../../src/core/public';
 import { useToasts } from '../lib/kibana';
 import { isAppError, AppError } from '../utils/api';
 
-export const useAppToasts = () => {
+export type UseAppToasts = Pick<ToastsStart, 'addSuccess'> & {
+  api: ToastsStart;
+  addError: (error: unknown, options: ErrorToastOptions) => Toast;
+};
+
+export const useAppToasts = (): UseAppToasts => {
   const toasts = useToasts();
+  const addError = useRef(toasts.addError.bind(toasts)).current;
+  const addSuccess = useRef(toasts.addSuccess.bind(toasts)).current;
 
   const addAppError = useCallback(
-    (error: AppError, options: ErrorToastOptions) => {
-      toasts.addError(error, {
+    (error: AppError, options: ErrorToastOptions) =>
+      addError(error, {
         ...options,
         toastMessage: error.body.message,
-      });
-    },
-    [toasts]
+      }),
+    [addError]
   );
 
-  const addError = useCallback(
+  const _addError = useCallback(
     (error: unknown, options: ErrorToastOptions) => {
       if (isAppError(error)) {
-        addAppError(error, options);
+        return addAppError(error, options);
       } else {
         if (error instanceof Error) {
-          toasts.addError(error, options);
+          return addError(error, options);
         } else {
-          toasts.addError(new Error(String(error)), options);
+          return addError(new Error(String(error)), options);
         }
       }
     },
-    [addAppError, toasts]
+    [addAppError, addError]
   );
 
-  return { ...toasts, addError };
+  return { api: toasts, addError: _addError, addSuccess };
 };

--- a/x-pack/plugins/security_solution/public/common/lib/clipboard/clipboard.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/clipboard/clipboard.tsx
@@ -4,13 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiGlobalToastListToast as Toast, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon } from '@elastic/eui';
 import copy from 'copy-to-clipboard';
 import React from 'react';
-import uuid from 'uuid';
 
 import * as i18n from './translations';
-import { useStateToaster } from '../../components/toasters';
+import { useAppToasts } from '../../hooks/use_app_toasts';
 
 export type OnCopy = ({
   content,
@@ -19,17 +18,6 @@ export type OnCopy = ({
   content: string | number;
   isSuccess: boolean;
 }) => void;
-
-interface GetSuccessToastParams {
-  titleSummary?: string;
-}
-
-const getSuccessToast = ({ titleSummary }: GetSuccessToastParams): Toast => ({
-  id: `copy-success-${uuid.v4()}`,
-  color: 'success',
-  iconType: 'copyClipboard',
-  title: `${i18n.COPIED} ${titleSummary} ${i18n.TO_THE_CLIPBOARD}`,
-});
 
 interface Props {
   children?: JSX.Element;
@@ -40,7 +28,7 @@ interface Props {
 }
 
 export const Clipboard = ({ children, content, onCopy, titleSummary, toastLifeTimeMs }: Props) => {
-  const dispatchToaster = useStateToaster()[1];
+  const { addSuccess } = useAppToasts();
   const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -52,10 +40,7 @@ export const Clipboard = ({ children, content, onCopy, titleSummary, toastLifeTi
     }
 
     if (isSuccess) {
-      dispatchToaster({
-        type: 'addToaster',
-        toast: { toastLifeTimeMs, ...getSuccessToast({ titleSummary }) },
-      });
+      addSuccess(`${i18n.COPIED} ${titleSummary} ${i18n.TO_THE_CLIPBOARD}`, { toastLifeTimeMs });
     }
   };
 

--- a/x-pack/plugins/security_solution/public/common/lib/kibana/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kibana/__mocks__/index.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { notificationServiceMock } from '../../../../../../../../src/core/public/mocks';
 import {
   createKibanaContextProviderMock,
   createUseUiSettingMock,
@@ -19,6 +20,7 @@ export const useUiSetting$ = jest.fn(createUseUiSetting$Mock());
 export const useTimeZone = jest.fn();
 export const useDateFormat = jest.fn();
 export const useBasePath = jest.fn(() => '/test/base/path');
+export const useToasts = jest.fn(() => notificationServiceMock.createStartContract().toasts);
 export const useCurrentUser = jest.fn();
 export const withKibana = jest.fn(createWithKibanaMock());
 export const KibanaContextProvider = jest.fn(createKibanaContextProviderMock());

--- a/x-pack/plugins/security_solution/public/common/utils/api/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/api/index.ts
@@ -6,14 +6,33 @@
 
 import { has } from 'lodash/fp';
 
-export interface KibanaApiError {
+export interface AppError {
   name: string;
   message: string;
+  body: {
+    message: string;
+  };
+}
+
+export interface KibanaError extends AppError {
+  body: {
+    message: string;
+    statusCode: number;
+  };
+}
+
+export interface SecurityAppError extends AppError {
   body: {
     message: string;
     status_code: number;
   };
 }
 
-export const isApiError = (error: unknown): error is KibanaApiError =>
+export const isKibanaError = (error: unknown): error is KibanaError =>
+  has('message', error) && has('body.message', error) && has('body.statusCode', error);
+
+export const isSecurityAppError = (error: unknown): error is SecurityAppError =>
   has('message', error) && has('body.message', error) && has('body.status_code', error);
+
+export const isAppError = (error: unknown): error is AppError =>
+  isKibanaError(error) || isSecurityAppError(error);

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.tsx
@@ -46,7 +46,7 @@ export const ValueListsModalComponent: React.FC<ValueListsModalProps> = ({
   const { start: findLists, ...lists } = useFindLists();
   const { start: deleteList, result: deleteResult } = useDeleteList();
   const [exportListId, setExportListId] = useState<string>();
-  const toasts = useAppToasts();
+  const { addError, addSuccess } = useAppToasts();
 
   const fetchLists = useCallback(() => {
     findLists({ cursor, http, pageIndex: pageIndex + 1, pageSize });
@@ -83,21 +83,21 @@ export const ValueListsModalComponent: React.FC<ValueListsModalProps> = ({
   const handleUploadError = useCallback(
     (error: Error) => {
       if (error.name !== 'AbortError') {
-        toasts.addError(error, { title: i18n.UPLOAD_ERROR });
+        addError(error, { title: i18n.UPLOAD_ERROR });
       }
     },
-    [toasts]
+    [addError]
   );
   const handleUploadSuccess = useCallback(
     (response: ListSchema) => {
-      toasts.addSuccess({
+      addSuccess({
         text: i18n.uploadSuccessMessage(response.name),
         title: i18n.UPLOAD_SUCCESS_TITLE,
       });
       fetchLists();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [toasts]
+    [addSuccess]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/modal.tsx
@@ -23,7 +23,8 @@ import {
   useDeleteList,
   useCursor,
 } from '../../../shared_imports';
-import { useToasts, useKibana } from '../../../common/lib/kibana';
+import { useKibana } from '../../../common/lib/kibana';
+import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import { GenericDownloader } from '../../../common/components/generic_downloader';
 import * as i18n from './translations';
 import { ValueListsTable } from './table';
@@ -45,7 +46,7 @@ export const ValueListsModalComponent: React.FC<ValueListsModalProps> = ({
   const { start: findLists, ...lists } = useFindLists();
   const { start: deleteList, result: deleteResult } = useDeleteList();
   const [exportListId, setExportListId] = useState<string>();
-  const toasts = useToasts();
+  const toasts = useAppToasts();
 
   const fetchLists = useCallback(() => {
     findLists({ cursor, http, pageIndex: pageIndex + 1, pageSize });

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_signal_index.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import { errorToToaster, useStateToaster } from '../../../../common/components/toasters';
 import { createSignalIndex, getSignalIndex } from './api';
 import * as i18n from './translations';
-import { isApiError } from '../../../../common/utils/api';
+import { isSecurityAppError } from '../../../../common/utils/api';
 
 type Func = () => void;
 
@@ -59,7 +59,7 @@ export const useSignalIndex = (): ReturnSignalIndex => {
             signalIndexName: null,
             createDeSignalIndex: createIndex,
           });
-          if (isApiError(error) && error.body.status_code !== 404) {
+          if (isSecurityAppError(error) && error.body.status_code !== 404) {
             errorToToaster({ title: i18n.SIGNAL_GET_NAME_FAILURE, error, dispatchToaster });
           }
         }
@@ -81,7 +81,7 @@ export const useSignalIndex = (): ReturnSignalIndex => {
         }
       } catch (error) {
         if (isSubscribed) {
-          if (isApiError(error) && error.body.status_code === 409) {
+          if (isSecurityAppError(error) && error.body.status_code === 409) {
             fetchData();
           } else {
             setSignalIndex({

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
@@ -32,10 +32,10 @@ export const useListsConfig = (): UseListsConfigReturn => {
   const needsConfiguration = !enabled || canWriteIndex === false || needsIndexConfiguration;
 
   useEffect(() => {
-    if (needsIndex && canManageIndex && !hasIndexError) {
+    if (needsIndex && canManageIndex) {
       createIndex();
     }
-  }, [canManageIndex, createIndex, hasIndexError, needsIndex]);
+  }, [canManageIndex, createIndex, needsIndex]);
 
   return { canManageIndex, canWriteIndex, enabled, loading, needsConfiguration };
 };

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
@@ -19,23 +19,23 @@ export interface UseListsConfigReturn {
 }
 
 export const useListsConfig = (): UseListsConfigReturn => {
-  const { createIndex, createIndexError, indexExists, loading: indexLoading } = useListsIndex();
+  const { createIndex, indexExists, loading: indexLoading, error: indexError } = useListsIndex();
   const { canManageIndex, canWriteIndex, loading: privilegesLoading } = useListsPrivileges();
   const { lists } = useKibana().services;
 
   const enabled = lists != null;
   const loading = indexLoading || privilegesLoading;
   const needsIndex = indexExists === false;
-  const indexCreationFailed = createIndexError != null;
+  const hasIndexError = indexError != null;
   const needsIndexConfiguration =
-    needsIndex && (canManageIndex === false || (canManageIndex === true && indexCreationFailed));
+    needsIndex && (canManageIndex === false || (canManageIndex === true && hasIndexError));
   const needsConfiguration = !enabled || canWriteIndex === false || needsIndexConfiguration;
 
   useEffect(() => {
-    if (needsIndex && canManageIndex) {
+    if (needsIndex && canManageIndex && !hasIndexError) {
       createIndex();
     }
-  }, [canManageIndex, createIndex, needsIndex]);
+  }, [canManageIndex, createIndex, hasIndexError, needsIndex]);
 
   return { canManageIndex, canWriteIndex, enabled, loading, needsConfiguration };
 };

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
@@ -7,28 +7,24 @@
 import { useEffect, useState, useCallback } from 'react';
 
 import { useReadListIndex, useCreateListIndex } from '../../../../shared_imports';
-import { useHttp, useToasts, useKibana } from '../../../../common/lib/kibana';
+import { useHttp, useKibana } from '../../../../common/lib/kibana';
 import { isApiError } from '../../../../common/utils/api';
 import * as i18n from './translations';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 
-export interface UseListsIndexState {
-  indexExists: boolean | null;
-}
-
-export interface UseListsIndexReturn extends UseListsIndexState {
-  loading: boolean;
+export interface UseListsIndexReturn {
   createIndex: () => void;
-  createIndexError: unknown;
-  createIndexResult: { acknowledged: boolean } | undefined;
+  indexExists: boolean | null;
+  error: unknown;
+  loading: boolean;
 }
 
 export const useListsIndex = (): UseListsIndexReturn => {
-  const [state, setState] = useState<UseListsIndexState>({
-    indexExists: null,
-  });
+  const [indexExists, setIndexExists] = useState<boolean | null>(null);
+  const [error, setError] = useState<unknown>(null);
   const { lists } = useKibana().services;
   const http = useHttp();
-  const toasts = useToasts();
+  const toasts = useAppToasts();
   const { loading: readLoading, start: readListIndex, ...readListIndexState } = useReadListIndex();
   const {
     loading: createLoading,
@@ -51,18 +47,17 @@ export const useListsIndex = (): UseListsIndexReturn => {
 
   // initial read list
   useEffect(() => {
-    if (!readLoading && state.indexExists === null) {
+    if (!readLoading && !error && indexExists === null) {
       readIndex();
     }
-  }, [readIndex, readLoading, state.indexExists]);
+  }, [error, indexExists, readIndex, readLoading]);
 
   // handle read result
   useEffect(() => {
     if (readListIndexState.result != null) {
-      setState({
-        indexExists:
-          readListIndexState.result.list_index && readListIndexState.result.list_item_index,
-      });
+      setIndexExists(
+        readListIndexState.result.list_index && readListIndexState.result.list_item_index
+      );
     }
   }, [readListIndexState.result]);
 
@@ -75,34 +70,30 @@ export const useListsIndex = (): UseListsIndexReturn => {
 
   // handle read error
   useEffect(() => {
-    const error = readListIndexState.error;
-    if (isApiError(error)) {
-      setState({ indexExists: false });
-      if (error.body.status_code !== 404) {
-        toasts.addError(error, {
-          title: i18n.LISTS_INDEX_FETCH_FAILURE,
-          toastMessage: error.body.message,
-        });
+    const err = readListIndexState.error;
+    if (err != null) {
+      if (isApiError(err) && err.body.status_code === 404) {
+        setIndexExists(false);
+      } else {
+        setError(err);
+        toasts.addError(err, { title: i18n.LISTS_INDEX_FETCH_FAILURE });
       }
     }
   }, [readListIndexState.error, toasts]);
 
   // handle create error
   useEffect(() => {
-    const error = createListIndexState.error;
-    if (isApiError(error)) {
-      toasts.addError(error, {
-        title: i18n.LISTS_INDEX_CREATE_FAILURE,
-        toastMessage: error.body.message,
-      });
+    const err = createListIndexState.error;
+    if (err != null) {
+      setError(err);
+      toasts.addError(err, { title: i18n.LISTS_INDEX_CREATE_FAILURE });
     }
   }, [createListIndexState.error, toasts]);
 
   return {
-    loading,
     createIndex,
-    createIndexError: createListIndexState.error,
-    createIndexResult: createListIndexState.result,
-    ...state,
+    error,
+    indexExists,
+    loading,
   };
 };

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState, useCallback } from 'react';
 
 import { useReadListIndex, useCreateListIndex } from '../../../../shared_imports';
 import { useHttp, useKibana } from '../../../../common/lib/kibana';
-import { isApiError } from '../../../../common/utils/api';
+import { isSecurityAppError } from '../../../../common/utils/api';
 import * as i18n from './translations';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 
@@ -72,7 +72,7 @@ export const useListsIndex = (): UseListsIndexReturn => {
   useEffect(() => {
     const err = readListIndexState.error;
     if (err != null) {
-      if (isApiError(err) && err.body.status_code === 404) {
+      if (isSecurityAppError(err) && err.body.status_code === 404) {
         setIndexExists(false);
       } else {
         setError(err);

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
@@ -24,7 +24,7 @@ export const useListsIndex = (): UseListsIndexReturn => {
   const [error, setError] = useState<unknown>(null);
   const { lists } = useKibana().services;
   const http = useHttp();
-  const { addError, addSucess } = useAppToasts();
+  const { addError } = useAppToasts();
   const { loading: readLoading, start: readListIndex, ...readListIndexState } = useReadListIndex();
   const {
     loading: createLoading,

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_index.tsx
@@ -24,7 +24,7 @@ export const useListsIndex = (): UseListsIndexReturn => {
   const [error, setError] = useState<unknown>(null);
   const { lists } = useKibana().services;
   const http = useHttp();
-  const toasts = useAppToasts();
+  const { addError, addSucess } = useAppToasts();
   const { loading: readLoading, start: readListIndex, ...readListIndexState } = useReadListIndex();
   const {
     loading: createLoading,
@@ -76,19 +76,19 @@ export const useListsIndex = (): UseListsIndexReturn => {
         setIndexExists(false);
       } else {
         setError(err);
-        toasts.addError(err, { title: i18n.LISTS_INDEX_FETCH_FAILURE });
+        addError(err, { title: i18n.LISTS_INDEX_FETCH_FAILURE });
       }
     }
-  }, [readListIndexState.error, toasts]);
+  }, [addError, readListIndexState.error]);
 
   // handle create error
   useEffect(() => {
     const err = createListIndexState.error;
     if (err != null) {
       setError(err);
-      toasts.addError(err, { title: i18n.LISTS_INDEX_CREATE_FAILURE });
+      addError(err, { title: i18n.LISTS_INDEX_CREATE_FAILURE });
     }
-  }, [createListIndexState.error, toasts]);
+  }, [addError, createListIndexState.error]);
 
   return {
     createIndex,

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_privileges.tsx
@@ -79,7 +79,7 @@ export const useListsPrivileges = (): UseListsPrivilegesReturn => {
   });
   const { lists } = useKibana().services;
   const http = useHttp();
-  const toasts = useAppToasts();
+  const { addError, addSuccess } = useAppToasts();
   const { loading, start: readListPrivileges, ...readState } = useReadListPrivileges();
 
   const readPrivileges = useCallback(() => {
@@ -121,11 +121,11 @@ export const useListsPrivileges = (): UseListsPrivilegesReturn => {
     const error = readState.error;
     if (error != null) {
       setState({ isAuthenticated: false, canManageIndex: false, canWriteIndex: false });
-      toasts.addError(error, {
+      addError(error, {
         title: i18n.LISTS_PRIVILEGES_READ_FAILURE,
       });
     }
-  }, [readState.error, toasts]);
+  }, [addError, readState.error]);
 
   return { loading, ...state };
 };

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_privileges.tsx
@@ -80,7 +80,7 @@ export const useListsPrivileges = (): UseListsPrivilegesReturn => {
   const { lists } = useKibana().services;
   const http = useHttp();
   const toasts = useAppToasts();
-  const { loading, start: readListPrivileges, ...privilegesState } = useReadListPrivileges();
+  const { loading, start: readListPrivileges, ...readState } = useReadListPrivileges();
 
   const readPrivileges = useCallback(() => {
     if (lists) {
@@ -90,20 +90,20 @@ export const useListsPrivileges = (): UseListsPrivilegesReturn => {
 
   // initRead
   useEffect(() => {
-    if (!loading && !privilegesState.error && state.isAuthenticated === null) {
+    if (!loading && !readState.error && state.isAuthenticated === null) {
       readPrivileges();
     }
-  }, [loading, privilegesState.error, readPrivileges, state.isAuthenticated]);
+  }, [loading, readState.error, readPrivileges, state.isAuthenticated]);
 
   // handleReadResult
   useEffect(() => {
-    if (privilegesState.result != null) {
+    if (readState.result != null) {
       try {
         const {
           is_authenticated: isAuthenticated,
           lists: { index: listsPrivileges },
           listItems: { index: listItemsPrivileges },
-        } = privilegesState.result as ListPrivileges;
+        } = readState.result as ListPrivileges;
 
         setState({
           isAuthenticated,
@@ -114,18 +114,18 @@ export const useListsPrivileges = (): UseListsPrivilegesReturn => {
         setState({ isAuthenticated: null, canManageIndex: false, canWriteIndex: false });
       }
     }
-  }, [privilegesState.result]);
+  }, [readState.result]);
 
   // handleReadError
   useEffect(() => {
-    const error = privilegesState.error;
+    const error = readState.error;
     if (error != null) {
       setState({ isAuthenticated: false, canManageIndex: false, canWriteIndex: false });
       toasts.addError(error, {
         title: i18n.LISTS_PRIVILEGES_READ_FAILURE,
       });
     }
-  }, [privilegesState.error, toasts]);
+  }, [readState.error, toasts]);
 
   return { loading, ...state };
 };

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_privileges.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_privileges.tsx
@@ -79,7 +79,7 @@ export const useListsPrivileges = (): UseListsPrivilegesReturn => {
   });
   const { lists } = useKibana().services;
   const http = useHttp();
-  const { addError, addSuccess } = useAppToasts();
+  const { addError } = useAppToasts();
   const { loading, start: readListPrivileges, ...readState } = useReadListPrivileges();
 
   const readPrivileges = useCallback(() => {


### PR DESCRIPTION
## Summary

A few changes related to toast messages:

* Better presentation of error data sent from the API (both general platform errors and app-specific errors)
* Uses platform's new Toasts service to prevent modal/toast z-index collision issues
* Updates both the Value Lists Modal and the Exceptions List Modals to use this new hook wrapping the above

This also fixes an issue with `useListsConfig` where, when the server is nonresponsive, it will not continue to poll awaiting a non-error response.

I'm not replacing all uses of our redux-based toaster implementation for now, but we can/should do that in a subsequent PR.


#### Example Toasts when trying to upload too large of a value list:
<img width="338" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/87720571-c13a9180-c77a-11ea-8647-59aaed6eda4b.png">
<img width="857" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/87720598-cac3f980-c77a-11ea-9983-a45d784b29c7.png">



### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
