### PR TITLE
[Security Solution][Exceptions] - Updates enum schema and tests

### DIFF
--- a/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
@@ -18,7 +18,6 @@ import {
   EsDataTypeUnion,
   ExceptionListTypeEnum,
   OperatorEnum,
-  OperatorTypeEnum,
   Type,
   esDataTypeGeoPoint,
   esDataTypeGeoPointRange,
@@ -28,61 +27,10 @@ import {
   esDataTypeUnion,
   exceptionListType,
   operator,
-  operator_type as operatorType,
   type,
 } from './schemas';
 
 describe('Common schemas', () => {
-  describe('operatorType', () => {
-    test('it should validate for "match"', () => {
-      const payload = 'match';
-      const decoded = operatorType.decode(payload);
-      const message = pipe(decoded, foldLeftRight);
-
-      expect(getPaths(left(message.errors))).toEqual([]);
-      expect(message.schema).toEqual(payload);
-    });
-
-    test('it should validate for "match_any"', () => {
-      const payload = 'match_any';
-      const decoded = operatorType.decode(payload);
-      const message = pipe(decoded, foldLeftRight);
-
-      expect(getPaths(left(message.errors))).toEqual([]);
-      expect(message.schema).toEqual(payload);
-    });
-
-    test('it should validate for "list"', () => {
-      const payload = 'list';
-      const decoded = operatorType.decode(payload);
-      const message = pipe(decoded, foldLeftRight);
-
-      expect(getPaths(left(message.errors))).toEqual([]);
-      expect(message.schema).toEqual(payload);
-    });
-
-    test('it should validate for "exists"', () => {
-      const payload = 'exists';
-      const decoded = operatorType.decode(payload);
-      const message = pipe(decoded, foldLeftRight);
-
-      expect(getPaths(left(message.errors))).toEqual([]);
-      expect(message.schema).toEqual(payload);
-    });
-
-    test('it should contain same amount of keys as enum', () => {
-      // Might seem like a weird test, but its meant to
-      // ensure that if operatorType is updated, you
-      // also update the OperatorTypeEnum, a workaround
-      // for io-ts not yet supporting enums
-      // https://github.com/gcanti/io-ts/issues/67
-      const keys = Object.keys(operatorType.keys);
-      const enumKeys = Object.keys(OperatorTypeEnum);
-
-      expect(keys.length).toEqual(enumKeys.length);
-    });
-  });
-
   describe('operator', () => {
     test('it should validate for "included"', () => {
       const payload = 'included';

--- a/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
@@ -16,6 +16,9 @@ import {
   EsDataTypeRangeTerm,
   EsDataTypeSingle,
   EsDataTypeUnion,
+  ExceptionListTypeEnum,
+  OperatorEnum,
+  OperatorTypeEnum,
   Type,
   esDataTypeGeoPoint,
   esDataTypeGeoPointRange,
@@ -67,15 +70,16 @@ describe('Common schemas', () => {
       expect(message.schema).toEqual(payload);
     });
 
-    test('it should contain 4 keys', () => {
+    test('it should contain same amount of keys as enum', () => {
       // Might seem like a weird test, but its meant to
       // ensure that if operatorType is updated, you
       // also update the OperatorTypeEnum, a workaround
       // for io-ts not yet supporting enums
       // https://github.com/gcanti/io-ts/issues/67
       const keys = Object.keys(operatorType.keys);
+      const enumKeys = Object.keys(OperatorTypeEnum);
 
-      expect(keys.length).toEqual(4);
+      expect(keys.length).toEqual(enumKeys.length);
     });
   });
 
@@ -98,15 +102,16 @@ describe('Common schemas', () => {
       expect(message.schema).toEqual(payload);
     });
 
-    test('it should contain 2 keys', () => {
+    test('it should contain same amount of keys as enum', () => {
       // Might seem like a weird test, but its meant to
       // ensure that if operator is updated, you
       // also update the operatorEnum, a workaround
       // for io-ts not yet supporting enums
       // https://github.com/gcanti/io-ts/issues/67
       const keys = Object.keys(operator.keys);
+      const enumKeys = Object.keys(OperatorEnum);
 
-      expect(keys.length).toEqual(2);
+      expect(keys.length).toEqual(enumKeys.length);
     });
   });
 
@@ -129,15 +134,16 @@ describe('Common schemas', () => {
       expect(message.schema).toEqual(payload);
     });
 
-    test('it should contain 2 keys', () => {
+    test('it should contain same amount of keys as enum', () => {
       // Might seem like a weird test, but its meant to
       // ensure that if exceptionListType is updated, you
       // also update the ExceptionListTypeEnum, a workaround
       // for io-ts not yet supporting enums
       // https://github.com/gcanti/io-ts/issues/67
       const keys = Object.keys(exceptionListType.keys);
+      const enumKeys = Object.keys(ExceptionListTypeEnum);
 
-      expect(keys.length).toEqual(2);
+      expect(keys.length).toEqual(enumKeys.length);
     });
   });
 

--- a/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.test.ts
@@ -56,10 +56,10 @@ describe('Common schemas', () => {
       // also update the operatorEnum, a workaround
       // for io-ts not yet supporting enums
       // https://github.com/gcanti/io-ts/issues/67
-      const keys = Object.keys(operator.keys);
-      const enumKeys = Object.keys(OperatorEnum);
+      const keys = Object.keys(operator.keys).sort().join(',').toLowerCase();
+      const enumKeys = Object.keys(OperatorEnum).sort().join(',').toLowerCase();
 
-      expect(keys.length).toEqual(enumKeys.length);
+      expect(keys).toEqual(enumKeys);
     });
   });
 
@@ -88,10 +88,10 @@ describe('Common schemas', () => {
       // also update the ExceptionListTypeEnum, a workaround
       // for io-ts not yet supporting enums
       // https://github.com/gcanti/io-ts/issues/67
-      const keys = Object.keys(exceptionListType.keys);
-      const enumKeys = Object.keys(ExceptionListTypeEnum);
+      const keys = Object.keys(exceptionListType.keys).sort().join(',').toLowerCase();
+      const enumKeys = Object.keys(ExceptionListTypeEnum).sort().join(',').toLowerCase();
 
-      expect(keys.length).toEqual(enumKeys.length);
+      expect(keys).toEqual(enumKeys);
     });
   });
 

--- a/x-pack/plugins/lists/common/schemas/common/schemas.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.ts
@@ -287,6 +287,7 @@ export const operator_type = t.keyof({
   list: null,
   match: null,
   match_any: null,
+  nested: null,
 });
 export type OperatorType = t.TypeOf<typeof operator_type>;
 export enum OperatorTypeEnum {

--- a/x-pack/plugins/lists/common/schemas/common/schemas.ts
+++ b/x-pack/plugins/lists/common/schemas/common/schemas.ts
@@ -282,14 +282,6 @@ export enum OperatorEnum {
   EXCLUDED = 'excluded',
 }
 
-export const operator_type = t.keyof({
-  exists: null,
-  list: null,
-  match: null,
-  match_any: null,
-  nested: null,
-});
-export type OperatorType = t.TypeOf<typeof operator_type>;
 export enum OperatorTypeEnum {
   NESTED = 'nested',
   MATCH = 'match',

--- a/x-pack/plugins/lists/common/shared_exports.ts
+++ b/x-pack/plugins/lists/common/shared_exports.ts
@@ -25,7 +25,6 @@ export {
   NamespaceType,
   Operator,
   OperatorEnum,
-  OperatorType,
   OperatorTypeEnum,
   ExceptionListTypeEnum,
   comment,

--- a/x-pack/plugins/security_solution/common/shared_imports.ts
+++ b/x-pack/plugins/security_solution/common/shared_imports.ts
@@ -25,7 +25,6 @@ export {
   NamespaceType,
   Operator,
   OperatorEnum,
-  OperatorType,
   OperatorTypeEnum,
   ExceptionListTypeEnum,
   exceptionListItemSchema,


### PR DESCRIPTION
## Summary

Thank you to @FrankHassanabad for catching a mistmatch between the io-ts type and the corresponding typescript enum. Currently, io-ts does not have support for enums (https://github.com/gcanti/io-ts/issues/67) - as a workaround I had made a matching typescript enum type. Tests were added to try to ensure the two stayed in sync, but didn't do a straight up comparison of the two, missing this mismatch Frank found.

Updated the tests to now error if the number of keys in the io-ts version and enum do not match.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
