### PR TITLE
[Ingest Manager] Rename agent configs SO to agent policies

### DIFF
--- a/x-pack/plugins/ingest_manager/common/constants/agent_config.ts
+++ b/x-pack/plugins/ingest_manager/common/constants/agent_config.ts
@@ -5,7 +5,7 @@
  */
 import { AgentConfigStatus, DefaultPackages } from '../types';
 
-export const AGENT_CONFIG_SAVED_OBJECT_TYPE = 'ingest-agent-configs';
+export const AGENT_CONFIG_SAVED_OBJECT_TYPE = 'ingest-agent-policies';
 
 export const DEFAULT_AGENT_CONFIG = {
   name: 'Default config',

--- a/x-pack/test/functional/es_archives/fleet/agents/data.json
+++ b/x-pack/test/functional/es_archives/fleet/agents/data.json
@@ -203,11 +203,11 @@
 {
   "type": "doc",
   "value": {
-    "id": "ingest-agent-configs:config1",
+    "id": "ingest-agent-policies:config1",
     "index": ".kibana",
     "source": {
-      "type": "ingest-agent-configs",
-      "ingest-agent-configs": {
+      "type": "ingest-agent-policies",
+      "ingest-agent-policies": {
         "name": "Test config",
         "namespace": "default",
         "description": "Config 1",

--- a/x-pack/test/functional/es_archives/fleet/agents/mappings.json
+++ b/x-pack/test/functional/es_archives/fleet/agents/mappings.json
@@ -58,7 +58,7 @@
           "siem-ui-timeline": "f2d929253ecd06ffbac78b4047f45a86",
           "kql-telemetry": "d12a98a6f19a2d273696597547e064ee",
           "ui-metric": "0d409297dc5ebe1e3a1da691c6ee32e3",
-          "ingest-agent-configs": "f4bdc17427437537ca1754d5d5057ad5",
+          "ingest-agent-policies": "f4bdc17427437537ca1754d5d5057ad5",
           "url": "b675c3be8d76ecf029294d51dc7ec65d",
           "migrationVersion": "4a1746014a75ade3a714e1db5763276f",
           "index-pattern": "66eccb05066c5a89924f48a9e9736499",
@@ -1797,7 +1797,7 @@
             }
           }
         },
-        "ingest-agent-configs": {
+        "ingest-agent-policies": {
           "properties": {
             "package_configs": {
               "type": "keyword"

--- a/x-pack/test/functional/es_archives/lists/mappings.json
+++ b/x-pack/test/functional/es_archives/lists/mappings.json
@@ -61,7 +61,7 @@
           "siem-ui-timeline": "94bc38c7a421d15fbfe8ea565370a421",
           "kql-telemetry": "d12a98a6f19a2d273696597547e064ee",
           "ui-metric": "0d409297dc5ebe1e3a1da691c6ee32e3",
-          "ingest-agent-configs": "9326f99c977fd2ef5ab24b6336a0675c",
+          "ingest-agent-policies": "9326f99c977fd2ef5ab24b6336a0675c",
           "url": "c7f66a0df8b1b52f17c28c4adb111105",
           "endpoint:user-artifact-manifest": "67c28185da541c1404e7852d30498cd6",
           "migrationVersion": "4a1746014a75ade3a714e1db5763276f",
@@ -1210,7 +1210,7 @@
             }
           }
         },
-        "ingest-agent-configs": {
+        "ingest-agent-policies": {
           "properties": {
             "description": {
               "type": "text"

--- a/x-pack/test/functional/es_archives/reporting/canvas_disallowed_url/mappings.json
+++ b/x-pack/test/functional/es_archives/reporting/canvas_disallowed_url/mappings.json
@@ -2,8 +2,7 @@
   "type": "index",
   "value": {
     "aliases": {
-      ".kibana": {
-      }
+      ".kibana": {}
     },
     "index": ".kibana_1",
     "mappings": {
@@ -38,7 +37,7 @@
           "fleet-enrollment-api-keys": "28b91e20b105b6f928e2012600085d8f",
           "graph-workspace": "cd7ba1330e6682e9cc00b78850874be1",
           "index-pattern": "66eccb05066c5a89924f48a9e9736499",
-          "ingest-agent-configs": "9326f99c977fd2ef5ab24b6336a0675c",
+          "ingest-agent-policies": "9326f99c977fd2ef5ab24b6336a0675c",
           "ingest-outputs": "8aa988c376e65443fefc26f1075e93a3",
           "ingest-package-configs": "48e8bd97e488008e21c0b5a2367b83ad",
           "ingest_manager_settings": "012cf278ec84579495110bb827d1ed09",
@@ -1149,7 +1148,7 @@
             }
           }
         },
-        "ingest-agent-configs": {
+        "ingest-agent-policies": {
           "properties": {
             "description": {
               "type": "text"

--- a/x-pack/test/security_solution_cypress/es_archives/export_rule/mappings.json
+++ b/x-pack/test/security_solution_cypress/es_archives/export_rule/mappings.json
@@ -39,7 +39,7 @@
           "graph-workspace": "cd7ba1330e6682e9cc00b78850874be1",
           "index-pattern": "66eccb05066c5a89924f48a9e9736499",
           "infrastructure-ui-source": "2b2809653635caf490c93f090502d04c",
-          "ingest-agent-configs": "9326f99c977fd2ef5ab24b6336a0675c",
+          "ingest-agent-policies": "9326f99c977fd2ef5ab24b6336a0675c",
           "ingest-outputs": "8aa988c376e65443fefc26f1075e93a3",
           "ingest-package-configs": "48e8bd97e488008e21c0b5a2367b83ad",
           "ingest_manager_settings": "012cf278ec84579495110bb827d1ed09",
@@ -1222,7 +1222,7 @@
             }
           }
         },
-        "ingest-agent-configs": {
+        "ingest-agent-policies": {
           "properties": {
             "description": {
               "type": "text"


### PR DESCRIPTION
## Summary

This PR is a proposal to rename `ingest-agent-configs` Saved Object type to `ingest-agent-policies` ahead of the rest of the work needed for renaming configs -> policies.

The other work involved in the renaming effort requires more SO changes, but those changes can be handled by creating SO migrations. Per Platform team, changing the SO "type" string using a migration is _theoretically_ possible, but may introduce a lot of complexity and unknowns. That's why I'd like to rename this string now to avoid potential breaking changes in a subsequent release.

This change is largely invisible to end users as we are not changing client routes, API routes, or UI yet. The only place where it surfaces is in the autocomplete for filtering agent configs, but I think this is acceptable for now:

![image](https://user-images.githubusercontent.com/1965714/89447687-3f031480-d70b-11ea-8a48-2278b5d2afde.png)
