### PR TITLE
[APM] Fixes error when loading APM without ML read permissions

### DIFF
--- a/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
+++ b/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
@@ -18,14 +18,23 @@ export const anomalyDetectionJobsRoute = createRoute(() => ({
   path: '/api/apm/settings/anomaly-detection',
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
-    const [jobs, legacyJobs] = await Promise.all([
-      getAnomalyDetectionJobs(setup, context.logger),
-      hasLegacyJobs(setup),
-    ]);
-    return {
-      jobs,
-      hasLegacyJobs: legacyJobs,
-    };
+    const { logger } = context;
+    try {
+      const [jobs, legacyJobs] = await Promise.all([
+        getAnomalyDetectionJobs(setup, logger),
+        hasLegacyJobs(setup),
+      ]);
+      return {
+        jobs,
+        hasLegacyJobs: legacyJobs,
+      };
+    } catch (error) {
+      logger.warn(error);
+      return {
+        jobs: [],
+        hasLegacyJobs: false,
+      };
+    }
   },
 }));
 


### PR DESCRIPTION
Closes #72241. By wrapping the anomaly detection ml calls in a try/catch block and returning no results on error. This addresses the case for users who don't have access to ML to still use APM without the integration.