### PR TITLE
[Ingest Manager] Fix limited concurrency helper

### DIFF
--- a/x-pack/plugins/ingest_manager/server/routes/limited_concurrency.test.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/limited_concurrency.test.ts
@@ -39,7 +39,7 @@ describe('registerLimitedConcurrencyRoutes', () => {
 });
 
 // assertions for calls to .decrease are commented out because it's called on the
-// "req.events.aborted$ observable (which) will never emit from a mocked request in a jest unit test environment"
+// "req.events.completed$ observable (which) will never emit from a mocked request in a jest unit test environment"
 // https://github.com/elastic/kibana/pull/72338#issuecomment-661908791
 describe('preAuthHandler', () => {
   test(`ignores routes when !isMatch`, async () => {

--- a/x-pack/plugins/ingest_manager/server/routes/limited_concurrency.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/limited_concurrency.ts
@@ -66,9 +66,7 @@ export function createLimitedPreAuthHandler({
 
     maxCounter.increase();
 
-    // requests.events.aborted$ has a bug (but has test which explicitly verifies) where it's fired even when the request completes
-    // https://github.com/elastic/kibana/pull/70495#issuecomment-656288766
-    request.events.aborted$.toPromise().then(() => {
+    request.events.completed$.toPromise().then(() => {
       maxCounter.decrease();
     });
 


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/pull/73898 introduced a `completed$` event that is more relevant than using the `aborted$` one for limiting the concurrency in fleet.

This PR change the event we listen to limit the concurrency

@jfsiii Do you think we should backport this to 7.9? the `aborted$` observable is now working as we expect (completing when a request finish) so the feature is already working