### PR TITLE
[Security Solution] modify circular deps checker to output images of circular deps graphs

### DIFF
--- a/x-pack/plugins/security_solution/scripts/check_circular_deps/run_check_circular_deps_cli.js
+++ b/x-pack/plugins/security_solution/scripts/check_circular_deps/run_check_circular_deps_cli.js
@@ -4,17 +4,17 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resolve } from 'path';
-
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import madge from 'madge';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { run, createFailError } from '@kbn/dev-utils';
+import * as os from 'os';
+import * as path from 'path';
 
 run(
-  async ({ log }) => {
+  async ({ log, flags }) => {
     const result = await madge(
-      [resolve(__dirname, '../../public'), resolve(__dirname, '../../common')],
+      [path.resolve(__dirname, '../../public'), path.resolve(__dirname, '../../common')],
       {
         fileExtensions: ['ts', 'js', 'tsx'],
         excludeRegExp: [
@@ -34,6 +34,13 @@ run(
 
     const circularFound = result.circular();
     if (circularFound.length !== 0) {
+      if (flags.svg) {
+        await outputSVGs(circularFound);
+      } else {
+        console.log(
+          'Run this program with the --svg flag to save an SVG showing the dependency graph.'
+        );
+      }
       throw createFailError(
         `SIEM circular dependencies of imports has been found:\n - ${circularFound.join('\n - ')}`
       );
@@ -42,6 +49,34 @@ run(
     }
   },
   {
-    description: 'Check the SIEM plugin for circular deps',
+    description:
+      'Check the Security Solution plugin for circular deps. If any are found, this will throw an Error.',
+    flags: {
+      help: '  --svg,             Output SVGs of circular dependency graphs',
+      boolean: ['svg'],
+      default: {
+        svg: false,
+      },
+    },
   }
 );
+
+async function outputSVGs(circularFound) {
+  let count = 0;
+  for (const found of circularFound) {
+    // Calculate the path using the os tmpdir and an increasing 'count'
+    const expectedImagePath = path.join(os.tmpdir(), `security_solution-circular-dep-${count}.svg`);
+    console.log(`Attempting to save SVG for circular dependency: ${found}`);
+    count++;
+
+    // Graph just the files in the found circular dependency.
+    const specificGraph = await madge(found, {
+      fileExtensions: ['ts', 'js', 'tsx'],
+    });
+
+    // Output an SVG in the tmp directory
+    const imagePath = await specificGraph.image(expectedImagePath);
+
+    console.log(`Saved SVG: ${imagePath}`);
+  }
+}


### PR DESCRIPTION
## Summary

The Security Solution team has a script that tries to block circular dependencies between typescript files. When the script detects a circular dependency it will now attempt to use graphviz to output an SVG showing a visualization of the circular dependency. This should help developers understand the circular dependency.


![image](https://user-images.githubusercontent.com/35559/90824488-8097e000-e305-11ea-8c5f-18401999013b.png)
<details>
<summary>When run with `--help`</summary>

```
raustin-mbp:security_solution raustin$ node scripts/check_circular_deps --help

  node scripts/check_circular_deps

  Check the Security Solution plugin for circular deps. If any are found, this will throw an Error.

  Options:
    --svg,             Output SVGs of circular dependency graphs
    --verbose, -v      Log verbosely
    --debug            Log debug messages (less than verbose)
    --quiet            Only log errors
    --silent           Don't log anything
    --help             Show this message
```

</details>

<details>
<summary>When there is a circular dep and no flags were passed</summary>

```
raustin-mbp:security_solution raustin$ node scripts/check_circular_deps
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.5.0

YOUR TYPESCRIPT VERSION: 3.9.5

Please only submit bug reports when using the officially supported version.

=============
Run this program with the --svg flag to save an SVG showing the dependency graph.
ERROR SIEM circular dependencies of imports has been found:
       - public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
```
</details>

<details>
<summary>When graphviz is installed and there is a circular dep and `--svg` was passed:</summary>

```
raustin-mbp:security_solution raustin$ node scripts/check_circular_deps --svg
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.5.0

YOUR TYPESCRIPT VERSION: 3.9.5

Please only submit bug reports when using the officially supported version.

=============
Attempting to save SVG for circular dependency: public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
Saved SVG: /var/folders/1r/y028x41x3kxd8jzrgf3vf3dr0000gp/T/security_solution-circular-dep-0.svg
ERROR SIEM circular dependencies of imports has been found:
       - public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
```
</details>

<details>
<summary>when there are 2 circular deps and you use `--svg`</summary>

```
raustin-mbp:security_solution raustin$ node scripts/check_circular_deps --svg
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.5.0

YOUR TYPESCRIPT VERSION: 3.9.5

Please only submit bug reports when using the officially supported version.

=============
Attempting to save SVG for circular dependency: public/app/404.tsx,public/network/routes.tsx
Saved SVG: /var/folders/1r/y028x41x3kxd8jzrgf3vf3dr0000gp/T/security_solution-circular-dep-0.svg
Attempting to save SVG for circular dependency: public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
Saved SVG: /var/folders/1r/y028x41x3kxd8jzrgf3vf3dr0000gp/T/security_solution-circular-dep-1.svg
ERROR SIEM circular dependencies of imports has been found:
       - public/app/404.tsx,public/network/routes.tsx
       - public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
```

</details>

<details>

<summary>when there are two circular deps and no flags were passed</summary>

```
raustin-mbp:security_solution raustin$ node scripts/check_circular_deps
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.5.0

YOUR TYPESCRIPT VERSION: 3.9.5

Please only submit bug reports when using the officially supported version.

=============
Run this program with the --svg flag to save an SVG showing the dependency graph.
ERROR SIEM circular dependencies of imports has been found:
       - public/app/404.tsx,public/network/routes.tsx
       - public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
```

</details>

<details>
<summary>When there are circular deps, `--svg` was passed, and graphviz isn't installed</summary>

```
raustin-mbp:security_solution raustin$ node scripts/check_circular_deps --svg
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.5.0

YOUR TYPESCRIPT VERSION: 3.9.5

Please only submit bug reports when using the officially supported version.

=============
Attempting to save SVG for circular dependency: public/timelines/store/timeline/types.ts,public/timelines/store/timeline/model.ts,public/common/store/types.ts
ERROR UNHANDLED ERROR
ERROR Error: Graphviz could not be found. Ensure that "gvpr" is in your $PATH.
      Error: Command failed: gvpr -V
      /bin/sh: gvpr: command not found

          at exec.catch (/Users/raustin/Code/elastic/kibana/node_modules/madge/lib/graph.js:36:10)
```
</details>

### Checklist

- [x] Doesn't do anything dramatic when graphviz is missing (as it will be for most users and CI)
- [x] Works when there is no circular dep detected
- [x] Works when multiple circular dependencies are detected. 

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
