### PR TITLE
[Lens] fix dimension popover design on mobile

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/field_select.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/field_select.tsx
@@ -181,7 +181,7 @@ export function FieldSelect({
       }}
       renderOption={(option, searchValue) => {
         return (
-          <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             <EuiFlexItem grow={null}>
               <LensFieldIcon
                 type={((option.value as unknown) as { dataType: DataType }).dataType}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/popover_editor.scss
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/popover_editor.scss
@@ -1,6 +1,7 @@
 .lnsIndexPatternDimensionEditor {
   width: $euiSize * 30;
   padding: $euiSizeS;
+  max-width: 100%;
 }
 
 .lnsIndexPatternDimensionEditor__left,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/75855
Fixes mobile view of dimension popover:
Before:
![image](https://user-images.githubusercontent.com/4283304/91170717-99bfd880-e6d9-11ea-8794-5ce8f71c3c84.png)
After:
![image](https://user-images.githubusercontent.com/4283304/91170759-af350280-e6d9-11ea-9e4e-78eb4e441416.png)