### PR TITLE
[Functional Tests] Add timeout for comboBox list loading 

### DIFF
--- a/test/functional/services/combo_box.js
+++ b/test/functional/services/combo_box.js
@@ -17,11 +17,12 @@
  * under the License.
  */
 
-export function ComboBoxProvider({ getService }) {
+export function ComboBoxProvider({ getService, getPageObjects }) {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const log = getService('log');
   const retry = getService('retry');
+  const PageObjects = getPageObjects(['common']);
 
   // wrapper around EuiComboBox interactions
   class ComboBox {
@@ -55,6 +56,7 @@ export function ComboBoxProvider({ getService }) {
 
     async _waitForOptionsListLoading(comboBoxElement) {
       await comboBoxElement.waitForDeletedByClassName('euiLoadingSpinner');
+      await PageObjects.common.sleep(1000);
     }
 
     async getOptionsList(comboBoxSelector) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/22233

The test that fails follows these steps:
1. clear comboBox content
2. Set comboBox content to 'osx' by these steps
   2.1. Open comboBox
   2.2. Type 'osx' to filter it out
   2.3. Choose the first filtered option

Between steps 2.2 and 2.3, the comboBox flickers and shows all the options. Instead of the right one, the first one is chosen - the problem is only reproducible on cloud, probably because it's a faster, stronger environment. Adding a timeout solves the issue.

The problem with this functional test was fixed with a complete refactoring of comboBox test service for version 7+ so we only need to fix it for 6.8. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
