### PR TITLE
fix: 🐛 don't Explore data action in dashboard_only mode

### DIFF
--- a/x-pack/plugins/discover_enhanced/kibana.json
+++ b/x-pack/plugins/discover_enhanced/kibana.json
@@ -5,7 +5,7 @@
   "server": true,
   "ui": true,
   "requiredPlugins": ["uiActions", "embeddable", "discover"],
-  "optionalPlugins": ["share"],
+  "optionalPlugins": ["share", "kibanaLegacy"],
   "configPath": ["xpack", "discoverEnhanced"],
   "requiredBundles": ["kibanaUtils", "data"]
 }

--- a/x-pack/plugins/discover_enhanced/public/actions/explore_data/abstract_explore_data_action.ts
+++ b/x-pack/plugins/discover_enhanced/public/actions/explore_data/abstract_explore_data_action.ts
@@ -9,6 +9,7 @@ import { DiscoverStart } from '../../../../../../src/plugins/discover/public';
 import { EmbeddableStart } from '../../../../../../src/plugins/embeddable/public';
 import { ViewMode, IEmbeddable } from '../../../../../../src/plugins/embeddable/public';
 import { StartServicesGetter } from '../../../../../../src/plugins/kibana_utils/public';
+import { KibanaLegacyStart } from '../../../../../../src/plugins/kibana_legacy/public';
 import { CoreStart } from '../../../../../../src/core/public';
 import { KibanaURL } from './kibana_url';
 import * as shared from './shared';
@@ -18,6 +19,11 @@ export const ACTION_EXPLORE_DATA = 'ACTION_EXPLORE_DATA';
 export interface PluginDeps {
   discover: Pick<DiscoverStart, 'urlGenerator'>;
   embeddable: Pick<EmbeddableStart, 'filtersAndTimeRangeFromContext'>;
+  kibanaLegacy?: {
+    dashboardConfig: {
+      getHideWriteControls: KibanaLegacyStart['dashboardConfig']['getHideWriteControls'];
+    };
+  };
 }
 
 export interface CoreDeps {
@@ -42,6 +48,12 @@ export abstract class AbstractExploreDataAction<Context extends { embeddable?: I
 
   public async isCompatible({ embeddable }: Context): Promise<boolean> {
     if (!embeddable) return false;
+
+    const isDashboardOnlyMode = !!this.params
+      .start()
+      .plugins.kibanaLegacy?.dashboardConfig.getHideWriteControls();
+    if (isDashboardOnlyMode) return false;
+
     if (!this.params.start().plugins.discover.urlGenerator) return false;
     if (!shared.hasExactlyOneIndexPattern(embeddable)) return false;
     if (embeddable.getInput().viewMode !== ViewMode.VIEW) return false;

--- a/x-pack/plugins/discover_enhanced/public/actions/explore_data/explore_data_chart_action.test.ts
+++ b/x-pack/plugins/discover_enhanced/public/actions/explore_data/explore_data_chart_action.test.ts
@@ -34,7 +34,10 @@ afterEach(() => {
   i18nTranslateSpy.mockClear();
 });
 
-const setup = ({ useRangeEvent = false }: { useRangeEvent?: boolean } = {}) => {
+const setup = ({
+  useRangeEvent = false,
+  dashboardOnlyMode = false,
+}: { useRangeEvent?: boolean; dashboardOnlyMode?: boolean } = {}) => {
   type UrlGenerator = UrlGeneratorContract<'DISCOVER_APP_URL_GENERATOR'>;
 
   const core = coreMock.createStart();
@@ -53,6 +56,11 @@ const setup = ({ useRangeEvent = false }: { useRangeEvent?: boolean } = {}) => {
     },
     embeddable: {
       filtersAndTimeRangeFromContext,
+    },
+    kibanaLegacy: {
+      dashboardConfig: {
+        getHideWriteControls: () => dashboardOnlyMode,
+      },
     },
   };
 
@@ -177,6 +185,13 @@ describe('"Explore underlying data" panel action', () => {
       const { action, input, context } = setup();
       input.viewMode = ViewMode.EDIT;
 
+      const isCompatible = await action.isCompatible(context);
+
+      expect(isCompatible).toBe(false);
+    });
+
+    test('return false for dashboard_only mode', async () => {
+      const { action, context } = setup({ dashboardOnlyMode: true });
       const isCompatible = await action.isCompatible(context);
 
       expect(isCompatible).toBe(false);

--- a/x-pack/plugins/discover_enhanced/public/actions/explore_data/explore_data_context_menu_action.test.ts
+++ b/x-pack/plugins/discover_enhanced/public/actions/explore_data/explore_data_context_menu_action.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
   i18nTranslateSpy.mockClear();
 });
 
-const setup = () => {
+const setup = ({ dashboardOnlyMode = false }: { dashboardOnlyMode?: boolean } = {}) => {
   type UrlGenerator = UrlGeneratorContract<'DISCOVER_APP_URL_GENERATOR'>;
 
   const core = coreMock.createStart();
@@ -47,6 +47,11 @@ const setup = () => {
     },
     embeddable: {
       filtersAndTimeRangeFromContext,
+    },
+    kibanaLegacy: {
+      dashboardConfig: {
+        getHideWriteControls: () => dashboardOnlyMode,
+      },
     },
   };
 
@@ -163,6 +168,13 @@ describe('"Explore underlying data" panel action', () => {
       const { action, input, context } = setup();
       input.viewMode = ViewMode.EDIT;
 
+      const isCompatible = await action.isCompatible(context);
+
+      expect(isCompatible).toBe(false);
+    });
+
+    test('return false for dashboard_only mode', async () => {
+      const { action, context } = setup({ dashboardOnlyMode: true });
       const isCompatible = await action.isCompatible(context);
 
       expect(isCompatible).toBe(false);

--- a/x-pack/plugins/discover_enhanced/public/plugin.ts
+++ b/x-pack/plugins/discover_enhanced/public/plugin.ts
@@ -15,6 +15,7 @@ import {
 import { createStartServicesGetter } from '../../../../src/plugins/kibana_utils/public';
 import { DiscoverSetup, DiscoverStart } from '../../../../src/plugins/discover/public';
 import { SharePluginSetup, SharePluginStart } from '../../../../src/plugins/share/public';
+import { KibanaLegacySetup, KibanaLegacyStart } from '../../../../src/plugins/kibana_legacy/public';
 import {
   EmbeddableSetup,
   EmbeddableStart,
@@ -39,6 +40,7 @@ declare module '../../../../src/plugins/ui_actions/public' {
 export interface DiscoverEnhancedSetupDependencies {
   discover: DiscoverSetup;
   embeddable: EmbeddableSetup;
+  kibanaLegacy?: KibanaLegacySetup;
   share?: SharePluginSetup;
   uiActions: UiActionsSetup;
 }
@@ -46,6 +48,7 @@ export interface DiscoverEnhancedSetupDependencies {
 export interface DiscoverEnhancedStartDependencies {
   discover: DiscoverStart;
   embeddable: EmbeddableStart;
+  kibanaLegacy?: KibanaLegacyStart;
   share?: SharePluginStart;
   uiActions: UiActionsStart;
 }


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/72838#issuecomment-662477779