### PR TITLE
Add README files for Kibana app plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,6 @@
 /x-pack/plugins/discover_enhanced/ @elastic/kibana-app
 /x-pack/plugins/lens/ @elastic/kibana-app
 /x-pack/plugins/graph/ @elastic/kibana-app
-/src/legacy/core_plugins/kibana/public/local_application_service/ @elastic/kibana-app
 /src/plugins/dashboard/ @elastic/kibana-app
 /src/plugins/discover/ @elastic/kibana-app
 /src/plugins/input_control_vis/ @elastic/kibana-app

--- a/src/plugins/dashboard/README.md
+++ b/src/plugins/dashboard/README.md
@@ -1,0 +1,1 @@
+Contains the dashboard application.

--- a/src/plugins/discover/README.md
+++ b/src/plugins/discover/README.md
@@ -1,0 +1,1 @@
+Contains the Discover application and the saved search embeddable.

--- a/src/plugins/input_control_vis/README.md
+++ b/src/plugins/input_control_vis/README.md
@@ -1,0 +1,1 @@
+Contains the input control visualization allowing to place custom filter controls on a dashboard.

--- a/src/plugins/timelion/README.md
+++ b/src/plugins/timelion/README.md
@@ -1,0 +1,2 @@
+Contains the deprecated timelion application. For the timelion visualization,
+which also contains the timelion APIs and backend look at the vis_type_timelion plugin.

--- a/src/plugins/timelion/README.md
+++ b/src/plugins/timelion/README.md
@@ -1,2 +1,2 @@
 Contains the deprecated timelion application. For the timelion visualization,
-which also contains the timelion APIs and backend look at the vis_type_timelion plugin.
+which also contains the timelion APIs and backend, look at the vis_type_timelion plugin.

--- a/src/plugins/vis_type_markdown/README.md
+++ b/src/plugins/vis_type_markdown/README.md
@@ -1,0 +1,1 @@
+The markdown visualization that can be used to place text panels on dashboards.

--- a/src/plugins/vis_type_metric/README.md
+++ b/src/plugins/vis_type_metric/README.md
@@ -1,0 +1,1 @@
+Contains the metric visualization.

--- a/src/plugins/vis_type_table/README.md
+++ b/src/plugins/vis_type_table/README.md
@@ -1,0 +1,1 @@
+Contains the data table visualization, that allows presenting data in a simple table format.

--- a/src/plugins/vis_type_tagcloud/README.md
+++ b/src/plugins/vis_type_tagcloud/README.md
@@ -1,0 +1,1 @@
+Contains the tagcloud visualization.

--- a/src/plugins/vis_type_timelion/README.md
+++ b/src/plugins/vis_type_timelion/README.md
@@ -1,5 +1,7 @@
 # Vis type Timelion
 
+Contains the timelion visualization and the timelion backend.
+
 # Generate a parser
 If your grammar was changed in `public/chain.peg` you need to re-generate the static parser. You could use a grunt task:
 

--- a/src/plugins/vis_type_timeseries/README.md
+++ b/src/plugins/vis_type_timeseries/README.md
@@ -1,0 +1,1 @@
+Contains everything around TSVB (the editor, visualizatin implementations and backends).

--- a/src/plugins/vis_type_vega/README.md
+++ b/src/plugins/vis_type_vega/README.md
@@ -1,0 +1,1 @@
+Contains the Vega visualization.

--- a/src/plugins/vis_type_vislib/README.md
+++ b/src/plugins/vis_type_vislib/README.md
@@ -1,2 +1,2 @@
-Contains the vislib visualiations. These are the classical area/line/bar, pie, gauge/goal and 
+Contains the vislib visualizations. These are the classical area/line/bar, pie, gauge/goal and 
 heatmap charts.

--- a/src/plugins/vis_type_vislib/README.md
+++ b/src/plugins/vis_type_vislib/README.md
@@ -1,0 +1,2 @@
+Contains the vislib visualiations. These are the classical area/line/bar, pie, gauge/goal and 
+heatmap charts.

--- a/src/plugins/vis_type_xy/README.md
+++ b/src/plugins/vis_type_xy/README.md
@@ -1,0 +1,2 @@
+Contains the new xy-axis chart using the elastic-charts library, which will eventually
+replace the vislib xy-axis (bar, area, line) charts.

--- a/src/plugins/visualizations/README.md
+++ b/src/plugins/visualizations/README.md
@@ -1,0 +1,2 @@
+Contains most of the visualization infrastructure, e.g. the visualization type registry or the 
+visualization embeddable.

--- a/src/plugins/visualize/README.md
+++ b/src/plugins/visualize/README.md
@@ -1,0 +1,2 @@
+Contains the visualize application which includes the listing page and the app frame,
+which will load the visualization's editor.

--- a/x-pack/plugins/dashboard_enhanced/README.md
+++ b/x-pack/plugins/dashboard_enhanced/README.md
@@ -1,1 +1,1 @@
-# X-Pack part of Dashboard app
+Contains the enhancements to the OSS dashboard app.

--- a/x-pack/plugins/dashboard_mode/README.md
+++ b/x-pack/plugins/dashboard_mode/README.md
@@ -1,0 +1,1 @@
+The deprecated dashboard only mode.

--- a/x-pack/plugins/discover_enhanced/README.md
+++ b/x-pack/plugins/discover_enhanced/README.md
@@ -1,0 +1,1 @@
+Contains the enhancements to the OSS discover app.


### PR DESCRIPTION
Adds Readme files for all Kibana App plugins to appear on https://www.elastic.co/guide/en/kibana/master/code-exploration.html.

Also removed one no longer existing folder from the CODEOWNERS file (I thought otherwise noone wants to ever setup a separate PR for that one line :D)