### PR TITLE
fixing encoding issue with \ for enroll command

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/components/enrollment_instructions/manual/index.tsx
@@ -36,8 +36,8 @@ export const ManualInstructions: React.FunctionComponent<Props> = ({
 systemctl enable elastic-agent
 systemctl start elastic-agent`;
 
-  const windowsCommand = `./elastic-agent enroll ${enrollArgs}
-./install-service-elastic-agent.ps1`;
+  const windowsCommand = `.\\elastic-agent enroll ${enrollArgs}
+.\\install-service-elastic-agent.ps1`;
 
   return (
     <>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/components/enrollment_instructions/manual/index.tsx
@@ -36,7 +36,7 @@ export const ManualInstructions: React.FunctionComponent<Props> = ({
 systemctl enable elastic-agent
 systemctl start elastic-agent`;
 
-  const windowsCommand = `.\elastic-agent enroll ${enrollArgs}
+  const windowsCommand = `./elastic-agent enroll ${enrollArgs}
 ./install-service-elastic-agent.ps1`;
 
   return (


### PR DESCRIPTION
## Summary
Fixes last change made for https://github.com/elastic/kibana/issues/73932
 - the changing of the ./ to .\ didn't work.  The \ is ommitted and so its just a period, which is worse than it was.  I should have tested better.  I'm doing so now.

It's an encoding issue, changing it to \\ works, so I'm changing it both Windows side locations.  

current master / 7.9
<img width="807" alt="Screen Shot 2020-08-05 at 11 28 39 AM" src="https://user-images.githubusercontent.com/12970373/89436855-cb660500-d714-11ea-823f-2b710da5cba5.png">

fixed:
<img width="757" alt="Screen Shot 2020-08-05 at 12 19 55 PM" src="https://user-images.githubusercontent.com/12970373/89437765-fd2b9b80-d715-11ea-83e2-b4addcba1171.png">
