### PR TITLE
Fix tsvb validation

### DIFF
--- a/src/plugins/vis_type_timeseries/common/vis_schema.ts
+++ b/src/plugins/vis_type_timeseries/common/vis_schema.ts
@@ -119,6 +119,10 @@ export const metricsItems = schema.object({
   type: stringRequired,
   value: stringOptionalNullable,
   values: schema.maybe(schema.nullable(schema.arrayOf(schema.nullable(schema.string())))),
+  size: stringOptionalNullable,
+  agg_with: stringOptionalNullable,
+  order: stringOptionalNullable,
+  order_by: stringOptionalNullable,
 });
 
 const splitFiltersItems = schema.object({


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/20368

This fixes TSVB validation for "top hit" metrics configured:

```
Request validation error: child "panels" fails because ["panels" at position 0 fails because [child "series" fails because ["series" at position 0 fails because [child "metrics" fails because ["metrics" at position 0 fails because ["size" is not allowed, "agg_with" is not allowed, "order" is not allowed, "order_by" is not allowed]]]]]]
```

There should be no error messages in Kibana server log when configuring a TSVB top hit metric, even when using all of the settings