### PR TITLE
[Ingest Manager] Fix config selection in enrollment flyout from config page.

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/config_selection.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/config_selection.tsx
@@ -64,6 +64,14 @@ export const EnrollmentStepAgentConfig: React.FC<Props> = (props) => {
   useEffect(
     function useDefaultConfigEffect() {
       if (agentConfigs && agentConfigs.length && !selectedState.agentConfigId) {
+        if (agentConfigs.length === 1) {
+          setSelectedState({
+            ...selectedState,
+            agentConfigId: agentConfigs[0].id,
+          });
+          return;
+        }
+
         const defaultConfig = agentConfigs.find((config) => config.is_default);
         if (defaultConfig) {
           setSelectedState({


### PR DESCRIPTION
## Description 

Resolve #73827

Fix config selection in enrollment flyout from config page.

## How to reproduce the bug

1. Setup fleet
1. Create a new configuration
1. go to the ingest manager config listing page http://localhost:5601/app/ingestManager#/configs
1. select a config (not the default one) and try to add an agent the flyout is broken


## UI change

<img width="1666" alt="Screen Shot 2020-07-30 at 12 42 15 PM" src="https://user-images.githubusercontent.com/1336873/88950290-6c127b80-d262-11ea-86c2-a416bd72eb85.png">
