### PR TITLE
[Metrics UI] Fix Metrics Explorer TSVB link to use workaround pattern

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.test.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.test.ts
@@ -157,6 +157,25 @@ describe('createTSVBLink()', () => {
     });
   });
 
+  it('should use the workaround index pattern when there are multiple listed in the source', () => {
+    const customSource = {
+      ...source,
+      metricAlias: 'my-beats-*,metrics-*',
+      fields: { ...source.fields, timestamp: 'time' },
+    };
+    const link = createTSVBLink(customSource, options, series, timeRange, chartOptions);
+    expect(link).toStrictEqual({
+      app: 'visualize',
+      hash: '/create',
+      search: {
+        _a:
+          "(filters:!(),linked:!f,query:(language:kuery,query:''),uiState:(),vis:(aggs:!(),params:(axis_formatter:number,axis_min:0,axis_position:left,axis_scale:normal,default_index_pattern:'metric*',filter:(language:kuery,query:'host.name : \"example-01\"'),id:test-id,index_pattern:'metric*',interval:auto,series:!((axis_position:right,chart_type:line,color:#6092C0,fill:0,formatter:percent,id:test-id,label:'avg(system.cpu.user.pct)',line_width:2,metrics:!((field:system.cpu.user.pct,id:test-id,type:avg)),point_size:0,separate_axis:0,split_mode:everything,stacked:none,value_template:{{value}})),show_grid:1,show_legend:1,time_field:time,type:timeseries),title:example-01,type:metrics))",
+        _g: '(refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))',
+        type: 'metrics',
+      },
+    });
+  });
+
   test('createFilterFromOptions()', () => {
     const customOptions = { ...options, groupBy: 'host.name' };
     const customSeries = { ...series, id: 'test"foo' };

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
@@ -27,6 +27,7 @@ import { LinkDescriptor } from '../../../../../hooks/use_link_props';
  We've recently changed the default index pattern in Metrics UI from `metricbeat-*` to 
  `metrics-*,metricbeat-*`. There is a bug in TSVB when there is an empty index in the pattern
  the field dropdowns are not populated correctly. This index pattern is a temporary fix.
+ See: https://github.com/elastic/kibana/issues/73987 
 */
 const TSVB_WORKAROUND_INDEX_PATTERN = 'metric*';
 

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
@@ -23,6 +23,13 @@ import { SourceQuery } from '../../../../../graphql/types';
 import { createMetricLabel } from './create_metric_label';
 import { LinkDescriptor } from '../../../../../hooks/use_link_props';
 
+/*
+ We've recently changed the default index pattern in Metrics UI from `metricbeat-*` to 
+ `metrics-*,metricbeat-*`. There is a bug in TSVB when there is an empty index in the pattern
+ the field dropdowns are not populated correctly. This index pattern is a temporary fix.
+*/
+const TSVB_WORKAROUND_INDEX_PATTERN = 'metric*';
+
 export const metricsExplorerMetricToTSVBMetric = (metric: MetricsExplorerOptionsMetric) => {
   if (metric.aggregation === 'rate') {
     const metricId = uuid.v1();
@@ -128,6 +135,13 @@ export const createFilterFromOptions = (
   return { language: 'kuery', query: filters.join(' and ') };
 };
 
+const createTSVBIndexPattern = (alias: string) => {
+  if (alias.split(',').length > 1) {
+    return TSVB_WORKAROUND_INDEX_PATTERN;
+  }
+  return alias;
+};
+
 export const createTSVBLink = (
   source: SourceQuery.Query['source']['configuration'] | undefined,
   options: MetricsExplorerOptions,
@@ -135,6 +149,9 @@ export const createTSVBLink = (
   timeRange: MetricsExplorerTimeOptions,
   chartOptions: MetricsExplorerChartOptions
 ): LinkDescriptor => {
+  const tsvbIndexPattern = createTSVBIndexPattern(
+    (source && source.metricAlias) || TSVB_WORKAROUND_INDEX_PATTERN
+  );
   const appState = {
     filters: [],
     linked: false,
@@ -147,8 +164,8 @@ export const createTSVBLink = (
         axis_position: 'left',
         axis_scale: 'normal',
         id: uuid.v1(),
-        default_index_pattern: (source && source.metricAlias) || 'metricbeat-*',
-        index_pattern: (source && source.metricAlias) || 'metricbeat-*',
+        default_index_pattern: tsvbIndexPattern,
+        index_pattern: tsvbIndexPattern,
         interval: 'auto',
         series: options.metrics.map(mapMetricToSeries(chartOptions)),
         show_grid: 1,


### PR DESCRIPTION
## Summary

This PR fixes #72529 by changing the fallback index pattern to `metric*` for any `metricAlias` that has multiple index patterns specified. If, for some reason, the metricAlias field is blank it will also use `metric*`.

### How to test this PR
1. Setup Metricbeat to index data from your local machine OR copy data using [this script.](https://gist.github.com/simianhacker/34dbddcf6e5833d69a92ff759d7d4d1e)
1. Open Metrics Explorer
1. Set the aggregation to `Average` and the metric field to `system.cpu.user.pct`
1. Group by `host.name`
1. On one for the charts, click on the `Action` menu and choose `Open in visualize`
1. The charts should look similar (with data)
1. Confirm that `Index pattern` under `Panel options` is set to `metric*`

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

Related issue in TSVB: https://github.com/elastic/kibana/issues/73987