### PR TITLE
[Security Solution] Hide KQL bar (all pages) and alerts filters (Detections) when Resolver is full screen

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/events_viewer.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/events_viewer.spec.ts
@@ -153,7 +153,7 @@ describe('Events Viewer', () => {
     });
   });
 
-  context('Events columns', () => {
+  context.skip('Events columns', () => {
     before(() => {
       loginAndWaitForPage(HOSTS_URL);
       openEvents();

--- a/x-pack/plugins/security_solution/public/common/components/filters_global/filters_global.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filters_global/filters_global.tsx
@@ -39,16 +39,27 @@ const Wrapper = styled.aside<{ isSticky?: boolean }>`
 `;
 Wrapper.displayName = 'Wrapper';
 
+const FiltersGlobalContainer = styled.header<{ show: boolean }>`
+  ${({ show }) => css`
+    ${show ? '' : 'display: none;'};
+  `}
+`;
+
+FiltersGlobalContainer.displayName = 'FiltersGlobalContainer';
+
 export interface FiltersGlobalProps {
   children: React.ReactNode;
+  show?: boolean;
 }
 
-export const FiltersGlobal = React.memo<FiltersGlobalProps>(({ children }) => (
+export const FiltersGlobal = React.memo<FiltersGlobalProps>(({ children, show = true }) => (
   <Sticky disableCompensation={disableStickyMq.matches} topOffset={-offsetChrome}>
     {({ style, isSticky }) => (
-      <Wrapper className="siemFiltersGlobal" isSticky={isSticky} style={style}>
-        {children}
-      </Wrapper>
+      <FiltersGlobalContainer show={show}>
+        <Wrapper className="siemFiltersGlobal" isSticky={isSticky} style={style}>
+          {children}
+        </Wrapper>
+      </FiltersGlobalContainer>
     )}
   </Sticky>
 ));

--- a/x-pack/plugins/security_solution/public/common/components/header_section/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_section/index.test.tsx
@@ -131,4 +131,28 @@ describe('HeaderSection', () => {
         .exists()
     ).toBe(true);
   });
+
+  test('it renders an inspect button when an `id` is provided', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <HeaderSection id="an id" title="Test title">
+          <p>{'Test children'}</p>
+        </HeaderSection>
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="inspect-icon-button"]').first().exists()).toBe(true);
+  });
+
+  test('it does NOT an inspect button when an `id` is NOT provided', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <HeaderSection title="Test title">
+          <p>{'Test children'}</p>
+        </HeaderSection>
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="inspect-icon-button"]').first().exists()).toBe(false);
+  });
 });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_filter_group/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/alerts_filter_group/index.tsx
@@ -36,7 +36,7 @@ const AlertsTableFilterGroupComponent: React.FC<Props> = ({ onFilterGroupChanged
   }, [setFilterGroup, onFilterGroupChanged]);
 
   return (
-    <EuiFilterGroup>
+    <EuiFilterGroup data-test-subj="alerts-table-filter-group">
       <EuiFilterButton
         data-test-subj="openAlerts"
         hasActiveFilters={filterGroup === FILTER_OPEN}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.test.tsx
@@ -82,6 +82,7 @@ describe('DetectionEnginePageComponent', () => {
       <TestProviders store={store}>
         <Router history={mockHistory}>
           <DetectionEnginePageComponent
+            graphEventId={undefined}
             query={{ query: 'query', language: 'language' }}
             filters={[]}
             setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -51,10 +51,15 @@ import {
   MIN_EVENTS_VIEWER_BODY_HEIGHT,
 } from '../../../timelines/components/timeline/body/helpers';
 import { footerHeight } from '../../../timelines/components/timeline/footer';
+import { showGlobalFilters } from '../../../timelines/components/timeline/helpers';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+import { timelineDefaults } from '../../../timelines/store/timeline/defaults';
+import { TimelineModel } from '../../../timelines/store/timeline/model';
 import { buildShowBuildingBlockFilter } from '../../components/alerts_table/default_config';
 
 export const DetectionEnginePageComponent: React.FC<PropsFromRedux> = ({
   filters,
+  graphEventId,
   query,
   setAbsoluteRangeDatePicker,
 }) => {
@@ -151,7 +156,7 @@ export const DetectionEnginePageComponent: React.FC<PropsFromRedux> = ({
       {indicesExist ? (
         <StickyContainer>
           <EuiWindowEvent event="resize" handler={noop} />
-          <FiltersGlobal>
+          <FiltersGlobal show={showGlobalFilters({ globalFullScreen, graphEventId })}>
             <SiemSearchBar id="global" indexPattern={indexPattern} />
           </FiltersGlobal>
 
@@ -232,13 +237,19 @@ export const DetectionEnginePageComponent: React.FC<PropsFromRedux> = ({
 
 const makeMapStateToProps = () => {
   const getGlobalInputs = inputsSelectors.globalSelector();
+  const getTimeline = timelineSelectors.getTimelineByIdSelector();
   return (state: State) => {
     const globalInputs: InputsRange = getGlobalInputs(state);
     const { query, filters } = globalInputs;
 
+    const timeline: TimelineModel =
+      getTimeline(state, TimelineId.detectionsPage) ?? timelineDefaults;
+    const { graphEventId } = timeline;
+
     return {
       query,
       filters,
+      graphEventId,
     };
   };
 };

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.test.tsx
@@ -82,6 +82,7 @@ describe('RuleDetailsPageComponent', () => {
       <TestProviders store={store}>
         <Router history={mockHistory}>
           <RuleDetailsPageComponent
+            graphEventId={undefined}
             query={{ query: '', language: 'language' }}
             filters={[]}
             setAbsoluteRangeDatePicker={setAbsoluteRangeDatePicker}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -92,6 +92,10 @@ import {
 import { footerHeight } from '../../../../../timelines/components/timeline/footer';
 import { isMlRule } from '../../../../../../common/machine_learning/helpers';
 import { isThresholdRule } from '../../../../../../common/detection_engine/utils';
+import { showGlobalFilters } from '../../../../../timelines/components/timeline/helpers';
+import { timelineSelectors } from '../../../../../timelines/store/timeline';
+import { timelineDefaults } from '../../../../../timelines/store/timeline/defaults';
+import { TimelineModel } from '../../../../../timelines/store/timeline/model';
 
 enum RuleDetailTabs {
   alerts = 'alerts',
@@ -122,6 +126,7 @@ const getRuleDetailsTabs = (rule: Rule | null) => {
 
 export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
   filters,
+  graphEventId,
   query,
   setAbsoluteRangeDatePicker,
 }) => {
@@ -351,7 +356,7 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
       {indicesExist ? (
         <StickyContainer>
           <EuiWindowEvent event="resize" handler={noop} />
-          <FiltersGlobal>
+          <FiltersGlobal show={showGlobalFilters({ globalFullScreen, graphEventId })}>
             <SiemSearchBar id="global" indexPattern={indexPattern} />
           </FiltersGlobal>
 
@@ -541,13 +546,19 @@ RuleDetailsPageComponent.displayName = 'RuleDetailsPageComponent';
 
 const makeMapStateToProps = () => {
   const getGlobalInputs = inputsSelectors.globalSelector();
+  const getTimeline = timelineSelectors.getTimelineByIdSelector();
   return (state: State) => {
     const globalInputs: InputsRange = getGlobalInputs(state);
     const { query, filters } = globalInputs;
 
+    const timeline: TimelineModel =
+      getTimeline(state, TimelineId.detectionsRulesDetailsPage) ?? timelineDefaults;
+    const { graphEventId } = timeline;
+
     return {
       query,
       filters,
+      graphEventId,
     };
   };
 };

--- a/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/hosts/pages/details/index.tsx
@@ -4,7 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
+import { EuiHorizontalRule, EuiSpacer, EuiWindowEvent } from '@elastic/eui';
+import { noop } from 'lodash/fp';
 import React, { useEffect, useCallback, useMemo } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { StickyContainer } from 'react-sticky';
@@ -44,6 +45,13 @@ import { navTabsHostDetails } from './nav_tabs';
 import { HostDetailsProps } from './types';
 import { type } from './utils';
 import { getHostDetailsPageFilters } from './helpers';
+import { showGlobalFilters } from '../../../timelines/components/timeline/helpers';
+import { useFullScreen } from '../../../common/containers/use_full_screen';
+import { Display } from '../display';
+import { timelineSelectors } from '../../../timelines/store/timeline';
+import { TimelineModel } from '../../../timelines/store/timeline/model';
+import { TimelineId } from '../../../../common/types/timeline';
+import { timelineDefaults } from '../../../timelines/store/timeline/defaults';
 
 const HostOverviewManage = manageQuery(HostOverview);
 const KpiHostDetailsManage = manageQuery(KpiHostsComponent);
@@ -51,6 +59,7 @@ const KpiHostDetailsManage = manageQuery(KpiHostsComponent);
 const HostDetailsComponent = React.memo<HostDetailsProps & PropsFromRedux>(
   ({
     filters,
+    graphEventId,
     query,
     setAbsoluteRangeDatePicker,
     setHostDetailsTablesActivePageToZero,
@@ -58,6 +67,7 @@ const HostDetailsComponent = React.memo<HostDetailsProps & PropsFromRedux>(
     hostDetailsPagePath,
   }) => {
     const { to, from, deleteQuery, setQuery, isInitializing } = useGlobalTime();
+    const { globalFullScreen } = useFullScreen();
     useEffect(() => {
       setHostDetailsTablesActivePageToZero();
     }, [setHostDetailsTablesActivePageToZero, detailName]);
@@ -93,90 +103,93 @@ const HostDetailsComponent = React.memo<HostDetailsProps & PropsFromRedux>(
       <>
         {indicesExist ? (
           <StickyContainer>
-            <FiltersGlobal>
+            <EuiWindowEvent event="resize" handler={noop} />
+            <FiltersGlobal show={showGlobalFilters({ globalFullScreen, graphEventId })}>
               <SiemSearchBar indexPattern={indexPattern} id="global" />
             </FiltersGlobal>
 
-            <WrapperPage>
-              <HeaderPage
-                border
-                subtitle={
-                  <LastEventTime indexKey={LastEventIndexKey.hostDetails} hostName={detailName} />
-                }
-                title={detailName}
-              />
+            <WrapperPage noPadding={globalFullScreen}>
+              <Display show={!globalFullScreen}>
+                <HeaderPage
+                  border
+                  subtitle={
+                    <LastEventTime indexKey={LastEventIndexKey.hostDetails} hostName={detailName} />
+                  }
+                  title={detailName}
+                />
 
-              <HostOverviewByNameQuery
-                sourceId="default"
-                hostName={detailName}
-                skip={isInitializing}
-                startDate={from}
-                endDate={to}
-              >
-                {({ hostOverview, loading, id, inspect, refetch }) => (
-                  <AnomalyTableProvider
-                    criteriaFields={hostToCriteria(hostOverview)}
-                    startDate={from}
-                    endDate={to}
-                    skip={isInitializing}
-                  >
-                    {({ isLoadingAnomaliesData, anomaliesData }) => (
-                      <HostOverviewManage
-                        id={id}
-                        inspect={inspect}
-                        refetch={refetch}
-                        setQuery={setQuery}
-                        data={hostOverview}
-                        anomaliesData={anomaliesData}
-                        isLoadingAnomaliesData={isLoadingAnomaliesData}
-                        loading={loading}
-                        startDate={from}
-                        endDate={to}
-                        narrowDateRange={(score, interval) => {
-                          const fromTo = scoreIntervalToDateTime(score, interval);
-                          setAbsoluteRangeDatePicker({
-                            id: 'global',
-                            from: fromTo.from,
-                            to: fromTo.to,
-                          });
-                        }}
-                      />
-                    )}
-                  </AnomalyTableProvider>
-                )}
-              </HostOverviewByNameQuery>
+                <HostOverviewByNameQuery
+                  sourceId="default"
+                  hostName={detailName}
+                  skip={isInitializing}
+                  startDate={from}
+                  endDate={to}
+                >
+                  {({ hostOverview, loading, id, inspect, refetch }) => (
+                    <AnomalyTableProvider
+                      criteriaFields={hostToCriteria(hostOverview)}
+                      startDate={from}
+                      endDate={to}
+                      skip={isInitializing}
+                    >
+                      {({ isLoadingAnomaliesData, anomaliesData }) => (
+                        <HostOverviewManage
+                          id={id}
+                          inspect={inspect}
+                          refetch={refetch}
+                          setQuery={setQuery}
+                          data={hostOverview}
+                          anomaliesData={anomaliesData}
+                          isLoadingAnomaliesData={isLoadingAnomaliesData}
+                          loading={loading}
+                          startDate={from}
+                          endDate={to}
+                          narrowDateRange={(score, interval) => {
+                            const fromTo = scoreIntervalToDateTime(score, interval);
+                            setAbsoluteRangeDatePicker({
+                              id: 'global',
+                              from: fromTo.from,
+                              to: fromTo.to,
+                            });
+                          }}
+                        />
+                      )}
+                    </AnomalyTableProvider>
+                  )}
+                </HostOverviewByNameQuery>
 
-              <EuiHorizontalRule />
+                <EuiHorizontalRule />
 
-              <KpiHostDetailsQuery
-                sourceId="default"
-                filterQuery={filterQuery}
-                skip={isInitializing}
-                startDate={from}
-                endDate={to}
-              >
-                {({ kpiHostDetails, id, inspect, loading, refetch }) => (
-                  <KpiHostDetailsManage
-                    data={kpiHostDetails}
-                    from={from}
-                    id={id}
-                    inspect={inspect}
-                    loading={loading}
-                    refetch={refetch}
-                    setQuery={setQuery}
-                    to={to}
-                    narrowDateRange={narrowDateRange}
-                  />
-                )}
-              </KpiHostDetailsQuery>
+                <KpiHostDetailsQuery
+                  sourceId="default"
+                  filterQuery={filterQuery}
+                  skip={isInitializing}
+                  startDate={from}
+                  endDate={to}
+                >
+                  {({ kpiHostDetails, id, inspect, loading, refetch }) => (
+                    <KpiHostDetailsManage
+                      data={kpiHostDetails}
+                      from={from}
+                      id={id}
+                      inspect={inspect}
+                      loading={loading}
+                      refetch={refetch}
+                      setQuery={setQuery}
+                      to={to}
+                      narrowDateRange={narrowDateRange}
+                    />
+                  )}
+                </KpiHostDetailsQuery>
 
-              <EuiSpacer />
+                <EuiSpacer />
 
-              <SiemNavigation
-                navTabs={navTabsHostDetails(detailName, hasMlUserPermissions(capabilities))}
-              />
+                <SiemNavigation
+                  navTabs={navTabsHostDetails(detailName, hasMlUserPermissions(capabilities))}
+                />
 
-              <EuiSpacer />
+                <EuiSpacer />
+              </Display>
 
               <HostDetailsTabs
                 docValueFields={docValueFields}
@@ -213,10 +226,18 @@ HostDetailsComponent.displayName = 'HostDetailsComponent';
 export const makeMapStateToProps = () => {
   const getGlobalQuerySelector = inputsSelectors.globalQuerySelector();
   const getGlobalFiltersQuerySelector = inputsSelectors.globalFiltersQuerySelector();
-  return (state: State) => ({
-    query: getGlobalQuerySelector(state),
-    filters: getGlobalFiltersQuerySelector(state),
-  });
+  const getTimeline = timelineSelectors.getTimelineByIdSelector();
+  return (state: State) => {
+    const timeline: TimelineModel =
+      getTimeline(state, TimelineId.hostsPageEvents) ?? timelineDefaults;
+    const { graphEventId } = timeline;
+
+    return {
+      query: getGlobalQuerySelector(state),
+      filters: getGlobalFiltersQuerySelector(state),
+      graphEventId,
+    };
+  };
 };
 
 const mapDispatchToProps = {

--- a/x-pack/plugins/security_solution/public/network/pages/network.tsx
+++ b/x-pack/plugins/security_solution/public/network/pages/network.tsx
@@ -41,6 +41,11 @@ import { OverviewEmpty } from '../../overview/components/overview_empty';
 import * as i18n from './translations';
 import { NetworkComponentProps } from './types';
 import { NetworkRouteType } from './navigation/types';
+import { showGlobalFilters } from '../../timelines/components/timeline/helpers';
+import { timelineSelectors } from '../../timelines/store/timeline';
+import { TimelineId } from '../../../common/types/timeline';
+import { timelineDefaults } from '../../timelines/store/timeline/defaults';
+import { TimelineModel } from '../../timelines/store/timeline/model';
 
 const KpiNetworkComponentManage = manageQuery(KpiNetworkComponent);
 const sourceId = 'default';
@@ -48,6 +53,7 @@ const sourceId = 'default';
 const NetworkComponent = React.memo<NetworkComponentProps & PropsFromRedux>(
   ({
     filters,
+    graphEventId,
     query,
     setAbsoluteRangeDatePicker,
     networkPagePath,
@@ -100,7 +106,7 @@ const NetworkComponent = React.memo<NetworkComponentProps & PropsFromRedux>(
         {indicesExist ? (
           <StickyContainer>
             <EuiWindowEvent event="resize" handler={noop} />
-            <FiltersGlobal>
+            <FiltersGlobal show={showGlobalFilters({ globalFullScreen, graphEventId })}>
               <SiemSearchBar indexPattern={indexPattern} id="global" />
             </FiltersGlobal>
 
@@ -189,10 +195,18 @@ NetworkComponent.displayName = 'NetworkComponent';
 const makeMapStateToProps = () => {
   const getGlobalQuerySelector = inputsSelectors.globalQuerySelector();
   const getGlobalFiltersQuerySelector = inputsSelectors.globalFiltersQuerySelector();
-  const mapStateToProps = (state: State) => ({
-    query: getGlobalQuerySelector(state),
-    filters: getGlobalFiltersQuerySelector(state),
-  });
+  const getTimeline = timelineSelectors.getTimelineByIdSelector();
+  const mapStateToProps = (state: State) => {
+    const timeline: TimelineModel =
+      getTimeline(state, TimelineId.networkPageExternalAlerts) ?? timelineDefaults;
+    const { graphEventId } = timeline;
+
+    return {
+      query: getGlobalQuerySelector(state),
+      filters: getGlobalFiltersQuerySelector(state),
+      graphEventId,
+    };
+  };
   return mapStateToProps;
 };
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.test.tsx
@@ -9,7 +9,7 @@ import { mockIndexPattern } from '../../../common/mock';
 
 import { DataProviderType } from './data_providers/data_provider';
 import { mockDataProviders } from './data_providers/mock/mock_data_providers';
-import { buildGlobalQuery, combineQueries } from './helpers';
+import { buildGlobalQuery, combineQueries, resolverIsShowing, showGlobalFilters } from './helpers';
 import { mockBrowserFields } from '../../../common/containers/source/mock';
 import { EsQueryConfig, Filter, esFilters } from '../../../../../../../src/plugins/data/public';
 
@@ -499,5 +499,45 @@ describe('Combined Queries', () => {
     expect(filterQuery).toEqual(
       '{"bool":{"must":[],"filter":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"bool":{"should":[{"match_phrase":{"name":"Provider 1"}}],"minimum_should_match":1}},{"bool":{"filter":[{"bool":{"should":[{"match_phrase":{"name":"Provider 3"}}],"minimum_should_match":1}},{"bool":{"should":[{"match_phrase":{"name":"Provider 4"}}],"minimum_should_match":1}}]}}]}},{"bool":{"filter":[{"bool":{"should":[{"match_phrase":{"name":"Provider 2"}}],"minimum_should_match":1}},{"bool":{"should":[{"match_phrase":{"name":"Provider 5"}}],"minimum_should_match":1}}]}}],"minimum_should_match":1}},{"bool":{"should":[{"match_phrase":{"host.name":"host-1"}}],"minimum_should_match":1}}]}}],"should":[],"must_not":[]}}'
     );
+  });
+
+  describe('resolverIsShowing', () => {
+    test('it returns true when graphEventId is NOT an empty string', () => {
+      expect(resolverIsShowing('a valid id')).toBe(true);
+    });
+
+    test('it returns false when graphEventId is undefined', () => {
+      expect(resolverIsShowing(undefined)).toBe(false);
+    });
+
+    test('it returns false when graphEventId is an empty string', () => {
+      expect(resolverIsShowing('')).toBe(false);
+    });
+  });
+
+  describe('showGlobalFilters', () => {
+    test('it returns false when `globalFullScreen` is true and `graphEventId` is NOT an empty string, because Resolver IS showing', () => {
+      expect(showGlobalFilters({ globalFullScreen: true, graphEventId: 'a valid id' })).toBe(false);
+    });
+
+    test('it returns true when `globalFullScreen` is true and `graphEventId` is undefined, because Resolver is NOT showing', () => {
+      expect(showGlobalFilters({ globalFullScreen: true, graphEventId: undefined })).toBe(true);
+    });
+
+    test('it returns true when `globalFullScreen` is true and `graphEventId` is an empty string, because Resolver is NOT showing', () => {
+      expect(showGlobalFilters({ globalFullScreen: true, graphEventId: '' })).toBe(true);
+    });
+
+    test('it returns true when `globalFullScreen` is false and `graphEventId` is NOT an empty string, because Resolver IS showing', () => {
+      expect(showGlobalFilters({ globalFullScreen: false, graphEventId: 'a valid id' })).toBe(true);
+    });
+
+    test('it returns true when `globalFullScreen` is false and `graphEventId` is undefined, because Resolver is NOT showing', () => {
+      expect(showGlobalFilters({ globalFullScreen: false, graphEventId: undefined })).toBe(true);
+    });
+
+    test('it returns true when `globalFullScreen` is false and `graphEventId` is an empty string, because Resolver is NOT showing', () => {
+      expect(showGlobalFilters({ globalFullScreen: false, graphEventId: '' })).toBe(true);
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/helpers.tsx
@@ -158,3 +158,14 @@ export const combineQueries = ({
 export const STATEFUL_EVENT_CSS_CLASS_NAME = 'event-column-view';
 
 export const DEFAULT_ICON_BUTTON_WIDTH = 24;
+
+export const resolverIsShowing = (graphEventId: string | undefined): boolean =>
+  graphEventId != null && graphEventId !== '';
+
+export const showGlobalFilters = ({
+  globalFullScreen,
+  graphEventId,
+}: {
+  globalFullScreen: boolean;
+  graphEventId: string | undefined;
+}): boolean => (globalFullScreen && resolverIsShowing(graphEventId) ? false : true);


### PR DESCRIPTION
## Summary

Fixes an issue where the KQL bar (on all pages) and alerts filters (on the `Detections` page) should be hidden when Resolver is in full screen mode.

**To reproduce:**

1) Navigate to the `Detections` page
2) Enter `agent.type : endpoint` in the KQL bar to only show endpoint alerts
3) Click the `Full screen` button in the detections table

**Expected result**
* The KQL bar, inspect button, alerts filters (`Open | In progress | Closed`), and `Showing n alerts`,  `Select all n alerts`, and `Additional filters` actions are visible in full screen mode

4) Click the `Analyze event` button to show Resolver

**Expected result**
* The KQL bar, inspect button, alerts filters (`Open | In progress | Closed`), `Showing n alerts`,  `Select all n alerts`, and `Additional filters` actions are  **NOT** visible in full screen mode **when Resolver is open**

**Actual result**
* The KQL bar, inspect button, alerts filters (`Open | In progress | Closed`), `Showing n alerts`,  `Select all n alerts`, and `Additional filters` actions are (incorrectly) visible in full screen mode, per the screenshot below:

![filters-in-full-screen-mode](https://user-images.githubusercontent.com/4459398/88079205-9f565b80-cb3a-11ea-996a-fb71bf43c473.png)

5) Click the `< Back to events` button

**Expected result**
* The KQL bar, inspect button, alerts filters (`Open | In progress | Closed`), `Showing n alerts`,  `Select all n alerts`, and `Additional filters` actions become visible again

6) Press the `Esc` (Escape) key to exit Full screen mode

**Expected result**
* The KQL bar, inspect button, alerts filters (`Open | In progress | Closed`), `Showing n alerts`,  `Select all n alerts`, and `Additional filters` actions are (still) visible

## Screenshot (fixed)

The following screenshot of the fix was taken from the `Detections` page after following the reproduction steps above:

![filters-in-full-screen-mode-fixed](https://user-images.githubusercontent.com/4459398/88125154-e882cb80-cb8b-11ea-9b45-718fd9ef0844.png)
