### PR TITLE
[Functional] Unskip chained controls tests

### DIFF
--- a/test/functional/apps/visualize/input_control_vis/chained_controls.js
+++ b/test/functional/apps/visualize/input_control_vis/chained_controls.js
@@ -26,8 +26,7 @@ export default function ({ getService, getPageObjects }) {
   const find = getService('find');
   const comboBox = getService('comboBox');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/68472
-  describe.skip('chained controls', function () {
+  describe('chained controls', function () {
     this.tags('includeFirefox');
 
     before(async () => {


### PR DESCRIPTION
## Summary

Closes #68472. This was skipped due to flakiness caused by the EUI combobox. An update on EUI has made it stable again.

Flaky test runner (50 times): https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/826/
Flaky test runner (50 times): https://kibana-ci.elastic.co/job/kibana+flaky-test-suite-runner/827/

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios