### PR TITLE
[Security Solutions] Show popovers inside modals

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/page/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/page/index.tsx
@@ -49,8 +49,8 @@ export const AppGlobalStyle = createGlobalStyle<{ theme: { eui: { euiColorPrimar
     border: none;
   }
 
-  /* hide open popovers when a modal is being displayed to prevent them from covering the modal */
-  body.euiBody-hasOverlayMask .euiPopover__panel-isOpen {
+  /* hide open draggable popovers when a modal is being displayed to prevent them from covering the modal */
+  body.euiBody-hasOverlayMask .withHoverActions__popover.euiPopover__panel-isOpen{
     visibility: hidden !important;
   }
 

--- a/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
@@ -90,6 +90,7 @@ export const WithHoverActions = React.memo<Props>(
           hasArrow={false}
           isOpen={isOpen}
           panelPaddingSize={!alwaysShow ? 's' : 'none'}
+          panelClassName="withHoverActions__popover"
         >
           {isOpen ? <>{hoverContent}</> : null}
         </WithHoverActionsPopover>


### PR DESCRIPTION
## Summary

This PR fixes an issue where popovers, like pagination or filters, inside a modal, are being hidden. With this fix, only draggable popovers are being hidden.

To test it:

1. Go to Hosts -> All hosts.
2. Hover over a hostname.
3. Chose the `Show top host.name menu` action.
4. Click the inspect button in the Top N popover.

Expected behavior: The Top N popover is hidden while the inspect modal is displayed.

1. Open timeline.
2. Give it a name.
3. Press the gear button.
4. Press `Add timeline to existing case...`
5. Click the Reporters, Tags and pagination filters

Expected behavior: The popovers should be visible.

### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
