### PR TITLE
Fix view saved search through a visualization

### DIFF
--- a/src/plugins/vis_default_editor/public/components/sidebar/sidebar_title.tsx
+++ b/src/plugins/vis_default_editor/public/components/sidebar/sidebar_title.tsx
@@ -65,7 +65,7 @@ export function LinkedSearch({ savedSearch, eventEmitter }: LinkedSearchProps) {
   }, [eventEmitter]);
   const onClickViewInDiscover = useCallback(() => {
     application.navigateToApp('discover', {
-      path: `#/${savedSearch.id}`,
+      path: `#/view/${savedSearch.id}`,
     });
   }, [application, savedSearch.id]);
 
@@ -128,7 +128,12 @@ export function LinkedSearch({ savedSearch, eventEmitter }: LinkedSearchProps) {
           <div style={{ width: 260 }}>
             <EuiText size="s">
               <p>
-                <EuiButtonEmpty flush="left" onClick={onClickViewInDiscover} size="xs">
+                <EuiButtonEmpty
+                  data-test-subj="viewSavedSearch"
+                  flush="left"
+                  onClick={onClickViewInDiscover}
+                  size="xs"
+                >
                   <FormattedMessage
                     id="visDefaultEditor.sidebar.savedSearch.goToDiscoverButtonText"
                     defaultMessage="View this search in Discover"

--- a/test/functional/apps/visualize/_linked_saved_searches.ts
+++ b/test/functional/apps/visualize/_linked_saved_searches.ts
@@ -21,8 +21,10 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const browser = getService('browser');
   const filterBar = getService('filterBar');
   const retry = getService('retry');
+  const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects([
     'common',
     'discover',
@@ -35,12 +37,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('saved search visualizations from visualize app', function describeIndexTests() {
     describe('linked saved searched', () => {
       const savedSearchName = 'vis_saved_search';
+      let discoverSavedSearchUrlPath: string;
 
       before(async () => {
         await PageObjects.common.navigateToApp('discover');
         await filterBar.addFilter('extension.raw', 'is', 'jpg');
         await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.discover.saveSearch(savedSearchName);
+        discoverSavedSearchUrlPath = (await browser.getCurrentUrl()).split('?')[0];
       });
 
       it('should create a visualization from a saved search', async () => {
@@ -52,6 +56,24 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const data = await PageObjects.visChart.getTableVisData();
           return data.trim() === '9,109';
         });
+      });
+
+      it('should have a valid link to the saved search from the visualization', async () => {
+        await testSubjects.click('showUnlinkSavedSearchPopover');
+        await testSubjects.click('viewSavedSearch');
+        await PageObjects.header.waitUntilLoadingHasFinished();
+
+        await retry.waitFor('wait discover load its breadcrumbs', async () => {
+          const discoverBreadcrumb = await PageObjects.discover.getCurrentQueryName();
+          return discoverBreadcrumb === savedSearchName;
+        });
+
+        const discoverURLPath = (await browser.getCurrentUrl()).split('?')[0];
+        expect(discoverURLPath).to.equal(discoverSavedSearchUrlPath);
+
+        // go back to visualize
+        await browser.goBack();
+        await PageObjects.header.waitUntilLoadingHasFinished();
       });
 
       it('should respect the time filter when linked to a saved search', async () => {


### PR DESCRIPTION
## Summary

This fixes an incorrect behavior while navigating to the linked search through a visualization based on a saved search:

![view_saved_search](https://user-images.githubusercontent.com/31325372/88290366-54397580-ccff-11ea-9591-6c06823d6ba9.gif)

This happens after introducing the `view` route in discover.
Functional test suite was also added to check this behavior.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
