### PR TITLE
[Security Solution] put back savedObjectId in error message

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/import_data_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/import_data_modal/index.tsx
@@ -96,7 +96,7 @@ export const ImportDataModalComponent = ({
         }
         if (importResponse.errors.length > 0) {
           const formattedErrors = importResponse.errors.map((e) =>
-            failedDetailed(e.rule_id, e.error.status_code, e.error.message)
+            failedDetailed(e.rule_id ?? e.id, e.error.status_code, e.error.message)
           );
           displayErrorToast(errorMessage, formattedErrors, dispatchToaster);
         }

--- a/x-pack/plugins/security_solution/public/common/components/import_data_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/import_data_modal/index.tsx
@@ -23,6 +23,8 @@ import React, { useCallback, useState } from 'react';
 import {
   ImportDataResponse,
   ImportDataProps,
+  ImportRulesResponseError,
+  ImportResponseError,
 } from '../../../detections/containers/detection_engine/rules';
 import {
   displayErrorToast,
@@ -47,6 +49,12 @@ interface ImportDataModalProps {
   successMessage: (totalCount: number) => string;
   title: string;
 }
+
+const isImportRulesResponseError = (
+  error: ImportRulesResponseError | ImportResponseError
+): error is ImportRulesResponseError => {
+  return (error as ImportRulesResponseError).rule_id !== undefined;
+};
 
 /**
  * Modal component for importing Rules from a json file
@@ -96,7 +104,11 @@ export const ImportDataModalComponent = ({
         }
         if (importResponse.errors.length > 0) {
           const formattedErrors = importResponse.errors.map((e) =>
-            failedDetailed(e.rule_id ?? e.id, e.error.status_code, e.error.message)
+            failedDetailed(
+              isImportRulesResponseError(e) ? e.rule_id : e.id,
+              e.error.status_code,
+              e.error.message
+            )
           );
           displayErrorToast(errorMessage, formattedErrors, dispatchToaster);
         }

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/types.ts
@@ -234,10 +234,18 @@ export interface ImportRulesResponseError {
   };
 }
 
+export interface ImportResponseError {
+  id: string;
+  error: {
+    status_code: number;
+    message: string;
+  };
+}
+
 export interface ImportDataResponse {
   success: boolean;
   success_count: number;
-  errors: ImportRulesResponseError[];
+  errors: Array<ImportRulesResponseError | ImportResponseError>;
 }
 
 export interface ExportDocumentsProps {


### PR DESCRIPTION
## Summary

This PR is to fix issue https://github.com/elastic/siem-team/issues/830

How to verify this PR:

- Preconditions
Elasticsearch and kibana should be up and running
Audit beat Data Shipper should be installed and running.


1. Select 'Security' from kibana Left Navigation bar.
2. Click on 'Timeline' Tab.
3. Create new template.
4. Export the Above Template.
5. Click on Import Timeline and select above template just saved
6. SavedObjectId should exist in error message

![savedobjectId](https://user-images.githubusercontent.com/6295984/89920638-8cdcb880-dbf4-11ea-86ca-0551909c77fe.gif)
