### PR TITLE
[Ingest Manager] Update "datasets" UI copy to "data streams"

### DIFF
--- a/x-pack/plugins/ingest_manager/dev_docs/definitions.md
+++ b/x-pack/plugins/ingest_manager/dev_docs/definitions.md
@@ -13,9 +13,9 @@ definitions for one or multiple inputs and each input can contain one or multipl
 With the example of the nginx Package policy, it contains two inputs: `logs` and `nginx/metrics`. Logs and metrics are collected
 differently. The `logs` input contains two streams, `access` and `error`, the `nginx/metrics` input contains the stubstatus stream.
 
-## Data Stream
+## Data stream
 
-Data Streams are a [new concept](https://github.com/elastic/elasticsearch/issues/53100) in Elasticsearch which simplify
+Data streams are a [new concept](https://github.com/elastic/elasticsearch/issues/53100) in Elasticsearch which simplify
 ingesting data and the setup of Elasticsearch.
 
 ## Elastic Agent
@@ -35,7 +35,7 @@ Fleet is the part of the Ingest Manager UI in Kibana that handles the part of en
 
 Ingest Management + Elastic Agent follow a strict new indexing strategy: `{type}-{dataset}-{namespace}`. An example
 for this is `logs-nginx.access-default`. More details about it can be found in the Index Strategy below. All data of
-the index strategy is sent to Data Streams.
+the index strategy is sent to data streams.
 
 ## Input
 

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/constants/page_paths.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/constants/page_paths.ts
@@ -53,7 +53,7 @@ export const PAGE_ROUTING_PATHS = {
   fleet_agent_details_events: '/fleet/agents/:agentId',
   fleet_agent_details_details: '/fleet/agents/:agentId/details',
   fleet_enrollment_tokens: '/fleet/enrollment-tokens',
-  data_streams: '/datasets',
+  data_streams: '/data-streams',
 };
 
 export const pagePathGetters: {
@@ -80,5 +80,5 @@ export const pagePathGetters: {
   fleet_agent_details: ({ agentId, tabId }) =>
     `/fleet/agents/${agentId}${tabId ? `/${tabId}` : ''}`,
   fleet_enrollment_tokens: () => '/fleet/enrollment-tokens',
-  data_streams: () => '/datasets',
+  data_streams: () => '/data-streams',
 };

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/hooks/use_breadcrumbs.tsx
@@ -207,7 +207,7 @@ const breadcrumbGetters: {
     BASE_BREADCRUMB,
     {
       text: i18n.translate('xpack.ingestManager.breadcrumbs.datastreamsPageTitle', {
-        defaultMessage: 'Datasets',
+        defaultMessage: 'Data streams',
       }),
     },
   ],

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
@@ -96,7 +96,7 @@ export const DefaultLayout: React.FunctionComponent<Props> = ({
                   <EuiTab isSelected={section === 'data_stream'} href={getHref('data_streams')}>
                     <FormattedMessage
                       id="xpack.ingestManager.appNavigation.dataStreamsLinkText"
-                      defaultMessage="Datasets"
+                      defaultMessage="Data streams"
                     />
                   </EuiTab>
                 </EuiTabs>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/data_stream/list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/data_stream/list_page/index.tsx
@@ -32,7 +32,7 @@ const DataStreamListPageLayout: React.FunctionComponent = ({ children }) => (
             <h1>
               <FormattedMessage
                 id="xpack.ingestManager.dataStreamList.pageTitle"
-                defaultMessage="Datasets"
+                defaultMessage="Data streams"
               />
             </h1>
           </EuiText>
@@ -173,7 +173,7 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
           <h2>
             <FormattedMessage
               id="xpack.ingestManager.dataStreamList.noDataStreamsPrompt"
-              defaultMessage="No datasets"
+              defaultMessage="No data streams"
             />
           </h2>
         }
@@ -216,14 +216,14 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
           isLoading ? (
             <FormattedMessage
               id="xpack.ingestManager.dataStreamList.loadingDataStreamsMessage"
-              defaultMessage="Loading datasets…"
+              defaultMessage="Loading data streams…"
             />
           ) : dataStreamsData && !dataStreamsData.data_streams.length ? (
             emptyPrompt
           ) : (
             <FormattedMessage
               id="xpack.ingestManager.dataStreamList.noFilteredDataStreamsMessage"
-              defaultMessage="No matching datasets found"
+              defaultMessage="No matching data streams found"
             />
           )
         }
@@ -253,7 +253,7 @@ export const DataStreamListPage: React.FunctionComponent<{}> = () => {
             placeholder: i18n.translate(
               'xpack.ingestManager.dataStreamList.searchPlaceholderTitle',
               {
-                defaultMessage: 'Filter datasets',
+                defaultMessage: 'Filter data streams',
               }
             ),
             incremental: true,

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -157,7 +157,7 @@ export const StandaloneInstructions: React.FunctionComponent<Props> = ({ agentPo
           <EuiText>
             <FormattedMessage
               id="xpack.ingestManager.agentEnrollment.stepCheckForDataDescription"
-              defaultMessage="The agent should begin sending data. Go to Datasets to view your data."
+              defaultMessage="The agent should begin sending data. Go to data streams to view your data."
             />
           </EuiText>
         </>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/datastream_section.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/overview/components/datastream_section.tsx
@@ -47,14 +47,14 @@ export const OverviewDatastreamSection: React.FC = () => {
     <EuiFlexItem component="section">
       <OverviewPanel
         title={i18n.translate('xpack.ingestManager.overviewPageDataStreamsPanelTitle', {
-          defaultMessage: 'Datasets',
+          defaultMessage: 'Data streams',
         })}
         tooltip={i18n.translate('xpack.ingestManager.overviewPageDataStreamsPanelTooltip', {
-          defaultMessage: 'Data that your agents collect are organized into various datasets.',
+          defaultMessage: 'Data that your agents collect are organized into various data streams.',
         })}
         linkTo={getHref('data_streams')}
         linkToText={i18n.translate('xpack.ingestManager.overviewPageDataStreamsPanelAction', {
-          defaultMessage: 'View datasets',
+          defaultMessage: 'View data streams',
         })}
       >
         <OverviewStats>
@@ -65,7 +65,7 @@ export const OverviewDatastreamSection: React.FC = () => {
               <EuiDescriptionListTitle>
                 <FormattedMessage
                   id="xpack.ingestManager.overviewDatastreamTotalTitle"
-                  defaultMessage="Datasets"
+                  defaultMessage="Data streams"
                 />
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription>

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/types/index.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/types/index.ts
@@ -43,7 +43,7 @@ export {
   CreatePackagePolicyResponse,
   UpdatePackagePolicyRequest,
   UpdatePackagePolicyResponse,
-  // API schemas - Data Streams
+  // API schemas - Data streams
   GetDataStreamsResponse,
   // API schemas - Agents
   GetAgentsResponse,


### PR DESCRIPTION
## Summary

Relates to #74842. This PR updates user facing "datasets" copy back to "data streams" and normalize some existing copy to sentence case. This is mostly a reversal of #70840.

`/app/ingestManager#/datasets` route was also updated to `/app/ingestManager#/data-streams`.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)