### PR TITLE
[docs] Fixes links to development getting started

### DIFF
--- a/docs/developer/getting-started/running-kibana-advanced.asciidoc
+++ b/docs/developer/getting-started/running-kibana-advanced.asciidoc
@@ -53,7 +53,7 @@ Unsupported URL Type: link:packages/eslint-config-kibana
 
 you’re likely running `npm`. To install dependencies in {kib} you
 need to run `yarn kbn bootstrap`. For more info, see
-link:#setting-up-your-development-environment[Setting Up Your
+link:#development-getting-started[Setting Up Your
 Development Environment] above.
 
 [discrete]

--- a/x-pack/plugins/ingest_manager/README.md
+++ b/x-pack/plugins/ingest_manager/README.md
@@ -25,7 +25,7 @@ Also you need to configure the hosts your agent is going to use to comunication 
 
 ### Getting started
 
-See the Kibana docs for [how to set up your dev environment](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#setting-up-your-development-environment), [run Elasticsearch](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#running-elasticsearch), and [start Kibana](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#running-kibana)
+See the Kibana docs for [how to set up your dev environment](https://www.elastic.co/guide/en/kibana/master/development-getting-started.html)
 
 One common development workflow is:
 


### PR DESCRIPTION
Noticed the link to setting up your development environment was incorrect.

Additionally, found another link in the ingest manager plugin readme that needed updating.

Preview: https://kibana_76207.docs-preview.app.elstc.co/guide/en/kibana/master/running-kibana-advanced.html

[skip-ci]