### PR TITLE
Move config setting for By Value Embeddables to Dashboard

### DIFF
--- a/src/plugins/dashboard/config.ts
+++ b/src/plugins/dashboard/config.ts
@@ -17,22 +17,10 @@
  * under the License.
  */
 
-import { PluginInitializerContext, PluginConfigDescriptor } from '../../../core/server';
-import { DashboardPlugin } from './plugin';
-import { configSchema, ConfigSchema } from '../config';
+import { schema, TypeOf } from '@kbn/config-schema';
 
-export const config: PluginConfigDescriptor<ConfigSchema> = {
-  exposeToBrowser: {
-    allowByValueEmbeddables: true,
-  },
-  schema: configSchema,
-};
+export const configSchema = schema.object({
+  allowByValueEmbeddables: schema.boolean({ defaultValue: false }),
+});
 
-//  This exports static code and TypeScript types,
-//  as well as, Kibana Platform `plugin()` initializer.
-
-export function plugin(initializerContext: PluginInitializerContext) {
-  return new DashboardPlugin(initializerContext);
-}
-
-export { DashboardPluginSetup, DashboardPluginStart } from './types';
+export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -94,6 +94,10 @@ declare module '../../share/public' {
 
 export type DashboardUrlGenerator = UrlGeneratorContract<typeof DASHBOARD_APP_URL_GENERATOR>;
 
+interface DashboardFeatureFlagConfig {
+  allowByValueEmbeddables: boolean;
+}
+
 interface SetupDependencies {
   data: DataPublicPluginSetup;
   embeddable: EmbeddableSetup;
@@ -125,6 +129,7 @@ export interface DashboardStart {
     embeddableType: string;
   }) => void | undefined;
   dashboardUrlGenerator?: DashboardUrlGenerator;
+  dashboardFeatureFlagConfig: DashboardFeatureFlagConfig;
   DashboardContainerByValueRenderer: ReturnType<typeof createDashboardContainerByValueRenderer>;
 }
 
@@ -411,6 +416,7 @@ export class DashboardPlugin
       getSavedDashboardLoader: () => savedDashboardLoader,
       addEmbeddableToDashboard: this.addEmbeddableToDashboard.bind(this, core),
       dashboardUrlGenerator: this.dashboardUrlGenerator,
+      dashboardFeatureFlagConfig: this.initializerContext.config.get<DashboardFeatureFlagConfig>(),
       DashboardContainerByValueRenderer: createDashboardContainerByValueRenderer({
         factory: dashboardContainerFactory,
       }),


### PR DESCRIPTION
## Summary
This PR moves the configuration item which determines whether or not to show the new flow for lens / visualize embeddable creation onto the dashboard start contract.

This way, all by value PRs, including https://github.com/elastic/kibana/pull/70272, https://github.com/elastic/kibana/pull/72256, and the upcoming PRs for the `add to library`, and `unlink from library` actions can refer to the same configuration setting.

#### Note
This config setting is temporary, and used to hide all 'by value' changes. Once all blockers to the 'by value' system are resolved (https://github.com/elastic/kibana/issues/61663, https://github.com/elastic/kibana/pull/67931, https://github.com/elastic/kibana/issues/71499), this config setting can be removed.

### Checklist

Delete any items that are not applicable to this PR.

~~- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios~~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
