### PR TITLE
[Visualize] fix performance degradation after lodash@4 upgrade

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/lib/vis_config.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/vis_config.js
@@ -41,7 +41,7 @@ export class VisConfig {
 
     const visType = visTypes[visConfigArgs.type];
     const typeDefaults = visType(visConfigArgs, this.data);
-    this._values = _.defaultsDeep({}, typeDefaults, DEFAULT_VIS_CONFIG);
+    this._values = _.defaultsDeep({ ...typeDefaults }, DEFAULT_VIS_CONFIG);
     this._values.el = el;
   }
 


### PR DESCRIPTION
## Summary

After merging lodash 4, there was a significant performance degradation for visualize charts with many buckets. 

Digging a bit deeper, I noticed that implementation of lodash `defaultsDeep` changed and causes issues when merging three objects (for area chart: 72 hours timepicker configured with y - count, x - date histogram on auto interval and split series with 5 buckets it increased from **0.7 ms to 400ms**!). 

A simple solution is to copy `typeDefaults` object and then run a function on a copy and `DEFAULT_VIS_CONFIG`. The behaviour is not changed. 

Here's before and after:

![image](https://user-images.githubusercontent.com/4283304/91153937-26aa6800-e6c1-11ea-9b4b-44182714f8be.png)
![image](https://user-images.githubusercontent.com/4283304/91153945-28742b80-e6c1-11ea-851f-d5ffabb2af22.png)
