### PR TITLE
[Ingest Manager] Wording & linking improvements

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/index.tsx
@@ -8,6 +8,8 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
+  EuiSpacer,
+  EuiText,
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
@@ -44,6 +46,14 @@ export const AgentEnrollmentFlyout: React.FunctionComponent<Props> = ({
             />
           </h2>
         </EuiTitle>
+        <EuiSpacer size="l" />
+        <EuiText>
+          <FormattedMessage
+            id="xpack.ingestManager.agentEnrollment.agentDescription"
+            defaultMessage="Add Elastic Agents to your hosts to collect data and send it to the Elastic Stack."
+          />
+        </EuiText>
+        <EuiSpacer size="l" />
         <EuiTabs style={{ marginBottom: '-25px' }}>
           <EuiTab isSelected={mode === 'managed'} onClick={() => setMode('managed')}>
             <FormattedMessage

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -75,13 +75,13 @@ export const ManagedInstructions: React.FunctionComponent<Props> = ({ agentPolic
         <>
           <FormattedMessage
             id="xpack.ingestManager.agentEnrollment.fleetNotInitializedText"
-            defaultMessage="Before enrolling agents, set up Fleet. {link}"
+            defaultMessage="Before enrolling agents, {link}."
             values={{
               link: (
                 <EuiLink href={getHref('fleet')}>
                   <FormattedMessage
-                    id="xpack.ingestManager.agentEnrollment.goToFleetButton"
-                    defaultMessage="Go to Fleet."
+                    id="xpack.ingestManager.agentEnrollment.setUpFleetLink"
+                    defaultMessage="set up Fleet"
                   />
                 </EuiLink>
               ),

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -15,12 +15,13 @@ import {
   EuiFlexGroup,
   EuiCodeBlock,
   EuiCopy,
+  EuiLink,
 } from '@elastic/eui';
 import { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { AgentPolicy } from '../../../../types';
-import { useCore, sendGetOneAgentPolicyFull } from '../../../../hooks';
+import { useCore, useLink, sendGetOneAgentPolicyFull } from '../../../../hooks';
 import { DownloadStep, AgentPolicySelectionStep } from './steps';
 import { fullAgentPolicyToYaml, agentPolicyRouteService } from '../../../../services';
 
@@ -31,6 +32,7 @@ interface Props {
 const RUN_INSTRUCTIONS = './elastic-agent run';
 
 export const StandaloneInstructions: React.FunctionComponent<Props> = ({ agentPolicies }) => {
+  const { getHref } = useLink();
   const core = useCore();
   const { notifications } = core;
 
@@ -157,7 +159,17 @@ export const StandaloneInstructions: React.FunctionComponent<Props> = ({ agentPo
           <EuiText>
             <FormattedMessage
               id="xpack.ingestManager.agentEnrollment.stepCheckForDataDescription"
-              defaultMessage="The agent should begin sending data. Go to data streams to view your data."
+              defaultMessage="The agent should begin sending data. Go to {link} to view your data."
+              values={{
+                link: (
+                  <EuiLink href={getHref('data_streams')}>
+                    <FormattedMessage
+                      id="xpack.ingestManager.agentEnrollment.goToDataStreamsLink"
+                      defaultMessage="data streams"
+                    />
+                  </EuiLink>
+                ),
+              }}
             />
           </EuiText>
         </>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -9123,7 +9123,6 @@
     "xpack.ingestManager.agentEnrollment.flyoutTitle": "エージェントの追加",
     "xpack.ingestManager.agentEnrollment.managedDescription": "必要なエージェントの数に関係なく、Fleetでは、簡単に一元的に更新を管理し、エージェントにデプロイすることができます。次の手順に従い、Elasticエージェントをダウンロードし、Fleetに登録してください。",
     "xpack.ingestManager.agentEnrollment.standaloneDescription": "スタンドアロンモードで実行中のエージェントは、構成を変更したい場合には、手動で更新する必要があります。次の手順に従い、スタンドアロンモードでElasticエージェントをダウンロードし、セットアップしてください。",
-    "xpack.ingestManager.agentEnrollment.stepCheckForDataDescription": "エージェントを起動した後、エージェントはデータの送信を開始します。Ingest Managerのデータセットページでは、このデータを確認できます。",
     "xpack.ingestManager.agentEnrollment.stepCheckForDataTitle": "データを確認",
     "xpack.ingestManager.agentEnrollment.stepChooseAgentPolicyTitle": "エージェント構成を選択",
     "xpack.ingestManager.agentEnrollment.stepConfigureAgentDescription": "この構成をコピーし、Elasticエージェントがインストールされているシステムのファイル{fileName}に置きます。必ず、構成ファイルの{outputSection}セクションで{ESUsernameVariable}と{ESPasswordVariable}を修正し、実際のElasticsearch認証資格情報が使用されるようにしてください。",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -9121,7 +9121,6 @@
     "xpack.ingestManager.agentEnrollment.enrollStandaloneTabLabel": "スタンドアロンモード",
     "xpack.ingestManager.agentEnrollment.fleetNotInitializedText": "エージェントを登録する前に、フリートを設定する必要があります。{link}",
     "xpack.ingestManager.agentEnrollment.flyoutTitle": "エージェントの追加",
-    "xpack.ingestManager.agentEnrollment.goToFleetButton": "フリートに移動します。",
     "xpack.ingestManager.agentEnrollment.managedDescription": "必要なエージェントの数に関係なく、Fleetでは、簡単に一元的に更新を管理し、エージェントにデプロイすることができます。次の手順に従い、Elasticエージェントをダウンロードし、Fleetに登録してください。",
     "xpack.ingestManager.agentEnrollment.standaloneDescription": "スタンドアロンモードで実行中のエージェントは、構成を変更したい場合には、手動で更新する必要があります。次の手順に従い、スタンドアロンモードでElasticエージェントをダウンロードし、セットアップしてください。",
     "xpack.ingestManager.agentEnrollment.stepCheckForDataDescription": "エージェントを起動した後、エージェントはデータの送信を開始します。Ingest Managerのデータセットページでは、このデータを確認できます。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -9126,7 +9126,6 @@
     "xpack.ingestManager.agentEnrollment.flyoutTitle": "添加代理",
     "xpack.ingestManager.agentEnrollment.managedDescription": "无论是需要一个代理还是需要数以千计的代理，Fleet 允许您轻松地集中管理并部署代理的更新。按照下面的说明下载 Elastic 代理并将代理注册到 Fleet。",
     "xpack.ingestManager.agentEnrollment.standaloneDescription": "如果希望对以独立模式运行的代理进行配置更改，则需要手动更新。按照下面的说明下载并设置独立模式的 Elastic 代理。",
-    "xpack.ingestManager.agentEnrollment.stepCheckForDataDescription": "启动代理后，代理应开始发送数据。您可以在采集管理器的数据集页面查看此数据。",
     "xpack.ingestManager.agentEnrollment.stepCheckForDataTitle": "检查数据",
     "xpack.ingestManager.agentEnrollment.stepChooseAgentPolicyTitle": "选择代理配置",
     "xpack.ingestManager.agentEnrollment.stepConfigureAgentDescription": "在安装 Elastic 代理的系统上复制此配置并将其放入名为 {fileName} 的文件中。切勿忘记修改配置文件中 {outputSection} 部分的{ESUsernameVariable} 和 {ESPasswordVariable}，以便其使用您的实际 Elasticsearch 凭据。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -9124,7 +9124,6 @@
     "xpack.ingestManager.agentEnrollment.enrollStandaloneTabLabel": "独立模式",
     "xpack.ingestManager.agentEnrollment.fleetNotInitializedText": "注册代理前需要设置 Fleet。{link}",
     "xpack.ingestManager.agentEnrollment.flyoutTitle": "添加代理",
-    "xpack.ingestManager.agentEnrollment.goToFleetButton": "前往 Fleet。",
     "xpack.ingestManager.agentEnrollment.managedDescription": "无论是需要一个代理还是需要数以千计的代理，Fleet 允许您轻松地集中管理并部署代理的更新。按照下面的说明下载 Elastic 代理并将代理注册到 Fleet。",
     "xpack.ingestManager.agentEnrollment.standaloneDescription": "如果希望对以独立模式运行的代理进行配置更改，则需要手动更新。按照下面的说明下载并设置独立模式的 Elastic 代理。",
     "xpack.ingestManager.agentEnrollment.stepCheckForDataDescription": "启动代理后，代理应开始发送数据。您可以在采集管理器的数据集页面查看此数据。",


### PR DESCRIPTION
## Summary

Partially implements https://github.com/elastic/kibana/issues/75807 .

### Changes

#### In the "add agent" flyout, if fleet hasn't been enabled yet, move the "Go to fleet" link to "set up fleet" in the preceding sentence

Before:

![image](https://user-images.githubusercontent.com/189073/91982840-1a5e8480-ed2b-11ea-9f2f-47bfc59b6f69.png)

After:

![image](https://user-images.githubusercontent.com/189073/91977741-6279a900-ed23-11ea-82e9-e50673d964a3.png)

***
#### Add some explanatory text to the top of the "add agent" flyout:

Before:

![image](https://user-images.githubusercontent.com/189073/91982889-2f3b1800-ed2b-11ea-9097-6d99d758ed90.png)

After:

![image](https://user-images.githubusercontent.com/189073/91974918-dcf3fa00-ed1e-11ea-8689-ad5c79e3ba31.png)

***
#### On the standalone tab of the "add agent" flyout, add a link to the data streams page:

Before:

![image](https://user-images.githubusercontent.com/189073/91982937-3feb8e00-ed2b-11ea-8e7c-736062bb9f23.png)

After:

![image](https://user-images.githubusercontent.com/189073/91981267-db2f3400-ed28-11ea-857d-192972b09b13.png)


