### PR TITLE
[Security Solution][Cases] Create useAllCasesModal hook

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/components/all_cases/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/all_cases/index.test.tsx
@@ -14,6 +14,8 @@ import { TestProviders } from '../../../common/mock';
 import { useGetCasesMockState } from '../../containers/mock';
 import * as i18n from './translations';
 
+import { useKibana } from '../../../common/lib/kibana';
+import { createUseKibanaMock } from '../../../common/mock/kibana_react';
 import { getEmptyTagValue } from '../../../common/components/empty_value';
 import { useDeleteCases } from '../../containers/use_delete_cases';
 import { useGetCases } from '../../containers/use_get_cases';
@@ -26,12 +28,15 @@ jest.mock('../../containers/use_delete_cases');
 jest.mock('../../containers/use_get_cases');
 jest.mock('../../containers/use_get_cases_status');
 
+const useKibanaMock = useKibana as jest.Mock;
 const useDeleteCasesMock = useDeleteCases as jest.Mock;
 const useGetCasesMock = useGetCases as jest.Mock;
 const useGetCasesStatusMock = useGetCasesStatus as jest.Mock;
 const useUpdateCasesMock = useUpdateCases as jest.Mock;
 
 jest.mock('../../../common/components/link_to');
+
+jest.mock('../../../common/lib/kibana');
 
 describe('AllCases', () => {
   const dispatchResetIsDeleted = jest.fn();
@@ -45,6 +50,7 @@ describe('AllCases', () => {
   const setSelectedCases = jest.fn();
   const updateBulkStatus = jest.fn();
   const fetchCasesStatus = jest.fn();
+  const onRowClick = jest.fn();
   const emptyTag = getEmptyTagValue().props.children;
 
   const defaultGetCases = {
@@ -77,6 +83,9 @@ describe('AllCases', () => {
     dispatchResetIsUpdated,
     updateBulkStatus,
   };
+
+  let navigateToApp: jest.Mock;
+
   /* eslint-disable no-console */
   // Silence until enzyme fixed to use ReactTestUtils.act()
   const originalError = console.error;
@@ -89,6 +98,16 @@ describe('AllCases', () => {
   /* eslint-enable no-console */
   beforeEach(() => {
     jest.resetAllMocks();
+    navigateToApp = jest.fn();
+    const kibanaMock = createUseKibanaMock()();
+    useKibanaMock.mockImplementation(() => ({
+      ...kibanaMock,
+      services: {
+        application: {
+          navigateToApp,
+        },
+      },
+    }));
     useUpdateCasesMock.mockImplementation(() => defaultUpdateCases);
     useGetCasesMock.mockImplementation(() => defaultGetCases);
     useDeleteCasesMock.mockImplementation(() => defaultDeleteCases);
@@ -319,5 +338,97 @@ describe('AllCases', () => {
     expect(refetchCases).toBeCalled();
     expect(fetchCasesStatus).toBeCalled();
     expect(dispatchResetIsUpdated).toBeCalled();
+  });
+
+  it('should not render header when modal=true', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={true} />
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="all-cases-header"]').exists()).toBe(false);
+  });
+
+  it('should not render table utility bar when modal=true', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={true} />
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="case-table-utility-bar-actions"]').exists()).toBe(false);
+  });
+
+  it('case table should not be selectable when modal=true', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={true} />
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="cases-table"]').first().prop('isSelectable')).toBe(false);
+  });
+
+  it('should call onRowClick with no cases and modal=true', () => {
+    useGetCasesMock.mockImplementation(() => ({
+      ...defaultGetCases,
+      data: {
+        ...defaultGetCases.data,
+        total: 0,
+        cases: [],
+      },
+    }));
+
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={true} onRowClick={onRowClick} />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="cases-table-add-case"]').first().simulate('click');
+    expect(onRowClick).toHaveBeenCalled();
+  });
+
+  it('should call navigateToApp with no cases and modal=false', () => {
+    useGetCasesMock.mockImplementation(() => ({
+      ...defaultGetCases,
+      data: {
+        ...defaultGetCases.data,
+        total: 0,
+        cases: [],
+      },
+    }));
+
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={false} />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="cases-table-add-case"]').first().simulate('click');
+    expect(navigateToApp).toHaveBeenCalledWith('securitySolution:case', { path: '/create' });
+  });
+
+  it('should call onRowClick when clicking a case with modal=true', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={true} onRowClick={onRowClick} />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="cases-table-row-1"]').first().simulate('click');
+    expect(onRowClick).toHaveBeenCalledWith('1');
+  });
+
+  it('should NOT call onRowClick when clicking a case with modal=true', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCases userCanCrud={true} isModal={false} />
+      </TestProviders>
+    );
+
+    wrapper.find('[data-test-subj="cases-table-row-1"]').first().simulate('click');
+    expect(onRowClick).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/public/cases/components/all_cases/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/all_cases/index.test.tsx
@@ -100,18 +100,18 @@ describe('AllCases', () => {
     jest.resetAllMocks();
     navigateToApp = jest.fn();
     const kibanaMock = createUseKibanaMock()();
-    useKibanaMock.mockImplementation(() => ({
+    useKibanaMock.mockReturnValue({
       ...kibanaMock,
       services: {
         application: {
           navigateToApp,
         },
       },
-    }));
-    useUpdateCasesMock.mockImplementation(() => defaultUpdateCases);
-    useGetCasesMock.mockImplementation(() => defaultGetCases);
-    useDeleteCasesMock.mockImplementation(() => defaultDeleteCases);
-    useGetCasesStatusMock.mockImplementation(() => defaultCasesStatus);
+    });
+    useUpdateCasesMock.mockReturnValue(defaultUpdateCases);
+    useGetCasesMock.mockReturnValue(defaultGetCases);
+    useDeleteCasesMock.mockReturnValue(defaultDeleteCases);
+    useGetCasesStatusMock.mockReturnValue(defaultCasesStatus);
     moment.tz.setDefault('UTC');
   });
   it('should render AllCases', () => {
@@ -144,7 +144,7 @@ describe('AllCases', () => {
     );
   });
   it('should render empty fields', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       data: {
         ...defaultGetCases.data,
@@ -160,7 +160,7 @@ describe('AllCases', () => {
           },
         ],
       },
-    }));
+    });
     const wrapper = mount(
       <TestProviders>
         <AllCases userCanCrud={true} />
@@ -221,10 +221,10 @@ describe('AllCases', () => {
     });
   });
   it('opens case when row action icon clicked', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       filterOptions: { ...defaultGetCases.filterOptions, status: 'closed' },
-    }));
+    });
 
     const wrapper = mount(
       <TestProviders>
@@ -242,10 +242,11 @@ describe('AllCases', () => {
     });
   });
   it('Bulk delete', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       selectedCases: useGetCasesMockState.data.cases,
-    }));
+    });
+
     useDeleteCasesMock
       .mockReturnValueOnce({
         ...defaultDeleteCases,
@@ -276,10 +277,10 @@ describe('AllCases', () => {
     );
   });
   it('Bulk close status update', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       selectedCases: useGetCasesMockState.data.cases,
-    }));
+    });
 
     const wrapper = mount(
       <TestProviders>
@@ -291,14 +292,14 @@ describe('AllCases', () => {
     expect(updateBulkStatus).toBeCalledWith(useGetCasesMockState.data.cases, 'closed');
   });
   it('Bulk open status update', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       selectedCases: useGetCasesMockState.data.cases,
       filterOptions: {
         ...defaultGetCases.filterOptions,
         status: 'closed',
       },
-    }));
+    });
 
     const wrapper = mount(
       <TestProviders>
@@ -310,10 +311,10 @@ describe('AllCases', () => {
     expect(updateBulkStatus).toBeCalledWith(useGetCasesMockState.data.cases, 'open');
   });
   it('isDeleted is true, refetch', () => {
-    useDeleteCasesMock.mockImplementation(() => ({
+    useDeleteCasesMock.mockReturnValue({
       ...defaultDeleteCases,
       isDeleted: true,
-    }));
+    });
 
     mount(
       <TestProviders>
@@ -325,10 +326,10 @@ describe('AllCases', () => {
     expect(dispatchResetIsDeleted).toBeCalled();
   });
   it('isUpdated is true, refetch', () => {
-    useUpdateCasesMock.mockImplementation(() => ({
+    useUpdateCasesMock.mockReturnValue({
       ...defaultUpdateCases,
       isUpdated: true,
-    }));
+    });
 
     mount(
       <TestProviders>
@@ -371,14 +372,14 @@ describe('AllCases', () => {
   });
 
   it('should call onRowClick with no cases and modal=true', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       data: {
         ...defaultGetCases.data,
         total: 0,
         cases: [],
       },
-    }));
+    });
 
     const wrapper = mount(
       <TestProviders>
@@ -391,14 +392,14 @@ describe('AllCases', () => {
   });
 
   it('should call navigateToApp with no cases and modal=false', () => {
-    useGetCasesMock.mockImplementation(() => ({
+    useGetCasesMock.mockReturnValue({
       ...defaultGetCases,
       data: {
         ...defaultGetCases.data,
         total: 0,
         cases: [],
       },
-    }));
+    });
 
     const wrapper = mount(
       <TestProviders>

--- a/x-pack/plugins/security_solution/public/cases/components/all_cases/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/all_cases/index.tsx
@@ -329,7 +329,13 @@ export const AllCases = React.memo<AllCasesProps>(
         )}
         {!isModal && (
           <CaseHeaderPage title={i18n.PAGE_TITLE}>
-            <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false} wrap={true}>
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="m"
+              responsive={false}
+              wrap={true}
+              data-test-subj="all-cases-header"
+            >
               <EuiFlexItem grow={false}>
                 <OpenClosedStats
                   dataTestSubj="openStatsHeader"
@@ -401,7 +407,7 @@ export const AllCases = React.memo<AllCasesProps>(
                     </UtilityBarText>
                   </UtilityBarGroup>
                   {!isModal && (
-                    <UtilityBarGroup>
+                    <UtilityBarGroup data-test-subj="case-table-utility-bar-actions">
                       <UtilityBarText data-test-subj="case-table-selected-case-count">
                         {i18n.SHOWING_SELECTED_CASES(selectedCases.length)}
                       </UtilityBarText>
@@ -441,6 +447,7 @@ export const AllCases = React.memo<AllCasesProps>(
                         onClick={goToCreateCase}
                         href={formatUrl(getCreateCaseUrl())}
                         iconType="plusInCircle"
+                        data-test-subj="cases-table-add-case"
                       >
                         {i18n.ADD_NEW_CASE}
                       </LinkButton>
@@ -452,13 +459,16 @@ export const AllCases = React.memo<AllCasesProps>(
                 rowProps={(item) =>
                   isModal
                     ? {
+                        'data-test-subj': `cases-table-row-${item.id}`,
                         onClick: () => {
                           if (onRowClick != null) {
                             onRowClick(item.id);
                           }
                         },
                       }
-                    : {}
+                    : {
+                        'data-test-subj': `cases-table-row-${item.id}`,
+                      }
                 }
                 selection={userCanCrud && !isModal ? euiBasicTableSelectionProps : undefined}
                 sorting={sorting}

--- a/x-pack/plugins/security_solution/public/cases/components/all_cases/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/all_cases/index.tsx
@@ -322,6 +322,26 @@ export const AllCases = React.memo<AllCasesProps>(
     const isDataEmpty = useMemo(() => data.total === 0, [data]);
 
     const TableWrap = useMemo(() => (isModal ? 'span' : Panel), [isModal]);
+
+    const tableRowProps = useCallback((item) => {
+      const rowProps = {
+        'data-test-subj': `cases-table-row-${item.id}`,
+      };
+
+      if (isModal) {
+        return {
+          ...rowProps,
+          onClick: () => {
+            if (onRowClick != null) {
+              onRowClick(item.id);
+            }
+          },
+        };
+      }
+
+      return rowProps;
+    }, []);
+
     return (
       <>
         {!isEmpty(actionsErrors) && (
@@ -456,20 +476,7 @@ export const AllCases = React.memo<AllCasesProps>(
                 }
                 onChange={tableOnChangeCallback}
                 pagination={memoizedPagination}
-                rowProps={(item) =>
-                  isModal
-                    ? {
-                        'data-test-subj': `cases-table-row-${item.id}`,
-                        onClick: () => {
-                          if (onRowClick != null) {
-                            onRowClick(item.id);
-                          }
-                        },
-                      }
-                    : {
-                        'data-test-subj': `cases-table-row-${item.id}`,
-                      }
-                }
+                rowProps={tableRowProps}
                 selection={userCanCrud && !isModal ? euiBasicTableSelectionProps : undefined}
                 sorting={sorting}
               />

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.test.tsx
@@ -9,35 +9,13 @@ import '../../../common/mock/match_media';
 import { AllCasesModal } from './all_cases_modal';
 import { TestProviders } from '../../../common/mock';
 
-import { useGetCasesMockState, basicCaseId } from '../../containers/mock';
-import { useDeleteCases } from '../../containers/use_delete_cases';
-import { useGetCases } from '../../containers/use_get_cases';
-import { useGetCasesStatus } from '../../containers/use_get_cases_status';
-import { useUpdateCases } from '../../containers/use_bulk_update_case';
-import { EuiTableRow } from '@elastic/eui';
-
-jest.mock('react-router-dom', () => {
-  const original = jest.requireActual('react-router-dom');
-
-  return {
-    ...original,
-    useHistory: () => ({
-      useHistory: jest.fn(),
-    }),
+jest.mock('../all_cases', () => {
+  const AllCases = () => {
+    return <></>;
   };
+  return { AllCases };
 });
 
-jest.mock('../../../common/components/link_to');
-
-jest.mock('../../containers/use_bulk_update_case');
-jest.mock('../../containers/use_delete_cases');
-jest.mock('../../containers/use_get_cases');
-jest.mock('../../containers/use_get_cases_status');
-
-const useDeleteCasesMock = useDeleteCases as jest.Mock;
-const useGetCasesMock = useGetCases as jest.Mock;
-const useGetCasesStatusMock = useGetCasesStatus as jest.Mock;
-const useUpdateCasesMock = useUpdateCases as jest.Mock;
 jest.mock('../../../common/lib/kibana', () => {
   const originalModule = jest.requireActual('../../../common/lib/kibana');
   return {
@@ -51,88 +29,21 @@ const onRowClick = jest.fn();
 const defaultProps = {
   onCloseCaseModal,
   onRowClick,
-  userCanCrud: true,
 };
-describe('AllCasesModal', () => {
-  const dispatchResetIsDeleted = jest.fn();
-  const dispatchResetIsUpdated = jest.fn();
-  const dispatchUpdateCaseProperty = jest.fn();
-  const handleOnDeleteConfirm = jest.fn();
-  const handleToggleModal = jest.fn();
-  const refetchCases = jest.fn();
-  const setFilters = jest.fn();
-  const setQueryParams = jest.fn();
-  const setSelectedCases = jest.fn();
-  const updateBulkStatus = jest.fn();
-  const fetchCasesStatus = jest.fn();
 
-  const defaultGetCases = {
-    ...useGetCasesMockState,
-    dispatchUpdateCaseProperty,
-    refetchCases,
-    setFilters,
-    setQueryParams,
-    setSelectedCases,
-  };
-  const defaultDeleteCases = {
-    dispatchResetIsDeleted,
-    handleOnDeleteConfirm,
-    handleToggleModal,
-    isDeleted: false,
-    isDisplayConfirmDeleteModal: false,
-    isLoading: false,
-  };
-  const defaultCasesStatus = {
-    countClosedCases: 0,
-    countOpenCases: 5,
-    fetchCasesStatus,
-    isError: false,
-    isLoading: true,
-  };
-  const defaultUpdateCases = {
-    isUpdated: false,
-    isLoading: false,
-    isError: false,
-    dispatchResetIsUpdated,
-    updateBulkStatus,
-  };
-  /* eslint-disable no-console */
-  // Silence until enzyme fixed to use ReactTestUtils.act()
-  const originalError = console.error;
-  beforeAll(() => {
-    console.error = jest.fn();
-  });
-  afterAll(() => {
-    console.error = originalError;
-  });
-  /* eslint-enable no-console */
+describe('AllCasesModal', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    useUpdateCasesMock.mockImplementation(() => defaultUpdateCases);
-    useGetCasesMock.mockImplementation(() => defaultGetCases);
-    useDeleteCasesMock.mockImplementation(() => defaultDeleteCases);
-    useGetCasesStatusMock.mockImplementation(() => defaultCasesStatus);
   });
 
-  it('renders with unselectable rows', () => {
+  it('renders', () => {
     const wrapper = mount(
       <TestProviders>
         <AllCasesModal {...defaultProps} />
       </TestProviders>
     );
+
     expect(wrapper.find(`[data-test-subj='all-cases-modal']`).exists()).toBeTruthy();
-    expect(wrapper.find(EuiTableRow).first().prop('isSelectable')).toBeFalsy();
-  });
-
-  it('onRowClick called when row is clicked', () => {
-    const wrapper = mount(
-      <TestProviders>
-        <AllCasesModal {...defaultProps} />
-      </TestProviders>
-    );
-    const firstRow = wrapper.find(EuiTableRow).first();
-    firstRow.simulate('click');
-    expect(onRowClick.mock.calls[0][0]).toEqual(basicCaseId);
   });
 
   it('Closing modal calls onCloseCaseModal', () => {
@@ -141,8 +52,23 @@ describe('AllCasesModal', () => {
         <AllCasesModal {...defaultProps} />
       </TestProviders>
     );
-    const modalClose = wrapper.find('.euiModal__closeIcon').first();
-    modalClose.simulate('click');
+
+    wrapper.find('.euiModal__closeIcon').first().simulate('click');
     expect(onCloseCaseModal).toBeCalled();
+  });
+
+  it('pass the correct props to AllCases component', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCasesModal {...defaultProps} />
+      </TestProviders>
+    );
+
+    const props = wrapper.find('AllCases').props();
+    expect(props).toEqual({
+      userCanCrud: false,
+      onRowClick,
+      isModal: true,
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { mount } from 'enzyme';
+import React from 'react';
+import '../../../common/mock/match_media';
+import { AllCasesModal } from './all_cases_modal';
+import { TestProviders } from '../../../common/mock';
+
+import { useGetCasesMockState, basicCaseId } from '../../containers/mock';
+import { useDeleteCases } from '../../containers/use_delete_cases';
+import { useGetCases } from '../../containers/use_get_cases';
+import { useGetCasesStatus } from '../../containers/use_get_cases_status';
+import { useUpdateCases } from '../../containers/use_bulk_update_case';
+import { EuiTableRow } from '@elastic/eui';
+
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+
+  return {
+    ...original,
+    useHistory: () => ({
+      useHistory: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../../common/components/link_to');
+
+jest.mock('../../containers/use_bulk_update_case');
+jest.mock('../../containers/use_delete_cases');
+jest.mock('../../containers/use_get_cases');
+jest.mock('../../containers/use_get_cases_status');
+
+const useDeleteCasesMock = useDeleteCases as jest.Mock;
+const useGetCasesMock = useGetCases as jest.Mock;
+const useGetCasesStatusMock = useGetCasesStatus as jest.Mock;
+const useUpdateCasesMock = useUpdateCases as jest.Mock;
+jest.mock('../../../common/lib/kibana', () => {
+  const originalModule = jest.requireActual('../../../common/lib/kibana');
+  return {
+    ...originalModule,
+    useGetUserSavedObjectPermissions: jest.fn(),
+  };
+});
+
+const onCloseCaseModal = jest.fn();
+const onRowClick = jest.fn();
+const defaultProps = {
+  onCloseCaseModal,
+  onRowClick,
+  userCanCrud: true,
+};
+describe('AllCasesModal', () => {
+  const dispatchResetIsDeleted = jest.fn();
+  const dispatchResetIsUpdated = jest.fn();
+  const dispatchUpdateCaseProperty = jest.fn();
+  const handleOnDeleteConfirm = jest.fn();
+  const handleToggleModal = jest.fn();
+  const refetchCases = jest.fn();
+  const setFilters = jest.fn();
+  const setQueryParams = jest.fn();
+  const setSelectedCases = jest.fn();
+  const updateBulkStatus = jest.fn();
+  const fetchCasesStatus = jest.fn();
+
+  const defaultGetCases = {
+    ...useGetCasesMockState,
+    dispatchUpdateCaseProperty,
+    refetchCases,
+    setFilters,
+    setQueryParams,
+    setSelectedCases,
+  };
+  const defaultDeleteCases = {
+    dispatchResetIsDeleted,
+    handleOnDeleteConfirm,
+    handleToggleModal,
+    isDeleted: false,
+    isDisplayConfirmDeleteModal: false,
+    isLoading: false,
+  };
+  const defaultCasesStatus = {
+    countClosedCases: 0,
+    countOpenCases: 5,
+    fetchCasesStatus,
+    isError: false,
+    isLoading: true,
+  };
+  const defaultUpdateCases = {
+    isUpdated: false,
+    isLoading: false,
+    isError: false,
+    dispatchResetIsUpdated,
+    updateBulkStatus,
+  };
+  /* eslint-disable no-console */
+  // Silence until enzyme fixed to use ReactTestUtils.act()
+  const originalError = console.error;
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+  afterAll(() => {
+    console.error = originalError;
+  });
+  /* eslint-enable no-console */
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useUpdateCasesMock.mockImplementation(() => defaultUpdateCases);
+    useGetCasesMock.mockImplementation(() => defaultGetCases);
+    useDeleteCasesMock.mockImplementation(() => defaultDeleteCases);
+    useGetCasesStatusMock.mockImplementation(() => defaultCasesStatus);
+  });
+
+  it('renders with unselectable rows', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCasesModal {...defaultProps} />
+      </TestProviders>
+    );
+    expect(wrapper.find(`[data-test-subj='all-cases-modal']`).exists()).toBeTruthy();
+    expect(wrapper.find(EuiTableRow).first().prop('isSelectable')).toBeFalsy();
+  });
+
+  it('onRowClick called when row is clicked', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCasesModal {...defaultProps} />
+      </TestProviders>
+    );
+    const firstRow = wrapper.find(EuiTableRow).first();
+    firstRow.simulate('click');
+    expect(onRowClick.mock.calls[0][0]).toEqual(basicCaseId);
+  });
+
+  it('Closing modal calls onCloseCaseModal', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AllCasesModal {...defaultProps} />
+      </TestProviders>
+    );
+    const modalClose = wrapper.find('.euiModal__closeIcon').first();
+    modalClose.simulate('click');
+    expect(onCloseCaseModal).toBeCalled();
+  });
+});

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.tsx
@@ -17,7 +17,7 @@ import { useGetUserSavedObjectPermissions } from '../../../common/lib/kibana';
 import { AllCases } from '../all_cases';
 import * as i18n from './translations';
 
-interface AllCasesModalProps {
+export interface AllCasesModalProps {
   onCloseCaseModal: () => void;
   onRowClick: (id?: string) => void;
 }

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/all_cases_modal.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import {
   EuiModal,
   EuiModalBody,
@@ -19,39 +19,29 @@ import * as i18n from './translations';
 
 interface AllCasesModalProps {
   onCloseCaseModal: () => void;
-  showCaseModal: boolean;
   onRowClick: (id?: string) => void;
 }
 
-export const AllCasesModalComponent = ({
+const AllCasesModalComponent: React.FC<AllCasesModalProps> = ({
   onCloseCaseModal,
   onRowClick,
-  showCaseModal,
 }: AllCasesModalProps) => {
   const userPermissions = useGetUserSavedObjectPermissions();
-  let modal;
-  if (showCaseModal) {
-    modal = (
-      <EuiOverlayMask data-test-subj="all-cases-modal">
-        <EuiModal onClose={onCloseCaseModal}>
-          <EuiModalHeader>
-            <EuiModalHeaderTitle>{i18n.SELECT_CASE_TITLE}</EuiModalHeaderTitle>
-          </EuiModalHeader>
-          <EuiModalBody>
-            <AllCases
-              onRowClick={onRowClick}
-              userCanCrud={userPermissions?.crud ?? false}
-              isModal
-            />
-          </EuiModalBody>
-        </EuiModal>
-      </EuiOverlayMask>
-    );
-  }
-
-  return <>{modal}</>;
+  const userCanCrud = userPermissions?.crud ?? false;
+  return (
+    <EuiOverlayMask data-test-subj="all-cases-modal">
+      <EuiModal onClose={onCloseCaseModal}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>{i18n.SELECT_CASE_TITLE}</EuiModalHeaderTitle>
+        </EuiModalHeader>
+        <EuiModalBody>
+          <AllCases onRowClick={onRowClick} userCanCrud={userCanCrud} isModal />
+        </EuiModalBody>
+      </EuiModal>
+    </EuiOverlayMask>
+  );
 };
 
-export const AllCasesModal = React.memo(AllCasesModalComponent);
+export const AllCasesModal = memo(AllCasesModalComponent);
 
 AllCasesModal.displayName = 'AllCasesModal';

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.test.tsx
@@ -44,7 +44,6 @@ describe('useAllCasesModal', () => {
       }
     );
 
-    expect(result.current.modal).toBe(null);
     expect(result.current.showModal).toBe(false);
   });
 
@@ -60,7 +59,6 @@ describe('useAllCasesModal', () => {
       result.current.onOpenModal();
     });
 
-    expect(result.current.modal).not.toBe(null);
     expect(result.current.showModal).toBe(true);
   });
 
@@ -77,7 +75,6 @@ describe('useAllCasesModal', () => {
       result.current.onCloseModal();
     });
 
-    expect(result.current.modal).toBe(null);
     expect(result.current.showModal).toBe(false);
   });
 
@@ -109,7 +106,6 @@ describe('useAllCasesModal', () => {
       result.current.onRowClick();
     });
 
-    expect(result.current.modal).toBe(null);
     expect(result.current.showModal).toBe(false);
   });
 

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.test.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+/* eslint-disable react/display-name */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { useKibana } from '../../../common/lib/kibana';
+import '../../../common/mock/match_media';
+import { TimelineId } from '../../../../common/types/timeline';
+import { useAllCasesModal, UseAllCasesModalProps, UseAllCasesModalReturnedValues } from '.';
+import { TestProviders } from '../../../common/mock';
+import { createUseKibanaMock } from '../../../common/mock/kibana_react';
+
+jest.mock('../../../common/lib/kibana');
+
+const useKibanaMock = useKibana as jest.Mock;
+
+describe('useAllCasesModal', () => {
+  const navigateToApp = jest.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const kibanaMock = createUseKibanaMock()();
+    useKibanaMock.mockImplementation(() => ({
+      ...kibanaMock,
+      services: {
+        application: {
+          navigateToApp,
+        },
+      },
+    }));
+  });
+
+  it('init', async () => {
+    const { result } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    expect(result.current.modal).toBe(null);
+    expect(result.current.showModal).toBe(false);
+  });
+
+  it('opens the modal', async () => {
+    const { result } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.onOpenModal();
+    });
+
+    expect(result.current.modal).not.toBe(null);
+    expect(result.current.showModal).toBe(true);
+  });
+
+  it('closes the modal', async () => {
+    const { result } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.onOpenModal();
+      result.current.onCloseModal();
+    });
+
+    expect(result.current.modal).toBe(null);
+    expect(result.current.showModal).toBe(false);
+  });
+
+  it('returns a memoized value', async () => {
+    const { result, rerender } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    const result1 = result.current;
+    act(() => rerender());
+    const result2 = result.current;
+
+    expect(result1).toBe(result2);
+  });
+
+  it('closes the modal when clicking a row', async () => {
+    const { result } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.onOpenModal();
+      result.current.onRowClick();
+    });
+
+    expect(result.current.modal).toBe(null);
+    expect(result.current.showModal).toBe(false);
+  });
+
+  it('navigates to the correct path without id', async () => {
+    const { result } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.onOpenModal();
+      result.current.onRowClick();
+    });
+
+    expect(navigateToApp).toHaveBeenCalledWith('securitySolution:case', { path: '/create' });
+  });
+
+  it('navigates to the correct path with id', async () => {
+    const { result } = renderHook<UseAllCasesModalProps, UseAllCasesModalReturnedValues>(
+      () => useAllCasesModal({ timelineId: TimelineId.test }),
+      {
+        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.onOpenModal();
+      result.current.onRowClick('case-id');
+    });
+
+    expect(navigateToApp).toHaveBeenCalledWith('securitySolution:case', { path: '/case-id' });
+  });
+});

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useState, useCallback, useMemo } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+import { APP_ID } from '../../../../common/constants';
+import { SecurityPageName } from '../../../app/types';
+import { useKibana } from '../../../common/lib/kibana';
+import { getCaseDetailsUrl, getCreateCaseUrl } from '../../../common/components/link_to';
+import { State } from '../../../common/store';
+import { setInsertTimeline } from '../../../timelines/store/timeline/actions';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+import { UNTITLED_TIMELINE } from '../../../timelines/components/timeline/properties/translations';
+
+import { AllCasesModal } from './all_cases_modal';
+
+export interface UseAllCasesModalProps {
+  timelineId: string;
+  graphEventId?: string;
+  title?: string;
+}
+
+export interface UseAllCasesModalReturnedValues {
+  modal: JSX.Element | null;
+  showModal: boolean;
+  onCloseModal: () => void;
+  onOpenModal: () => void;
+  onRowClick: (id?: string) => void;
+}
+
+export const useAllCasesModal = ({
+  timelineId,
+  graphEventId,
+  title,
+}: UseAllCasesModalProps): UseAllCasesModalReturnedValues => {
+  const dispatch = useDispatch();
+  const { navigateToApp } = useKibana().services.application;
+  const timelineSavedObjectId = useSelector(
+    (state: State) => timelineSelectors.selectTimeline(state, timelineId)?.savedObjectId ?? ''
+  );
+
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const onCloseModal = useCallback(() => setShowModal(false), []);
+  const onOpenModal = useCallback(() => setShowModal(true), []);
+
+  const onRowClick = useCallback(
+    (id?: string) => {
+      onCloseModal();
+
+      navigateToApp(`${APP_ID}:${SecurityPageName.case}`, {
+        path: id != null ? getCaseDetailsUrl({ id }) : getCreateCaseUrl(),
+      }).then(() =>
+        dispatch(
+          setInsertTimeline({
+            graphEventId,
+            timelineId,
+            timelineSavedObjectId,
+            timelineTitle: title && title.length > 0 ? title : UNTITLED_TIMELINE,
+          })
+        )
+      );
+    },
+    // dispatch causes unnecessary rerenders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [timelineSavedObjectId, graphEventId, navigateToApp, onCloseModal, timelineId, title]
+  );
+
+  const Modal = useMemo(
+    () => <AllCasesModal onCloseCaseModal={onCloseModal} onRowClick={onRowClick} />,
+    [onCloseModal, onRowClick]
+  );
+
+  const state = useMemo(
+    () => ({
+      modal: showModal ? Modal : null,
+      showModal,
+      onCloseModal,
+      onOpenModal,
+      onRowClick,
+    }),
+    [showModal, onCloseModal, onOpenModal, onRowClick, Modal]
+  );
+
+  return state;
+};

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.tsx
@@ -48,20 +48,20 @@ export const useAllCasesModal = ({
   const onOpenModal = useCallback(() => setShowModal(true), []);
 
   const onRowClick = useCallback(
-    (id?: string) => {
+    async (id?: string) => {
       onCloseModal();
 
-      navigateToApp(`${APP_ID}:${SecurityPageName.case}`, {
+      await navigateToApp(`${APP_ID}:${SecurityPageName.case}`, {
         path: id != null ? getCaseDetailsUrl({ id }) : getCreateCaseUrl(),
-      }).then(() =>
-        dispatch(
-          setInsertTimeline({
-            graphEventId,
-            timelineId,
-            timelineSavedObjectId,
-            timelineTitle: title && title.length > 0 ? title : UNTITLED_TIMELINE,
-          })
-        )
+      });
+
+      dispatch(
+        setInsertTimeline({
+          graphEventId,
+          timelineId,
+          timelineSavedObjectId,
+          timelineTitle: title && title.length > 0 ? title : UNTITLED_TIMELINE,
+        })
       );
     },
     // dispatch causes unnecessary rerenders

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/index.tsx
@@ -14,18 +14,15 @@ import { getCaseDetailsUrl, getCreateCaseUrl } from '../../../common/components/
 import { State } from '../../../common/store';
 import { setInsertTimeline } from '../../../timelines/store/timeline/actions';
 import { timelineSelectors } from '../../../timelines/store/timeline';
-import { UNTITLED_TIMELINE } from '../../../timelines/components/timeline/properties/translations';
 
 import { AllCasesModal } from './all_cases_modal';
 
 export interface UseAllCasesModalProps {
   timelineId: string;
-  graphEventId?: string;
-  title?: string;
 }
 
 export interface UseAllCasesModalReturnedValues {
-  modal: JSX.Element | null;
+  Modal: React.FC;
   showModal: boolean;
   onCloseModal: () => void;
   onOpenModal: () => void;
@@ -34,13 +31,11 @@ export interface UseAllCasesModalReturnedValues {
 
 export const useAllCasesModal = ({
   timelineId,
-  graphEventId,
-  title,
 }: UseAllCasesModalProps): UseAllCasesModalReturnedValues => {
   const dispatch = useDispatch();
   const { navigateToApp } = useKibana().services.application;
-  const timelineSavedObjectId = useSelector(
-    (state: State) => timelineSelectors.selectTimeline(state, timelineId)?.savedObjectId ?? ''
+  const timeline = useSelector((state: State) =>
+    timelineSelectors.selectTimeline(state, timelineId)
   );
 
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -57,26 +52,27 @@ export const useAllCasesModal = ({
 
       dispatch(
         setInsertTimeline({
-          graphEventId,
+          graphEventId: timeline.graphEventId ?? '',
           timelineId,
-          timelineSavedObjectId,
-          timelineTitle: title && title.length > 0 ? title : UNTITLED_TIMELINE,
+          timelineSavedObjectId: timeline.savedObjectId ?? '',
+          timelineTitle: timeline.title,
         })
       );
     },
     // dispatch causes unnecessary rerenders
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [timelineSavedObjectId, graphEventId, navigateToApp, onCloseModal, timelineId, title]
+    [timeline, navigateToApp, onCloseModal, timelineId]
   );
 
-  const Modal = useMemo(
-    () => <AllCasesModal onCloseCaseModal={onCloseModal} onRowClick={onRowClick} />,
-    [onCloseModal, onRowClick]
+  const Modal: React.FC = useCallback(
+    () =>
+      showModal ? <AllCasesModal onCloseCaseModal={onCloseModal} onRowClick={onRowClick} /> : null,
+    [onCloseModal, onRowClick, showModal]
   );
 
   const state = useMemo(
     () => ({
-      modal: showModal ? Modal : null,
+      Modal,
       showModal,
       onCloseModal,
       onOpenModal,

--- a/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/cases/components/use_all_cases_modal/translations.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { i18n } from '@kbn/i18n';
+export const SELECT_CASE_TITLE = i18n.translate('xpack.securitySolution.case.caseModal.title', {
+  defaultMessage: 'Select case to attach timeline',
+});

--- a/x-pack/plugins/security_solution/public/common/lib/kibana/__mocks__/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kibana/__mocks__/index.ts
@@ -24,3 +24,4 @@ export const useToasts = jest.fn(() => notificationServiceMock.createStartContra
 export const useCurrentUser = jest.fn();
 export const withKibana = jest.fn(createWithKibanaMock());
 export const KibanaContextProvider = jest.fn(createKibanaContextProviderMock());
+export const useGetUserSavedObjectPermissions = jest.fn();

--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -13,18 +13,14 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { noop } from 'lodash/fp';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { connect, ConnectedProps, useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
-import { SecurityPageName } from '../../../app/types';
 import { FULL_SCREEN } from '../timeline/body/column_headers/translations';
-import { AllCasesModal } from '../../../cases/components/all_cases_modal';
 import { EXIT_FULL_SCREEN } from '../../../common/components/exit_full_screen/translations';
-import { APP_ID, FULL_SCREEN_TOGGLED_CLASS_NAME } from '../../../../common/constants';
+import { FULL_SCREEN_TOGGLED_CLASS_NAME } from '../../../../common/constants';
 import { useFullScreen } from '../../../common/containers/use_full_screen';
-import { getCaseDetailsUrl, getCreateCaseUrl } from '../../../common/components/link_to';
-import { useKibana } from '../../../common/lib/kibana';
 import { State } from '../../../common/store';
 import { TimelineId, TimelineType } from '../../../../common/types/timeline';
 import { timelineSelectors } from '../../store/timeline';
@@ -32,12 +28,9 @@ import { timelineDefaults } from '../../store/timeline/defaults';
 import { TimelineModel } from '../../store/timeline/model';
 import { isFullScreen } from '../timeline/body/column_headers';
 import { NewCase, ExistingCase } from '../timeline/properties/helpers';
-import { UNTITLED_TIMELINE } from '../timeline/properties/translations';
-import {
-  setInsertTimeline,
-  updateTimelineGraphEventId,
-} from '../../../timelines/store/timeline/actions';
+import { updateTimelineGraphEventId } from '../../../timelines/store/timeline/actions';
 import { Resolver } from '../../../resolver/view';
+import { useAllCasesModal } from '../../../cases/components/use_all_cases_modal';
 
 import * as i18n from './translations';
 
@@ -112,35 +105,20 @@ const GraphOverlayComponent = ({
   timelineType,
 }: OwnProps & PropsFromRedux) => {
   const dispatch = useDispatch();
-  const { navigateToApp } = useKibana().services.application;
   const onCloseOverlay = useCallback(() => {
     dispatch(updateTimelineGraphEventId({ id: timelineId, graphEventId: '' }));
   }, [dispatch, timelineId]);
-  const [showCaseModal, setShowCaseModal] = useState<boolean>(false);
-  const onOpenCaseModal = useCallback(() => setShowCaseModal(true), []);
-  const onCloseCaseModal = useCallback(() => setShowCaseModal(false), [setShowCaseModal]);
+
   const currentTimeline = useSelector((state: State) =>
     timelineSelectors.selectTimeline(state, timelineId)
   );
-  const onRowClick = useCallback(
-    (id?: string) => {
-      onCloseCaseModal();
 
-      navigateToApp(`${APP_ID}:${SecurityPageName.case}`, {
-        path: id != null ? getCaseDetailsUrl({ id }) : getCreateCaseUrl(),
-      }).then(() => {
-        dispatch(
-          setInsertTimeline({
-            graphEventId,
-            timelineId,
-            timelineSavedObjectId: currentTimeline.savedObjectId,
-            timelineTitle: title.length > 0 ? title : UNTITLED_TIMELINE,
-          })
-        );
-      });
-    },
-    [currentTimeline, dispatch, graphEventId, navigateToApp, onCloseCaseModal, timelineId, title]
-  );
+  const { modal: allCasesModal, onOpenModal: onOpenCaseModal } = useAllCasesModal({
+    timelineId,
+    graphEventId,
+    title,
+  });
+
   const {
     timelineFullScreen,
     setTimelineFullScreen,
@@ -210,11 +188,7 @@ const GraphOverlayComponent = ({
         databaseDocumentID={graphEventId}
         resolverComponentInstanceID={currentTimeline.id}
       />
-      <AllCasesModal
-        onCloseCaseModal={onCloseCaseModal}
-        showCaseModal={showCaseModal}
-        onRowClick={onRowClick}
-      />
+      {allCasesModal}
     </OverlayContainer>
   );
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -113,11 +113,7 @@ const GraphOverlayComponent = ({
     timelineSelectors.selectTimeline(state, timelineId)
   );
 
-  const { modal: allCasesModal, onOpenModal: onOpenCaseModal } = useAllCasesModal({
-    timelineId,
-    graphEventId,
-    title,
-  });
+  const { Modal: AllCasesModal, onOpenModal: onOpenCaseModal } = useAllCasesModal({ timelineId });
 
   const {
     timelineFullScreen,
@@ -188,7 +184,7 @@ const GraphOverlayComponent = ({
         databaseDocumentID={graphEventId}
         resolverComponentInstanceID={currentTimeline.id}
       />
-      {allCasesModal}
+      <AllCasesModal />
     </OverlayContainer>
   );
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/index.tsx
@@ -92,11 +92,7 @@ export const Properties = React.memo<Props>(
       setShowTimelineModal(true);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-    const { modal: allCasesModal, onOpenModal: onOpenCaseModal } = useAllCasesModal({
-      timelineId,
-      graphEventId,
-      title,
-    });
+    const { Modal: AllCasesModal, onOpenModal: onOpenCaseModal } = useAllCasesModal({ timelineId });
 
     const datePickerWidth = useMemo(
       () =>
@@ -163,7 +159,7 @@ export const Properties = React.memo<Props>(
           updateNote={updateNote}
           usersViewing={usersViewing}
         />
-        {allCasesModal}
+        <AllCasesModal />
       </TimelineProperties>
     );
   }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/index.tsx
@@ -6,7 +6,6 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 
-import { useDispatch, useSelector } from 'react-redux';
 import { TimelineStatusLiteral, TimelineTypeLiteral } from '../../../../../common/types/timeline';
 import { useThrottledResizeObserver } from '../../../../common/components/utils';
 import { Note } from '../../../../common/lib/note';
@@ -17,15 +16,7 @@ import { AssociateNote, UpdateNote } from '../../notes/helpers';
 import { TimelineProperties } from './styles';
 import { PropertiesRight } from './properties_right';
 import { PropertiesLeft } from './properties_left';
-import { AllCasesModal } from '../../../../cases/components/all_cases_modal';
-import { SecurityPageName } from '../../../../app/types';
-import * as i18n from './translations';
-import { State } from '../../../../common/store';
-import { timelineSelectors } from '../../../store/timeline';
-import { setInsertTimeline } from '../../../store/timeline/actions';
-import { useKibana } from '../../../../common/lib/kibana';
-import { APP_ID } from '../../../../../common/constants';
-import { getCaseDetailsUrl, getCreateCaseUrl } from '../../../../common/components/link_to';
+import { useAllCasesModal } from '../../../../cases/components/use_all_cases_modal';
 
 type UpdateIsFavorite = ({ id, isFavorite }: { id: string; isFavorite: boolean }) => void;
 type UpdateTitle = ({ id, title }: { id: string; title: string }) => void;
@@ -86,12 +77,10 @@ export const Properties = React.memo<Props>(
     updateTitle,
     usersViewing,
   }) => {
-    const { navigateToApp } = useKibana().services.application;
     const { ref, width = 0 } = useThrottledResizeObserver(300);
     const [showActions, setShowActions] = useState(false);
     const [showNotes, setShowNotes] = useState(false);
     const [showTimelineModal, setShowTimelineModal] = useState(false);
-    const dispatch = useDispatch();
 
     const onButtonClick = useCallback(() => setShowActions(!showActions), [showActions]);
     const onToggleShowNotes = useCallback(() => setShowNotes(!showNotes), [showNotes]);
@@ -103,32 +92,11 @@ export const Properties = React.memo<Props>(
       setShowTimelineModal(true);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-    const [showCaseModal, setShowCaseModal] = useState(false);
-    const onCloseCaseModal = useCallback(() => setShowCaseModal(false), []);
-    const onOpenCaseModal = useCallback(() => setShowCaseModal(true), []);
-    const currentTimeline = useSelector((state: State) =>
-      timelineSelectors.selectTimeline(state, timelineId)
-    );
-
-    const onRowClick = useCallback(
-      (id?: string) => {
-        onCloseCaseModal();
-
-        navigateToApp(`${APP_ID}:${SecurityPageName.case}`, {
-          path: id != null ? getCaseDetailsUrl({ id }) : getCreateCaseUrl(),
-        }).then(() =>
-          dispatch(
-            setInsertTimeline({
-              graphEventId,
-              timelineId,
-              timelineSavedObjectId: currentTimeline.savedObjectId,
-              timelineTitle: title.length > 0 ? title : i18n.UNTITLED_TIMELINE,
-            })
-          )
-        );
-      },
-      [currentTimeline, dispatch, graphEventId, navigateToApp, onCloseCaseModal, timelineId, title]
-    );
+    const { modal: allCasesModal, onOpenModal: onOpenCaseModal } = useAllCasesModal({
+      timelineId,
+      graphEventId,
+      title,
+    });
 
     const datePickerWidth = useMemo(
       () =>
@@ -195,11 +163,7 @@ export const Properties = React.memo<Props>(
           updateNote={updateNote}
           usersViewing={usersViewing}
         />
-        <AllCasesModal
-          onCloseCaseModal={onCloseCaseModal}
-          showCaseModal={showCaseModal}
-          onRowClick={onRowClick}
-        />
+        {allCasesModal}
       </TimelineProperties>
     );
   }


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/kibana/issues/70115. It introduces a new hook called `useAllCasesModal`.

Props:

```
interface UseAllCasesModalProps {
  timelineId: string;
  graphEventId?: string;
  title?: string;
}
```

Returned values:

``` 
interface UseAllCasesModalReturnedValues {
  modal: JSX.Element | null;
  showModal: boolean;
  onCloseModal: () => void;
  onOpenModal: () => void;
  onRowClick: (id?: string) => void;
}

```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
