### PR TITLE
[Ingest Manager] Show all step numbers on manual agent enrollment

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -152,7 +152,6 @@ export const StandaloneInstructions: React.FunctionComponent<Props> = ({ agentCo
       title: i18n.translate('xpack.ingestManager.agentEnrollment.stepCheckForDataTitle', {
         defaultMessage: 'Check for data',
       }),
-      status: 'incomplete',
       children: (
         <>
           <EuiText>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/72418

Shows the step number for the last step on the manual agent enrollment instruction flyout.

Comparing with the descriptions on https://elastic.github.io/eui/#/navigation/steps , I believe this is a better choice than showing an incomplete step without any option for the user to "complete" it.

Before:

![image](https://user-images.githubusercontent.com/189073/88192549-efb5e200-cc3c-11ea-846f-4271dba2bc1e.png)

After:

![image](https://user-images.githubusercontent.com/189073/88192630-0eb47400-cc3d-11ea-9e8c-9dd116146934.png)


