### PR TITLE
[Security Solution][Lists] - Tests cleanup and remove unnecessary import

### DIFF
--- a/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   EsDataTypeGeoPoint,

--- a/x-pack/plugins/lists/common/schemas/common/schemas.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.ts
@@ -9,7 +9,7 @@
 import * as t from 'io-ts';
 
 import { DefaultNamespace } from '../types/default_namespace';
-import { DefaultStringArray, NonEmptyString } from '../../siem_common_deps';
+import { DefaultStringArray, NonEmptyString } from '../../shared_imports';
 
 export const name = t.string;
 export type Name = t.TypeOf<typeof name>;

--- a/x-pack/plugins/lists/common/schemas/elastic_response/search_es_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/elastic_response/search_es_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { SearchEsListItemSchema, searchEsListItemSchema } from './search_es_list_item_schema';
 import { getSearchEsListItemMock } from './search_es_list_item_schema.mock';
@@ -22,7 +22,7 @@ describe('search_es_list_item_schema', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should not validate with a madeup value', () => {
+  test('it should FAIL validation when a madeup value', () => {
     const payload: SearchEsListItemSchema & { madeupValue: string } = {
       ...getSearchEsListItemMock(),
       madeupValue: 'madeupvalue',

--- a/x-pack/plugins/lists/common/schemas/elastic_response/search_es_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/elastic_response/search_es_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { SearchEsListSchema, searchEsListSchema } from './search_es_list_schema';
 import { getSearchEsListMock } from './search_es_list_schema.mock';
@@ -22,7 +22,7 @@ describe('search_es_list_schema', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should not validate with a madeup value', () => {
+  test('it should FAIL validation when a madeup value', () => {
     const payload: SearchEsListSchema & { madeupValue: string } = {
       ...getSearchEsListMock(),
       madeupValue: 'madeupvalue',

--- a/x-pack/plugins/lists/common/schemas/request/create_endpoint_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_endpoint_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 import { getCreateCommentsArrayMock } from '../types/create_comment.mock';
 import { getCommentsMock } from '../types/comment.mock';
 import { CommentsArray } from '../types';

--- a/x-pack/plugins/lists/common/schemas/request/create_endpoint_list_item_schema.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_endpoint_list_item_schema.ts
@@ -22,7 +22,7 @@ import {
 import { RequiredKeepUndefined } from '../../types';
 import { CreateCommentsArray, DefaultCreateCommentsArray, nonEmptyEntriesArray } from '../types';
 import { EntriesArray } from '../types/entries';
-import { DefaultUuid } from '../../siem_common_deps';
+import { DefaultUuid } from '../../shared_imports';
 
 export const createEndpointListItemSchema = t.intersection([
   t.exact(

--- a/x-pack/plugins/lists/common/schemas/request/create_exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 import { getCreateCommentsArrayMock } from '../types/create_comment.mock';
 import { getCommentsMock } from '../types/comment.mock';
 import { CommentsArray } from '../types';

--- a/x-pack/plugins/lists/common/schemas/request/create_exception_list_item_schema.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_exception_list_item_schema.ts
@@ -29,7 +29,7 @@ import {
   nonEmptyEntriesArray,
 } from '../types';
 import { EntriesArray } from '../types/entries';
-import { DefaultUuid } from '../../siem_common_deps';
+import { DefaultUuid } from '../../shared_imports';
 
 export const createExceptionListItemSchema = t.intersection([
   t.exact(

--- a/x-pack/plugins/lists/common/schemas/request/create_exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   CreateExceptionListSchema,

--- a/x-pack/plugins/lists/common/schemas/request/create_exception_list_schema.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_exception_list_schema.ts
@@ -25,7 +25,7 @@ import {
   DefaultUuid,
   DefaultVersionNumber,
   DefaultVersionNumberDecoded,
-} from '../../siem_common_deps';
+} from '../../shared_imports';
 import { NamespaceType } from '../types';
 
 export const createExceptionListSchema = t.intersection([

--- a/x-pack/plugins/lists/common/schemas/request/create_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getCreateListItemSchemaMock } from './create_list_item_schema.mock';
 import { CreateListItemSchema, createListItemSchema } from './create_list_item_schema';

--- a/x-pack/plugins/lists/common/schemas/request/create_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { CreateListSchema, createListSchema } from './create_list_schema';
 import { getCreateListSchemaMock } from './create_list_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/request/create_list_schema.ts
+++ b/x-pack/plugins/lists/common/schemas/request/create_list_schema.ts
@@ -8,7 +8,7 @@ import * as t from 'io-ts';
 
 import { description, deserializer, id, meta, name, serializer, type } from '../common/schemas';
 import { RequiredKeepUndefined } from '../../types';
-import { DefaultVersionNumber, DefaultVersionNumberDecoded } from '../../siem_common_deps';
+import { DefaultVersionNumber, DefaultVersionNumberDecoded } from '../../shared_imports';
 
 export const createListSchema = t.intersection([
   t.exact(

--- a/x-pack/plugins/lists/common/schemas/request/delete_endpoint_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/delete_endpoint_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   DeleteEndpointListItemSchema,

--- a/x-pack/plugins/lists/common/schemas/request/delete_exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/delete_exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   DeleteExceptionListItemSchema,

--- a/x-pack/plugins/lists/common/schemas/request/delete_exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/delete_exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   DeleteExceptionListSchema,

--- a/x-pack/plugins/lists/common/schemas/request/delete_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/delete_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DeleteListItemSchema, deleteListItemSchema } from './delete_list_item_schema';
 import { getDeleteListItemSchemaMock } from './delete_list_item_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/request/delete_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/delete_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DeleteListSchema, deleteListSchema } from './delete_list_schema';
 import { getDeleteListSchemaMock } from './delete_list_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/request/export_list_item_query_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/export_list_item_query_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   ExportListItemQuerySchema,

--- a/x-pack/plugins/lists/common/schemas/request/find_endpoint_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/find_endpoint_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   getFindEndpointListItemSchemaDecodedMock,

--- a/x-pack/plugins/lists/common/schemas/request/find_exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/find_exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 import { LIST_ID } from '../../constants.mock';
 
 import {

--- a/x-pack/plugins/lists/common/schemas/request/find_exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/find_exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   getFindExceptionListSchemaDecodedMock,

--- a/x-pack/plugins/lists/common/schemas/request/find_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/find_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 import { LIST_ID } from '../../constants.mock';
 
 import {

--- a/x-pack/plugins/lists/common/schemas/request/find_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/find_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getFindListSchemaDecodedMock, getFindListSchemaMock } from './find_list_schema.mock';
 import { FindListSchemaEncoded, findListSchema } from './find_list_schema';

--- a/x-pack/plugins/lists/common/schemas/request/import_list_item_query_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/import_list_item_query_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   ImportListItemQuerySchema,

--- a/x-pack/plugins/lists/common/schemas/request/import_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/import_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { ImportListItemSchema, importListItemSchema } from './import_list_item_schema';
 import { getImportListItemSchemaMock } from './import_list_item_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/request/patch_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/patch_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getPathListItemSchemaMock } from './patch_list_item_schema.mock';
 import { PatchListItemSchema, patchListItemSchema } from './patch_list_item_schema';

--- a/x-pack/plugins/lists/common/schemas/request/patch_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/patch_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getPathListSchemaMock } from './patch_list_schema.mock';
 import { PatchListSchema, patchListSchema } from './patch_list_schema';

--- a/x-pack/plugins/lists/common/schemas/request/read_endpoint_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/read_endpoint_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getReadEndpointListItemSchemaMock } from './read_endpoint_list_item_schema.mock';
 import {

--- a/x-pack/plugins/lists/common/schemas/request/read_exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/read_exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getReadExceptionListItemSchemaMock } from './read_exception_list_item_schema.mock';
 import {

--- a/x-pack/plugins/lists/common/schemas/request/read_exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/read_exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getReadExceptionListSchemaMock } from './read_exception_list_schema.mock';
 import { ReadExceptionListSchema, readExceptionListSchema } from './read_exception_list_schema';

--- a/x-pack/plugins/lists/common/schemas/request/read_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/read_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getReadListItemSchemaMock } from './read_list_item_schema.mock';
 import { ReadListItemSchema, readListItemSchema } from './read_list_item_schema';

--- a/x-pack/plugins/lists/common/schemas/request/read_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/read_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getReadListSchemaMock } from './read_list_schema.mock';
 import { ReadListSchema, readListSchema } from './read_list_schema';

--- a/x-pack/plugins/lists/common/schemas/request/update_endpoint_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/update_endpoint_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   UpdateEndpointListItemSchema,

--- a/x-pack/plugins/lists/common/schemas/request/update_exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/update_exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   UpdateExceptionListItemSchema,

--- a/x-pack/plugins/lists/common/schemas/request/update_exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/update_exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import {
   UpdateExceptionListSchema,

--- a/x-pack/plugins/lists/common/schemas/request/update_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/request/update_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { UpdateListItemSchema, updateListItemSchema } from './update_list_item_schema';
 import { getUpdateListItemSchemaMock } from './update_list_item_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/response/acknowledge_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/acknowledge_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getAcknowledgeSchemaResponseMock } from './acknowledge_schema.mock';
 import { AcknowledgeSchema, acknowledgeSchema } from './acknowledge_schema';

--- a/x-pack/plugins/lists/common/schemas/response/create_endpoint_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/create_endpoint_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getExceptionListSchemaMock } from './exception_list_schema.mock';
 import { CreateEndpointListSchema, createEndpointListSchema } from './create_endpoint_list_schema';

--- a/x-pack/plugins/lists/common/schemas/response/exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getExceptionListItemSchemaMock } from './exception_list_item_schema.mock';
 import { ExceptionListItemSchema, exceptionListItemSchema } from './exception_list_item_schema';

--- a/x-pack/plugins/lists/common/schemas/response/exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getExceptionListSchemaMock } from './exception_list_schema.mock';
 import { ExceptionListSchema, exceptionListSchema } from './exception_list_schema';

--- a/x-pack/plugins/lists/common/schemas/response/found_exception_list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/found_exception_list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getExceptionListItemSchemaMock } from './exception_list_item_schema.mock';
 import { getFoundExceptionListItemSchemaMock } from './found_exception_list_item_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/response/found_exception_list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/found_exception_list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getExceptionListSchemaMock } from './exception_list_schema.mock';
 import { getFoundExceptionListSchemaMock } from './found_exception_list_schema.mock';

--- a/x-pack/plugins/lists/common/schemas/response/list_item_index_exist_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/list_item_index_exist_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getListItemIndexExistSchemaResponseMock } from './list_item_index_exist_schema.mock';
 import { ListItemIndexExistSchema, listItemIndexExistSchema } from './list_item_index_exist_schema';

--- a/x-pack/plugins/lists/common/schemas/response/list_item_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/list_item_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getListItemResponseMock } from './list_item_schema.mock';
 import { ListItemSchema, listItemSchema } from './list_item_schema';

--- a/x-pack/plugins/lists/common/schemas/response/list_schema.test.ts
+++ b/x-pack/plugins/lists/common/schemas/response/list_schema.test.ts
@@ -7,7 +7,7 @@
 import { left } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
-import { exactCheck, foldLeftRight, getPaths } from '../../siem_common_deps';
+import { exactCheck, foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getListResponseMock } from './list_schema.mock';
 import { ListSchema, listSchema } from './list_schema';

--- a/x-pack/plugins/lists/common/schemas/types/comment.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/comment.test.ts
@@ -8,7 +8,7 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
 import { DATE_NOW } from '../../constants.mock';
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getCommentsArrayMock, getCommentsMock } from './comment.mock';
 import {

--- a/x-pack/plugins/lists/common/schemas/types/comment.ts
+++ b/x-pack/plugins/lists/common/schemas/types/comment.ts
@@ -8,7 +8,7 @@
 
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 import { created_at, created_by, id, updated_at, updated_by } from '../common/schemas';
 
 export const comment = t.intersection([

--- a/x-pack/plugins/lists/common/schemas/types/create_comment.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/create_comment.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getCreateCommentsArrayMock, getCreateCommentsMock } from './create_comment.mock';
 import {

--- a/x-pack/plugins/lists/common/schemas/types/create_comment.ts
+++ b/x-pack/plugins/lists/common/schemas/types/create_comment.ts
@@ -5,7 +5,7 @@
  */
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 
 export const createComment = t.exact(
   t.type({

--- a/x-pack/plugins/lists/common/schemas/types/default_comments_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/default_comments_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DefaultCommentsArray } from './default_comments_array';
 import { CommentsArray } from './comment';

--- a/x-pack/plugins/lists/common/schemas/types/default_create_comments_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/default_create_comments_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DefaultCreateCommentsArray } from './default_create_comments_array';
 import { CreateCommentsArray } from './create_comment';

--- a/x-pack/plugins/lists/common/schemas/types/default_namespace.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/default_namespace.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DefaultNamespace } from './default_namespace';
 
@@ -48,7 +48,7 @@ describe('default_namespace', () => {
     expect(message.schema).toEqual('single');
   });
 
-  test('it should NOT validate if not "single" or "agnostic"', () => {
+  test('it should FAIL validation if not "single" or "agnostic"', () => {
     const payload = 'something else';
     const decoded = DefaultNamespace.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/default_namespace_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/default_namespace_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DefaultNamespaceArray, DefaultNamespaceArrayType } from './default_namespace_array';
 
@@ -21,7 +21,7 @@ describe('default_namespace_array', () => {
     expect(message.schema).toEqual(['single']);
   });
 
-  test('it should NOT validate a numeric value', () => {
+  test('it should FAIL validation of numeric value', () => {
     const payload = 5;
     const decoded = DefaultNamespaceArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -86,7 +86,7 @@ describe('default_namespace_array', () => {
     expect(message.schema).toEqual(['single', 'agnostic', 'single']);
   });
 
-  test('it should not validate 3 elements of "single,agnostic,junk" since the 3rd value is junk', () => {
+  test('it should FAIL validation when given 3 elements of "single,agnostic,junk" since the 3rd value is junk', () => {
     const payload: DefaultNamespaceArrayType = 'single,agnostic,junk';
     const decoded = DefaultNamespaceArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/default_update_comments_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/default_update_comments_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { DefaultUpdateCommentsArray } from './default_update_comments_array';
 import { UpdateCommentsArray } from './update_comment';

--- a/x-pack/plugins/lists/common/schemas/types/empty_string_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/empty_string_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { EmptyStringArray, EmptyStringArrayEncoded } from './empty_string_array';
 
@@ -57,7 +57,7 @@ describe('empty_string_array', () => {
     expect(message.schema).toEqual(['a', 'b', 'c']);
   });
 
-  test('it should NOT validate a number', () => {
+  test('it should FAIL validation of number', () => {
     const payload: number = 5;
     const decoded = EmptyStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.mock.ts
@@ -12,21 +12,18 @@ import { getEntryExistsMock } from './entry_exists.mock';
 import { getEntryNestedMock } from './entry_nested.mock';
 
 export const getListAndNonListEntriesArrayMock = (): EntriesArray => [
-  { ...getEntryMatchMock() },
-  { ...getEntryMatchAnyMock() },
-  { ...getEntryListMock() },
-  { ...getEntryExistsMock() },
-  { ...getEntryNestedMock() },
+  getEntryMatchMock(),
+  getEntryMatchAnyMock(),
+  getEntryListMock(),
+  getEntryExistsMock(),
+  getEntryNestedMock(),
 ];
 
-export const getListEntriesArrayMock = (): EntriesArray => [
-  { ...getEntryListMock() },
-  { ...getEntryListMock() },
-];
+export const getListEntriesArrayMock = (): EntriesArray => [getEntryListMock(), getEntryListMock()];
 
 export const getEntriesArrayMock = (): EntriesArray => [
-  { ...getEntryMatchMock() },
-  { ...getEntryMatchAnyMock() },
-  { ...getEntryExistsMock() },
-  { ...getEntryNestedMock() },
+  getEntryMatchMock(),
+  getEntryMatchAnyMock(),
+  getEntryExistsMock(),
+  getEntryNestedMock(),
 ];

--- a/x-pack/plugins/lists/common/schemas/types/entries.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entries.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
@@ -20,7 +20,7 @@ import { entriesArray, entriesArrayOrUndefined, entry } from './entries';
 describe('Entries', () => {
   describe('entry', () => {
     test('it should validate a match entry', () => {
-      const payload = { ...getEntryMatchMock() };
+      const payload = getEntryMatchMock();
       const decoded = entry.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -29,7 +29,7 @@ describe('Entries', () => {
     });
 
     test('it should validate a match_any entry', () => {
-      const payload = { ...getEntryMatchAnyMock() };
+      const payload = getEntryMatchAnyMock();
       const decoded = entry.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -38,7 +38,7 @@ describe('Entries', () => {
     });
 
     test('it should validate a exists entry', () => {
-      const payload = { ...getEntryExistsMock() };
+      const payload = getEntryExistsMock();
       const decoded = entry.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -47,7 +47,7 @@ describe('Entries', () => {
     });
 
     test('it should validate a list entry', () => {
-      const payload = { ...getEntryListMock() };
+      const payload = getEntryListMock();
       const decoded = entry.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -55,8 +55,8 @@ describe('Entries', () => {
       expect(message.schema).toEqual(payload);
     });
 
-    test('it should NOT validate a nested entry', () => {
-      const payload = { ...getEntryNestedMock() };
+    test('it should FAIL validation of nested entry', () => {
+      const payload = getEntryNestedMock();
       const decoded = entry.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -79,7 +79,7 @@ describe('Entries', () => {
 
   describe('entriesArray', () => {
     test('it should validate an array with match entry', () => {
-      const payload = [{ ...getEntryMatchMock() }];
+      const payload = [getEntryMatchMock()];
       const decoded = entriesArray.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -88,7 +88,7 @@ describe('Entries', () => {
     });
 
     test('it should validate an array with match_any entry', () => {
-      const payload = [{ ...getEntryMatchAnyMock() }];
+      const payload = [getEntryMatchAnyMock()];
       const decoded = entriesArray.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -97,7 +97,7 @@ describe('Entries', () => {
     });
 
     test('it should validate an array with exists entry', () => {
-      const payload = [{ ...getEntryExistsMock() }];
+      const payload = [getEntryExistsMock()];
       const decoded = entriesArray.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -106,7 +106,7 @@ describe('Entries', () => {
     });
 
     test('it should validate an array with list entry', () => {
-      const payload = [{ ...getEntryListMock() }];
+      const payload = [getEntryListMock()];
       const decoded = entriesArray.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -115,7 +115,7 @@ describe('Entries', () => {
     });
 
     test('it should validate an array with nested entry', () => {
-      const payload = [{ ...getEntryNestedMock() }];
+      const payload = [getEntryNestedMock()];
       const decoded = entriesArray.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 
@@ -144,7 +144,7 @@ describe('Entries', () => {
     });
 
     test('it should validate an array with nested entry', () => {
-      const payload = [{ ...getEntryNestedMock() }];
+      const payload = [getEntryNestedMock()];
       const decoded = entriesArrayOrUndefined.decode(payload);
       const message = pipe(decoded, foldLeftRight);
 

--- a/x-pack/plugins/lists/common/schemas/types/entry_exists.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_exists.test.ts
@@ -7,14 +7,14 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryExistsMock } from './entry_exists.mock';
 import { EntryExists, entriesExists } from './entry_exists';
 
 describe('entriesExists', () => {
   test('it should validate an entry', () => {
-    const payload = { ...getEntryExistsMock() };
+    const payload = getEntryExistsMock();
     const decoded = entriesExists.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -23,7 +23,7 @@ describe('entriesExists', () => {
   });
 
   test('it should validate when "operator" is "included"', () => {
-    const payload = { ...getEntryExistsMock() };
+    const payload = getEntryExistsMock();
     const decoded = entriesExists.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -32,7 +32,7 @@ describe('entriesExists', () => {
   });
 
   test('it should validate when "operator" is "excluded"', () => {
-    const payload = { ...getEntryExistsMock() };
+    const payload = getEntryExistsMock();
     payload.operator = 'excluded';
     const decoded = entriesExists.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -41,7 +41,7 @@ describe('entriesExists', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should not validate when "field" is empty string', () => {
+  test('it should FAIL validation when "field" is empty string', () => {
     const payload: Omit<EntryExists, 'field'> & { field: string } = {
       ...getEntryExistsMock(),
       field: '',
@@ -56,16 +56,16 @@ describe('entriesExists', () => {
   test('it should strip out extra keys', () => {
     const payload: EntryExists & {
       extraKey?: string;
-    } = { ...getEntryExistsMock() };
+    } = getEntryExistsMock();
     payload.extraKey = 'some extra key';
     const decoded = entriesExists.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
-    expect(message.schema).toEqual({ ...getEntryExistsMock() });
+    expect(message.schema).toEqual(getEntryExistsMock());
   });
 
-  test('it should not validate when "type" is not "exists"', () => {
+  test('it should FAIL validation when "type" is not "exists"', () => {
     const payload: Omit<EntryExists, 'type'> & { type: string } = {
       ...getEntryExistsMock(),
       type: 'match',

--- a/x-pack/plugins/lists/common/schemas/types/entry_exists.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_exists.ts
@@ -8,7 +8,7 @@
 
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 import { operator } from '../common/schemas';
 
 export const entriesExists = t.exact(

--- a/x-pack/plugins/lists/common/schemas/types/entry_list.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_list.test.ts
@@ -7,14 +7,14 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryListMock } from './entry_list.mock';
 import { EntryList, entriesList } from './entry_list';
 
 describe('entriesList', () => {
   test('it should validate an entry', () => {
-    const payload = { ...getEntryListMock() };
+    const payload = getEntryListMock();
     const decoded = entriesList.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -23,7 +23,7 @@ describe('entriesList', () => {
   });
 
   test('it should validate when operator is "included"', () => {
-    const payload = { ...getEntryListMock() };
+    const payload = getEntryListMock();
     const decoded = entriesList.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -32,7 +32,7 @@ describe('entriesList', () => {
   });
 
   test('it should validate when "operator" is "excluded"', () => {
-    const payload = { ...getEntryListMock() };
+    const payload = getEntryListMock();
     payload.operator = 'excluded';
     const decoded = entriesList.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -41,7 +41,7 @@ describe('entriesList', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should not validate when "list" is not expected value', () => {
+  test('it should FAIL validation when "list" is not expected value', () => {
     const payload: Omit<EntryList, 'list'> & { list: string } = {
       ...getEntryListMock(),
       list: 'someListId',
@@ -55,7 +55,7 @@ describe('entriesList', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when "list.id" is empty string', () => {
+  test('it should FAIL validation when "list.id" is empty string', () => {
     const payload: Omit<EntryList, 'list'> & { list: { id: string; type: 'ip' } } = {
       ...getEntryListMock(),
       list: { id: '', type: 'ip' },
@@ -67,7 +67,7 @@ describe('entriesList', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when "type" is not "lists"', () => {
+  test('it should FAIL validation when "type" is not "lists"', () => {
     const payload: Omit<EntryList, 'type'> & { type: 'match_any' } = {
       ...getEntryListMock(),
       type: 'match_any',
@@ -84,12 +84,12 @@ describe('entriesList', () => {
   test('it should strip out extra keys', () => {
     const payload: EntryList & {
       extraKey?: string;
-    } = { ...getEntryListMock() };
+    } = getEntryListMock();
     payload.extraKey = 'some extra key';
     const decoded = entriesList.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
-    expect(message.schema).toEqual({ ...getEntryListMock() });
+    expect(message.schema).toEqual(getEntryListMock());
   });
 });

--- a/x-pack/plugins/lists/common/schemas/types/entry_list.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_list.ts
@@ -8,7 +8,7 @@
 
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 import { operator, type } from '../common/schemas';
 
 export const entriesList = t.exact(

--- a/x-pack/plugins/lists/common/schemas/types/entry_match.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_match.test.ts
@@ -7,14 +7,14 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryMatchMock } from './entry_match.mock';
 import { EntryMatch, entriesMatch } from './entry_match';
 
 describe('entriesMatch', () => {
   test('it should validate an entry', () => {
-    const payload = { ...getEntryMatchMock() };
+    const payload = getEntryMatchMock();
     const decoded = entriesMatch.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -23,7 +23,7 @@ describe('entriesMatch', () => {
   });
 
   test('it should validate when operator is "included"', () => {
-    const payload = { ...getEntryMatchMock() };
+    const payload = getEntryMatchMock();
     const decoded = entriesMatch.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -32,7 +32,7 @@ describe('entriesMatch', () => {
   });
 
   test('it should validate when "operator" is "excluded"', () => {
-    const payload = { ...getEntryMatchMock() };
+    const payload = getEntryMatchMock();
     payload.operator = 'excluded';
     const decoded = entriesMatch.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -41,7 +41,7 @@ describe('entriesMatch', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should not validate when "field" is empty string', () => {
+  test('it should FAIL validation when "field" is empty string', () => {
     const payload: Omit<EntryMatch, 'field'> & { field: string } = {
       ...getEntryMatchMock(),
       field: '',
@@ -53,7 +53,7 @@ describe('entriesMatch', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when "value" is not string', () => {
+  test('it should FAIL validation when "value" is not string', () => {
     const payload: Omit<EntryMatch, 'value'> & { value: string[] } = {
       ...getEntryMatchMock(),
       value: ['some value'],
@@ -67,7 +67,7 @@ describe('entriesMatch', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when "value" is empty string', () => {
+  test('it should FAIL validation when "value" is empty string', () => {
     const payload: Omit<EntryMatch, 'value'> & { value: string } = {
       ...getEntryMatchMock(),
       value: '',
@@ -79,7 +79,7 @@ describe('entriesMatch', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when "type" is not "match"', () => {
+  test('it should FAIL validation when "type" is not "match"', () => {
     const payload: Omit<EntryMatch, 'type'> & { type: string } = {
       ...getEntryMatchMock(),
       type: 'match_any',
@@ -96,12 +96,12 @@ describe('entriesMatch', () => {
   test('it should strip out extra keys', () => {
     const payload: EntryMatch & {
       extraKey?: string;
-    } = { ...getEntryMatchMock() };
+    } = getEntryMatchMock();
     payload.extraKey = 'some value';
     const decoded = entriesMatch.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
-    expect(message.schema).toEqual({ ...getEntryMatchMock() });
+    expect(message.schema).toEqual(getEntryMatchMock());
   });
 });

--- a/x-pack/plugins/lists/common/schemas/types/entry_match.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_match.ts
@@ -8,7 +8,7 @@
 
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 import { operator } from '../common/schemas';
 
 export const entriesMatch = t.exact(

--- a/x-pack/plugins/lists/common/schemas/types/entry_match_any.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_match_any.test.ts
@@ -7,14 +7,14 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
 import { EntryMatchAny, entriesMatchAny } from './entry_match_any';
 
 describe('entriesMatchAny', () => {
   test('it should validate an entry', () => {
-    const payload = { ...getEntryMatchAnyMock() };
+    const payload = getEntryMatchAnyMock();
     const decoded = entriesMatchAny.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -23,7 +23,7 @@ describe('entriesMatchAny', () => {
   });
 
   test('it should validate when operator is "included"', () => {
-    const payload = { ...getEntryMatchAnyMock() };
+    const payload = getEntryMatchAnyMock();
     const decoded = entriesMatchAny.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -32,7 +32,7 @@ describe('entriesMatchAny', () => {
   });
 
   test('it should validate when operator is "excluded"', () => {
-    const payload = { ...getEntryMatchAnyMock() };
+    const payload = getEntryMatchAnyMock();
     payload.operator = 'excluded';
     const decoded = entriesMatchAny.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -41,7 +41,7 @@ describe('entriesMatchAny', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should not validate when field is empty string', () => {
+  test('it should FAIL validation when field is empty string', () => {
     const payload: Omit<EntryMatchAny, 'field'> & { field: string } = {
       ...getEntryMatchAnyMock(),
       field: '',
@@ -53,7 +53,7 @@ describe('entriesMatchAny', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when value is empty array', () => {
+  test('it should FAIL validation when value is empty array', () => {
     const payload: Omit<EntryMatchAny, 'value'> & { value: string[] } = {
       ...getEntryMatchAnyMock(),
       value: [],
@@ -65,7 +65,7 @@ describe('entriesMatchAny', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when value is not string array', () => {
+  test('it should FAIL validation when value is not string array', () => {
     const payload: Omit<EntryMatchAny, 'value'> & { value: string } = {
       ...getEntryMatchAnyMock(),
       value: 'some string',
@@ -79,7 +79,7 @@ describe('entriesMatchAny', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should not validate when "type" is not "match_any"', () => {
+  test('it should FAIL validation when "type" is not "match_any"', () => {
     const payload: Omit<EntryMatchAny, 'type'> & { type: string } = {
       ...getEntryMatchAnyMock(),
       type: 'match',
@@ -94,12 +94,12 @@ describe('entriesMatchAny', () => {
   test('it should strip out extra keys', () => {
     const payload: EntryMatchAny & {
       extraKey?: string;
-    } = { ...getEntryMatchAnyMock() };
+    } = getEntryMatchAnyMock();
     payload.extraKey = 'some extra key';
     const decoded = entriesMatchAny.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
-    expect(message.schema).toEqual({ ...getEntryMatchAnyMock() });
+    expect(message.schema).toEqual(getEntryMatchAnyMock());
   });
 });

--- a/x-pack/plugins/lists/common/schemas/types/entry_match_any.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_match_any.ts
@@ -8,7 +8,7 @@
 
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 import { operator } from '../common/schemas';
 
 import { nonEmptyOrNullableStringArray } from './non_empty_or_nullable_string_array';

--- a/x-pack/plugins/lists/common/schemas/types/entry_nested.mock.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_nested.mock.ts
@@ -11,7 +11,7 @@ import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
 
 export const getEntryNestedMock = (): EntryNested => ({
-  entries: [{ ...getEntryMatchMock() }, { ...getEntryMatchAnyMock() }],
+  entries: [getEntryMatchMock(), getEntryMatchAnyMock()],
   field: FIELD,
   type: NESTED,
 });

--- a/x-pack/plugins/lists/common/schemas/types/entry_nested.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_nested.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryNestedMock } from './entry_nested.mock';
 import { EntryNested, entriesNested } from './entry_nested';
@@ -16,7 +16,7 @@ import { getEntryExistsMock } from './entry_exists.mock';
 
 describe('entriesNested', () => {
   test('it should validate a nested entry', () => {
-    const payload = { ...getEntryNestedMock() };
+    const payload = getEntryNestedMock();
     const decoded = entriesNested.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -24,7 +24,7 @@ describe('entriesNested', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should NOT validate when "type" is not "nested"', () => {
+  test('it should FAIL validation when "type" is not "nested"', () => {
     const payload: Omit<EntryNested, 'type'> & { type: 'match' } = {
       ...getEntryNestedMock(),
       type: 'match',
@@ -36,7 +36,7 @@ describe('entriesNested', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate when "field" is empty string', () => {
+  test('it should FAIL validation when "field" is empty string', () => {
     const payload: Omit<EntryNested, 'field'> & {
       field: string;
     } = { ...getEntryNestedMock(), field: '' };
@@ -47,7 +47,7 @@ describe('entriesNested', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate when "field" is not a string', () => {
+  test('it should FAIL validation when "field" is not a string', () => {
     const payload: Omit<EntryNested, 'field'> & {
       field: number;
     } = { ...getEntryNestedMock(), field: 1 };
@@ -58,7 +58,7 @@ describe('entriesNested', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate when "entries" is not a an array', () => {
+  test('it should FAIL validation when "entries" is not a an array', () => {
     const payload: Omit<EntryNested, 'entries'> & {
       entries: string;
     } = { ...getEntryNestedMock(), entries: 'im a string' };
@@ -72,7 +72,7 @@ describe('entriesNested', () => {
   });
 
   test('it should validate when "entries" contains an entry item that is type "match"', () => {
-    const payload = { ...getEntryNestedMock(), entries: [{ ...getEntryMatchAnyMock() }] };
+    const payload = { ...getEntryNestedMock(), entries: [getEntryMatchAnyMock()] };
     const decoded = entriesNested.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -92,7 +92,7 @@ describe('entriesNested', () => {
   });
 
   test('it should validate when "entries" contains an entry item that is type "exists"', () => {
-    const payload = { ...getEntryNestedMock(), entries: [{ ...getEntryExistsMock() }] };
+    const payload = { ...getEntryNestedMock(), entries: [getEntryExistsMock()] };
     const decoded = entriesNested.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -113,12 +113,12 @@ describe('entriesNested', () => {
   test('it should strip out extra keys', () => {
     const payload: EntryNested & {
       extraKey?: string;
-    } = { ...getEntryNestedMock() };
+    } = getEntryNestedMock();
     payload.extraKey = 'some extra key';
     const decoded = entriesNested.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
     expect(getPaths(left(message.errors))).toEqual([]);
-    expect(message.schema).toEqual({ ...getEntryNestedMock() });
+    expect(message.schema).toEqual(getEntryNestedMock());
   });
 });

--- a/x-pack/plugins/lists/common/schemas/types/entry_nested.ts
+++ b/x-pack/plugins/lists/common/schemas/types/entry_nested.ts
@@ -8,7 +8,7 @@
 
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 
 import { nonEmptyNestedEntriesArray } from './non_empty_nested_entries_array';
 

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_entries_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
@@ -22,7 +22,7 @@ import { nonEmptyEntriesArray } from './non_empty_entries_array';
 import { EntriesArray } from './entries';
 
 describe('non_empty_entries_array', () => {
-  test('it should NOT validate an empty array', () => {
+  test('it should FAIL validation when given an empty array', () => {
     const payload: EntriesArray = [];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -33,7 +33,7 @@ describe('non_empty_entries_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "undefined"', () => {
+  test('it should FAIL validation when given "undefined"', () => {
     const payload = undefined;
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -44,7 +44,7 @@ describe('non_empty_entries_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "null"', () => {
+  test('it should FAIL validation when given "null"', () => {
     const payload = null;
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -56,7 +56,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "match" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryMatchMock() }, { ...getEntryMatchMock() }];
+    const payload: EntriesArray = [getEntryMatchMock(), getEntryMatchMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -65,7 +65,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "match_any" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryMatchAnyMock() }, { ...getEntryMatchAnyMock() }];
+    const payload: EntriesArray = [getEntryMatchAnyMock(), getEntryMatchAnyMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -74,7 +74,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "exists" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryExistsMock() }, { ...getEntryExistsMock() }];
+    const payload: EntriesArray = [getEntryExistsMock(), getEntryExistsMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -92,7 +92,7 @@ describe('non_empty_entries_array', () => {
   });
 
   test('it should validate an array of "nested" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryNestedMock() }, { ...getEntryNestedMock() }];
+    const payload: EntriesArray = [getEntryNestedMock(), getEntryNestedMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -109,7 +109,7 @@ describe('non_empty_entries_array', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should NOT validate an array of entries of value list and non-value list entries', () => {
+  test('it should FAIL validation when given an array of entries of value list and non-value list entries', () => {
     const payload: EntriesArray = [...getListAndNonListEntriesArrayMock()];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -118,7 +118,7 @@ describe('non_empty_entries_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate an array of non entries', () => {
+  test('it should FAIL validation when given an array of non entries', () => {
     const payload = [1];
     const decoded = nonEmptyEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_nested_entries_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_nested_entries_array.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getEntryMatchMock } from './entry_match.mock';
 import { getEntryMatchAnyMock } from './entry_match_any.mock';
@@ -17,7 +17,7 @@ import { nonEmptyNestedEntriesArray } from './non_empty_nested_entries_array';
 import { EntriesArray } from './entries';
 
 describe('non_empty_nested_entries_array', () => {
-  test('it should NOT validate an empty array', () => {
+  test('it should FAIL validation when given an empty array', () => {
     const payload: EntriesArray = [];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -28,7 +28,7 @@ describe('non_empty_nested_entries_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "undefined"', () => {
+  test('it should FAIL validation when given "undefined"', () => {
     const payload = undefined;
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -39,7 +39,7 @@ describe('non_empty_nested_entries_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "null"', () => {
+  test('it should FAIL validation when given "null"', () => {
     const payload = null;
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -51,7 +51,7 @@ describe('non_empty_nested_entries_array', () => {
   });
 
   test('it should validate an array of "match" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryMatchMock() }, { ...getEntryMatchMock() }];
+    const payload: EntriesArray = [getEntryMatchMock(), getEntryMatchMock()];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -60,7 +60,7 @@ describe('non_empty_nested_entries_array', () => {
   });
 
   test('it should validate an array of "match_any" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryMatchAnyMock() }, { ...getEntryMatchAnyMock() }];
+    const payload: EntriesArray = [getEntryMatchAnyMock(), getEntryMatchAnyMock()];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -69,7 +69,7 @@ describe('non_empty_nested_entries_array', () => {
   });
 
   test('it should validate an array of "exists" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryExistsMock() }, { ...getEntryExistsMock() }];
+    const payload: EntriesArray = [getEntryExistsMock(), getEntryExistsMock()];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -77,8 +77,8 @@ describe('non_empty_nested_entries_array', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should NOT validate an array of "nested" entries', () => {
-    const payload: EntriesArray = [{ ...getEntryNestedMock() }, { ...getEntryNestedMock() }];
+  test('it should FAIL validation when given an array of "nested" entries', () => {
+    const payload: EntriesArray = [getEntryNestedMock(), getEntryNestedMock()];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
 
@@ -105,9 +105,9 @@ describe('non_empty_nested_entries_array', () => {
 
   test('it should validate an array of entries', () => {
     const payload: EntriesArray = [
-      { ...getEntryExistsMock() },
-      { ...getEntryMatchAnyMock() },
-      { ...getEntryMatchMock() },
+      getEntryExistsMock(),
+      getEntryMatchAnyMock(),
+      getEntryMatchMock(),
     ];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -116,7 +116,7 @@ describe('non_empty_nested_entries_array', () => {
     expect(message.schema).toEqual(payload);
   });
 
-  test('it should NOT validate an array of non entries', () => {
+  test('it should FAIL validation when given an array of non entries', () => {
     const payload = [1];
     const decoded = nonEmptyNestedEntriesArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_or_nullable_string_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_or_nullable_string_array.test.ts
@@ -7,12 +7,12 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { nonEmptyOrNullableStringArray } from './non_empty_or_nullable_string_array';
 
 describe('nonEmptyOrNullableStringArray', () => {
-  test('it should NOT validate an empty array', () => {
+  test('it should FAIL validation when given an empty array', () => {
     const payload: string[] = [];
     const decoded = nonEmptyOrNullableStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -23,7 +23,7 @@ describe('nonEmptyOrNullableStringArray', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "undefined"', () => {
+  test('it should FAIL validation when given "undefined"', () => {
     const payload = undefined;
     const decoded = nonEmptyOrNullableStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -34,7 +34,7 @@ describe('nonEmptyOrNullableStringArray', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "null"', () => {
+  test('it should FAIL validation when given "null"', () => {
     const payload = null;
     const decoded = nonEmptyOrNullableStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -45,7 +45,7 @@ describe('nonEmptyOrNullableStringArray', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate an array of with an empty string', () => {
+  test('it should FAIL validation when given an array of with an empty string', () => {
     const payload: string[] = ['im good', ''];
     const decoded = nonEmptyOrNullableStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -56,7 +56,7 @@ describe('nonEmptyOrNullableStringArray', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate an array of non strings', () => {
+  test('it should FAIL validation when given an array of non strings', () => {
     const payload = [1];
     const decoded = nonEmptyOrNullableStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/non_empty_string_array.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/non_empty_string_array.test.ts
@@ -7,12 +7,12 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { NonEmptyStringArray } from './non_empty_string_array';
 
 describe('non_empty_string_array', () => {
-  test('it should NOT validate "null"', () => {
+  test('it should FAIL validation when given "null"', () => {
     const payload: NonEmptyStringArray | null = null;
     const decoded = NonEmptyStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -23,7 +23,7 @@ describe('non_empty_string_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate "undefined"', () => {
+  test('it should FAIL validation when given "undefined"', () => {
     const payload: NonEmptyStringArray | undefined = undefined;
     const decoded = NonEmptyStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -34,7 +34,7 @@ describe('non_empty_string_array', () => {
     expect(message.schema).toEqual({});
   });
 
-  test('it should NOT validate a single value of an empty string ""', () => {
+  test('it should FAIL validation of single value of an empty string ""', () => {
     const payload: NonEmptyStringArray = '';
     const decoded = NonEmptyStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);
@@ -72,7 +72,7 @@ describe('non_empty_string_array', () => {
     expect(message.schema).toEqual(['a', 'b', 'c']);
   });
 
-  test('it should NOT validate a number', () => {
+  test('it should FAIL validation of number', () => {
     const payload: number = 5;
     const decoded = NonEmptyStringArray.decode(payload);
     const message = pipe(decoded, foldLeftRight);

--- a/x-pack/plugins/lists/common/schemas/types/update_comment.test.ts
+++ b/x-pack/plugins/lists/common/schemas/types/update_comment.test.ts
@@ -7,7 +7,7 @@
 import { pipe } from 'fp-ts/lib/pipeable';
 import { left } from 'fp-ts/lib/Either';
 
-import { foldLeftRight, getPaths } from '../../siem_common_deps';
+import { foldLeftRight, getPaths } from '../../shared_imports';
 
 import { getUpdateCommentMock, getUpdateCommentsArrayMock } from './update_comment.mock';
 import {

--- a/x-pack/plugins/lists/common/schemas/types/update_comment.ts
+++ b/x-pack/plugins/lists/common/schemas/types/update_comment.ts
@@ -5,7 +5,7 @@
  */
 import * as t from 'io-ts';
 
-import { NonEmptyString } from '../../siem_common_deps';
+import { NonEmptyString } from '../../shared_imports';
 import { id } from '../common/schemas';
 
 export const updateComment = t.intersection([

--- a/x-pack/plugins/lists/common/siem_common_deps.ts
+++ b/x-pack/plugins/lists/common/siem_common_deps.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
-
-// DEPRECATED: Do not add exports to this file; please import from shared_imports instead
-
-export * from './shared_imports';

--- a/x-pack/plugins/lists/public/exceptions/api.ts
+++ b/x-pack/plugins/lists/public/exceptions/api.ts
@@ -29,7 +29,7 @@ import {
   updateExceptionListItemSchema,
   updateExceptionListSchema,
 } from '../../common/schemas';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 
 import {
   AddEndpointExceptionListProps,

--- a/x-pack/plugins/lists/public/lists/api.ts
+++ b/x-pack/plugins/lists/public/lists/api.ts
@@ -29,7 +29,7 @@ import {
   listSchema,
 } from '../../common/schemas';
 import { LIST_INDEX, LIST_ITEM_URL, LIST_PRIVILEGES_URL, LIST_URL } from '../../common/constants';
-import { validateEither } from '../../common/siem_common_deps';
+import { validateEither } from '../../common/shared_imports';
 import { toError, toPromise } from '../common/fp_utils';
 
 import {

--- a/x-pack/plugins/lists/server/routes/create_endpoint_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_endpoint_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { ENDPOINT_LIST_ID, ENDPOINT_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   CreateEndpointListItemSchemaDecoded,
   createEndpointListItemSchema,

--- a/x-pack/plugins/lists/server/routes/create_endpoint_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_endpoint_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { ENDPOINT_LIST_URL } from '../../common/constants';
 import { buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { createEndpointListSchema } from '../../common/schemas';
 
 import { getExceptionListClient } from './utils/get_exception_list_client';

--- a/x-pack/plugins/lists/server/routes/create_exception_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_exception_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   CreateExceptionListItemSchemaDecoded,
   createExceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/create_exception_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_exception_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   CreateExceptionListSchemaDecoded,
   createExceptionListSchema,

--- a/x-pack/plugins/lists/server/routes/create_list_index_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_list_index_route.ts
@@ -7,7 +7,7 @@
 import { IRouter } from 'kibana/server';
 
 import { buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { LIST_INDEX } from '../../common/constants';
 import { acknowledgeSchema } from '../../common/schemas';
 

--- a/x-pack/plugins/lists/server/routes/create_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_list_item_route.ts
@@ -9,7 +9,7 @@ import { IRouter } from 'kibana/server';
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
 import { createListItemSchema, listItemSchema } from '../../common/schemas';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 
 import { getListClient } from '.';
 

--- a/x-pack/plugins/lists/server/routes/create_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/create_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { CreateListSchemaDecoded, createListSchema, listSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/delete_endpoint_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/delete_endpoint_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { ENDPOINT_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   DeleteEndpointListItemSchemaDecoded,
   deleteEndpointListItemSchema,

--- a/x-pack/plugins/lists/server/routes/delete_exception_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/delete_exception_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   DeleteExceptionListItemSchemaDecoded,
   deleteExceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/delete_exception_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/delete_exception_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   DeleteExceptionListSchemaDecoded,
   deleteExceptionListSchema,

--- a/x-pack/plugins/lists/server/routes/delete_list_index_route.ts
+++ b/x-pack/plugins/lists/server/routes/delete_list_index_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_INDEX } from '../../common/constants';
 import { buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { acknowledgeSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/delete_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/delete_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { deleteListItemSchema, listItemArraySchema, listItemSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/delete_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/delete_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { deleteListSchema, listSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/find_endpoint_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/find_endpoint_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { ENDPOINT_LIST_ID, ENDPOINT_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   FindEndpointListItemSchemaDecoded,
   findEndpointListItemSchema,

--- a/x-pack/plugins/lists/server/routes/find_exception_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/find_exception_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   FindExceptionListItemSchemaDecoded,
   findExceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/find_exception_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/find_exception_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   FindExceptionListSchemaDecoded,
   findExceptionListSchema,

--- a/x-pack/plugins/lists/server/routes/find_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/find_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   FindListItemSchemaDecoded,
   findListItemSchema,

--- a/x-pack/plugins/lists/server/routes/find_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/find_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { findListSchema, foundListSchema } from '../../common/schemas';
 import { decodeCursor } from '../services/utils';
 

--- a/x-pack/plugins/lists/server/routes/import_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/import_list_item_route.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { importListItemQuerySchema, listSchema } from '../../common/schemas';
 import { ConfigType } from '../config';
 

--- a/x-pack/plugins/lists/server/routes/patch_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/patch_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { listItemSchema, patchListItemSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/patch_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/patch_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { listSchema, patchListSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/read_endpoint_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_endpoint_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { ENDPOINT_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   ReadEndpointListItemSchemaDecoded,
   exceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/read_exception_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_exception_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   ReadExceptionListItemSchemaDecoded,
   exceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/read_exception_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_exception_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   ReadExceptionListSchemaDecoded,
   exceptionListSchema,

--- a/x-pack/plugins/lists/server/routes/read_list_index_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_list_index_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_INDEX } from '../../common/constants';
 import { buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { listItemIndexExistSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/read_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_list_item_route.ts
@@ -9,7 +9,7 @@ import { IRouter } from 'kibana/server';
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
 import { listItemArraySchema, listItemSchema, readListItemSchema } from '../../common/schemas';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 
 import { getListClient } from '.';
 

--- a/x-pack/plugins/lists/server/routes/read_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/read_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { listSchema, readListSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/update_endpoint_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/update_endpoint_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { ENDPOINT_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   UpdateEndpointListItemSchemaDecoded,
   exceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/update_exception_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/update_exception_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   UpdateExceptionListItemSchemaDecoded,
   exceptionListItemSchema,

--- a/x-pack/plugins/lists/server/routes/update_exception_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/update_exception_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { EXCEPTION_LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import {
   UpdateExceptionListSchemaDecoded,
   exceptionListSchema,

--- a/x-pack/plugins/lists/server/routes/update_list_item_route.ts
+++ b/x-pack/plugins/lists/server/routes/update_list_item_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_ITEM_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { listItemSchema, updateListItemSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/update_list_route.ts
+++ b/x-pack/plugins/lists/server/routes/update_list_route.ts
@@ -8,7 +8,7 @@ import { IRouter } from 'kibana/server';
 
 import { LIST_URL } from '../../common/constants';
 import { buildRouteValidation, buildSiemResponse, transformError } from '../siem_server_deps';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 import { listSchema, updateListSchema } from '../../common/schemas';
 
 import { getListClient } from '.';

--- a/x-pack/plugins/lists/server/routes/validate.ts
+++ b/x-pack/plugins/lists/server/routes/validate.ts
@@ -8,7 +8,7 @@ import { ExceptionListClient } from '../services/exception_lists/exception_list_
 import { MAX_EXCEPTION_LIST_SIZE } from '../../common/constants';
 import { foundExceptionListItemSchema } from '../../common/schemas';
 import { NamespaceType } from '../../common/schemas/types';
-import { validate } from '../../common/siem_common_deps';
+import { validate } from '../../common/shared_imports';
 
 export const validateExceptionListSize = async (
   exceptionLists: ExceptionListClient,

--- a/x-pack/plugins/lists/server/services/utils/encode_decode_cursor.ts
+++ b/x-pack/plugins/lists/server/services/utils/encode_decode_cursor.ts
@@ -9,7 +9,7 @@ import { fold } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import { CursorOrUndefined, SortFieldOrUndefined } from '../../../common/schemas';
-import { exactCheck } from '../../../common/siem_common_deps';
+import { exactCheck } from '../../../common/shared_imports';
 
 /**
  * Used only internally for this ad-hoc opaque cursor structure to keep track of the

--- a/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/build_exceptions_query.test.ts
@@ -15,86 +15,13 @@ import {
   getLanguageBooleanOperator,
   buildNested,
 } from './build_exceptions_query';
-import {
-  EntryNested,
-  EntryExists,
-  EntryMatch,
-  EntryMatchAny,
-  EntriesArray,
-  Operator,
-} from '../../../lists/common/schemas';
+import { EntryNested, EntryMatchAny, EntriesArray } from '../../../lists/common/schemas';
 import { getExceptionListItemSchemaMock } from '../../../lists/common/schemas/response/exception_list_item_schema.mock';
 import { getEntryMatchMock } from '../../../lists/common/schemas/types/entry_match.mock';
 import { getEntryMatchAnyMock } from '../../../lists/common/schemas/types/entry_match_any.mock';
 import { getEntryExistsMock } from '../../../lists/common/schemas/types/entry_exists.mock';
 
 describe('build_exceptions_query', () => {
-  const makeMatchEntry = ({
-    field,
-    value = 'value-1',
-    operator = 'included',
-  }: {
-    field: string;
-    value?: string;
-    operator?: Operator;
-  }): EntryMatch => {
-    return {
-      field,
-      operator,
-      type: 'match',
-      value,
-    };
-  };
-  const makeMatchAnyEntry = ({
-    field,
-    operator = 'included',
-    value = ['value-1', 'value-2'],
-  }: {
-    field: string;
-    operator?: Operator;
-    value?: string[];
-  }): EntryMatchAny => {
-    return {
-      field,
-      operator,
-      value,
-      type: 'match_any',
-    };
-  };
-  const makeExistsEntry = ({
-    field,
-    operator = 'included',
-  }: {
-    field: string;
-    operator?: Operator;
-  }): EntryExists => {
-    return {
-      field,
-      operator,
-      type: 'exists',
-    };
-  };
-  const matchEntryWithIncluded: EntryMatch = makeMatchEntry({
-    field: 'host.name',
-    value: 'suricata',
-  });
-  const matchEntryWithExcluded: EntryMatch = makeMatchEntry({
-    field: 'host.name',
-    value: 'suricata',
-    operator: 'excluded',
-  });
-  const matchAnyEntryWithIncludedAndTwoValues: EntryMatchAny = makeMatchAnyEntry({
-    field: 'host.name',
-    value: ['suricata', 'auditd'],
-  });
-  const existsEntryWithIncluded: EntryExists = makeExistsEntry({
-    field: 'host.name',
-  });
-  const existsEntryWithExcluded: EntryExists = makeExistsEntry({
-    field: 'host.name',
-    operator: 'excluded',
-  });
-
   describe('getLanguageBooleanOperator', () => {
     test('it returns value as uppercase if language is "lucene"', () => {
       const result = getLanguageBooleanOperator({ language: 'lucene', value: 'not' });
@@ -137,14 +64,14 @@ describe('build_exceptions_query', () => {
     describe('kuery', () => {
       test('it returns formatted wildcard string when operator is "excluded"', () => {
         const query = buildExists({
-          entry: existsEntryWithExcluded,
+          entry: { ...getEntryExistsMock(), operator: 'excluded' },
           language: 'kuery',
         });
         expect(query).toEqual('not host.name:*');
       });
       test('it returns formatted wildcard string when operator is "included"', () => {
         const query = buildExists({
-          entry: existsEntryWithIncluded,
+          entry: { ...getEntryExistsMock(), operator: 'included' },
           language: 'kuery',
         });
         expect(query).toEqual('host.name:*');
@@ -154,14 +81,14 @@ describe('build_exceptions_query', () => {
     describe('lucene', () => {
       test('it returns formatted wildcard string when operator is "excluded"', () => {
         const query = buildExists({
-          entry: existsEntryWithExcluded,
+          entry: { ...getEntryExistsMock(), operator: 'excluded' },
           language: 'lucene',
         });
         expect(query).toEqual('NOT _exists_host.name');
       });
       test('it returns formatted wildcard string when operator is "included"', () => {
         const query = buildExists({
-          entry: existsEntryWithIncluded,
+          entry: { ...getEntryExistsMock(), operator: 'included' },
           language: 'lucene',
         });
         expect(query).toEqual('_exists_host.name');
@@ -173,52 +100,55 @@ describe('build_exceptions_query', () => {
     describe('kuery', () => {
       test('it returns formatted string when operator is "included"', () => {
         const query = buildMatch({
-          entry: matchEntryWithIncluded,
+          entry: { ...getEntryMatchMock(), operator: 'included' },
           language: 'kuery',
         });
-        expect(query).toEqual('host.name:"suricata"');
+        expect(query).toEqual('host.name:"some host name"');
       });
       test('it returns formatted string when operator is "excluded"', () => {
         const query = buildMatch({
-          entry: matchEntryWithExcluded,
+          entry: { ...getEntryMatchMock(), operator: 'excluded' },
           language: 'kuery',
         });
-        expect(query).toEqual('not host.name:"suricata"');
+        expect(query).toEqual('not host.name:"some host name"');
       });
     });
 
     describe('lucene', () => {
       test('it returns formatted string when operator is "included"', () => {
         const query = buildMatch({
-          entry: matchEntryWithIncluded,
+          entry: { ...getEntryMatchMock(), operator: 'included' },
           language: 'lucene',
         });
-        expect(query).toEqual('host.name:"suricata"');
+        expect(query).toEqual('host.name:"some host name"');
       });
       test('it returns formatted string when operator is "excluded"', () => {
         const query = buildMatch({
-          entry: matchEntryWithExcluded,
+          entry: { ...getEntryMatchMock(), operator: 'excluded' },
           language: 'lucene',
         });
-        expect(query).toEqual('NOT host.name:"suricata"');
+        expect(query).toEqual('NOT host.name:"some host name"');
       });
     });
   });
 
   describe('buildMatchAny', () => {
-    const entryWithIncludedAndNoValues: EntryMatchAny = makeMatchAnyEntry({
+    const entryWithIncludedAndNoValues: EntryMatchAny = {
+      ...getEntryMatchAnyMock(),
       field: 'host.name',
       value: [],
-    });
-    const entryWithIncludedAndOneValue: EntryMatchAny = makeMatchAnyEntry({
+    };
+    const entryWithIncludedAndOneValue: EntryMatchAny = {
+      ...getEntryMatchAnyMock(),
       field: 'host.name',
-      value: ['suricata'],
-    });
-    const entryWithExcludedAndTwoValues: EntryMatchAny = makeMatchAnyEntry({
+      value: ['some host name'],
+    };
+    const entryWithExcludedAndTwoValues: EntryMatchAny = {
+      ...getEntryMatchAnyMock(),
       field: 'host.name',
-      value: ['suricata', 'auditd'],
+      value: ['some host name', 'auditd'],
       operator: 'excluded',
-    });
+    };
 
     describe('kuery', () => {
       test('it returns empty string if given an empty array for "values"', () => {
@@ -235,16 +165,16 @@ describe('build_exceptions_query', () => {
           language: 'kuery',
         });
 
-        expect(exceptionSegment).toEqual('host.name:("suricata")');
+        expect(exceptionSegment).toEqual('host.name:("some host name")');
       });
 
       test('it returns formatted string when operator is "included"', () => {
         const exceptionSegment = buildMatchAny({
-          entry: matchAnyEntryWithIncludedAndTwoValues,
+          entry: { ...getEntryMatchAnyMock(), value: ['some host name', 'auditd'] },
           language: 'kuery',
         });
 
-        expect(exceptionSegment).toEqual('host.name:("suricata" or "auditd")');
+        expect(exceptionSegment).toEqual('host.name:("some host name" or "auditd")');
       });
 
       test('it returns formatted string when operator is "excluded"', () => {
@@ -253,18 +183,18 @@ describe('build_exceptions_query', () => {
           language: 'kuery',
         });
 
-        expect(exceptionSegment).toEqual('not host.name:("suricata" or "auditd")');
+        expect(exceptionSegment).toEqual('not host.name:("some host name" or "auditd")');
       });
     });
 
     describe('lucene', () => {
       test('it returns formatted string when operator is "included"', () => {
         const exceptionSegment = buildMatchAny({
-          entry: matchAnyEntryWithIncludedAndTwoValues,
+          entry: { ...getEntryMatchAnyMock(), value: ['some host name', 'auditd'] },
           language: 'lucene',
         });
 
-        expect(exceptionSegment).toEqual('host.name:("suricata" OR "auditd")');
+        expect(exceptionSegment).toEqual('host.name:("some host name" OR "auditd")');
       });
       test('it returns formatted string when operator is "excluded"', () => {
         const exceptionSegment = buildMatchAny({
@@ -272,7 +202,7 @@ describe('build_exceptions_query', () => {
           language: 'lucene',
         });
 
-        expect(exceptionSegment).toEqual('NOT host.name:("suricata" OR "auditd")');
+        expect(exceptionSegment).toEqual('NOT host.name:("some host name" OR "auditd")');
       });
       test('it returns formatted string when "values" includes only one item', () => {
         const exceptionSegment = buildMatchAny({
@@ -280,7 +210,7 @@ describe('build_exceptions_query', () => {
           language: 'lucene',
         });
 
-        expect(exceptionSegment).toEqual('host.name:("suricata")');
+        expect(exceptionSegment).toEqual('host.name:("some host name")');
       });
     });
   });
@@ -394,7 +324,7 @@ describe('build_exceptions_query', () => {
     describe('kuery', () => {
       test('it returns formatted wildcard string when "type" is "exists"', () => {
         const result = buildEntry({
-          entry: existsEntryWithIncluded,
+          entry: { ...getEntryExistsMock(), operator: 'included' },
           language: 'kuery',
         });
         expect(result).toEqual('host.name:*');
@@ -402,25 +332,25 @@ describe('build_exceptions_query', () => {
 
       test('it returns formatted string when "type" is "match"', () => {
         const result = buildEntry({
-          entry: matchEntryWithIncluded,
+          entry: { ...getEntryMatchMock(), operator: 'included' },
           language: 'kuery',
         });
-        expect(result).toEqual('host.name:"suricata"');
+        expect(result).toEqual('host.name:"some host name"');
       });
 
       test('it returns formatted string when "type" is "match_any"', () => {
         const result = buildEntry({
-          entry: matchAnyEntryWithIncludedAndTwoValues,
+          entry: { ...getEntryMatchAnyMock(), value: ['some host name', 'auditd'] },
           language: 'kuery',
         });
-        expect(result).toEqual('host.name:("suricata" or "auditd")');
+        expect(result).toEqual('host.name:("some host name" or "auditd")');
       });
     });
 
     describe('lucene', () => {
       test('it returns formatted wildcard string when "type" is "exists"', () => {
         const result = buildEntry({
-          entry: existsEntryWithIncluded,
+          entry: { ...getEntryExistsMock(), operator: 'included' },
           language: 'lucene',
         });
         expect(result).toEqual('_exists_host.name');
@@ -428,18 +358,18 @@ describe('build_exceptions_query', () => {
 
       test('it returns formatted string when "type" is "match"', () => {
         const result = buildEntry({
-          entry: matchEntryWithIncluded,
+          entry: { ...getEntryMatchMock(), operator: 'included' },
           language: 'lucene',
         });
-        expect(result).toEqual('host.name:"suricata"');
+        expect(result).toEqual('host.name:"some host name"');
       });
 
       test('it returns formatted string when "type" is "match_any"', () => {
         const result = buildEntry({
-          entry: matchAnyEntryWithIncludedAndTwoValues,
+          entry: { ...getEntryMatchAnyMock(), value: ['some host name', 'auditd'] },
           language: 'lucene',
         });
-        expect(result).toEqual('host.name:("suricata" OR "auditd")');
+        expect(result).toEqual('host.name:("some host name" OR "auditd")');
       });
     });
   });
@@ -456,26 +386,31 @@ describe('build_exceptions_query', () => {
 
     test('it returns expected query when more than one item in exception item', () => {
       const payload: EntriesArray = [
-        makeMatchAnyEntry({ field: 'b' }),
-        makeMatchEntry({ field: 'c', operator: 'excluded', value: 'value-3' }),
+        { ...getEntryMatchAnyMock(), field: 'b' },
+        { ...getEntryMatchMock(), field: 'c', operator: 'excluded', value: 'value-3' },
       ];
       const query = buildExceptionItem({
         language: 'kuery',
         entries: payload,
       });
-      const expectedQuery = 'b:("value-1" or "value-2") and not c:"value-3"';
+      const expectedQuery = 'b:("some host name") and not c:"value-3"';
 
       expect(query).toEqual(expectedQuery);
     });
 
     test('it returns expected query when exception item includes nested value', () => {
       const entries: EntriesArray = [
-        makeMatchAnyEntry({ field: 'b' }),
+        { ...getEntryMatchAnyMock(), field: 'b' },
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            makeMatchEntry({ field: 'nestedField', operator: 'included', value: 'value-3' }),
+            {
+              ...getEntryMatchMock(),
+              field: 'nestedField',
+              operator: 'included',
+              value: 'value-3',
+            },
           ],
         },
       ];
@@ -483,56 +418,65 @@ describe('build_exceptions_query', () => {
         language: 'kuery',
         entries,
       });
-      const expectedQuery = 'b:("value-1" or "value-2") and parent:{ nestedField:"value-3" }';
+      const expectedQuery = 'b:("some host name") and parent:{ nestedField:"value-3" }';
 
       expect(query).toEqual(expectedQuery);
     });
 
     test('it returns expected query when exception item includes multiple items and nested "and" values', () => {
       const entries: EntriesArray = [
-        makeMatchAnyEntry({ field: 'b' }),
+        { ...getEntryMatchAnyMock(), field: 'b' },
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            makeMatchEntry({ field: 'nestedField', operator: 'included', value: 'value-3' }),
+            {
+              ...getEntryMatchMock(),
+              field: 'nestedField',
+              operator: 'included',
+              value: 'value-3',
+            },
           ],
         },
-        makeExistsEntry({ field: 'd' }),
+        { ...getEntryExistsMock(), field: 'd' },
       ];
       const query = buildExceptionItem({
         language: 'kuery',
         entries,
       });
-      const expectedQuery =
-        'b:("value-1" or "value-2") and parent:{ nestedField:"value-3" } and d:*';
+      const expectedQuery = 'b:("some host name") and parent:{ nestedField:"value-3" } and d:*';
       expect(query).toEqual(expectedQuery);
     });
 
     test('it returns expected query when language is "lucene"', () => {
       const entries: EntriesArray = [
-        makeMatchAnyEntry({ field: 'b' }),
+        { ...getEntryMatchAnyMock(), field: 'b' },
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            makeMatchEntry({ field: 'nestedField', operator: 'excluded', value: 'value-3' }),
+            {
+              ...getEntryMatchMock(),
+              field: 'nestedField',
+              operator: 'excluded',
+              value: 'value-3',
+            },
           ],
         },
-        makeExistsEntry({ field: 'e', operator: 'excluded' }),
+        { ...getEntryExistsMock(), field: 'e', operator: 'excluded' },
       ];
       const query = buildExceptionItem({
         language: 'lucene',
         entries,
       });
       const expectedQuery =
-        'b:("value-1" OR "value-2") AND parent:{ NOT nestedField:"value-3" } AND NOT _exists_e';
+        'b:("some host name") AND parent:{ NOT nestedField:"value-3" } AND NOT _exists_e';
       expect(query).toEqual(expectedQuery);
     });
 
     describe('exists', () => {
       test('it returns expected query when list includes single list item with operator of "included"', () => {
-        const entries: EntriesArray = [makeExistsEntry({ field: 'b' })];
+        const entries: EntriesArray = [{ ...getEntryExistsMock(), field: 'b' }];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
@@ -543,7 +487,9 @@ describe('build_exceptions_query', () => {
       });
 
       test('it returns expected query when list includes single list item with operator of "excluded"', () => {
-        const entries: EntriesArray = [makeExistsEntry({ field: 'b', operator: 'excluded' })];
+        const entries: EntriesArray = [
+          { ...getEntryExistsMock(), field: 'b', operator: 'excluded' },
+        ];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
@@ -555,11 +501,13 @@ describe('build_exceptions_query', () => {
 
       test('it returns expected query when exception item includes entry item with "and" values', () => {
         const entries: EntriesArray = [
-          makeExistsEntry({ field: 'b', operator: 'excluded' }),
+          { ...getEntryExistsMock(), field: 'b', operator: 'excluded' },
           {
             field: 'parent',
             type: 'nested',
-            entries: [makeMatchEntry({ field: 'c', operator: 'included', value: 'value-1' })],
+            entries: [
+              { ...getEntryMatchMock(), field: 'c', operator: 'included', value: 'value-1' },
+            ],
           },
         ];
         const query = buildExceptionItem({
@@ -573,16 +521,16 @@ describe('build_exceptions_query', () => {
 
       test('it returns expected query when list includes multiple items', () => {
         const entries: EntriesArray = [
-          makeExistsEntry({ field: 'b' }),
+          { ...getEntryExistsMock(), field: 'b' },
           {
             field: 'parent',
             type: 'nested',
             entries: [
-              makeMatchEntry({ field: 'c', operator: 'excluded', value: 'value-1' }),
-              makeMatchEntry({ field: 'd', value: 'value-2' }),
+              { ...getEntryMatchMock(), field: 'c', operator: 'excluded', value: 'value-1' },
+              { ...getEntryMatchMock(), field: 'd', value: 'value-2' },
             ],
           },
-          makeExistsEntry({ field: 'e' }),
+          { ...getEntryExistsMock(), field: 'e' },
         ];
         const query = buildExceptionItem({
           language: 'kuery',
@@ -596,7 +544,7 @@ describe('build_exceptions_query', () => {
 
     describe('match', () => {
       test('it returns expected query when list includes single list item with operator of "included"', () => {
-        const entries: EntriesArray = [makeMatchEntry({ field: 'b', value: 'value' })];
+        const entries: EntriesArray = [{ ...getEntryMatchMock(), field: 'b', value: 'value' }];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
@@ -608,7 +556,7 @@ describe('build_exceptions_query', () => {
 
       test('it returns expected query when list includes single list item with operator of "excluded"', () => {
         const entries: EntriesArray = [
-          makeMatchEntry({ field: 'b', operator: 'excluded', value: 'value' }),
+          { ...getEntryMatchMock(), field: 'b', operator: 'excluded', value: 'value' },
         ];
         const query = buildExceptionItem({
           language: 'kuery',
@@ -621,11 +569,13 @@ describe('build_exceptions_query', () => {
 
       test('it returns expected query when list includes list item with "and" values', () => {
         const entries: EntriesArray = [
-          makeMatchEntry({ field: 'b', operator: 'excluded', value: 'value' }),
+          { ...getEntryMatchMock(), field: 'b', operator: 'excluded', value: 'value' },
           {
             field: 'parent',
             type: 'nested',
-            entries: [makeMatchEntry({ field: 'c', operator: 'included', value: 'valueC' })],
+            entries: [
+              { ...getEntryMatchMock(), field: 'c', operator: 'included', value: 'valueC' },
+            ],
           },
         ];
         const query = buildExceptionItem({
@@ -639,16 +589,16 @@ describe('build_exceptions_query', () => {
 
       test('it returns expected query when list includes multiple items', () => {
         const entries: EntriesArray = [
-          makeMatchEntry({ field: 'b', value: 'value' }),
+          { ...getEntryMatchMock(), field: 'b', value: 'value' },
           {
             field: 'parent',
             type: 'nested',
             entries: [
-              makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
-              makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
+              { ...getEntryMatchMock(), field: 'c', operator: 'excluded', value: 'valueC' },
+              { ...getEntryMatchMock(), field: 'd', operator: 'excluded', value: 'valueD' },
             ],
           },
-          makeMatchEntry({ field: 'e', value: 'valueE' }),
+          { ...getEntryMatchMock(), field: 'e', value: 'valueE' },
         ];
         const query = buildExceptionItem({
           language: 'kuery',
@@ -663,55 +613,59 @@ describe('build_exceptions_query', () => {
 
     describe('match_any', () => {
       test('it returns expected query when list includes single list item with operator of "included"', () => {
-        const entries: EntriesArray = [makeMatchAnyEntry({ field: 'b' })];
+        const entries: EntriesArray = [{ ...getEntryMatchAnyMock(), field: 'b' }];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
         });
-        const expectedQuery = 'b:("value-1" or "value-2")';
+        const expectedQuery = 'b:("some host name")';
 
         expect(query).toEqual(expectedQuery);
       });
 
       test('it returns expected query when list includes single list item with operator of "excluded"', () => {
-        const entries: EntriesArray = [makeMatchAnyEntry({ field: 'b', operator: 'excluded' })];
+        const entries: EntriesArray = [
+          { ...getEntryMatchAnyMock(), field: 'b', operator: 'excluded' },
+        ];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
         });
-        const expectedQuery = 'not b:("value-1" or "value-2")';
+        const expectedQuery = 'not b:("some host name")';
 
         expect(query).toEqual(expectedQuery);
       });
 
       test('it returns expected query when list includes list item with nested values', () => {
         const entries: EntriesArray = [
-          makeMatchAnyEntry({ field: 'b', operator: 'excluded' }),
+          { ...getEntryMatchAnyMock(), field: 'b', operator: 'excluded' },
           {
             field: 'parent',
             type: 'nested',
-            entries: [makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' })],
+            entries: [
+              { ...getEntryMatchMock(), field: 'c', operator: 'excluded', value: 'valueC' },
+            ],
           },
         ];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
         });
-        const expectedQuery = 'not b:("value-1" or "value-2") and parent:{ not c:"valueC" }';
+        const expectedQuery = 'not b:("some host name") and parent:{ not c:"valueC" }';
 
         expect(query).toEqual(expectedQuery);
       });
 
       test('it returns expected query when list includes multiple items', () => {
         const entries: EntriesArray = [
-          makeMatchAnyEntry({ field: 'b' }),
-          makeMatchAnyEntry({ field: 'c' }),
+          { ...getEntryMatchAnyMock(), field: 'b' },
+          { ...getEntryMatchAnyMock(), field: 'c' },
         ];
         const query = buildExceptionItem({
           language: 'kuery',
           entries,
         });
-        const expectedQuery = 'b:("value-1" or "value-2") and c:("value-1" or "value-2")';
+        const expectedQuery = 'b:("some host name") and c:("some host name")';
 
         expect(query).toEqual(expectedQuery);
       });
@@ -735,16 +689,16 @@ describe('build_exceptions_query', () => {
       const payload = getExceptionListItemSchemaMock();
       const payload2 = getExceptionListItemSchemaMock();
       payload2.entries = [
-        makeMatchAnyEntry({ field: 'b' }),
+        { ...getEntryMatchAnyMock(), field: 'b' },
         {
           field: 'parent',
           type: 'nested',
           entries: [
-            makeMatchEntry({ field: 'c', operator: 'included', value: 'valueC' }),
-            makeMatchEntry({ field: 'd', operator: 'included', value: 'valueD' }),
+            { ...getEntryMatchMock(), field: 'c', operator: 'included', value: 'valueC' },
+            { ...getEntryMatchMock(), field: 'd', operator: 'included', value: 'valueD' },
           ],
         },
-        makeMatchAnyEntry({ field: 'e', operator: 'excluded' }),
+        { ...getEntryMatchAnyMock(), field: 'e', operator: 'excluded' },
       ];
       const queries = buildExceptionListQueries({
         language: 'kuery',
@@ -758,7 +712,7 @@ describe('build_exceptions_query', () => {
         },
         {
           query:
-            'b:("value-1" or "value-2") and parent:{ c:"valueC" and d:"valueD" } and not e:("value-1" or "value-2")',
+            'b:("some host name") and parent:{ c:"valueC" and d:"valueD" } and not e:("some host name")',
           language: 'kuery',
         },
       ];
@@ -768,20 +722,26 @@ describe('build_exceptions_query', () => {
 
     test('it returns expected query when lists exist and language is "lucene"', () => {
       const payload = getExceptionListItemSchemaMock();
-      payload.entries = [makeMatchAnyEntry({ field: 'a' }), makeMatchAnyEntry({ field: 'b' })];
+      payload.entries = [
+        { ...getEntryMatchAnyMock(), field: 'a' },
+        { ...getEntryMatchAnyMock(), field: 'b' },
+      ];
       const payload2 = getExceptionListItemSchemaMock();
-      payload2.entries = [makeMatchAnyEntry({ field: 'c' }), makeMatchAnyEntry({ field: 'd' })];
+      payload2.entries = [
+        { ...getEntryMatchAnyMock(), field: 'c' },
+        { ...getEntryMatchAnyMock(), field: 'd' },
+      ];
       const queries = buildExceptionListQueries({
         language: 'lucene',
         lists: [payload, payload2],
       });
       const expectedQueries = [
         {
-          query: 'a:("value-1" OR "value-2") AND b:("value-1" OR "value-2")',
+          query: 'a:("some host name") AND b:("some host name")',
           language: 'lucene',
         },
         {
-          query: 'c:("value-1" OR "value-2") AND d:("value-1" OR "value-2")',
+          query: 'c:("some host name") AND d:("some host name")',
           language: 'lucene',
         },
       ];
@@ -793,17 +753,17 @@ describe('build_exceptions_query', () => {
       const payload = getExceptionListItemSchemaMock();
       const payload2 = getExceptionListItemSchemaMock();
       payload2.entries = [
-        makeMatchAnyEntry({ field: 'b' }),
+        { ...getEntryMatchAnyMock(), field: 'b' },
         {
           field: 'parent',
           type: 'nested',
           entries: [
             // TODO: these operators are not being respected. buildNested needs to be updated
-            makeMatchEntry({ field: 'c', operator: 'excluded', value: 'valueC' }),
-            makeMatchEntry({ field: 'd', operator: 'excluded', value: 'valueD' }),
+            { ...getEntryMatchMock(), field: 'c', operator: 'excluded', value: 'valueC' },
+            { ...getEntryMatchMock(), field: 'd', operator: 'excluded', value: 'valueD' },
           ],
         },
-        makeMatchAnyEntry({ field: 'e' }),
+        { ...getEntryMatchAnyMock(), field: 'e' },
       ];
       const queries = buildExceptionListQueries({
         language: 'kuery',
@@ -817,7 +777,7 @@ describe('build_exceptions_query', () => {
         },
         {
           query:
-            'b:("value-1" or "value-2") and parent:{ not c:"valueC" and not d:"valueD" } and e:("value-1" or "value-2")',
+            'b:("some host name") and parent:{ not c:"valueC" and not d:"valueD" } and e:("some host name")',
           language: 'kuery',
         },
       ];

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/builder/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/builder/helpers.test.tsx
@@ -225,7 +225,7 @@ describe('Exception builder helpers', () => {
 
   describe('#isEntryNested', () => {
     test('it returns "false" if payload is not of type EntryNested', () => {
-      const payload: BuilderEntry = { ...getEntryMatchMock() };
+      const payload: BuilderEntry = getEntryMatchMock();
       const output = isEntryNested(payload);
       const expected = false;
       expect(output).toEqual(expected);
@@ -242,7 +242,7 @@ describe('Exception builder helpers', () => {
   describe('#getFormattedBuilderEntries', () => {
     test('it returns formatted entry with field undefined if it unable to find a matching index pattern field', () => {
       const payloadIndexPattern: IIndexPattern = getMockIndexPattern();
-      const payloadItems: BuilderEntry[] = [{ ...getEntryMatchMock() }];
+      const payloadItems: BuilderEntry[] = [getEntryMatchMock()];
       const output = getFormattedBuilderEntries(payloadIndexPattern, payloadItems);
       const expected: FormattedBuilderEntry[] = [
         {

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
@@ -365,7 +365,7 @@ describe('Exception helpers', () => {
       const mockEmptyException: EntryNested = {
         field: '',
         type: OperatorTypeEnum.NESTED,
-        entries: [{ ...getEntryMatchMock() }],
+        entries: [getEntryMatchMock()],
       };
       const output: Array<
         ExceptionListItemSchema | CreateExceptionListItemSchema


### PR DESCRIPTION
## Summary

Addresses feedback from https://github.com/elastic/kibana/pull/72748

- Updates `plugins/lists` tests text from `should not validate` to `should FAIL validation` after feedback that previous text is a bit confusing and can be interpreted to mean that validation is not conducted
- Remove unnecessary spreads from one of my late night PRs 🧟‍♀️ 
- Removes `siem_common_deps` in favor of `shared_imports` in `plugins/lists`
- Updates `build_exceptions_query.test.ts` to use existing mocks

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
  - **Non added, just modified text**