### PR TITLE
[SIEM] [Detections] Reject on value list + other exception entries in single exception item

### DIFF
--- a/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
@@ -11,10 +11,22 @@ import { getEntryListMock } from './entry_list.mock';
 import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
 
-export const getEntriesArrayMock = (): EntriesArray => [
+export const getListAndNonListEntriesArrayMock = (): EntriesArray => [
   { ...getEntryMatchMock() },
   { ...getEntryMatchAnyMock() },
   { ...getEntryListMock() },
+  { ...getEntryExistsMock() },
+  { ...getEntryNestedMock() },
+];
+
+export const getListEntriesArrayMock = (): EntriesArray => [
+  { ...getEntryListMock() },
+  { ...getEntryListMock() },
+];
+
+export const getEntriesArrayMock = (): EntriesArray => [
+  { ...getEntryMatchMock() },
+  { ...getEntryMatchAnyMock() },
   { ...getEntryExistsMock() },
   { ...getEntryNestedMock() },
 ];

--- a/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
@@ -14,7 +14,6 @@ import { getEntryNestedMock } from './entry_nested.mock';
 export const getListAndNonListEntriesArrayMock = (): EntriesArray => [
   { ...getEntryMatchMock() },
   { ...getEntryMatchAnyMock() },
-  { ...getEntryListMock() },
   { ...getEntryExistsMock() },
   { ...getEntryNestedMock() },
 ];

--- a/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
@@ -14,6 +14,7 @@ import { getEntryNestedMock } from './entry_nested.mock';
 export const getListAndNonListEntriesArrayMock = (): EntriesArray => [
   { ...getEntryMatchMock() },
   { ...getEntryMatchAnyMock() },
+  { ...getEntryListMock() },
   { ...getEntryExistsMock() },
   { ...getEntryNestedMock() },
 ];

--- a/x-pack/plugins/lists/common/schemas/types/entries.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.test.ts
@@ -14,7 +14,7 @@ import { getEntryMatchAnyMock } from './entry_match_any.mock';
 import { getEntryListMock } from './entry_list.mock';
 import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
-import { getEntriesArrayMock } from './entries.mock';
+import { getEntriesArrayMock, getListEntriesArrayMock } from './entries.mock';
 import { entriesArray, entriesArrayOrUndefined, entry } from './entries';
 
 describe('Entries', () => {
@@ -130,6 +130,39 @@ describe('Entries', () => {
 
       expect(getPaths(left(message.errors))).toEqual([]);
       expect(message.schema).toEqual(payload);
+    });
+
+    test('it should NOT validate an array with list and non-list types of entries', () => {
+      const payload = [...getEntriesArrayMock(), ...getListEntriesArrayMock()];
+      const decoded = entriesArray.decode(payload);
+      const message = pipe(decoded, foldLeftRight);
+
+      expect(getPaths(left(message.errors))).toEqual([
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "value"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "value"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "entries"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "value"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "value"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "entries"',
+        'Invalid value "list" supplied to "type"',
+        'Invalid value "undefined" supplied to "list"',
+        'Invalid value "match" supplied to "type"',
+        'Invalid value "undefined" supplied to "list"',
+        'Invalid value "match_any" supplied to "type"',
+        'Invalid value "undefined" supplied to "list"',
+        'Invalid value "exists" supplied to "type"',
+        'Invalid value "undefined" supplied to "list"',
+        'Invalid value "undefined" supplied to "operator"',
+        'Invalid value "nested" supplied to "type"',
+      ]);
+      expect(message.schema).toEqual({});
     });
   });
 

--- a/x-pack/plugins/lists/common/schemas/types/entries.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.test.ts
@@ -14,7 +14,7 @@ import { getEntryMatchAnyMock } from './entry_match_any.mock';
 import { getEntryListMock } from './entry_list.mock';
 import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
-import { getEntriesArrayMock, getListEntriesArrayMock } from './entries.mock';
+import { getEntriesArrayMock } from './entries.mock';
 import { entriesArray, entriesArrayOrUndefined, entry } from './entries';
 
 describe('Entries', () => {
@@ -130,39 +130,6 @@ describe('Entries', () => {
 
       expect(getPaths(left(message.errors))).toEqual([]);
       expect(message.schema).toEqual(payload);
-    });
-
-    test('it should NOT validate an array with list and non-list types of entries', () => {
-      const payload = [...getEntriesArrayMock(), ...getListEntriesArrayMock()];
-      const decoded = entriesArray.decode(payload);
-      const message = pipe(decoded, foldLeftRight);
-
-      expect(getPaths(left(message.errors))).toEqual([
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "value"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "value"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "entries"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "value"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "value"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "entries"',
-        'Invalid value "list" supplied to "type"',
-        'Invalid value "undefined" supplied to "list"',
-        'Invalid value "match" supplied to "type"',
-        'Invalid value "undefined" supplied to "list"',
-        'Invalid value "match_any" supplied to "type"',
-        'Invalid value "undefined" supplied to "list"',
-        'Invalid value "exists" supplied to "type"',
-        'Invalid value "undefined" supplied to "list"',
-        'Invalid value "undefined" supplied to "operator"',
-        'Invalid value "nested" supplied to "type"',
-      ]);
-      expect(message.schema).toEqual({});
     });
   });
 

--- a/x-pack/plugins/lists/common/schemas/types/entries.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.ts
@@ -17,9 +17,13 @@ import { entriesNested } from './entry_nested';
 export const entry = t.union([entriesMatch, entriesMatchAny, entriesList, entriesExists]);
 export type Entry = t.TypeOf<typeof entry>;
 
-export const entriesArray = t.array(
-  t.union([entriesMatch, entriesMatchAny, entriesList, entriesExists, entriesNested])
+export const nonListEntriesArray = t.array(
+  t.union([entriesMatch, entriesMatchAny, entriesExists, entriesNested])
 );
+export const listEntriesArray = t.array(entriesList);
+
+export const entriesArray = t.union([nonListEntriesArray, listEntriesArray]);
+
 export type EntriesArray = t.TypeOf<typeof entriesArray>;
 
 export const entriesArrayOrUndefined = t.union([entriesArray, t.undefined]);

--- a/x-pack/plugins/lists/common/schemas/types/entries.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.ts
@@ -17,13 +17,9 @@ import { entriesNested } from './entry_nested';
 export const entry = t.union([entriesMatch, entriesMatchAny, entriesList, entriesExists]);
 export type Entry = t.TypeOf<typeof entry>;
 
-export const nonListEntriesArray = t.array(
-  t.union([entriesMatch, entriesMatchAny, entriesExists, entriesNested])
+export const entriesArray = t.array(
+  t.union([entriesMatch, entriesMatchAny, entriesList, entriesExists, entriesNested])
 );
-export const listEntriesArray = t.array(entriesList);
-
-export const entriesArray = t.union([nonListEntriesArray, listEntriesArray]);
-
 export type EntriesArray = t.TypeOf<typeof entriesArray>;
 
 export const entriesArrayOrUndefined = t.union([entriesArray, t.undefined]);

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
@@ -11,10 +11,13 @@ import { foldLeftRight, getPaths } from '../../siem_common_deps';
 
 import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
-import { getEntryListMock } from './entry_list.mock';
 import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
-import { getEntriesArrayMock } from './entries.mock';
+import {
+  getEntriesArrayMock,
+  getListAndNonListEntriesArrayMock,
+  getListEntriesArrayMock,
+} from './entries.mock';
 import { nonEmptyEntriesArray } from './non_empty_entries_array';
 import { EntriesArray } from './entries';
 
@@ -80,7 +83,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "list" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryListMock() }, { ...getEntryListMock() }];
+    const payload: EntriesArray = [...getListEntriesArrayMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -104,6 +107,15 @@ describe('non_empty_entries_array', () => {
 
     expect(getPaths(left(message.errors))).toEqual([]);
     expect(message.schema).toEqual(payload);
+  });
+
+  test('it should NOT validate an array of entries of value list and non-value list entries', () => {
+    const payload: EntriesArray = [...getListAndNonListEntriesArrayMock()];
+    const decoded = nonEmptyEntriesArray.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual(['Cannot have entry of type list and other']);
+    expect(message.schema).toEqual({});
   });
 
   test('it should NOT validate an array of non entries', () => {

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
@@ -13,11 +13,7 @@ import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
 import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
-import {
-  getEntriesArrayMock,
-  getListAndNonListEntriesArrayMock,
-  getListEntriesArrayMock,
-} from './entries.mock';
+import { getEntriesArrayMock, getListEntriesArrayMock } from './entries.mock';
 import { nonEmptyEntriesArray } from './non_empty_entries_array';
 import { EntriesArray } from './entries';
 
@@ -27,9 +23,9 @@ describe('non_empty_entries_array', () => {
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))).toEqual([
-      'Invalid value "[]" supplied to "NonEmptyEntriesArray"',
-    ]);
+    expect(getPaths(left(message.errors))[0]).toEqual(
+      'Invalid value "[]" supplied to "NonEmptyEntriesArray"'
+    );
     expect(message.schema).toEqual({});
   });
 
@@ -38,9 +34,9 @@ describe('non_empty_entries_array', () => {
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))).toEqual([
-      'Invalid value "undefined" supplied to "NonEmptyEntriesArray"',
-    ]);
+    expect(getPaths(left(message.errors))[0]).toEqual(
+      'Invalid value "undefined" supplied to "NonEmptyEntriesArray"'
+    );
     expect(message.schema).toEqual({});
   });
 
@@ -49,9 +45,9 @@ describe('non_empty_entries_array', () => {
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))).toEqual([
-      'Invalid value "null" supplied to "NonEmptyEntriesArray"',
-    ]);
+    expect(getPaths(left(message.errors))[0]).toEqual(
+      'Invalid value "null" supplied to "NonEmptyEntriesArray"'
+    );
     expect(message.schema).toEqual({});
   });
 
@@ -83,7 +79,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "list" entries', () => {
-    const payload: EntriesArray = [...getListEntriesArrayMock()];
+    const payload: EntriesArray = getListEntriesArrayMock();
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -101,21 +97,12 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of entries', () => {
-    const payload: EntriesArray = [...getEntriesArrayMock()];
+    const payload: EntriesArray = getEntriesArrayMock();
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
     expect(message.schema).toEqual(payload);
-  });
-
-  test('it should NOT validate an array of entries of value list and non-value list entries', () => {
-    const payload: EntriesArray = [...getListAndNonListEntriesArrayMock()];
-    const decoded = nonEmptyEntriesArray.decode(payload);
-    const message = pipe(decoded, foldLeftRight);
-
-    expect(getPaths(left(message.errors))).toEqual(['Cannot have entry of type list and other']);
-    expect(message.schema).toEqual({});
   });
 
   test('it should NOT validate an array of non entries', () => {

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
@@ -13,7 +13,11 @@ import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
 import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
-import { getEntriesArrayMock, getListEntriesArrayMock } from './entries.mock';
+import {
+  getEntriesArrayMock,
+  getListAndNonListEntriesArrayMock,
+  getListEntriesArrayMock,
+} from './entries.mock';
 import { nonEmptyEntriesArray } from './non_empty_entries_array';
 import { EntriesArray } from './entries';
 
@@ -23,9 +27,9 @@ describe('non_empty_entries_array', () => {
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))[0]).toEqual(
-      'Invalid value "[]" supplied to "NonEmptyEntriesArray"'
-    );
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "[]" supplied to "NonEmptyEntriesArray"',
+    ]);
     expect(message.schema).toEqual({});
   });
 
@@ -34,9 +38,9 @@ describe('non_empty_entries_array', () => {
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))[0]).toEqual(
-      'Invalid value "undefined" supplied to "NonEmptyEntriesArray"'
-    );
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "undefined" supplied to "NonEmptyEntriesArray"',
+    ]);
     expect(message.schema).toEqual({});
   });
 
@@ -45,9 +49,9 @@ describe('non_empty_entries_array', () => {
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
-    expect(getPaths(left(message.errors))[0]).toEqual(
-      'Invalid value "null" supplied to "NonEmptyEntriesArray"'
-    );
+    expect(getPaths(left(message.errors))).toEqual([
+      'Invalid value "null" supplied to "NonEmptyEntriesArray"',
+    ]);
     expect(message.schema).toEqual({});
   });
 
@@ -79,7 +83,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "list" entries', () => {
-    const payload: EntriesArray = getListEntriesArrayMock();
+    const payload: EntriesArray = [...getListEntriesArrayMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -97,12 +101,21 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of entries', () => {
-    const payload: EntriesArray = getEntriesArrayMock();
+    const payload: EntriesArray = [...getEntriesArrayMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
     expect(message.schema).toEqual(payload);
+  });
+
+  test('it should NOT validate an array of entries of value list and non-value list entries', () => {
+    const payload: EntriesArray = [...getListAndNonListEntriesArrayMock()];
+    const decoded = nonEmptyEntriesArray.decode(payload);
+    const message = pipe(decoded, foldLeftRight);
+
+    expect(getPaths(left(message.errors))).toEqual(['Cannot have entry of type list and other']);
+    expect(message.schema).toEqual({});
   });
 
   test('it should NOT validate an array of non entries', () => {

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
@@ -8,6 +8,7 @@ import * as t from 'io-ts';
 import { Either } from 'fp-ts/lib/Either';
 
 import { EntriesArray, entriesArray } from './entries';
+import { entriesList } from './entry_list';
 
 /**
  * Types the nonEmptyEntriesArray as:
@@ -21,6 +22,14 @@ export const nonEmptyEntriesArray = new t.Type<EntriesArray, EntriesArray, unkno
     if (Array.isArray(input) && input.length === 0) {
       return t.failure(input, context);
     } else {
+      if (
+        Array.isArray(input) &&
+        input.some((entry) => entriesList.is(entry)) &&
+        input.some((entry) => !entriesList.is(entry))
+      ) {
+        // fail when an exception item contains both a value list entry and a non-value list entry
+        return t.failure(input, context, 'Cannot have entry of type list and other');
+      }
       return entriesArray.validate(input, context);
     }
   },

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
@@ -27,7 +27,7 @@ export const nonEmptyEntriesArray = new t.Type<EntriesArray, EntriesArray, unkno
         input.some((entry) => entriesList.is(entry)) &&
         input.some((entry) => !entriesList.is(entry))
       ) {
-        // fail when an entry contains a value list entry and a non-value list entry
+        // fail when an exception item contains both a value list entry and a non-value list entry
         return t.failure(input, context, 'Cannot have entry of type list and other');
       }
       return entriesArray.validate(input, context);

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
@@ -8,6 +8,7 @@ import * as t from 'io-ts';
 import { Either } from 'fp-ts/lib/Either';
 
 import { EntriesArray, entriesArray } from './entries';
+import { entriesList } from './entry_list';
 
 /**
  * Types the nonEmptyEntriesArray as:
@@ -21,6 +22,14 @@ export const nonEmptyEntriesArray = new t.Type<EntriesArray, EntriesArray, unkno
     if (Array.isArray(input) && input.length === 0) {
       return t.failure(input, context);
     } else {
+      if (
+        Array.isArray(input) &&
+        input.some((entry) => entriesList.is(entry)) &&
+        input.some((entry) => !entriesList.is(entry))
+      ) {
+        // fail when an entry contains a value list entry and a non-value list entry
+        return t.failure(input, context, 'Cannot have entry of type list and other');
+      }
       return entriesArray.validate(input, context);
     }
   },

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.ts
@@ -8,7 +8,6 @@ import * as t from 'io-ts';
 import { Either } from 'fp-ts/lib/Either';
 
 import { EntriesArray, entriesArray } from './entries';
-import { entriesList } from './entry_list';
 
 /**
  * Types the nonEmptyEntriesArray as:
@@ -22,14 +21,6 @@ export const nonEmptyEntriesArray = new t.Type<EntriesArray, EntriesArray, unkno
     if (Array.isArray(input) && input.length === 0) {
       return t.failure(input, context);
     } else {
-      if (
-        Array.isArray(input) &&
-        input.some((entry) => entriesList.is(entry)) &&
-        input.some((entry) => !entriesList.is(entry))
-      ) {
-        // fail when an exception item contains both a value list entry and a non-value list entry
-        return t.failure(input, context, 'Cannot have entry of type list and other');
-      }
       return entriesArray.validate(input, context);
     }
   },

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/helpers.test.tsx
@@ -96,12 +96,6 @@ describe('Exception viewer helpers', () => {
         {
           fieldName: 'host.name',
           isNested: false,
-          operator: 'is in list',
-          value: 'some-list-id',
-        },
-        {
-          fieldName: 'host.name',
-          isNested: false,
           operator: 'exists',
           value: undefined,
         },


### PR DESCRIPTION
## Summary

Add validation to reject when value list and other exception type are entries in the same exception item. Also adds tests for this situation on the schema validation

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
