### PR TITLE
[Security Solution][Detections] Disables add exception for ML and threshold rules

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/default_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/default_config.tsx
@@ -9,6 +9,7 @@ import ApolloClient from 'apollo-client';
 import { Dispatch } from 'redux';
 
 import { EuiText } from '@elastic/eui';
+import { RuleType } from '../../../../common/detection_engine/types';
 import { isMlRule } from '../../../../common/machine_learning/helpers';
 import { RowRendererId } from '../../../../common/types/timeline';
 import { DEFAULT_INDEX_PATTERN } from '../../../../common/constants';
@@ -41,7 +42,6 @@ import { Ecs, TimelineNonEcsData } from '../../../graphql/types';
 import { AddExceptionModalBaseProps } from '../../../common/components/exceptions/add_exception_modal';
 import { getMappedNonEcsValue } from '../../../common/components/exceptions/helpers';
 import { isThresholdRule } from '../../../../common/detection_engine/utils';
-import { Rule } from '../../containers/detection_engine/rules';
 
 export const buildAlertStatusFilter = (status: Status): Filter[] => [
   {
@@ -321,12 +321,12 @@ export const getAlertActions = ({
     return module === 'endpoint' && kind === 'alert';
   };
 
-  const isFromValidRule = () => {
+  const exceptionsAreAllowed = () => {
     const ruleTypes = getMappedNonEcsValue({
       data: nonEcsRowData,
       fieldName: 'signal.rule.type',
     });
-    const [ruleType] = ruleTypes as Array<Rule['type']>;
+    const [ruleType] = ruleTypes as RuleType[];
     return !isMlRule(ruleType) && !isThresholdRule(ruleType);
   };
 
@@ -399,7 +399,7 @@ export const getAlertActions = ({
         }
       },
       id: 'addException',
-      isActionDisabled: () => !canUserCRUD || !hasIndexWrite || !isFromValidRule(),
+      isActionDisabled: () => !canUserCRUD || !hasIndexWrite || !exceptionsAreAllowed(),
       dataTestSubj: 'add-exception-menu-item',
       ariaLabel: 'Add Exception',
       content: <EuiText size="m">{i18n.ACTION_ADD_EXCEPTION}</EuiText>,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/default_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/default_config.tsx
@@ -9,6 +9,7 @@ import ApolloClient from 'apollo-client';
 import { Dispatch } from 'redux';
 
 import { EuiText } from '@elastic/eui';
+import { isMlRule } from '../../../../common/machine_learning/helpers';
 import { RowRendererId } from '../../../../common/types/timeline';
 import { DEFAULT_INDEX_PATTERN } from '../../../../common/constants';
 import { Status } from '../../../../common/detection_engine/schemas/common/schemas';
@@ -39,6 +40,8 @@ import {
 import { Ecs, TimelineNonEcsData } from '../../../graphql/types';
 import { AddExceptionModalBaseProps } from '../../../common/components/exceptions/add_exception_modal';
 import { getMappedNonEcsValue } from '../../../common/components/exceptions/helpers';
+import { isThresholdRule } from '../../../../common/detection_engine/utils';
+import { Rule } from '../../containers/detection_engine/rules';
 
 export const buildAlertStatusFilter = (status: Status): Filter[] => [
   {
@@ -193,6 +196,7 @@ export const requiredFieldsForActions = [
   'signal.rule.query',
   'signal.rule.to',
   'signal.rule.id',
+  'signal.rule.type',
   'signal.original_event.kind',
   'signal.original_event.module',
 
@@ -317,6 +321,15 @@ export const getAlertActions = ({
     return module === 'endpoint' && kind === 'alert';
   };
 
+  const isFromValidRule = () => {
+    const ruleTypes = getMappedNonEcsValue({
+      data: nonEcsRowData,
+      fieldName: 'signal.rule.type',
+    });
+    const [ruleType] = ruleTypes as Array<Rule['type']>;
+    return !isMlRule(ruleType) && !isThresholdRule(ruleType);
+  };
+
   return [
     {
       ...getInvestigateInResolverAction({ dispatch, timelineId }),
@@ -386,7 +399,7 @@ export const getAlertActions = ({
         }
       },
       id: 'addException',
-      isActionDisabled: () => !canUserCRUD || !hasIndexWrite,
+      isActionDisabled: () => !canUserCRUD || !hasIndexWrite || !isFromValidRule(),
       dataTestSubj: 'add-exception-menu-item',
       ariaLabel: 'Add Exception',
       content: <EuiText size="m">{i18n.ACTION_ADD_EXCEPTION}</EuiText>,


### PR DESCRIPTION
## Summary

Disables the add exception feature for exceptions created by Machine learning and threshold based rules (#75154)

![Screen Shot 2020-08-24 at 1 15 26 PM](https://user-images.githubusercontent.com/56367316/91079074-906b3900-e611-11ea-9ad6-398a1f337c13.png)
![Screen Shot 2020-08-24 at 1 52 26 PM](https://user-images.githubusercontent.com/56367316/91079076-9103cf80-e611-11ea-9ec3-ce96a61c219c.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
