### PR TITLE
[Security Solution][Detections] Do not display our app URL field on read-only view

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/description_step/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/description_step/index.tsx
@@ -213,6 +213,8 @@ export const getDescriptionItem = (
   } else if (field === 'ruleType') {
     const ruleType: RuleType = get(field, data);
     return buildRuleTypeDescription(label, ruleType);
+  } else if (field === 'kibanaSiemAppUrl') {
+    return [];
   }
 
   const description: string = get(field, data);


### PR DESCRIPTION
## Summary
This is a "hidden" field added as metadata during rule creation. It is omitted from all other views, but in the case of an error response during rule creation, the read-only view will display this field.

In lieu of any broad changes here (coming in 7.10), this hides that field from the read-only view of that data.

UI issue before this fix:
![](https://user-images.githubusercontent.com/22619280/89175664-31585e00-d556-11ea-89b5-2a4cfc6ba3e8.png)

#### Steps to reproduce (locally):

1. Modify the backend to return an error during rule creation:
      ```diff
      diff --git a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
      index 482edb9925..4f6bf2e0a9 100644
      --- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
      +++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/create_rules_route.ts
      @@ -194,8 +194,8 @@ export const createRulesRoute = (router: IRouter, ml: SetupPlugins['ml']): void
                 ruleActions,
                 ruleStatuses.saved_objects[0]
               );
      -        if (errors != null) {
      -          return siemResponse.error({ statusCode: 500, body: errors });
      +        if (errors == null) {
      +          return siemResponse.error({ statusCode: 500, body: ['foo'] });
               } else {
                 return response.ok({ body: validated ?? {} });
               }
      
      ```
2. Navigate and fill the Rule Creation form and click "Create" (you do not need to add actions or any specific fields)
3. Observe the failed submission and error toaster, and click "edit" on a previous step of the form
4. Observe the app URL being displayed in the "Rule actions" section


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
