### PR TITLE
[7.9] [Metrics UI] Fix hasData call to ensure it has data not just indices (#72969)

### DIFF
--- a/x-pack/plugins/infra/server/lib/create_search_client.ts
+++ b/x-pack/plugins/infra/server/lib/create_search_client.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { RequestHandlerContext } from 'src/core/server';
+import { CallWithRequestParams, InfraDatabaseSearchResponse } from './adapters/framework';
+import { KibanaFramework } from './adapters/framework/kibana_framework_adapter';
+
+export const createSearchClient = (
+  requestContext: RequestHandlerContext,
+  framework: KibanaFramework
+) => <Hit = {}, Aggregation = undefined>(
+  opts: CallWithRequestParams
+): Promise<InfraDatabaseSearchResponse<Hit, Aggregation>> =>
+  framework.callWithRequest(requestContext, 'search', opts);

--- a/x-pack/plugins/infra/server/lib/sources/has_data.ts
+++ b/x-pack/plugins/infra/server/lib/sources/has_data.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ESSearchClient } from '../snapshot';
+
+export const hasData = async (index: string, client: ESSearchClient) => {
+  const params = {
+    index,
+    allowNoIndices: true,
+    terminate_after: 1,
+    ignoreUnavailable: true,
+    body: {
+      size: 0,
+    },
+  };
+  const results = await client(params);
+  return results.hits.total.value !== 0;
+};

--- a/x-pack/plugins/infra/server/routes/snapshot/index.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/index.ts
@@ -13,7 +13,7 @@ import { UsageCollector } from '../../usage/usage_collector';
 import { parseFilterQuery } from '../../utils/serialized_query';
 import { SnapshotRequestRT, SnapshotNodeResponseRT } from '../../../common/http_api/snapshot_api';
 import { throwErrors } from '../../../common/runtime_types';
-import { CallWithRequestParams, InfraDatabaseSearchResponse } from '../../lib/adapters/framework';
+import { createSearchClient } from '../../lib/create_search_client';
 
 const escapeHatch = schema.object({}, { unknowns: 'allow' });
 
@@ -63,12 +63,8 @@ export const initSnapshotRoute = (libs: InfraBackendLibs) => {
           overrideCompositeSize,
         };
 
-        const searchES = <Hit = {}, Aggregation = undefined>(
-          opts: CallWithRequestParams
-        ): Promise<InfraDatabaseSearchResponse<Hit, Aggregation>> =>
-          framework.callWithRequest(requestContext, 'search', opts);
-
-        const nodesWithInterval = await libs.snapshot.getNodes(searchES, options);
+        const client = createSearchClient(requestContext, framework);
+        const nodesWithInterval = await libs.snapshot.getNodes(client, options);
         return response.ok({
           body: SnapshotNodeResponseRT.encode(nodesWithInterval),
         });

--- a/x-pack/plugins/infra/server/routes/source/index.ts
+++ b/x-pack/plugins/infra/server/routes/source/index.ts
@@ -7,6 +7,8 @@ import { schema } from '@kbn/config-schema';
 import { SourceResponseRuntimeType } from '../../../common/http_api/source_api';
 import { InfraBackendLibs } from '../../lib/infra_types';
 import { InfraIndexType } from '../../graphql/types';
+import { hasData } from '../../lib/sources/has_data';
+import { createSearchClient } from '../../lib/create_search_client';
 
 const typeToInfraIndexType = (value: string | undefined) => {
   switch (value) {
@@ -80,13 +82,17 @@ export const initSourceRoute = (libs: InfraBackendLibs) => {
       try {
         const { type, sourceId } = request.params;
 
-        const hasData =
-          type === 'metrics'
-            ? await libs.sourceStatus.hasMetricIndices(requestContext, sourceId)
-            : (await libs.sourceStatus.getLogIndexStatus(requestContext, sourceId)) !== 'missing';
+        const client = createSearchClient(requestContext, framework);
+        const source = await libs.sources.getSourceConfiguration(
+          requestContext.core.savedObjects.client,
+          sourceId
+        );
+        const indexPattern =
+          type === 'metrics' ? source.configuration.metricAlias : source.configuration.logAlias;
+        const results = await hasData(indexPattern, client);
 
         return response.ok({
-          body: { hasData },
+          body: { hasData: results },
         });
       } catch (error) {
         return response.internalError({


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [Metrics UI] Fix hasData call to ensure it has data not just indices (#72969)