### PR TITLE
[Ingest Manager] stop creating events-* index pattern and placeholder index

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/kibana/index_pattern/install.ts
@@ -72,7 +72,6 @@ export interface IndexPatternField {
 export enum IndexPatternType {
   logs = 'logs',
   metrics = 'metrics',
-  events = 'events',
 }
 // TODO: use a function overload and make pkgName and pkgVersion required for install/update
 // and not for an update removal.  or separate out the functions
@@ -111,11 +110,7 @@ export async function installIndexPatterns(
   const installedPackagesInfo = await Promise.all(installedPackagesFetchInfoPromise);
 
   // for each index pattern type, create an index pattern
-  const indexPatternTypes = [
-    IndexPatternType.logs,
-    IndexPatternType.metrics,
-    IndexPatternType.events,
-  ];
+  const indexPatternTypes = [IndexPatternType.logs, IndexPatternType.metrics];
   indexPatternTypes.forEach(async (indexPatternType) => {
     // if this is an update because a package is being unisntalled (no pkgkey argument passed) and no other packages are installed, remove the index pattern
     if (!pkgName && installedPackages.length === 0) {

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/install_remove_assets.ts
@@ -85,11 +85,6 @@ export default function (providerContext: FtrProviderContext) {
           id: 'metrics-*',
         });
         expect(resIndexPatternMetrics.id).equal('metrics-*');
-        const resIndexPatternEvents = await kibanaServer.savedObjects.get({
-          type: 'index-pattern',
-          id: 'events-*',
-        });
-        expect(resIndexPatternEvents.id).equal('events-*');
         const resDashboard = await kibanaServer.savedObjects.get({
           type: 'dashboard',
           id: 'sample_dashboard',

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/install_remove_assets.ts
@@ -106,6 +106,18 @@ export default function (providerContext: FtrProviderContext) {
         });
         expect(resSearch.id).equal('sample_search');
       });
+      it('should have installed placeholder indices', async function () {
+        const resLogsIndexPatternPlaceholder = await es.transport.request({
+          method: 'GET',
+          path: `/logs-index_pattern_placeholder`,
+        });
+        expect(resLogsIndexPatternPlaceholder.statusCode).equal(200);
+        const resMetricsIndexPatternPlaceholder = await es.transport.request({
+          method: 'GET',
+          path: `/metrics-index_pattern_placeholder`,
+        });
+        expect(resMetricsIndexPatternPlaceholder.statusCode).equal(200);
+      });
       it('should have created the correct saved object', async function () {
         const res = await kibanaServer.savedObjects.get({
           type: 'epm-packages',


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/74641

### Changes
- removes `events` as a default index pattern type so `events-*` and the placeholder index will no longer be created
- updates integration test to not expect `events-*` index pattern to be created
- adds integration test to check that the right placeholder indices were created for `logs-*` and `metrics-*` types index patterns (`logs-index_pattern_placeholder`, `metrics-index_pattern_placeholder`);

### Test
- the integration test should succeed
- or manually test with a fresh elasticsearch instance after logging into Kibana, ensuring no such index pattern exists (http://localhost:5601/ssg/api/saved_objects/index-pattern/events-*) or index placeholder exists, `events-index_pattern_placeholder` (`GET /_cat/indices`)