### PR TITLE
[Security Solution][Exceptions Modal] Switches modal header

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/add_exception_modal/translations.ts
@@ -13,7 +13,7 @@ export const CANCEL = i18n.translate('xpack.securitySolution.exceptions.addExcep
 export const ADD_EXCEPTION = i18n.translate(
   'xpack.securitySolution.exceptions.addException.addException',
   {
-    defaultMessage: 'Add Exception',
+    defaultMessage: 'Add Rule Exception',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/edit_exception_modal/translations.ts
@@ -20,7 +20,7 @@ export const EDIT_EXCEPTION_SAVE_BUTTON = i18n.translate(
 export const EDIT_EXCEPTION_TITLE = i18n.translate(
   'xpack.securitySolution.exceptions.editException.editExceptionTitle',
   {
-    defaultMessage: 'Edit Exception',
+    defaultMessage: 'Edit Rule Exception',
   }
 );
 


### PR DESCRIPTION
## Summary

Updates add and edit exceptions modal header to match the context menu language (`exception` -> `rule exception`)

![Screen Shot 2020-08-26 at 2 46 10 PM](https://user-images.githubusercontent.com/56367316/91344119-81b88980-e7ab-11ea-99fe-2d1a881d2eba.png)
![Screen Shot 2020-08-26 at 2 47 48 PM](https://user-images.githubusercontent.com/56367316/91344122-82512000-e7ab-11ea-8923-d511462bfc10.png)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
