### PR TITLE
[7.x] [Metrics UI] Make composite size configurable to avoid max buckets (#72955)

### DIFF
--- a/x-pack/plugins/infra/common/http_api/snapshot_api.ts
+++ b/x-pack/plugins/infra/common/http_api/snapshot_api.ts
@@ -107,6 +107,7 @@ export const SnapshotRequestRT = rt.intersection([
     region: rt.string,
     filterQuery: rt.union([rt.string, rt.null]),
     includeTimeseries: rt.boolean,
+    overrideCompositeSize: rt.number,
   }),
 ]);
 

--- a/x-pack/plugins/infra/public/metrics_overview_fetchers.test.ts
+++ b/x-pack/plugins/infra/public/metrics_overview_fetchers.test.ts
@@ -75,6 +75,7 @@ describe('Metrics UI Observability Homepage Functions', () => {
           groupBy: [],
           nodeType: 'host',
           includeTimeseries: true,
+          overrideCompositeSize: 5,
           timerange: {
             from: startTime.valueOf(),
             to: endTime.valueOf(),

--- a/x-pack/plugins/infra/public/metrics_overview_fetchers.ts
+++ b/x-pack/plugins/infra/public/metrics_overview_fetchers.ts
@@ -87,6 +87,7 @@ export const createMetricsFetchData = (
     groupBy: [],
     nodeType: 'host',
     includeTimeseries: true,
+    overrideCompositeSize: 5,
     timerange: {
       from: start,
       to: end,

--- a/x-pack/plugins/infra/server/lib/snapshot/snapshot.ts
+++ b/x-pack/plugins/infra/server/lib/snapshot/snapshot.ts
@@ -86,7 +86,7 @@ const requestGroupedNodes = async (
       aggregations: {
         nodes: {
           composite: {
-            size: SNAPSHOT_COMPOSITE_REQUEST_SIZE,
+            size: options.overrideCompositeSize || SNAPSHOT_COMPOSITE_REQUEST_SIZE,
             sources: getGroupedNodesSources(options),
           },
           aggs: {
@@ -142,7 +142,7 @@ const requestNodeMetrics = async (
       aggregations: {
         nodes: {
           composite: {
-            size: SNAPSHOT_COMPOSITE_REQUEST_SIZE,
+            size: options.overrideCompositeSize || SNAPSHOT_COMPOSITE_REQUEST_SIZE,
             sources: getMetricsSources(options),
           },
           aggregations: {

--- a/x-pack/plugins/infra/server/routes/snapshot/index.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/index.ts
@@ -40,6 +40,7 @@ export const initSnapshotRoute = (libs: InfraBackendLibs) => {
           accountId,
           region,
           includeTimeseries,
+          overrideCompositeSize,
         } = pipe(
           SnapshotRequestRT.decode(request.body),
           fold(throwErrors(Boom.badRequest), identity)
@@ -59,6 +60,7 @@ export const initSnapshotRoute = (libs: InfraBackendLibs) => {
           metrics,
           timerange,
           includeTimeseries,
+          overrideCompositeSize,
         };
 
         const searchES = <Hit = {}, Aggregation = undefined>(


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Make composite size configurable to avoid max buckets (#72955)