### PR TITLE
[SIEM] Executes Cypress when there is a change on some Alerts files 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ kibanaPipeline(timeoutMinutes: 155, checkPrChanges: true, setCommitStatus: true)
             'xpack-accessibility': kibanaPipeline.functionalTestProcess('xpack-accessibility', './test/scripts/jenkins_xpack_accessibility.sh'),
             'xpack-savedObjectsFieldMetrics': kibanaPipeline.functionalTestProcess('xpack-savedObjectsFieldMetrics', './test/scripts/jenkins_xpack_saved_objects_field_metrics.sh'),
             'xpack-securitySolutionCypress': { processNumber ->
-              whenChanged(['x-pack/plugins/security_solution/', 'x-pack/test/security_solution_cypress/']) {
+              whenChanged(['x-pack/plugins/security_solution/', 'x-pack/test/security_solution_cypress/', 'x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/', 'x-pack/plugins/triggers_actions_ui/public/application/context/actions_connectors_context.tsx']) {
                 kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypress', './test/scripts/jenkins_security_solution_cypress.sh')(processNumber)
               }
             },


### PR DESCRIPTION
## Summary

Our Cypress tests are only executed when there is a change on:
- x-pack/plugins/security_solution/
- x-pack/test/security_solution_cypress/

We have some dependencies with Alerting team. In this PR we are extending the configuration to execute our tests also for:
- x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/
- x-pack/plugins/triggers_actions_ui/public/application/context/actions_connectors_context.tsx