### PR TITLE
[7.x] [ML] Functional tests - re-activate DFA clone tests (#73777)

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  // Flaky: https://github.com/elastic/kibana/issues/70885
-  describe.skip('jobs cloning supported by UI form', function () {
+  describe('jobs cloning supported by UI form', function () {
     const testDataList: Array<{
       suiteTitle: string;
       archive: string;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Functional tests - re-activate DFA clone tests (#73777)