### PR TITLE
[Security Solution] [Cases] Bugfix for special character tags filtering

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/containers/api.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/containers/api.test.tsx
@@ -159,7 +159,7 @@ describe('Case Configuration API', () => {
         query: {
           ...DEFAULT_QUERY_PARAMS,
           reporters,
-          tags,
+          tags: ['"coke"', '"pepsi"'],
           search: 'hello',
         },
         signal: abortCtrl.signal,

--- a/x-pack/plugins/security_solution/public/cases/containers/api.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/containers/api.test.tsx
@@ -165,6 +165,31 @@ describe('Case Configuration API', () => {
         signal: abortCtrl.signal,
       });
     });
+    test('tags with weird chars get handled gracefully', async () => {
+      const weirdTags: string[] = ['(', '"double"'];
+
+      await getCases({
+        filterOptions: {
+          ...DEFAULT_FILTER_OPTIONS,
+          reporters: [...respReporters, { username: null, full_name: null, email: null }],
+          tags: weirdTags,
+          status: '',
+          search: 'hello',
+        },
+        queryParams: DEFAULT_QUERY_PARAMS,
+        signal: abortCtrl.signal,
+      });
+      expect(fetchMock).toHaveBeenCalledWith(`${CASES_URL}/_find`, {
+        method: 'GET',
+        query: {
+          ...DEFAULT_QUERY_PARAMS,
+          reporters,
+          tags: ['"("', '"\\"double\\""'],
+          search: 'hello',
+        },
+        signal: abortCtrl.signal,
+      });
+    });
 
     test('happy path', async () => {
       const resp = await getCases({

--- a/x-pack/plugins/security_solution/public/cases/containers/api.ts
+++ b/x-pack/plugins/security_solution/public/cases/containers/api.ts
@@ -132,7 +132,7 @@ export const getCases = async ({
 }: FetchCasesProps): Promise<AllCases> => {
   const query = {
     reporters: filterOptions.reporters.map((r) => r.username ?? '').filter((r) => r !== ''),
-    tags: filterOptions.tags,
+    tags: filterOptions.tags.map((t) => `"${t.replace(/"/g, '\\"')}"`),
     ...(filterOptions.status !== '' ? { status: filterOptions.status } : {}),
     ...(filterOptions.search.length > 0 ? { search: filterOptions.search } : {}),
     ...queryParams,


### PR DESCRIPTION
## Summary

If you create a case with tags that have an AND, OR, (, ), etc... then you would blow up with an error when you try to filter based off of that like the screen shot below:
![image](https://user-images.githubusercontent.com/6935300/90015823-bd613880-dc6e-11ea-9006-287ac0ba41a1.png)
Now you don't blow up:
<img width="1149" alt="Screen Shot 2020-08-12 at 7 38 48 AM" src="https://user-images.githubusercontent.com/6935300/90015948-ec77aa00-dc6e-11ea-9cd1-a7b6b6939366.png">

This fixes it by adding double quotes around the filters and a unit test to confirm the fix

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios