### PR TITLE
[Security Solution] Load prepackage timelines by default

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.test.tsx
@@ -25,11 +25,10 @@ import { getTimelineTabsUrl } from '../../../common/components/link_to';
 import { DEFAULT_SEARCH_RESULTS_PER_PAGE } from '../../pages/timelines_page';
 import { useGetAllTimeline, getAllTimeline } from '../../containers/all';
 
+import { useTimelineStatus } from './use_timeline_status';
 import { NotePreviews } from './note_previews';
 import { OPEN_TIMELINE_CLASS_NAME } from './helpers';
-
 import { StatefulOpenTimeline } from '.';
-
 import { TimelineTabsStyle } from './types';
 import {
   useTimelineTypes,
@@ -75,9 +74,17 @@ jest.mock('../../../common/components/link_to', () => {
   };
 });
 
+jest.mock('./use_timeline_status', () => {
+  return {
+    useTimelineStatus: jest.fn(),
+  };
+});
+
 describe('StatefulOpenTimeline', () => {
   const title = 'All Timelines / Open Timelines';
   let mockHistory: History[];
+  const mockInstallPrepackagedTimelines = jest.fn();
+
   beforeEach(() => {
     (useParams as jest.Mock).mockReturnValue({
       tabName: TimelineType.default,
@@ -95,6 +102,13 @@ describe('StatefulOpenTimeline', () => {
       totalCount: mockOpenTimelineQueryResults[0].result.data.getAllTimeline.totalCount,
       refetch: jest.fn(),
     });
+    ((useTimelineStatus as unknown) as jest.Mock).mockReturnValue({
+      timelineStatus: null,
+      templateTimelineType: null,
+      templateTimelineFilter: <div />,
+      installPrepackagedTimelines: mockInstallPrepackagedTimelines,
+    });
+    mockInstallPrepackagedTimelines.mockClear();
   });
 
   afterEach(() => {

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/open_timeline_modal/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/open_timeline_modal/index.test.tsx
@@ -12,10 +12,11 @@ import { ThemeProvider } from 'styled-components';
 
 // we don't have the types for waitFor just yet, so using "as waitFor" until when we do
 import { wait as waitFor } from '@testing-library/react';
+
 import { TestProviderWithoutDragAndDrop } from '../../../../common/mock/test_providers';
 import { mockOpenTimelineQueryResults } from '../../../../common/mock/timeline_results';
 import { useGetAllTimeline, getAllTimeline } from '../../../containers/all';
-
+import { useTimelineStatus } from '../use_timeline_status';
 import { OpenTimelineModal } from '.';
 
 jest.mock('../../../../common/lib/kibana');
@@ -39,8 +40,15 @@ jest.mock('../use_timeline_types', () => {
   };
 });
 
+jest.mock('../use_timeline_status', () => {
+  return {
+    useTimelineStatus: jest.fn(),
+  };
+});
+
 describe('OpenTimelineModal', () => {
   const theme = () => ({ eui: euiDarkVars, darkMode: true });
+  const mockInstallPrepackagedTimelines = jest.fn();
   beforeEach(() => {
     ((useGetAllTimeline as unknown) as jest.Mock).mockReturnValue({
       fetchAllTimeline: jest.fn(),
@@ -52,6 +60,16 @@ describe('OpenTimelineModal', () => {
       totalCount: mockOpenTimelineQueryResults[0].result.data.getAllTimeline.totalCount,
       refetch: jest.fn(),
     });
+    ((useTimelineStatus as unknown) as jest.Mock).mockReturnValue({
+      timelineStatus: null,
+      templateTimelineType: null,
+      templateTimelineFilter: <div />,
+      installPrepackagedTimelines: mockInstallPrepackagedTimelines,
+    });
+  });
+
+  afterEach(() => {
+    mockInstallPrepackagedTimelines.mockClear();
   });
 
   test('it renders the expected modal', async () => {
@@ -72,6 +90,27 @@ describe('OpenTimelineModal', () => {
         expect(wrapper.find('div[data-test-subj="open-timeline-modal"].euiModal').length).toEqual(
           1
         );
+      },
+      { timeout: 10000 }
+    );
+  }, 20000);
+
+  test('it installs elastic prebuilt templates', async () => {
+    const wrapper = mount(
+      <ThemeProvider theme={theme}>
+        <TestProviderWithoutDragAndDrop>
+          <MockedProvider mocks={mockOpenTimelineQueryResults} addTypename={false}>
+            <OpenTimelineModal onClose={jest.fn()} />
+          </MockedProvider>
+        </TestProviderWithoutDragAndDrop>
+      </ThemeProvider>
+    );
+
+    await waitFor(
+      () => {
+        wrapper.update();
+
+        expect(mockInstallPrepackagedTimelines).toHaveBeenCalled();
       },
       { timeout: 10000 }
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_timeline_status.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_timeline_status.tsx
@@ -102,7 +102,7 @@ export const useTimelineStatus = ({
   }, [templateTimelineType, filters, isTemplateFilterEnabled, onFilterClicked]);
 
   const installPrepackagedTimelines = useCallback(async () => {
-    if (templateTimelineType === TemplateTimelineType.elastic) {
+    if (templateTimelineType !== TemplateTimelineType.custom) {
       await installPrepackedTimelines();
     }
   }, [templateTimelineType]);


### PR DESCRIPTION
## Summary

As we want to show the elastic templates once users landing on template’s tab, but since few weeks ago it stops showing elastic templates automatically.
This PR is to fix the issue and load Elastic prebuilt templates by default.

How to verify this PR:

case one:
1. cd  x-pack/plugins/security_solution/server/lib/detection_engine/scripts
2. sh timelines/delete_all_timelines.sh
3. go to timeline's tab, clicking on `templates`, and make sure elastic templates are loaded by default


case two:
1. cd  x-pack/plugins/security_solution/server/lib/detection_engine/scripts
2. sh timelines/delete_all_timelines.sh
3. go to host page (or any page with timeline's flyout but don't go to timelines' page), clicking on the flyout > gear > open timeline, and make sure elastic templates are loaded by default

