### PR TITLE
[SIEM][Detections] Updates 'External alerts' tab text

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/translations.ts
@@ -29,7 +29,7 @@ export const SIGNAL = i18n.translate('xpack.securitySolution.detectionEngine.sig
 });
 
 export const ALERT = i18n.translate('xpack.securitySolution.detectionEngine.alertTitle', {
-  defaultMessage: 'External alerts',
+  defaultMessage: 'Detection alerts',
 });
 
 export const BUTTON_MANAGE_RULES = i18n.translate(


### PR DESCRIPTION
## Summary

"External Alerts" tab is renamed to "Detection Alerts".