### PR TITLE
[Ingest Manager] Don't send kibana version to registry on master.

### DIFF
--- a/x-pack/plugins/ingest_manager/server/mocks.ts
+++ b/x-pack/plugins/ingest_manager/server/mocks.ts
@@ -18,6 +18,7 @@ export const createAppContextStartContractMock = (): IngestManagerAppContext => 
     logger: loggingSystemMock.create().get(),
     isProductionMode: true,
     kibanaVersion: '8.0.0',
+    kibanaBranch: 'master',
   };
 };
 

--- a/x-pack/plugins/ingest_manager/server/plugin.ts
+++ b/x-pack/plugins/ingest_manager/server/plugin.ts
@@ -15,6 +15,7 @@ import {
   HttpServiceSetup,
 } from 'kibana/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
+import packageJSON from '../../../../package.json';
 import { LicensingPluginSetup, ILicense } from '../../licensing/server';
 import {
   EncryptedSavedObjectsPluginStart,
@@ -85,6 +86,7 @@ export interface IngestManagerAppContext {
   savedObjects: SavedObjectsServiceStart;
   isProductionMode: boolean;
   kibanaVersion: string;
+  kibanaBranch: string;
   cloud?: CloudSetup;
   logger?: Logger;
   httpSetup?: HttpServiceSetup;
@@ -145,6 +147,7 @@ export class IngestManagerPlugin
 
   private isProductionMode: boolean;
   private kibanaVersion: string;
+  private kibanaBranch: string;
   private httpSetup: HttpServiceSetup | undefined;
   private encryptedSavedObjectsSetup: EncryptedSavedObjectsPluginSetup | undefined;
 
@@ -152,6 +155,7 @@ export class IngestManagerPlugin
     this.config$ = this.initializerContext.config.create<IngestManagerConfigType>();
     this.isProductionMode = this.initializerContext.env.mode.prod;
     this.kibanaVersion = this.initializerContext.env.packageInfo.version;
+    this.kibanaBranch = packageJSON.branch;
     this.logger = this.initializerContext.logger.get();
   }
 
@@ -257,6 +261,7 @@ export class IngestManagerPlugin
       savedObjects: core.savedObjects,
       isProductionMode: this.isProductionMode,
       kibanaVersion: this.kibanaVersion,
+      kibanaBranch: this.kibanaBranch,
       httpSetup: this.httpSetup,
       cloud: this.cloud,
       logger: this.logger,

--- a/x-pack/plugins/ingest_manager/server/services/app_context.ts
+++ b/x-pack/plugins/ingest_manager/server/services/app_context.ts
@@ -24,6 +24,7 @@ class AppContextService {
   private savedObjects: SavedObjectsServiceStart | undefined;
   private isProductionMode: boolean = false;
   private kibanaVersion: string | undefined;
+  private kibanaBranch: string | undefined;
   private cloud?: CloudSetup;
   private logger: Logger | undefined;
   private httpSetup?: HttpServiceSetup;
@@ -38,6 +39,7 @@ class AppContextService {
     this.cloud = appContext.cloud;
     this.logger = appContext.logger;
     this.kibanaVersion = appContext.kibanaVersion;
+    this.kibanaBranch = appContext.kibanaBranch;
     this.httpSetup = appContext.httpSetup;
 
     if (appContext.config$) {
@@ -123,6 +125,13 @@ class AppContextService {
       throw new Error('Kibana version is not set.');
     }
     return this.kibanaVersion;
+  }
+
+  public getKibanaBranch() {
+    if (!this.kibanaBranch) {
+      throw new Error('Kibana branch is not set.');
+    }
+    return this.kibanaBranch;
   }
 
   public addExternalCallback(type: ExternalCallback[0], callback: ExternalCallback[1]) {

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/index.ts
@@ -40,6 +40,8 @@ export const pkgToPkgKey = ({ name, version }: { name: string; version: string }
 export async function fetchList(params?: SearchParams): Promise<RegistrySearchResults> {
   const registryUrl = getRegistryUrl();
   const url = new URL(`${registryUrl}/search`);
+  const kibanaVersion = appContextService.getKibanaVersion().split('-')[0]; // may be x.y.z-SNAPSHOT
+  const kibanaBranch = appContextService.getKibanaBranch();
   if (params) {
     if (params.category) {
       url.searchParams.set('category', params.category);
@@ -48,8 +50,9 @@ export async function fetchList(params?: SearchParams): Promise<RegistrySearchRe
       url.searchParams.set('experimental', params.experimental.toString());
     }
   }
-  const kibanaVersion = appContextService.getKibanaVersion().split('-')[0]; // may be 8.0.0-SNAPSHOT
-  if (kibanaVersion) {
+
+  // on master, request all packages regardless of version
+  if (kibanaVersion && kibanaBranch !== 'master') {
     url.searchParams.set('kibana.version', kibanaVersion);
   }
 
@@ -58,11 +61,14 @@ export async function fetchList(params?: SearchParams): Promise<RegistrySearchRe
 
 export async function fetchFindLatestPackage(packageName: string): Promise<RegistrySearchResult> {
   const registryUrl = getRegistryUrl();
+  const kibanaVersion = appContextService.getKibanaVersion().split('-')[0]; // may be x.y.z-SNAPSHOT
+  const kibanaBranch = appContextService.getKibanaBranch();
   const url = new URL(
     `${registryUrl}/search?package=${packageName}&internal=true&experimental=true`
   );
-  const kibanaVersion = appContextService.getKibanaVersion().split('-')[0]; // may be 8.0.0-SNAPSHOT
-  if (kibanaVersion) {
+
+  // on master, request all packages regardless of version
+  if (kibanaVersion && kibanaBranch !== 'master') {
     url.searchParams.set('kibana.version', kibanaVersion);
   }
   const res = await fetchUrl(url.toString());

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/list.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/list.ts
@@ -29,7 +29,7 @@ export default function ({ getService }: FtrProviderContext) {
           return response.body;
         };
         const listResponse = await fetchPackageList();
-        expect(listResponse.response.length).to.be(6);
+        expect(listResponse.response.length).to.be(13);
       } else {
         warnAndSkipTest(this, log);
       }


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/73291

Picks the `branch` from the main `package.json` file and puts it into our app context.

Uses this branch to decide whether to send the `kibana.version` parameter to the package registry. On `master`, the desired behavior is that all packages are shown, regardless of their version restrictions.

Background: on `master`, `kibanaVersion` may be `8.0.0` (when run locally) or `8.0.0-SNAPSHOT` (when running from a snapshot). This test could just as well be done by checking if the semver part of the version equals `8.0.0`, but this will stop being correct once we branch `8.x`.

Instead, the check implemented in this PR will stop being correct if `master` is renamed. This feels slightly less risky to be overlooked to me.

### How to test this

Run locally, against any package registry that has packages with version requirements that exclude `8.0.0`, e.g. `^7.9.0` instead of `>=7.9.0`. Verify that these packages are shown in Ingest Manager.