### PR TITLE
[Ingest Manager] Return ID when default output is found

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/output.ts
+++ b/x-pack/plugins/ingest_manager/server/services/output.ts
@@ -15,7 +15,7 @@ let cachedAdminUser: null | { username: string; password: string } = null;
 
 class OutputService {
   public async getDefaultOutput(soClient: SavedObjectsClientContract) {
-    return await soClient.find<Output>({
+    return await soClient.find<OutputSOAttributes>({
       type: OUTPUT_SAVED_OBJECT_TYPE,
       searchFields: ['is_default'],
       search: 'true',

--- a/x-pack/plugins/ingest_manager/server/services/output.ts
+++ b/x-pack/plugins/ingest_manager/server/services/output.ts
@@ -42,6 +42,7 @@ class OutputService {
     }
 
     return {
+      id: outputs.saved_objects[0].id,
       ...outputs.saved_objects[0].attributes,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #75916, from https://github.com/elastic/kibana/issues/75916#issuecomment-680258242:

> The issue in the code occurs here: if a default output object has already been created, we return the output object without its ID (versus returning the full object with its ID when we need to create one). I suspect this can happen as a result of a race condition if /setup is hit in succession with the right timing. I'll verify reproduction steps during my fix.

Unfortunately, I was not able to find a way to reproduce the original behavior. We improved setup handling recently (#75372) so it's possible that this behavior was fixed (or occurrence reduced) as a side effect of those those general improvements. Either way, it's still good to fix the code logic here.