### PR TITLE
[Ingest Manager] Change copy to Agent ID in agent details page

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/agent_details.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/agent_details.tsx
@@ -37,7 +37,7 @@ export const AgentDetailsContent: React.FunctionComponent<{
         },
         {
           title: i18n.translate('xpack.ingestManager.agentDetails.hostIdLabel', {
-            defaultMessage: 'Host ID',
+            defaultMessage: 'Agent ID',
           }),
           description: agent.id,
         },


### PR DESCRIPTION
## Summary

Resolves #72767. Updates copy "Host ID" to "Agent ID" to reduce confusion.
