### PR TITLE
[Ingest Manager] prevent crash on unhandled rejection from setupIngestManager

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/setup.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { setupIngestManager } from './setup';
+import { savedObjectsClientMock } from 'src/core/server/mocks';
+
+describe('setupIngestManager', () => {
+  it('returned promise should reject if errors thrown', async () => {
+    const { savedObjectsClient, callClusterMock } = makeErrorMocks();
+    const setupPromise = setupIngestManager(savedObjectsClient, callClusterMock);
+    await expect(setupPromise).rejects.toThrow('mocked');
+  });
+});
+
+function makeErrorMocks() {
+  jest.mock('./app_context'); // else fails w/"Logger not set."
+  jest.mock('./epm/registry/registry_url', () => {
+    return {
+      fetchUrl: () => {
+        throw new Error('mocked registry#fetchUrl');
+      },
+    };
+  });
+
+  const callClusterMock = jest.fn();
+  const savedObjectsClient = savedObjectsClientMock.create();
+  savedObjectsClient.find = jest.fn().mockImplementation(() => {
+    throw new Error('mocked SO#find');
+  });
+  savedObjectsClient.get = jest.fn().mockImplementation(() => {
+    throw new Error('mocked SO#get');
+  });
+  savedObjectsClient.update = jest.fn().mockImplementation(() => {
+    throw new Error('mocked SO#update');
+  });
+
+  return {
+    savedObjectsClient,
+    callClusterMock,
+  };
+}

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -127,6 +127,11 @@ export async function setupIngestManager(
     // if anything errors, reject/fail
     onSetupReject(error);
   }
+
+  // be sure to return the promise because it has the resolved/rejected status attached to it
+  // otherwise, we effectively return success every time even if there are errors
+  // because `return undefined` -> `Promise.resolve(undefined)` in an `async` function
+  return setupIngestStatus;
 }
 
 export async function setupFleet(


### PR DESCRIPTION
## Summary
fixes https://github.com/elastic/kibana/issues/73997 (POST /setup with unreachable Registry can crash Kibana)

From comments at the change
```javascript
  // be sure to return the promise because it has the resolved/rejected status attached to it
  // otherwise, we effectively return success every time even if there are errors
  // because `return undefined` -> `Promise.resolve(undefined)` in an `async` function
  return setupIngestStatus;
```

**`master`:** By returning no value, `await setupIngestManager` resolves as a success, but hits issues later because of the silent or unhandled failures.

**PR:** By returning the promise `await` and KP do what we want

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### Testing
**Jest test** 
https://github.com/elastic/kibana/commit/afd064af0a41e693be8ab9fd97e27ef2ac258b47 to ensure failures in `setupIngestManager` are treated as errors by `await` & `try/catch`

**In the terminal**
**`master`** https://github.com/elastic/kibana/issues/73997 shows that POST /setup crashes with a bad `registryUrl`

**this PR**, they return a [502 as expected](https://github.com/jfsiii/kibana/blob/5cabe9c95dd0e7ae2e6181c2d062268eb3fef601/x-pack/plugins/ingest_manager/server/errors.ts#L16-L18
) 
```javascript
  if (error instanceof RegistryError) {
    return 502; // Bad Gateway
  }
```

```
> curl -X POST 'http://localhost:5601/api/ingest_manager/setup' -H 'kbn-xsrf: <string>' --user elastic:changeme
{"statusCode":502,"error":"Bad Gateway","message":"Error connecting to package registry at http://localhost:9999/search?package=system&internal=true&experimental=true: request to http://localhost:9999/search?package=system&internal=true&experimental=true failed, reason: connect ECONNREFUSED 127.0.0.1:9999"}

> curl -X POST 'http://localhost:5601/api/ingest_manager/setup' -H 'kbn-xsrf: <string>' --user elastic:changeme
{"statusCode":502,"error":"Bad Gateway","message":"Error connecting to package registry at http://localhost:9999/search?package=system&internal=true&experimental=true: request to http://localhost:9999/search?package=system&internal=true&experimental=true failed, reason: connect ECONNREFUSED 127.0.0.1:9999"}

> curl -X POST 'http://localhost:5601/api/ingest_manager/setup' -H 'kbn-xsrf: <string>' --user elastic:changeme
{"statusCode":502,"error":"Bad Gateway","message":"Error connecting to package registry at http://localhost:9999/search?package=system&internal=true&experimental=true: request to http://localhost:9999/search?package=system&internal=true&experimental=true failed, reason: connect ECONNREFUSED 127.0.0.1:9999"}

> curl -X POST 'http://localhost:5601/api/ingest_manager/setup' -H 'kbn-xsrf: <string>' --user elastic:changeme
{"statusCode":502,"error":"Bad Gateway","message":"Error connecting to package registry at http://localhost:9999/search?package=system&internal=true&experimental=true: request to http://localhost:9999/search?package=system&internal=true&experimental=true failed, reason: connect ECONNREFUSED 127.0.0.1:9999"}

> curl -X POST 'http://localhost:5601/api/ingest_manager/setup' -H 'kbn-xsrf: <string>' --user elastic:changeme
{"statusCode":502,"error":"Bad Gateway","message":"Error connecting to package registry at http://localhost:9999/search?package=system&internal=true&experimental=true: request to http://localhost:9999/search?package=system&internal=true&experimental=true failed, reason: connect ECONNREFUSED 127.0.0.1:9999"}
```

