### PR TITLE
Change experimental message for visualizations

### DIFF
--- a/src/plugins/visualize/public/application/components/experimental_vis_info.tsx
+++ b/src/plugins/visualize/public/application/components/experimental_vis_info.tsx
@@ -26,12 +26,20 @@ export const InfoComponent = () => {
     <>
       <FormattedMessage
         id="visualize.experimentalVisInfoText"
-        defaultMessage="This visualization is marked as experimental. Have feedback? Please create an issue in"
-      />{' '}
-      <EuiLink external href="https://github.com/elastic/kibana/issues/new/choose" target="_blank">
-        GitHub
-      </EuiLink>
-      {'.'}
+        defaultMessage="This visualization is experimental and is not subject to the support SLA of official GA features.
+          For feedback, please create an issue in {githubLink}."
+        values={{
+          githubLink: (
+            <EuiLink
+              external
+              href="https://github.com/elastic/kibana/issues/new/choose"
+              target="_blank"
+            >
+              GitHub
+            </EuiLink>
+          ),
+        }}
+      />
     </>
   );
 

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4529,7 +4529,6 @@
     "visualize.createVisualization.noVisTypeErrorMessage": "有効なビジュアライゼーションタイプを指定してください",
     "visualize.editor.createBreadcrumb": "作成",
     "visualize.error.title": "ビジュアライゼーションエラー",
-    "visualize.experimentalVisInfoText": "このビジュアライゼーションは実験的なものです。フィードバックがありますか？で問題を報告してください。",
     "visualize.helpMenu.appName": "可視化",
     "visualize.linkedToSearch.unlinkSuccessNotificationText": "保存された検索「{searchTitle}」からリンクが解除されました",
     "visualize.listing.betaTitle": "ベータ",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4530,7 +4530,6 @@
     "visualize.createVisualization.noVisTypeErrorMessage": "必须提供有效的可视化类型",
     "visualize.editor.createBreadcrumb": "创建",
     "visualize.error.title": "可视化错误",
-    "visualize.experimentalVisInfoText": "此可视化标记为“实验性”。想反馈？请在以下位置创建问题：",
     "visualize.helpMenu.appName": "Visualize",
     "visualize.linkedToSearch.unlinkSuccessNotificationText": "已取消与已保存搜索“{searchTitle}”的链接",
     "visualize.listing.betaTitle": "公测版",


### PR DESCRIPTION
## Summary

This slightly adjusts the experimental banner in visualizations according to feedback from @gchaps in https://github.com/elastic/kibana/pull/73805#issuecomment-668173404

![screenshot-20200805-132559](https://user-images.githubusercontent.com/877229/89407708-8d221300-d71f-11ea-8e47-76a629f8ce70.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
