### PR TITLE
[Ingest Manager] fix removing ingest pipelines from elasticsearch

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/ingest_pipeline/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/ingest_pipeline/index.ts
@@ -6,4 +6,4 @@
 
 export { installPipelines } from './install';
 
-export { deletePipelines, deletePipeline } from './remove';
+export { deletePreviousPipelines, deletePipeline } from './remove';

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
@@ -22,7 +22,7 @@ import * as Registry from '../registry';
 import { getInstallation, getInstallationObject, isRequiredPackage } from './index';
 import { installTemplates } from '../elasticsearch/template/install';
 import { generateESIndexPatterns } from '../elasticsearch/template/template';
-import { installPipelines, deletePipelines } from '../elasticsearch/ingest_pipeline/';
+import { installPipelines, deletePreviousPipelines } from '../elasticsearch/ingest_pipeline/';
 import { installILMPolicy } from '../elasticsearch/ilm/install';
 import {
   installKibanaAssets,
@@ -183,7 +183,7 @@ export async function installPackage({
 
   // if this is an update, delete the previous version's pipelines
   if (installedPkg && !reinstall) {
-    await deletePipelines(
+    await deletePreviousPipelines(
       callCluster,
       savedObjectsClient,
       pkgName,

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/install_remove_assets.ts
@@ -61,6 +61,16 @@ export default function (providerContext: FtrProviderContext) {
           path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}`,
         });
         expect(res.statusCode).equal(200);
+        const resPipeline1 = await es.transport.request({
+          method: 'GET',
+          path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}-pipeline1`,
+        });
+        expect(resPipeline1.statusCode).equal(200);
+        const resPipeline2 = await es.transport.request({
+          method: 'GET',
+          path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}-pipeline2`,
+        });
+        expect(resPipeline2.statusCode).equal(200);
       });
       it('should have installed the template components', async function () {
         const res = await es.transport.request({
@@ -148,6 +158,14 @@ export default function (providerContext: FtrProviderContext) {
               type: 'ingest_pipeline',
             },
             {
+              id: 'logs-all_assets.test_logs-0.1.0-pipeline1',
+              type: 'ingest_pipeline',
+            },
+            {
+              id: 'logs-all_assets.test_logs-0.1.0-pipeline2',
+              type: 'ingest_pipeline',
+            },
+            {
               id: 'logs-all_assets.test_logs',
               type: 'index_template',
             },
@@ -207,6 +225,26 @@ export default function (providerContext: FtrProviderContext) {
           }
         );
         expect(res.statusCode).equal(404);
+        const resPipeline1 = await es.transport.request(
+          {
+            method: 'GET',
+            path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}-pipeline1`,
+          },
+          {
+            ignore: [404],
+          }
+        );
+        expect(resPipeline1.statusCode).equal(404);
+        const resPipeline2 = await es.transport.request(
+          {
+            method: 'GET',
+            path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}-pipeline2`,
+          },
+          {
+            ignore: [404],
+          }
+        );
+        expect(resPipeline2.statusCode).equal(404);
       });
       it('should have uninstalled the kibana assets', async function () {
         let resDashboard;

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/update_assets.ts
@@ -154,24 +154,49 @@ export default function (providerContext: FtrProviderContext) {
         },
       });
     });
-    it('should have installed the new versionized pipeline', async function () {
+    it('should have installed the new versionized pipelines', async function () {
       const res = await es.transport.request({
         method: 'GET',
         path: `/_ingest/pipeline/${logsTemplateName}-${pkgUpdateVersion}`,
       });
       expect(res.statusCode).equal(200);
+      const resPipeline1 = await es.transport.request({
+        method: 'GET',
+        path: `/_ingest/pipeline/${logsTemplateName}-${pkgUpdateVersion}-pipeline1`,
+      });
+      expect(resPipeline1.statusCode).equal(200);
     });
     it('should have removed the old versionized pipelines', async function () {
-      let res;
-      try {
-        res = await es.transport.request({
+      const res = await es.transport.request(
+        {
           method: 'GET',
           path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}`,
-        });
-      } catch (err) {
-        res = err;
-      }
+        },
+        {
+          ignore: [404],
+        }
+      );
       expect(res.statusCode).equal(404);
+      const resPipeline1 = await es.transport.request(
+        {
+          method: 'GET',
+          path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}-pipeline1`,
+        },
+        {
+          ignore: [404],
+        }
+      );
+      expect(resPipeline1.statusCode).equal(404);
+      const resPipeline2 = await es.transport.request(
+        {
+          method: 'GET',
+          path: `/_ingest/pipeline/${logsTemplateName}-${pkgVersion}-pipeline2`,
+        },
+        {
+          ignore: [404],
+        }
+      );
+      expect(resPipeline2.statusCode).equal(404);
     });
     it('should have updated the template components', async function () {
       const res = await es.transport.request({
@@ -270,6 +295,10 @@ export default function (providerContext: FtrProviderContext) {
         installed_es: [
           {
             id: 'logs-all_assets.test_logs-0.2.0',
+            type: 'ingest_pipeline',
+          },
+          {
+            id: 'logs-all_assets.test_logs-0.2.0-pipeline1',
             type: 'ingest_pipeline',
           },
           {

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,20 +1,7 @@
 ---
-description: Pipeline for normalizing Kubernetes CoreDNS logs.
+description: Pipeline for parsing test logs
+  plugins.
 processors:
-  - pipeline:
-      if: ctx.message.charAt(0) == (char)("{")
-      name: '{{IngestPipeline "pipeline1" }}'
-  - pipeline:
-      if: ctx.message.charAt(0) != (char)("{")
-      name: '{{IngestPipeline "pipeline2" }}'
-  - script:
-      lang: painless
-      source: >
-        ctx.event.created = ctx['@timestamp'];
-        ctx['@timestamp'] = ctx['timestamp'];
-        ctx.remove('timestamp');
-      ignore_failure: true
-on_failure:
-  - set:
-      field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+- set:
+    field: error.message
+    value: '{{ _ingest.on_failure_message }}'

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,7 +1,20 @@
 ---
-description: Pipeline for parsing test logs
-  plugins.
+description: Pipeline for normalizing Kubernetes CoreDNS logs.
 processors:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - pipeline:
+      if: ctx.message.charAt(0) == (char)("{")
+      name: '{{IngestPipeline "pipeline1" }}'
+  - pipeline:
+      if: ctx.message.charAt(0) != (char)("{")
+      name: '{{IngestPipeline "pipeline2" }}'
+  - script:
+      lang: painless
+      source: >
+        ctx.event.created = ctx['@timestamp'];
+        ctx['@timestamp'] = ctx['timestamp'];
+        ctx.remove('timestamp');
+      ignore_failure: true
+on_failure:
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/pipeline1.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/pipeline1.yml
@@ -1,0 +1,9 @@
+---
+description: Pipeline test
+processors:
+- remove:
+    field: messag
+on_failure:
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/pipeline2.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/dataset/test_logs/elasticsearch/ingest_pipeline/pipeline2.yml
@@ -1,0 +1,9 @@
+---
+description: Pipeline test
+processors:
+- remove:
+    field: messag
+on_failure:
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,7 +1,17 @@
 ---
-description: Pipeline for parsing test logs
-  plugins.
+description: Pipeline test
 processors:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - pipeline:
+      if: ctx.message.charAt(0) == (char)("{")
+      name: '{{IngestPipeline "pipeline1" }}'
+  - script:
+      lang: painless
+      source: >
+        ctx.event.created = ctx['@timestamp'];
+        ctx['@timestamp'] = ctx['timestamp'];
+        ctx.remove('timestamp');
+      ignore_failure: true
+on_failure:
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/dataset/test_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,17 +1,7 @@
 ---
-description: Pipeline test
+description: Pipeline for parsing test logs
+  plugins.
 processors:
-  - pipeline:
-      if: ctx.message.charAt(0) == (char)("{")
-      name: '{{IngestPipeline "pipeline1" }}'
-  - script:
-      lang: painless
-      source: >
-        ctx.event.created = ctx['@timestamp'];
-        ctx['@timestamp'] = ctx['timestamp'];
-        ctx.remove('timestamp');
-      ignore_failure: true
-on_failure:
-  - set:
-      field: error.message
-      value: "{{ _ingest.on_failure_message }}"
+- set:
+    field: error.message
+    value: '{{ _ingest.on_failure_message }}'

--- a/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/dataset/test_logs/elasticsearch/ingest_pipeline/pipeline1.yml
+++ b/x-pack/test/ingest_manager_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/dataset/test_logs/elasticsearch/ingest_pipeline/pipeline1.yml
@@ -1,0 +1,9 @@
+---
+description: Pipeline test
+processors:
+- remove:
+    field: messag
+on_failure:
+  - set:
+      field: error.message
+      value: "{{ _ingest.on_failure_message }}"


### PR DESCRIPTION
Fixes bug where non entry ingest pipelines were not being deleted from elasticsearch when package was removed or there was a pipeline removal between updates.  Since no packages seem to be using non entry pipelines at the moment it should not be an issue currently.

### Changes
- deletes each pipeline based on the id in the saved object package installation, ensuring each pipeline is deleted
- adds integration test that the right pipelines were removed during an install and an update, including non entry pipelines