### PR TITLE
[Ingest Manager] Add cacheClear & cacheDelete methods

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/cache.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/cache.ts
@@ -8,4 +8,6 @@ const cache: Map<string, Buffer> = new Map();
 export const cacheGet = (key: string) => cache.get(key);
 export const cacheSet = (key: string, value: Buffer) => cache.set(key, value);
 export const cacheHas = (key: string) => cache.has(key);
+export const cacheClear = () => cache.clear();
+export const cacheDelete = (key: string) => cache.delete(key);
 export const getCacheKey = (key: string) => key + '.tar.gz';


### PR DESCRIPTION
## Summary

There are currently no cache invalidation/reduction methods for the EPM asset/archive cache. Add `cacheDelete` to remove one items and `cacheClear` to remove all.

We haven't needed them until now but `cacheDelete` would be useful for  https://github.com/elastic/kibana/issues/68890

`cacheClear` doesn't have an explicit PR/issue afaik but I thought it'd be nice to have the ability to clear/purge without a Kibana restart