### PR TITLE
[Discover] Context unskip date nanos functional tests

### DIFF
--- a/src/plugins/discover/public/application/angular/context/api/utils/date_conversion.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/date_conversion.ts
@@ -32,15 +32,6 @@ export function extractNanos(timeFieldValue: string = ''): string {
 }
 
 /**
- * extract the nanoseconds as string of a given ISO formatted timestamp
- */
-export function convertIsoToNanosAsStr(isoValue: string): string {
-  const nanos = extractNanos(isoValue);
-  const millis = convertIsoToMillis(isoValue);
-  return `${millis}${nanos.substr(3, 6)}`;
-}
-
-/**
  * convert an iso formatted string to number of milliseconds since
  * 1970-01-01T00:00:00.000Z
  * @param {string} isoValue

--- a/src/plugins/discover/public/application/angular/context/api/utils/get_es_query_search_after.ts
+++ b/src/plugins/discover/public/application/angular/context/api/utils/get_es_query_search_after.ts
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { convertIsoToNanosAsStr } from './date_conversion';
 import { SurrDocType, EsHitRecordList, EsHitRecord } from '../context';
 
 export type EsQuerySearchAfter = [string | number, string | number];
@@ -38,15 +37,10 @@ export function getEsQuerySearchAfter(
     // already surrounding docs -> first or last record  is used
     const afterTimeRecIdx = type === 'successors' && documents.length ? documents.length - 1 : 0;
     const afterTimeDoc = documents[afterTimeRecIdx];
-    const afterTimeValue = nanoSeconds
-      ? convertIsoToNanosAsStr(afterTimeDoc.fields[timeFieldName][0])
-      : afterTimeDoc.sort[0];
+    const afterTimeValue = nanoSeconds ? afterTimeDoc._source[timeFieldName] : afterTimeDoc.sort[0];
     return [afterTimeValue, afterTimeDoc.sort[1]];
   }
   // if data_nanos adapt timestamp value for sorting, since numeric value was rounded by browser
   // ES search_after also works when number is provided as string
-  return [
-    nanoSeconds ? convertIsoToNanosAsStr(anchor.fields[timeFieldName][0]) : anchor.sort[0],
-    anchor.sort[1],
-  ];
+  return [nanoSeconds ? anchor._source[timeFieldName] : anchor.sort[0], anchor.sort[1]];
 }

--- a/test/functional/apps/context/_date_nanos.js
+++ b/test/functional/apps/context/_date_nanos.js
@@ -30,8 +30,7 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['common', 'context', 'timePicker', 'discover']);
   const esArchiver = getService('esArchiver');
 
-  // FLAKY/FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/58815
-  describe.skip('context view for date_nanos', () => {
+  describe('context view for date_nanos', () => {
     before(async function () {
       await security.testUser.setRoles(['kibana_admin', 'kibana_date_nanos']);
       await esArchiver.loadIfNeeded('date_nanos');

--- a/test/functional/apps/context/_date_nanos_custom_timestamp.js
+++ b/test/functional/apps/context/_date_nanos_custom_timestamp.js
@@ -30,10 +30,7 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['common', 'context', 'timePicker', 'discover']);
   const esArchiver = getService('esArchiver');
 
-  // skipped due to a recent change in ES that caused search_after queries with data containing
-  // custom timestamp formats like in the testdata to fail
-  // https://github.com/elastic/kibana/issues/58815
-  describe.skip('context view for date_nanos with custom timestamp', () => {
+  describe('context view for date_nanos with custom timestamp', () => {
     before(async function () {
       await security.testUser.setRoles(['kibana_admin', 'kibana_date_nanos_custom']);
       await esArchiver.loadIfNeeded('date_nanos_custom');


### PR DESCRIPTION
## Summary
Unskips `date_nanos` functional tests, and improves the `search_after` submission to Elasticsearch for `date_nanos`.  
It's now possible to use string formatted dates (https://github.com/elastic/elasticsearch/pull/60328). The new solution is using this improvement, it's no longer a workaround 🥳. Furthermore it supports custom date time formats, so this tests now also work 🎂 . Due to [64bit integer value browser limitations](https://github.com/elastic/kibana/issues/40183) the date_nanos value had to be built in a custom function and was submitted as a text value before (else it was automatically rounded by the browser).

Fixes #58815

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
