### PR TITLE
Change / to \ for Windows Enrollment command in Fleet

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/components/enrollment_instructions/manual/index.tsx
@@ -36,7 +36,7 @@ export const ManualInstructions: React.FunctionComponent<Props> = ({
 systemctl enable elastic-agent
 systemctl start elastic-agent`;
 
-  const windowsCommand = `./elastic-agent enroll ${enrollArgs}
+  const windowsCommand = `.\elastic-agent enroll ${enrollArgs}
 ./install-service-elastic-agent.ps1`;
 
   return (


### PR DESCRIPTION
## Summary
Follow up to https://github.com/elastic/kibana/issues/73932
 ...about the Enrollment Flyout text for windows section.  

This pr changes the enrollment command / to a \ to be more appropriate (tho it works with the / slash because Windows powershell app is savvy). 

So its purely cosmetic, but many folks have noted and asked about it (not aware that it would work in this 'incorrect' citation for windows - it will be a nice peace-of-mind fix for users who know Windows well.