### PR TITLE
[Ingest Manager] Fix long combo box option breaking Add/Edit integration layout

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_package_config_page/components/package_config_input_stream.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_config/create_package_config_page/components/package_config_input_stream.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useState, Fragment, memo, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
+import styled from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n/react';
 import {
   EuiFlexGrid,
@@ -22,6 +23,10 @@ import {
   validationHasErrors,
 } from '../services';
 import { PackageConfigInputVarField } from './package_config_input_var_field';
+
+const FlexItemWithMaxWidth = styled(EuiFlexItem)`
+  max-width: calc(50% - ${(props) => props.theme.eui.euiSizeL});
+`;
 
 export const PackageConfigInputStreamConfig: React.FunctionComponent<{
   packageInputStream: RegistryStream;
@@ -91,7 +96,7 @@ export const PackageConfigInputStreamConfig: React.FunctionComponent<{
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <FlexItemWithMaxWidth>
           <EuiFlexGroup direction="column" gutterSize="m">
             {requiredVars.map((varDef) => {
               const { name: varName, type: varType } = varDef;
@@ -178,7 +183,7 @@ export const PackageConfigInputStreamConfig: React.FunctionComponent<{
               </Fragment>
             ) : null}
           </EuiFlexGroup>
-        </EuiFlexItem>
+        </FlexItemWithMaxWidth>
       </EuiFlexGrid>
     );
   }


### PR DESCRIPTION
## Summary

Fixes #72444 by adding a workaround for EUI bug https://github.com/elastic/eui/issues/3775.

The original issue can be reproduced by entering any long string into a combo box field, eventually it will break out of its layout and drop into another row. Now it won't:

![image](https://user-images.githubusercontent.com/1965714/87976030-4a0a4380-ca81-11ea-93ec-27e067585be1.png)
