### PR TITLE
[Ingest Manager] Make api integration tests test less brittle

### DIFF
--- a/x-pack/test/ingest_manager_api_integration/apis/epm/list.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/list.ts
@@ -29,7 +29,7 @@ export default function ({ getService }: FtrProviderContext) {
           return response.body;
         };
         const listResponse = await fetchPackageList();
-        expect(listResponse.response.length).to.be(8);
+        expect(listResponse.response.length).not.to.be(0);
       } else {
         warnAndSkipTest(this, log);
       }


### PR DESCRIPTION
## Summary

Adjusts one api integration test to no longer depend on the exact number of packages in the registry docker container, as this tends to change a lot between registry builds.

## How to test this

Run the api integration tests locally, or wait for CI to complete.

(cc @neptunian @jonathan-buttner you were right!)