### PR TITLE
[Ingest Manager] Adjust dataset aggs to use datastream fields instead

### DIFF
--- a/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
@@ -54,19 +54,19 @@ export const getListHandler: RequestHandler = async (context, request, response)
             aggs: {
               dataset: {
                 terms: {
-                  field: 'dataset.name',
+                  field: 'datastream.dataset',
                   size: 1,
                 },
               },
               namespace: {
                 terms: {
-                  field: 'dataset.namespace',
+                  field: 'datastream.namespace',
                   size: 1,
                 },
               },
               type: {
                 terms: {
-                  field: 'dataset.type',
+                  field: 'datastream.type',
                   size: 1,
                 },
               },

--- a/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
@@ -31,12 +31,12 @@ export const getListHandler: RequestHandler = async (context, request, response)
             must: [
               {
                 exists: {
-                  field: 'data_stream.namespace',
+                  field: 'datastream.namespace',
                 },
               },
               {
                 exists: {
-                  field: 'data_stream.dataset',
+                  field: 'datastream.dataset',
                 },
               },
             ],
@@ -54,19 +54,19 @@ export const getListHandler: RequestHandler = async (context, request, response)
             aggs: {
               dataset: {
                 terms: {
-                  field: 'data_stream.dataset',
+                  field: 'datastream.dataset',
                   size: 1,
                 },
               },
               namespace: {
                 terms: {
-                  field: 'data_stream.namespace',
+                  field: 'datastream.namespace',
                   size: 1,
                 },
               },
               type: {
                 terms: {
-                  field: 'data_stream.type',
+                  field: 'datastream.type',
                   size: 1,
                 },
               },

--- a/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
@@ -31,12 +31,12 @@ export const getListHandler: RequestHandler = async (context, request, response)
             must: [
               {
                 exists: {
-                  field: 'datastream.namespace',
+                  field: 'data_stream.namespace',
                 },
               },
               {
                 exists: {
-                  field: 'datastream.dataset',
+                  field: 'data_stream.dataset',
                 },
               },
             ],
@@ -54,19 +54,19 @@ export const getListHandler: RequestHandler = async (context, request, response)
             aggs: {
               dataset: {
                 terms: {
-                  field: 'datastream.dataset',
+                  field: 'data_stream.dataset',
                   size: 1,
                 },
               },
               namespace: {
                 terms: {
-                  field: 'datastream.namespace',
+                  field: 'data_stream.namespace',
                   size: 1,
                 },
               },
               type: {
                 terms: {
-                  field: 'datastream.type',
+                  field: 'data_stream.type',
                   size: 1,
                 },
               },

--- a/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/data_streams/handlers.ts
@@ -31,12 +31,12 @@ export const getListHandler: RequestHandler = async (context, request, response)
             must: [
               {
                 exists: {
-                  field: 'dataset.namespace',
+                  field: 'data_stream.namespace',
                 },
               },
               {
                 exists: {
-                  field: 'dataset.name',
+                  field: 'data_stream.dataset',
                 },
               },
             ],
@@ -54,19 +54,19 @@ export const getListHandler: RequestHandler = async (context, request, response)
             aggs: {
               dataset: {
                 terms: {
-                  field: 'datastream.dataset',
+                  field: 'data_stream.dataset',
                   size: 1,
                 },
               },
               namespace: {
                 terms: {
-                  field: 'datastream.namespace',
+                  field: 'data_stream.namespace',
                   size: 1,
                 },
               },
               type: {
                 terms: {
-                  field: 'datastream.type',
+                  field: 'data_stream.type',
                   size: 1,
                 },
               },

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -393,14 +393,14 @@ const updateExistingIndex = async ({
   // are added in https://github.com/elastic/kibana/issues/66551.  namespace value we will continue
   // to skip updating and assume the value in the index mapping is correct
   delete mappings.properties.stream;
-  delete mappings.properties.datastream;
+  delete mappings.properties.data_stream;
 
-  // get the datastream values from the index template to compose data stream name
+  // get the data_stream values from the index template to compose data stream name
   const indexMappings = await getIndexMappings(indexName, callCluster);
-  const datastream = indexMappings[indexName].mappings.properties.datastream.properties;
-  if (!datastream.type.value || !datastream.dataset.value || !datastream.namespace.value)
-    throw new Error(`datastream values are missing from the index template ${indexName}`);
-  const datastreamName = `${datastream.type.value}-${datastream.dataset.value}-${datastream.namespace.value}`;
+  const dataStream = indexMappings[indexName].mappings.properties.data_stream.properties;
+  if (!dataStream.type.value || !dataStream.dataset.value || !dataStream.namespace.value)
+    throw new Error(`data_stream values are missing from the index template ${indexName}`);
+  const dataStreamName = `${dataStream.type.value}-${dataStream.dataset.value}-${dataStream.namespace.value}`;
 
   // try to update the mappings first
   try {
@@ -411,13 +411,13 @@ const updateExistingIndex = async ({
     // if update fails, rollover data stream
   } catch (err) {
     try {
-      const path = `/${datastreamName}/_rollover`;
+      const path = `/${dataStreamName}/_rollover`;
       await callCluster('transport.request', {
         method: 'POST',
         path,
       });
     } catch (error) {
-      throw new Error(`cannot rollover data stream ${datastreamName}`);
+      throw new Error(`cannot rollover data stream ${dataStreamName}`);
     }
   }
   // update settings after mappings was successful to ensure

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -413,13 +413,13 @@ const updateExistingIndex = async ({
     // if update fails, rollover data stream
   } catch (err) {
     try {
-      const path = `/${dataStreamName}/_rollover`;
+      const path = `/${datastreamName}/_rollover`;
       await callCluster('transport.request', {
         method: 'POST',
         path,
       });
     } catch (error) {
-      throw new Error(`cannot rollover data stream ${dataStreamName}`);
+      throw new Error(`cannot rollover data stream ${datastreamName}`);
     }
   }
   // update settings after mappings was successful to ensure

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -393,14 +393,16 @@ const updateExistingIndex = async ({
   // are added in https://github.com/elastic/kibana/issues/66551.  namespace value we will continue
   // to skip updating and assume the value in the index mapping is correct
   delete mappings.properties.stream;
-  delete mappings.properties.dataset;
+  delete mappings.properties.data_stream;
 
-  // get the dataset values from the index template to compose data stream name
+  // get the data_stream values from the index template to compose data stream name
   const indexMappings = await getIndexMappings(indexName, callCluster);
-  const dataset = indexMappings[indexName].mappings.properties.dataset.properties;
-  if (!dataset.type.value || !dataset.name.value || !dataset.namespace.value)
-    throw new Error(`dataset values are missing from the index template ${indexName}`);
-  const dataStreamName = `${dataset.type.value}-${dataset.name.value}-${dataset.namespace.value}`;
+  // Use snake case for easier grepping across files
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  const data_stream = indexMappings[indexName].mappings.properties.data_stream.properties;
+  if (!data_stream.type.value || !data_stream.dataset.value || !data_stream.namespace.value)
+    throw new Error(`data_stream values are missing from the index template ${indexName}`);
+  const datastreamName = `${data_stream.type.value}-${data_stream.dataset.value}-${data_stream.namespace.value}`;
 
   // try to update the mappings first
   try {

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/template/template.ts
@@ -393,16 +393,14 @@ const updateExistingIndex = async ({
   // are added in https://github.com/elastic/kibana/issues/66551.  namespace value we will continue
   // to skip updating and assume the value in the index mapping is correct
   delete mappings.properties.stream;
-  delete mappings.properties.data_stream;
+  delete mappings.properties.datastream;
 
-  // get the data_stream values from the index template to compose data stream name
+  // get the datastream values from the index template to compose data stream name
   const indexMappings = await getIndexMappings(indexName, callCluster);
-  // Use snake case for easier grepping across files
-  // eslint-disable-next-line @typescript-eslint/camelcase
-  const data_stream = indexMappings[indexName].mappings.properties.data_stream.properties;
-  if (!data_stream.type.value || !data_stream.dataset.value || !data_stream.namespace.value)
-    throw new Error(`data_stream values are missing from the index template ${indexName}`);
-  const datastreamName = `${data_stream.type.value}-${data_stream.dataset.value}-${data_stream.namespace.value}`;
+  const datastream = indexMappings[indexName].mappings.properties.datastream.properties;
+  if (!datastream.type.value || !datastream.dataset.value || !datastream.namespace.value)
+    throw new Error(`datastream values are missing from the index template ${indexName}`);
+  const datastreamName = `${datastream.type.value}-${datastream.dataset.value}-${datastream.namespace.value}`;
 
   // try to update the mappings first
   try {


### PR DESCRIPTION
## Summary

This is a remake of https://github.com/elastic/kibana/pull/74226 against `master`. Implements https://github.com/elastic/kibana/issues/74257

Elastic Agent and Elasticsearch are switching over from using dataset.* to data_stream.*. This adjust the aggregation on the dataset page to get the data_streams.

For this to work properly, the most recent version of Elasticsearch 7.9 must be used and is pending updates on all the packages to ship also the data_stream fields, see https://github.com/elastic/integrations/pull/213 and https://github.com/elastic/elasticsearch/pull/60715

