### PR TITLE
[Security Solution][Detections] Adds loading states to export/delete on modal

### DIFF
--- a/x-pack/plugins/lists/public/common/hooks/use_async.test.ts
+++ b/x-pack/plugins/lists/public/common/hooks/use_async.test.ts
@@ -95,4 +95,36 @@ describe('useAsync', () => {
 
     expect(result.current.loading).toBe(false);
   });
+
+  it('multiple start calls reset state', async () => {
+    let resolve: (result: string) => void;
+    fn.mockImplementation(() => new Promise((_resolve) => (resolve = _resolve)));
+
+    const { result, waitForNextUpdate } = renderHook(() => useAsync(fn));
+
+    act(() => {
+      result.current.start(args);
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    act(() => resolve('result'));
+    await waitForNextUpdate();
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.result).toBe('result');
+
+    act(() => {
+      result.current.start(args);
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.result).toBe(undefined);
+
+    act(() => resolve('result'));
+    await waitForNextUpdate();
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.result).toBe('result');
+  });
 });

--- a/x-pack/plugins/lists/public/common/hooks/use_async.ts
+++ b/x-pack/plugins/lists/public/common/hooks/use_async.ts
@@ -32,6 +32,8 @@ export const useAsync = <Args extends unknown[], Result>(
   const start = useCallback(
     (...args: Args) => {
       setLoading(true);
+      setResult(undefined);
+      setError(undefined);
       fn(...args)
         .then((r) => isMounted() && setResult(r))
         .catch((e) => isMounted() && setError(e))

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.test.tsx
@@ -11,15 +11,23 @@ import { act } from 'react-dom/test-utils';
 import { getListResponseMock } from '../../../../../lists/common/schemas/response/list_schema.mock';
 import { ListSchema } from '../../../../../lists/common/schemas/response';
 import { TestProviders } from '../../../common/mock';
-import { ValueListsTable } from './table';
+import { ValueListsTable, TableItem } from './table';
+
+const buildItems = (lists: ListSchema[]): TableItem[] =>
+  lists.map((list) => ({
+    ...list,
+    isDeleting: false,
+    isExporting: false,
+  }));
 
 describe('ValueListsTable', () => {
   it('renders a row for each list', () => {
     const lists = Array<ListSchema>(3).fill(getListResponseMock());
+    const items = buildItems(lists);
     const container = mount(
       <TestProviders>
         <ValueListsTable
-          lists={lists}
+          items={items}
           onChange={jest.fn()}
           loading={false}
           onExport={jest.fn()}
@@ -34,11 +42,12 @@ describe('ValueListsTable', () => {
 
   it('calls onChange when pagination is modified', () => {
     const lists = Array<ListSchema>(6).fill(getListResponseMock());
+    const items = buildItems(lists);
     const onChange = jest.fn();
     const container = mount(
       <TestProviders>
         <ValueListsTable
-          lists={lists}
+          items={items}
           onChange={onChange}
           loading={false}
           onExport={jest.fn()}
@@ -59,11 +68,12 @@ describe('ValueListsTable', () => {
 
   it('calls onExport when export is clicked', () => {
     const lists = Array<ListSchema>(3).fill(getListResponseMock());
+    const items = buildItems(lists);
     const onExport = jest.fn();
     const container = mount(
       <TestProviders>
         <ValueListsTable
-          lists={lists}
+          items={items}
           onChange={jest.fn()}
           loading={false}
           onExport={onExport}
@@ -86,11 +96,12 @@ describe('ValueListsTable', () => {
 
   it('calls onDelete when delete is clicked', () => {
     const lists = Array<ListSchema>(3).fill(getListResponseMock());
+    const items = buildItems(lists);
     const onDelete = jest.fn();
     const container = mount(
       <TestProviders>
         <ValueListsTable
-          lists={lists}
+          items={items}
           onChange={jest.fn()}
           loading={false}
           onExport={jest.fn()}

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.test.tsx
@@ -11,7 +11,8 @@ import { act } from 'react-dom/test-utils';
 import { getListResponseMock } from '../../../../../lists/common/schemas/response/list_schema.mock';
 import { ListSchema } from '../../../../../lists/common/schemas/response';
 import { TestProviders } from '../../../common/mock';
-import { ValueListsTable, TableItem } from './table';
+import { ValueListsTable } from './table';
+import { TableItem } from './types';
 
 const buildItems = (lists: ListSchema[]): TableItem[] =>
   lists.map((list) => ({

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.tsx
@@ -5,25 +5,18 @@
  */
 
 import React from 'react';
-import { EuiBasicTable, EuiBasicTableProps, EuiText, EuiPanel } from '@elastic/eui';
+import { EuiBasicTable, EuiText, EuiPanel } from '@elastic/eui';
 
-import { ListSchema } from '../../../../../lists/common/schemas/response';
 import * as i18n from './translations';
 import { buildColumns } from './table_helpers';
-
-export interface TableItem extends ListSchema {
-  isDeleting: boolean;
-  isExporting: boolean;
-}
-export type TableProps = EuiBasicTableProps<TableItem>;
-export type ActionCallback = (item: TableItem) => void;
+import { TableProps, TableItemCallback } from './types';
 
 export interface ValueListsTableProps {
   items: TableProps['items'];
   loading: boolean;
   onChange: TableProps['onChange'];
-  onExport: ActionCallback;
-  onDelete: ActionCallback;
+  onExport: TableItemCallback;
+  onDelete: TableItemCallback;
   pagination: Exclude<TableProps['pagination'], undefined>;
 }
 

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table.tsx
@@ -8,14 +8,18 @@ import React from 'react';
 import { EuiBasicTable, EuiBasicTableProps, EuiText, EuiPanel } from '@elastic/eui';
 
 import { ListSchema } from '../../../../../lists/common/schemas/response';
-import { FormattedDate } from '../../../common/components/formatted_date';
 import * as i18n from './translations';
+import { buildColumns } from './table_helpers';
 
-type TableProps = EuiBasicTableProps<ListSchema>;
-type ActionCallback = (item: ListSchema) => void;
+export interface TableItem extends ListSchema {
+  isDeleting: boolean;
+  isExporting: boolean;
+}
+export type TableProps = EuiBasicTableProps<TableItem>;
+export type ActionCallback = (item: TableItem) => void;
 
 export interface ValueListsTableProps {
-  lists: TableProps['items'];
+  items: TableProps['items'];
   loading: boolean;
   onChange: TableProps['onChange'];
   onExport: ActionCallback;
@@ -23,56 +27,8 @@ export interface ValueListsTableProps {
   pagination: Exclude<TableProps['pagination'], undefined>;
 }
 
-const buildColumns = (
-  onExport: ActionCallback,
-  onDelete: ActionCallback
-): TableProps['columns'] => [
-  {
-    field: 'name',
-    name: i18n.COLUMN_FILE_NAME,
-    truncateText: true,
-  },
-  {
-    field: 'created_at',
-    name: i18n.COLUMN_UPLOAD_DATE,
-    /* eslint-disable-next-line react/display-name */
-    render: (value: ListSchema['created_at']) => (
-      <FormattedDate value={value} fieldName="created_at" />
-    ),
-    width: '30%',
-  },
-  {
-    field: 'created_by',
-    name: i18n.COLUMN_CREATED_BY,
-    truncateText: true,
-    width: '20%',
-  },
-  {
-    name: i18n.COLUMN_ACTIONS,
-    actions: [
-      {
-        name: i18n.ACTION_EXPORT_NAME,
-        description: i18n.ACTION_EXPORT_DESCRIPTION,
-        icon: 'exportAction',
-        type: 'icon',
-        onClick: onExport,
-        'data-test-subj': 'action-export-value-list',
-      },
-      {
-        name: i18n.ACTION_DELETE_NAME,
-        description: i18n.ACTION_DELETE_DESCRIPTION,
-        icon: 'trash',
-        type: 'icon',
-        onClick: onDelete,
-        'data-test-subj': 'action-delete-value-list',
-      },
-    ],
-    width: '15%',
-  },
-];
-
 export const ValueListsTableComponent: React.FC<ValueListsTableProps> = ({
-  lists,
+  items,
   loading,
   onChange,
   onExport,
@@ -87,7 +43,7 @@ export const ValueListsTableComponent: React.FC<ValueListsTableProps> = ({
       </EuiText>
       <EuiBasicTable
         columns={columns}
-        items={lists}
+        items={items}
         loading={loading}
         onChange={onChange}
         pagination={pagination}

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
@@ -16,6 +16,7 @@ import * as i18n from './translations';
 import { ActionCallback, TableItem, TableProps } from './table';
 
 const AlignedSpinner = styled(EuiLoadingSpinner)`
+  margin: ${({ theme }) => theme.eui.euiSizeXS};
   vertical-align: middle;
 `;
 
@@ -29,7 +30,7 @@ const ActionButton: React.FC<{
 }> = ({ content, dataTestSubj, icon, item, onClick, isLoading }) => (
   <EuiToolTip content={content}>
     {isLoading ? (
-      <AlignedSpinner size="l" />
+      <AlignedSpinner size="m" />
     ) : (
       <EuiButtonIcon
         aria-label={content}

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+/* eslint-disable react/display-name */
+
+import React from 'react';
+import styled from 'styled-components';
+import { EuiButtonIcon, IconType, EuiLoadingSpinner, EuiToolTip } from '@elastic/eui';
+
+import { ListSchema } from '../../../../../lists/common/schemas/response';
+import { FormattedDate } from '../../../common/components/formatted_date';
+import * as i18n from './translations';
+import { ActionCallback, TableItem, TableProps } from './table';
+
+const AlignedSpinner = styled(EuiLoadingSpinner)`
+  vertical-align: middle;
+`;
+
+const ActionButton: React.FC<{
+  content: string;
+  dataTestSubj: string;
+  icon: IconType;
+  isLoading: boolean;
+  item: TableItem;
+  onClick: ActionCallback;
+}> = ({ content, dataTestSubj, icon, item, onClick, isLoading }) => (
+  <EuiToolTip content={content}>
+    {isLoading ? (
+      <AlignedSpinner size="m" />
+    ) : (
+      <EuiButtonIcon
+        aria-label={content}
+        data-test-subj={dataTestSubj}
+        iconType={icon}
+        onClick={() => onClick(item)}
+      />
+    )}
+  </EuiToolTip>
+);
+
+export const buildColumns = (
+  onExport: ActionCallback,
+  onDelete: ActionCallback
+): TableProps['columns'] => [
+  {
+    field: 'name',
+    name: i18n.COLUMN_FILE_NAME,
+    truncateText: true,
+  },
+  {
+    field: 'created_at',
+    name: i18n.COLUMN_UPLOAD_DATE,
+    render: (value: ListSchema['created_at']) => (
+      <FormattedDate value={value} fieldName="created_at" />
+    ),
+    width: '30%',
+  },
+  {
+    field: 'created_by',
+    name: i18n.COLUMN_CREATED_BY,
+    truncateText: true,
+    width: '20%',
+  },
+  {
+    name: i18n.COLUMN_ACTIONS,
+    actions: [
+      {
+        render: (item) => (
+          <ActionButton
+            content={i18n.ACTION_EXPORT_DESCRIPTION}
+            dataTestSubj="action-export-value-list"
+            icon="exportAction"
+            item={item}
+            onClick={onExport}
+            isLoading={item.isExporting}
+          />
+        ),
+      },
+      {
+        render: (item) => (
+          <ActionButton
+            content={i18n.ACTION_DELETE_DESCRIPTION}
+            dataTestSubj="action-delete-value-list"
+            icon="trash"
+            item={item}
+            onClick={onDelete}
+            isLoading={item.isDeleting}
+          />
+        ),
+      },
+    ],
+    width: '15%',
+  },
+];

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
@@ -13,7 +13,7 @@ import { EuiButtonIcon, IconType, EuiLoadingSpinner, EuiToolTip } from '@elastic
 import { ListSchema } from '../../../../../lists/common/schemas/response';
 import { FormattedDate } from '../../../common/components/formatted_date';
 import * as i18n from './translations';
-import { ActionCallback, TableItem, TableProps } from './table';
+import { TableItem, TableItemCallback, TableProps } from './types';
 
 const AlignedSpinner = styled(EuiLoadingSpinner)`
   margin: ${({ theme }) => theme.eui.euiSizeXS};
@@ -26,7 +26,7 @@ const ActionButton: React.FC<{
   icon: IconType;
   isLoading: boolean;
   item: TableItem;
-  onClick: ActionCallback;
+  onClick: TableItemCallback;
 }> = ({ content, dataTestSubj, icon, item, onClick, isLoading }) => (
   <EuiToolTip content={content}>
     {isLoading ? (
@@ -43,8 +43,8 @@ const ActionButton: React.FC<{
 );
 
 export const buildColumns = (
-  onExport: ActionCallback,
-  onDelete: ActionCallback
+  onExport: TableItemCallback,
+  onDelete: TableItemCallback
 ): TableProps['columns'] => [
   {
     field: 'name',

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/table_helpers.tsx
@@ -29,7 +29,7 @@ const ActionButton: React.FC<{
 }> = ({ content, dataTestSubj, icon, item, onClick, isLoading }) => (
   <EuiToolTip content={content}>
     {isLoading ? (
-      <AlignedSpinner size="m" />
+      <AlignedSpinner size="l" />
     ) : (
       <EuiButtonIcon
         aria-label={content}

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { EuiBasicTableProps } from '@elastic/eui';
+
+import { ListSchema } from '../../../../../lists/common/schemas/response';
+
+export interface TableItem extends ListSchema {
+  isDeleting: boolean;
+  isExporting: boolean;
+}
+export type TableProps = EuiBasicTableProps<TableItem>;
+export type TableItemCallback = (item: TableItem) => void;


### PR DESCRIPTION
## Summary

This PR replaces the export/delete buttons on the value lists modal with loading spinners while the corresponding action is pending.

#### Spinners in action (old style)
![value_list_loading](https://user-images.githubusercontent.com/657252/88002295-d0e20f00-cac7-11ea-8108-de0ada6d1acf.gif)

#### New spinners style:
<img width="829" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/88082311-3e815000-cb47-11ea-9ab9-dd5f61ad0e7a.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

