### PR TITLE
[7.9] Fix API Keys functional test in cloud (#74075)

### DIFF
--- a/x-pack/test/functional/apps/api_keys/home_page.ts
+++ b/x-pack/test/functional/apps/api_keys/home_page.ts
@@ -11,6 +11,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['common', 'apiKeys']);
   const log = getService('log');
   const security = getService('security');
+  const testSubjects = getService('testSubjects');
 
   describe('Home page', function () {
     before(async () => {
@@ -32,10 +33,16 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     it('Loads the app', async () => {
       await security.testUser.setRoles(['test_api_keys']);
       log.debug('Checking for section header');
-      const headerText = await pageObjects.apiKeys.noAPIKeysHeading();
-      expect(headerText).to.be('No API keys');
-      const goToConsoleButton = await pageObjects.apiKeys.getGoToConsoleButton();
-      expect(await goToConsoleButton.isDisplayed()).to.be(true);
+      const headers = await testSubjects.findAll('noApiKeysHeader');
+      if (headers.length > 0) {
+        expect(await headers[0].getVisibleText()).to.be('No API keys');
+        const goToConsoleButton = await pageObjects.apiKeys.getGoToConsoleButton();
+        expect(await goToConsoleButton.isDisplayed()).to.be(true);
+      } else {
+        // page may already contain EiTable with data, then check API Key Admin text
+        const description = await pageObjects.apiKeys.getApiKeyAdminDesc();
+        expect(description).to.be('You are an API Key administrator.');
+      }
     });
   });
 };

--- a/x-pack/test/functional/page_objects/api_keys_page.ts
+++ b/x-pack/test/functional/page_objects/api_keys_page.ts
@@ -14,6 +14,10 @@ export function ApiKeysPageProvider({ getService }: FtrProviderContext) {
       return await testSubjects.getVisibleText('noApiKeysHeader');
     },
 
+    async getApiKeyAdminDesc() {
+      return await testSubjects.getVisibleText('apiKeyAdminDescriptionCallOut');
+    },
+
     async getGoToConsoleButton() {
       return await testSubjects.find('goToConsoleButton');
     },


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Fix API Keys functional test in cloud (#74075)