### PR TITLE
[Security Solution] [Threat Hunting] [Cases]  Fix API integration tests and enable in CI

### DIFF
--- a/x-pack/scripts/functional_tests.js
+++ b/x-pack/scripts/functional_tests.js
@@ -22,6 +22,7 @@ const onlyNotInCoverageTests = [
   require.resolve('../test/alerting_api_integration/basic/config.ts'),
   require.resolve('../test/alerting_api_integration/spaces_only/config.ts'),
   require.resolve('../test/alerting_api_integration/security_and_spaces/config.ts'),
+  require.resolve('../test/case_api_integration/basic/config.ts'),
   require.resolve('../test/apm_api_integration/basic/config.ts'),
   require.resolve('../test/apm_api_integration/trial/config.ts'),
   require.resolve('../test/detection_engine_api_integration/security_and_spaces/config.ts'),

--- a/x-pack/test/case_api_integration/common/config.ts
+++ b/x-pack/test/case_api_integration/common/config.ts
@@ -21,10 +21,11 @@ interface CreateTestConfigOptions {
 const enabledActionTypes = [
   '.email',
   '.index',
+  '.jira',
   '.pagerduty',
+  '.resilient',
   '.server-log',
   '.servicenow',
-  '.jira',
   '.slack',
   '.webhook',
   'test.authorization',

--- a/x-pack/test/case_api_integration/common/lib/utils.ts
+++ b/x-pack/test/case_api_integration/common/lib/utils.ts
@@ -33,7 +33,7 @@ export const getServiceNowConnector = () => ({
   },
   config: {
     apiUrl: 'http://some.non.existent.com',
-    casesConfiguration: {
+    incidentConfiguration: {
       mapping: [
         {
           source: 'title',
@@ -52,6 +52,7 @@ export const getServiceNowConnector = () => ({
         },
       ],
     },
+    isCaseOwned: true,
   },
 });
 
@@ -65,6 +66,38 @@ export const getJiraConnector = () => ({
   config: {
     apiUrl: 'http://some.non.existent.com',
     projectKey: 'pkey',
+    casesConfiguration: {
+      mapping: [
+        {
+          source: 'title',
+          target: 'summary',
+          actionType: 'overwrite',
+        },
+        {
+          source: 'description',
+          target: 'description',
+          actionType: 'overwrite',
+        },
+        {
+          source: 'comments',
+          target: 'comments',
+          actionType: 'append',
+        },
+      ],
+    },
+  },
+});
+
+export const getResilientConnector = () => ({
+  name: 'Resilient Connector',
+  actionTypeId: '.resilient',
+  secrets: {
+    apiKeyId: 'id',
+    apiKeySecret: 'secret',
+  },
+  config: {
+    apiUrl: 'http://some.non.existent.com',
+    orgId: 'pkey',
     casesConfiguration: {
       mapping: [
         {


### PR DESCRIPTION
## Summary

Case API integration tests were not enabled in CI. This PR enables them, and updates a few action config keys that had changed. Also added a test for the IBM Resilient connector.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

