### PR TITLE
[Security Solutions][Case] Fix quote handling

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/components/add_comment/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/add_comment/index.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { AddComment } from '.';
+import { AddComment, AddCommentRefObject } from '.';
 import { TestProviders } from '../../../common/mock';
 import { getFormMock } from '../__mock__/form';
 import { Router, routeData, mockHistory, mockLocation } from '../__mock__/router';
@@ -60,9 +60,11 @@ const defaultPostCommment = {
   isError: false,
   postComment,
 };
+
 const sampleData = {
   comment: 'what a cool comment',
 };
+
 describe('AddComment ', () => {
   const formHookMock = getFormMock(sampleData);
 
@@ -122,16 +124,18 @@ describe('AddComment ', () => {
     ).toBeTruthy();
   });
 
-  it('should insert a quote if one is available', () => {
+  it('should insert a quote', () => {
     const sampleQuote = 'what a cool quote';
+    const ref = React.createRef<AddCommentRefObject>();
     mount(
       <TestProviders>
         <Router history={mockHistory}>
-          <AddComment {...{ ...addCommentProps, insertQuote: sampleQuote }} />
+          <AddComment {...{ ...addCommentProps }} ref={ref} />
         </Router>
       </TestProviders>
     );
 
+    ref.current!.addQuote(sampleQuote);
     expect(formHookMock.setFieldValue).toBeCalledWith(
       'comment',
       `${sampleData.comment}\n\n${sampleQuote}`

--- a/x-pack/plugins/security_solution/public/cases/components/user_action_tree/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/user_action_tree/index.tsx
@@ -14,7 +14,7 @@ import * as i18n from '../case_view/translations';
 import { Case, CaseUserActions } from '../../containers/types';
 import { useUpdateComment } from '../../containers/use_update_comment';
 import { useCurrentUser } from '../../../common/lib/kibana';
-import { AddComment } from '../add_comment';
+import { AddComment, AddCommentRefObject } from '../add_comment';
 import { getLabelTitle } from './helpers';
 import { UserActionItem } from './user_action_item';
 import { UserActionMarkdown } from './user_action_markdown';
@@ -58,12 +58,12 @@ export const UserActionTree = React.memo(
   }: UserActionTreeProps) => {
     const { commentId } = useParams();
     const handlerTimeoutId = useRef(0);
+    const addCommentRef = useRef<AddCommentRefObject>(null);
     const [initLoading, setInitLoading] = useState(true);
     const [selectedOutlineCommentId, setSelectedOutlineCommentId] = useState('');
     const { isLoadingIds, patchComment } = useUpdateComment();
     const currentUser = useCurrentUser();
     const [manageMarkdownEditIds, setManangeMardownEditIds] = useState<string[]>([]);
-    const [insertQuote, setInsertQuote] = useState<string | null>(null);
     const handleManageMarkdownEditId = useCallback(
       (id: string) => {
         if (!manageMarkdownEditIds.includes(id)) {
@@ -111,14 +111,17 @@ export const UserActionTree = React.memo(
           window.clearTimeout(handlerTimeoutId.current);
         }, 2400);
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [handlerTimeoutId.current]
+      [handlerTimeoutId]
     );
 
     const handleManageQuote = useCallback(
       (quote: string) => {
         const addCarrots = quote.replace(new RegExp('\r?\n', 'g'), '  \n> ');
-        setInsertQuote(`> ${addCarrots} \n`);
+
+        if (addCommentRef && addCommentRef.current) {
+          addCommentRef.current.addQuote(`> ${addCarrots} \n`);
+        }
+
         handleOutlineComment('add-comment');
       },
       [handleOutlineComment]
@@ -152,14 +155,13 @@ export const UserActionTree = React.memo(
         <AddComment
           caseId={caseData.id}
           disabled={!userCanCrud}
-          insertQuote={insertQuote}
+          ref={addCommentRef}
           onCommentPosted={handleUpdate}
           onCommentSaving={handleManageMarkdownEditId.bind(null, NEW_ID)}
           showLoading={false}
         />
       ),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [caseData.id, handleUpdate, insertQuote, userCanCrud]
+      [caseData.id, handleUpdate, userCanCrud, handleManageMarkdownEditId]
     );
 
     useEffect(() => {
@@ -169,8 +171,7 @@ export const UserActionTree = React.memo(
           handleOutlineComment(commentId);
         }
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [commentId, initLoading, isLoadingUserActions, isLoadingIds]);
+    }, [commentId, initLoading, isLoadingUserActions, isLoadingIds, handleOutlineComment]);
     return (
       <>
         <UserActionItem


### PR DESCRIPTION
## Summary

Quotes are not being handled properly. When you press the quote button, delete the text, and press again the quote button the quote is not being added to the new comment text area. Also, on 7.9 branch when you press the quote button the text is being added twice and you cannot delete it. This PR addresses both bugs and improves the handling of the quotes. 

Test on master:

1. Create a case.
2. Press the ellipses button on the description and press Quote.
3. Delete the text on the new comment text area.
4. Press again the ellipses button on the description and press Quote.

Expected behavior:

The quote should be added properly.

Test on 7.9:

1. Create a case.
2. Press the ellipses button on the description and press Quote.
3. Delete the text on the new comment text area.

Expected behavior:

The quote should be added once and be able to be deleted. The master's test should be working at 7.9.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
