### PR TITLE
add i18n translation for 'No results found'

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/errors.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/errors.ts
@@ -53,7 +53,7 @@ export class PieContainsAllZeros extends VislibError {
 export class NoResults extends VislibError {
   constructor() {
     super(
-      i18n.translate('visualizations.noResultsFoundTitle', {
+      i18n.translate('visTypeVislib.vislib.errors.noResultsFoundTitle', {
         defaultMessage: 'No results found',
       })
     );

--- a/src/plugins/vis_type_vislib/public/vislib/errors.ts
+++ b/src/plugins/vis_type_vislib/public/vislib/errors.ts
@@ -19,6 +19,7 @@
 
 /* eslint-disable max-classes-per-file */
 
+import { i18n } from '@kbn/i18n';
 import { KbnError } from '../../../kibana_utils/public';
 
 export class VislibError extends KbnError {
@@ -51,6 +52,10 @@ export class PieContainsAllZeros extends VislibError {
 
 export class NoResults extends VislibError {
   constructor() {
-    super('No results found');
+    super(
+      i18n.translate('visualizations.noResultsFoundTitle', {
+        defaultMessage: 'No results found',
+      })
+    );
   }
 }

--- a/src/plugins/visualizations/public/components/visualization_noresults.tsx
+++ b/src/plugins/visualizations/public/components/visualization_noresults.tsx
@@ -18,6 +18,7 @@
  */
 
 import { EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import React from 'react';
 
 interface VisualizationNoResultsProps {
@@ -37,7 +38,11 @@ export class VisualizationNoResults extends React.Component<VisualizationNoResul
 
             <EuiSpacer size="s" />
 
-            <p>No results found</p>
+            <p>
+              {i18n.translate('visualizations.noResultsFoundTitle', {
+                defaultMessage: 'No results found',
+              })}
+            </p>
           </EuiText>
         </div>
         <div className="item bottom" />


### PR DESCRIPTION
This PR aims to add i18n support for the two remaining 'No results found' texts that were without i18n support.