### PR TITLE
[code coverage] always download node for team assignment script

### DIFF
--- a/vars/kibanaTeamAssign.groovy
+++ b/vars/kibanaTeamAssign.groovy
@@ -1,6 +1,6 @@
 def loadIngestionPipeline(ingestionPipelineName, title) {
   kibanaPipeline.bash("""
-    source src/dev/ci_setup/setup_env.sh
+    source src/dev/ci_setup/setup_env.sh true
     yarn kbn bootstrap --prefer-offline
 
     . src/dev/code_coverage/shell_scripts/assign_teams.sh '${ingestionPipelineName}'


### PR DESCRIPTION
## Summary

```
13:58:48  Setting up node.js and yarn in /var/lib/jenkins/workspace/elastic+kibana+code-coverage/kibana
13:58:48   -- Running on OS: linux
13:58:48  src/dev/ci_setup/setup_env.sh: line 113: node: command not found
```

We had the same error while collecting coverage #68421

Apllying the same fix: Adding true as an argument to setup_env.sh to force download node.

