### PR TITLE
Use prefix search in visualize editor's field and aggregation select

### DIFF
--- a/src/plugins/vis_default_editor/public/components/agg_select.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_select.tsx
@@ -157,6 +157,7 @@ function DefaultEditorAggSelect({
         isClearable={false}
         isInvalid={showValidation ? !isValid : false}
         fullWidth={true}
+        sortMatchesBy="startsWith"
         compressed
       />
     </EuiFormRow>

--- a/src/plugins/vis_default_editor/public/components/controls/field.tsx
+++ b/src/plugins/vis_default_editor/public/components/controls/field.tsx
@@ -124,6 +124,7 @@ function FieldParamEditor({
         onChange={onChange}
         onBlur={setTouched}
         onSearchChange={onSearchChange}
+        sortMatchesBy="startsWith"
         data-test-subj="visDefaultEditorField"
         fullWidth={true}
       />


### PR DESCRIPTION
## Summary

This will make the aggregation and fields combo box in the visualize editor list results that matches the query in the beginning before all others. Thus searching for "te" would list "Terms" now as the first result and not the last (alphabetical order of all matches) anymore.

This feature is already present in EUI, thus we just set the flag on the combo box. Since I don't want to test EUI behavior in Kibana, this change adds no tests.

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
