### PR TITLE
[SIEM] Fixes error toaster in one spot with custom date time formats

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/hosts/query.detail_host.dsl.ts
+++ b/x-pack/plugins/security_solution/server/lib/hosts/query.detail_host.dsl.ts
@@ -26,6 +26,7 @@ export const buildHostOverviewQuery = ({
     {
       range: {
         [timestamp]: {
+          format: 'strict_date_optional_time',
           gte: from,
           lte: to,
         },


### PR DESCRIPTION
## Summary

Related closed issues:
https://github.com/elastic/kibana/issues/58965
https://github.com/elastic/kibana/pull/70713

If you add a custom mapping and go to the hosts details page you will get an error toaster:
<img width="838" alt="Screen Shot 2020-08-03 at 7 53 16 PM" src="https://user-images.githubusercontent.com/1151048/89244409-a7df7500-d5c3-11ea-933c-99d96bffc589.png">

If running local host you can configure your index patterns to use a custom one I setup with custom date time formats and a single record which can cause this:
<img width="1223" alt="Screen Shot 2020-08-03 at 7 50 12 PM" src="https://user-images.githubusercontent.com/1151048/89243967-8fbb2600-d5c2-11ea-8de2-4422e870f9f0.png">


Then visit this URL and set your date time to go backwards by 1 year
```ts
http://localhost:5601/app/security/hosts/app/security/hosts/MacBook-Pro.local/alerts
```

And with the fix you no longer get the error toaster.

