### PR TITLE
[Lens] Fix rollup related bugs

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
@@ -84,6 +84,7 @@ const initialState: IndexPatternPrivateState = {
       id: '1',
       title: 'idx1',
       timeFieldName: 'timestamp',
+      hasRestrictions: false,
       fields: [
         {
           name: 'timestamp',
@@ -134,6 +135,7 @@ const initialState: IndexPatternPrivateState = {
       id: '2',
       title: 'idx2',
       timeFieldName: 'timestamp',
+      hasRestrictions: true,
       fields: [
         {
           name: 'timestamp',
@@ -191,6 +193,7 @@ const initialState: IndexPatternPrivateState = {
       id: '3',
       title: 'idx3',
       timeFieldName: 'timestamp',
+      hasRestrictions: false,
       fields: [
         {
           name: 'timestamp',
@@ -322,8 +325,20 @@ describe('IndexPattern Data Panel', () => {
           isFirstExistenceFetch: false,
           currentIndexPatternId: 'a',
           indexPatterns: {
-            a: { id: 'a', title: 'aaa', timeFieldName: 'atime', fields: [] },
-            b: { id: 'b', title: 'bbb', timeFieldName: 'btime', fields: [] },
+            a: {
+              id: 'a',
+              title: 'aaa',
+              timeFieldName: 'atime',
+              fields: [],
+              hasRestrictions: false,
+            },
+            b: {
+              id: 'b',
+              title: 'bbb',
+              timeFieldName: 'btime',
+              fields: [],
+              hasRestrictions: false,
+            },
           },
           layers: {
             1: {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
@@ -599,7 +599,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                     Math.max(PAGINATION_SIZE, Math.min(pageSize * 1.5, displayedFieldLength))
                   );
                 }}
-                showExistenceFetchError={fieldInfoUnavailable}
+                showExistenceFetchError={existenceFetchFailed}
                 renderCallout={
                   <NoFieldsCallout
                     isAffectedByGlobalFilter={!!filters.length}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
@@ -580,6 +580,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                       })
                 }
                 exists={true}
+                hideDetails={fieldInfoUnavailable}
                 hasLoaded={!!hasSyncedExistingFields}
                 fieldsCount={filteredFieldGroups.availableFields.length}
                 isFiltered={

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.tsx
@@ -126,6 +126,7 @@ export function IndexPatternDataPanel({
       title: indexPatterns[id].title,
       timeFieldName: indexPatterns[id].timeFieldName,
       fields: indexPatterns[id].fields,
+      hasRestrictions: indexPatterns[id].hasRestrictions,
     }));
 
   const dslQuery = buildSafeEsQuery(
@@ -422,6 +423,8 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
     ]
   );
 
+  const fieldInfoUnavailable = existenceFetchFailed || currentIndexPattern.hasRestrictions;
+
   return (
     <ChildDragDropProvider {...dragDropContext}>
       <EuiFlexGroup
@@ -568,7 +571,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                 initialIsOpen={localState.isAvailableAccordionOpen}
                 id="lnsIndexPatternAvailableFields"
                 label={
-                  existenceFetchFailed
+                  fieldInfoUnavailable
                     ? i18n.translate('xpack.lens.indexPattern.allFieldsLabel', {
                         defaultMessage: 'All fields',
                       })
@@ -596,7 +599,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                     Math.max(PAGINATION_SIZE, Math.min(pageSize * 1.5, displayedFieldLength))
                   );
                 }}
-                showExistenceFetchError={existenceFetchFailed}
+                showExistenceFetchError={fieldInfoUnavailable}
                 renderCallout={
                   <NoFieldsCallout
                     isAffectedByGlobalFilter={!!filters.length}
@@ -609,7 +612,7 @@ export const InnerIndexPatternDataPanel = function InnerIndexPatternDataPanel({
                 }
               />
               <EuiSpacer size="m" />
-              {!existenceFetchFailed && (
+              {!fieldInfoUnavailable && (
                 <FieldsAccordion
                   initialIsOpen={localState.isEmptyAccordionOpen}
                   isFiltered={

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -42,6 +42,7 @@ const expectedIndexPatterns = {
     title: 'my-fake-index-pattern',
     timeFieldName: 'timestamp',
     hasExistence: true,
+    hasRestrictions: false,
     fields: [
       {
         name: 'timestamp',
@@ -1256,6 +1257,7 @@ describe('IndexPatternDimensionEditorPanel', () => {
           foo: {
             id: 'foo',
             title: 'Foo pattern',
+            hasRestrictions: false,
             fields: [
               {
                 aggregatable: true,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/fields_accordion.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/fields_accordion.tsx
@@ -47,6 +47,7 @@ export interface FieldsAccordionProps {
   renderCallout: JSX.Element;
   exists: boolean;
   showExistenceFetchError?: boolean;
+  hideDetails?: boolean;
 }
 
 export const InnerFieldsAccordion = function InnerFieldsAccordion({
@@ -61,13 +62,20 @@ export const InnerFieldsAccordion = function InnerFieldsAccordion({
   fieldProps,
   renderCallout,
   exists,
+  hideDetails,
   showExistenceFetchError,
 }: FieldsAccordionProps) {
   const renderField = useCallback(
     (field: IndexPatternField) => (
-      <FieldItem {...fieldProps} key={field.name} field={field} exists={!!exists} />
+      <FieldItem
+        {...fieldProps}
+        key={field.name}
+        field={field}
+        exists={exists}
+        hideDetails={hideDetails}
+      />
     ),
-    [fieldProps, exists]
+    [fieldProps, exists, hideDetails]
   );
 
   return (

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
@@ -21,6 +21,7 @@ const expectedIndexPatterns = {
     id: '1',
     title: 'my-fake-index-pattern',
     timeFieldName: 'timestamp',
+    hasRestrictions: false,
     fields: [
       {
         name: 'timestamp',
@@ -70,6 +71,7 @@ const expectedIndexPatterns = {
     id: '2',
     title: 'my-fake-restricted-pattern',
     timeFieldName: 'timestamp',
+    hasRestrictions: true,
     fields: [
       {
         name: 'timestamp',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -20,6 +20,7 @@ const expectedIndexPatterns = {
     id: '1',
     title: 'my-fake-index-pattern',
     timeFieldName: 'timestamp',
+    hasRestrictions: false,
     fields: [
       {
         name: 'timestamp',
@@ -68,6 +69,7 @@ const expectedIndexPatterns = {
   2: {
     id: '2',
     title: 'my-fake-restricted-pattern',
+    hasRestrictions: true,
     timeFieldName: 'timestamp',
     fields: [
       {
@@ -322,6 +324,7 @@ describe('IndexPattern Data Source suggestions', () => {
             1: {
               id: '1',
               title: 'no timefield',
+              hasRestrictions: false,
               fields: [
                 {
                   name: 'bytes',
@@ -532,6 +535,7 @@ describe('IndexPattern Data Source suggestions', () => {
             1: {
               id: '1',
               title: 'no timefield',
+              hasRestrictions: false,
               fields: [
                 {
                   name: 'bytes',
@@ -1350,6 +1354,7 @@ describe('IndexPattern Data Source suggestions', () => {
           1: {
             id: '1',
             title: 'my-fake-index-pattern',
+            hasRestrictions: false,
             fields: [
               {
                 name: 'field1',
@@ -1493,6 +1498,7 @@ describe('IndexPattern Data Source suggestions', () => {
           1: {
             id: '1',
             title: 'my-fake-index-pattern',
+            hasRestrictions: false,
             fields: [
               {
                 name: 'field1',
@@ -1555,6 +1561,7 @@ describe('IndexPattern Data Source suggestions', () => {
           1: {
             id: '1',
             title: 'my-fake-index-pattern',
+            hasRestrictions: false,
             fields: [
               {
                 name: 'field1',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/layerpanel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/layerpanel.test.tsx
@@ -62,6 +62,7 @@ const initialState: IndexPatternPrivateState = {
       id: '1',
       title: 'my-fake-index-pattern',
       timeFieldName: 'timestamp',
+      hasRestrictions: false,
       fields: [
         {
           name: 'timestamp',
@@ -103,6 +104,7 @@ const initialState: IndexPatternPrivateState = {
     '2': {
       id: '2',
       title: 'my-fake-restricted-pattern',
+      hasRestrictions: true,
       timeFieldName: 'timestamp',
       fields: [
         {
@@ -160,6 +162,7 @@ const initialState: IndexPatternPrivateState = {
       id: '3',
       title: 'my-compatible-pattern',
       timeFieldName: 'timestamp',
+      hasRestrictions: false,
       fields: [
         {
           name: 'timestamp',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.test.ts
@@ -40,6 +40,7 @@ const indexPattern1 = ({
   id: '1',
   title: 'my-fake-index-pattern',
   timeFieldName: 'timestamp',
+  hasRestrictions: false,
   fields: [
     {
       name: 'timestamp',
@@ -105,6 +106,7 @@ const indexPattern2 = ({
   id: '2',
   title: 'my-fake-restricted-pattern',
   timeFieldName: 'timestamp',
+  hasRestrictions: true,
   fields: [
     {
       name: 'timestamp',
@@ -733,9 +735,9 @@ describe('loader', () => {
         dateRange: { fromDate: '1900-01-01', toDate: '2000-01-01' },
         fetchJson,
         indexPatterns: [
-          { id: '1', title: '1', fields: [] },
-          { id: '2', title: '1', fields: [] },
-          { id: '3', title: '1', fields: [] },
+          { id: '1', title: '1', fields: [], hasRestrictions: false },
+          { id: '2', title: '1', fields: [], hasRestrictions: false },
+          { id: '3', title: '1', fields: [], hasRestrictions: false },
         ],
         setState,
         dslQuery,
@@ -783,9 +785,9 @@ describe('loader', () => {
         dateRange: { fromDate: '1900-01-01', toDate: '2000-01-01' },
         fetchJson,
         indexPatterns: [
-          { id: '1', title: '1', fields: [] },
-          { id: '2', title: '1', fields: [] },
-          { id: 'c', title: '1', fields: [] },
+          { id: '1', title: '1', fields: [], hasRestrictions: false },
+          { id: '2', title: '1', fields: [], hasRestrictions: false },
+          { id: 'c', title: '1', fields: [], hasRestrictions: false },
         ],
         setState,
         dslQuery,
@@ -817,6 +819,7 @@ describe('loader', () => {
           {
             id: '1',
             title: '1',
+            hasRestrictions: false,
             fields: [{ name: 'field1' }, { name: 'field2' }] as IndexPatternField[],
           },
         ],

--- a/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/loader.ts
@@ -91,7 +91,7 @@ export async function loadIndexPatterns({
         timeFieldName,
         fieldFormatMap,
         fields: newFields,
-        hasRestrictions: !!typeMeta?.aggs
+        hasRestrictions: !!typeMeta?.aggs,
       };
 
       return {
@@ -410,59 +410,3 @@ function isSingleEmptyLayer(layerMap: IndexPatternPrivateState['layers']) {
   const layers = Object.values(layerMap);
   return layers.length === 1 && layers[0].columnOrder.length === 0;
 }
-<<<<<<< HEAD
-=======
-
-function fromSavedObject(
-  savedObject: SimpleSavedObject<SavedIndexPatternAttributes>
-): IndexPattern {
-  const { id, attributes, type } = savedObject;
-  const indexPattern = {
-    ...attributes,
-    id,
-    type,
-    title: attributes.title,
-    fields: (JSON.parse(attributes.fields) as IFieldType[])
-      .filter(
-        (field) =>
-          !indexPatternsUtils.isNestedField(field) && (!!field.aggregatable || !!field.scripted)
-      )
-      .concat(documentField) as IndexPatternField[],
-    typeMeta: attributes.typeMeta
-      ? (JSON.parse(attributes.typeMeta) as IndexPatternTypeMeta)
-      : undefined,
-    fieldFormatMap: attributes.fieldFormatMap ? JSON.parse(attributes.fieldFormatMap) : undefined,
-  };
-
-  const { typeMeta } = indexPattern;
-  if (!typeMeta) {
-    return { ...indexPattern, hasRestrictions: false };
-  }
-
-  const newFields = [...(indexPattern.fields as IndexPatternField[])];
-
-  if (typeMeta.aggs) {
-    const aggs = Object.keys(typeMeta.aggs);
-    newFields.forEach((field, index) => {
-      const restrictionsObj: IndexPatternField['aggregationRestrictions'] = {};
-      aggs.forEach((agg) => {
-        const restriction = typeMeta.aggs && typeMeta.aggs[agg] && typeMeta.aggs[agg][field.name];
-        if (restriction) {
-          restrictionsObj[agg] = restriction;
-        }
-      });
-      if (Object.keys(restrictionsObj).length) {
-        newFields[index] = { ...field, aggregationRestrictions: restrictionsObj };
-      }
-    });
-  }
-
-  return {
-    id: indexPattern.id,
-    title: indexPattern.title,
-    timeFieldName: indexPattern.timeFieldName || undefined,
-    fields: newFields,
-    hasRestrictions: true,
-  };
-}
->>>>>>> fix some rollup related bugs

--- a/x-pack/plugins/lens/public/indexpattern_datasource/mocks.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/mocks.ts
@@ -11,6 +11,7 @@ export const createMockedIndexPattern = (): IndexPattern => ({
   id: '1',
   title: 'my-fake-index-pattern',
   timeFieldName: 'timestamp',
+  hasRestrictions: false,
   fields: [
     {
       name: 'timestamp',
@@ -70,6 +71,7 @@ export const createMockedRestrictedIndexPattern = () => ({
   id: '2',
   title: 'my-fake-restricted-pattern',
   timeFieldName: 'timestamp',
+  hasRestrictions: true,
   fields: [
     {
       name: 'timestamp',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.test.tsx
@@ -254,6 +254,7 @@ describe('date_histogram', () => {
           fields: [
             {
               name: 'timestamp',
+              displayName: 'timestamp',
               aggregatable: true,
               searchable: true,
               type: 'date',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.test.tsx
@@ -55,6 +55,7 @@ describe('date_histogram', () => {
           id: '1',
           title: 'Mock Indexpattern',
           timeFieldName: 'timestamp',
+          hasRestrictions: false,
           fields: [
             {
               name: 'timestamp',
@@ -69,6 +70,7 @@ describe('date_histogram', () => {
         2: {
           id: '2',
           title: 'Mock Indexpattern 2',
+          hasRestrictions: false,
           fields: [
             {
               name: 'other_timestamp',
@@ -229,13 +231,49 @@ describe('date_histogram', () => {
     it('should reflect params correctly', () => {
       const esAggsConfig = dateHistogramOperation.toEsAggsConfig(
         state.layers.first.columns.col1 as DateHistogramIndexPatternColumn,
-        'col1'
+        'col1',
+        state.indexPatterns['1']
       );
       expect(esAggsConfig).toEqual(
         expect.objectContaining({
           params: expect.objectContaining({
             interval: '42w',
             field: 'timestamp',
+            useNormalizedEsInterval: true,
+          }),
+        })
+      );
+    });
+
+    it('should not use normalized es interval for rollups', () => {
+      const esAggsConfig = dateHistogramOperation.toEsAggsConfig(
+        state.layers.first.columns.col1 as DateHistogramIndexPatternColumn,
+        'col1',
+        {
+          ...state.indexPatterns['1'],
+          fields: [
+            {
+              name: 'timestamp',
+              aggregatable: true,
+              searchable: true,
+              type: 'date',
+              aggregationRestrictions: {
+                date_histogram: {
+                  agg: 'date_histogram',
+                  time_zone: 'UTC',
+                  calendar_interval: '42w',
+                },
+              },
+            },
+          ],
+        }
+      );
+      expect(esAggsConfig).toEqual(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            interval: '42w',
+            field: 'timestamp',
+            useNormalizedEsInterval: false,
           }),
         })
       );
@@ -300,6 +338,7 @@ describe('date_histogram', () => {
         {
           title: '',
           id: '',
+          hasRestrictions: true,
           fields: [
             {
               name: 'dateField',
@@ -343,6 +382,7 @@ describe('date_histogram', () => {
         {
           title: '',
           id: '',
+          hasRestrictions: false,
           fields: [
             {
               name: 'dateField',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.tsx
@@ -127,7 +127,7 @@ export const dateHistogramOperation: OperationDefinition<DateHistogramIndexPatte
     params: {
       field: column.sourceField,
       time_zone: column.params.timeZone,
-      useNormalizedEsInterval: true,
+      useNormalizedEsInterval: false,
       interval: column.params.interval,
       drop_partials: false,
       min_doc_count: 0,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/date_histogram.tsx
@@ -119,21 +119,24 @@ export const dateHistogramOperation: OperationDefinition<DateHistogramIndexPatte
       sourceField: field.name,
     };
   },
-  toEsAggsConfig: (column, columnId) => ({
-    id: columnId,
-    enabled: true,
-    type: 'date_histogram',
-    schema: 'segment',
-    params: {
-      field: column.sourceField,
-      time_zone: column.params.timeZone,
-      useNormalizedEsInterval: false,
-      interval: column.params.interval,
-      drop_partials: false,
-      min_doc_count: 0,
-      extended_bounds: {},
-    },
-  }),
+  toEsAggsConfig: (column, columnId, indexPattern) => {
+    const usedField = indexPattern.fields.find((field) => field.name === column.sourceField);
+    return {
+      id: columnId,
+      enabled: true,
+      type: 'date_histogram',
+      schema: 'segment',
+      params: {
+        field: column.sourceField,
+        time_zone: column.params.timeZone,
+        useNormalizedEsInterval: !usedField || !usedField.aggregationRestrictions?.date_histogram,
+        interval: column.params.interval,
+        drop_partials: false,
+        min_doc_count: 0,
+        extended_bounds: {},
+      },
+    };
+  },
   paramEditor: ({ state, setState, currentColumn: currentColumn, layerId, dateRange, data }) => {
     const field =
       currentColumn &&

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/index.ts
@@ -84,7 +84,7 @@ interface BaseOperationDefinitionProps<C extends BaseIndexPatternColumn> {
    * Function turning a column into an agg config passed to the `esaggs` function
    * together with the agg configs returned from other columns.
    */
-  toEsAggsConfig: (column: C, columnId: string) => unknown;
+  toEsAggsConfig: (column: C, columnId: string, indexPattern: IndexPattern) => unknown;
   /**
    * Returns true if the `column` can also be used on `newIndexPattern`.
    * If this function returns false, the column is removed when switching index pattern

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
@@ -68,7 +68,7 @@ function buildMetricOperation<T extends MetricColumn<string>>({
         sourceField: field.name,
       };
     },
-    toEsAggsConfig: (column, columnId) => ({
+    toEsAggsConfig: (column, columnId, _indexPattern) => ({
       id: columnId,
       enabled: true,
       type: column.operationType,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms.test.tsx
@@ -13,7 +13,7 @@ import { dataPluginMock } from '../../../../../../../src/plugins/data/public/moc
 import { createMockedIndexPattern } from '../../mocks';
 import { TermsIndexPatternColumn } from './terms';
 import { termsOperation } from './index';
-import { IndexPatternPrivateState } from '../../types';
+import { IndexPatternPrivateState, IndexPattern } from '../../types';
 
 const defaultProps = {
   storage: {} as IStorageWrapper,
@@ -69,7 +69,8 @@ describe('terms', () => {
     it('should reflect params correctly', () => {
       const esAggsConfig = termsOperation.toEsAggsConfig(
         state.layers.first.columns.col1 as TermsIndexPatternColumn,
-        'col1'
+        'col1',
+        {} as IndexPattern
       );
       expect(esAggsConfig).toEqual(
         expect.objectContaining({

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms.tsx
@@ -95,7 +95,7 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn> = {
       },
     };
   },
-  toEsAggsConfig: (column, columnId) => ({
+  toEsAggsConfig: (column, columnId, _indexPattern) => ({
     id: columnId,
     enabled: true,
     type: 'terms',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/operations.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/operations.test.ts
@@ -16,6 +16,7 @@ const expectedIndexPatterns = {
     id: '1',
     title: 'my-fake-index-pattern',
     timeFieldName: 'timestamp',
+    hasRestrictions: false,
     fields: [
       {
         name: 'timestamp',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/state_helpers.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/state_helpers.test.ts
@@ -570,6 +570,7 @@ describe('state_helpers', () => {
     const indexPattern: IndexPattern = {
       id: 'test',
       title: '',
+      hasRestrictions: true,
       fields: [
         {
           name: 'fieldA',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/to_expression.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/to_expression.ts
@@ -21,7 +21,11 @@ function getExpressionForLayer(
   }
 
   function getEsAggsConfig<C extends IndexPatternColumn>(column: C, columnId: string) {
-    return operationDefinitionMap[column.operationType].toEsAggsConfig(column, columnId);
+    return operationDefinitionMap[column.operationType].toEsAggsConfig(
+      column,
+      columnId,
+      indexPattern
+    );
   }
 
   const columnEntries = columnOrder.map((colId) => [colId, columns[colId]] as const);

--- a/x-pack/plugins/lens/public/indexpattern_datasource/types.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/types.ts
@@ -19,6 +19,7 @@ export interface IndexPattern {
       params: unknown;
     }
   >;
+  hasRestrictions: boolean;
 }
 
 export interface IndexPatternField {

--- a/x-pack/test/functional/apps/lens/index.ts
+++ b/x-pack/test/functional/apps/lens/index.ts
@@ -31,6 +31,9 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       loadTestFile(require.resolve('./dashboard'));
       loadTestFile(require.resolve('./persistent_context'));
       loadTestFile(require.resolve('./lens_reporting'));
+
+      // has to be last one in the suite because it overrides saved objects
+      loadTestFile(require.resolve('./rollup'));
     });
   });
 }

--- a/x-pack/test/functional/apps/lens/rollup.ts
+++ b/x-pack/test/functional/apps/lens/rollup.ts
@@ -11,15 +11,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['visualize', 'lens']);
   const find = getService('find');
   const listingTable = getService('listingTable');
-  const testSubjects = getService('testSubjects');
+  const esArchiver = getService('esArchiver');
 
-  describe('lens smokescreen tests', () => {
-    it('should allow editing saved visualizations', async () => {
-      await PageObjects.visualize.gotoVisualizationLandingPage();
-      await listingTable.searchForItemWithName('Artistpreviouslyknownaslens');
-      await PageObjects.lens.clickVisualizeListItemTitle('Artistpreviouslyknownaslens');
-      await PageObjects.lens.goToTimeRange();
-      await PageObjects.lens.assertMetric('Maximum of bytes', '19,986');
+  describe('lens rollup tests', () => {
+    before(async () => {
+      await esArchiver.loadIfNeeded('lens/rollup/data');
+      await esArchiver.loadIfNeeded('lens/rollup/config');
+    });
+
+    after(async () => {
+      await esArchiver.unload('lens/rollup/data');
+      await esArchiver.unload('lens/rollup/config');
     });
 
     it('should allow creation of lens xy chart', async () => {
@@ -35,25 +37,16 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await PageObjects.lens.configureDimension({
         dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
-        operation: 'avg',
+        operation: 'sum',
         field: 'bytes',
       });
 
       await PageObjects.lens.configureDimension({
         dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
         operation: 'terms',
-        field: '@message.raw',
+        field: 'geo.src',
       });
-
-      await PageObjects.lens.switchToVisualization('lnsDatatable');
-      await PageObjects.lens.removeDimension('lnsDatatable_column');
-      await PageObjects.lens.switchToVisualization('bar_stacked');
-
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
-        operation: 'terms',
-        field: 'ip',
-      });
+      expect(await find.allByCssSelector('.echLegendItem')).to.have.length(2);
 
       await PageObjects.lens.save('Afancilenstest');
 
@@ -68,183 +61,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // .echLegendItem__title is the only viable way of getting the xy chart's
       // legend item(s), so we're using a class selector here.
-      expect(await find.allByCssSelector('.echLegendItem')).to.have.length(3);
+      expect(await find.allByCssSelector('.echLegendItem')).to.have.length(2);
     });
 
     it('should allow seamless transition to and from table view', async () => {
-      await PageObjects.visualize.gotoVisualizationLandingPage();
-      await listingTable.searchForItemWithName('Artistpreviouslyknownaslens');
-      await PageObjects.lens.clickVisualizeListItemTitle('Artistpreviouslyknownaslens');
-      await PageObjects.lens.goToTimeRange();
-      await PageObjects.lens.assertMetric('Maximum of bytes', '19,986');
-      await PageObjects.lens.switchToVisualization('lnsDatatable');
-      expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('Maximum of bytes');
-      expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('19,986');
       await PageObjects.lens.switchToVisualization('lnsMetric');
-      await PageObjects.lens.assertMetric('Maximum of bytes', '19,986');
-    });
-
-    it('should switch from a multi-layer stacked bar to a multi-layer line chart', async () => {
-      await PageObjects.visualize.navigateToNewVisualization();
-      await PageObjects.visualize.clickVisType('lens');
-      await PageObjects.lens.goToTimeRange();
-
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
-        operation: 'date_histogram',
-        field: '@timestamp',
-      });
-
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
-        operation: 'avg',
-        field: 'bytes',
-      });
-
-      await PageObjects.lens.createLayer();
-
-      expect(await PageObjects.lens.hasChartSwitchWarning('line')).to.eql(false);
-
-      await PageObjects.lens.switchToVisualization('line');
-
-      expect(await PageObjects.lens.getLayerCount()).to.eql(2);
-    });
-
-    it('should switch from a multi-layer stacked bar to donut chart using suggestions', async () => {
-      await PageObjects.visualize.navigateToNewVisualization();
-      await PageObjects.visualize.clickVisType('lens');
-      await PageObjects.lens.goToTimeRange();
-
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
-        operation: 'terms',
-        field: 'geo.dest',
-      });
-
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
-        operation: 'avg',
-        field: 'bytes',
-      });
-
-      await PageObjects.lens.createLayer();
-
-      await PageObjects.lens.configureDimension(
-        {
-          dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
-          operation: 'terms',
-          field: 'geo.src',
-        },
-        1
-      );
-
-      await PageObjects.lens.configureDimension(
-        {
-          dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
-          operation: 'avg',
-          field: 'bytes',
-        },
-        1
-      );
-      await PageObjects.lens.save('twolayerchart');
-      await testSubjects.click('lnsSuggestion-asDonut > lnsSuggestion');
-
-      expect(await PageObjects.lens.getLayerCount()).to.eql(1);
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sliceByDimensionPanel')).to.eql(
-        'Top values of geo.dest'
-      );
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sizeByDimensionPanel')).to.eql(
-        'Average of bytes'
-      );
-    });
-
-    it('should allow transition from line chart to donut chart and to bar chart', async () => {
-      await PageObjects.visualize.gotoVisualizationLandingPage();
-      await listingTable.searchForItemWithName('lnsXYvis');
-      await PageObjects.lens.clickVisualizeListItemTitle('lnsXYvis');
-      await PageObjects.lens.goToTimeRange();
-      expect(await PageObjects.lens.hasChartSwitchWarning('donut')).to.eql(true);
-      await PageObjects.lens.switchToVisualization('donut');
-
-      expect(await PageObjects.lens.getTitle()).to.eql('lnsXYvis');
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sliceByDimensionPanel')).to.eql(
-        'Top values of ip'
-      );
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sizeByDimensionPanel')).to.eql(
-        'Average of bytes'
-      );
-
-      expect(await PageObjects.lens.hasChartSwitchWarning('bar')).to.eql(false);
-      await PageObjects.lens.switchToVisualization('bar');
-      expect(await PageObjects.lens.getTitle()).to.eql('lnsXYvis');
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_xDimensionPanel')).to.eql(
-        'Top values of ip'
-      );
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
-        'Average of bytes'
-      );
-    });
-
-    it('should allow seamless transition from bar chart to line chart using layer chart switch', async () => {
-      await PageObjects.visualize.gotoVisualizationLandingPage();
-      await listingTable.searchForItemWithName('lnsXYvis');
-      await PageObjects.lens.clickVisualizeListItemTitle('lnsXYvis');
-      await PageObjects.lens.goToTimeRange();
-      await PageObjects.lens.switchLayerSeriesType('line');
-      expect(await PageObjects.lens.getTitle()).to.eql('lnsXYvis');
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_xDimensionPanel')).to.eql(
-        '@timestamp'
-      );
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
-        'Average of bytes'
-      );
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_splitDimensionPanel')).to.eql(
-        'Top values of ip'
-      );
-    });
-
-    it('should allow seamless transition from pie chart to treemap chart', async () => {
-      await PageObjects.visualize.gotoVisualizationLandingPage();
-      await listingTable.searchForItemWithName('lnsPieVis');
-      await PageObjects.lens.clickVisualizeListItemTitle('lnsPieVis');
-      await PageObjects.lens.goToTimeRange();
-      expect(await PageObjects.lens.hasChartSwitchWarning('treemap')).to.eql(false);
-      await PageObjects.lens.switchToVisualization('treemap');
-      expect(
-        await PageObjects.lens.getDimensionTriggerText('lnsPie_groupByDimensionPanel', 0)
-      ).to.eql('Top values of geo.dest');
-      expect(
-        await PageObjects.lens.getDimensionTriggerText('lnsPie_groupByDimensionPanel', 1)
-      ).to.eql('Top values of geo.src');
-      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sizeByDimensionPanel')).to.eql(
-        'Average of bytes'
-      );
-    });
-
-    it('should allow creating a pie chart and switching to datatable', async () => {
-      await PageObjects.visualize.navigateToNewVisualization();
-      await PageObjects.visualize.clickVisType('lens');
-      await PageObjects.lens.goToTimeRange();
-      await PageObjects.lens.switchToVisualization('pie');
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsPie_sliceByDimensionPanel > lns-empty-dimension',
-        operation: 'date_histogram',
-        field: '@timestamp',
-      });
-
-      await PageObjects.lens.configureDimension({
-        dimension: 'lnsPie_sizeByDimensionPanel > lns-empty-dimension',
-        operation: 'avg',
-        field: 'bytes',
-      });
-
-      expect(await PageObjects.lens.hasChartSwitchWarning('lnsDatatable')).to.eql(false);
+      await PageObjects.lens.assertMetric('Sum of bytes', '16,788');
       await PageObjects.lens.switchToVisualization('lnsDatatable');
-
-      expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('@timestamp per 3 hours');
-      expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('2015-09-20 00:00');
-      expect(await PageObjects.lens.getDatatableHeaderText(1)).to.eql('Average of bytes');
-      expect(await PageObjects.lens.getDatatableCellText(0, 1)).to.eql('6,011.351');
+      expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('Sum of bytes');
+      expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('16,788');
     });
   });
 }

--- a/x-pack/test/functional/apps/lens/rollup.ts
+++ b/x-pack/test/functional/apps/lens/rollup.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['visualize', 'lens']);
+  const find = getService('find');
+  const listingTable = getService('listingTable');
+  const testSubjects = getService('testSubjects');
+
+  describe('lens smokescreen tests', () => {
+    it('should allow editing saved visualizations', async () => {
+      await PageObjects.visualize.gotoVisualizationLandingPage();
+      await listingTable.searchForItemWithName('Artistpreviouslyknownaslens');
+      await PageObjects.lens.clickVisualizeListItemTitle('Artistpreviouslyknownaslens');
+      await PageObjects.lens.goToTimeRange();
+      await PageObjects.lens.assertMetric('Maximum of bytes', '19,986');
+    });
+
+    it('should allow creation of lens xy chart', async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('lens');
+      await PageObjects.lens.goToTimeRange();
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'avg',
+        field: 'bytes',
+      });
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
+        operation: 'terms',
+        field: '@message.raw',
+      });
+
+      await PageObjects.lens.switchToVisualization('lnsDatatable');
+      await PageObjects.lens.removeDimension('lnsDatatable_column');
+      await PageObjects.lens.switchToVisualization('bar_stacked');
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_splitDimensionPanel > lns-empty-dimension',
+        operation: 'terms',
+        field: 'ip',
+      });
+
+      await PageObjects.lens.save('Afancilenstest');
+
+      // Ensure the visualization shows up in the visualize list, and takes
+      // us back to the visualization as we configured it.
+      await PageObjects.visualize.gotoVisualizationLandingPage();
+      await listingTable.searchForItemWithName('Afancilenstest');
+      await PageObjects.lens.clickVisualizeListItemTitle('Afancilenstest');
+      await PageObjects.lens.goToTimeRange();
+
+      expect(await PageObjects.lens.getTitle()).to.eql('Afancilenstest');
+
+      // .echLegendItem__title is the only viable way of getting the xy chart's
+      // legend item(s), so we're using a class selector here.
+      expect(await find.allByCssSelector('.echLegendItem')).to.have.length(3);
+    });
+
+    it('should allow seamless transition to and from table view', async () => {
+      await PageObjects.visualize.gotoVisualizationLandingPage();
+      await listingTable.searchForItemWithName('Artistpreviouslyknownaslens');
+      await PageObjects.lens.clickVisualizeListItemTitle('Artistpreviouslyknownaslens');
+      await PageObjects.lens.goToTimeRange();
+      await PageObjects.lens.assertMetric('Maximum of bytes', '19,986');
+      await PageObjects.lens.switchToVisualization('lnsDatatable');
+      expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('Maximum of bytes');
+      expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('19,986');
+      await PageObjects.lens.switchToVisualization('lnsMetric');
+      await PageObjects.lens.assertMetric('Maximum of bytes', '19,986');
+    });
+
+    it('should switch from a multi-layer stacked bar to a multi-layer line chart', async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('lens');
+      await PageObjects.lens.goToTimeRange();
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'avg',
+        field: 'bytes',
+      });
+
+      await PageObjects.lens.createLayer();
+
+      expect(await PageObjects.lens.hasChartSwitchWarning('line')).to.eql(false);
+
+      await PageObjects.lens.switchToVisualization('line');
+
+      expect(await PageObjects.lens.getLayerCount()).to.eql(2);
+    });
+
+    it('should switch from a multi-layer stacked bar to donut chart using suggestions', async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('lens');
+      await PageObjects.lens.goToTimeRange();
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'terms',
+        field: 'geo.dest',
+      });
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+        operation: 'avg',
+        field: 'bytes',
+      });
+
+      await PageObjects.lens.createLayer();
+
+      await PageObjects.lens.configureDimension(
+        {
+          dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+          operation: 'terms',
+          field: 'geo.src',
+        },
+        1
+      );
+
+      await PageObjects.lens.configureDimension(
+        {
+          dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
+          operation: 'avg',
+          field: 'bytes',
+        },
+        1
+      );
+      await PageObjects.lens.save('twolayerchart');
+      await testSubjects.click('lnsSuggestion-asDonut > lnsSuggestion');
+
+      expect(await PageObjects.lens.getLayerCount()).to.eql(1);
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sliceByDimensionPanel')).to.eql(
+        'Top values of geo.dest'
+      );
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sizeByDimensionPanel')).to.eql(
+        'Average of bytes'
+      );
+    });
+
+    it('should allow transition from line chart to donut chart and to bar chart', async () => {
+      await PageObjects.visualize.gotoVisualizationLandingPage();
+      await listingTable.searchForItemWithName('lnsXYvis');
+      await PageObjects.lens.clickVisualizeListItemTitle('lnsXYvis');
+      await PageObjects.lens.goToTimeRange();
+      expect(await PageObjects.lens.hasChartSwitchWarning('donut')).to.eql(true);
+      await PageObjects.lens.switchToVisualization('donut');
+
+      expect(await PageObjects.lens.getTitle()).to.eql('lnsXYvis');
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sliceByDimensionPanel')).to.eql(
+        'Top values of ip'
+      );
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sizeByDimensionPanel')).to.eql(
+        'Average of bytes'
+      );
+
+      expect(await PageObjects.lens.hasChartSwitchWarning('bar')).to.eql(false);
+      await PageObjects.lens.switchToVisualization('bar');
+      expect(await PageObjects.lens.getTitle()).to.eql('lnsXYvis');
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_xDimensionPanel')).to.eql(
+        'Top values of ip'
+      );
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
+        'Average of bytes'
+      );
+    });
+
+    it('should allow seamless transition from bar chart to line chart using layer chart switch', async () => {
+      await PageObjects.visualize.gotoVisualizationLandingPage();
+      await listingTable.searchForItemWithName('lnsXYvis');
+      await PageObjects.lens.clickVisualizeListItemTitle('lnsXYvis');
+      await PageObjects.lens.goToTimeRange();
+      await PageObjects.lens.switchLayerSeriesType('line');
+      expect(await PageObjects.lens.getTitle()).to.eql('lnsXYvis');
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_xDimensionPanel')).to.eql(
+        '@timestamp'
+      );
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_yDimensionPanel')).to.eql(
+        'Average of bytes'
+      );
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsXY_splitDimensionPanel')).to.eql(
+        'Top values of ip'
+      );
+    });
+
+    it('should allow seamless transition from pie chart to treemap chart', async () => {
+      await PageObjects.visualize.gotoVisualizationLandingPage();
+      await listingTable.searchForItemWithName('lnsPieVis');
+      await PageObjects.lens.clickVisualizeListItemTitle('lnsPieVis');
+      await PageObjects.lens.goToTimeRange();
+      expect(await PageObjects.lens.hasChartSwitchWarning('treemap')).to.eql(false);
+      await PageObjects.lens.switchToVisualization('treemap');
+      expect(
+        await PageObjects.lens.getDimensionTriggerText('lnsPie_groupByDimensionPanel', 0)
+      ).to.eql('Top values of geo.dest');
+      expect(
+        await PageObjects.lens.getDimensionTriggerText('lnsPie_groupByDimensionPanel', 1)
+      ).to.eql('Top values of geo.src');
+      expect(await PageObjects.lens.getDimensionTriggerText('lnsPie_sizeByDimensionPanel')).to.eql(
+        'Average of bytes'
+      );
+    });
+
+    it('should allow creating a pie chart and switching to datatable', async () => {
+      await PageObjects.visualize.navigateToNewVisualization();
+      await PageObjects.visualize.clickVisType('lens');
+      await PageObjects.lens.goToTimeRange();
+      await PageObjects.lens.switchToVisualization('pie');
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsPie_sliceByDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
+      });
+
+      await PageObjects.lens.configureDimension({
+        dimension: 'lnsPie_sizeByDimensionPanel > lns-empty-dimension',
+        operation: 'avg',
+        field: 'bytes',
+      });
+
+      expect(await PageObjects.lens.hasChartSwitchWarning('lnsDatatable')).to.eql(false);
+      await PageObjects.lens.switchToVisualization('lnsDatatable');
+
+      expect(await PageObjects.lens.getDatatableHeaderText()).to.eql('@timestamp per 3 hours');
+      expect(await PageObjects.lens.getDatatableCellText(0, 0)).to.eql('2015-09-20 00:00');
+      expect(await PageObjects.lens.getDatatableHeaderText(1)).to.eql('Average of bytes');
+      expect(await PageObjects.lens.getDatatableCellText(0, 1)).to.eql('6,011.351');
+    });
+  });
+}

--- a/x-pack/test/functional/es_archives/lens/rollup/config/data.json
+++ b/x-pack/test/functional/es_archives/lens/rollup/config/data.json
@@ -1,0 +1,65 @@
+{
+  "type": "doc",
+  "value": {
+    "id": "space:default",
+    "index": ".kibana_1",
+    "source": {
+      "migrationVersion": {
+        "space": "6.6.0"
+      },
+      "references": [],
+      "space": {
+        "_reserved": true,
+        "description": "This is the default space!",
+        "disabledFeatures": [],
+        "name": "Default"
+      },
+      "type": "space"
+    },
+    "type": "_doc"
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "index-pattern:lens-rolled-up-data",
+    "index": ".kibana_1",
+    "source": {
+      "index-pattern" : {
+        "title" : "lens_rolled_up_data",
+        "timeFieldName" : "@timestamp",
+        "fields" : "[{\"count\":0,\"name\":\"_source\",\"type\":\"_source\",\"esTypes\":[\"_source\"],\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_id\",\"type\":\"string\",\"esTypes\":[\"_id\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_type\",\"type\":\"string\",\"esTypes\":[\"_type\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_index\",\"type\":\"string\",\"esTypes\":[\"_index\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"count\":0,\"name\":\"_score\",\"type\":\"number\",\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\",\"esTypes\":[\"date\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"bytes\",\"type\":\"number\",\"esTypes\":[\"float\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"count\":0,\"name\":\"geo.src\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]",
+        "type" : "rollup",
+        "typeMeta" : "{\"params\":{\"rollup_index\":\"lens_rolled_up_data\"},\"aggs\":{\"date_histogram\":{\"@timestamp\":{\"agg\":\"date_histogram\",\"fixed_interval\":\"60m\",\"time_zone\":\"UTC\"}},\"sum\":{\"bytes\":{\"agg\":\"sum\"}},\"max\":{\"bytes\":{\"agg\":\"max\"}},\"terms\":{\"geo.src\":{\"agg\":\"terms\"}}}}"
+      },
+      "type" : "index-pattern",
+      "references" : [ ],
+      "migrationVersion" : {
+        "index-pattern" : "7.6.0"
+      },
+      "updated_at" : "2020-08-19T08:39:09.998Z"
+    },
+    "type": "_doc"
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "id": "config:8.0.0",
+    "index": ".kibana_1",
+    "source": {
+      "config": {
+        "accessibility:disableAnimations": true,
+        "buildNum": 9007199254740991,
+        "dateFormat:tz": "UTC",
+        "defaultIndex": "logstash-*"
+      },
+      "references": [],
+      "type": "config",
+      "updated_at": "2019-09-04T18:47:24.761Z"
+    },
+    "type": "_doc"
+  }
+}

--- a/x-pack/test/functional/es_archives/lens/rollup/config/mappings.json
+++ b/x-pack/test/functional/es_archives/lens/rollup/config/mappings.json
@@ -1,0 +1,1294 @@
+{
+  "type": "index",
+  "value": {
+    "aliases": {
+      ".kibana": {
+      }
+    },
+    "index": ".kibana_1",
+    "mappings": {
+      "_meta": {
+        "migrationMappingPropertyHashes": {
+          "apm-telemetry": "07ee1939fa4302c62ddc052ec03fed90",
+          "canvas-element": "7390014e1091044523666d97247392fc",
+          "canvas-workpad": "b0a1706d356228dbdcb4a17e6b9eb231",
+          "config": "87aca8fdb053154f11383fce3dbf3edf",
+          "dashboard": "d00f614b29a80360e1190193fd333bab",
+          "file-upload-telemetry": "0ed4d3e1983d1217a30982630897092e",
+          "graph-workspace": "cd7ba1330e6682e9cc00b78850874be1",
+          "index-pattern": "66eccb05066c5a89924f48a9e9736499",
+          "infrastructure-ui-source": "ddc0ecb18383f6b26101a2fadb2dab0c",
+          "inventory-view": "84b320fd67209906333ffce261128462",
+          "kql-telemetry": "d12a98a6f19a2d273696597547e064ee",
+          "lens": "21c3ea0763beb1ecb0162529706b88c5",
+          "map": "23d7aa4a720d4938ccde3983f87bd58d",
+          "maps-telemetry": "a4229f8b16a6820c6d724b7e0c1f729d",
+          "metrics-explorer-view": "53c5365793677328df0ccb6138bf3cdd",
+          "migrationVersion": "4a1746014a75ade3a714e1db5763276f",
+          "ml-telemetry": "257fd1d4b4fdbb9cb4b8a3b27da201e9",
+          "namespace": "2f4316de49999235636386fe51dc06c1",
+          "query": "11aaeb7f5f7fa5bb43f25e18ce26e7d9",
+          "references": "7997cf5a56cc02bdc9c93361bde732b0",
+          "sample-data-telemetry": "7d3cfeb915303c9641c59681967ffeb4",
+          "search": "181661168bbadd1eff5902361e2a0d5c",
+          "server": "ec97f1c5da1a19609a60874e5af1100c",
+          "siem-ui-timeline": "1f6f0860ad7bc0dba3e42467ca40470d",
+          "siem-ui-timeline-note": "8874706eedc49059d4cf0f5094559084",
+          "siem-ui-timeline-pinned-event": "20638091112f0e14f0e443d512301c29",
+          "space": "c5ca8acafa0beaa4d08d014a97b6bc6b",
+          "telemetry": "e1c8bc94e443aefd9458932cc0697a4d",
+          "timelion-sheet": "9a2a2748877c7a7b582fef201ab1d4cf",
+          "type": "2f4316de49999235636386fe51dc06c1",
+          "ui-metric": "0d409297dc5ebe1e3a1da691c6ee32e3",
+          "updated_at": "00da57df13e94e9d98437d13ace4bfe0",
+          "upgrade-assistant-reindex-operation": "a53a20fe086b72c9a86da3cc12dad8a6",
+          "upgrade-assistant-telemetry": "56702cec857e0a9dacfb696655b4ff7b",
+          "url": "c7f66a0df8b1b52f17c28c4adb111105",
+          "visualization": "52d7a13ad68a150c4525b292d23e12cc"
+        }
+      },
+      "dynamic": "strict",
+      "properties": {
+        "action": {
+          "properties": {
+            "actionTypeId": {
+              "type": "keyword"
+            },
+            "config": {
+              "enabled": false,
+              "type": "object"
+            },
+            "description": {
+              "type": "text"
+            },
+            "secrets": {
+              "type": "binary"
+            }
+          }
+        },
+        "action_task_params": {
+          "properties": {
+            "actionId": {
+              "type": "keyword"
+            },
+            "apiKey": {
+              "type": "binary"
+            },
+            "params": {
+              "enabled": false,
+              "type": "object"
+            }
+          }
+        },
+        "alert": {
+          "properties": {
+            "actions": {
+              "properties": {
+                "actionRef": {
+                  "type": "keyword"
+                },
+                "group": {
+                  "type": "keyword"
+                },
+                "params": {
+                  "enabled": false,
+                  "type": "object"
+                }
+              },
+              "type": "nested"
+            },
+            "alertTypeId": {
+              "type": "keyword"
+            },
+            "params": {
+              "enabled": false,
+              "type": "object"
+            },
+            "apiKey": {
+              "type": "binary"
+            },
+            "apiKeyOwner": {
+              "type": "keyword"
+            },
+            "createdBy": {
+              "type": "keyword"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "keyword"
+            },
+            "scheduledTaskId": {
+              "type": "keyword"
+            },
+            "updatedBy": {
+              "type": "keyword"
+            }
+          }
+        },
+        "apm-telemetry": {
+          "properties": {
+            "has_any_services": {
+              "type": "boolean"
+            },
+            "services_per_agent": {
+              "properties": {
+                "dotnet": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "go": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "java": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "js-base": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "nodejs": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "python": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "ruby": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "rum-js": {
+                  "null_value": 0,
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "canvas-element": {
+          "dynamic": "false",
+          "properties": {
+            "@created": {
+              "type": "date"
+            },
+            "@timestamp": {
+              "type": "date"
+            },
+            "content": {
+              "type": "text"
+            },
+            "help": {
+              "type": "text"
+            },
+            "image": {
+              "type": "text"
+            },
+            "name": {
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "canvas-workpad": {
+          "dynamic": "false",
+          "properties": {
+            "@created": {
+              "type": "date"
+            },
+            "@timestamp": {
+              "type": "date"
+            },
+            "name": {
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "config": {
+          "dynamic": "true",
+          "properties": {
+            "accessibility:disableAnimations": {
+              "type": "boolean"
+            },
+            "buildNum": {
+              "type": "keyword"
+            },
+            "dateFormat:tz": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            },
+            "defaultIndex": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "dashboard": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "optionsJSON": {
+              "type": "text"
+            },
+            "panelsJSON": {
+              "type": "text"
+            },
+            "refreshInterval": {
+              "properties": {
+                "display": {
+                  "type": "keyword"
+                },
+                "pause": {
+                  "type": "boolean"
+                },
+                "section": {
+                  "type": "integer"
+                },
+                "value": {
+                  "type": "integer"
+                }
+              }
+            },
+            "timeFrom": {
+              "type": "keyword"
+            },
+            "timeRestore": {
+              "type": "boolean"
+            },
+            "timeTo": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "file-upload-telemetry": {
+          "properties": {
+            "filesUploadedTotalCount": {
+              "type": "long"
+            }
+          }
+        },
+        "gis-map": {
+          "properties": {
+            "bounds": {
+              "strategy": "recursive",
+              "type": "geo_shape"
+            },
+            "description": {
+              "type": "text"
+            },
+            "layerListJSON": {
+              "type": "text"
+            },
+            "mapStateJSON": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "graph-workspace": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "numLinks": {
+              "type": "integer"
+            },
+            "numVertices": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "wsState": {
+              "type": "text"
+            }
+          }
+        },
+        "index-pattern": {
+          "properties": {
+            "fieldFormatMap": {
+              "type": "text"
+            },
+            "fields": {
+              "type": "text"
+            },
+            "intervalName": {
+              "type": "keyword"
+            },
+            "notExpandable": {
+              "type": "boolean"
+            },
+            "sourceFilters": {
+              "type": "text"
+            },
+            "timeFieldName": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "typeMeta": {
+              "type": "keyword"
+            }
+          }
+        },
+        "infrastructure-ui-source": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "fields": {
+              "properties": {
+                "container": {
+                  "type": "keyword"
+                },
+                "host": {
+                  "type": "keyword"
+                },
+                "pod": {
+                  "type": "keyword"
+                },
+                "tiebreaker": {
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "logAlias": {
+              "type": "keyword"
+            },
+            "logColumns": {
+              "properties": {
+                "fieldColumn": {
+                  "properties": {
+                    "field": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "messageColumn": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "timestampColumn": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "nested"
+            },
+            "metricAlias": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "text"
+            }
+          }
+        },
+        "inventory-view": {
+          "properties": {
+            "autoBounds": {
+              "type": "boolean"
+            },
+            "autoReload": {
+              "type": "boolean"
+            },
+            "boundsOverride": {
+              "properties": {
+                "max": {
+                  "type": "integer"
+                },
+                "min": {
+                  "type": "integer"
+                }
+              }
+            },
+            "customOptions": {
+              "properties": {
+                "field": {
+                  "type": "keyword"
+                },
+                "text": {
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            },
+            "filterQuery": {
+              "properties": {
+                "expression": {
+                  "type": "keyword"
+                },
+                "kind": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "groupBy": {
+              "properties": {
+                "field": {
+                  "type": "keyword"
+                },
+                "label": {
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            },
+            "metric": {
+              "properties": {
+                "type": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "nodeType": {
+              "type": "keyword"
+            },
+            "time": {
+              "type": "integer"
+            },
+            "view": {
+              "type": "keyword"
+            }
+          }
+        },
+        "kql-telemetry": {
+          "properties": {
+            "optInCount": {
+              "type": "long"
+            },
+            "optOutCount": {
+              "type": "long"
+            }
+          }
+        },
+        "lens": {
+          "properties": {
+            "expression": {
+              "index": false,
+              "type": "keyword"
+            },
+            "state": {
+              "type": "flattened"
+            },
+            "title": {
+              "type": "text"
+            },
+            "visualizationType": {
+              "type": "keyword"
+            }
+          }
+        },
+        "map": {
+          "properties": {
+            "bounds": {
+              "type": "geo_shape"
+            },
+            "description": {
+              "type": "text"
+            },
+            "layerListJSON": {
+              "type": "text"
+            },
+            "mapStateJSON": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "maps-telemetry": {
+          "properties": {
+            "attributesPerMap": {
+              "properties": {
+                "dataSourcesCount": {
+                  "properties": {
+                    "avg": {
+                      "type": "long"
+                    },
+                    "max": {
+                      "type": "long"
+                    },
+                    "min": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "emsVectorLayersCount": {
+                  "dynamic": "true",
+                  "type": "object"
+                },
+                "layerTypesCount": {
+                  "dynamic": "true",
+                  "type": "object"
+                },
+                "layersCount": {
+                  "properties": {
+                    "avg": {
+                      "type": "long"
+                    },
+                    "max": {
+                      "type": "long"
+                    },
+                    "min": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "mapsTotalCount": {
+              "type": "long"
+            },
+            "timeCaptured": {
+              "type": "date"
+            }
+          }
+        },
+        "metrics-explorer-view": {
+          "properties": {
+            "chartOptions": {
+              "properties": {
+                "stack": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "keyword"
+                },
+                "yAxisMode": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "currentTimerange": {
+              "properties": {
+                "from": {
+                  "type": "keyword"
+                },
+                "interval": {
+                  "type": "keyword"
+                },
+                "to": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "options": {
+              "properties": {
+                "aggregation": {
+                  "type": "keyword"
+                },
+                "filterQuery": {
+                  "type": "keyword"
+                },
+                "groupBy": {
+                  "type": "keyword"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "properties": {
+                    "aggregation": {
+                      "type": "keyword"
+                    },
+                    "color": {
+                      "type": "keyword"
+                    },
+                    "field": {
+                      "type": "keyword"
+                    },
+                    "label": {
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                }
+              }
+            }
+          }
+        },
+        "migrationVersion": {
+          "dynamic": "true",
+          "properties": {
+            "index-pattern": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            },
+            "space": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            },
+            "visualization": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "ml-telemetry": {
+          "properties": {
+            "file_data_visualizer": {
+              "properties": {
+                "index_creation_count": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "namespace": {
+          "type": "keyword"
+        },
+        "query": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "filters": {
+              "enabled": false,
+              "type": "object"
+            },
+            "query": {
+              "properties": {
+                "language": {
+                  "type": "keyword"
+                },
+                "query": {
+                  "index": false,
+                  "type": "keyword"
+                }
+              }
+            },
+            "timefilter": {
+              "enabled": false,
+              "type": "object"
+            },
+            "title": {
+              "type": "text"
+            }
+          }
+        },
+        "references": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            }
+          },
+          "type": "nested"
+        },
+        "sample-data-telemetry": {
+          "properties": {
+            "installCount": {
+              "type": "long"
+            },
+            "unInstallCount": {
+              "type": "long"
+            }
+          }
+        },
+        "search": {
+          "properties": {
+            "columns": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "sort": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "server": {
+          "properties": {
+            "uuid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "siem-ui-timeline": {
+          "properties": {
+            "columns": {
+              "properties": {
+                "aggregatable": {
+                  "type": "boolean"
+                },
+                "category": {
+                  "type": "keyword"
+                },
+                "columnHeaderType": {
+                  "type": "keyword"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "example": {
+                  "type": "text"
+                },
+                "id": {
+                  "type": "keyword"
+                },
+                "indexes": {
+                  "type": "keyword"
+                },
+                "name": {
+                  "type": "text"
+                },
+                "placeholder": {
+                  "type": "text"
+                },
+                "searchable": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "created": {
+              "type": "date"
+            },
+            "createdBy": {
+              "type": "text"
+            },
+            "dataProviders": {
+              "properties": {
+                "and": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "excluded": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "kqlQuery": {
+                      "type": "text"
+                    },
+                    "name": {
+                      "type": "text"
+                    },
+                    "queryMatch": {
+                      "properties": {
+                        "displayField": {
+                          "type": "text"
+                        },
+                        "displayValue": {
+                          "type": "text"
+                        },
+                        "field": {
+                          "type": "text"
+                        },
+                        "operator": {
+                          "type": "text"
+                        },
+                        "value": {
+                          "type": "text"
+                        }
+                      }
+                    }
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "excluded": {
+                  "type": "boolean"
+                },
+                "id": {
+                  "type": "keyword"
+                },
+                "kqlQuery": {
+                  "type": "text"
+                },
+                "name": {
+                  "type": "text"
+                },
+                "queryMatch": {
+                  "properties": {
+                    "displayField": {
+                      "type": "text"
+                    },
+                    "displayValue": {
+                      "type": "text"
+                    },
+                    "field": {
+                      "type": "text"
+                    },
+                    "operator": {
+                      "type": "text"
+                    },
+                    "value": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+            },
+            "dateRange": {
+              "properties": {
+                "end": {
+                  "type": "date"
+                },
+                "start": {
+                  "type": "date"
+                }
+              }
+            },
+            "description": {
+              "type": "text"
+            },
+            "favorite": {
+              "properties": {
+                "favoriteDate": {
+                  "type": "date"
+                },
+                "fullName": {
+                  "type": "text"
+                },
+                "keySearch": {
+                  "type": "text"
+                },
+                "userName": {
+                  "type": "text"
+                }
+              }
+            },
+            "kqlMode": {
+              "type": "keyword"
+            },
+            "kqlQuery": {
+              "properties": {
+                "filterQuery": {
+                  "properties": {
+                    "kuery": {
+                      "properties": {
+                        "expression": {
+                          "type": "text"
+                        },
+                        "kind": {
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "serializedQuery": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+            },
+            "sort": {
+              "properties": {
+                "columnId": {
+                  "type": "keyword"
+                },
+                "sortDirection": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "title": {
+              "type": "text"
+            },
+            "updated": {
+              "type": "date"
+            },
+            "updatedBy": {
+              "type": "text"
+            }
+          }
+        },
+        "siem-ui-timeline-note": {
+          "properties": {
+            "created": {
+              "type": "date"
+            },
+            "createdBy": {
+              "type": "text"
+            },
+            "eventId": {
+              "type": "keyword"
+            },
+            "note": {
+              "type": "text"
+            },
+            "timelineId": {
+              "type": "keyword"
+            },
+            "updated": {
+              "type": "date"
+            },
+            "updatedBy": {
+              "type": "text"
+            }
+          }
+        },
+        "siem-ui-timeline-pinned-event": {
+          "properties": {
+            "created": {
+              "type": "date"
+            },
+            "createdBy": {
+              "type": "text"
+            },
+            "eventId": {
+              "type": "keyword"
+            },
+            "timelineId": {
+              "type": "keyword"
+            },
+            "updated": {
+              "type": "date"
+            },
+            "updatedBy": {
+              "type": "text"
+            }
+          }
+        },
+        "space": {
+          "properties": {
+            "_reserved": {
+              "type": "boolean"
+            },
+            "color": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "disabledFeatures": {
+              "type": "keyword"
+            },
+            "imageUrl": {
+              "index": false,
+              "type": "text"
+            },
+            "initials": {
+              "type": "keyword"
+            },
+            "name": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 2048,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
+        "telemetry": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
+        "timelion-sheet": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "timelion_chart_height": {
+              "type": "integer"
+            },
+            "timelion_columns": {
+              "type": "integer"
+            },
+            "timelion_interval": {
+              "type": "keyword"
+            },
+            "timelion_other_interval": {
+              "type": "keyword"
+            },
+            "timelion_rows": {
+              "type": "integer"
+            },
+            "timelion_sheet": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "ui-metric": {
+          "properties": {
+            "count": {
+              "type": "integer"
+            }
+          }
+        },
+        "updated_at": {
+          "type": "date"
+        },
+        "upgrade-assistant-reindex-operation": {
+          "dynamic": "true",
+          "properties": {
+            "indexName": {
+              "type": "keyword"
+            },
+            "status": {
+              "type": "integer"
+            }
+          }
+        },
+        "upgrade-assistant-telemetry": {
+          "properties": {
+            "features": {
+              "properties": {
+                "deprecation_logging": {
+                  "properties": {
+                    "enabled": {
+                      "null_value": true,
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            },
+            "ui_open": {
+              "properties": {
+                "cluster": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "indices": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "overview": {
+                  "null_value": 0,
+                  "type": "long"
+                }
+              }
+            },
+            "ui_reindex": {
+              "properties": {
+                "close": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "open": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "start": {
+                  "null_value": 0,
+                  "type": "long"
+                },
+                "stop": {
+                  "null_value": 0,
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "url": {
+          "properties": {
+            "accessCount": {
+              "type": "long"
+            },
+            "accessDate": {
+              "type": "date"
+            },
+            "createDate": {
+              "type": "date"
+            },
+            "url": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 2048,
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
+        "visualization": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "savedSearchRefName": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "visState": {
+              "type": "text"
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "number_of_replicas": "0",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}

--- a/x-pack/test/functional/es_archives/lens/rollup/data/data.json
+++ b/x-pack/test/functional/es_archives/lens/rollup/data/data.json
@@ -1,0 +1,59 @@
+{
+  "type": "doc",
+  "value": {
+    "index": "lens_rolled_up_data",
+    "id": "lens_rolled_up_data$vuSq1a9Ph2Nq-2yfGpE34g",
+    "source": {
+      "@timestamp.date_histogram.time_zone": "UTC",
+      "@timestamp.date_histogram.timestamp": 1442710800000,
+      "geo.src.terms.value": "CN",
+      "bytes.max.value": 5678.0,
+      "_rollup.version": 2,
+      "bytes.sum.value": 5678.0,
+      "@timestamp.date_histogram.interval": "60m",
+      "geo.src.terms._count": 1,
+      "@timestamp.date_histogram._count": 1,
+      "_rollup.id": "lens_rolled_up_data"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "index": "lens_rolled_up_data",
+    "id": "lens_rolled_up_data$QFyUWoecErSYPMrIb6CgZA",
+    "source": {
+      "@timestamp.date_histogram.time_zone": "UTC",
+      "@timestamp.date_histogram.timestamp": 1442710800000,
+      "geo.src.terms.value": "US",
+      "bytes.max.value": 1234.0,
+      "_rollup.version": 2,
+      "bytes.sum.value": 1234.0,
+      "@timestamp.date_histogram.interval": "60m",
+      "geo.src.terms._count": 1,
+      "@timestamp.date_histogram._count": 1,
+      "_rollup.id": "lens_rolled_up_data"
+    }
+  }
+}
+
+{
+  "type": "doc",
+  "value": {
+    "index": "lens_rolled_up_data",
+    "id": "lens_rolled_up_data$cKCjv1OPjYiyv5WPPblohw",
+    "source": {
+      "@timestamp.date_histogram.time_zone": "UTC",
+      "@timestamp.date_histogram.timestamp": 1442714400000,
+      "geo.src.terms.value": "CN",
+      "bytes.max.value": 9876.0,
+      "_rollup.version": 2,
+      "bytes.sum.value": 9876.0,
+      "@timestamp.date_histogram.interval": "60m",
+      "geo.src.terms._count": 1,
+      "@timestamp.date_histogram._count": 1,
+      "_rollup.id": "lens_rolled_up_data"
+    }
+  }
+}

--- a/x-pack/test/functional/es_archives/lens/rollup/data/mappings.json
+++ b/x-pack/test/functional/es_archives/lens/rollup/data/mappings.json
@@ -1,0 +1,129 @@
+{
+  "type": "index",
+  "value": {
+    "index": "lens_rolled_up_data",
+    "mappings": {
+      "_meta": {
+        "_rollup": {
+          "lens_rolled_up_data": {
+            "cron": "0 * * * * ?",
+            "rollup_index": "lens_rolled_up_data",
+            "groups": {
+              "date_histogram": {
+                "fixed_interval": "60m",
+                "field": "@timestamp",
+                "time_zone": "UTC"
+              },
+              "terms": {
+                "fields": ["geo.src", "ip"]
+              }
+            },
+            "id": "lens_rolled_up_data",
+            "metrics": [
+              {
+                "field": "bytes",
+                "metrics": ["sum", "max"]
+              }
+            ],
+            "index_pattern": "lens_raw",
+            "timeout": "20s",
+            "page_size": 1000
+          }
+        },
+        "rollup-version": "8.0.0"
+      },
+      "dynamic_templates": [
+        {
+          "strings": {
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "date_histograms": {
+            "path_match": "*.date_histogram.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "properties": {
+            "date_histogram": {
+              "properties": {
+                "_count": {
+                  "type": "long"
+                },
+                "interval": {
+                  "type": "keyword"
+                },
+                "time_zone": {
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                }
+              }
+            }
+          }
+        },
+        "_rollup": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "version": {
+              "type": "long"
+            }
+          }
+        },
+        "bytes": {
+          "properties": {
+            "max": {
+              "properties": {
+                "value": {
+                  "type": "float"
+                }
+              }
+            },
+            "sum": {
+              "properties": {
+                "value": {
+                  "type": "float"
+                }
+              }
+            }
+          }
+        },
+        "geo": {
+          "properties": {
+            "src": {
+              "properties": {
+                "terms": {
+                  "properties": {
+                    "_count": {
+                      "type": "long"
+                    },
+                    "value": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/74348

This PR fixes problems with the Lens rollup integration.

* `useNormalizedEsIntervals` has to be set to false for rollup date fields - this PR passes the index pattern to the `toEsAggsConfig` function of the individual operations to pull out the information about restrictions there
* The field existence endpoint doesn't work for rolled up fields. This PR avoids the request when there are restrictions and simply shows all fields in this case - I extended the local `IndexPattern` type with a `hasRestrictions` flag
* This PR also adds some functional tests for rollups in Lens