### PR TITLE
[Security Solution][Detections] Critical: Filter out non-Detections jobs in Detections telemetry

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -141,6 +141,13 @@ export const UNAUTHENTICATED_USER = 'Unauthenticated';
 export const MINIMUM_ML_LICENSE = 'platinum';
 
 /*
+  Machine Learning constants
+ */
+export const ML_GROUP_ID = 'security';
+export const LEGACY_ML_GROUP_ID = 'siem';
+export const ML_GROUP_IDS = [ML_GROUP_ID, LEGACY_ML_GROUP_ID];
+
+/*
   Rule notifications options
 */
 export const NOTIFICATION_SUPPORTED_ACTION_TYPES_IDS = [

--- a/x-pack/plugins/security_solution/common/machine_learning/is_security_job.test.ts
+++ b/x-pack/plugins/security_solution/common/machine_learning/is_security_job.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MlSummaryJob } from '../../../ml/common/types/anomaly_detection_jobs';
+import { isSecurityJob } from './is_security_job';
+
+describe('isSecurityJob', () => {
+  it('counts a job with a group of "siem"', () => {
+    const job = { groups: ['siem', 'other'] } as MlSummaryJob;
+    expect(isSecurityJob(job)).toEqual(true);
+  });
+
+  it('counts a job with a group of "security"', () => {
+    const job = { groups: ['security', 'other'] } as MlSummaryJob;
+    expect(isSecurityJob(job)).toEqual(true);
+  });
+
+  it('counts a job in both "security" and "siem"', () => {
+    const job = { groups: ['siem', 'security'] } as MlSummaryJob;
+    expect(isSecurityJob(job)).toEqual(true);
+  });
+
+  it('does not count a job in a related group', () => {
+    const job = { groups: ['auditbeat', 'process'] } as MlSummaryJob;
+    expect(isSecurityJob(job)).toEqual(false);
+  });
+});

--- a/x-pack/plugins/security_solution/common/machine_learning/is_security_job.ts
+++ b/x-pack/plugins/security_solution/common/machine_learning/is_security_job.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MlSummaryJob } from '../../../ml/common/types/anomaly_detection_jobs';
+import { ML_GROUP_IDS } from '../constants';
+
+export const isSecurityJob = (job: MlSummaryJob): boolean =>
+  job.groups.some((group) => ML_GROUP_IDS.includes(group));

--- a/x-pack/plugins/security_solution/server/usage/detections/detections.mocks.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/detections.mocks.ts
@@ -41,7 +41,7 @@ export const getMockJobSummaryResponse = () => [
   {
     id: 'other_job',
     description: 'a job that is custom',
-    groups: ['auditbeat', 'process'],
+    groups: ['auditbeat', 'process', 'security'],
     processed_record_count: 0,
     memory_status: 'ok',
     jobState: 'closed',
@@ -54,6 +54,19 @@ export const getMockJobSummaryResponse = () => [
   {
     id: 'another_job',
     description: 'another job that is custom',
+    groups: ['auditbeat', 'process', 'security'],
+    processed_record_count: 0,
+    memory_status: 'ok',
+    jobState: 'opened',
+    hasDatafeed: true,
+    datafeedId: 'datafeed-another',
+    datafeedIndices: ['auditbeat-*'],
+    datafeedState: 'started',
+    isSingleMetricViewerJob: true,
+  },
+  {
+    id: 'irrelevant_job',
+    description: 'a non-security job',
     groups: ['auditbeat', 'process'],
     processed_record_count: 0,
     memory_status: 'ok',


### PR DESCRIPTION
## Summary

Our jobs summary call returns all installed jobs regardless of group; passing groups as jobIds does not perform group filtering. As a result, we were counting _all_ installed ML jobs, not just those in the `security` group.

This adds a helper predicate on which to filter these results, and updates tests accordingly.

### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
