### PR TITLE
[Security Solution] Do not render descriptionless actions within an EuiCard

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/empty_page/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/common/components/empty_page/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`EmptyPage component renders actions with descriptions 1`] = `
 <EmptyPrompt
   actions={
     <EuiFlexGroup
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
         }
       >
         <EuiCard
-          description={false}
+          description="My Description"
           footer={
             <EuiButton
               data-test-subj="empty-page-actions-action"
@@ -27,6 +27,38 @@ exports[`renders correctly 1`] = `
           }
           title={false}
         />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  }
+  iconType="logoSecurity"
+  title={
+    <h2>
+      My Super Title
+    </h2>
+  }
+/>
+`;
+
+exports[`EmptyPage component renders actions without descriptions 1`] = `
+<EmptyPrompt
+  actions={
+    <EuiFlexGroup
+      justifyContent="center"
+    >
+      <EuiFlexItem
+        grow={false}
+        style={
+          Object {
+            "maxWidth": 283,
+          }
+        }
+      >
+        <EuiButton
+          data-test-subj="empty-page-actions-action"
+          href="my/url/from/nowwhere"
+        >
+          Do Something
+        </EuiButton>
       </EuiFlexItem>
     </EuiFlexGroup>
   }

--- a/x-pack/plugins/security_solution/public/common/components/empty_page/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/empty_page/index.test.tsx
@@ -9,13 +9,27 @@ import React from 'react';
 
 import { EmptyPage } from './index';
 
-test('renders correctly', () => {
-  const actions = {
-    actions: {
-      label: 'Do Something',
-      url: 'my/url/from/nowwhere',
-    },
-  };
-  const EmptyComponent = shallow(<EmptyPage actions={actions} title="My Super Title" />);
-  expect(EmptyComponent).toMatchSnapshot();
+describe('EmptyPage component', () => {
+  it('renders actions without descriptions', () => {
+    const actions = {
+      actions: {
+        label: 'Do Something',
+        url: 'my/url/from/nowwhere',
+      },
+    };
+    const EmptyComponent = shallow(<EmptyPage actions={actions} title="My Super Title" />);
+    expect(EmptyComponent).toMatchSnapshot();
+  });
+
+  it('renders actions with descriptions', () => {
+    const actions = {
+      actions: {
+        description: 'My Description',
+        label: 'Do Something',
+        url: 'my/url/from/nowwhere',
+      },
+    };
+    const EmptyComponent = shallow(<EmptyPage actions={actions} title="My Super Title" />);
+    expect(EmptyComponent).toMatchSnapshot();
+  });
 });

--- a/x-pack/plugins/security_solution/public/common/components/empty_page/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/empty_page/index.tsx
@@ -51,16 +51,7 @@ const EmptyPageComponent = React.memo<EmptyPageProps>(({ actions, message, title
         .filter((a) => a.label && a.url)
         .map(
           (
-            {
-              icon,
-              label,
-              target,
-              url,
-              descriptionTitle = false,
-              description = false,
-              onClick,
-              fill = true,
-            },
+            { icon, label, target, url, descriptionTitle, description, onClick, fill = true },
             idx
           ) =>
             descriptionTitle != null || description != null ? (
@@ -70,8 +61,8 @@ const EmptyPageComponent = React.memo<EmptyPageProps>(({ actions, message, title
                 key={`empty-page-${titles[idx]}-action`}
               >
                 <EuiCard
-                  title={descriptionTitle}
-                  description={description}
+                  title={descriptionTitle ?? false}
+                  description={description ?? false}
                   footer={
                     /* eslint-disable-next-line @elastic/eui/href-or-on-click */
                     <EuiButton


### PR DESCRIPTION
## Summary
This updates the logic of EmptyPage to better handle these cases. Adds snapshot tests to verify. 

The more complicated Prompts (as shown in https://github.com/elastic/kibana/pull/73050) remain unchanged.

### Simple prompt before:
<img width="1232" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/88751399-1b453a80-d11d-11ea-933f-a5e4b61228e4.png">

### Simple prompt after:
<img width="970" alt="Detections_-_Kibana" src="https://user-images.githubusercontent.com/657252/88751447-34e68200-d11d-11ea-960d-ee018ada444f.png">


### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
