### PR TITLE
[reporting] Pass along generic parameters in high-order route handler

### DIFF
--- a/x-pack/plugins/reporting/server/routes/jobs.ts
+++ b/x-pack/plugins/reporting/server/routes/jobs.ts
@@ -15,11 +15,6 @@ import {
   downloadJobResponseHandlerFactory,
 } from './lib/job_response_handler';
 
-interface ListQuery {
-  page: string;
-  size: string;
-  ids?: string; // optional field forbids us from extending RequestQuery
-}
 const MAIN_ENTRY = `${API_BASE_URL}/jobs`;
 
 const handleUnavailable = (res: any) => {
@@ -52,11 +47,7 @@ export function registerJobInfoRoutes(reporting: ReportingCore) {
       const {
         management: { jobTypes = [] },
       } = await reporting.getLicenseInfo();
-      const {
-        page: queryPage = '0',
-        size: querySize = '10',
-        ids: queryIds = null,
-      } = req.query as ListQuery; // NOTE: type inference is not working here. userHandler breaks it?
+      const { page: queryPage = '0', size: querySize = '10', ids: queryIds = null } = req.query;
       const page = parseInt(queryPage, 10) || 0;
       const size = Math.min(100, parseInt(querySize, 10) || 10);
       const jobIds = queryIds ? queryIds.split(',') : null;
@@ -116,7 +107,7 @@ export function registerJobInfoRoutes(reporting: ReportingCore) {
         return handleUnavailable(res);
       }
 
-      const { docId } = req.params as { docId: string };
+      const { docId } = req.params;
       const {
         management: { jobTypes = [] },
       } = await reporting.getLicenseInfo();
@@ -161,7 +152,7 @@ export function registerJobInfoRoutes(reporting: ReportingCore) {
         return res.custom({ statusCode: 503 });
       }
 
-      const { docId } = req.params as { docId: string };
+      const { docId } = req.params;
       const {
         management: { jobTypes = [] },
       } = await reporting.getLicenseInfo();
@@ -213,7 +204,7 @@ export function registerJobInfoRoutes(reporting: ReportingCore) {
         return handleUnavailable(res);
       }
 
-      const { docId } = req.params as { docId: string };
+      const { docId } = req.params;
       const {
         management: { jobTypes = [] },
       } = await reporting.getLicenseInfo();
@@ -239,7 +230,7 @@ export function registerJobInfoRoutes(reporting: ReportingCore) {
         return handleUnavailable(res);
       }
 
-      const { docId } = req.params as { docId: string };
+      const { docId } = req.params;
       const {
         management: { jobTypes = [] },
       } = await reporting.getLicenseInfo();

--- a/x-pack/plugins/reporting/server/routes/lib/authorized_user_pre_routing.ts
+++ b/x-pack/plugins/reporting/server/routes/lib/authorized_user_pre_routing.ts
@@ -12,7 +12,7 @@ import { getUserFactory } from './get_user';
 type ReportingUser = AuthenticatedUser | null;
 const superuserRole = 'superuser';
 
-export type RequestHandlerUser = RequestHandler extends (...a: infer U) => infer R
+export type RequestHandlerUser<P, Q, B> = RequestHandler<P, Q, B> extends (...a: infer U) => infer R
   ? (user: ReportingUser, ...a: U) => R
   : never;
 
@@ -21,7 +21,7 @@ export const authorizedUserPreRoutingFactory = function authorizedUserPreRouting
 ) {
   const setupDeps = reporting.getPluginSetupDeps();
   const getUser = getUserFactory(setupDeps.security);
-  return <P, Q, B>(handler: RequestHandlerUser): RequestHandler<P, Q, B, RouteMethod> => {
+  return <P, Q, B>(handler: RequestHandlerUser<P, Q, B>): RequestHandler<P, Q, B, RouteMethod> => {
     return (context, req, res) => {
       let user: ReportingUser = null;
       if (setupDeps.security && setupDeps.security.license.isEnabled()) {


### PR DESCRIPTION
## Summary

Fix some type parameter issues that were preventing type inference from working in the Reporting plugin.

Fixed version of https://github.com/elastic/kibana/pull/74879

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
