### PR TITLE
[Security Solution][Case] Fix long tag display

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/components/all_cases/columns.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/all_cases/columns.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback } from 'react';
 import {
   EuiAvatar,
+  EuiBadgeGroup,
   EuiBadge,
   EuiLink,
   EuiTableActionsColumnType,
@@ -19,7 +20,6 @@ import { getEmptyTagValue } from '../../../common/components/empty_value';
 import { Case } from '../../containers/types';
 import { FormattedRelativePreferenceDate } from '../../../common/components/formatted_date';
 import { CaseDetailsLink } from '../../../common/components/links';
-import { TruncatableText } from '../../../common/components/truncatable_text';
 import * as i18n from './translations';
 
 export type CasesColumns =
@@ -33,6 +33,10 @@ const MediumShadeText = styled.p`
 
 const Spacer = styled.span`
   margin-left: ${({ theme }) => theme.eui.paddingSizes.s};
+`;
+
+const TagWrapper = styled(EuiBadgeGroup)`
+  width: 100%;
 `;
 
 const renderStringField = (field: string, dataTestSubj: string) =>
@@ -96,7 +100,7 @@ export const getCasesColumns = (
       render: (tags: Case['tags']) => {
         if (tags != null && tags.length > 0) {
           return (
-            <TruncatableText>
+            <TagWrapper>
               {tags.map((tag: string, i: number) => (
                 <EuiBadge
                   color="hollow"
@@ -106,7 +110,7 @@ export const getCasesColumns = (
                   {tag}
                 </EuiBadge>
               ))}
-            </TruncatableText>
+            </TagWrapper>
           );
         }
         return getEmptyTagValue();

--- a/x-pack/plugins/security_solution/public/cases/components/case_view/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/case_view/index.test.tsx
@@ -119,10 +119,16 @@ describe('CaseView ', () => {
       );
       expect(
         wrapper
-          .find(`[data-test-subj="case-view-tag-list"] [data-test-subj="case-tag"]`)
+          .find(`[data-test-subj="case-view-tag-list"] [data-test-subj="case-tag-coke"]`)
           .first()
           .text()
       ).toEqual(data.tags[0]);
+      expect(
+        wrapper
+          .find(`[data-test-subj="case-view-tag-list"] [data-test-subj="case-tag-pepsi"]`)
+          .first()
+          .text()
+      ).toEqual(data.tags[1]);
       expect(wrapper.find(`[data-test-subj="case-view-username"]`).first().text()).toEqual(
         data.createdBy.username
       );

--- a/x-pack/plugins/security_solution/public/cases/components/tag_list/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/tag_list/index.test.tsx
@@ -102,14 +102,14 @@ describe('TagList ', () => {
         <TagList {...props} />
       </TestProviders>
     );
-    expect(wrapper.find(`[data-test-subj="case-tag"]`).last().exists()).toBeTruthy();
+    expect(wrapper.find(`[data-test-subj="case-tag-pepsi"]`).last().exists()).toBeTruthy();
     wrapper.find(`[data-test-subj="tag-list-edit-button"]`).last().simulate('click');
     await act(async () => {
-      expect(wrapper.find(`[data-test-subj="case-tag"]`).last().exists()).toBeFalsy();
+      expect(wrapper.find(`[data-test-subj="case-tag-pepsi"]`).last().exists()).toBeFalsy();
       wrapper.find(`[data-test-subj="edit-tags-cancel"]`).last().simulate('click');
       await waitFor(() => {
         wrapper.update();
-        expect(wrapper.find(`[data-test-subj="case-tag"]`).last().exists()).toBeTruthy();
+        expect(wrapper.find(`[data-test-subj="case-tag-pepsi"]`).last().exists()).toBeTruthy();
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/cases/components/tag_list/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/tag_list/index.tsx
@@ -103,7 +103,7 @@ export const TagList = React.memo(
             {tags.length > 0 &&
               !isEditTags &&
               tags.map((tag, key) => (
-                <EuiBadge data-test-subj={`case-tag-${key}`} color="hollow">
+                <EuiBadge data-test-subj={`case-tag-${tag}`} color="hollow">
                   {tag}
                 </EuiBadge>
               ))}

--- a/x-pack/plugins/security_solution/public/cases/components/tag_list/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/tag_list/index.tsx
@@ -10,6 +10,7 @@ import {
   EuiHorizontalRule,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiBadgeGroup,
   EuiBadge,
   EuiButton,
   EuiButtonEmpty,
@@ -98,15 +99,15 @@ export const TagList = React.memo(
         <EuiHorizontalRule margin="xs" />
         <MyFlexGroup gutterSize="xs" data-test-subj="case-tags">
           {tags.length === 0 && !isEditTags && <p data-test-subj="no-tags">{i18n.NO_TAGS}</p>}
-          {tags.length > 0 &&
-            !isEditTags &&
-            tags.map((tag, key) => (
-              <EuiFlexItem grow={false} key={`${tag}${key}`}>
-                <EuiBadge data-test-subj="case-tag" color="hollow">
+          <EuiBadgeGroup>
+            {tags.length > 0 &&
+              !isEditTags &&
+              tags.map((tag, key) => (
+                <EuiBadge data-test-subj={`case-tag-${key}`} color="hollow">
                   {tag}
                 </EuiBadge>
-              </EuiFlexItem>
-            ))}
+              ))}
+          </EuiBadgeGroup>
           {isEditTags && (
             <EuiFlexGroup data-test-subj="edit-tags" direction="column">
               <EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/cases/components/user_action_tree/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/user_action_tree/helpers.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiBadge, EuiLink } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiBadgeGroup, EuiBadge, EuiLink } from '@elastic/eui';
 import React from 'react';
 
 import { CaseFullExternalService, Connector } from '../../../../../case/common/api';
@@ -50,14 +50,14 @@ const getTagsLabelTitle = (action: CaseUserActions) => (
       {action.action === 'add' && i18n.ADDED_FIELD}
       {action.action === 'delete' && i18n.REMOVED_FIELD} {i18n.TAGS.toLowerCase()}
     </EuiFlexItem>
-    {action.newValue != null &&
-      action.newValue.split(',').map((tag) => (
-        <EuiFlexItem grow={false} key={tag}>
+    <EuiBadgeGroup>
+      {action.newValue != null &&
+        action.newValue.split(',').map((tag) => (
           <EuiBadge data-test-subj={`ua-tag`} color="default">
             {tag}
           </EuiBadge>
-        </EuiFlexItem>
-      ))}
+        ))}
+    </EuiBadgeGroup>
   </EuiFlexGroup>
 );
 


### PR DESCRIPTION
## Summary

This PR fixes the display of very long tags in cases.

Ref: https://github.com/elastic/siem-team/issues/580.

**All cases:**

**Before:**

<img width="1708" alt="Screenshot 2020-07-23 at 2 28 10 PM" src="https://user-images.githubusercontent.com/7871006/88283435-08350380-ccf4-11ea-8e1c-1cdf1b60d065.png">

**After:**

<img width="1714" alt="Screenshot 2020-07-23 at 2 27 13 PM" src="https://user-images.githubusercontent.com/7871006/88283453-11be6b80-ccf4-11ea-9f04-21fc06527d20.png">

**Single Case:**

**Before:**

<img width="1265" alt="Screenshot 2020-07-23 at 2 49 46 PM" src="https://user-images.githubusercontent.com/7871006/88283619-6d88f480-ccf4-11ea-8f9e-199a0db3c792.png">

<img width="910" alt="Screenshot 2020-07-23 at 2 40 47 PM" src="https://user-images.githubusercontent.com/7871006/88284346-e9d00780-ccf5-11ea-9f2b-147bd2893740.png">

**After:**

<img width="1213" alt="Screenshot 2020-07-23 at 3 06 10 PM" src="https://user-images.githubusercontent.com/7871006/88284435-14ba5b80-ccf6-11ea-9f47-4d19c463fccd.png">

<img width="434" alt="Screenshot 2020-07-23 at 2 39 48 PM" src="https://user-images.githubusercontent.com/7871006/88284351-ec326180-ccf5-11ea-8c38-82cf56a6c83d.png">

### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
