### PR TITLE
[Lens] Fix inconsistencies when switching with empty layer

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
@@ -1007,7 +1007,8 @@ describe('editor_frame', () => {
       expect(mockVisualization2.initialize).toHaveBeenCalledWith(
         expect.objectContaining({
           datasourceLayers: expect.objectContaining({ first: mockDatasource.publicAPIMock }),
-        })
+        }),
+        undefined
       );
       expect(mockVisualization2.getConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({ state: { initial: true } })

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.test.tsx
@@ -480,6 +480,34 @@ describe('chart_switch', () => {
     expect(frame.removeLayers).not.toHaveBeenCalled();
   });
 
+  it('should not remove layers and initialize with existing state when switching between subtypes without data', () => {
+    const dispatch = jest.fn();
+    const frame = mockFrame(['a']);
+    frame.datasourceLayers.a.getTableSpec = jest.fn().mockReturnValue([]);
+    const visualizations = mockVisualizations();
+    visualizations.visC.getSuggestions = jest.fn().mockReturnValue([]);
+    visualizations.visC.switchVisualizationType = jest.fn(() => 'switched');
+
+    const component = mount(
+      <ChartSwitch
+        visualizationId="visC"
+        visualizationState={{ type: 'subvisC1' }}
+        visualizationMap={visualizations}
+        dispatch={dispatch}
+        framePublicAPI={frame}
+        datasourceMap={mockDatasourceMap()}
+        datasourceStates={mockDatasourceStates()}
+      />
+    );
+
+    switchTo('subvisC3', component);
+
+    expect(visualizations.visC.switchVisualizationType).toHaveBeenCalledWith('subvisC3', {
+      type: 'subvisC1',
+    });
+    expect(frame.removeLayers).not.toHaveBeenCalled();
+  });
+
   it('should switch to the updated datasource state', () => {
     const dispatch = jest.fn();
     const visualizations = mockVisualizations();

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -160,12 +160,16 @@ export function ChartSwitch(props: Props) {
         : () => {
             return switchVisType(
               subVisualizationId,
-              newVisualization.initialize(props.framePublicAPI)
+              newVisualization.initialize(
+                props.framePublicAPI,
+                props.visualizationId === newVisualization.id ? props.visualizationState : undefined
+              )
             );
           },
       keptLayerIds: topSuggestion ? topSuggestion.keptLayerIds : [],
       datasourceState: topSuggestion ? topSuggestion.datasourceState : undefined,
       datasourceId: topSuggestion ? topSuggestion.datasourceId : undefined,
+      sameDatasources: dataLoss === 'nothing' && props.visualizationId === newVisualization.id,
     };
   }
 

--- a/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.test.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.test.ts
@@ -408,6 +408,39 @@ describe('xy_suggestions', () => {
     expect(suggestion.hide).toBeTruthy();
   });
 
+  test('keeps existing seriesType for initial tables', () => {
+    const currentState: XYState = {
+      legend: { isVisible: true, position: 'bottom' },
+      fittingFunction: 'None',
+      preferredSeriesType: 'line',
+      layers: [
+        {
+          accessors: [],
+          layerId: 'first',
+          seriesType: 'line',
+          splitAccessor: undefined,
+          xAccessor: '',
+        },
+      ],
+    };
+    const suggestions = getSuggestions({
+      table: {
+        isMultiRow: true,
+        columns: [numCol('price'), dateCol('date')],
+        layerId: 'first',
+        changeType: 'initial',
+      },
+      state: currentState,
+      keptLayerIds: ['first'],
+    });
+
+    expect(suggestions).toHaveLength(1);
+
+    expect(suggestions[0].hide).toEqual(false);
+    expect(suggestions[0].state.preferredSeriesType).toEqual('line');
+    expect(suggestions[0].state.layers[0].seriesType).toEqual('line');
+  });
+
   test('makes a visible seriesType suggestion for unchanged table without split', () => {
     const currentState: XYState = {
       legend: { isVisible: true, position: 'bottom' },

--- a/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.ts
@@ -318,11 +318,7 @@ function getSeriesType(
     return closestSeriesType.startsWith('bar') ? closestSeriesType : defaultType;
   }
 
-  if (changeType === 'initial') {
-    return defaultType;
-  }
-
-  return closestSeriesType !== defaultType ? closestSeriesType : defaultType;
+  return closestSeriesType;
 }
 
 function getSuggestionTitle(


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/72749

This PR fixes the behavior of Lens when switching the chart using the chart switcher without any data configured. It also improves the behavior when dragging in a field.

The following changes were made:
* Chart switcher: When switching between subtypes and there is no top suggestion, reuse the current state instead of initializing from scratch. This prevents the `initialize` routine from creating an unnecessary layer, instead the existing empty one is simply reused https://github.com/elastic/kibana/pull/72809/files#diff-d1d4dfa90d8f9d84296810bf9a3ee522R163-R166
* Chart switcher: When switching between subtypes and there is no data loss, do not clear out the layers (because they are now reused, see step 1) https://github.com/elastic/kibana/pull/72809/files#diff-d1d4dfa90d8f9d84296810bf9a3ee522R172
* XY suggestion builder: If there is an existing preferred series type (because the currently active chart is an xy chart as well), use it even if the data table is of type `initial` (created from scratch). This allows Lens to configure the chart type before the first field is dragged. Before this change, changing to Line and dragging in the "Records" field would switch back to stacked bar. Note that when the table is using an ordinal scale on the x axis column, the already selected series type will not be respected if it's line or area based. https://github.com/elastic/kibana/pull/72809/files#diff-e4fd356362a87d0bb42766a35c2bcc5bL321-R321