### PR TITLE
[Security Solution][Detections] Loosen lists permissions

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
@@ -29,7 +29,7 @@ export const useListsConfig = (): UseListsConfigReturn => {
   const hasIndexError = indexError != null;
   const needsIndexConfiguration =
     needsIndex && (canManageIndex === false || (canManageIndex === true && hasIndexError));
-  const needsConfiguration = !enabled || canWriteIndex === false || needsIndexConfiguration;
+  const needsConfiguration = !enabled || needsIndexConfiguration;
 
   useEffect(() => {
     if (needsIndex && canManageIndex) {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
@@ -54,6 +54,7 @@ const RulesPageComponent: React.FC = () => {
   } = useUserInfo();
   const {
     loading: listsConfigLoading,
+    canWriteIndex: canWriteListsIndex,
     needsConfiguration: needsListsConfiguration,
   } = useListsConfig();
   const loading = userInfoLoading || listsConfigLoading;
@@ -208,7 +209,7 @@ const RulesPageComponent: React.FC = () => {
                 <EuiButton
                   data-test-subj="open-value-lists-modal-button"
                   iconType="importAction"
-                  isDisabled={userHasNoPermissions(canUserCRUD) || loading}
+                  isDisabled={!canWriteListsIndex || loading}
                   onClick={showValueListsModal}
                 >
                   {i18n.UPLOAD_VALUE_LISTS}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/index.tsx
@@ -40,9 +40,7 @@ type Func = (refreshPrePackagedRule?: boolean) => void;
 const RulesPageComponent: React.FC = () => {
   const history = useHistory();
   const [showImportModal, setShowImportModal] = useState(false);
-  const [isValueListsModalShown, setIsValueListsModalShown] = useState(false);
-  const showValueListsModal = useCallback(() => setIsValueListsModalShown(true), []);
-  const hideValueListsModal = useCallback(() => setIsValueListsModalShown(false), []);
+  const [showValueListsModal, setShowValueListsModal] = useState(false);
   const refreshRulesData = useRef<null | Func>(null);
   const {
     loading: userInfoLoading,
@@ -148,7 +146,10 @@ const RulesPageComponent: React.FC = () => {
   return (
     <>
       {userHasNoPermissions(canUserCRUD) && <ReadOnlyCallOut />}
-      <ValueListsModal showModal={isValueListsModalShown} onClose={hideValueListsModal} />
+      <ValueListsModal
+        showModal={showValueListsModal}
+        onClose={() => setShowValueListsModal(false)}
+      />
       <ImportDataModal
         checkBoxLabel={i18n.OVERWRITE_WITH_SAME_NAME}
         closeModal={() => setShowImportModal(false)}
@@ -210,7 +211,7 @@ const RulesPageComponent: React.FC = () => {
                   data-test-subj="open-value-lists-modal-button"
                   iconType="importAction"
                   isDisabled={!canWriteListsIndex || loading}
-                  onClick={showValueListsModal}
+                  onClick={() => setShowValueListsModal(true)}
                 >
                   {i18n.UPLOAD_VALUE_LISTS}
                 </EuiButton>


### PR DESCRIPTION
## Summary

In 7.9 we required that a user has `write` permissions to the lists indexes in order to use Detections. This relaxes that requirement, leaving the following behaviors:

1. If the lists indexes do not exist, we show a configuration page if the user cannot create them (lists `manage`)
2. If the lists indexes exist but the user cannot write to them (lists `write`), we disable the "Upload Value Lists" modal button

### Review Steps

1. Setup: a kibana instance with Security Solution enabled and set up
    * namely: both the alerts and lists indexes are created
1. Create a user with the following permissions:
<kbd><img width="888" alt="Home_-_Elastic" src="https://user-images.githubusercontent.com/657252/90572320-587b7600-e179-11ea-8e9b-21527f3b23df.png"></kbd>
<kbd><img width="538" alt="Home_-_Elastic" src="https://user-images.githubusercontent.com/657252/90572444-a5f7e300-e179-11ea-90f0-f3229a49c2b2.png"></kbd>
13. Navigate to detections and verify that:
    1. No "needs configuration" screen is displayed, and instead you can interact with the plugin
    2. The "Upload Value Lists" modal button is disabled


    
### Checklist

Delete any items that are not applicable to this PR.


- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
