### PR TITLE
[code coverage] add iframe embedded and enterprise search tests

### DIFF
--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -10,6 +10,8 @@ const alwaysImportedTests = [
   require.resolve('../test/functional_with_es_ssl/config.ts'),
   require.resolve('../test/functional/config_security_basic.ts'),
   require.resolve('../test/functional/config_security_trial.ts'),
+  require.resolve('../test/functional_embedded/config.ts'),
+  require.resolve('../test/functional_enterprise_search/without_host_configured.config.ts'),
 ];
 const onlyNotInCoverageTests = [
   require.resolve('../test/api_integration/config_security_basic.ts'),
@@ -51,9 +53,7 @@ const onlyNotInCoverageTests = [
   require.resolve('../test/licensing_plugin/config.legacy.ts'),
   require.resolve('../test/endpoint_api_integration_no_ingest/config.ts'),
   require.resolve('../test/reporting_api_integration/config.js'),
-  require.resolve('../test/functional_embedded/config.ts'),
   require.resolve('../test/ingest_manager_api_integration/config.ts'),
-  require.resolve('../test/functional_enterprise_search/without_host_configured.config.ts'),
 ];
 
 require('@kbn/plugin-helpers').babelRegister();


### PR DESCRIPTION
## Summary

Add 2 configs with functional tests to Code Coverage set:

<img width="1305" alt="elastic+kibana+qa-research #54 Test Results  Jenkins  2020-07-27 15-05-43" src="https://user-images.githubusercontent.com/10977896/88545141-d9cc6680-d01a-11ea-84eb-9a23e5a5b06d.png">



tested with https://kibana-ci.elastic.co/job/elastic+kibana+qa-research/54/