### PR TITLE
skip query of detections page when we do not have .siem-signals index

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/containers/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/helpers.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { TimelineId } from '../../../common/types/timeline';
+import { skipQueryForDetectionsPage } from './helpers';
+
+describe('skipQueryForDetectionsPage', () => {
+  test('Make sure to NOT skip the query when it is not a timeline from a detection pages', () => {
+    expect(skipQueryForDetectionsPage(TimelineId.active, ['auditbeat-*', 'filebeat-*'])).toBe(
+      false
+    );
+    expect(
+      skipQueryForDetectionsPage(TimelineId.hostsPageEvents, ['auditbeat-*', 'filebeat-*'])
+    ).toBe(false);
+    expect(
+      skipQueryForDetectionsPage(TimelineId.hostsPageExternalAlerts, ['auditbeat-*', 'filebeat-*'])
+    ).toBe(false);
+    expect(
+      skipQueryForDetectionsPage(TimelineId.networkPageExternalAlerts, [
+        'auditbeat-*',
+        'filebeat-*',
+      ])
+    ).toBe(false);
+  });
+
+  test('Make sure to SKIP the query when it is a timeline from a detection pages without the siem-signals', () => {
+    expect(
+      skipQueryForDetectionsPage(TimelineId.detectionsPage, ['auditbeat-*', 'filebeat-*'])
+    ).toBe(true);
+    expect(
+      skipQueryForDetectionsPage(TimelineId.detectionsRulesDetailsPage, [
+        'auditbeat-*',
+        'filebeat-*',
+      ])
+    ).toBe(true);
+  });
+
+  test('Make sure to NOT skip the query when it is a timeline from a detection pages with the siem-signals', () => {
+    expect(
+      skipQueryForDetectionsPage(TimelineId.detectionsPage, [
+        'auditbeat-*',
+        '.siem-signals-rainbow-butterfly',
+      ])
+    ).toBe(false);
+    expect(
+      skipQueryForDetectionsPage(TimelineId.detectionsRulesDetailsPage, [
+        '.siem-signals-rainbow-butterfly',
+      ])
+    ).toBe(false);
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/containers/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/helpers.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { TimelineId } from '../../../common/types/timeline';
+
+export const dectectionsTimelineIds = [
+  TimelineId.detectionsPage,
+  TimelineId.detectionsRulesDetailsPage,
+];
+
+export const skipQueryForDetectionsPage = (id: string, defaultIndex: string[]) =>
+  id != null &&
+  dectectionsTimelineIds.some((timelineId) => timelineId === id) &&
+  !defaultIndex.some((di) => di.toLowerCase().startsWith('.siem-signals'));

--- a/x-pack/plugins/security_solution/public/timelines/containers/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/helpers.ts
@@ -6,12 +6,12 @@
 
 import { TimelineId } from '../../../common/types/timeline';
 
-export const dectectionsTimelineIds = [
+export const detectionsTimelineIds = [
   TimelineId.detectionsPage,
   TimelineId.detectionsRulesDetailsPage,
 ];
 
 export const skipQueryForDetectionsPage = (id: string, defaultIndex: string[]) =>
   id != null &&
-  dectectionsTimelineIds.some((timelineId) => timelineId === id) &&
+  detectionsTimelineIds.some((timelineId) => timelineId === id) &&
   !defaultIndex.some((di) => di.toLowerCase().startsWith('.siem-signals'));

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
@@ -11,7 +11,6 @@ import { Query } from 'react-apollo';
 import { compose, Dispatch } from 'redux';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { TimelineId } from '../../../common/types/timeline';
 import { DEFAULT_INDEX_KEY } from '../../../common/constants';
 import { IIndexPattern } from '../../../../../../src/plugins/data/common/index_patterns';
 import {
@@ -28,8 +27,7 @@ import { QueryTemplate, QueryTemplateProps } from '../../common/containers/query
 import { EventType } from '../../timelines/store/timeline/model';
 import { timelineQuery } from './index.gql_query';
 import { timelineActions } from '../../timelines/store/timeline';
-
-const timelineIds = [TimelineId.detectionsPage, TimelineId.detectionsRulesDetailsPage];
+import { dectectionsTimelineIds, skipQueryForDetectionsPage } from './helpers';
 
 export interface TimelineArgs {
   events: TimelineItem[];
@@ -130,6 +128,7 @@ class TimelineQueryComponent extends QueryTemplate<
         query={timelineQuery}
         fetchPolicy="network-only"
         notifyOnNetworkStatusChange
+        skip={skipQueryForDetectionsPage(id, defaultIndex)}
         variables={variables}
       >
         {({ data, loading, fetchMore, refetch }) => {
@@ -202,7 +201,7 @@ const makeMapStateToProps = () => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearSignalsState: ({ id }: { id?: string }) => {
-    if (id != null && timelineIds.some((timelineId) => timelineId === id)) {
+    if (id != null && dectectionsTimelineIds.some((timelineId) => timelineId === id)) {
       dispatch(timelineActions.clearEventsLoading({ id }));
       dispatch(timelineActions.clearEventsDeleted({ id }));
     }

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
@@ -27,7 +27,7 @@ import { QueryTemplate, QueryTemplateProps } from '../../common/containers/query
 import { EventType } from '../../timelines/store/timeline/model';
 import { timelineQuery } from './index.gql_query';
 import { timelineActions } from '../../timelines/store/timeline';
-import { dectectionsTimelineIds, skipQueryForDetectionsPage } from './helpers';
+import { detectionsTimelineIds, skipQueryForDetectionsPage } from './helpers';
 
 export interface TimelineArgs {
   events: TimelineItem[];
@@ -201,7 +201,7 @@ const makeMapStateToProps = () => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearSignalsState: ({ id }: { id?: string }) => {
-    if (id != null && dectectionsTimelineIds.some((timelineId) => timelineId === id)) {
+    if (id != null && detectionsTimelineIds.some((timelineId) => timelineId === id)) {
       dispatch(timelineActions.clearEventsLoading({ id }));
       dispatch(timelineActions.clearEventsDeleted({ id }));
     }


### PR DESCRIPTION
## Summary

This PR is to resolve this issue https://github.com/elastic/kibana/issues/74180 

* Go to the detections page.
* Sort by rule name
* Reload your page

<img width="1655" alt="Screen Shot 2020-08-03 at 3 42 18 PM" src="https://user-images.githubusercontent.com/1151048/89230414-7a350480-d5a0-11ea-9167-82db58ef90c0.png">

If you look at the error toaster you will see this:
<img width="809" alt="Screen Shot 2020-08-03 at 3 42 30 PM" src="https://user-images.githubusercontent.com/1151048/89230478-9a64c380-d5a0-11ea-8eeb-88d2e5a61c0d.png">

The root of the issue looks to be that when timeline mounts its self it is causing initial queries against the `sime:defaultIndex` and does not have the siem signals:
<img width="906" alt="Screen Shot 2020-08-03 at 3 43 07 PM" src="https://user-images.githubusercontent.com/1151048/89230897-6c33b380-d5a1-11ea-9c8f-d0c7dc09f252.png">

Later queries will be the correct ones which will be just the siem-signals index and not include these extra indexes on page load. We really want to eliminate duplicate queries of timeline when it first mounts and want to eliminate it from querying the `siem:defaultIndex` on page load. You do run the risk of the second query taking longer than the first and possibly wrong data on your visualization:
<img width="946" alt="Screen Shot 2020-08-03 at 3 54 25 PM" src="https://user-images.githubusercontent.com/1151048/89231144-f845db00-d5a1-11ea-90da-09844c02f2f9.png">


### Checklist

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
