### PR TITLE
[APM] Fix anomaly detection settings link using the ML capabilities API

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Home/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Home/index.tsx
@@ -84,7 +84,7 @@ interface Props {
 
 export function Home({ tab }: Props) {
   const { config, core } = useApmPluginContext();
-  const isMLEnabled = !!core.application.capabilities.ml;
+  const canAccessML = !!core.application.capabilities.ml?.canAccessML;
   const homeTabs = getHomeTabs(config);
   const selectedTab = homeTabs.find(
     (homeTab) => homeTab.name === tab
@@ -106,7 +106,7 @@ export function Home({ tab }: Props) {
               </EuiButtonEmpty>
             </SettingsLink>
           </EuiFlexItem>
-          {isMLEnabled && (
+          {canAccessML && (
             <EuiFlexItem grow={false}>
               <AnomalyDetectionSetupLink />
             </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/app/Settings/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/index.tsx
@@ -20,7 +20,7 @@ import { useApmPluginContext } from '../../../hooks/useApmPluginContext';
 
 export function Settings(props: { children: ReactNode }) {
   const plugin = useApmPluginContext();
-  const isMLEnabled = !!plugin.core.application.capabilities.ml;
+  const canAccessML = !!plugin.core.application.capabilities.ml?.canAccessML;
   const { search, pathname } = useLocation();
   return (
     <>
@@ -51,7 +51,7 @@ export function Settings(props: { children: ReactNode }) {
                       '/settings/agent-configuration'
                     ),
                   },
-                  ...(isMLEnabled
+                  ...(canAccessML
                     ? [
                         {
                           name: i18n.translate(


### PR DESCRIPTION
Closes #73998 by using `canAccessML` in the ML capabilities API to enable anomaly detection settings in APM.