### PR TITLE
[Monitoring] Different messaging for CPU usage alert on cloud

### DIFF
--- a/x-pack/plugins/monitoring/server/alerts/base_alert.ts
+++ b/x-pack/plugins/monitoring/server/alerts/base_alert.ts
@@ -50,6 +50,7 @@ export class BaseAlert {
   protected getLogger!: (...scopes: string[]) => Logger;
   protected config!: MonitoringConfig;
   protected kibanaUrl!: string;
+  protected isCloud: boolean = false;
   protected defaultParams: CommonAlertParams | {} = {};
   public get paramDetails() {
     return {};
@@ -82,13 +83,15 @@ export class BaseAlert {
     monitoringCluster: ILegacyCustomClusterClient,
     getLogger: (...scopes: string[]) => Logger,
     config: MonitoringConfig,
-    kibanaUrl: string
+    kibanaUrl: string,
+    isCloud: boolean
   ) {
     this.getUiSettingsService = getUiSettingsService;
     this.monitoringCluster = monitoringCluster;
     this.config = config;
     this.kibanaUrl = kibanaUrl;
     this.getLogger = getLogger;
+    this.isCloud = isCloud;
   }
 
   public getAlertType(): AlertType {

--- a/x-pack/plugins/monitoring/server/alerts/cluster_health_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/cluster_health_alert.test.ts
@@ -112,7 +112,8 @@ describe('ClusterHealthAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -175,7 +176,8 @@ describe('ClusterHealthAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -223,7 +225,8 @@ describe('ClusterHealthAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/alerts/cpu_usage_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/cpu_usage_alert.test.ts
@@ -116,7 +116,8 @@ describe('CpuUsageAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -214,7 +215,8 @@ describe('CpuUsageAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -286,7 +288,8 @@ describe('CpuUsageAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -352,7 +355,8 @@ describe('CpuUsageAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -436,7 +440,8 @@ describe('CpuUsageAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/alerts/cpu_usage_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/cpu_usage_alert.test.ts
@@ -564,5 +564,34 @@ describe('CpuUsageAlert', () => {
         },
       ]);
     });
+
+    it('should fire with different messaging for cloud', async () => {
+      const alert = new CpuUsageAlert();
+      alert.initializeAlertType(
+        getUiSettingsService as any,
+        monitoringCluster as any,
+        getLogger as any,
+        config as any,
+        kibanaUrl,
+        true
+      );
+      const type = alert.getAlertType();
+      await type.executor({
+        ...executorOptions,
+        // @ts-ignore
+        params: alert.defaultParams,
+      } as any);
+      const count = 1;
+      expect(scheduleActions).toHaveBeenCalledWith('default', {
+        internalFullMessage: `CPU usage alert is firing for ${count} node(s) in cluster: ${clusterName}. Verify CPU levels across affected nodes.`,
+        internalShortMessage: `CPU usage alert is firing for ${count} node(s) in cluster: ${clusterName}. Verify CPU levels across affected nodes.`,
+        action: `[View nodes](http://localhost:5601/app/monitoring#elasticsearch/nodes?_g=(cluster_uuid:${clusterUuid}))`,
+        actionPlain: 'Verify CPU levels across affected nodes.',
+        clusterName,
+        count,
+        nodes: `${nodeName}:${cpuUsage.toFixed(2)}`,
+        state: 'firing',
+      });
+    });
   });
 });

--- a/x-pack/plugins/monitoring/server/alerts/cpu_usage_alert.ts
+++ b/x-pack/plugins/monitoring/server/alerts/cpu_usage_alert.ts
@@ -322,29 +322,31 @@ export class CpuUsageAlert extends BaseAlert {
         ','
       )})`;
       const action = `[${fullActionText}](${url})`;
+      const internalShortMessage = i18n.translate(
+        'xpack.monitoring.alerts.cpuUsage.firing.internalShortMessage',
+        {
+          defaultMessage: `CPU usage alert is firing for {count} node(s) in cluster: {clusterName}. {shortActionText}`,
+          values: {
+            count: firingCount,
+            clusterName: cluster.clusterName,
+            shortActionText,
+          },
+        }
+      );
+      const internalFullMessage = i18n.translate(
+        'xpack.monitoring.alerts.cpuUsage.firing.internalFullMessage',
+        {
+          defaultMessage: `CPU usage alert is firing for {count} node(s) in cluster: {clusterName}. {action}`,
+          values: {
+            count: firingCount,
+            clusterName: cluster.clusterName,
+            action,
+          },
+        }
+      );
       instance.scheduleActions('default', {
-        internalShortMessage: i18n.translate(
-          'xpack.monitoring.alerts.cpuUsage.firing.internalShortMessage',
-          {
-            defaultMessage: `CPU usage alert is firing for {count} node(s) in cluster: {clusterName}. {shortActionText}`,
-            values: {
-              count: firingCount,
-              clusterName: cluster.clusterName,
-              shortActionText,
-            },
-          }
-        ),
-        internalFullMessage: i18n.translate(
-          'xpack.monitoring.alerts.cpuUsage.firing.internalFullMessage',
-          {
-            defaultMessage: `CPU usage alert is firing for {count} node(s) in cluster: {clusterName}. {action}`,
-            values: {
-              count: firingCount,
-              clusterName: cluster.clusterName,
-              action,
-            },
-          }
-        ),
+        internalShortMessage,
+        internalFullMessage: this.isCloud ? internalShortMessage : internalFullMessage,
         state: FIRING,
         nodes: firingNodes,
         count: firingCount,

--- a/x-pack/plugins/monitoring/server/alerts/elasticsearch_version_mismatch_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/elasticsearch_version_mismatch_alert.test.ts
@@ -115,7 +115,8 @@ describe('ElasticsearchVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -166,7 +167,8 @@ describe('ElasticsearchVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -214,7 +216,8 @@ describe('ElasticsearchVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/alerts/kibana_version_mismatch_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/kibana_version_mismatch_alert.test.ts
@@ -118,7 +118,8 @@ describe('KibanaVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -168,7 +169,8 @@ describe('KibanaVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -216,7 +218,8 @@ describe('KibanaVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/alerts/license_expiration_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/license_expiration_alert.test.ts
@@ -122,7 +122,8 @@ describe('LicenseExpirationAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -195,7 +196,8 @@ describe('LicenseExpirationAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -243,7 +245,8 @@ describe('LicenseExpirationAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/alerts/logstash_version_mismatch_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/logstash_version_mismatch_alert.test.ts
@@ -115,7 +115,8 @@ describe('LogstashVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -165,7 +166,8 @@ describe('LogstashVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -213,7 +215,8 @@ describe('LogstashVersionMismatchAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/alerts/nodes_changed_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/nodes_changed_alert.test.ts
@@ -128,7 +128,8 @@ describe('NodesChangedAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({
@@ -180,7 +181,8 @@ describe('NodesChangedAlert', () => {
         monitoringCluster as any,
         getLogger as any,
         config as any,
-        kibanaUrl
+        kibanaUrl,
+        false
       );
       const type = alert.getAlertType();
       await type.executor({

--- a/x-pack/plugins/monitoring/server/plugin.ts
+++ b/x-pack/plugins/monitoring/server/plugin.ts
@@ -126,10 +126,17 @@ export class Plugin {
       const coreStart = (await core.getStartServices())[0];
       return coreStart.uiSettings;
     };
-
+    const isCloud = Boolean(plugins.cloud?.isCloudEnabled);
     const alerts = AlertsFactory.getAll();
     for (const alert of alerts) {
-      alert.initializeAlertType(getUiSettingsService, cluster, this.getLogger, config, kibanaUrl);
+      alert.initializeAlertType(
+        getUiSettingsService,
+        cluster,
+        this.getLogger,
+        config,
+        kibanaUrl,
+        isCloud
+      );
       plugins.alerts.registerType(alert.getAlertType());
     }
 

--- a/x-pack/plugins/monitoring/server/types.ts
+++ b/x-pack/plugins/monitoring/server/types.ts
@@ -44,6 +44,7 @@ export interface PluginsSetup {
   features: FeaturesPluginSetupContract;
   alerts: AlertingPluginSetupContract;
   infra: InfraPluginSetup;
+  cloud: CloudSetup;
 }
 
 export interface PluginsStart {

--- a/x-pack/plugins/monitoring/server/types.ts
+++ b/x-pack/plugins/monitoring/server/types.ts
@@ -17,6 +17,7 @@ import { InfraPluginSetup } from '../../infra/server';
 import { LicensingPluginSetup } from '../../licensing/server';
 import { PluginSetupContract as FeaturesPluginSetupContract } from '../../features/server';
 import { EncryptedSavedObjectsPluginSetup } from '../../encrypted_saved_objects/server';
+import { CloudSetup } from '../../cloud/server';
 
 export interface MonitoringLicenseService {
   refresh: () => Promise<any>;


### PR DESCRIPTION
Fixes #73316

Until we can figure out the right way to get the cloud url right, we should omit it.

This PR makes it so the link back doesn't appear in the full message on cloud

## Testing

- Visit the stack monitoring UI and enter setup mode
- Change the threshold for the CPU usage alert to something like `-1` to ensure it will fire
- Also, change the default throttle period down to like `30s`
- Configure an email action and use the default messaging provided (the subject doesn't matter, but you can use `{{context.internalShortMessage}}`)
- If you are not actually testing on cloud, fake it here: https://github.com/elastic/kibana/compare/master...chrisronline:monitoring/cloud_message?expand=1#diff-eef915a6b8dba3b904a62609b073163aR129