### PR TITLE
[SECURITY] Bug truncation on timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/add_filter_to_global_search_bar/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/add_filter_to_global_search_bar/index.test.tsx
@@ -157,8 +157,10 @@ describe('AddFilterToGlobalSearchBar Component', () => {
       </TestProviders>
     );
 
+    wrapper.find('[data-test-subj="withHoverActionsButton"]').simulate('mouseenter');
+    wrapper.update();
+
     wrapper
-      .simulate('mouseenter')
       .find('[data-test-subj="hover-actions-container"] [data-euiicon-type]')
       .first()
       .simulate('click');

--- a/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper.test.tsx
@@ -65,7 +65,7 @@ describe('DraggableWrapper', () => {
       expect(wrapper.find('[data-test-subj="copy-to-clipboard"]').exists()).toBe(false);
     });
 
-    test('it renders hover actions when the mouse is over the draggable wrapper', () => {
+    test('it renders hover actions when the mouse is over the text of draggable wrapper', () => {
       const wrapper = mount(
         <TestProviders>
           <MockedProvider mocks={mocksSource} addTypename={false}>
@@ -76,7 +76,7 @@ describe('DraggableWrapper', () => {
         </TestProviders>
       );
 
-      wrapper.simulate('mouseenter');
+      wrapper.find('[data-test-subj="withHoverActionsButton"]').simulate('mouseenter');
       wrapper.update();
       expect(wrapper.find('[data-test-subj="copy-to-clipboard"]').exists()).toBe(true);
     });

--- a/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
@@ -65,7 +65,11 @@ export const WithHoverActions = React.memo<Props>(
     }, []);
 
     const content = useMemo(
-      () => <div onMouseEnter={onMouseEnter}>{render(showHoverContent)}</div>,
+      () => (
+        <div data-test-subj="withHoverActionsButton" onMouseEnter={onMouseEnter}>
+          {render(showHoverContent)}
+        </div>
+      ),
       [onMouseEnter, render, showHoverContent]
     );
 

--- a/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
@@ -17,10 +17,6 @@ const WithHoverActionsPopover = (styled(EuiPopover as any)`
   }
 ` as unknown) as typeof EuiPopover;
 
-const Container = styled.div`
-  width: fit-content;
-`;
-
 interface Props {
   /**
    * Always show the hover menu contents (default: false)
@@ -68,7 +64,10 @@ export const WithHoverActions = React.memo<Props>(
       setShowHoverContent(false);
     }, []);
 
-    const content = useMemo(() => <>{render(showHoverContent)}</>, [render, showHoverContent]);
+    const content = useMemo(
+      () => <div onMouseEnter={onMouseEnter}>{render(showHoverContent)}</div>,
+      [onMouseEnter, render, showHoverContent]
+    );
 
     useEffect(() => {
       setIsOpen(hoverContent != null && (showHoverContent || alwaysShow));
@@ -79,7 +78,7 @@ export const WithHoverActions = React.memo<Props>(
     }, [closePopOverTrigger]);
 
     return (
-      <Container onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <div onMouseLeave={onMouseLeave}>
         <WithHoverActionsPopover
           anchorPosition={'downCenter'}
           button={content}
@@ -90,7 +89,7 @@ export const WithHoverActions = React.memo<Props>(
         >
           {isOpen ? <>{hoverContent}</> : null}
         </WithHoverActionsPopover>
-      </Container>
+      </div>
     );
   }
 );

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/field_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/field_name.test.tsx
@@ -46,7 +46,7 @@ describe('FieldName', () => {
         <FieldName {...defaultProps} />
       </TestProviders>
     );
-    wrapper.find('div').at(1).simulate('mouseenter');
+    wrapper.find('[data-test-subj="withHoverActionsButton"]').at(0).simulate('mouseenter');
     wrapper.update();
     expect(wrapper.find('[data-test-subj="copy-to-clipboard"]').exists()).toBe(true);
   });


### PR DESCRIPTION
## Summary

In a recent PR, I was trying to only allow to show the menu context to filter in/out + send to timeline + top N + copy to clipboard when you go over the text of draggable and by doing that I broke the truncation. So this PR is my redemption to fix that.

![Jul-16-2020 23-33-10](https://user-images.githubusercontent.com/189600/87745966-59596a80-c7bd-11ea-8f8b-ad6a4a36c894.gif)


