### PR TITLE
[Ingest Manager] Update registry URL to point to CDN

### DIFF
--- a/x-pack/plugins/ingest_manager/common/constants/epm.ts
+++ b/x-pack/plugins/ingest_manager/common/constants/epm.ts
@@ -6,5 +6,5 @@
 
 export const PACKAGES_SAVED_OBJECT_TYPE = 'epm-packages';
 export const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
-export const DEFAULT_REGISTRY_URL = 'https://epr-snapshot.ea-web.elastic.dev';
+export const DEFAULT_REGISTRY_URL = 'https://epr-snapshot.elastic.co';
 export const INDEX_PATTERN_PLACEHOLDER_SUFFIX = '-index_pattern_placeholder';


### PR DESCRIPTION
When the change was made for snapshot, the CDN url was not available yet. Now that is is available, the new url is used.