### PR TITLE
[Security Solution][Detections]Exceptions modal bugs

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -21,6 +21,7 @@ import {
   EuiCallOut,
   EuiText,
 } from '@elastic/eui';
+import { Status } from '../../../../../common/detection_engine/schemas/common/schemas';
 import { alertsIndexPattern } from '../../../../../common/endpoint/constants';
 import {
   ExceptionListItemSchema,
@@ -67,6 +68,7 @@ interface AddExceptionModalProps {
   };
   onCancel: () => void;
   onConfirm: (didCloseAlert: boolean) => void;
+  alertStatus?: Status;
 }
 
 const Modal = styled(EuiModal)`
@@ -105,6 +107,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
   alertData,
   onCancel,
   onConfirm,
+  alertStatus,
 }: AddExceptionModalProps) {
   const { http } = useKibana().services;
   const [comment, setComment] = useState('');
@@ -335,7 +338,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
               </ModalBodySection>
               <EuiHorizontalRule />
               <ModalBodySection>
-                {alertData !== undefined && (
+                {(alertData !== undefined || alertStatus === 'closed') && (
                   <EuiFormRow fullWidth>
                     <EuiCheckbox
                       id="close-alert-on-add-add-exception-checkbox"

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/index.tsx
@@ -186,7 +186,8 @@ export const AddExceptionModal = memo(function AddExceptionModal({
     if (indexPatternLoading === false && isSignalIndexLoading === false) {
       setShouldDisableBulkClose(
         entryHasListType(exceptionItemsToAdd) ||
-          entryHasNonEcsType(exceptionItemsToAdd, indexPatterns)
+          entryHasNonEcsType(exceptionItemsToAdd, indexPatterns) ||
+          exceptionItemsToAdd.length === 0
       );
     }
   }, [
@@ -338,7 +339,7 @@ export const AddExceptionModal = memo(function AddExceptionModal({
               </ModalBodySection>
               <EuiHorizontalRule />
               <ModalBodySection>
-                {(alertData !== undefined || alertStatus === 'closed') && (
+                {alertData !== undefined && alertStatus !== 'closed' && (
                   <EuiFormRow fullWidth>
                     <EuiCheckbox
                       id="close-alert-on-add-add-exception-checkbox"

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -207,7 +207,7 @@ export const EditExceptionModal = memo(function EditExceptionModal({
         </ModalHeader>
 
         {(addExceptionIsLoading || indexPatternLoading || isSignalIndexLoading) && (
-          <Loader data-test-subj="loadingAddExceptionModal" size="xl" />
+          <Loader data-test-subj="loadingEditExceptionModal" size="xl" />
         )}
 
         {!isSignalIndexLoading && !addExceptionIsLoading && !indexPatternLoading && (

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/index.tsx
@@ -41,6 +41,7 @@ import {
   entryHasListType,
   entryHasNonEcsType,
 } from '../helpers';
+import { Loader } from '../../loader';
 
 interface EditExceptionModalProps {
   ruleName: string;
@@ -124,7 +125,8 @@ export const EditExceptionModal = memo(function EditExceptionModal({
     if (indexPatternLoading === false && isSignalIndexLoading === false) {
       setShouldDisableBulkClose(
         entryHasListType(exceptionItemsToAdd) ||
-          entryHasNonEcsType(exceptionItemsToAdd, indexPatterns)
+          entryHasNonEcsType(exceptionItemsToAdd, indexPatterns) ||
+          exceptionItemsToAdd.length === 0
       );
     }
   }, [
@@ -204,7 +206,11 @@ export const EditExceptionModal = memo(function EditExceptionModal({
           </ModalHeaderSubtitle>
         </ModalHeader>
 
-        {!isSignalIndexLoading && (
+        {(addExceptionIsLoading || indexPatternLoading || isSignalIndexLoading) && (
+          <Loader data-test-subj="loadingAddExceptionModal" size="xl" />
+        )}
+
+        {!isSignalIndexLoading && !addExceptionIsLoading && !indexPatternLoading && (
           <>
             <ModalBodySection className="builder-section">
               <EuiText>{i18n.EXCEPTION_BUILDER_INFO}</EuiText>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -458,6 +458,7 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
           alertData={addExceptionModalState.alertData}
           onCancel={onAddExceptionCancel}
           onConfirm={onAddExceptionConfirm}
+          alertStatus={filterGroup}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Addresses:
* disabling bulk close checkbox on empty builder
* making close alert checkbox not available when alert is already closed
* adds loading spinner to edit exceptions modal

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
