### PR TITLE
[APM] Service maps layout enhancements

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -282,6 +282,13 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
+This product includes code in the function applyCubicBezierStyles that was
+inspired by a public Codepen, which was available under a "MIT" license.
+
+Copyright (c) 2020 by Guillaume (https://codepen.io/guillaumethomas/pen/xxbbBKO)
+MIT License http://www.opensource.org/licenses/mit-license.php
+
+---
 This product includes code that is adapted from mapbox-gl-js, which is
 available under a "BSD-3-Clause" license.
 https://github.com/mapbox/mapbox-gl-js/blob/master/src/util/image.js

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -286,7 +286,7 @@ This product includes code in the function applyCubicBezierStyles that was
 inspired by a public Codepen, which was available under a "MIT" license.
 
 Copyright (c) 2020 by Guillaume (https://codepen.io/guillaumethomas/pen/xxbbBKO)
-MIT License http://www.opensource.org/licenses/mit-license.php
+MIT License http://www.opensource.org/licenses/mit-license
 
 ---
 This product includes code that is adapted from mapbox-gl-js, which is

--- a/src/dev/notice/generate_notice_from_source.ts
+++ b/src/dev/notice/generate_notice_from_source.ts
@@ -41,7 +41,7 @@ interface Options {
  * into the repository.
  */
 export async function generateNoticeFromSource({ productName, directory, log }: Options) {
-  const globs = ['**/*.{js,less,css,ts}'];
+  const globs = ['**/*.{js,less,css,ts,tsx}'];
 
   const options = {
     cwd: directory,

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -305,6 +305,7 @@
     "concat-stream": "1.6.2",
     "content-disposition": "0.5.3",
     "cytoscape": "^3.10.0",
+    "cytoscape-dagre": "^2.2.2",
     "d3-array": "1.2.4",
     "dedent": "^0.7.0",
     "del": "^5.1.0",

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -137,8 +137,6 @@ export function Cytoscape({
           resetConnectedEdgeStyle();
         }
         cy.layout(getLayoutOptions(nodeHeight)).run();
-        cy.nodes().grabify();
-        // cy.elements().panify();
       }
     };
     let layoutstopDelayTimeout: NodeJS.Timeout;

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -13,6 +13,7 @@ import React, {
   useState,
 } from 'react';
 import cytoscape from 'cytoscape';
+import dagre from 'cytoscape-dagre';
 import { debounce } from 'lodash';
 import { useTheme } from '../../../hooks/useTheme';
 import {
@@ -22,6 +23,8 @@ import {
 } from './cytoscapeOptions';
 import { useUiTracker } from '../../../../../observability/public';
 
+cytoscape.use(dagre);
+
 export const CytoscapeContext = createContext<cytoscape.Core | undefined>(
   undefined
 );
@@ -30,7 +33,6 @@ interface CytoscapeProps {
   children?: ReactNode;
   elements: cytoscape.ElementDefinition[];
   height: number;
-  width: number;
   serviceName?: string;
   style?: CSSProperties;
 }
@@ -57,59 +59,42 @@ function useCytoscape(options: cytoscape.CytoscapeOptions) {
   return [ref, cy] as [React.MutableRefObject<any>, cytoscape.Core | undefined];
 }
 
-function rotatePoint(
-  { x, y }: { x: number; y: number },
-  degreesRotated: number
-) {
-  const radiansPerDegree = Math.PI / 180;
-  const θ = radiansPerDegree * degreesRotated;
-  const cosθ = Math.cos(θ);
-  const sinθ = Math.sin(θ);
+function getLayoutOptions(nodeHeight: number): cytoscape.LayoutOptions {
   return {
-    x: x * cosθ - y * sinθ,
-    y: x * sinθ + y * cosθ,
-  };
-}
-
-function getLayoutOptions(
-  selectedRoots: string[],
-  height: number,
-  width: number,
-  nodeHeight: number
-): cytoscape.LayoutOptions {
-  return {
-    name: 'breadthfirst',
-    // @ts-ignore DefinitelyTyped is incorrect here. Roots can be an Array
-    roots: selectedRoots.length ? selectedRoots : undefined,
+    name: 'dagre',
     fit: true,
     padding: nodeHeight,
     spacingFactor: 1.2,
     // @ts-ignore
-    // Rotate nodes counter-clockwise to transform layout from top→bottom to left→right.
-    // The extra 5° achieves the effect of separating overlapping taxi-styled edges.
-    transform: (node: any, pos: cytoscape.Position) => rotatePoint(pos, -95),
-    // swap width/height of boundingBox to compensate for the rotation
-    boundingBox: { x1: 0, y1: 0, w: height, h: width },
+    nodeSep: nodeHeight,
+    edgeSep: 32,
+    rankSep: 128,
+    rankDir: 'LR',
+    ranker: 'network-simplex',
   };
 }
 
-function selectRoots(cy: cytoscape.Core): string[] {
-  const bfs = cy.elements().bfs({
-    roots: cy.elements().leaves(),
+function applyCubicBezierStyles(edges: cytoscape.EdgeCollection) {
+  edges.forEach((edge) => {
+    const { x: x0, y: y0 } = edge.source().position();
+    const { x: x1, y: y1 } = edge.target().position();
+    const x = x1 - x0;
+    const y = y1 - y0;
+    const z = Math.sqrt(x * x + y * y);
+    const costheta = z === 0 ? 0 : x / z;
+    const alpha = 0.25;
+    edge.style('control-point-distances', [
+      -alpha * y * costheta,
+      alpha * y * costheta,
+    ]);
+    edge.style('control-point-weights', [alpha, 1 - alpha]);
   });
-  const furthestNodeFromLeaves = bfs.path.last();
-  return cy
-    .elements()
-    .roots()
-    .union(furthestNodeFromLeaves)
-    .map((el) => el.id());
 }
 
 export function Cytoscape({
   children,
   elements,
   height,
-  width,
   serviceName,
   style,
 }: CytoscapeProps) {
@@ -151,13 +136,9 @@ export function Cytoscape({
         } else {
           resetConnectedEdgeStyle();
         }
-
-        const selectedRoots = selectRoots(event.cy);
-        const layout = cy.layout(
-          getLayoutOptions(selectedRoots, height, width, nodeHeight)
-        );
-
-        layout.run();
+        cy.layout(getLayoutOptions(nodeHeight)).run();
+        cy.nodes().grabify();
+        // cy.elements().panify();
       }
     };
     let layoutstopDelayTimeout: NodeJS.Timeout;
@@ -180,6 +161,7 @@ export function Cytoscape({
           event.cy.fit(undefined, nodeHeight);
         }
       }, 0);
+      applyCubicBezierStyles(event.cy.edges());
     };
     // debounce hover tracking so it doesn't spam telemetry with redundant events
     const trackNodeEdgeHover = debounce(
@@ -211,6 +193,9 @@ export function Cytoscape({
         console.debug('cytoscape:', event);
       }
     };
+    const dragHandler: cytoscape.EventHandler = (event) => {
+      applyCubicBezierStyles(event.target.connectedEdges());
+    };
 
     if (cy) {
       cy.on('data layoutstop select unselect', debugHandler);
@@ -220,6 +205,7 @@ export function Cytoscape({
       cy.on('mouseout', 'edge, node', mouseoutHandler);
       cy.on('select', 'node', selectHandler);
       cy.on('unselect', 'node', unselectHandler);
+      cy.on('drag', 'node', dragHandler);
 
       cy.remove(cy.elements());
       cy.add(elements);
@@ -239,19 +225,11 @@ export function Cytoscape({
         cy.removeListener('mouseout', 'edge, node', mouseoutHandler);
         cy.removeListener('select', 'node', selectHandler);
         cy.removeListener('unselect', 'node', unselectHandler);
+        cy.removeListener('drag', 'node', dragHandler);
       }
       clearTimeout(layoutstopDelayTimeout);
     };
-  }, [
-    cy,
-    elements,
-    height,
-    serviceName,
-    trackApmEvent,
-    width,
-    nodeHeight,
-    theme,
-  ]);
+  }, [cy, elements, height, serviceName, trackApmEvent, nodeHeight, theme]);
 
   return (
     <CytoscapeContext.Provider value={cy}>

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -74,6 +74,14 @@ function getLayoutOptions(nodeHeight: number): cytoscape.LayoutOptions {
   };
 }
 
+/*
+ * @notice
+ * This product includes code in the function applyCubicBezierStyles that was
+ * inspired by a public Codepen, which was available under a "MIT" license.
+ *
+ * Copyright (c) 2020 by Guillaume (https://codepen.io/guillaumethomas/pen/xxbbBKO)
+ * MIT License http://www.opensource.org/licenses/mit-license.php
+ */
 function applyCubicBezierStyles(edges: cytoscape.EdgeCollection) {
   edges.forEach((edge) => {
     const { x: x0, y: y0 } = edge.source().position();
@@ -83,6 +91,8 @@ function applyCubicBezierStyles(edges: cytoscape.EdgeCollection) {
     const z = Math.sqrt(x * x + y * y);
     const costheta = z === 0 ? 0 : x / z;
     const alpha = 0.25;
+    // Two values for control-point-distances represent a pair symmetric quadratic
+    // bezier curves joined to appear as a single cubic bezier curve:
     edge.style('control-point-distances', [
       -alpha * y * costheta,
       alpha * y * costheta,

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -80,7 +80,7 @@ function getLayoutOptions(nodeHeight: number): cytoscape.LayoutOptions {
  * inspired by a public Codepen, which was available under a "MIT" license.
  *
  * Copyright (c) 2020 by Guillaume (https://codepen.io/guillaumethomas/pen/xxbbBKO)
- * MIT License http://www.opensource.org/licenses/mit-license.php
+ * MIT License http://www.opensource.org/licenses/mit-license
  */
 function applyCubicBezierStyles(edges: cytoscape.EdgeCollection) {
   edges.forEach((edge) => {
@@ -92,7 +92,7 @@ function applyCubicBezierStyles(edges: cytoscape.EdgeCollection) {
     const costheta = z === 0 ? 0 : x / z;
     const alpha = 0.25;
     // Two values for control-point-distances represent a pair symmetric quadratic
-    // bezier curves joined to appear as a single cubic bezier curve:
+    // bezier curves joined in the middle as a seamless cubic bezier curve:
     edge.style('control-point-distances', [
       -alpha * y * costheta,
       alpha * y * costheta,

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/index.tsx
@@ -71,6 +71,7 @@ export function Popover({ focusedServiceName }: PopoverProps) {
       cy.on('select', 'node', selectHandler);
       cy.on('unselect', 'node', deselect);
       cy.on('data viewport', deselect);
+      cy.on('drag', 'node', deselect);
     }
 
     return () => {
@@ -78,6 +79,7 @@ export function Popover({ focusedServiceName }: PopoverProps) {
         cy.removeListener('select', 'node', selectHandler);
         cy.removeListener('unselect', 'node', deselect);
         cy.removeListener('data viewport', undefined, deselect);
+        cy.removeListener('drag', 'node', deselect);
       }
     };
   }, [cy, deselect]);

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/Cytoscape.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/Cytoscape.stories.tsx
@@ -49,13 +49,11 @@ storiesOf('app/ServiceMap/Cytoscape', module)
         },
       ];
       const height = 300;
-      const width = 1340;
       const serviceName = 'opbeans-python';
       return (
         <Cytoscape
           elements={elements}
           height={height}
-          width={width}
           serviceName={serviceName}
         />
       );
@@ -330,7 +328,7 @@ storiesOf('app/ServiceMap/Cytoscape', module)
           },
         },
       ];
-      return <Cytoscape elements={elements} height={600} width={1340} />;
+      return <Cytoscape elements={elements} height={600} />;
     },
     {
       info: { propTables: false, source: false },

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/CytoscapeExampleData.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/CytoscapeExampleData.stories.tsx
@@ -35,6 +35,9 @@ function setSessionJson(json: string) {
   window.sessionStorage.setItem(SESSION_STORAGE_KEY, json);
 }
 
+const getCytoscapeWidth = () => window.innerWidth - 240;
+const getCytoscapeHeight = () => window.innerHeight - 300;
+
 storiesOf(STORYBOOK_PATH, module)
   .addDecorator((storyFn) => <EuiThemeProvider>{storyFn()}</EuiThemeProvider>)
   .add(
@@ -43,16 +46,17 @@ storiesOf(STORYBOOK_PATH, module)
       const [size, setSize] = useState<number>(10);
       const [json, setJson] = useState<string>('');
       const [elements, setElements] = useState<any[]>(
-        generateServiceMapElements(size)
+        generateServiceMapElements({ size, hasAnomalies: true })
       );
-
       return (
         <div>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiButton
                 onClick={() => {
-                  setElements(generateServiceMapElements(size));
+                  setElements(
+                    generateServiceMapElements({ size, hasAnomalies: true })
+                  );
                   setJson('');
                 }}
               >
@@ -79,7 +83,11 @@ storiesOf(STORYBOOK_PATH, module)
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          <Cytoscape elements={elements} height={600} width={1340} />
+          <Cytoscape
+            elements={elements}
+            height={getCytoscapeHeight()}
+            width={getCytoscapeWidth()}
+          />
 
           {json && (
             <EuiCodeEditor
@@ -121,7 +129,11 @@ storiesOf(STORYBOOK_PATH, module)
 
       return (
         <div>
-          <Cytoscape elements={elements} height={600} width={1340} />
+          <Cytoscape
+            elements={elements}
+            height={getCytoscapeHeight()}
+            width={getCytoscapeWidth()}
+          />
           <EuiForm isInvalid={error !== undefined} error={error}>
             <EuiFlexGroup>
               <EuiFlexItem>
@@ -204,8 +216,8 @@ storiesOf(STORYBOOK_PATH, module)
         <div>
           <Cytoscape
             elements={exampleResponseTodo.elements}
-            height={600}
-            width={1340}
+            height={getCytoscapeHeight()}
+            width={getCytoscapeWidth()}
           />
         </div>
       );
@@ -224,8 +236,8 @@ storiesOf(STORYBOOK_PATH, module)
         <div>
           <Cytoscape
             elements={exampleResponseOpbeansBeats.elements}
-            height={600}
-            width={1340}
+            height={getCytoscapeHeight()}
+            width={getCytoscapeWidth()}
           />
         </div>
       );
@@ -244,8 +256,8 @@ storiesOf(STORYBOOK_PATH, module)
         <div>
           <Cytoscape
             elements={exampleResponseHipsterStore.elements}
-            height={600}
-            width={1340}
+            height={getCytoscapeHeight()}
+            width={getCytoscapeWidth()}
           />
         </div>
       );
@@ -264,8 +276,8 @@ storiesOf(STORYBOOK_PATH, module)
         <div>
           <Cytoscape
             elements={exampleResponseOneDomainManyIPs.elements}
-            height={600}
-            width={1340}
+            height={getCytoscapeHeight()}
+            width={getCytoscapeWidth()}
           />
         </div>
       );

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/CytoscapeExampleData.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/CytoscapeExampleData.stories.tsx
@@ -35,7 +35,6 @@ function setSessionJson(json: string) {
   window.sessionStorage.setItem(SESSION_STORAGE_KEY, json);
 }
 
-const getCytoscapeWidth = () => window.innerWidth - 240;
 const getCytoscapeHeight = () => window.innerHeight - 300;
 
 storiesOf(STORYBOOK_PATH, module)
@@ -83,11 +82,7 @@ storiesOf(STORYBOOK_PATH, module)
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          <Cytoscape
-            elements={elements}
-            height={getCytoscapeHeight()}
-            width={getCytoscapeWidth()}
-          />
+          <Cytoscape elements={elements} height={getCytoscapeHeight()} />
 
           {json && (
             <EuiCodeEditor
@@ -129,11 +124,7 @@ storiesOf(STORYBOOK_PATH, module)
 
       return (
         <div>
-          <Cytoscape
-            elements={elements}
-            height={getCytoscapeHeight()}
-            width={getCytoscapeWidth()}
-          />
+          <Cytoscape elements={elements} height={getCytoscapeHeight()} />
           <EuiForm isInvalid={error !== undefined} error={error}>
             <EuiFlexGroup>
               <EuiFlexItem>
@@ -217,7 +208,6 @@ storiesOf(STORYBOOK_PATH, module)
           <Cytoscape
             elements={exampleResponseTodo.elements}
             height={getCytoscapeHeight()}
-            width={getCytoscapeWidth()}
           />
         </div>
       );
@@ -237,7 +227,6 @@ storiesOf(STORYBOOK_PATH, module)
           <Cytoscape
             elements={exampleResponseOpbeansBeats.elements}
             height={getCytoscapeHeight()}
-            width={getCytoscapeWidth()}
           />
         </div>
       );
@@ -257,7 +246,6 @@ storiesOf(STORYBOOK_PATH, module)
           <Cytoscape
             elements={exampleResponseHipsterStore.elements}
             height={getCytoscapeHeight()}
-            width={getCytoscapeWidth()}
           />
         </div>
       );
@@ -277,7 +265,6 @@ storiesOf(STORYBOOK_PATH, module)
           <Cytoscape
             elements={exampleResponseOneDomainManyIPs.elements}
             height={getCytoscapeHeight()}
-            width={getCytoscapeWidth()}
           />
         </div>
       );

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/generate_service_map_elements.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/__stories__/generate_service_map_elements.ts
@@ -4,9 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { getSeverity } from '../Popover/getSeverity';
-
-export function generateServiceMapElements(size: number): any[] {
+export function generateServiceMapElements({
+  size,
+  hasAnomalies,
+}: {
+  size: number;
+  hasAnomalies: boolean;
+}): any[] {
   const services = range(size).map((i) => {
     const name = getName();
     const anomalyScore = randn(101);
@@ -15,11 +19,14 @@ export function generateServiceMapElements(size: number): any[] {
       'service.environment': 'production',
       'service.name': name,
       'agent.name': getAgentName(),
-      anomaly_score: anomalyScore,
-      anomaly_severity: getSeverity(anomalyScore),
-      actual_value: Math.random() * 2000000,
-      typical_value: Math.random() * 1000000,
-      ml_job_id: `${name}-request-high_mean_response_time`,
+      serviceAnomalyStats: hasAnomalies
+        ? {
+            transactionType: 'request',
+            anomalyScore,
+            actualValue: Math.random() * 2000000,
+            jobId: `${name}-request-high_mean_response_time`,
+          }
+        : undefined,
     };
   });
 
@@ -146,7 +153,7 @@ const NAMES = [
   'leech',
   'loki',
   'longshot',
-  'lumpkin,',
+  'lumpkin',
   'madame-web',
   'magician',
   'magneto',

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
@@ -168,9 +168,7 @@ const getStyle = (theme: EuiTheme): cytoscape.Stylesheet[] => {
     {
       selector: 'edge',
       style: {
-        'curve-style': 'taxi',
-        // @ts-ignore
-        'taxi-direction': 'auto',
+        'curve-style': 'unbundled-bezier',
         'line-color': lineColor,
         'overlay-opacity': 0,
         'target-arrow-color': lineColor,
@@ -264,7 +262,7 @@ ${theme.eui.euiColorLightShade}`,
 export const getCytoscapeOptions = (
   theme: EuiTheme
 ): cytoscape.CytoscapeOptions => ({
-  autoungrabify: true,
+  // autoungrabify: true,
   boxSelectionEnabled: false,
   maxZoom: 3,
   minZoom: 0.2,

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/cytoscapeOptions.ts
@@ -262,7 +262,6 @@ ${theme.eui.euiColorLightShade}`,
 export const getCytoscapeOptions = (
   theme: EuiTheme
 ): cytoscape.CytoscapeOptions => ({
-  // autoungrabify: true,
   boxSelectionEnabled: false,
   maxZoom: 3,
   minZoom: 0.2,

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/index.tsx
@@ -57,7 +57,7 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
     }
   }, [license, serviceName, urlParams]);
 
-  const { ref, height, width } = useRefDimensions();
+  const { ref, height } = useRefDimensions();
 
   useTrackPageview({ app: 'apm', path: 'service_map' });
   useTrackPageview({ app: 'apm', path: 'service_map', delay: 15000 });
@@ -78,7 +78,6 @@ export function ServiceMap({ serviceName }: ServiceMapProps) {
         height={height}
         serviceName={serviceName}
         style={getCytoscapeDivStyle(theme)}
-        width={width}
       >
         <Controls />
         <BetaBadge />

--- a/x-pack/plugins/apm/typings/cytoscape_dagre.d.ts
+++ b/x-pack/plugins/apm/typings/cytoscape_dagre.d.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+declare module 'cytoscape-dagre';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9997,6 +9997,13 @@ cypress@4.11.0:
     url "0.11.0"
     yauzl "2.10.0"
 
+cytoscape-dagre@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cytoscape-dagre/-/cytoscape-dagre-2.2.2.tgz#5f32a85c0ba835f167efee531df9e89ac58ff411"
+  integrity sha512-zsg36qNwua/L2stJSWkcbSDcvW3E6VZf6KRe6aLnQJxuXuz89tMqI5EVYVKEcNBgzTEzFMFv0PE3T0nD4m6VDw==
+  dependencies:
+    dagre "^0.8.2"
+
 cytoscape@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.10.0.tgz#3b462e0d35121ecd2d2702f470915fd6dae01777"
@@ -10208,6 +10215,14 @@ d@1:
   integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
   dependencies:
     es5-ext "^0.10.9"
+
+dagre@^0.8.2:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  dependencies:
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
 
 damerau-levenshtein@^1.0.4:
   version "1.0.4"
@@ -14373,6 +14388,13 @@ graceful-fs@~1.1:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.1.14.tgz#07078db5f6377f6321fceaaedf497de124dc9465"
   integrity sha1-BweNtfY3f2Mh/Oqu30l94STclGU=
+
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
 
 graphql-anywhere@^4.1.0-alpha.0:
   version "4.1.16"


### PR DESCRIPTION
Closes #71770 for APM service maps by replacing `breadthfirst` layout with one from the `cytoscape-dagre` extension. Also replaces the `taxi` edges with approximated cubic `unbundled-bezier` edges. Finally, this adds the ability to drag individual nodes around the service map. Also fixes storybook anomaly score generation and better utilizes available vertical space in storybook.

![Screen Shot 2020-09-02 at 1 48 47 AM](https://user-images.githubusercontent.com/1967266/91961788-835ce280-ecc0-11ea-95c1-7dd37de3aa4e.png)

Drag and drop nodes:
![service-maps-layout-drag](https://user-images.githubusercontent.com/1967266/92003691-309e1d80-ecf6-11ea-844b-bba141487eb2.gif)


