### PR TITLE
[Monitoring] Handle getClient call throwing an exception

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.js
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.js
@@ -119,65 +119,67 @@ export async function getClustersFromRequest(
     // add alerts data
     if (isInCodePath(codePaths, [CODE_PATH_ALERTS])) {
       const alertsClient = req.getAlertsClient();
-      for (const cluster of clusters) {
-        const verification = verifyMonitoringLicense(req.server);
-        if (!verification.enabled) {
-          // return metadata detailing that alerts is disabled because of the monitoring cluster license
-          cluster.alerts = {
-            alertsMeta: {
-              enabled: verification.enabled,
-              message: verification.message, // NOTE: this is only defined when the alert feature is disabled
-            },
-            list: {},
-          };
-          continue;
-        }
+      if (alertsClient) {
+        for (const cluster of clusters) {
+          const verification = verifyMonitoringLicense(req.server);
+          if (!verification.enabled) {
+            // return metadata detailing that alerts is disabled because of the monitoring cluster license
+            cluster.alerts = {
+              alertsMeta: {
+                enabled: verification.enabled,
+                message: verification.message, // NOTE: this is only defined when the alert feature is disabled
+              },
+              list: {},
+            };
+            continue;
+          }
 
-        // check the license type of the production cluster for alerts feature support
-        const license = cluster.license || {};
-        const prodLicenseInfo = checkLicenseForAlerts(
-          license.type,
-          license.status === 'active',
-          'production'
-        );
-        if (prodLicenseInfo.clusterAlerts.enabled) {
+          // check the license type of the production cluster for alerts feature support
+          const license = cluster.license || {};
+          const prodLicenseInfo = checkLicenseForAlerts(
+            license.type,
+            license.status === 'active',
+            'production'
+          );
+          if (prodLicenseInfo.clusterAlerts.enabled) {
+            cluster.alerts = {
+              list: await fetchStatus(
+                alertsClient,
+                req.server.plugins.monitoring.info,
+                undefined,
+                cluster.cluster_uuid,
+                start,
+                end,
+                []
+              ),
+              alertsMeta: {
+                enabled: true,
+              },
+            };
+            continue;
+          }
+
           cluster.alerts = {
-            list: await fetchStatus(
-              alertsClient,
-              req.server.plugins.monitoring.info,
-              undefined,
-              cluster.cluster_uuid,
-              start,
-              end,
-              []
-            ),
+            list: {},
             alertsMeta: {
               enabled: true,
             },
+            clusterMeta: {
+              enabled: false,
+              message: i18n.translate(
+                'xpack.monitoring.clusterAlerts.unsupportedClusterAlertsDescription',
+                {
+                  defaultMessage:
+                    'Cluster [{clusterName}] license type [{licenseType}] does not support Cluster Alerts',
+                  values: {
+                    clusterName: cluster.cluster_name,
+                    licenseType: `${license.type}`,
+                  },
+                }
+              ),
+            },
           };
-          continue;
         }
-
-        cluster.alerts = {
-          list: {},
-          alertsMeta: {
-            enabled: true,
-          },
-          clusterMeta: {
-            enabled: false,
-            message: i18n.translate(
-              'xpack.monitoring.clusterAlerts.unsupportedClusterAlertsDescription',
-              {
-                defaultMessage:
-                  'Cluster [{clusterName}] license type [{licenseType}] does not support Cluster Alerts',
-                values: {
-                  clusterName: cluster.cluster_name,
-                  licenseType: `${license.type}`,
-                },
-              }
-            ),
-          },
-        };
       }
     }
   }

--- a/x-pack/plugins/monitoring/server/plugin.ts
+++ b/x-pack/plugins/monitoring/server/plugin.ts
@@ -335,7 +335,7 @@ export class Plugin {
             },
             getActionsClient: () => {
               try {
-                return plugins.alerts.getActionsClientWithRequest(req);
+                return plugins.actions.getActionsClientWithRequest(req);
               } catch (err) {
                 // If security is disabled, this call will throw an error unless a certain config is set for dist builds
                 return null;

--- a/x-pack/plugins/monitoring/server/plugin.ts
+++ b/x-pack/plugins/monitoring/server/plugin.ts
@@ -325,8 +325,22 @@ export class Plugin {
             getKibanaStatsCollector: () => this.legacyShimDependencies.kibanaStatsCollector,
             getUiSettingsService: () => context.core.uiSettings.client,
             getActionTypeRegistry: () => context.actions?.listTypes(),
-            getAlertsClient: () => plugins.alerts.getAlertsClientWithRequest(req),
-            getActionsClient: () => plugins.actions.getActionsClientWithRequest(req),
+            getAlertsClient: () => {
+              try {
+                return plugins.alerts.getAlertsClientWithRequest(req);
+              } catch (err) {
+                // If security is disabled, this call will throw an error unless a certain config is set for dist builds
+                return null;
+              }
+            },
+            getActionsClient: () => {
+              try {
+                return plugins.alerts.getActionsClientWithRequest(req);
+              } catch (err) {
+                // If security is disabled, this call will throw an error unless a certain config is set for dist builds
+                return null;
+              }
+            },
             server: {
               config: legacyConfigWrapper,
               newPlatform: {


### PR DESCRIPTION
Resolves #74522

`getActionsClientWithRequest()` can throw an error if there is no encryption key set and we aren't handling that properly.

This PR fixes that.