### PR TITLE
[fix] Adding new visualization when session storage enabled

### DIFF
--- a/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_app_controller.tsx
@@ -172,6 +172,10 @@ export class DashboardAppController {
       chrome.docTitle.change(dash.title);
     }
 
+    const incomingEmbeddable = embeddable
+      .getStateTransfer(scopedHistory())
+      .getIncomingEmbeddablePackage();
+
     const dashboardStateManager = new DashboardStateManager({
       savedDashboard: dash,
       hideWriteControls: dashboardConfig.getHideWriteControls(),
@@ -427,21 +431,24 @@ export class DashboardAppController {
               refreshDashboardContainer();
             });
 
-            const incomingState = embeddable
-              .getStateTransfer(scopedHistory())
-              .getIncomingEmbeddablePackage();
-            if (incomingState) {
-              if ('id' in incomingState) {
-                container.addOrUpdateEmbeddable<SavedObjectEmbeddableInput>(incomingState.type, {
-                  savedObjectId: incomingState.id,
-                });
-              } else if ('input' in incomingState) {
-                const input = incomingState.input;
+            if (incomingEmbeddable) {
+              if ('id' in incomingEmbeddable) {
+                container.addOrUpdateEmbeddable<SavedObjectEmbeddableInput>(
+                  incomingEmbeddable.type,
+                  {
+                    savedObjectId: incomingEmbeddable.id,
+                  }
+                );
+              } else if ('input' in incomingEmbeddable) {
+                const input = incomingEmbeddable.input;
                 delete input.id;
                 const explicitInput = {
                   savedVis: input,
                 };
-                container.addOrUpdateEmbeddable<EmbeddableInput>(incomingState.type, explicitInput);
+                container.addOrUpdateEmbeddable<EmbeddableInput>(
+                  incomingEmbeddable.type,
+                  explicitInput
+                );
               }
             }
           }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/73013

The above issue was caused by the conflict between `browserHistory` and `hashHistory`, where subscribing to `hashHistory` clears the `history.location.state`. The following [code sandbox](https://codesandbox.io/s/historyconflict-w565y?file=/src/index.js) illustrates the problem.

When store in session storage is enabled, the location state is cleared prior to the creation of the dashboard container, which resulted in no embeddable being added.  ~~Once https://github.com/elastic/kibana/issues/65614 is closed, and angular routing is removed from dashboard, the location state should no longer be cleared.~~ 
Once we have switched away from using hash routing https://github.com/elastic/kibana/issues/67470, this issue should be resolved.

In the meantime, this workaround loads the `incomingEmbeddable` much earlier in the `dashboard_app_controller`'s constructor.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
