### PR TITLE
[Security Solution] Fix icon type for immutable timeline callout message

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/index.test.tsx
@@ -85,5 +85,100 @@ describe('Header', () => {
 
       expect(wrapper.find('[data-test-subj="timelineCallOutUnauthorized"]').exists()).toEqual(true);
     });
+
+    test('it renders the unauthorized call out with correct icon', () => {
+      const testProps = {
+        ...props,
+        filterManager: new FilterManager(mockUiSettingsForFilterManager),
+        showCallOutUnauthorizedMsg: true,
+      };
+
+      const wrapper = mount(
+        <TestProviders>
+          <TimelineHeader {...testProps} />
+        </TestProviders>
+      );
+
+      expect(
+        wrapper.find('[data-test-subj="timelineCallOutUnauthorized"]').first().prop('iconType')
+      ).toEqual('alert');
+    });
+
+    test('it renders the unauthorized call out with correct message', () => {
+      const testProps = {
+        ...props,
+        filterManager: new FilterManager(mockUiSettingsForFilterManager),
+        showCallOutUnauthorizedMsg: true,
+      };
+
+      const wrapper = mount(
+        <TestProviders>
+          <TimelineHeader {...testProps} />
+        </TestProviders>
+      );
+
+      expect(
+        wrapper.find('[data-test-subj="timelineCallOutUnauthorized"]').first().prop('title')
+      ).toEqual(
+        'You can use Timeline to investigate events, but you do not have the required permissions to save timelines for future use. If you need to save timelines, contact your Kibana administrator.'
+      );
+    });
+
+    test('it renders the immutable timeline call out providers', () => {
+      const testProps = {
+        ...props,
+        filterManager: new FilterManager(mockUiSettingsForFilterManager),
+        showCallOutUnauthorizedMsg: false,
+        status: TimelineStatus.immutable,
+      };
+
+      const wrapper = mount(
+        <TestProviders>
+          <TimelineHeader {...testProps} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="timelineImmutableCallOut"]').exists()).toEqual(true);
+    });
+
+    test('it renders the immutable timeline call out with correct icon', () => {
+      const testProps = {
+        ...props,
+        filterManager: new FilterManager(mockUiSettingsForFilterManager),
+        showCallOutUnauthorizedMsg: false,
+        status: TimelineStatus.immutable,
+      };
+
+      const wrapper = mount(
+        <TestProviders>
+          <TimelineHeader {...testProps} />
+        </TestProviders>
+      );
+
+      expect(
+        wrapper.find('[data-test-subj="timelineImmutableCallOut"]').first().prop('iconType')
+      ).toEqual('alert');
+    });
+
+    test('it renders the immutable timeline call out with correct message', () => {
+      const testProps = {
+        ...props,
+        filterManager: new FilterManager(mockUiSettingsForFilterManager),
+        showCallOutUnauthorizedMsg: false,
+        status: TimelineStatus.immutable,
+      };
+
+      const wrapper = mount(
+        <TestProviders>
+          <TimelineHeader {...testProps} />
+        </TestProviders>
+      );
+
+      expect(
+        wrapper.find('[data-test-subj="timelineImmutableCallOut"]').first().prop('title')
+      ).toEqual(
+        'This timeline is immutable, therefore not allowed to save it within the security application, though you may continue to use the timeline to search and filter security events'
+      );
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/index.tsx
@@ -75,7 +75,7 @@ const TimelineHeaderComponent: React.FC<Props> = ({
         data-test-subj="timelineImmutableCallOut"
         title={i18n.CALL_OUT_IMMUTIABLE}
         color="primary"
-        iconType="info"
+        iconType="alert"
         size="s"
       />
     )}


### PR DESCRIPTION
## Summary

https://github.com/elastic/siem-team/issues/794

How to verify this PR:
1. click on one of the Elastic templates
2. when the flyout appears, check if the icon of callout message shows correctly

before:
<img width="429" alt="Screenshot 2020-07-23 at 16 23 14" src="https://user-images.githubusercontent.com/17427073/88298591-a380a580-cd01-11ea-8ab4-1853eca2b559.png">

<img width="152" alt="Screenshot 2020-07-23 at 16 23 28" src="https://user-images.githubusercontent.com/17427073/88298611-aa0f1d00-cd01-11ea-8c38-4f00d9f39476.png">


after:
<img width="1393" alt="Screenshot 2020-07-27 at 10 43 32" src="https://user-images.githubusercontent.com/6295984/88532003-b5ad5d00-cffb-11ea-8542-ffdcd453917d.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] ~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
