### PR TITLE
[Fix] Lose OriginatingApp Connection on Save After Create new

### DIFF
--- a/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
@@ -114,7 +114,7 @@ export const getTopNavConfig = (
             application.navigateToApp(originatingApp);
           }
         } else {
-          if (setOriginatingApp && originatingApp && savedVis.copyOnSave) {
+          if (setOriginatingApp && originatingApp && newlyCreated) {
             setOriginatingApp(undefined);
           }
           chrome.docTitle.change(savedVis.lastSavedTitle);

--- a/test/functional/apps/dashboard/edit_embeddable_redirects.js
+++ b/test/functional/apps/dashboard/edit_embeddable_redirects.js
@@ -21,8 +21,10 @@ import expect from '@kbn/expect';
 export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['dashboard', 'header', 'visualize', 'settings', 'common']);
   const esArchiver = getService('esArchiver');
+  const testSubjects = getService('testSubjects');
   const kibanaServer = getService('kibanaServer');
   const dashboardPanelActions = getService('dashboardPanelActions');
+  const dashboardVisualizations = getService('dashboardVisualizations');
 
   describe('edit embeddable redirects', () => {
     before(async () => {
@@ -81,6 +83,23 @@ export default function ({ getService, getPageObjects }) {
       await PageObjects.header.waitUntilLoadingHasFinished();
       await dashboardPanelActions.openContextMenu();
       await dashboardPanelActions.clickEdit();
+      await PageObjects.visualize.linkedToOriginatingApp();
+      await PageObjects.visualize.saveVisualizationExpectSuccess(newTitle, {
+        saveAsNew: true,
+        redirectToOrigin: false,
+      });
+      await PageObjects.visualize.notLinkedToOriginatingApp();
+      await PageObjects.common.navigateToApp('dashboard');
+    });
+
+    it('loses originatingApp connection after first save when redirectToOrigin is false', async () => {
+      const newTitle = 'test create panel originatingApp';
+      await PageObjects.dashboard.loadSavedDashboard('few panels');
+      await PageObjects.dashboard.switchToEditMode();
+      await testSubjects.exists('dashboardAddNewPanelButton');
+      await testSubjects.click('dashboardAddNewPanelButton');
+      await dashboardVisualizations.ensureNewVisualizationDialogIsShowing();
+      await PageObjects.visualize.clickMarkdownWidget();
       await PageObjects.visualize.saveVisualizationExpectSuccess(newTitle, {
         saveAsNew: true,
         redirectToOrigin: false,

--- a/test/functional/services/dashboard/visualizations.ts
+++ b/test/functional/services/dashboard/visualizations.ts
@@ -124,7 +124,18 @@ export function DashboardVisualizationProvider({ getService, getPageObjects }: F
       }
     }
 
-    async createAndAddMarkdown({ name, markdown }: { name: string; markdown: string }) {
+    async createAndAddMarkdown({
+      name,
+      markdown,
+      saveOptions = {
+        saveAsNew: false,
+        redirectToOrigin: true,
+      },
+    }: {
+      name: string;
+      markdown: string;
+      saveOptions: { saveAsNew: boolean; redirectToOrigin: boolean };
+    }) {
       log.debug(`createAndAddMarkdown(${markdown})`);
       const inViewMode = await PageObjects.dashboard.getIsInViewMode();
       if (inViewMode) {
@@ -135,8 +146,8 @@ export function DashboardVisualizationProvider({ getService, getPageObjects }: F
       await PageObjects.visEditor.setMarkdownTxt(markdown);
       await PageObjects.visEditor.clickGo();
       await PageObjects.visualize.saveVisualizationExpectSuccess(name, {
-        saveAsNew: false,
-        redirectToOrigin: true,
+        saveAsNew: saveOptions.saveAsNew,
+        redirectToOrigin: saveOptions.redirectToOrigin,
       });
     }
 

--- a/test/functional/services/dashboard/visualizations.ts
+++ b/test/functional/services/dashboard/visualizations.ts
@@ -124,18 +124,7 @@ export function DashboardVisualizationProvider({ getService, getPageObjects }: F
       }
     }
 
-    async createAndAddMarkdown({
-      name,
-      markdown,
-      saveOptions = {
-        saveAsNew: false,
-        redirectToOrigin: true,
-      },
-    }: {
-      name: string;
-      markdown: string;
-      saveOptions: { saveAsNew: boolean; redirectToOrigin: boolean };
-    }) {
+    async createAndAddMarkdown({ name, markdown }: { name: string; markdown: string }) {
       log.debug(`createAndAddMarkdown(${markdown})`);
       const inViewMode = await PageObjects.dashboard.getIsInViewMode();
       if (inViewMode) {
@@ -146,8 +135,8 @@ export function DashboardVisualizationProvider({ getService, getPageObjects }: F
       await PageObjects.visEditor.setMarkdownTxt(markdown);
       await PageObjects.visEditor.clickGo();
       await PageObjects.visualize.saveVisualizationExpectSuccess(name, {
-        saveAsNew: saveOptions.saveAsNew,
-        redirectToOrigin: saveOptions.redirectToOrigin,
+        saveAsNew: false,
+        redirectToOrigin: true,
       });
     }
 

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -323,9 +323,7 @@ export function App({
           ...s,
           isSaveModalVisible: false,
           originatingApp:
-            saveProps.newCopyOnSave && !saveProps.returnToOrigin
-              ? undefined
-              : currentOriginatingApp,
+            newlyCreated && !saveProps.returnToOrigin ? undefined : currentOriginatingApp,
           persistedDoc: newDoc,
           lastKnownDoc: newDoc,
         }));


### PR DESCRIPTION
## Summary

Closes #74400 by fixing a small typo made in https://github.com/elastic/kibana/pull/72725. This typo resulted in the originatingApp connection not being severed after the user saved a _newly created_ visualization and had not specifically checked the `save as new visualization` button.

### How to test
- create a new panel from dashboard
- Once you are in the editor, use the modal (save), to save the visualization / lens visualization
- Deselect 'return to...' and save.
- The originatingApp connection should now be lost, and the top nav menu should only display `save`

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials~~
~~- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
~~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
~~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~~
### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
