### PR TITLE
Move POST Copy to use JSON vs long encoded rison string

### DIFF
--- a/x-pack/plugins/reporting/public/lib/reporting_api_client.ts
+++ b/x-pack/plugins/reporting/public/lib/reporting_api_client.ts
@@ -4,8 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { stringify } from 'query-string';
 import rison from 'rison-node';
+import url from 'url';
 import { HttpSetup } from 'src/core/public';
 import { JobId, SourceJob } from '../../common/types';
 import { API_BASE_GENERATE, API_LIST_URL, REPORTING_MANAGEMENT_HOME } from '../../constants';
@@ -126,10 +126,13 @@ export class ReportingAPIClient {
   /*
    * Return a URL to queue a job, with the job params encoded in the query string of the URL. Used for copying POST URL
    */
-  public getReportingJobPath = (exportType: string, jobParams: JobParams) => {
-    const params = stringify({ jobParams: rison.encode(jobParams) });
-    return `${this.http.basePath.prepend(API_BASE_GENERATE)}/${exportType}?${params}`;
-  };
+  public getReportingJobPath = (exportType: string, jobParams: JobParams) => ({
+    url: url.resolve(
+      window.location.href,
+      `${this.http.basePath.prepend(API_BASE_GENERATE)}/${exportType}`
+    ),
+    payload: JSON.stringify({ jobParams: rison.encode(jobParams) }),
+  });
 
   /*
    * Sends a request to queue a job, with the job params in the POST body


### PR DESCRIPTION
## Summary

WIP moving our "Copy URL" button to use a JSON payload vs a query-string payload.
