### PR TITLE
[Security Solution][Detections] Validate file type of value lists

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.test.tsx
@@ -26,7 +26,7 @@ const mockSelectFile: <P>(container: ReactWrapper<P>, file: File) => Promise<voi
   const fileChange = container.find('EuiFilePicker').prop('onChange');
   act(() => {
     if (fileChange) {
-      fileChange(([file] as unknown) as FormEvent);
+      fileChange(({ item: () => file } as unknown) as FormEvent);
     }
   });
 };
@@ -81,6 +81,29 @@ describe('ValueListsForm', () => {
     );
 
     expect(onError).toHaveBeenCalledWith('whoops');
+  });
+
+  it('disables upload and displays an error if file has invalid extension', async () => {
+    const badMockFile = ({
+      name: 'foo.unknown',
+      path: '/home/foo.unknown',
+    } as unknown) as File;
+
+    const container = mount(
+      <TestProviders>
+        <ValueListsForm onError={jest.fn()} onSuccess={jest.fn()} />
+      </TestProviders>
+    );
+
+    await mockSelectFile(container, badMockFile);
+
+    expect(
+      container.find('button[data-test-subj="value-lists-form-import-action"]').prop('disabled')
+    ).toEqual(true);
+
+    expect(container.find('div[data-test-subj="value-list-file-picker-row"]').text()).toContain(
+      'Value list must have a .csv or .txt extension.'
+    );
   });
 
   it('calls onSuccess if import succeeds', async () => {

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.test.tsx
@@ -16,7 +16,7 @@ const mockUseImportList = useImportList as jest.Mock;
 
 const mockFile = ({
   name: 'foo.csv',
-  path: '/home/foo.csv',
+  type: 'text/csv',
 } as unknown) as File;
 
 const mockSelectFile: <P>(container: ReactWrapper<P>, file: File) => Promise<void> = async (
@@ -85,8 +85,8 @@ describe('ValueListsForm', () => {
 
   it('disables upload and displays an error if file has invalid extension', async () => {
     const badMockFile = ({
-      name: 'foo.unknown',
-      path: '/home/foo.unknown',
+      name: 'foo.pdf',
+      type: 'application/pdf',
     } as unknown) as File;
 
     const container = mount(
@@ -102,7 +102,7 @@ describe('ValueListsForm', () => {
     ).toEqual(true);
 
     expect(container.find('div[data-test-subj="value-list-file-picker-row"]').text()).toContain(
-      'Value list must have a .csv or .txt extension.'
+      'File must be one of the following types: [text/csv, text/plain]'
     );
   });
 

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.tsx
@@ -46,6 +46,8 @@ const options: ListTypeOptions[] = [
 ];
 
 const defaultListType: Type = 'keyword';
+const validFileExtensions = ['.csv', '.txt'];
+const validFileTypes = ['text/csv', 'text/plain'];
 
 export interface ValueListsFormProps {
   onError: (error: Error) => void;
@@ -54,23 +56,30 @@ export interface ValueListsFormProps {
 
 export const ValueListsFormComponent: React.FC<ValueListsFormProps> = ({ onError, onSuccess }) => {
   const ctrl = useRef(new AbortController());
-  const [files, setFiles] = useState<FileList | null>(null);
+  const [file, setFile] = useState<File | null>(null);
   const [type, setType] = useState<Type>(defaultListType);
   const filePickerRef = useRef<EuiFilePicker | null>(null);
   const { http } = useKibana().services;
   const { start: importList, ...importState } = useImportList();
 
+  const fileIsValid =
+    !file || validFileExtensions.some((extension) => file.name.endsWith(extension));
+
   // EuiRadioGroup's onChange only infers 'string' from our options
   const handleRadioChange = useCallback((t: string) => setType(t as Type), [setType]);
+
+  const handleFileChange = useCallback((files: FileList | null) => {
+    setFile(files?.item(0) ?? null);
+  }, []);
 
   const resetForm = useCallback(() => {
     if (filePickerRef.current?.fileInput) {
       filePickerRef.current.fileInput.value = '';
       filePickerRef.current.handleChange();
     }
-    setFiles(null);
+    setFile(null);
     setType(defaultListType);
-  }, [setType]);
+  }, []);
 
   const handleCancel = useCallback(() => {
     ctrl.current.abort();
@@ -91,17 +100,17 @@ export const ValueListsFormComponent: React.FC<ValueListsFormProps> = ({ onError
   );
 
   const handleImport = useCallback(() => {
-    if (!importState.loading && files && files.length) {
+    if (!importState.loading && file) {
       ctrl.current = new AbortController();
       importList({
-        file: files[0],
+        file,
         listId: undefined,
         http,
         signal: ctrl.current.signal,
         type,
       });
     }
-  }, [importState.loading, files, importList, http, type]);
+  }, [importState.loading, file, importList, http, type]);
 
   useEffect(() => {
     if (!importState.loading && importState.result) {
@@ -117,14 +126,22 @@ export const ValueListsFormComponent: React.FC<ValueListsFormProps> = ({ onError
 
   return (
     <EuiForm>
-      <EuiFormRow label={i18n.FILE_PICKER_LABEL} fullWidth>
+      <EuiFormRow
+        data-test-subj="value-list-file-picker-row"
+        label={i18n.FILE_PICKER_LABEL}
+        fullWidth
+        isInvalid={!fileIsValid}
+        error={[i18n.FILE_PICKER_INVALID_EXTENSION]}
+      >
         <EuiFilePicker
+          accept={validFileTypes.join()}
           id="value-list-file-picker"
           initialPromptText={i18n.FILE_PICKER_PROMPT}
           ref={filePickerRef}
-          onChange={setFiles}
+          onChange={handleFileChange}
           fullWidth={true}
           isLoading={importState.loading}
+          isInvalid={!fileIsValid}
         />
       </EuiFormRow>
       <EuiFormRow fullWidth>
@@ -151,7 +168,7 @@ export const ValueListsFormComponent: React.FC<ValueListsFormProps> = ({ onError
                   <EuiButton
                     data-test-subj="value-lists-form-import-action"
                     onClick={handleImport}
-                    disabled={!files?.length || importState.loading}
+                    disabled={file == null || !fileIsValid || importState.loading}
                   >
                     {i18n.UPLOAD_BUTTON}
                   </EuiButton>

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/form.tsx
@@ -46,7 +46,6 @@ const options: ListTypeOptions[] = [
 ];
 
 const defaultListType: Type = 'keyword';
-const validFileExtensions = ['.csv', '.txt'];
 const validFileTypes = ['text/csv', 'text/plain'];
 
 export interface ValueListsFormProps {
@@ -62,8 +61,7 @@ export const ValueListsFormComponent: React.FC<ValueListsFormProps> = ({ onError
   const { http } = useKibana().services;
   const { start: importList, ...importState } = useImportList();
 
-  const fileIsValid =
-    !file || validFileExtensions.some((extension) => file.name.endsWith(extension));
+  const fileIsValid = !file || validFileTypes.some((fileType) => file.type === fileType);
 
   // EuiRadioGroup's onChange only infers 'string' from our options
   const handleRadioChange = useCallback((t: string) => setType(t as Type), [setType]);
@@ -131,7 +129,7 @@ export const ValueListsFormComponent: React.FC<ValueListsFormProps> = ({ onError
         label={i18n.FILE_PICKER_LABEL}
         fullWidth
         isInvalid={!fileIsValid}
-        error={[i18n.FILE_PICKER_INVALID_EXTENSION]}
+        error={[i18n.FILE_PICKER_INVALID_FILE_TYPE(validFileTypes.join(', '))]}
       >
         <EuiFilePicker
           accept={validFileTypes.join()}

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
@@ -24,12 +24,11 @@ export const FILE_PICKER_PROMPT = i18n.translate(
   }
 );
 
-export const FILE_PICKER_INVALID_EXTENSION = i18n.translate(
-  'xpack.securitySolution.lists.uploadValueListExtensionValidationMessage',
-  {
-    defaultMessage: 'Value list must have a .csv or .txt extension.',
-  }
-);
+export const FILE_PICKER_INVALID_FILE_TYPE = (fileTypes: string): string =>
+  i18n.translate('xpack.securitySolution.lists.uploadValueListExtensionValidationMessage', {
+    values: { fileTypes },
+    defaultMessage: 'File must be one of the following types: [{fileTypes}]',
+  });
 
 export const CLOSE_BUTTON = i18n.translate(
   'xpack.securitySolution.lists.closeValueListsModalTitle',

--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
@@ -24,6 +24,13 @@ export const FILE_PICKER_PROMPT = i18n.translate(
   }
 );
 
+export const FILE_PICKER_INVALID_EXTENSION = i18n.translate(
+  'xpack.securitySolution.lists.uploadValueListExtensionValidationMessage',
+  {
+    defaultMessage: 'Value list must have a .csv or .txt extension.',
+  }
+);
+
 export const CLOSE_BUTTON = i18n.translate(
   'xpack.securitySolution.lists.closeValueListsModalTitle',
   {


### PR DESCRIPTION
## Summary

When choosing a value list to upload, this PR adds the following behaviors:

* The file picker is restricted to files of type `text/csv` or `text/plain` (.csv and .txt, along with a few other text extensions)
* If dragging/dropping a file with an invalid type, a validation message is displayed and the upload button is disabled.

__NB: this does not restrict file uploads via the API__
![value_list_extension_validation](https://user-images.githubusercontent.com/657252/88107571-ee1ce900-cb6c-11ea-86db-7035d54d0463.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
