### PR TITLE
[Security Solution] Keep original note creator

### DIFF
--- a/x-pack/plugins/security_solution/public/graphql/introspection.json
+++ b/x-pack/plugins/security_solution/public/graphql/introspection.json
@@ -13142,24 +13142,6 @@
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "TemplateTimelineType",
-        "description": "",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "elastic",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          { "name": "custom", "description": "", "isDeprecated": false, "deprecationReason": null }
-        ],
-        "possibleTypes": null
       }
     ],
     "directives": [

--- a/x-pack/plugins/security_solution/public/graphql/types.ts
+++ b/x-pack/plugins/security_solution/public/graphql/types.ts
@@ -423,11 +423,6 @@ export enum FlowDirection {
   biDirectional = 'biDirectional',
 }
 
-export enum TemplateTimelineType {
-  elastic = 'elastic',
-  custom = 'custom',
-}
-
 export type ToStringArrayNoNullable = any;
 
 export type ToIFieldSubTypeNonNullable = any;

--- a/x-pack/plugins/security_solution/server/graphql/note/resolvers.ts
+++ b/x-pack/plugins/security_solution/server/graphql/note/resolvers.ts
@@ -81,10 +81,16 @@ export const createNoteResolvers = (
       return true;
     },
     async persistNote(root, args, { req }) {
-      return libs.note.persistNote(req, args.noteId || null, args.version || null, {
-        ...args.note,
-        timelineId: args.note.timelineId || null,
-      });
+      return libs.note.persistNote(
+        req,
+        args.noteId || null,
+        args.version || null,
+        {
+          ...args.note,
+          timelineId: args.note.timelineId || null,
+        },
+        true
+      );
     },
   },
 });

--- a/x-pack/plugins/security_solution/server/graphql/types.ts
+++ b/x-pack/plugins/security_solution/server/graphql/types.ts
@@ -425,11 +425,6 @@ export enum FlowDirection {
   biDirectional = 'biDirectional',
 }
 
-export enum TemplateTimelineType {
-  elastic = 'elastic',
-  custom = 'custom',
-}
-
 export type ToStringArrayNoNullable = any;
 
 export type ToIFieldSubTypeNonNullable = any;

--- a/x-pack/plugins/security_solution/server/lib/note/saved_object.ts
+++ b/x-pack/plugins/security_solution/server/lib/note/saved_object.ts
@@ -136,7 +136,8 @@ export const persistNote = async (
   request: FrameworkRequest,
   noteId: string | null,
   version: string | null,
-  note: SavedNote
+  note: SavedNote,
+  overideNote: boolean = true
 ): Promise<ResponseNote> => {
   try {
     const savedObjectsClient = request.context.core.savedObjects.client;
@@ -163,14 +164,14 @@ export const persistNote = async (
         note: convertSavedObjectToSavedNote(
           await savedObjectsClient.create(
             noteSavedObjectType,
-            pickSavedNote(noteId, note, request.user)
+            overideNote ? pickSavedNote(noteId, note, request.user) : note
           ),
           timelineVersionSavedObject != null ? timelineVersionSavedObject : undefined
         ),
       };
     }
 
-    // Update new note
+    // Update existing note
 
     const existingNote = await getSavedNote(request, noteId);
     return {
@@ -180,7 +181,7 @@ export const persistNote = async (
         await savedObjectsClient.update(
           noteSavedObjectType,
           noteId,
-          pickSavedNote(noteId, note, request.user),
+          overideNote ? pickSavedNote(noteId, note, request.user) : note,
           {
             version: existingNote.version || undefined,
           }

--- a/x-pack/plugins/security_solution/server/lib/note/saved_object.ts
+++ b/x-pack/plugins/security_solution/server/lib/note/saved_object.ts
@@ -50,7 +50,7 @@ export interface Note {
     noteId: string | null,
     version: string | null,
     note: SavedNote,
-    overideOwner: boolean
+    overrideOwner: boolean
   ) => Promise<ResponseNote>;
   convertSavedObjectToSavedNote: (
     savedObject: unknown,
@@ -138,7 +138,7 @@ export const persistNote = async (
   noteId: string | null,
   version: string | null,
   note: SavedNote,
-  overideOwner: boolean = true
+  overrideOwner: boolean = true
 ): Promise<ResponseNote> => {
   try {
     const savedObjectsClient = request.context.core.savedObjects.client;
@@ -165,7 +165,7 @@ export const persistNote = async (
         note: convertSavedObjectToSavedNote(
           await savedObjectsClient.create(
             noteSavedObjectType,
-            overideOwner ? pickSavedNote(noteId, note, request.user) : note
+            overrideOwner ? pickSavedNote(noteId, note, request.user) : note
           ),
           timelineVersionSavedObject != null ? timelineVersionSavedObject : undefined
         ),
@@ -182,7 +182,7 @@ export const persistNote = async (
         await savedObjectsClient.update(
           noteSavedObjectType,
           noteId,
-          overideOwner ? pickSavedNote(noteId, note, request.user) : note,
+          overrideOwner ? pickSavedNote(noteId, note, request.user) : note,
           {
             version: existingNote.version || undefined,
           }

--- a/x-pack/plugins/security_solution/server/lib/note/saved_object.ts
+++ b/x-pack/plugins/security_solution/server/lib/note/saved_object.ts
@@ -49,7 +49,8 @@ export interface Note {
     request: FrameworkRequest,
     noteId: string | null,
     version: string | null,
-    note: SavedNote
+    note: SavedNote,
+    overideOwner: boolean
   ) => Promise<ResponseNote>;
   convertSavedObjectToSavedNote: (
     savedObject: unknown,
@@ -137,7 +138,7 @@ export const persistNote = async (
   noteId: string | null,
   version: string | null,
   note: SavedNote,
-  overideNote: boolean = true
+  overideOwner: boolean = true
 ): Promise<ResponseNote> => {
   try {
     const savedObjectsClient = request.context.core.savedObjects.client;
@@ -164,7 +165,7 @@ export const persistNote = async (
         note: convertSavedObjectToSavedNote(
           await savedObjectsClient.create(
             noteSavedObjectType,
-            overideNote ? pickSavedNote(noteId, note, request.user) : note
+            overideOwner ? pickSavedNote(noteId, note, request.user) : note
           ),
           timelineVersionSavedObject != null ? timelineVersionSavedObject : undefined
         ),
@@ -181,7 +182,7 @@ export const persistNote = async (
         await savedObjectsClient.update(
           noteSavedObjectType,
           noteId,
-          overideNote ? pickSavedNote(noteId, note, request.user) : note,
+          overideOwner ? pickSavedNote(noteId, note, request.user) : note,
           {
             version: existingNote.version || undefined,
           }

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/create_timelines_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/create_timelines_route.ts
@@ -20,6 +20,7 @@ import {
   TimelineStatusActions,
 } from './utils/common';
 import { createTimelines } from './utils/create_timelines';
+import { DEFAULT_ERROR } from './utils/failure_cases';
 
 export const createTimelinesRoute = (
   router: IRouter,
@@ -85,7 +86,7 @@ export const createTimelinesRoute = (
           return siemResponse.error(
             compareTimelinesStatus.checkIsFailureCases(TimelineStatusActions.create) || {
               statusCode: 405,
-              body: 'update timeline error',
+              body: DEFAULT_ERROR,
             }
           );
         }

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/import_timelines_route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/import_timelines_route.test.ts
@@ -243,16 +243,28 @@ describe('import timelines', () => {
       expect(mockPersistNote.mock.calls[0][3]).toEqual({
         eventId: undefined,
         note: mockUniqueParsedObjects[0].globalNotes[0].note,
+        created: mockUniqueParsedObjects[0].globalNotes[0].created,
+        createdBy: mockUniqueParsedObjects[0].globalNotes[0].createdBy,
+        updated: mockUniqueParsedObjects[0].globalNotes[0].updated,
+        updatedBy: mockUniqueParsedObjects[0].globalNotes[0].updatedBy,
         timelineId: mockCreatedTimeline.savedObjectId,
       });
       expect(mockPersistNote.mock.calls[1][3]).toEqual({
         eventId: mockUniqueParsedObjects[0].eventNotes[0].eventId,
         note: mockUniqueParsedObjects[0].eventNotes[0].note,
+        created: mockUniqueParsedObjects[0].eventNotes[0].created,
+        createdBy: mockUniqueParsedObjects[0].eventNotes[0].createdBy,
+        updated: mockUniqueParsedObjects[0].eventNotes[0].updated,
+        updatedBy: mockUniqueParsedObjects[0].eventNotes[0].updatedBy,
         timelineId: mockCreatedTimeline.savedObjectId,
       });
       expect(mockPersistNote.mock.calls[2][3]).toEqual({
         eventId: mockUniqueParsedObjects[0].eventNotes[1].eventId,
         note: mockUniqueParsedObjects[0].eventNotes[1].note,
+        created: mockUniqueParsedObjects[0].eventNotes[1].created,
+        createdBy: mockUniqueParsedObjects[0].eventNotes[1].createdBy,
+        updated: mockUniqueParsedObjects[0].eventNotes[1].updated,
+        updatedBy: mockUniqueParsedObjects[0].eventNotes[1].updatedBy,
         timelineId: mockCreatedTimeline.savedObjectId,
       });
     });
@@ -573,6 +585,10 @@ describe('import timeline templates', () => {
       expect(mockPersistNote.mock.calls[0][3]).toEqual({
         eventId: undefined,
         note: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].note,
+        created: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].created,
+        createdBy: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].createdBy,
+        updated: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].updated,
+        updatedBy: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].updatedBy,
         timelineId: mockCreatedTemplateTimeline.savedObjectId,
       });
     });
@@ -721,6 +737,10 @@ describe('import timeline templates', () => {
       expect(mockPersistNote.mock.calls[0][3]).toEqual({
         eventId: undefined,
         note: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].note,
+        created: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].created,
+        createdBy: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].createdBy,
+        updated: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].updated,
+        updatedBy: mockUniqueParsedTemplateTimelineObjects[0].globalNotes[0].updatedBy,
         timelineId: mockCreatedTemplateTimeline.savedObjectId,
       });
     });

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/import_timelines_route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/import_timelines_route.test.ts
@@ -46,6 +46,7 @@ describe('import timelines', () => {
   let mockPersistTimeline: jest.Mock;
   let mockPersistPinnedEventOnTimeline: jest.Mock;
   let mockPersistNote: jest.Mock;
+  let mockGetNote: jest.Mock;
   let mockGetTupleDuplicateErrorsAndUniqueTimeline: jest.Mock;
 
   beforeEach(() => {
@@ -69,6 +70,7 @@ describe('import timelines', () => {
     mockPersistTimeline = jest.fn();
     mockPersistPinnedEventOnTimeline = jest.fn();
     mockPersistNote = jest.fn();
+    mockGetNote = jest.fn();
     mockGetTupleDuplicateErrorsAndUniqueTimeline = jest.fn();
 
     jest.doMock('../create_timelines_stream_from_ndjson', () => {
@@ -113,6 +115,37 @@ describe('import timelines', () => {
       jest.doMock('../../note/saved_object', () => {
         return {
           persistNote: mockPersistNote,
+          getNote: mockGetNote
+            .mockResolvedValueOnce({
+              noteId: 'd2649d40-6bc5-11ea-86f0-5db0048c6086',
+              version: 'WzExNjQsMV0=',
+              eventId: undefined,
+              note: 'original note',
+              created: '1584830796960',
+              createdBy: 'original author A',
+              updated: '1584830796960',
+              updatedBy: 'original author A',
+            })
+            .mockResolvedValueOnce({
+              noteId: '73ac2370-6bc2-11ea-a90b-f5341fb7a189',
+              version: 'WzExMjgsMV0=',
+              eventId: 'ZaAi8nAB5OldxqFfdhke',
+              note: 'original event note',
+              created: '1584830796960',
+              createdBy: 'original author B',
+              updated: '1584830796960',
+              updatedBy: 'original author B',
+            })
+            .mockResolvedValue({
+              noteId: 'f7b71620-6bc2-11ea-a0b6-33c7b2a78885',
+              version: 'WzExMzUsMV0=',
+              eventId: 'ZaAi8nAB5OldxqFfdhke',
+              note: 'event note2',
+              created: '1584830796960',
+              createdBy: 'angela',
+              updated: '1584830796960',
+              updatedBy: 'angela',
+            }),
         };
       });
 
@@ -213,6 +246,14 @@ describe('import timelines', () => {
       );
     });
 
+    test('should Check if note exists', async () => {
+      const mockRequest = getImportTimelinesRequest();
+      await server.inject(mockRequest, context);
+      expect(mockGetNote.mock.calls[0][1]).toEqual(
+        mockUniqueParsedObjects[0].globalNotes[0].noteId
+      );
+    });
+
     test('should Create notes', async () => {
       const mockRequest = getImportTimelinesRequest();
       await server.inject(mockRequest, context);
@@ -237,34 +278,69 @@ describe('import timelines', () => {
       expect(mockPersistNote.mock.calls[0][2]).toEqual(mockCreatedTimeline.version);
     });
 
-    test('should provide new notes when Creating notes for a timeline', async () => {
+    test('should provide new notes with original author info when Creating notes for a timeline', async () => {
       const mockRequest = getImportTimelinesRequest();
       await server.inject(mockRequest, context);
       expect(mockPersistNote.mock.calls[0][3]).toEqual({
         eventId: undefined,
-        note: mockUniqueParsedObjects[0].globalNotes[0].note,
-        created: mockUniqueParsedObjects[0].globalNotes[0].created,
-        createdBy: mockUniqueParsedObjects[0].globalNotes[0].createdBy,
-        updated: mockUniqueParsedObjects[0].globalNotes[0].updated,
-        updatedBy: mockUniqueParsedObjects[0].globalNotes[0].updatedBy,
+        note: 'original note',
+        created: '1584830796960',
+        createdBy: 'original author A',
+        updated: '1584830796960',
+        updatedBy: 'original author A',
         timelineId: mockCreatedTimeline.savedObjectId,
       });
       expect(mockPersistNote.mock.calls[1][3]).toEqual({
         eventId: mockUniqueParsedObjects[0].eventNotes[0].eventId,
-        note: mockUniqueParsedObjects[0].eventNotes[0].note,
-        created: mockUniqueParsedObjects[0].eventNotes[0].created,
-        createdBy: mockUniqueParsedObjects[0].eventNotes[0].createdBy,
-        updated: mockUniqueParsedObjects[0].eventNotes[0].updated,
-        updatedBy: mockUniqueParsedObjects[0].eventNotes[0].updatedBy,
+        note: 'original event note',
+        created: '1584830796960',
+        createdBy: 'original author B',
+        updated: '1584830796960',
+        updatedBy: 'original author B',
         timelineId: mockCreatedTimeline.savedObjectId,
       });
       expect(mockPersistNote.mock.calls[2][3]).toEqual({
         eventId: mockUniqueParsedObjects[0].eventNotes[1].eventId,
-        note: mockUniqueParsedObjects[0].eventNotes[1].note,
+        note: 'event note2',
+        created: '1584830796960',
+        createdBy: 'angela',
+        updated: '1584830796960',
+        updatedBy: 'angela',
+        timelineId: mockCreatedTimeline.savedObjectId,
+      });
+    });
+
+    test('should keep current author if note does not exist when Creating notes for a timeline', async () => {
+      mockGetNote.mockReset();
+      mockGetNote.mockRejectedValue(new Error());
+
+      const mockRequest = getImportTimelinesRequest();
+      await server.inject(mockRequest, context);
+      expect(mockPersistNote.mock.calls[0][3]).toEqual({
+        created: mockUniqueParsedObjects[0].globalNotes[0].created,
+        createdBy: mockUniqueParsedObjects[0].globalNotes[0].createdBy,
+        updated: mockUniqueParsedObjects[0].globalNotes[0].updated,
+        updatedBy: mockUniqueParsedObjects[0].globalNotes[0].updatedBy,
+        eventId: undefined,
+        note: mockUniqueParsedObjects[0].globalNotes[0].note,
+        timelineId: mockCreatedTimeline.savedObjectId,
+      });
+      expect(mockPersistNote.mock.calls[1][3]).toEqual({
+        created: mockUniqueParsedObjects[0].eventNotes[0].created,
+        createdBy: mockUniqueParsedObjects[0].eventNotes[0].createdBy,
+        updated: mockUniqueParsedObjects[0].eventNotes[0].updated,
+        updatedBy: mockUniqueParsedObjects[0].eventNotes[0].updatedBy,
+        eventId: mockUniqueParsedObjects[0].eventNotes[0].eventId,
+        note: mockUniqueParsedObjects[0].eventNotes[0].note,
+        timelineId: mockCreatedTimeline.savedObjectId,
+      });
+      expect(mockPersistNote.mock.calls[2][3]).toEqual({
         created: mockUniqueParsedObjects[0].eventNotes[1].created,
         createdBy: mockUniqueParsedObjects[0].eventNotes[1].createdBy,
         updated: mockUniqueParsedObjects[0].eventNotes[1].updated,
         updatedBy: mockUniqueParsedObjects[0].eventNotes[1].updatedBy,
+        eventId: mockUniqueParsedObjects[0].eventNotes[1].eventId,
+        note: mockUniqueParsedObjects[0].eventNotes[1].note,
         timelineId: mockCreatedTimeline.savedObjectId,
       });
     });

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/create_timelines.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/create_timelines.ts
@@ -112,9 +112,9 @@ interface CreateTimelineProps {
   isImmutable?: boolean;
 }
 
-/** allow override means overriding by current username,
- * disallow override means keep the original username.
- * override = false only happens when import timeline templates,
+/** allow overrideNotesOwner means overriding by current username,
+ * disallow overrideNotesOwner means keep the original username.
+ * overrideNotesOwner = false only happens when import timeline templates,
  * as we want to keep the original creator for notes
  **/
 export const createTimelines = async ({

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/create_timelines.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/create_timelines.ts
@@ -114,7 +114,7 @@ interface CreateTimelineProps {
 
 /** allow override means overriding by current username,
  * disallow override means keep the original username.
- * override = flase only happens when import timeline templates,
+ * override = false only happens when import timeline templates,
  * as we want to keep the original creator for notes
  **/
 export const createTimelines = async ({

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/failure_cases.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/failure_cases.ts
@@ -37,6 +37,7 @@ export const NOT_ALLOW_UPDATE_TIMELINE_TYPE_ERROR_MESSAGE =
   'You cannot convert a Timeline template to a timeline, or a timeline to a Timeline template.';
 export const UPDAT_TIMELINE_VIA_IMPORT_NOT_ALLOWED_ERROR_MESSAGE =
   'You cannot update a timeline via imports. Use the UI to modify existing timelines.';
+export const DEFAULT_ERROR = `Something has gone wrong. We didn't handle something properly. To help us fix this, please upload your file to https://discuss.elastic.co/c/security/siem.`;
 
 const isUpdatingStatus = (
   isHandlingTemplateTimeline: boolean,

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/import_timelines.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/import_timelines.ts
@@ -163,6 +163,7 @@ export const importTimelines = async (
                   pinnedEventIds: isTemplateTimeline ? null : pinnedEventIds,
                   notes: isTemplateTimeline ? globalNotes : [...globalNotes, ...eventNotes],
                   isImmutable,
+                  overideNotes: false,
                 });
 
                 resolve({
@@ -196,6 +197,7 @@ export const importTimelines = async (
                     notes: globalNotes,
                     existingNoteIds: compareTimelinesStatus.timelineInput.data?.noteIds,
                     isImmutable,
+                    overideNotes: false,
                   });
 
                   resolve({

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/import_timelines.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/utils/import_timelines.ts
@@ -26,6 +26,7 @@ import { createPromiseFromStreams } from '../../../../../../../../src/legacy/uti
 import { getTupleDuplicateErrorsAndUniqueTimeline } from './get_timelines_from_stream';
 import { CompareTimelinesStatus } from './compare_timelines_status';
 import { TimelineStatusActions } from './common';
+import { DEFAULT_ERROR } from './failure_cases';
 
 export type ImportedTimeline = SavedTimeline & {
   savedObjectId: string | null;
@@ -78,7 +79,6 @@ export const timelineSavedObjectOmittedFields = [
 ];
 
 const CHUNK_PARSED_OBJECT_SIZE = 10;
-const DEFAULT_IMPORT_ERROR = `Something has gone wrong. We didn't handle something properly. To help us fix this, please upload your file to https://discuss.elastic.co/c/security/siem.`;
 
 export const importTimelines = async (
   file: Readable,
@@ -163,7 +163,7 @@ export const importTimelines = async (
                   pinnedEventIds: isTemplateTimeline ? null : pinnedEventIds,
                   notes: isTemplateTimeline ? globalNotes : [...globalNotes, ...eventNotes],
                   isImmutable,
-                  overideNotes: false,
+                  overrideNotesOwner: false,
                 });
 
                 resolve({
@@ -177,7 +177,7 @@ export const importTimelines = async (
                 const errorMessage = compareTimelinesStatus.checkIsFailureCases(
                   TimelineStatusActions.createViaImport
                 );
-                const message = errorMessage?.body ?? DEFAULT_IMPORT_ERROR;
+                const message = errorMessage?.body ?? DEFAULT_ERROR;
 
                 resolve(
                   createBulkErrorObject({
@@ -197,7 +197,7 @@ export const importTimelines = async (
                     notes: globalNotes,
                     existingNoteIds: compareTimelinesStatus.timelineInput.data?.noteIds,
                     isImmutable,
-                    overideNotes: false,
+                    overrideNotesOwner: false,
                   });
 
                   resolve({
@@ -210,7 +210,7 @@ export const importTimelines = async (
                     TimelineStatusActions.updateViaImport
                   );
 
-                  const message = errorMessage?.body ?? DEFAULT_IMPORT_ERROR;
+                  const message = errorMessage?.body ?? DEFAULT_ERROR;
 
                   resolve(
                     createBulkErrorObject({


### PR DESCRIPTION
## Summary

The notes creator of imported timelines / templates should be remained instead of being override by current user.
<img width="2875" alt="Screenshot 2020-08-04 at 00 46 56" src="https://user-images.githubusercontent.com/6295984/89238049-ba21d900-d5ec-11ea-8139-f6ec5d9a1aef.png">

Before the fix, it overrides the original note creator
<img width="2876" alt="Screenshot 2020-08-04 at 01 07 48" src="https://user-images.githubusercontent.com/6295984/89238741-053ceb80-d5ef-11ea-91da-8e5798eabb7c.png">


solution:
Introducing a flag `overideNote `:
`allow override` means overriding by current username,
`disallow override` means keep the original username.
`disallow override` only happens when import timeline templates, as we want to keep the original creator for notes


How to verify this PR:

1. Download [templates_with_note.txt](https://github.com/elastic/kibana/files/5019370/templates_with_note.txt)
2. change the extension from .txt into .ndjson
3. import it and expend the note for the timeline you just imported from timeline's table
4. the original author should be displayed





### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] ~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] ~This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)~
