### PR TITLE
[Security Solution][Detections] Fixes exception viewer overflow bug

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/exception_item/exception_entries.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/viewer/exception_item/exception_entries.tsx
@@ -13,6 +13,7 @@ import {
   EuiTableFieldDataColumnType,
   EuiHideFor,
   EuiBadge,
+  EuiBadgeGroup,
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import styled, { css } from 'styled-components';
@@ -58,6 +59,10 @@ const MyNestedValueContainer = styled.div`
 
 const MyNestedValue = styled.span`
   margin-left: ${({ theme }) => theme.eui.euiSizeS};
+`;
+
+const ValueBadgeGroup = styled(EuiBadgeGroup)`
+  width: 100%;
 `;
 
 interface ExceptionEntriesComponentProps {
@@ -115,15 +120,11 @@ const ExceptionEntriesComponent = ({
         render: (values: string | string[] | null) => {
           if (Array.isArray(values)) {
             return (
-              <EuiFlexGroup gutterSize="xs" direction="row" justifyContent="flexStart">
+              <ValueBadgeGroup gutterSize="xs">
                 {values.map((value) => {
-                  return (
-                    <EuiFlexItem key={value} grow={false}>
-                      <EuiBadge color="#DDD">{value}</EuiBadge>
-                    </EuiFlexItem>
-                  );
+                  return <EuiBadge color="#DDD">{value}</EuiBadge>;
                 })}
-              </EuiFlexGroup>
+              </ValueBadgeGroup>
             );
           } else {
             return values ?? getEmptyValue();


### PR DESCRIPTION
## Summary

Fixes exceptions viewer overflow bug by vertically displaying the badges and hiding overflow. Full paths can be seen by hovering over badges or opening the edit exceptions modal

**Before**
![image](https://user-images.githubusercontent.com/56367316/90795712-64337d80-e2dc-11ea-98a6-e15cc4a43e03.png)

**After**
<img width="891" alt="Screen Shot 2020-08-19 at 2 06 03 PM" src="https://user-images.githubusercontent.com/56367316/90684012-74dce880-e235-11ea-95a2-1fea9728e23c.png">
<img width="891" alt="Screen Shot 2020-08-19 at 2 09 09 PM" src="https://user-images.githubusercontent.com/56367316/90684014-75757f00-e235-11ea-82dc-2605263facb5.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
