### PR TITLE
[TSVB] On group by mode change, cleanup the query field

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/splits/filter.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/splits/filter.js
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { createSelectHandler } from '../lib/create_select_handler';
 import { GroupBySelect } from './group_by_select';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -30,8 +29,13 @@ export const SplitByFilter = (props) => {
   const { onChange, uiRestrictions, indexPattern } = props;
   const defaults = { filter: { language: getDefaultQueryLanguage(), query: '' } };
   const model = { ...defaults, ...props.model };
+  const queryLanguage = model.filter.language || getDefaultQueryLanguage();
   const htmlId = htmlIdGenerator();
-  const handleSelectChange = createSelectHandler(onChange);
+  const handleSelectChange = (options) => {
+    // On changing the split mode, it also cleans the query
+    onChange({ split_mode: options[0].value, filter: { language: queryLanguage, query: '' } });
+  };
+
   return (
     <EuiFlexGroup alignItems="center">
       <EuiFlexItem>
@@ -46,7 +50,7 @@ export const SplitByFilter = (props) => {
         >
           <GroupBySelect
             value={model.split_mode}
-            onChange={handleSelectChange('split_mode')}
+            onChange={handleSelectChange}
             uiRestrictions={uiRestrictions}
           />
         </EuiFormRow>
@@ -63,7 +67,7 @@ export const SplitByFilter = (props) => {
         >
           <QueryBarWrapper
             query={{
-              language: model.filter.language || getDefaultQueryLanguage(),
+              language: queryLanguage,
               query: model.filter.query || '',
             }}
             onChange={(filter) => onChange({ filter })}


### PR DESCRIPTION
## Summary

Closes #50955.

**Before**:
The user selects Group by Filter and adds a query, then changes to Group by Terms but the filter was still applied causing the charts to display filtered by query series.

**Now**:
If the user changes the Group by mode, the query is cleaned up so the series is displayed correctly.