### PR TITLE
[Functional Tests] Increase the timeout when locating the tableview

### DIFF
--- a/test/functional/page_objects/visual_builder_page.ts
+++ b/test/functional/page_objects/visual_builder_page.ts
@@ -408,7 +408,7 @@ export function VisualBuilderPageProvider({ getService, getPageObjects }: FtrPro
      * @memberof VisualBuilderPage
      */
     public async getViewTable(): Promise<string> {
-      const tableView = await testSubjects.find('tableView');
+      const tableView = await testSubjects.find('tableView', 20000);
       return await tableView.getVisibleText();
     }
 


### PR DESCRIPTION
## Summary

Closes #40325. This test doesn't fail very often. I doubled the timeout to locate the `tableview`. 
Flaky server runner [here](https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/668/) - configured to run for 100 times.

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios