### PR TITLE
[7.9] updates file picker label (#74136)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/value_lists_management_modal/translations.ts
@@ -13,7 +13,7 @@ export const MODAL_TITLE = i18n.translate('xpack.securitySolution.lists.uploadVa
 export const FILE_PICKER_LABEL = i18n.translate(
   'xpack.securitySolution.lists.uploadValueListDescription',
   {
-    defaultMessage: 'Upload single value lists to use while writing rules or rule exceptions.',
+    defaultMessage: 'Upload single value lists to use while writing rule exceptions.',
   }
 );
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - updates file picker label (#74136)