### PR TITLE
APM and Observability storybook fixes

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/Popover.stories.tsx
@@ -27,16 +27,18 @@ storiesOf('app/ServiceMap/Popover', module)
         avgCpuUsage: 0.32809666568309237,
         avgErrorRate: 0.556068173242986,
         avgMemoryUsage: 0.5504868173242986,
-        avgRequestsPerMinute: 164.47222031860858,
-        avgTransactionDuration: 61634.38905590272,
+        transactionStats: {
+          avgRequestsPerMinute: 164.47222031860858,
+          avgTransactionDuration: 61634.38905590272,
+        },
       }),
     } as unknown) as HttpSetup;
 
     createCallApmApi(httpMock);
 
-    setImmediate(() => {
-      cy.$('example service').select();
-    });
+    setTimeout(() => {
+      cy.$id('example service').select();
+    }, 0);
 
     return (
       <EuiThemeProvider>
@@ -59,9 +61,10 @@ storiesOf('app/ServiceMap/Popover', module)
       info: {
         propTablesExclude: [
           CytoscapeContext.Provider,
+          EuiThemeProvider,
           MockApmPluginContextWrapper,
           MockUrlParamsContextProvider,
-          EuiThemeProvider,
+          Popover,
         ],
         source: false,
       },

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/Cytoscape.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/Cytoscape.stories.tsx
@@ -288,43 +288,51 @@ storiesOf('app/ServiceMap/Cytoscape', module).add(
   }
 );
 
-storiesOf('app/ServiceMap/Cytoscape', module).add(
-  'node severity',
-  () => {
-    const elements = [
-      { data: { id: 'undefined', 'service.name': 'severity: undefined' } },
-      {
-        data: {
-          id: 'warning',
-          'service.name': 'severity: warning',
-          severity: 'warning',
+storiesOf('app/ServiceMap/Cytoscape', module)
+  .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+  .add(
+    'node severity',
+    () => {
+      const elements = [
+        {
+          data: {
+            id: 'undefined',
+            'service.name': 'severity: undefined',
+            serviceAnomalyStats: { anomalyScore: undefined },
+          },
         },
-      },
-      {
-        data: {
-          id: 'minor',
-          'service.name': 'severity: minor',
-          severity: 'minor',
+        {
+          data: {
+            id: 'warning',
+            'service.name': 'severity: warning',
+            serviceAnomalyStats: { anomalyScore: 0 },
+          },
         },
-      },
-      {
-        data: {
-          id: 'major',
-          'service.name': 'severity: major',
-          severity: 'major',
+        {
+          data: {
+            id: 'minor',
+            'service.name': 'severity: minor',
+            serviceAnomalyStats: { anomalyScore: 40 },
+          },
         },
-      },
-      {
-        data: {
-          id: 'critical',
-          'service.name': 'severity: critical',
-          severity: 'critical',
+        {
+          data: {
+            id: 'major',
+            'service.name': 'severity: major',
+            serviceAnomalyStats: { anomalyScore: 60 },
+          },
         },
-      },
-    ];
-    return <Cytoscape elements={elements} height={600} width={1340} />;
-  },
-  {
-    info: { propTables: false, source: false },
-  }
-);
+        {
+          data: {
+            id: 'critical',
+            'service.name': 'severity: critical',
+            serviceAnomalyStats: { anomalyScore: 80 },
+          },
+        },
+      ];
+      return <Cytoscape elements={elements} height={600} width={1340} />;
+    },
+    {
+      info: { propTables: false, source: false },
+    }
+  );

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/AgentConfigurationCreateEdit/index.stories.tsx
@@ -69,6 +69,11 @@ storiesOf(
     },
     {
       info: {
+        propTablesExclude: [
+          AgentConfigurationCreateEdit,
+          ApmPluginContext.Provider,
+          EuiThemeProvider,
+        ],
         source: false,
       },
     }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/SyncBadge.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/SyncBadge.stories.tsx
@@ -4,31 +4,21 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { SyncBadge } from './SyncBadge';
 
 storiesOf('app/TransactionDetails/SyncBadge', module)
+  .addDecorator(withKnobs)
   .add(
-    'sync=true',
+    'example',
     () => {
-      return <SyncBadge sync={true} />;
+      return <SyncBadge sync={boolean('sync', true)} />;
     },
     {
-      info: {
-        source: false,
-      },
-    }
-  )
-  .add(
-    'sync=false',
-    () => {
-      return <SyncBadge sync={false} />;
-    },
-    {
-      info: {
-        source: false,
-      },
+      showPanel: true,
+      info: { source: false },
     }
   )
   .add(
@@ -36,9 +26,5 @@ storiesOf('app/TransactionDetails/SyncBadge', module)
     () => {
       return <SyncBadge />;
     },
-    {
-      info: {
-        source: false,
-      },
-    }
+    { info: { source: false } }
   );

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/WaterfallContainer.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/WaterfallContainer.stories.tsx
@@ -18,79 +18,88 @@ import {
   inferredSpans,
 } from './waterfallContainer.stories.data';
 import { getWaterfall } from './Waterfall/waterfall_helpers/waterfall_helpers';
+import { EuiThemeProvider } from '../../../../../../../observability/public';
 
-storiesOf('app/TransactionDetails/Waterfall', module).add(
-  'simple',
-  () => {
-    const waterfall = getWaterfall(
-      simpleTrace as TraceAPIResponse,
-      '975c8d5bfd1dd20b'
-    );
-    return (
-      <WaterfallContainer
-        location={location}
-        urlParams={urlParams}
-        waterfall={waterfall}
-        exceedsMax={false}
-      />
-    );
-  },
-  { info: { source: false } }
-);
+storiesOf('app/TransactionDetails/Waterfall', module)
+  .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+  .add(
+    'example',
+    () => {
+      const waterfall = getWaterfall(
+        simpleTrace as TraceAPIResponse,
+        '975c8d5bfd1dd20b'
+      );
+      return (
+        <WaterfallContainer
+          location={location}
+          urlParams={urlParams}
+          waterfall={waterfall}
+          exceedsMax={false}
+        />
+      );
+    },
+    { info: { propTablesExclude: [EuiThemeProvider], source: false } }
+  );
 
-storiesOf('app/TransactionDetails/Waterfall', module).add(
-  'with errors',
-  () => {
-    const waterfall = getWaterfall(
-      (traceWithErrors as unknown) as TraceAPIResponse,
-      '975c8d5bfd1dd20b'
-    );
-    return (
-      <WaterfallContainer
-        location={location}
-        urlParams={urlParams}
-        waterfall={waterfall}
-        exceedsMax={false}
-      />
-    );
-  },
-  { info: { source: false } }
-);
+storiesOf('app/TransactionDetails/Waterfall', module)
+  .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+  .add(
+    'with errors',
+    () => {
+      const waterfall = getWaterfall(
+        (traceWithErrors as unknown) as TraceAPIResponse,
+        '975c8d5bfd1dd20b'
+      );
+      return (
+        <WaterfallContainer
+          location={location}
+          urlParams={urlParams}
+          waterfall={waterfall}
+          exceedsMax={false}
+        />
+      );
+    },
+    { info: { propTablesExclude: [EuiThemeProvider], source: false } }
+  );
 
-storiesOf('app/TransactionDetails/Waterfall', module).add(
-  'child starts before parent',
-  () => {
-    const waterfall = getWaterfall(
-      traceChildStartBeforeParent as TraceAPIResponse,
-      '975c8d5bfd1dd20b'
-    );
-    return (
-      <WaterfallContainer
-        location={location}
-        urlParams={urlParams}
-        waterfall={waterfall}
-        exceedsMax={false}
-      />
-    );
-  },
-  { info: { source: false } }
-);
+storiesOf('app/TransactionDetails/Waterfall', module)
+  .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+  .add(
+    'child starts before parent',
+    () => {
+      const waterfall = getWaterfall(
+        traceChildStartBeforeParent as TraceAPIResponse,
+        '975c8d5bfd1dd20b'
+      );
+      return (
+        <WaterfallContainer
+          location={location}
+          urlParams={urlParams}
+          waterfall={waterfall}
+          exceedsMax={false}
+        />
+      );
+    },
+    { info: { propTablesExclude: [EuiThemeProvider], source: false } }
+  );
 
-storiesOf('app/TransactionDetails/Waterfall', module).add(
-  'inferred spans',
-  () => {
-    const waterfall = getWaterfall(
-      inferredSpans as TraceAPIResponse,
-      'f2387d37260d00bd'
-    );
-    return (
-      <WaterfallContainer
-        location={location}
-        urlParams={urlParams}
-        waterfall={waterfall}
-        exceedsMax={false}
-      />
-    );
-  },
-  { info: { source: false } }
-);
+storiesOf('app/TransactionDetails/Waterfall', module)
+  .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+  .add(
+    'inferred spans',
+    () => {
+      const waterfall = getWaterfall(
+        inferredSpans as TraceAPIResponse,
+        'f2387d37260d00bd'
+      );
+      return (
+        <WaterfallContainer
+          location={location}
+          urlParams={urlParams}
+          waterfall={waterfall}
+          exceedsMax={false}
+        />
+      );
+    },
+    { info: { propTablesExclude: [EuiThemeProvider], source: false } }
+  );

--- a/x-pack/plugins/apm/public/components/shared/ErrorRateAlertTrigger/index.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ErrorRateAlertTrigger/index.stories.tsx
@@ -13,23 +13,32 @@ import {
   MockApmPluginContextWrapper,
 } from '../../../context/ApmPluginContext/MockApmPluginContext';
 
-storiesOf('app/ErrorRateAlertTrigger', module).add('example', () => {
-  const params = {
-    threshold: 2,
-    window: '5m',
-  };
+storiesOf('app/ErrorRateAlertTrigger', module).add(
+  'example',
+  () => {
+    const params = {
+      threshold: 2,
+      window: '5m',
+    };
 
-  return (
-    <MockApmPluginContextWrapper
-      value={(mockApmPluginContextValue as unknown) as ApmPluginContextValue}
-    >
-      <div style={{ width: 400 }}>
-        <ErrorRateAlertTrigger
-          alertParams={params as any}
-          setAlertParams={() => undefined}
-          setAlertProperty={() => undefined}
-        />
-      </div>
-    </MockApmPluginContextWrapper>
-  );
-});
+    return (
+      <MockApmPluginContextWrapper
+        value={(mockApmPluginContextValue as unknown) as ApmPluginContextValue}
+      >
+        <div style={{ width: 400 }}>
+          <ErrorRateAlertTrigger
+            alertParams={params as any}
+            setAlertParams={() => undefined}
+            setAlertProperty={() => undefined}
+          />
+        </div>
+      </MockApmPluginContextWrapper>
+    );
+  },
+  {
+    info: {
+      propTablesExclude: [ErrorRateAlertTrigger, MockApmPluginContextWrapper],
+      source: false,
+    },
+  }
+);

--- a/x-pack/plugins/apm/public/components/shared/LicensePrompt/LicensePrompt.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/LicensePrompt/LicensePrompt.stories.tsx
@@ -27,6 +27,7 @@ storiesOf('app/LicensePrompt', module).add(
   },
   {
     info: {
+      propTablesExclude: [ApmPluginContext.Provider, LicensePrompt],
       source: false,
     },
   }

--- a/x-pack/plugins/observability/public/pages/overview/overview.stories.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview.stories.tsx
@@ -122,7 +122,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -156,7 +156,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -180,7 +180,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -209,7 +209,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core: coreWithAlerts }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -238,7 +238,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core: coreWithAlerts }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -272,7 +272,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -311,7 +311,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core: coreWithAlerts }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -350,7 +350,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core: coreWithNewsFeed }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -389,7 +389,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -437,7 +437,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core: coreAlertsThrowsError }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -484,7 +484,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core: coreWithAlerts }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))
@@ -534,7 +534,7 @@ storiesOf('app/Overview', module)
   .addDecorator((storyFn) => (
     <MemoryRouter>
       <PluginContext.Provider value={{ core }}>
-        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
+        <EuiThemeProvider>{storyFn()}</EuiThemeProvider>
       </PluginContext.Provider>
     </MemoryRouter>
   ))


### PR DESCRIPTION
In APM:

* Fix stories crashing with errors
* Hide some additional prop tables
* Fix node severities story to show correct node severities
* Fix Service Map Popover story
* Use knobs on sync badge story

In Observability:

* Remove an extra stray paren in decorators

There's additional refactoring and fixes that can be done but this just gets everything in working order.
