### PR TITLE
[Ingest Manager] Add registry as npm dependency via git url

### DIFF
--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -200,6 +200,7 @@
     "@elastic/maki": "6.3.0",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.0",
+    "@elastic/package-registry": "https://github.com/elastic/package-registry.git#master",
     "@elastic/safer-lodash-set": "0.0.0",
     "@kbn/babel-preset": "1.0.0",
     "@kbn/config-schema": "1.0.0",

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
@@ -3,8 +3,38 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { DEFAULT_REGISTRY_URL } from '../../../constants';
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { safeLoad } from 'js-yaml';
 import { appContextService, licenseService } from '../../';
+
+function loadSpec() {
+  const xpackRootPath = path.join(__dirname, '../../../../../../..');
+  const openApiPath = path.join(
+    xpackRootPath,
+    'node_modules/@elastic/package-registry/openapi.yml'
+  );
+  const yamlString = readFileSync(openApiPath, 'utf-8');
+  const parsedSpec = safeLoad(yamlString);
+  return parsedSpec;
+}
+
+// https://swagger.io/specification/#server-object
+interface OASServerObject {
+  url: string;
+  description?: string;
+}
+// this works "for now" but not by design/contract
+// description can be emtpy, duplicated, and contain CommonMark markup
+// it's also possible that the registry could add a key like `x-server-id` to each server entry
+const getServer = (key: string) => {
+  const servers: OASServerObject[] = loadSpec()?.servers;
+  const server = servers.find((o: OASServerObject) => o.description === key);
+  return server;
+};
+
+const DEFAULT_REGISTRY_URL = getServer('public')?.url || 'https://epr.elastic.co';
 
 export const getRegistryUrl = (): string => {
   const license = licenseService.getLicenseInformation();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,6 +2321,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/numeral/-/numeral-2.5.0.tgz#8da714827fc278f17546601fdfe55f5c920e2bc5"
   integrity sha512-NVTuy9Wzblp6nOH86CXjWXTajHgJGn5Tk2l59/Z5cWFU14KlE+8/zqPTgZdxYABzBJFE3L7S07kJDMN8sDvTmA==
 
+"@elastic/package-registry@https://github.com/elastic/package-registry.git#master":
+  version "0.0.0"
+  resolved "https://github.com/elastic/package-registry.git#02ca71731cdc092db213cd4c9069db43b74ac01b"
+
 "@elastic/request-crypto@1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@elastic/request-crypto/-/request-crypto-1.1.4.tgz#2189d5fea65f7afe1de9f5fa3d0dd420e93e3124"
@@ -20760,7 +20764,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@>4.17.4, lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.10.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.15, lodash@~4.17.5:
+lodash@4.17.11, lodash@4.17.19, lodash@>4.17.4, lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.10.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.15, lodash@~4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -20769,11 +20773,6 @@ lodash@4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@4.17.19, lodash@^4.17.16:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lodash@^3.10.1:
   version "3.10.1"


### PR DESCRIPTION
## Summary

refs https://github.com/elastic/kibana/issues/70711

I forgot that we can use yarn/npm for the dependency. We did this in before a draft PR exploring sharing types.

Quick example showing getting the public registry server from the spec file

