### PR TITLE
[Functional Tests] Fix flakiness on TSVB chart on switching index pat…

### DIFF
--- a/test/functional/services/combo_box.ts
+++ b/test/functional/services/combo_box.ts
@@ -90,7 +90,7 @@ export function ComboBoxProvider({ getService, getPageObjects }: FtrProviderCont
           await this.clickOption(options.clickWithMouse, selectOptions[0]);
         } else {
           // if it doesn't find the item which text starts with value, it will choose the first option
-          const firstOption = await find.byCssSelector('.euiFilterSelectItem');
+          const firstOption = await find.byCssSelector('.euiFilterSelectItem', 5000);
           await this.clickOption(options.clickWithMouse, firstOption);
         }
       } else {


### PR DESCRIPTION
…terns test

## Summary

Fixes #44132. I could replicate it locally (on headless mode) and on the cloud. The problem was that it timed out when trying to locate the `.euiFilterSelectItem` with the default timeout of 2500. When I doubled it to 5000 everything seems to work fine!

Flaky tests runner: https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/666/


### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
