### PR TITLE
[Security Solution][Detections] Change detections breadcrumb title

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.test.ts
@@ -23,6 +23,6 @@ describe('getBreadcrumbs', () => {
         [],
         getUrlForAppMock
       )
-    ).toEqual([{ href: 'securitySolution:detections', text: 'Detection alerts' }]);
+    ).toEqual([{ href: 'securitySolution:detections', text: 'Detections' }]);
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -57,7 +57,7 @@ export const getBreadcrumbs = (
 ): ChromeBreadcrumb[] => {
   let breadcrumb = [
     {
-      text: i18nDetections.PAGE_TITLE,
+      text: i18nDetections.BREADCRUMB_TITLE,
       href: getUrlForApp(`${APP_ID}:${SecurityPageName.detections}`, {
         path: !isEmpty(search[0]) ? search[0] : '',
       }),

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/translations.ts
@@ -6,6 +6,13 @@
 
 import { i18n } from '@kbn/i18n';
 
+export const BREADCRUMB_TITLE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.detectionsBreadcrumbTitle',
+  {
+    defaultMessage: 'Detections',
+  }
+);
+
 export const PAGE_TITLE = i18n.translate(
   'xpack.securitySolution.detectionEngine.detectionsPageTitle',
   {


### PR DESCRIPTION
## Summary

This PR changes the detections breadcrumb title from `Detections alerts` to `Detections`.

Fixes: https://github.com/elastic/siem-team/issues/788

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines]~(https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] ~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~
- [ ] ~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
