### PR TITLE
[Security Solution] Fix Lists route permissions

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/create/helpers.ts
@@ -12,6 +12,7 @@ import { NOTIFICATION_THROTTLE_NO_ACTIONS } from '../../../../../../common/const
 import { transformAlertToRuleAction } from '../../../../../../common/detection_engine/transform_actions';
 import { RuleType } from '../../../../../../common/detection_engine/types';
 import { isMlRule } from '../../../../../../common/machine_learning/helpers';
+import { isThresholdRule } from '../../../../../../common/detection_engine/utils';
 import { List } from '../../../../../../common/detection_engine/schemas/types';
 import { ENDPOINT_LIST_ID } from '../../../../../shared_imports';
 import { NewRule, Rule } from '../../../../containers/detection_engine/rules';
@@ -57,7 +58,7 @@ export interface RuleFields {
 }
 type QueryRuleFields<T> = Omit<T, 'anomalyThreshold' | 'machineLearningJobId' | 'threshold'>;
 type ThresholdRuleFields<T> = Omit<T, 'anomalyThreshold' | 'machineLearningJobId'>;
-type MlRuleFields<T> = Omit<T, 'queryBar' | 'index'>;
+type MlRuleFields<T> = Omit<T, 'queryBar' | 'index' | 'threshold'>;
 
 const isMlFields = <T>(
   fields: QueryRuleFields<T> | MlRuleFields<T> | ThresholdRuleFields<T>
@@ -69,9 +70,9 @@ const isThresholdFields = <T>(
 
 export const filterRuleFieldsForType = <T extends RuleFields>(fields: T, type: RuleType) => {
   if (isMlRule(type)) {
-    const { index, queryBar, ...mlRuleFields } = fields;
+    const { index, queryBar, threshold, ...mlRuleFields } = fields;
     return mlRuleFields;
-  } else if (type === 'threshold') {
+  } else if (isThresholdRule(type)) {
     const { anomalyThreshold, machineLearningJobId, ...thresholdRuleFields } = fields;
     return thresholdRuleFields;
   } else {

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -179,7 +179,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         all: {
           app: [...securitySubPlugins, 'kibana'],
           catalogue: ['securitySolution'],
-          api: ['securitySolution', 'lists-all'],
+          api: ['securitySolution', 'lists-all', 'lists-read'],
           savedObject: {
             all: [
               'alert',


### PR DESCRIPTION
## Summary

In the course of testing permissions on Security Solution I found a few bugs:
* Users with the 'all' feature permission for Security Solution would be unable to access most lists routes as they were not given the `lists-read` capability

* An ML rule's (unused) `threshold` value was incorrectly displayed:
<img width="1051" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/88596191-27040480-d02a-11ea-98ab-4814fa9652be.png">




### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
