### PR TITLE
[Ingest Manager] Improve perfomance of fetching unacknowledged actions

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/agent.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/agent.ts
@@ -25,22 +25,22 @@ export type AgentActionType = 'CONFIG_CHANGE' | 'DATA_DUMP' | 'RESUME' | 'PAUSE'
 export interface NewAgentAction {
   type: AgentActionType;
   data?: any;
-  sent_at?: string;
 }
 
 export interface AgentAction extends NewAgentAction {
   id: string;
   agent_id: string;
   created_at: string;
+  acknowledged_at?: string;
 }
 
 export interface AgentActionSOAttributes {
   type: AgentActionType;
-  sent_at?: string;
   timestamp?: string;
   created_at: string;
   agent_id: string;
   data?: string;
+  acknowledged_at?: string;
 }
 
 export interface NewAgentEvent {
@@ -103,9 +103,11 @@ export interface Agent extends AgentBase {
   access_api_key?: string;
   status?: string;
   packages: string[];
+  not_acknowledged_actions: string[];
 }
 
 export interface AgentSOAttributes extends AgentBase {
   current_error_events?: string;
   packages?: string[];
+  not_acknowledged_actions?: string[];
 }

--- a/x-pack/plugins/ingest_manager/server/routes/agent/actions_handlers.test.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/agent/actions_handlers.test.ts
@@ -25,7 +25,6 @@ describe('test actions handlers schema', () => {
       NewAgentActionSchema.validate({
         type: 'CONFIG_CHANGE',
         data: 'data',
-        sent_at: '2020-03-14T19:45:02.620Z',
       })
     ).toBeTruthy();
   });
@@ -34,7 +33,6 @@ describe('test actions handlers schema', () => {
     expect(() => {
       NewAgentActionSchema.validate({
         data: 'data',
-        sent_at: '2020-03-14T19:45:02.620Z',
       });
     }).toThrowError();
   });
@@ -55,7 +53,6 @@ describe('test actions handlers', () => {
         action: {
           type: 'CONFIG_CHANGE',
           data: 'data',
-          sent_at: '2020-03-14T19:45:02.620Z',
         },
       },
       params: {
@@ -68,7 +65,6 @@ describe('test actions handlers', () => {
     const agentAction = ({
       type: 'CONFIG_CHANGE',
       id: 'action1',
-      sent_at: '2020-03-14T19:45:02.620Z',
       timestamp: '2019-01-04T14:32:03.36764-05:00',
       created_at: '2020-03-14T19:45:02.620Z',
     } as unknown) as AgentAction;

--- a/x-pack/plugins/ingest_manager/server/saved_objects/index.ts
+++ b/x-pack/plugins/ingest_manager/server/saved_objects/index.ts
@@ -78,6 +78,7 @@ const savedObjectTypes: { [key: string]: SavedObjectsType } = {
         updated_at: { type: 'date' },
         current_error_events: { type: 'text', index: false },
         packages: { type: 'keyword' },
+        not_acknowledged_actions: { type: 'keyword', index: false },
       },
     },
     migrations: {
@@ -96,8 +97,8 @@ const savedObjectTypes: { [key: string]: SavedObjectsType } = {
         agent_id: { type: 'keyword' },
         type: { type: 'keyword' },
         data: { type: 'binary' },
-        sent_at: { type: 'date' },
         created_at: { type: 'date' },
+        acknowledged_at: { type: 'date' },
       },
     },
   },
@@ -351,11 +352,12 @@ export function registerEncryptedSavedObjects(
       'unenrolled_at',
       'unenrollment_started_at',
       'packages',
+      'not_acknowledged_actions',
     ]),
   });
   encryptedSavedObjects.registerType({
     type: AGENT_ACTION_SAVED_OBJECT_TYPE,
     attributesToEncrypt: new Set(['data']),
-    attributesToExcludeFromAAD: new Set(['agent_id', 'type', 'sent_at', 'created_at']),
+    attributesToExcludeFromAAD: new Set(['agent_id', 'acknowledged_at', 'type', 'created_at']),
   });
 }

--- a/x-pack/plugins/ingest_manager/server/services/agents/acks.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/acks.test.ts
@@ -39,7 +39,7 @@ describe('test agent acks services', () => {
         attributes: {
           type: 'CONFIG_CHANGE',
           agent_id: 'id',
-          sent_at: '2020-03-14T19:45:02.620Z',
+          acknowledged_at: '2020-03-14T19:45:02.620Z',
           timestamp: '2019-01-04T14:32:03.36764-05:00',
           created_at: '2020-03-14T19:45:02.620Z',
         },
@@ -56,7 +56,7 @@ describe('test agent acks services', () => {
             attributes: {
               type: 'CONFIG_CHANGE',
               agent_id: 'id',
-              sent_at: '2020-03-14T19:45:02.620Z',
+              acknowledged_at: '2020-03-14T19:45:02.620Z',
               timestamp: '2019-01-04T14:32:03.36764-05:00',
               created_at: '2020-03-14T19:45:02.620Z',
             },
@@ -70,6 +70,7 @@ describe('test agent acks services', () => {
       ({
         id: 'id',
         type: AGENT_TYPE_PERMANENT,
+        not_acknowledged_actions: [],
       } as unknown) as Agent,
       [
         {
@@ -86,7 +87,7 @@ describe('test agent acks services', () => {
         type: 'CONFIG_CHANGE',
         id: 'action1',
         agent_id: 'id',
-        sent_at: '2020-03-14T19:45:02.620Z',
+        acknowledged_at: '2020-03-14T19:45:02.620Z',
         timestamp: '2019-01-04T14:32:03.36764-05:00',
         created_at: '2020-03-14T19:45:02.620Z',
       } as unknown) as AgentAction,
@@ -112,7 +113,7 @@ describe('test agent acks services', () => {
         attributes: {
           type: 'CONFIG_CHANGE',
           agent_id: 'id',
-          sent_at: '2020-03-14T19:45:02.620Z',
+          acknowledged_at: '2020-03-14T19:45:02.620Z',
           timestamp: '2019-01-04T14:32:03.36764-05:00',
           created_at: '2020-03-14T19:45:02.620Z',
           data: JSON.stringify({
@@ -193,7 +194,7 @@ describe('test agent acks services', () => {
             attributes: {
               type: 'CONFIG_CHANGE',
               agent_id: 'id',
-              sent_at: '2020-03-14T19:45:02.620Z',
+              acknowledged_at: '2020-03-14T19:45:02.620Z',
               timestamp: '2019-01-04T14:32:03.36764-05:00',
               created_at: '2020-03-14T19:45:02.620Z',
             },
@@ -208,6 +209,7 @@ describe('test agent acks services', () => {
         id: 'id',
         type: AGENT_TYPE_PERMANENT,
         policy_id: 'policy1',
+        not_acknowledged_actions: ['actionNotAcknowledged:id', 'action1'],
       } as unknown) as Agent,
       [
         {
@@ -224,6 +226,9 @@ describe('test agent acks services', () => {
     expect(mockSavedObjectsClient.bulkUpdate.mock.calls[0][0][0]).toMatchInlineSnapshot(`
       Object {
         "attributes": Object {
+          "not_acknowledged_actions": Array [
+            "actionNotAcknowledged:id",
+          ],
           "packages": Array [
             "system",
           ],
@@ -254,7 +259,7 @@ describe('test agent acks services', () => {
         attributes: {
           type: 'CONFIG_CHANGE',
           agent_id: 'id',
-          sent_at: '2020-03-14T19:45:02.620Z',
+          acknowledged_at: '2020-03-14T19:45:02.620Z',
           timestamp: '2019-01-04T14:32:03.36764-05:00',
           created_at: '2020-03-14T19:45:02.620Z',
           data: JSON.stringify({
@@ -335,7 +340,7 @@ describe('test agent acks services', () => {
             attributes: {
               type: 'CONFIG_CHANGE',
               agent_id: 'id',
-              sent_at: '2020-03-14T19:45:02.620Z',
+              acknowledged_at: '2020-03-14T19:45:02.620Z',
               timestamp: '2019-01-04T14:32:03.36764-05:00',
               created_at: '2020-03-14T19:45:02.620Z',
             },
@@ -351,6 +356,7 @@ describe('test agent acks services', () => {
         type: AGENT_TYPE_PERMANENT,
         policy_id: 'policy1',
         policy_revision: 100,
+        not_acknowledged_actions: [],
       } as unknown) as Agent,
       [
         {
@@ -363,7 +369,7 @@ describe('test agent acks services', () => {
       ]
     );
     expect(mockSavedObjectsClient.bulkUpdate).toBeCalled();
-    expect(mockSavedObjectsClient.bulkUpdate.mock.calls[0][0]).toHaveLength(1);
+    expect(mockSavedObjectsClient.bulkUpdate.mock.calls[0][0]).toHaveLength(2);
   });
 
   it('should fail for actions that cannot be found on agent actions list', async () => {
@@ -388,6 +394,7 @@ describe('test agent acks services', () => {
         ({
           id: 'id',
           type: AGENT_TYPE_PERMANENT,
+          not_acknowledged_actions: [],
         } as unknown) as Agent,
         [
           ({
@@ -418,7 +425,7 @@ describe('test agent acks services', () => {
             attributes: {
               type: 'CONFIG_CHANGE',
               agent_id: 'id',
-              sent_at: '2020-03-14T19:45:02.620Z',
+              acknowledged_at: '2020-03-14T19:45:02.620Z',
               timestamp: '2019-01-04T14:32:03.36764-05:00',
               created_at: '2020-03-14T19:45:02.620Z',
             },
@@ -433,6 +440,7 @@ describe('test agent acks services', () => {
         ({
           id: 'id',
           type: AGENT_TYPE_PERMANENT,
+          not_acknowledged_actions: [],
         } as unknown) as Agent,
         [
           ({

--- a/x-pack/plugins/ingest_manager/server/services/agents/actions.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/actions.test.ts
@@ -17,7 +17,6 @@ describe('test agent actions services', () => {
       agent_id: 'agentid',
       type: 'CONFIG_CHANGE',
       data: { content: 'data' },
-      sent_at: '2020-03-14T19:45:02.620Z',
       created_at: '2020-03-14T19:45:02.620Z',
     };
     mockSavedObjectsClient.create.mockReturnValue(
@@ -32,6 +31,5 @@ describe('test agent actions services', () => {
     expect(createdAction).toBeDefined();
     expect(createdAction?.type).toEqual(newAgentAction.type);
     expect(createdAction?.data).toEqual(JSON.stringify(newAgentAction.data));
-    expect(createdAction?.sent_at).toEqual(newAgentAction.sent_at);
   });
 });

--- a/x-pack/plugins/ingest_manager/server/services/agents/actions.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/actions.ts
@@ -27,22 +27,21 @@ export async function createAgentAction(
 
 export async function getAgentActionsForCheckin(
   soClient: SavedObjectsClientContract,
-  agentId: string
+  agent: Agent
 ): Promise<AgentAction[]> {
-  const res = await soClient.find<AgentActionSOAttributes>({
-    type: AGENT_ACTION_SAVED_OBJECT_TYPE,
-    filter: `not ${AGENT_ACTION_SAVED_OBJECT_TYPE}.attributes.sent_at: * and ${AGENT_ACTION_SAVED_OBJECT_TYPE}.attributes.agent_id:${agentId}`,
-  });
+  if (agent.not_acknowledged_actions.length === 0) {
+    return [];
+  }
 
   return Promise.all(
-    res.saved_objects.map(async (so) => {
+    agent.not_acknowledged_actions.map(async (actionId) => {
       // Get decrypted actions
       return savedObjectToAgentAction(
         await appContextService
           .getEncryptedSavedObjects()
           .getDecryptedAsInternalUser<AgentActionSOAttributes>(
             AGENT_ACTION_SAVED_OBJECT_TYPE,
-            so.id
+            actionId
           )
       );
     })
@@ -80,7 +79,7 @@ export async function getAgentActionByIds(
 export async function getNewActionsSince(soClient: SavedObjectsClientContract, timestamp: string) {
   const res = await soClient.find<AgentActionSOAttributes>({
     type: AGENT_ACTION_SAVED_OBJECT_TYPE,
-    filter: `not ${AGENT_ACTION_SAVED_OBJECT_TYPE}.attributes.sent_at: * AND ${AGENT_ACTION_SAVED_OBJECT_TYPE}.attributes.created_at >= "${timestamp}"`,
+    filter: `not ${AGENT_ACTION_SAVED_OBJECT_TYPE}.attributes.acknowledged_at: * AND ${AGENT_ACTION_SAVED_OBJECT_TYPE}.attributes.created_at >= "${timestamp}"`,
   });
 
   return res.saved_objects.map(savedObjectToAgentAction);

--- a/x-pack/plugins/ingest_manager/server/services/agents/checkin/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/checkin/index.ts
@@ -44,7 +44,7 @@ export async function agentCheckin(
   }
 
   // Check if some actions are not acknowledged
-  let actions = await getAgentActionsForCheckin(soClient, agent.id);
+  let actions = await getAgentActionsForCheckin(soClient, agent);
   if (actions.length > 0) {
     return { actions };
   }

--- a/x-pack/plugins/ingest_manager/server/services/agents/checkin/state_new_actions.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/checkin/state_new_actions.ts
@@ -134,7 +134,10 @@ async function createAgentActionFromAgentPolicy(
     type: 'CONFIG_CHANGE',
     data: { config: newAgentPolicy } as any,
     created_at: new Date().toISOString(),
-    sent_at: undefined,
+  });
+
+  await soClient.update<AgentSOAttributes>(AGENT_SAVED_OBJECT_TYPE, agent.id, {
+    not_acknowledged_actions: [...agent.not_acknowledged_actions, policyChangeAction.id],
   });
 
   return [policyChangeAction];

--- a/x-pack/plugins/ingest_manager/server/services/agents/saved_objects.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/saved_objects.ts
@@ -24,6 +24,7 @@ export function savedObjectToAgent(so: SavedObject<AgentSOAttributes>): Agent {
     access_api_key: undefined,
     status: undefined,
     packages: so.attributes.packages ?? [],
+    not_acknowledged_actions: so.attributes.not_acknowledged_actions ?? [],
   };
 }
 

--- a/x-pack/plugins/ingest_manager/server/types/models/agent.ts
+++ b/x-pack/plugins/ingest_manager/server/types/models/agent.ts
@@ -69,5 +69,4 @@ export const NewAgentActionSchema = schema.object({
     schema.literal('PAUSE'),
   ]),
   data: schema.maybe(schema.any()),
-  sent_at: schema.maybe(schema.string()),
 });


### PR DESCRIPTION
## Description 

Currently fetching unacknowledged actions for an agent is a performance bottleneck because of parsing KQL (see https://github.com/elastic/kibana/issues/75646)

This PR change our data model to avoid that KQL query.


Change made in this PR:
* Denormalize our model and a new property `not_acknowledged_actions` on the agent so we do not need to do a search to find not acknowledged action for an agent.
* rename `sent_at` => `acknowledged_at` in AgentAction schema as it's more accurate.


## Load test

### 2000 agents 

#### Before

```
2020/08/25 10:35:17 timer requests.healthcheck.latency
2020/08/25 10:35:17   count:            1052
2020/08/25 10:35:17   min:                46.28ms
2020/08/25 10:35:17   max:              2816.12ms
2020/08/25 10:35:17   mean:              297.97ms
2020/08/25 10:35:17   stddev:            320.69ms
2020/08/25 10:35:17   median:            217.33ms
2020/08/25 10:35:17   75%:               280.85ms
2020/08/25 10:35:17   95%:               723.66ms
2020/08/25 10:35:17   99%:              2140.05ms
2020/08/25 10:35:17   99.9%:            2801.34ms
2020/08/25 10:35:17   1-min rate:          1.29
2020/08/25 10:35:17   5-min rate:          1.28
2020/08/25 10:35:17   15-min rate:         1.32
2020/08/25 10:35:17   mean rate:           1.25
2020/08/25 10:35:17 counter requests.healthcheck.concurrent_count
2020/08/25 10:35:17   count:               1
2020/08/25 10:35:17 meter requests.healthcheck.success
2020/08/25 10:35:17   count:            1052
2020/08/25 10:35:17   1-min rate:          1.29
2020/08/25 10:35:17   5-min rate:          1.28
2020/08/25 10:35:17   15-min rate:         1.32
2020/08/25 10:35:17   mean rate:           1.25
2020/08/25 10:35:17 Policy revision summary
2020/08/25 10:35:17   revision  1:   2000 agents
```

#### After

```
2020/08/25 10:06:44 timer requests.healthcheck.latency
2020/08/25 10:06:44   count:            1061
2020/08/25 10:06:44   min:                44.09ms
2020/08/25 10:06:44   max:              2202.55ms
2020/08/25 10:06:44   mean:              254.06ms
2020/08/25 10:06:44   stddev:            273.90ms
2020/08/25 10:06:44   median:            205.27ms
2020/08/25 10:06:44   75%:               232.60ms
2020/08/25 10:06:44   95%:               500.66ms
2020/08/25 10:06:44   99%:              1689.15ms
2020/08/25 10:06:44   99.9%:            2197.51ms
2020/08/25 10:06:44   1-min rate:          1.32
2020/08/25 10:06:44   5-min rate:          1.32
2020/08/25 10:06:44   15-min rate:         1.35
2020/08/25 10:06:44   mean rate:           1.33
2020/08/25 10:06:44 counter requests.healthcheck.concurrent_count
2020/08/25 10:06:44   count:               0
2020/08/25 10:06:44 meter requests.healthcheck.success
2020/08/25 10:06:44   count:            1061
2020/08/25 10:06:44   1-min rate:          1.32
2020/08/25 10:06:44   5-min rate:          1.32
2020/08/25 10:06:44   15-min rate:         1.35
2020/08/25 10:06:44   mean rate:           1.33
2020/08/25 10:06:44 Policy revision summary
2020/08/25 10:06:44   revision  1:   2000 agents
```

### 4000 agents

### Before

```
2020/08/25 11:06:34 counter requests.healthcheck.concurrent_count
2020/08/25 11:06:34   count:               1
2020/08/25 11:06:34 meter requests.healthcheck.success
2020/08/25 11:06:34   count:            1575
2020/08/25 11:06:34   1-min rate:          1.02
2020/08/25 11:06:34   5-min rate:          0.96
2020/08/25 11:06:34   15-min rate:         1.03
2020/08/25 11:06:34   mean rate:           0.96
2020/08/25 11:06:34 timer requests.healthcheck.latency
2020/08/25 11:06:34   count:            1575
2020/08/25 11:06:34   min:                49.46ms
2020/08/25 11:06:34   max:              4281.60ms
2020/08/25 11:06:34   mean:              562.76ms
2020/08/25 11:06:34   stddev:            800.22ms
2020/08/25 11:06:34   median:            313.69ms
2020/08/25 11:06:34   75%:               477.01ms
2020/08/25 11:06:34   95%:              3045.95ms
2020/08/25 11:06:34   99%:              3669.76ms
2020/08/25 11:06:34   99.9%:            4279.77ms
2020/08/25 11:06:34   1-min rate:          1.02
2020/08/25 11:06:34   5-min rate:          0.96
2020/08/25 11:06:34   15-min rate:         1.03
2020/08/25 11:06:34   mean rate:           0.96
2020/08/25 11:06:34 Agent rollout
2020/08/25 11:06:34   agents:  4000
2020/08/25 11:06:34 Policy revision summary
2020/08/25 11:06:34   revision  1:   4000 agents
```


#### After

```
2020/08/25 11:42:32 meter requests.healthcheck.success
2020/08/25 11:42:32   count:            1831
2020/08/25 11:42:32   1-min rate:          1.16
2020/08/25 11:42:32   5-min rate:          1.10
2020/08/25 11:42:32   15-min rate:         1.06
2020/08/25 11:42:32   mean rate:           1.07
2020/08/25 11:42:32 counter requests.healthcheck.concurrent_count
2020/08/25 11:42:32   count:               1
2020/08/25 11:42:32 timer requests.healthcheck.latency
2020/08/25 11:42:32   count:            1831
2020/08/25 11:42:32   min:                44.90ms
2020/08/25 11:42:32   max:              3568.79ms
2020/08/25 11:42:32   mean:              430.63ms
2020/08/25 11:42:32   stddev:            665.81ms
2020/08/25 11:42:32   median:            229.46ms
2020/08/25 11:42:32   75%:               310.05ms
2020/08/25 11:42:32   95%:              2580.73ms
2020/08/25 11:42:32   99%:              3182.45ms
2020/08/25 11:42:32   99.9%:            3566.68ms
2020/08/25 11:42:32   1-min rate:          1.16
2020/08/25 11:42:32   5-min rate:          1.10
2020/08/25 11:42:32   15-min rate:         1.06
2020/08/25 11:42:32   mean rate:           1.07
2020/08/25 11:42:32 Agent rollout
2020/08/25 11:42:32   agents:  4000
2020/08/25 11:42:32 Policy revision summary
2020/08/25 11:42:32   revision  1:   4000 agents
```

## TODO

- [ ] Add SO migrations for sent_at field


