### PR TITLE
[Ingest Manager] Fix /agent_config/delete API 500 if default config missing

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/agent_config.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_config.ts
@@ -336,7 +336,7 @@ class AgentConfigService {
       throw new Error('Agent configuration not found');
     }
 
-    const defaultConfigId = await this.getDefaultAgentConfigId(soClient);
+    const { id: defaultConfigId } = await this.ensureDefaultAgentConfig(soClient);
     if (id === defaultConfigId) {
       throw new Error('The default agent configuration cannot be deleted');
     }

--- a/x-pack/test/ingest_manager_api_integration/apis/agent_config/agent_config.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/agent_config/agent_config.ts
@@ -38,6 +38,24 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
+    describe('POST /api/ingest_manager/agent_configs/delete', () => {
+      it('should delete a config', async () => {
+        const { body: apiResponse } = await supertest
+          .post(`/api/ingest_manager/agent_configs`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'asdfasf',
+            namespace: 'asfdasdfasdf',
+          })
+          .expect(200);
+
+        await supertest
+          .post(`/api/ingest_manager/agent_configs/delete`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({ agentConfigId: apiResponse.item.id })
+          .expect(200);
+      });
+    });
     describe('POST /api/ingest_manager/agent_configs/{agentConfigId}/copy', () => {
       before(async () => {
         await esArchiver.loadIfNeeded('fleet/agents');


### PR DESCRIPTION
## Summary

Broke the changes from https://github.com/elastic/kibana/pull/73212/commits/b4f40517c51956f22371a08d08a572676c1f00e5 out to a separate PR & added a test

> getDefaultAgentConfigId errors if there isn't a default config.  The config is added by `setupIngestManager` which _was_ always called during plugin#start but is no longer.
>
> We could add the setup call to the test/suite, but instead I changed AgentConfigService.delete to use ensureDefaultAgentConfig instead of getDefaultAgentConfigId.
>
> ensureDefaultAgentConfig adds one if it's missing. The check in delete is to make sure we don't delete the default config. We can still do that and now we add a config if it wasn't already there (which seems like A Good Thing)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
