### PR TITLE
[APM] Update aggregations to support script sources

### DIFF
--- a/x-pack/plugins/apm/server/lib/ui_filters/local_ui_filters/get_local_filter_query.ts
+++ b/x-pack/plugins/apm/server/lib/ui_filters/local_ui_filters/get_local_filter_query.ts
@@ -23,17 +23,15 @@ export const getLocalFilterQuery = ({
   const field = localUIFilters[localUIFilterName];
   const filter = getUiFiltersES(omit(uiFilters, field.name));
 
-  const projectionSource =
-    projection.body.aggs &&
-    projection.body.aggs[Object.keys(projection.body.aggs)[0]].terms;
-  const bucketCountAggregation = projectionSource
+  const bucketCountAggregation = projection.body.aggs
     ? {
         aggs: {
           bucket_count: {
-            cardinality:
-              'field' in projectionSource
-                ? { field: projectionSource.field }
-                : { script: projectionSource.script },
+            cardinality: {
+              field:
+                projection.body.aggs[Object.keys(projection.body.aggs)[0]].terms
+                  .field,
+            },
           },
         },
       }

--- a/x-pack/plugins/apm/server/lib/ui_filters/local_ui_filters/get_local_filter_query.ts
+++ b/x-pack/plugins/apm/server/lib/ui_filters/local_ui_filters/get_local_filter_query.ts
@@ -23,15 +23,17 @@ export const getLocalFilterQuery = ({
   const field = localUIFilters[localUIFilterName];
   const filter = getUiFiltersES(omit(uiFilters, field.name));
 
-  const bucketCountAggregation = projection.body.aggs
+  const projectionSource =
+    projection.body.aggs &&
+    projection.body.aggs[Object.keys(projection.body.aggs)[0]].terms;
+  const bucketCountAggregation = projectionSource
     ? {
         aggs: {
           bucket_count: {
-            cardinality: {
-              field:
-                projection.body.aggs[Object.keys(projection.body.aggs)[0]].terms
-                  .field,
-            },
+            cardinality:
+              'field' in projectionSource
+                ? { field: projectionSource.field }
+                : { script: projectionSource.script },
           },
         },
       }

--- a/x-pack/plugins/apm/server/projections/typings.ts
+++ b/x-pack/plugins/apm/server/projections/typings.ts
@@ -15,7 +15,7 @@ export type Projection = Omit<APMEventESSearchRequest, 'body'> & {
   body: Omit<ESSearchBody, 'aggs'> & {
     aggs?: {
       [key: string]: {
-        terms: AggregationOptionsByType['terms'];
+        terms: AggregationOptionsByType['terms'] & { field: string };
         aggs?: AggregationInputMap;
       };
     };

--- a/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
+++ b/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
@@ -13,11 +13,11 @@ export type SortOptions = SortOrder | SortInstruction | SortInstruction[];
 type Script =
   | string
   | {
-      lang?: string;
-      id?: string;
-      source?: string;
-      params?: Record<string, string | number>;
-    };
+    lang?: string;
+    id?: string;
+    source?: string;
+    params?: Record<string, string | number>;
+  };
 
 type BucketsPath = string | Record<string, string>;
 
@@ -25,12 +25,12 @@ type SourceOptions = string | string[];
 
 type MetricsAggregationOptions =
   | {
-      field: string;
-      missing?: number;
-    }
+    field: string;
+    missing?: number;
+  }
   | {
-      script?: Script;
-    };
+    script?: Script;
+  };
 
 interface MetricsAggregationResponsePart {
   value: number | null;
@@ -43,9 +43,9 @@ interface DateHistogramBucket {
 
 type GetCompositeKeys<
   TAggregationOptionsMap extends AggregationOptionsMap
-> = TAggregationOptionsMap extends {
-  composite: { sources: Array<infer Source> };
-}
+  > = TAggregationOptionsMap extends {
+    composite: { sources: Array<infer Source> };
+  }
   ? keyof Source
   : never;
 
@@ -56,30 +56,27 @@ type CompositeOptionsSource = Record<
 
 export interface AggregationOptionsByType {
   terms: {
-    field: string;
     size?: number;
     missing?: string;
     order?: SortOptions;
     execution_hint?: 'map' | 'global_ordinals';
-  };
+  } & MetricsAggregationOptions;
   date_histogram: {
-    field: string;
     format?: string;
     min_doc_count?: number;
     extended_bounds?: {
       min: number;
       max: number;
     };
-  } & ({ calendar_interval: string } | { fixed_interval: string });
+  } & ({ calendar_interval: string } | { fixed_interval: string }) & MetricsAggregationOptions;
   histogram: {
-    field: string;
     interval: number;
     min_doc_count?: number;
     extended_bounds?: {
       min?: number | string;
       max?: number | string;
     };
-  };
+  } & MetricsAggregationOptions;
   avg: MetricsAggregationOptions;
   max: MetricsAggregationOptions;
   min: MetricsAggregationOptions;
@@ -89,10 +86,9 @@ export interface AggregationOptionsByType {
     precision_threshold?: number;
   };
   percentiles: {
-    field: string;
     percents?: number[];
     hdr?: { number_of_significant_value_digits: number };
-  };
+  } & MetricsAggregationOptions;
   extended_stats: {
     field: string;
   };
@@ -133,7 +129,6 @@ export interface AggregationOptionsByType {
     reduce_script: Script;
   };
   date_range: {
-    field: string;
     format?: string;
     ranges: Array<
       | { from: string | number }
@@ -141,17 +136,15 @@ export interface AggregationOptionsByType {
       | { from: string | number; to: string | number }
     >;
     keyed?: boolean;
-  };
+  } & MetricsAggregationOptions;
   auto_date_histogram: {
-    field: string;
     buckets: number;
-  };
+  } & MetricsAggregationOptions;
   percentile_ranks: {
-    field: string;
     values: string[];
     keyed?: boolean;
     hdr?: { number_of_significant_value_digits: number };
-  };
+  } & MetricsAggregationOptions;
 }
 
 type AggregationType = keyof AggregationOptionsByType;
@@ -178,14 +171,14 @@ export interface AggregationInputMap {
 type BucketSubAggregationResponse<
   TAggregationInputMap extends AggregationInputMap | undefined,
   TDocument
-> = TAggregationInputMap extends AggregationInputMap
+  > = TAggregationInputMap extends AggregationInputMap
   ? AggregationResponseMap<TAggregationInputMap, TDocument>
   : {};
 
 interface AggregationResponsePart<
   TAggregationOptionsMap extends AggregationOptionsMap,
   TDocument
-> {
+  > {
   terms: {
     buckets: Array<
       {
@@ -211,7 +204,7 @@ interface AggregationResponsePart<
   date_histogram: {
     buckets: Array<
       DateHistogramBucket &
-        BucketSubAggregationResponse<TAggregationOptionsMap['aggs'], TDocument>
+      BucketSubAggregationResponse<TAggregationOptionsMap['aggs'], TDocument>
     >;
   };
   avg: MetricsAggregationResponsePart;
@@ -255,38 +248,38 @@ interface AggregationResponsePart<
     doc_count: number;
   } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
   filters: TAggregationOptionsMap extends { filters: { filters: any[] } }
-    ? Array<
-        { doc_count: number } & AggregationResponseMap<
-          TAggregationOptionsMap['aggs'],
-          TDocument
-        >
-      >
-    : TAggregationOptionsMap extends {
-        filters: {
-          filters: Record<string, any>;
-        };
-      }
-    ? {
-        buckets: {
-          [key in keyof TAggregationOptionsMap['filters']['filters']]: {
-            doc_count: number;
-          } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
-        };
-      }
-    : never;
+  ? Array<
+    { doc_count: number } & AggregationResponseMap<
+      TAggregationOptionsMap['aggs'],
+      TDocument
+    >
+  >
+  : TAggregationOptionsMap extends {
+    filters: {
+      filters: Record<string, any>;
+    };
+  }
+  ? {
+    buckets: {
+      [key in keyof TAggregationOptionsMap['filters']['filters']]: {
+        doc_count: number;
+      } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
+    };
+  }
+  : never;
   sampler: {
     doc_count: number;
   } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
   derivative:
-    | {
-        value: number;
-      }
-    | undefined;
+  | {
+    value: number;
+  }
+  | undefined;
   bucket_script:
-    | {
-        value: number | null;
-      }
-    | undefined;
+  | {
+    value: number | null;
+  }
+  | undefined;
   composite: {
     after_key: Record<
       GetCompositeKeys<TAggregationOptionsMap>,
@@ -310,13 +303,13 @@ interface AggregationResponsePart<
   };
   date_range: {
     buckets: TAggregationOptionsMap extends { date_range: { keyed: true } }
-      ? Record<string, DateRangeBucket>
-      : { buckets: DateRangeBucket[] };
+    ? Record<string, DateRangeBucket>
+    : { buckets: DateRangeBucket[] };
   };
   auto_date_histogram: {
     buckets: Array<
       DateHistogramBucket &
-        AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>
+      AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>
     >;
     interval: string;
   };
@@ -325,8 +318,8 @@ interface AggregationResponsePart<
     values: TAggregationOptionsMap extends {
       percentile_ranks: { keyed: false };
     }
-      ? Array<{ key: number; value: number }>
-      : Record<string, number>;
+    ? Array<{ key: number; value: number }>
+    : Record<string, number>;
   };
 }
 
@@ -347,16 +340,16 @@ interface AggregationResponsePart<
 // types, e.g. { foo: string; bar?: undefined } | { foo?: undefined; bar: string };
 export type ValidAggregationKeysOf<
   T extends Record<string, any>
-> = keyof (UnionToIntersection<T> extends never ? T : UnionToIntersection<T>);
+  > = keyof (UnionToIntersection<T> extends never ? T : UnionToIntersection<T>);
 
 export type AggregationResponseMap<
   TAggregationInputMap extends AggregationInputMap | undefined,
   TDocument
-> = TAggregationInputMap extends AggregationInputMap
+  > = TAggregationInputMap extends AggregationInputMap
   ? {
-      [TName in keyof TAggregationInputMap]: AggregationResponsePart<
-        TAggregationInputMap[TName],
-        TDocument
-      >[AggregationType & ValidAggregationKeysOf<TAggregationInputMap[TName]>];
-    }
+    [TName in keyof TAggregationInputMap]: AggregationResponsePart<
+      TAggregationInputMap[TName],
+      TDocument
+    >[AggregationType & ValidAggregationKeysOf<TAggregationInputMap[TName]>];
+  }
   : undefined;

--- a/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
+++ b/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
@@ -13,11 +13,11 @@ export type SortOptions = SortOrder | SortInstruction | SortInstruction[];
 type Script =
   | string
   | {
-    lang?: string;
-    id?: string;
-    source?: string;
-    params?: Record<string, string | number>;
-  };
+      lang?: string;
+      id?: string;
+      source?: string;
+      params?: Record<string, string | number>;
+    };
 
 type BucketsPath = string | Record<string, string>;
 
@@ -25,12 +25,12 @@ type SourceOptions = string | string[];
 
 type MetricsAggregationOptions =
   | {
-    field: string;
-    missing?: number;
-  }
+      field: string;
+      missing?: number;
+    }
   | {
-    script?: Script;
-  };
+      script?: Script;
+    };
 
 interface MetricsAggregationResponsePart {
   value: number | null;
@@ -43,9 +43,9 @@ interface DateHistogramBucket {
 
 type GetCompositeKeys<
   TAggregationOptionsMap extends AggregationOptionsMap
-  > = TAggregationOptionsMap extends {
-    composite: { sources: Array<infer Source> };
-  }
+> = TAggregationOptionsMap extends {
+  composite: { sources: Array<infer Source> };
+}
   ? keyof Source
   : never;
 
@@ -68,7 +68,8 @@ export interface AggregationOptionsByType {
       min: number;
       max: number;
     };
-  } & ({ calendar_interval: string } | { fixed_interval: string }) & MetricsAggregationOptions;
+  } & ({ calendar_interval: string } | { fixed_interval: string }) &
+    MetricsAggregationOptions;
   histogram: {
     interval: number;
     min_doc_count?: number;
@@ -171,14 +172,14 @@ export interface AggregationInputMap {
 type BucketSubAggregationResponse<
   TAggregationInputMap extends AggregationInputMap | undefined,
   TDocument
-  > = TAggregationInputMap extends AggregationInputMap
+> = TAggregationInputMap extends AggregationInputMap
   ? AggregationResponseMap<TAggregationInputMap, TDocument>
   : {};
 
 interface AggregationResponsePart<
   TAggregationOptionsMap extends AggregationOptionsMap,
   TDocument
-  > {
+> {
   terms: {
     buckets: Array<
       {
@@ -204,7 +205,7 @@ interface AggregationResponsePart<
   date_histogram: {
     buckets: Array<
       DateHistogramBucket &
-      BucketSubAggregationResponse<TAggregationOptionsMap['aggs'], TDocument>
+        BucketSubAggregationResponse<TAggregationOptionsMap['aggs'], TDocument>
     >;
   };
   avg: MetricsAggregationResponsePart;
@@ -248,38 +249,38 @@ interface AggregationResponsePart<
     doc_count: number;
   } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
   filters: TAggregationOptionsMap extends { filters: { filters: any[] } }
-  ? Array<
-    { doc_count: number } & AggregationResponseMap<
-      TAggregationOptionsMap['aggs'],
-      TDocument
-    >
-  >
-  : TAggregationOptionsMap extends {
-    filters: {
-      filters: Record<string, any>;
-    };
-  }
-  ? {
-    buckets: {
-      [key in keyof TAggregationOptionsMap['filters']['filters']]: {
-        doc_count: number;
-      } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
-    };
-  }
-  : never;
+    ? Array<
+        { doc_count: number } & AggregationResponseMap<
+          TAggregationOptionsMap['aggs'],
+          TDocument
+        >
+      >
+    : TAggregationOptionsMap extends {
+        filters: {
+          filters: Record<string, any>;
+        };
+      }
+    ? {
+        buckets: {
+          [key in keyof TAggregationOptionsMap['filters']['filters']]: {
+            doc_count: number;
+          } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
+        };
+      }
+    : never;
   sampler: {
     doc_count: number;
   } & AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>;
   derivative:
-  | {
-    value: number;
-  }
-  | undefined;
+    | {
+        value: number;
+      }
+    | undefined;
   bucket_script:
-  | {
-    value: number | null;
-  }
-  | undefined;
+    | {
+        value: number | null;
+      }
+    | undefined;
   composite: {
     after_key: Record<
       GetCompositeKeys<TAggregationOptionsMap>,
@@ -303,13 +304,13 @@ interface AggregationResponsePart<
   };
   date_range: {
     buckets: TAggregationOptionsMap extends { date_range: { keyed: true } }
-    ? Record<string, DateRangeBucket>
-    : { buckets: DateRangeBucket[] };
+      ? Record<string, DateRangeBucket>
+      : { buckets: DateRangeBucket[] };
   };
   auto_date_histogram: {
     buckets: Array<
       DateHistogramBucket &
-      AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>
+        AggregationResponseMap<TAggregationOptionsMap['aggs'], TDocument>
     >;
     interval: string;
   };
@@ -318,8 +319,8 @@ interface AggregationResponsePart<
     values: TAggregationOptionsMap extends {
       percentile_ranks: { keyed: false };
     }
-    ? Array<{ key: number; value: number }>
-    : Record<string, number>;
+      ? Array<{ key: number; value: number }>
+      : Record<string, number>;
   };
 }
 
@@ -340,16 +341,16 @@ interface AggregationResponsePart<
 // types, e.g. { foo: string; bar?: undefined } | { foo?: undefined; bar: string };
 export type ValidAggregationKeysOf<
   T extends Record<string, any>
-  > = keyof (UnionToIntersection<T> extends never ? T : UnionToIntersection<T>);
+> = keyof (UnionToIntersection<T> extends never ? T : UnionToIntersection<T>);
 
 export type AggregationResponseMap<
   TAggregationInputMap extends AggregationInputMap | undefined,
   TDocument
-  > = TAggregationInputMap extends AggregationInputMap
+> = TAggregationInputMap extends AggregationInputMap
   ? {
-    [TName in keyof TAggregationInputMap]: AggregationResponsePart<
-      TAggregationInputMap[TName],
-      TDocument
-    >[AggregationType & ValidAggregationKeysOf<TAggregationInputMap[TName]>];
-  }
+      [TName in keyof TAggregationInputMap]: AggregationResponsePart<
+        TAggregationInputMap[TName],
+        TDocument
+      >[AggregationType & ValidAggregationKeysOf<TAggregationInputMap[TName]>];
+    }
   : undefined;

--- a/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
+++ b/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
@@ -23,13 +23,13 @@ type BucketsPath = string | Record<string, string>;
 
 type SourceOptions = string | string[];
 
-type MetricsAggregationOptions =
+type AggregationSourceOptions =
   | {
       field: string;
-      missing?: number;
+      missing?: unknown;
     }
   | {
-      script?: Script;
+      script: Script;
     };
 
 interface MetricsAggregationResponsePart {
@@ -57,10 +57,9 @@ type CompositeOptionsSource = Record<
 export interface AggregationOptionsByType {
   terms: {
     size?: number;
-    missing?: string;
     order?: SortOptions;
     execution_hint?: 'map' | 'global_ordinals';
-  } & MetricsAggregationOptions;
+  } & AggregationSourceOptions;
   date_histogram: {
     format?: string;
     min_doc_count?: number;
@@ -69,7 +68,7 @@ export interface AggregationOptionsByType {
       max: number;
     };
   } & ({ calendar_interval: string } | { fixed_interval: string }) &
-    MetricsAggregationOptions;
+    AggregationSourceOptions;
   histogram: {
     interval: number;
     min_doc_count?: number;
@@ -77,19 +76,19 @@ export interface AggregationOptionsByType {
       min?: number | string;
       max?: number | string;
     };
-  } & MetricsAggregationOptions;
-  avg: MetricsAggregationOptions;
-  max: MetricsAggregationOptions;
-  min: MetricsAggregationOptions;
-  sum: MetricsAggregationOptions;
-  value_count: MetricsAggregationOptions;
-  cardinality: MetricsAggregationOptions & {
+  } & AggregationSourceOptions;
+  avg: AggregationSourceOptions;
+  max: AggregationSourceOptions;
+  min: AggregationSourceOptions;
+  sum: AggregationSourceOptions;
+  value_count: AggregationSourceOptions;
+  cardinality: AggregationSourceOptions & {
     precision_threshold?: number;
   };
   percentiles: {
     percents?: number[];
     hdr?: { number_of_significant_value_digits: number };
-  } & MetricsAggregationOptions;
+  } & AggregationSourceOptions;
   extended_stats: {
     field: string;
   };
@@ -137,15 +136,15 @@ export interface AggregationOptionsByType {
       | { from: string | number; to: string | number }
     >;
     keyed?: boolean;
-  } & MetricsAggregationOptions;
+  } & AggregationSourceOptions;
   auto_date_histogram: {
     buckets: number;
-  } & MetricsAggregationOptions;
+  } & AggregationSourceOptions;
   percentile_ranks: {
     values: string[];
     keyed?: boolean;
     hdr?: { number_of_significant_value_digits: number };
-  } & MetricsAggregationOptions;
+  } & AggregationSourceOptions;
 }
 
 type AggregationType = keyof AggregationOptionsByType;


### PR DESCRIPTION
`field` is not always required on aggregations, it's either `field` or `script` parameters. This distinction was represented for metric aggregations, but not for bucket aggregations.
