### PR TITLE
[Telemetry][API Integration] size_in_bytes to be a number

### DIFF
--- a/test/api_integration/apis/telemetry/telemetry_local.js
+++ b/test/api_integration/apis/telemetry/telemetry_local.js
@@ -90,7 +90,7 @@ export default function ({ getService }) {
       expect(stats.stack_stats.data[0].index_count).to.be(1);
       expect(stats.stack_stats.data[0].doc_count).to.be(0);
       expect(stats.stack_stats.data[0].ecs_index_count).to.be(0);
-      expect(stats.stack_stats.data[0].size_in_bytes).to.be.greaterThan(0);
+      expect(stats.stack_stats.data[0].size_in_bytes).to.be.a('number');
     });
 
     it('should pull local stats and validate fields', async () => {


### PR DESCRIPTION
## Summary

Fixes #74625. 

During the tests, we are only creating the index and not indexing any document. It might be better to check the field exists and it's a number instead of expecting the empty index to use any space in disk.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
