### PR TITLE
[SECURITY] Bug investigate timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
@@ -7,6 +7,7 @@
 import { isEmpty } from 'lodash/fp';
 import { useEffect, useMemo, useState, useRef } from 'react';
 
+import { deepEqual } from 'hoek';
 import { DEFAULT_INDEX_KEY } from '../../../../common/constants';
 import { MatrixHistogramQueryProps } from '../../components/matrix_histogram/types';
 import { errorToToaster, useStateToaster } from '../../components/toasters';
@@ -34,7 +35,6 @@ export const useQuery = ({
     }
     return configIndex;
   }, [configIndex, indexToAdd]);
-
   const [, dispatchToaster] = useStateToaster();
   const refetch = useRef<inputsModel.Refetch>();
   const [loading, setLoading] = useState<boolean>(false);
@@ -43,20 +43,54 @@ export const useQuery = ({
   const [totalCount, setTotalCount] = useState<number>(-1);
   const apolloClient = useApolloClient();
 
+  const [matrixHistogramVariables, setMatrixHistogramVariables] = useState<
+    GetMatrixHistogramQuery.Variables
+  >({
+    filterQuery: createFilter(filterQuery),
+    sourceId: 'default',
+    timerange: {
+      interval: '12h',
+      from: startDate!,
+      to: endDate!,
+    },
+    defaultIndex,
+    inspect: isInspected,
+    stackByField,
+    histogramType,
+  });
+
   useEffect(() => {
-    const matrixHistogramVariables: GetMatrixHistogramQuery.Variables = {
-      filterQuery: createFilter(filterQuery),
-      sourceId: 'default',
-      timerange: {
-        interval: '12h',
-        from: startDate!,
-        to: endDate!,
-      },
-      defaultIndex,
-      inspect: isInspected,
-      stackByField,
-      histogramType,
-    };
+    setMatrixHistogramVariables((prevVariables) => {
+      const localVariables = {
+        filterQuery: createFilter(filterQuery),
+        sourceId: 'default',
+        timerange: {
+          interval: '12h',
+          from: startDate!,
+          to: endDate!,
+        },
+        defaultIndex,
+        inspect: isInspected,
+        stackByField,
+        histogramType,
+      };
+      if (!deepEqual(prevVariables, localVariables)) {
+        return localVariables;
+      }
+      return prevVariables;
+    });
+  }, [
+    defaultIndex,
+    filterQuery,
+    histogramType,
+    indexToAdd,
+    isInspected,
+    stackByField,
+    startDate,
+    endDate,
+  ]);
+
+  useEffect(() => {
     let isSubscribed = true;
     const abortCtrl = new AbortController();
     const abortSignal = abortCtrl.signal;
@@ -102,19 +136,7 @@ export const useQuery = ({
       isSubscribed = false;
       abortCtrl.abort();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    defaultIndex,
-    errorMessage,
-    filterQuery,
-    histogramType,
-    indexToAdd,
-    isInspected,
-    stackByField,
-    startDate,
-    endDate,
-    data,
-  ]);
+  }, [apolloClient, dispatchToaster, errorMessage, matrixHistogramVariables]);
 
   return { data, loading, inspect, totalCount, refetch: refetch.current };
 };

--- a/x-pack/plugins/security_solution/public/common/mock/timeline_results.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/timeline_results.ts
@@ -8,7 +8,13 @@ import { FilterStateStore } from '../../../../../../src/plugins/data/common/es_q
 import { TimelineType, TimelineStatus } from '../../../common/types/timeline';
 
 import { OpenTimelineResult } from '../../timelines/components/open_timeline/types';
-import { GetAllTimeline, SortFieldTimeline, TimelineResult, Direction } from '../../graphql/types';
+import {
+  GetAllTimeline,
+  SortFieldTimeline,
+  TimelineResult,
+  Direction,
+  DetailItem,
+} from '../../graphql/types';
 import { allTimelinesQuery } from '../../timelines/containers/all/index.gql_query';
 import { CreateTimelineProps } from '../../detections/components/alerts_table/types';
 import { TimelineModel } from '../../timelines/store/timeline/model';
@@ -2252,5 +2258,32 @@ export const defaultTimelineProps: CreateTimelineProps = {
     width: 1100,
   },
   to: '2018-11-05T19:03:25.937Z',
+  notes: null,
   ruleNote: '# this is some markdown documentation',
+};
+
+export const mockTimelineDetails: DetailItem[] = [
+  {
+    field: 'host.name',
+    values: ['apache'],
+    originalValue: 'apache',
+  },
+  {
+    field: 'user.id',
+    values: ['1'],
+    originalValue: 1,
+  },
+];
+
+export const mockTimelineDetailsApollo = {
+  data: {
+    source: {
+      TimelineDetails: {
+        data: mockTimelineDetails,
+      },
+    },
+  },
+  loading: false,
+  networkStatus: 7,
+  stale: false,
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.test.tsx
@@ -3,6 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
+import { get } from 'lodash/fp';
 import sinon from 'sinon';
 import moment from 'moment';
 
@@ -12,6 +14,7 @@ import {
   defaultTimelineProps,
   apolloClient,
   mockTimelineApolloResult,
+  mockTimelineDetailsApollo,
 } from '../../../common/mock/';
 import { CreateTimeline, UpdateTimelineLoading } from './types';
 import { Ecs } from '../../../graphql/types';
@@ -37,7 +40,13 @@ describe('alert actions', () => {
     createTimeline = jest.fn() as jest.Mocked<CreateTimeline>;
     updateTimelineIsLoading = jest.fn() as jest.Mocked<UpdateTimelineLoading>;
 
-    jest.spyOn(apolloClient, 'query').mockResolvedValue(mockTimelineApolloResult);
+    jest.spyOn(apolloClient, 'query').mockImplementation((obj) => {
+      const id = get('variables.id', obj);
+      if (id != null) {
+        return Promise.resolve(mockTimelineApolloResult);
+      }
+      return Promise.resolve(mockTimelineDetailsApollo);
+    });
 
     clock = sinon.useFakeTimers(unix);
   });
@@ -71,6 +80,7 @@ describe('alert actions', () => {
         });
         const expected = {
           from: '2018-11-05T18:58:25.937Z',
+          notes: null,
           timeline: {
             columns: [
               {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/helpers.ts
@@ -4,14 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { get, isEmpty } from 'lodash/fp';
+import { isEmpty } from 'lodash/fp';
 import { Filter, esKuery, KueryNode } from '../../../../../../../src/plugins/data/public';
 import {
   DataProvider,
   DataProviderType,
   DataProvidersAnd,
 } from '../../../timelines/components/timeline/data_providers/data_provider';
-import { Ecs, TimelineType } from '../../../graphql/types';
+import { DetailItem, TimelineType } from '../../../graphql/types';
 
 interface FindValueToChangeInQuery {
   field: string;
@@ -47,8 +47,12 @@ const templateFields = [
  * @param data The unknown data that is typically a ECS value to get the value
  * @param localConsole The local console which can be sent in to make this pure (for tests) or use the default console
  */
-export const getStringArray = (field: string, data: unknown, localConsole = console): string[] => {
-  const value: unknown | undefined = get(field, data);
+export const getStringArray = (
+  field: string,
+  data: DetailItem[],
+  localConsole = console
+): string[] => {
+  const value: unknown | undefined = data.find((d) => d.field === field)?.values ?? null;
   if (value == null) {
     return [];
   } else if (typeof value === 'string') {
@@ -104,14 +108,14 @@ export const findValueToChangeInQuery = (
 
 export const replaceTemplateFieldFromQuery = (
   query: string,
-  ecsData: Ecs,
+  eventData: DetailItem[],
   timelineType: TimelineType = TimelineType.default
 ): string => {
   if (timelineType === TimelineType.default) {
     if (query.trim() !== '') {
       const valueToChange = findValueToChangeInQuery(esKuery.fromKueryExpression(query));
       return valueToChange.reduce((newQuery, vtc) => {
-        const newValue = getStringArray(vtc.field, ecsData);
+        const newValue = getStringArray(vtc.field, eventData);
         if (newValue.length) {
           return newQuery.replace(vtc.valueToChange, newValue[0]);
         } else {
@@ -126,14 +130,17 @@ export const replaceTemplateFieldFromQuery = (
   return query.trim();
 };
 
-export const replaceTemplateFieldFromMatchFilters = (filters: Filter[], ecsData: Ecs): Filter[] =>
+export const replaceTemplateFieldFromMatchFilters = (
+  filters: Filter[],
+  eventData: DetailItem[]
+): Filter[] =>
   filters.map((filter) => {
     if (
       filter.meta.type === 'phrase' &&
       filter.meta.key != null &&
       templateFields.includes(filter.meta.key)
     ) {
-      const newValue = getStringArray(filter.meta.key, ecsData);
+      const newValue = getStringArray(filter.meta.key, eventData);
       if (newValue.length) {
         filter.meta.params = { query: newValue[0] };
         filter.query = { match_phrase: { [filter.meta.key]: newValue[0] } };
@@ -144,13 +151,13 @@ export const replaceTemplateFieldFromMatchFilters = (filters: Filter[], ecsData:
 
 export const reformatDataProviderWithNewValue = <T extends DataProvider | DataProvidersAnd>(
   dataProvider: T,
-  ecsData: Ecs,
+  eventData: DetailItem[],
   timelineType: TimelineType = TimelineType.default
 ): T => {
   // Support for legacy "template-like" timeline behavior that is using hardcoded list of templateFields
   if (timelineType !== TimelineType.template) {
     if (templateFields.includes(dataProvider.queryMatch.field)) {
-      const newValue = getStringArray(dataProvider.queryMatch.field, ecsData);
+      const newValue = getStringArray(dataProvider.queryMatch.field, eventData);
       if (newValue.length) {
         dataProvider.id = dataProvider.id.replace(dataProvider.name, newValue[0]);
         dataProvider.name = newValue[0];
@@ -168,7 +175,7 @@ export const reformatDataProviderWithNewValue = <T extends DataProvider | DataPr
       dataProvider.type === DataProviderType.template &&
       dataProvider.queryMatch.operator === ':'
     ) {
-      const newValue = getStringArray(dataProvider.queryMatch.field, ecsData);
+      const newValue = getStringArray(dataProvider.queryMatch.field, eventData);
 
       if (!newValue.length) {
         dataProvider.enabled = false;
@@ -194,14 +201,14 @@ export const reformatDataProviderWithNewValue = <T extends DataProvider | DataPr
 
 export const replaceTemplateFieldFromDataProviders = (
   dataProviders: DataProvider[],
-  ecsData: Ecs,
+  eventData: DetailItem[],
   timelineType: TimelineType = TimelineType.default
 ): DataProvider[] =>
   dataProviders.map((dataProvider) => {
-    const newDataProvider = reformatDataProviderWithNewValue(dataProvider, ecsData, timelineType);
+    const newDataProvider = reformatDataProviderWithNewValue(dataProvider, eventData, timelineType);
     if (newDataProvider.and != null && !isEmpty(newDataProvider.and)) {
       newDataProvider.and = newDataProvider.and.map((andDataProvider) =>
-        reformatDataProviderWithNewValue(andDataProvider, ecsData, timelineType)
+        reformatDataProviderWithNewValue(andDataProvider, eventData, timelineType)
       );
     }
     return newDataProvider;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -147,13 +147,14 @@ export const AlertsTableComponent: React.FC<AlertsTableComponentProps> = ({
 
   // Callback for creating a new timeline -- utilized by row/batch actions
   const createTimelineCallback = useCallback(
-    ({ from: fromTimeline, timeline, to: toTimeline, ruleNote }: CreateTimelineProps) => {
+    ({ from: fromTimeline, timeline, to: toTimeline, ruleNote, notes }: CreateTimelineProps) => {
       updateTimelineIsLoading({ id: 'timeline-1', isLoading: false });
       updateTimeline({
         duplicate: true,
+        forceNotes: true,
         from: fromTimeline,
         id: 'timeline-1',
-        notes: [],
+        notes,
         timeline: {
           ...timeline,
           show: true,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/types.ts
@@ -7,7 +7,7 @@
 import ApolloClient from 'apollo-client';
 
 import { Status } from '../../../../common/detection_engine/schemas/common/schemas';
-import { Ecs, TimelineNonEcsData } from '../../../graphql/types';
+import { Ecs, NoteResult, TimelineNonEcsData } from '../../../graphql/types';
 import { TimelineModel } from '../../../timelines/store/timeline/model';
 import { inputsModel } from '../../../common/store';
 
@@ -63,6 +63,7 @@ export interface CreateTimelineProps {
   from: string;
   timeline: TimelineModel;
   to: string;
+  notes: NoteResult[] | null;
   ruleNote?: string;
 }
 

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.ts
@@ -363,6 +363,7 @@ export const queryTimelineById = <TCache>({
 export const dispatchUpdateTimeline = (dispatch: Dispatch): DispatchUpdateTimeline => ({
   duplicate,
   id,
+  forceNotes = false,
   from,
   notes,
   timeline,
@@ -407,7 +408,7 @@ export const dispatchUpdateTimeline = (dispatch: Dispatch): DispatchUpdateTimeli
     dispatch(dispatchAddGlobalTimelineNote({ noteId: newNote.id, id }));
   }
 
-  if (!duplicate) {
+  if (!duplicate || forceNotes) {
     dispatch(
       dispatchAddNotes({
         notes:

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
@@ -192,6 +192,7 @@ export interface OpenTimelineProps {
 export interface UpdateTimeline {
   duplicate: boolean;
   id: string;
+  forceNotes?: boolean;
   from: string;
   notes: NoteResult[] | null | undefined;
   timeline: TimelineModel;


### PR DESCRIPTION
## Summary

- [x] [58] Timeline Notes from the timeline template are not present when investigating in timeline.  They are either leftovers from the old template associated with the rule, or are absent.
- [x] [59] Some fields (agent.version) not being substituted correctly when used in template as template field.
Template: 
![image](https://user-images.githubusercontent.com/22619280/89418249-cf3a5d00-d6fd-11ea-8433-2704e92d5869.png)
Investigate in Timeline:
![image](https://user-images.githubusercontent.com/22619280/89418380-f98c1a80-d6fd-11ea-9176-8a6ea5f47f6d.png)


### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
