### PR TITLE
[TSVB] Fixes bug on TopN weird behavior with zero values

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/top_n.js
@@ -110,7 +110,9 @@ export class TopN extends Component {
       const isPositiveValue = lastValue >= 0;
 
       const intervalLength = TopN.calcDomain(renderMode, min, max);
-      const width = 100 * (Math.abs(lastValue) / intervalLength);
+      // if both are 0, the division returns NaN causing unexpected behavior.
+      // For this it defaults to 0
+      const width = 100 * (Math.abs(lastValue) / intervalLength) || 0;
 
       const styles = reactcss(
         {


### PR DESCRIPTION
## Summary

Closes #72604. When the value was zero, the division returned NaN, causing this weird behaviour on TopN.
I changed it to default on 0 when NaN is detected.

### Checklist
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
