### PR TITLE
[Canvas][Docs] Adds `var` and `var_set` to expression function reference

### DIFF
--- a/docs/canvas/canvas-function-reference.asciidoc
+++ b/docs/canvas/canvas-function-reference.asciidoc
@@ -2880,7 +2880,7 @@ Default: `""`
 [[var_fn]]
 === `var`
 
-Updates kibana global context
+Updates the Kibana global context.
 
 *Accepts:* `any`
 
@@ -2892,7 +2892,7 @@ Updates kibana global context
 
 Alias: `name`
 |`string`
-|Specify name of the variable
+|Specify the name of the variable.
 |===
 
 *Returns:* Depends on your input and arguments
@@ -2902,7 +2902,7 @@ Alias: `name`
 [[var_set_fn]]
 === `var_set`
 
-Updates kibana global context
+Updates the Kibana global context.
 
 *Accepts:* `any`
 
@@ -2914,13 +2914,13 @@ Updates kibana global context
 
 Alias: `name`
 |`string`
-|Specify name of the variable
+|Specify the name of the variable.
 
 |`value`
 
 Alias: `val`
 |`any`
-|Specify value for the variable. If not provided input context will be used
+|Specify the value for the variable. When unspecified, the input context is used.
 |===
 
 *Returns:* Depends on your input and arguments

--- a/docs/canvas/canvas-function-reference.asciidoc
+++ b/docs/canvas/canvas-function-reference.asciidoc
@@ -13,7 +13,7 @@ A *** denotes a required argument.
 
 A † denotes an argument can be passed multiple times.
 
-<<a_fns>> | B | <<c_fns>> | <<d_fns>> | <<e_fns>> | <<f_fns>> | <<g_fns>> | <<h_fns>> | <<i_fns>> | <<j_fns>> | K | <<l_fns>> | <<m_fns>> | <<n_fns>> | O | <<p_fns>> | Q | <<r_fns>> | <<s_fns>> | <<t_fns>> | <<u_fns>> | V | W | X | Y | Z
+<<a_fns>> | B | <<c_fns>> | <<d_fns>> | <<e_fns>> | <<f_fns>> | <<g_fns>> | <<h_fns>> | <<i_fns>> | <<j_fns>> | K | <<l_fns>> | <<m_fns>> | <<n_fns>> | O | <<p_fns>> | Q | <<r_fns>> | <<s_fns>> | <<t_fns>> | <<u_fns>> | <<v_fns>> | W | X | Y | Z
 
 [float]
 [[a_fns]]
@@ -897,7 +897,7 @@ Default: `"-_index:.kibana"`
 |`string`
 |An index or index pattern. For example, `"logstash-*"`.
 
-Default: `_all`
+Default: `"_all"`
 |===
 
 *Returns:* `number`
@@ -965,7 +965,7 @@ Default: `1000`
 |`string`
 |An index or index pattern. For example, `"logstash-*"`.
 
-Default: `_all`
+Default: `"_all"`
 
 |`metaFields`
 |`string`
@@ -1026,7 +1026,7 @@ Alias: `tz`
 |`string`
 |The timezone to use for date operations. Valid ISO8601 formats and UTC offsets both work.
 
-Default: `UTC`
+Default: `"UTC"`
 |===
 
 *Returns:* `datatable`
@@ -1238,7 +1238,7 @@ filters
 |`string`
 |The horizontal text alignment.
 
-Default: `left`
+Default: `"left"`
 
 |`color`
 |`string`
@@ -1280,7 +1280,7 @@ Default: `false`
 |`string`
 |The font weight. For example, `"normal"`, `"bold"`, `"bolder"`, `"lighter"`, `"100"`, `"200"`, `"300"`, `"400"`, `"500"`, `"600"`, `"700"`, `"800"`, or `"900"`.
 
-Default: `normal`
+Default: `"normal"`
 |===
 
 *Returns:* `style`
@@ -2469,7 +2469,7 @@ Alias: `shape`
 |`string`
 |Pick a shape.
 
-Default: `square`
+Default: `"square"`
 
 |`border`
 
@@ -2732,7 +2732,7 @@ Aliases: `c`, `field`
 |`string`
 |The column or field that you want to filter.
 
-Default: `@timestamp`
+Default: `"@timestamp"`
 
 |`compact`
 |`boolean`
@@ -2871,3 +2871,56 @@ Default: `""`
 |===
 
 *Returns:* `string`
+
+[float]
+[[v_fns]]
+== V
+
+[float]
+[[var_fn]]
+=== `var`
+
+Updates kibana global context
+
+*Accepts:* `any`
+
+[cols="3*^<"]
+|===
+|Argument |Type |Description
+
+|_Unnamed_ ***
+
+Alias: `name`
+|`string`
+|Specify name of the variable
+|===
+
+*Returns:* Depends on your input and arguments
+
+
+[float]
+[[var_set_fn]]
+=== `var_set`
+
+Updates kibana global context
+
+*Accepts:* `any`
+
+[cols="3*^<"]
+|===
+|Argument |Type |Description
+
+|_Unnamed_ ***
+
+Alias: `name`
+|`string`
+|Specify name of the variable
+
+|`value`
+
+Alias: `val`
+|`any`
+|Specify value for the variable. If not provided input context will be used
+|===
+
+*Returns:* Depends on your input and arguments

--- a/src/plugins/expressions/common/expression_functions/specs/var.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var.ts
@@ -34,7 +34,7 @@ export type ExpressionFunctionVar = ExpressionFunctionDefinition<
 export const variable: ExpressionFunctionVar = {
   name: 'var',
   help: i18n.translate('expressions.functions.var.help', {
-    defaultMessage: 'Updates kibana global context',
+    defaultMessage: 'Updates the Kibana global context.',
   }),
   args: {
     name: {
@@ -42,7 +42,7 @@ export const variable: ExpressionFunctionVar = {
       aliases: ['_'],
       required: true,
       help: i18n.translate('expressions.functions.var.name.help', {
-        defaultMessage: 'Specify name of the variable',
+        defaultMessage: 'Specify the name of the variable.',
       }),
     },
   },

--- a/src/plugins/expressions/common/expression_functions/specs/var_set.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/var_set.ts
@@ -35,7 +35,7 @@ export type ExpressionFunctionVarSet = ExpressionFunctionDefinition<
 export const variableSet: ExpressionFunctionVarSet = {
   name: 'var_set',
   help: i18n.translate('expressions.functions.varset.help', {
-    defaultMessage: 'Updates kibana global context',
+    defaultMessage: 'Updates the Kibana global context.',
   }),
   args: {
     name: {
@@ -43,14 +43,14 @@ export const variableSet: ExpressionFunctionVarSet = {
       aliases: ['_'],
       required: true,
       help: i18n.translate('expressions.functions.varset.name.help', {
-        defaultMessage: 'Specify name of the variable',
+        defaultMessage: 'Specify the name of the variable.',
       }),
     },
     value: {
       aliases: ['val'],
       help: i18n.translate('expressions.functions.varset.val.help', {
         defaultMessage:
-          'Specify value for the variable. If not provided input context will be used',
+          'Specify the value for the variable. When unspecified, the input context is used.',
       }),
     },
   },


### PR DESCRIPTION
## Summary

Related to #66139.

This adds function definition sections for `var` and `var_set`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
