### PR TITLE
[Dashboard] Sample data link does not work

### DIFF
--- a/src/plugins/dashboard/public/application/listing/__snapshots__/dashboard_listing.test.js.snap
+++ b/src/plugins/dashboard/public/application/listing/__snapshots__/dashboard_listing.test.js.snap
@@ -11,6 +11,7 @@ exports[`after fetch hideWriteControls 1`] = `
     findItems={[Function]}
     headingId="dashboardListingHeading"
     initialFilter=""
+    initialPageSize={10}
     listingLimit={1}
     noItemsFragment={
       <div>
@@ -68,6 +69,7 @@ exports[`after fetch initialFilter 1`] = `
     findItems={[Function]}
     headingId="dashboardListingHeading"
     initialFilter="my dashboard"
+    initialPageSize={10}
     listingLimit={1000}
     noItemsFragment={
       <div>
@@ -169,6 +171,7 @@ exports[`after fetch renders call to action when no dashboards exist 1`] = `
     findItems={[Function]}
     headingId="dashboardListingHeading"
     initialFilter=""
+    initialPageSize={10}
     listingLimit={1}
     noItemsFragment={
       <div>
@@ -270,6 +273,7 @@ exports[`after fetch renders table rows 1`] = `
     findItems={[Function]}
     headingId="dashboardListingHeading"
     initialFilter=""
+    initialPageSize={10}
     listingLimit={1000}
     noItemsFragment={
       <div>
@@ -371,6 +375,7 @@ exports[`after fetch renders warning when listingLimit is exceeded 1`] = `
     findItems={[Function]}
     headingId="dashboardListingHeading"
     initialFilter=""
+    initialPageSize={10}
     listingLimit={1}
     noItemsFragment={
       <div>

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.js
@@ -115,7 +115,7 @@ export class DashboardListing extends React.Component {
                     sampleDataInstallLink: (
                       <EuiLink
                         onClick={() =>
-                          this.props.core.application.navigateTo('home', {
+                          this.props.core.application.navigateToApp('home', {
                             path: '#/tutorial_directory/sampleData',
                           })
                         }

--- a/src/plugins/dashboard/public/application/listing/dashboard_listing.test.js
+++ b/src/plugins/dashboard/public/application/listing/dashboard_listing.test.js
@@ -79,6 +79,7 @@ describe('after fetch', () => {
         getViewUrl={() => {}}
         listingLimit={1000}
         hideWriteControls={false}
+        initialPageSize={10}
         initialFilter="my dashboard"
         core={{ notifications: { toasts: {} }, uiSettings: { get: jest.fn(() => 10) } }}
       />
@@ -101,6 +102,7 @@ describe('after fetch', () => {
         editItem={() => {}}
         getViewUrl={() => {}}
         listingLimit={1000}
+        initialPageSize={10}
         hideWriteControls={false}
         core={{ notifications: { toasts: {} }, uiSettings: { get: jest.fn(() => 10) } }}
       />
@@ -123,6 +125,7 @@ describe('after fetch', () => {
         editItem={() => {}}
         getViewUrl={() => {}}
         listingLimit={1}
+        initialPageSize={10}
         hideWriteControls={false}
         core={{ notifications: { toasts: {} }, uiSettings: { get: jest.fn(() => 10) } }}
       />
@@ -145,6 +148,7 @@ describe('after fetch', () => {
         editItem={() => {}}
         getViewUrl={() => {}}
         listingLimit={1}
+        initialPageSize={10}
         hideWriteControls={true}
         core={{ notifications: { toasts: {} }, uiSettings: { get: jest.fn(() => 10) } }}
       />
@@ -167,6 +171,7 @@ describe('after fetch', () => {
         editItem={() => {}}
         getViewUrl={() => {}}
         listingLimit={1}
+        initialPageSize={10}
         hideWriteControls={false}
         core={{ notifications: { toasts: {} }, uiSettings: { get: jest.fn(() => 10) } }}
       />


### PR DESCRIPTION
Closes #74812

## Summary

**Describe the bug:**
The 'Install Some Sample Data' link shown on the dashboard listing page when there are no dashboards to list does nothing.

**Steps to reproduce:**
1. Navigate to the dashboard listing page when your space has no dashboards
2. Click the 'Install Some Sample Data' link.
3. See that it doesn't redirect.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
