### PR TITLE
[Ingest Manager] Fix config rollout move to limit concurrent config change instead of config per second

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/index.ts
+++ b/x-pack/plugins/ingest_manager/common/types/index.ts
@@ -22,8 +22,7 @@ export interface IngestManagerConfigType {
       host?: string;
       ca_sha256?: string;
     };
-    agentConfigRollupRateLimitIntervalMs: number;
-    agentConfigRollupRateLimitRequestPerInterval: number;
+    agentConfigRolloutConcurrency: number;
   };
 }
 

--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -35,8 +35,7 @@ export const config = {
         host: schema.maybe(schema.string()),
         ca_sha256: schema.maybe(schema.string()),
       }),
-      agentConfigRollupRateLimitIntervalMs: schema.number({ defaultValue: 5000 }),
-      agentConfigRollupRateLimitRequestPerInterval: schema.number({ defaultValue: 50 }),
+      agentConfigRolloutConcurrency: schema.number({ defaultValue: 10 }),
     }),
   }),
 };

--- a/x-pack/plugins/ingest_manager/server/services/agents/checkin/rxjs_utils.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/checkin/rxjs_utils.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as Rx from 'rxjs';
+import { share } from 'rxjs/operators';
+import { createSubscriberConcurrencyLimiter } from './rxjs_utils';
+
+function createSpyObserver(o: Rx.Observable<any>): [Rx.Subscription, jest.Mock] {
+  const spy = jest.fn();
+  const observer = o.subscribe(spy);
+  return [observer, spy];
+}
+
+describe('createSubscriberConcurrencyLimiter', () => {
+  it('should not publish to more than n concurrent subscriber', async () => {
+    const subject = new Rx.Subject<any>();
+    const sharedObservable = subject.pipe(share());
+
+    const limiter = createSubscriberConcurrencyLimiter(2);
+
+    const [observer1, spy1] = createSpyObserver(sharedObservable.pipe(limiter()));
+    const [observer2, spy2] = createSpyObserver(sharedObservable.pipe(limiter()));
+    const [observer3, spy3] = createSpyObserver(sharedObservable.pipe(limiter()));
+    const [observer4, spy4] = createSpyObserver(sharedObservable.pipe(limiter()));
+    subject.next('test1');
+
+    expect(spy1).toBeCalled();
+    expect(spy2).toBeCalled();
+    expect(spy3).not.toBeCalled();
+    expect(spy4).not.toBeCalled();
+
+    observer1.unsubscribe();
+    expect(spy3).toBeCalled();
+    expect(spy4).not.toBeCalled();
+
+    observer2.unsubscribe();
+    expect(spy4).toBeCalled();
+
+    observer3.unsubscribe();
+    observer4.unsubscribe();
+  });
+});

--- a/x-pack/plugins/ingest_manager/server/services/agents/checkin/rxjs_utils.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/checkin/rxjs_utils.ts
@@ -43,49 +43,33 @@ export const toPromiseAbortable = <T>(
     }
   });
 
-export function createLimiter(ratelimitIntervalMs: number, ratelimitRequestPerInterval: number) {
-  function createCurrentInterval() {
-    return {
-      startedAt: Rx.asyncScheduler.now(),
-      numRequests: 0,
-    };
-  }
-
-  let currentInterval: { startedAt: number; numRequests: number } = createCurrentInterval();
+export function createSubscriberConcurrencyLimiter() {
   let observers: Array<[Rx.Subscriber<any>, any]> = [];
-  let timerSubscription: Rx.Subscription | undefined;
+  let activeObservers: Array<Rx.Subscriber<any>> = [];
 
-  function createTimeout() {
-    if (timerSubscription) {
+  function processNext(maxConcurrency: number) {
+    if (activeObservers.length >= maxConcurrency) {
       return;
     }
-    timerSubscription = Rx.asyncScheduler.schedule(() => {
-      timerSubscription = undefined;
-      currentInterval = createCurrentInterval();
-      for (const [waitingObserver, value] of observers) {
-        if (currentInterval.numRequests >= ratelimitRequestPerInterval) {
-          createTimeout();
-          continue;
-        }
-        currentInterval.numRequests++;
-        waitingObserver.next(value);
-      }
-    }, ratelimitIntervalMs);
+    const observerValuePair = observers.shift();
+
+    if (!observerValuePair) {
+      return;
+    }
+
+    const [observer, value] = observerValuePair;
+    activeObservers.push(observer);
+    observer.next(value);
   }
 
-  return function limit<T>(): Rx.MonoTypeOperatorFunction<T> {
+  return function limit<T>(maxConcurrency: number): Rx.MonoTypeOperatorFunction<T> {
     return (observable) =>
       new Rx.Observable<T>((observer) => {
         const subscription = observable.subscribe({
           next(value) {
-            if (currentInterval.numRequests < ratelimitRequestPerInterval) {
-              currentInterval.numRequests++;
-              observer.next(value);
-              return;
-            }
-
             observers = [...observers, [observer, value]];
-            createTimeout();
+
+            processNext(maxConcurrency);
           },
           error(err) {
             observer.error(err);
@@ -96,8 +80,10 @@ export function createLimiter(ratelimitIntervalMs: number, ratelimitRequestPerIn
         });
 
         return () => {
+          activeObservers = activeObservers.filter((o) => o !== observer);
           observers = observers.filter((o) => o[0] !== observer);
           subscription.unsubscribe();
+          processNext(maxConcurrency);
         };
       });
   };


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/72072

This PR fix the configuration of agent config rollout, also we moved from a rate limit per second to a number of concurrent config upgrade.


Add a new config variable `xpack.ingestManager.fleet.agentConfigRolloutConcurrency` (by default set to 10)

## Benchmark

I enrolled 2000 agents and triggered a config change


Before that change

<img width="2541" alt="86636922-deb17380-bfa2-11ea-9b6f-e363f2d1aacf" src="https://user-images.githubusercontent.com/1336873/88211508-cb014080-cc23-11ea-94d5-d28904db9229.png">

After the change with different concurency setup

<img width="1281" alt="Screen Shot 2020-07-22 at 11 17 47 AM" src="https://user-images.githubusercontent.com/1336873/88211537-d5bbd580-cc23-11ea-8542-ba4d44aec0cc.png">
<img width="2546" alt="Screen Shot 2020-07-22 at 1 43 23 PM" src="https://user-images.githubusercontent.com/1336873/88211534-d48aa880-cc23-11ea-810c-5caaaa24f3f7.png">
<img width="1283" alt="Screen Shot 2020-07-22 at 1 20 32 PM" src="https://user-images.githubusercontent.com/1336873/88211535-d5233f00-cc23-11ea-9bc3-2e10823e7a68.png">

