### PR TITLE
[ftr] temporary disable fetching browser logs

### DIFF
--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -163,18 +163,7 @@ async function attemptToCreateCommand(
 
         return {
           session,
-          consoleLog$: pollForLogEntry$(
-            session,
-            logging.Type.BROWSER,
-            config.logPollingMs,
-            lifecycle.cleanup.after$
-          ).pipe(
-            takeUntil(lifecycle.cleanup.after$),
-            map(({ message, level: { name: level } }) => ({
-              message: message.replace(/\\n/g, '\n'),
-              level,
-            }))
-          ),
+          consoleLog$: Rx.EMPTY,
         };
       }
 
@@ -200,18 +189,7 @@ async function attemptToCreateCommand(
             .build();
           return {
             session,
-            consoleLog$: pollForLogEntry$(
-              session,
-              logging.Type.BROWSER,
-              config.logPollingMs,
-              lifecycle.cleanup.after$
-            ).pipe(
-              takeUntil(lifecycle.cleanup.after$),
-              map(({ message, level: { name: level } }) => ({
-                message: message.replace(/\\n/g, '\n'),
-                level,
-              }))
-            ),
+            consoleLog$: Rx.EMPTY,
           };
         } else {
           throw new Error(

--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -21,7 +21,7 @@ import { resolve } from 'path';
 import Fs from 'fs';
 
 import * as Rx from 'rxjs';
-import { mergeMap, map, takeUntil, catchError } from 'rxjs/operators';
+import { mergeMap, map, catchError } from 'rxjs/operators';
 import { Lifecycle } from '@kbn/test/src/functional_test_runner/lib/lifecycle';
 import { ToolingLog } from '@kbn/dev-utils';
 import chromeDriver from 'chromedriver';
@@ -38,7 +38,6 @@ import { getLogger } from 'selenium-webdriver/lib/logging';
 import { installDriver } from 'ms-chromium-edge-driver';
 
 import { REPO_ROOT } from '@kbn/dev-utils';
-import { pollForLogEntry$ } from './poll_for_log_entry';
 import { createStdoutSocket } from './create_stdout_stream';
 import { preventParallelCalls } from './prevent_parallel_calls';
 


### PR DESCRIPTION
## Summary

Since Chrome update to v85 we observe random failures in functional tests on CI:

```
10:21:15                 └-> "before each" hook: global before each
10:21:15                 │ERROR browser[SEVERE] ERROR FETCHING BROWSR LOGS: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
10:21:25                 │ERROR browser[SEVERE] ERROR FETCHING BROWSR LOGS: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
10:21:35                 │ERROR browser[SEVERE] ERROR FETCHING BROWSR LOGS: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
...
10:21:45                 │ERROR browser[SEVERE] ERROR FETCHING BROWSR LOGS: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
HING BROWSR LOGS: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
10:25:16                 │ERROR SCREENSHOT FAILED
10:25:16                 │ERROR Error: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
10:25:16                 │          at ClientRequest.<anonymous> (/dev/shm/workspace/kibana/node_modules/selenium-webdriver/http/index.js:262:15)
10:25:16                 │          at ClientRequest.emit (events.js:198:13)
10:25:16                 │          at Socket.socketErrorListener (_http_client.js:401:9)
10:25:16                 │          at Socket.emit (events.js:198:13)
10:25:16                 │          at emitErrorNT (internal/streams/destroy.js:91:8)
10:25:16                 │          at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
10:25:16                 │          at process._tickCallback (internal/process/next_tick.js:63:19)
10:25:16                 └- ✖ fail: core plugins application using leave confirmation when navigating to another app allows navigation if user click confirm on the confirmation dialog
10:25:16                 │      Error: ECONNREFUSED connect ECONNREFUSED 127.0.0.1:49072
10:25:16                 │       at ClientRequest.<anonymous> (/dev/shm/workspace/kibana/node_modules/selenium-webdriver/http/index.js:262:15)
10:25:16                 │       at Socket.socketErrorListener (_http_client.js:401:9)
10:25:16                 │       at emitErrorNT (internal/streams/destroy.js:91:8)
10:25:16                 │       at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
10:25:16                 │       at process._tickCallback (internal/process/next_tick.js:63:19)
```

The issue is unclear, but it can be related to constant pulling of browser console logs. This PR temporary disables it.