### PR TITLE
[APM] Minor style improvements to stacktraces

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/CauseStacktrace.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/CauseStacktrace.tsx
@@ -8,13 +8,14 @@ import React from 'react';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
 import { EuiAccordion, EuiTitle } from '@elastic/eui';
-import { px, unit } from '../../../style/variables';
+import { px, unit, units } from '../../../style/variables';
 import { Stacktrace } from '.';
 import { Stackframe } from '../../../../typings/es_schemas/raw/fields/stackframe';
 
 // @ts-ignore Styled Components has trouble inferring the types of the default props here.
 const Accordion = styled(EuiAccordion)`
   border-top: ${({ theme }) => theme.eui.euiBorderThin};
+  margin-top: ${px(units.half)};
 `;
 
 const CausedByContainer = styled('h5')`

--- a/x-pack/plugins/apm/public/components/shared/Stacktrace/Stackframe.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Stacktrace/Stackframe.tsx
@@ -35,7 +35,7 @@ const ContextContainer = styled.div<{ isLibraryFrame: boolean }>`
 
 // Indent the non-context frames the same amount as the accordion control
 const NoContextFrameHeadingWrapper = styled.div`
-  margin-left: ${px(units.unit + units.half + units.eighth)};
+  margin-left: ${px(units.unit + units.half + units.quarter)};
 `;
 
 interface Props {


### PR DESCRIPTION
## Summary

Made some minor improvements to the stracktraces styles that were recently implemented (https://github.com/elastic/kibana/pull/75924).

- [x] Added some more spacing for the indention inside a nested accordion

<img width="698" alt="Screenshot 2020-09-01 at 15 25 17" src="https://user-images.githubusercontent.com/4104278/91858482-8bd5fe80-ec69-11ea-8ae7-e79b41b79ae8.png">

- [x] Added additional spacing to the `CausedBy` accordions that created some space between the content and the containers.

<img width="1663" alt="Screenshot 2020-09-01 at 15 40 12" src="https://user-images.githubusercontent.com/4104278/91858467-84aef080-ec69-11ea-9220-e5ffdd0d5461.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
- [ ] ~~This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~~
- [ ] ~~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~~
- [ ] ~~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~~

### For maintainers

- [ ] ~~This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~
