### PR TITLE
[Ingest Manager] Support DEGRADED state in fleet agent event

### DIFF
--- a/x-pack/plugins/ingest_manager/common/openapi/spec_oas3.json
+++ b/x-pack/plugins/ingest_manager/common/openapi/spec_oas3.json
@@ -4203,6 +4203,7 @@
               "FAILED",
               "STOPPING",
               "STOPPED",
+              "DEGRADED",
               "DATA_DUMP",
               "ACKNOWLEDGED",
               "UNKNOWN"

--- a/x-pack/plugins/ingest_manager/common/types/models/agent.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/agent.ts
@@ -53,6 +53,7 @@ export interface NewAgentEvent {
     | 'FAILED'
     | 'STOPPING'
     | 'STOPPED'
+    | 'DEGRADED'
     // Action results
     | 'DATA_DUMP'
     // Actions

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/type_labels.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/type_labels.tsx
@@ -95,6 +95,14 @@ export const SUBTYPE_LABEL: { [key in AgentEvent['subtype']]: JSX.Element } = {
       />
     </EuiBadge>
   ),
+  DEGRADED: (
+    <EuiBadge color="hollow">
+      <FormattedMessage
+        id="xpack.ingestManager.agentEventSubtype.degradedLabel"
+        defaultMessage="Degraded"
+      />
+    </EuiBadge>
+  ),
   DATA_DUMP: (
     <EuiBadge color="hollow">
       <FormattedMessage

--- a/x-pack/plugins/ingest_manager/server/types/models/agent.ts
+++ b/x-pack/plugins/ingest_manager/server/types/models/agent.ts
@@ -29,6 +29,7 @@ const AgentEventBase = {
     schema.literal('FAILED'),
     schema.literal('STOPPING'),
     schema.literal('STOPPED'),
+    schema.literal('DEGRADED'),
     // Action results
     schema.literal('DATA_DUMP'),
     // Actions

--- a/x-pack/plugins/ingest_manager/server/types/models/agent.ts
+++ b/x-pack/plugins/ingest_manager/server/types/models/agent.ts
@@ -22,14 +22,16 @@ const AgentEventBase = {
   ]),
   subtype: schema.oneOf([
     // State
-    schema.literal('RUNNING'),
-    schema.literal('STARTING'),
-    schema.literal('IN_PROGRESS'),
-    schema.literal('CONFIG'),
-    schema.literal('FAILED'),
-    schema.literal('STOPPING'),
-    schema.literal('STOPPED'),
-    schema.literal('DEGRADED'),
+    schema.oneOf([
+      schema.literal('RUNNING'),
+      schema.literal('STARTING'),
+      schema.literal('IN_PROGRESS'),
+      schema.literal('CONFIG'),
+      schema.literal('FAILED'),
+      schema.literal('STOPPING'),
+      schema.literal('STOPPED'),
+      schema.literal('DEGRADED'),
+    ]),
     // Action results
     schema.literal('DATA_DUMP'),
     // Actions


### PR DESCRIPTION
## Summary

Related to #72960

Currently the agent is sending a `RUNNING` subtype when we have a partial error, we should support the `DEGRADED` subtype

### UI example

<img width="1276" alt="Screen Shot 2020-07-23 at 1 44 41 PM" src="https://user-images.githubusercontent.com/1336873/88319815-ade37500-ccea-11ea-808b-a23b8d289e17.png">


cc @blakerouse 