### PR TITLE
[APM] Fix license management URL

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/LicensePrompt/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/LicensePrompt/index.tsx
@@ -16,8 +16,7 @@ interface Props {
 
 export function LicensePrompt({ text, showBetaBadge = false }: Props) {
   const licensePageUrl = useKibanaUrl(
-    '/app/kibana',
-    '/management/stack/license_management/home'
+    '/app/management/stack/license_management'
   );
 
   const renderLicenseBody = (

--- a/x-pack/plugins/apm/public/context/LicenseContext/InvalidLicenseNotification.tsx
+++ b/x-pack/plugins/apm/public/context/LicenseContext/InvalidLicenseNotification.tsx
@@ -6,11 +6,10 @@
 import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useApmPluginContext } from '../../hooks/useApmPluginContext';
+import { useKibanaUrl } from '../../hooks/useKibanaUrl';
 
 export function InvalidLicenseNotification() {
-  const { core } = useApmPluginContext();
-  const manageLicenseURL = core.http.basePath.prepend(
+  const manageLicenseURL = useKibanaUrl(
     '/app/management/stack/license_management'
   );
 

--- a/x-pack/plugins/apm/public/hooks/useKibanaUrl.ts
+++ b/x-pack/plugins/apm/public/hooks/useKibanaUrl.ts
@@ -9,7 +9,7 @@ import { useApmPluginContext } from './useApmPluginContext';
 
 export function useKibanaUrl(
   /** The path to the plugin */ path: string,
-  /** The hash path */ hash: string
+  /** The hash path */ hash?: string
 ) {
   const { core } = useApmPluginContext();
   return url.format({


### PR DESCRIPTION
The URL to license management has changed, so update our links, both in the prompt on the Service Map, and in the app-wide expired license message.

Use `useKibanaUrl` in both places and update that hook to make the `hash` argument optional, since many apps don't use a hash now.

I looked for a more reliable way to get the URL for that app but couldn't come up with anything. I'd appreciate any suggestions if there's a better method.

Fixes #72998.