### PR TITLE
[Security Solution][Detections] Fixes risk score mapping bug and updates copy on empty rules message

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/pre_packaged_rules/translations.ts
@@ -17,7 +17,7 @@ export const PRE_BUILT_MSG = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.prePackagedRules.emptyPromptMessage',
   {
     defaultMessage:
-      'Elastic Security comes with prebuilt detection rules that run in the background and create alerts when their conditions are met. By default, all prebuilt rules are disabled and you select which rules you want to activate.',
+      'Elastic Security comes with prebuilt detection rules that run in the background and create alerts when their conditions are met. By default, all prebuilt rules except the Elastic Endpoint Security rule are disabled. You can select additional rules you want to activate.',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/risk_score_mapping/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/risk_score_mapping/index.tsx
@@ -70,7 +70,7 @@ export const RiskScoreField = ({
           {
             field: newField?.name ?? '',
             operator: 'equals',
-            value: undefined,
+            value: '',
             riskScore: undefined,
           },
         ],


### PR DESCRIPTION
## Summary

Fixes issue where Rules with a `Risk Score Mapping` could not be created.

Fixes copy for the Rules Table empty view that says all rules are disabled by default (no longer true for the `Elastic Endpoint Security Rule`)
<p align="center">
  <img width="500" src="https://user-images.githubusercontent.com/2946766/88980405-e2be7180-d280-11ea-976d-6072c415c688.png" />
</p>



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
