### PR TITLE
[Ingest Manager] Create default Error handler. Use on /setup & EPM routes

### DIFF
--- a/x-pack/plugins/ingest_manager/server/errors.test.ts
+++ b/x-pack/plugins/ingest_manager/server/errors.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import Boom from 'boom';
+import { httpServerMock } from 'src/core/server/mocks';
+import { createAppContextStartContractMock } from './mocks';
+
+import {
+  IngestManagerError,
+  RegistryError,
+  PackageNotFoundError,
+  defaultIngestErrorHandler,
+} from './errors';
+import { appContextService } from './services';
+
+describe('defaultIngestErrorHandler', () => {
+  let mockContract: ReturnType<typeof createAppContextStartContractMock>;
+  beforeEach(async () => {
+    // prevents `Logger not set.` and other appContext errors
+    mockContract = createAppContextStartContractMock();
+    appContextService.start(mockContract);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    appContextService.stop();
+  });
+
+  describe('IngestManagerError', () => {
+    it('502: RegistryError', async () => {
+      const error = new RegistryError('xyz');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 502,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith(error.message);
+    });
+
+    it('404: PackageNotFoundError', async () => {
+      const error = new PackageNotFoundError('123');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 404,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith(error.message);
+    });
+
+    it('400: IngestManagerError', async () => {
+      const error = new IngestManagerError('123');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 400,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith(error.message);
+    });
+  });
+
+  describe('Boom', () => {
+    it('500: constructor - one arg', async () => {
+      const error = new Boom('bam');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 500,
+        body: { message: 'An internal server error occurred' },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith('An internal server error occurred');
+    });
+
+    it('custom: constructor - 2 args', async () => {
+      const error = new Boom('Problem doing something', {
+        statusCode: 456,
+      });
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 456,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith('Problem doing something');
+    });
+
+    it('400: Boom.badRequest', async () => {
+      const error = Boom.badRequest('nope');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 400,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith('nope');
+    });
+
+    it('404: Boom.notFound', async () => {
+      const error = Boom.notFound('sorry');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 404,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith('sorry');
+    });
+  });
+
+  describe('all other errors', () => {
+    it('500', async () => {
+      const error = new Error('something');
+      const response = httpServerMock.createResponseFactory();
+
+      await defaultIngestErrorHandler({ error, response });
+
+      // response
+      expect(response.ok).toHaveBeenCalledTimes(0);
+      expect(response.customError).toHaveBeenCalledTimes(1);
+      expect(response.customError).toHaveBeenCalledWith({
+        statusCode: 500,
+        body: { message: error.message },
+      });
+
+      // logging
+      expect(mockContract.logger?.error).toHaveBeenCalledTimes(1);
+      expect(mockContract.logger?.error).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/x-pack/plugins/ingest_manager/server/errors.ts
+++ b/x-pack/plugins/ingest_manager/server/errors.ts
@@ -6,7 +6,12 @@
 
 /* eslint-disable max-classes-per-file */
 import Boom from 'boom';
-import { RequestHandlerContext, KibanaRequest, KibanaResponseFactory } from 'src/core/server';
+import {
+  RequestHandlerContext,
+  KibanaRequest,
+  IKibanaResponse,
+  KibanaResponseFactory,
+} from 'src/core/server';
 import { appContextService } from './services';
 
 export class IngestManagerError extends Error {
@@ -27,7 +32,7 @@ export const getHTTPResponseCode = (error: IngestManagerError): number => {
   return 400; // Bad Request
 };
 
-interface IngestErrorHandler {
+interface IngestErrorHandlerParams {
   error: IngestManagerError | Boom | Error;
   response: KibanaResponseFactory;
   request?: KibanaRequest;
@@ -39,7 +44,7 @@ export const defaultIngestErrorHandler = async ({
   request,
   response,
   context,
-}: IngestErrorHandler) => {
+}: IngestErrorHandlerParams): Promise<IKibanaResponse> => {
   const logger = appContextService.getLogger();
   if (error instanceof IngestManagerError) {
     logger.error(error.message);

--- a/x-pack/plugins/ingest_manager/server/errors.ts
+++ b/x-pack/plugins/ingest_manager/server/errors.ts
@@ -32,7 +32,7 @@ export class IngestManagerError extends Error {
   }
 }
 
-export const getHTTPResponseCode = (error: IngestManagerError): number => {
+const getHTTPResponseCode = (error: IngestManagerError): number => {
   if (error instanceof RegistryError) {
     return 502; // Bad Gateway
   }

--- a/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
@@ -150,6 +150,8 @@ export const installPackageHandler: RequestHandler<
     };
     return response.ok({ body });
   } catch (e) {
+    // could have also done `return defaultIngestErrorHandler({ error: e, response })` at each of the returns,
+    // but doing it this way will log the outer/install errors before any inner/rollback errors
     const defaultResult = await defaultIngestErrorHandler({ error: e, response });
     if (e instanceof IngestManagerError) {
       return defaultResult;

--- a/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
@@ -32,7 +32,7 @@ import {
   getLimitedPackages,
   getInstallationObject,
 } from '../../services/epm/packages';
-import { IngestManagerError, getHTTPResponseCode } from '../../errors';
+import { IngestManagerError, getHTTPResponseCode, defaultIngestErrorHandler } from '../../errors';
 import { splitPkgKey } from '../../services/epm/registry';
 
 export const getCategoriesHandler: RequestHandler<
@@ -45,11 +45,8 @@ export const getCategoriesHandler: RequestHandler<
       response: res,
     };
     return response.ok({ body });
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 
@@ -69,11 +66,8 @@ export const getListHandler: RequestHandler<
     return response.ok({
       body,
     });
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 
@@ -87,11 +81,8 @@ export const getLimitedListHandler: RequestHandler = async (context, request, re
     return response.ok({
       body,
     });
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 
@@ -112,11 +103,8 @@ export const getFileHandler: RequestHandler<TypeOf<typeof GetFileRequestSchema.p
       customResponseObj.headers = { 'Content-Type': contentType };
     }
     return response.custom(customResponseObj);
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 
@@ -135,11 +123,8 @@ export const getInfoHandler: RequestHandler<TypeOf<typeof GetInfoRequestSchema.p
       response: res,
     };
     return response.ok({ body });
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 
@@ -203,16 +188,7 @@ export const deletePackageHandler: RequestHandler<TypeOf<
       response: res,
     };
     return response.ok({ body });
-  } catch (e) {
-    if (e.isBoom) {
-      return response.customError({
-        statusCode: e.output.statusCode,
-        body: { message: e.output.payload.message },
-      });
-    }
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };

--- a/x-pack/plugins/ingest_manager/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/setup/handlers.ts
@@ -46,11 +46,8 @@ export const getFleetStatusHandler: RequestHandler = async (context, request, re
     return response.ok({
       body,
     });
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 

--- a/x-pack/plugins/ingest_manager/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/setup/handlers.ts
@@ -9,7 +9,7 @@ import { outputService, appContextService } from '../../services';
 import { GetFleetStatusResponse, PostIngestSetupResponse } from '../../../common';
 import { setupIngestManager, setupFleet } from '../../services/setup';
 import { PostFleetSetupRequestSchema } from '../../types';
-import { IngestManagerError, getHTTPResponseCode } from '../../errors';
+import { defaultIngestErrorHandler } from '../../errors';
 
 export const getFleetStatusHandler: RequestHandler = async (context, request, response) => {
   const soClient = context.core.savedObjects.client;
@@ -70,44 +70,22 @@ export const createFleetSetupHandler: RequestHandler<
     return response.ok({
       body: { isInitialized: true },
     });
-  } catch (e) {
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };
 
 export const ingestManagerSetupHandler: RequestHandler = async (context, request, response) => {
   const soClient = context.core.savedObjects.client;
   const callCluster = context.core.elasticsearch.legacy.client.callAsCurrentUser;
-  const logger = appContextService.getLogger();
+
   try {
     const body: PostIngestSetupResponse = { isInitialized: true };
     await setupIngestManager(soClient, callCluster);
     return response.ok({
       body,
     });
-  } catch (e) {
-    if (e instanceof IngestManagerError) {
-      logger.error(e.message);
-      return response.customError({
-        statusCode: getHTTPResponseCode(e),
-        body: { message: e.message },
-      });
-    }
-    if (e.isBoom) {
-      logger.error(e.output.payload.message);
-      return response.customError({
-        statusCode: e.output.statusCode,
-        body: { message: e.output.payload.message },
-      });
-    }
-    logger.error(e.message);
-    logger.error(e.stack);
-    return response.customError({
-      statusCode: 500,
-      body: { message: e.message },
-    });
+  } catch (error) {
+    return defaultIngestErrorHandler({ error, response });
   }
 };


### PR DESCRIPTION
## Summary

* Added `defaultIngestErrorHandler`
  - error handler which deals with logging & responses in a consistent way. Based on discussions/iterations like https://github.com/elastic/kibana/issues/66688#issuecomment-629836991 and elsewhere
* Use it for error handling on these API routes
  - /setup
  - /fleet/setup
  - /epm/* (7 handlers)


This adds an `IngestErrorHandler` type/function. It has same output as a `RequestHandler` and its inputs are the 3 `RequestHandler` inputs + `error`. 

```typescript
type IngestErrorHandler = (
  params: IngestErrorHandlerParams
) => IKibanaResponse | Promise<IKibanaResponse>;

interface IngestErrorHandlerParams {
  error: IngestManagerError | Boom | Error;
  response: KibanaResponseFactory;
  request?: KibanaRequest;
  context?: RequestHandlerContext;
}
```

It maps an `Error` and `ResponseFactory` to an `IKibanaResponse`.  Now the handlers look roughly like:

```typescript
async function handler(context, request, response): KibanaResponse {
  try {
    const result = await something();
    return response.ok({ body: result });
  } catch (error) {
    return defaultIngestErrorHandler({ error, response });
  }
}
```

I've started with `defaultIngestErrorHandler` and we can add different Error handlers when/if needed.

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

 * The tests added in ensure the `POST /setup` case didn't regress, but I'm not sure what additional tests we want.
 * ~~I'll add~~ tests to confirm `defaultIngestErrorHandler` behaves as advertised
```
  defaultIngestErrorHandler
    IngestManagerError
      ✓ 502: RegistryError (7ms)
      ✓ 404: PackageNotFoundError (2ms)
      ✓ 400: IngestManagerError (2ms)
    Boom
      ✓ 500: constructor - one arg (2ms)
      ✓ custom: constructor - 2 args (1ms)
      ✓ 400: Boom.badRequest (2ms)
      ✓ 404: Boom.notFound (1ms)
    all other errors
      ✓ 500 (2ms)
```