### PR TITLE
[Security Solution] Fix legend's color

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/charts/barchart.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/barchart.test.tsx
@@ -356,6 +356,71 @@ describe.each(chartDataSets)('BarChart with stackByField', () => {
   });
 });
 
+describe.each(chartDataSets)('BarChart with custom color', () => {
+  let wrapper: ReactWrapper;
+
+  const data = [
+    {
+      key: 'python.exe',
+      value: [
+        {
+          x: 1586754900000,
+          y: 9675,
+          g: 'python.exe',
+        },
+      ],
+      color: '#1EA591',
+    },
+    {
+      key: 'kernel',
+      value: [
+        {
+          x: 1586754900000,
+          y: 8708,
+          g: 'kernel',
+        },
+        {
+          x: 1586757600000,
+          y: 9282,
+          g: 'kernel',
+        },
+      ],
+      color: '#000000',
+    },
+    {
+      key: 'sshd',
+      value: [
+        {
+          x: 1586754900000,
+          y: 5907,
+          g: 'sshd',
+        },
+      ],
+      color: '#ffffff',
+    },
+  ];
+
+  const expectedColors = ['#1EA591', '#000000', '#ffffff'];
+
+  const stackByField = 'process.name';
+
+  beforeAll(() => {
+    wrapper = mount(
+      <ThemeProvider theme={theme}>
+        <TestProviders>
+          <BarChartComponent configs={mockConfig} barChart={data} stackByField={stackByField} />
+        </TestProviders>
+      </ThemeProvider>
+    );
+  });
+
+  expectedColors.forEach((color, i) => {
+    test(`it renders the expected legend color ${color} for legend item ${i}`, () => {
+      expect(wrapper.find(`div [color="${color}"]`).exists()).toBe(true);
+    });
+  });
+});
+
 describe.each(chartHolderDataSets)('BarChart with invalid data [%o]', (data) => {
   let shallowWrapper: ShallowWrapper;
 

--- a/x-pack/plugins/security_solution/public/common/components/charts/barchart.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/charts/barchart.tsx
@@ -133,7 +133,7 @@ export const BarChartComponent: React.FC<BarChartComponentProps> = ({
     () =>
       barChart != null && stackByField != null
         ? barChart.map((d, i) => ({
-            color: d.color ?? i < defaultLegendColors.length ? defaultLegendColors[i] : undefined,
+            color: d.color ?? (i < defaultLegendColors.length ? defaultLegendColors[i] : undefined),
             dataProviderId: escapeDataProviderId(
               `draggable-legend-item-${uuid.v4()}-${stackByField}-${d.key}`
             ),


### PR DESCRIPTION
## Summary

This PR is to fix
https://github.com/elastic/siem-team/issues/825

<img width="2005" alt="Screenshot 2020-08-03 at 17 00 49" src="https://user-images.githubusercontent.com/6295984/89202473-e9175b00-d5aa-11ea-9ace-e9ccd11d9650.png">

How to verify this PR:

1. Navigate to Security > Hosts
2. Click on Authentications
3. The colors in the histogram match with the legend
4. Switch freely on pages that contains a chart and see if it renders correctly

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] ~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
