### PR TITLE
[SIEM][Exceptions] Updates file picker label

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
@@ -13,7 +13,7 @@ export const MODAL_TITLE = i18n.translate('xpack.securitySolution.lists.uploadVa
 export const FILE_PICKER_LABEL = i18n.translate(
   'xpack.securitySolution.lists.uploadValueListDescription',
   {
-    defaultMessage: 'Upload single value lists to use while writing rules or rule exceptions.',
+    defaultMessage: 'Upload single value lists to use while writing rule exceptions.',
   }
 );
 


### PR DESCRIPTION
## Summary

Updates file picker label following @MikePaquette observation tickets.

Before:

![image](https://user-images.githubusercontent.com/17427073/89213565-9008f080-d5c5-11ea-8c6f-8e1e639c12f6.png)

After:

<img width="804" alt="Screenshot 2020-08-03 at 19 52 20" src="https://user-images.githubusercontent.com/17427073/89213658-b595fa00-d5c5-11ea-96f0-3a12fa8b4be1.png">


