### PR TITLE
[SIEM] [Detections] Adds error callback when exception is thrown trying to decrypt alerting ESO

### DIFF
--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -323,8 +323,8 @@ export class TaskRunner {
             this.logger.debug(message);
           } else {
             this.logger.error(message);
-            if (this.alertType.errorCB != null) {
-              this.alertType.errorCB({ alertId, message });
+            if (this.alertType.onError != null) {
+              this.alertType.onError({ alertId, message });
             }
           }
           return {

--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -317,6 +317,7 @@ export class TaskRunner {
             previousStartedAt,
           };
         },
+        // @ts-expect-error
         async (err: Error) => {
           const message = `Executing Alert "${alertId}" has resulted in Error: ${err.message}`;
           if (isAlertSavedObjectNotFoundError(err, alertId)) {

--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -317,7 +317,6 @@ export class TaskRunner {
             previousStartedAt,
           };
         },
-
         (err: Error) => {
           const message = `Executing Alert "${alertId}" has resulted in Error: ${err.message}`;
           if (isAlertSavedObjectNotFoundError(err, alertId)) {

--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -317,14 +317,14 @@ export class TaskRunner {
             previousStartedAt,
           };
         },
-        // @ts-expect-error
-        async (err: Error) => {
+
+        (err: Error) => {
           const message = `Executing Alert "${alertId}" has resulted in Error: ${err.message}`;
           if (isAlertSavedObjectNotFoundError(err, alertId)) {
             this.logger.debug(message);
           } else {
             this.logger.error(message);
-            await this.alertType.errorCB({ alertId, message });
+            this.alertType.errorCB({ alertId, message });
           }
           return {
             ...originalState,

--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -317,12 +317,13 @@ export class TaskRunner {
             previousStartedAt,
           };
         },
-        (err: Error) => {
+        async (err: Error) => {
           const message = `Executing Alert "${alertId}" has resulted in Error: ${err.message}`;
           if (isAlertSavedObjectNotFoundError(err, alertId)) {
             this.logger.debug(message);
           } else {
             this.logger.error(message);
+            await this.alertType.errorCB({ alertId, message });
           }
           return {
             ...originalState,

--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -324,7 +324,9 @@ export class TaskRunner {
             this.logger.debug(message);
           } else {
             this.logger.error(message);
-            this.alertType.errorCB({ alertId, message });
+            if (this.alertType.errorCB != null) {
+              this.alertType.errorCB({ alertId, message });
+            }
           }
           return {
             ...originalState,

--- a/x-pack/plugins/alerts/server/types.ts
+++ b/x-pack/plugins/alerts/server/types.ts
@@ -86,7 +86,7 @@ export interface AlertType {
     state?: ActionVariable[];
     params?: ActionVariable[];
   };
-  errorCB?: ({ alertId, message }: { alertId: string; message: string }) => Promise<void>;
+  onError?: ({ alertId, message }: { alertId: string; message: string }) => Promise<void>;
 }
 
 export interface RawAlertAction extends SavedObjectAttributes {

--- a/x-pack/plugins/alerts/server/types.ts
+++ b/x-pack/plugins/alerts/server/types.ts
@@ -86,7 +86,7 @@ export interface AlertType {
     state?: ActionVariable[];
     params?: ActionVariable[];
   };
-  errorCB: ({ alertId, message }: { alertId: string; message: string }) => Promise<void>;
+  errorCB?: ({ alertId, message }: { alertId: string; message: string }) => Promise<void>;
 }
 
 export interface RawAlertAction extends SavedObjectAttributes {

--- a/x-pack/plugins/alerts/server/types.ts
+++ b/x-pack/plugins/alerts/server/types.ts
@@ -86,6 +86,7 @@ export interface AlertType {
     state?: ActionVariable[];
     params?: ActionVariable[];
   };
+  errorCB: ({ alertId, message }: { alertId: string; message: string }) => Promise<void>;
 }
 
 export interface RawAlertAction extends SavedObjectAttributes {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/rule_status_saved_objects_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/rule_status_saved_objects_client.ts
@@ -10,6 +10,7 @@ import {
   SavedObjectsUpdateResponse,
   SavedObjectsFindOptions,
   SavedObjectsFindResponse,
+  SavedObjectsRepository,
 } from '../../../../../../../src/core/server';
 import { ruleStatusSavedObjectType } from '../rules/saved_object_mappings';
 import { IRuleStatusAttributes } from '../rules/types';
@@ -27,7 +28,7 @@ export interface RuleStatusSavedObjectsClient {
 }
 
 export const ruleStatusSavedObjectsClientFactory = (
-  savedObjectsClient: SavedObjectsClientContract
+  savedObjectsClient: SavedObjectsClientContract | SavedObjectsRepository
 ): RuleStatusSavedObjectsClient => ({
   find: (options) =>
     savedObjectsClient.find<IRuleStatusAttributes>({ ...options, type: ruleStatusSavedObjectType }),

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/rule_status_saved_objects_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/rule_status_saved_objects_client.ts
@@ -10,7 +10,7 @@ import {
   SavedObjectsUpdateResponse,
   SavedObjectsFindOptions,
   SavedObjectsFindResponse,
-  SavedObjectsRepository,
+  ISavedObjectsRepository,
 } from '../../../../../../../src/core/server';
 import { ruleStatusSavedObjectType } from '../rules/saved_object_mappings';
 import { IRuleStatusAttributes } from '../rules/types';
@@ -28,7 +28,7 @@ export interface RuleStatusSavedObjectsClient {
 }
 
 export const ruleStatusSavedObjectsClientFactory = (
-  savedObjectsClient: SavedObjectsClientContract | SavedObjectsRepository
+  savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository
 ): RuleStatusSavedObjectsClient => ({
   find: (options) =>
     savedObjectsClient.find<IRuleStatusAttributes>({ ...options, type: ruleStatusSavedObjectType }),

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
@@ -129,6 +129,7 @@ describe('rules_notification_alert_type', () => {
       version,
       ml: mlMock,
       lists: listMock.createSetup(),
+      errorService: undefined,
     });
   });
 
@@ -236,6 +237,7 @@ describe('rules_notification_alert_type', () => {
           version,
           ml: undefined,
           lists: undefined,
+          errorService: undefined,
         });
         await alert.executor(payload);
         expect(logger.error).toHaveBeenCalled();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
@@ -5,7 +5,8 @@
  */
 
 import moment from 'moment';
-import { loggingSystemMock } from 'src/core/server/mocks';
+
+import { loggingSystemMock, savedObjectsRepositoryMock } from 'src/core/server/mocks';
 import { getResult, getMlResult } from '../routes/__mocks__/request_responses';
 import { signalRulesAlertType } from './signal_rule_alert_type';
 import { alertsMock, AlertServicesMock } from '../../../../../alerts/server/mocks';
@@ -129,7 +130,7 @@ describe('rules_notification_alert_type', () => {
       version,
       ml: mlMock,
       lists: listMock.createSetup(),
-      errorService: undefined,
+      securitySavedObjectsClient: (async () => savedObjectsRepositoryMock.create())(),
     });
   });
 
@@ -237,7 +238,7 @@ describe('rules_notification_alert_type', () => {
           version,
           ml: undefined,
           lists: undefined,
-          errorService: undefined,
+          securitySavedObjectsClient: (async () => savedObjectsRepositoryMock.create())(),
         });
         await alert.executor(payload);
         expect(logger.error).toHaveBeenCalled();

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -428,8 +428,6 @@ export const signalRulesAlertType = ({
         });
         await ruleStatusService.error(message);
       }
-
-      return Promise.resolve(logger.error(message));
     },
   };
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable complexity */
 
-import { Logger, KibanaRequest } from 'src/core/server';
+import { Logger, KibanaRequest, ISavedObjectsRepository } from 'src/core/server';
 
 import {
   SIGNALS_ID,
@@ -50,13 +50,13 @@ export const signalRulesAlertType = ({
   version,
   ml,
   lists,
-  errorService,
+  securitySavedObjectsClient,
 }: {
   logger: Logger;
   version: string;
   ml: SetupPlugins['ml'];
   lists: SetupPlugins['lists'] | undefined;
-  errorService: SetupPlugins['errorService'];
+  securitySavedObjectsClient: Promise<ISavedObjectsRepository>;
 }): SignalRuleAlertTypeDefinition => {
   return {
     id: SIGNALS_ID,
@@ -415,9 +415,9 @@ export const signalRulesAlertType = ({
         });
       }
     },
-    errorCB: async ({ alertId, message }) => {
+    onError: async ({ alertId, message }) => {
       logger.error(`Detections rule with alert Id: ${alertId} failed with message: ${message}`);
-      const savedObjectsClient = await errorService;
+      const savedObjectsClient = await securitySavedObjectsClient;
       if (savedObjectsClient != null) {
         const ruleStatusClient = ruleStatusSavedObjectsClientFactory(savedObjectsClient);
         const ruleStatusService = await ruleStatusServiceFactory({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable complexity */
 
-import { Logger, KibanaRequest, SavedObjectsRepository } from 'src/core/server';
+import { Logger, KibanaRequest } from 'src/core/server';
 
 import {
   SIGNALS_ID,
@@ -419,9 +419,7 @@ export const signalRulesAlertType = ({
       logger.error(`Detections rule with alert Id: ${alertId} failed with message: ${message}`);
       const savedObjectsClient = await errorService;
       if (savedObjectsClient != null) {
-        const ruleStatusClient = ruleStatusSavedObjectsClientFactory(
-          savedObjectsClient as SavedObjectsRepository
-        );
+        const ruleStatusClient = ruleStatusSavedObjectsClientFactory(savedObjectsClient);
         const ruleStatusService = await ruleStatusServiceFactory({
           alertId,
           ruleStatusClient,

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -16,7 +16,6 @@ import {
   Plugin as IPlugin,
   PluginInitializerContext,
   SavedObjectsClient,
-  SavedObjectsRepository,
   ISavedObjectsRepository,
 } from '../../../../src/core/server';
 import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/server';

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -16,7 +16,6 @@ import {
   Plugin as IPlugin,
   PluginInitializerContext,
   SavedObjectsClient,
-  ISavedObjectsRepository,
 } from '../../../../src/core/server';
 import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/server';
 import { PluginSetupContract as AlertingSetup } from '../../alerts/server';
@@ -71,7 +70,6 @@ export interface SetupPlugins {
   spaces?: SpacesSetup;
   taskManager?: TaskManagerSetupContract;
   usageCollection?: UsageCollectionSetup;
-  errorService?: Promise<ISavedObjectsRepository>;
 }
 
 export interface StartPlugins {
@@ -236,7 +234,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         version: this.context.env.packageInfo.version,
         ml: plugins.ml,
         lists: plugins.lists,
-        errorService: (async () => {
+        securitySavedObjectsClient: (async () => {
           const [coreStart] = await core.getStartServices();
           return coreStart.savedObjects.createInternalRepository();
         })(),

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -114,6 +114,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     this.appClientFactory = new AppClientFactory();
     // Cache up to three artifacts with a max retention of 5 mins each
     this.exceptionsCache = new LRU<string, Buffer>({ max: 3, maxAge: 1000 * 60 * 5 });
+
     this.logger.debug('plugin initialized');
   }
 

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -235,16 +235,16 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         version: this.context.env.packageInfo.version,
         ml: plugins.ml,
         lists: plugins.lists,
-        errorService: core.getStartServices().then(async ([coreStart]) => {
+        errorService: (async () => {
+          const [coreStart] = await core.getStartServices();
           return coreStart.savedObjects.createInternalRepository();
-        }),
+        })(),
       });
       const ruleNotificationType = rulesNotificationAlertType({
         logger: this.logger,
       });
 
       if (isAlertExecutor(signalRuleType)) {
-        // add status callback here in order to pick up failures on task manager
         plugins.alerts.registerType(signalRuleType);
       }
 


### PR DESCRIPTION
## Summary

Adds error callback when exception is thrown while trying to validate encryption keys against encrypted saved objects. This allows us to set our rules to a failing state and gives us better error handling on exceptions that happen inside of task manager and can't trigger our executor code.

<img width="888" alt="Screen Shot 2020-08-05 at 1 42 47 PM" src="https://user-images.githubusercontent.com/915763/89449939-ca8a9e80-d727-11ea-9c3f-1c2ccb974570.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
