### PR TITLE
[Ingest Manager] Disable unenroll from listing for inactive agent

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/components/actions_menu.tsx
@@ -53,6 +53,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
             onClick={() => {
               setIsReassignFlyoutOpen(true);
             }}
+            disabled={!agent.active}
             key="reassignConfig"
           >
             <FormattedMessage

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
@@ -90,6 +90,7 @@ const RowActions = React.memo<{ agent: Agent; onReassignClick: () => void; refre
             onClick={() => {
               onReassignClick();
             }}
+            disabled={!agent.active}
             key="reassignConfig"
           >
             <FormattedMessage
@@ -97,11 +98,10 @@ const RowActions = React.memo<{ agent: Agent; onReassignClick: () => void; refre
               defaultMessage="Assign new agent config"
             />
           </EuiContextMenuItem>,
-
           <AgentUnenrollProvider forceUnenroll={isUnenrolling}>
             {(unenrollAgentsPrompt) => (
               <EuiContextMenuItem
-                disabled={!hasWriteCapabilites}
+                disabled={!hasWriteCapabilites || !agent.active}
                 icon="cross"
                 onClick={() => {
                   unenrollAgentsPrompt([agent.id], 1, () => {


### PR DESCRIPTION
## Summary


We should not allow an user to unenroll an agent that is already unenrolled.

This was correctly done in the details view, this PR fix the agent listing.

Also disabled the reassign config as it make not sense for an inactive agent.

## UI Change
<img width="1059" alt="Screen Shot 2020-07-27 at 4 17 28 PM" src="https://user-images.githubusercontent.com/1336873/88587961-c625fd80-d024-11ea-8745-afff74090862.png">
<img width="1399" alt="Screen Shot 2020-07-27 at 4 18 23 PM" src="https://user-images.githubusercontent.com/1336873/88588000-d63ddd00-d024-11ea-939c-f0e09e200201.png">

