### PR TITLE
[Enterprise Search] Update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -209,8 +209,19 @@ x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json @elastic/kib
 /x-pack/test/functional_with_es_ssl/fixtures/plugins/alerts/ @elastic/kibana-alerting-services
 
 # Enterprise Search
-/x-pack/plugins/enterprise_search/ @elastic/app-search-frontend @elastic/workplace-search-frontend
-/x-pack/test/functional_enterprise_search/ @elastic/app-search-frontend @elastic/workplace-search-frontend
+# Shared
+/x-pack/plugins/enterprise_search/ @elastic/enterprise-search-frontend
+/x-pack/test/functional_enterprise_search/ @elastic/enterprise-search-frontend
+# App Search
+/x-pack/plugins/enterprise_search/public/applications/app_search @elastic/app-search-frontend
+/x-pack/plugins/enterprise_search/server/routes/app_search @elastic/app-search-frontend
+/x-pack/plugins/enterprise_search/server/collectors/app_search @elastic/app-search-frontend
+/x-pack/plugins/enterprise_search/server/saved_objects/app_search @elastic/app-search-frontend
+# Workplace Search
+/x-pack/plugins/enterprise_search/public/applications/workplace_search @elastic/workplace-search-frontend
+/x-pack/plugins/enterprise_search/server/routes/workplace_search @elastic/workplace-search-frontend
+/x-pack/plugins/enterprise_search/server/collectors/workplace_search @elastic/workplace-search-frontend
+/x-pack/plugins/enterprise_search/server/saved_objects/workplace_search @elastic/workplace-search-frontend
 
 # Elasticsearch UI
 /src/plugins/dev_tools/ @elastic/es-ui


### PR DESCRIPTION
## Summary

@elastic/enterprise-search-frontend is a new shared team consisting of both @elastic/app-search-frontend and @elastic/workplace-search-frontend (pending). Combining it into one group in CODEOWNERS means only 1 reviewer is required (as opposed to 1 per team):

<img width="627" alt="Screen Shot 2020-09-02 at 2 30 38 PM" src="https://user-images.githubusercontent.com/549407/92038838-e4200580-ed28-11ea-8cd6-d57d315a915d.png">

In a future world where Kibana changes to a [domain-based directory structure](https://github.com/elastic/kibana/issues/71566#issuecomment-661974439), we can hopefully simplify the 4+ lines of AS/WS-specific code owners to just 1 line/folder.