### PR TITLE
[7.x] Remove flaky note from gauge tests (#73240)

### DIFF
--- a/test/functional/apps/visualize/_gauge_chart.js
+++ b/test/functional/apps/visualize/_gauge_chart.js
@@ -26,7 +26,6 @@ export default function ({ getService, getPageObjects }) {
   const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects(['visualize', 'visEditor', 'visChart', 'timePicker']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/45089
   describe('gauge chart', function indexPatternCreation() {
     async function initGaugeVis() {
       log.debug('navigateToApp visualize');


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove flaky note from gauge tests (#73240)