### PR TITLE
[Ingest Manager] Add permission to write and creates uptime's data stream

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/api_keys/index.ts
@@ -24,7 +24,16 @@ export async function generateOutputApiKey(
       cluster: ['monitor'],
       index: [
         {
-          names: ['logs-*', 'metrics-*', 'events-*', '.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          names: [
+            'logs-*',
+            'metrics-*',
+            'events-*',
+            'synthetics-*',
+            '.ds-logs-*',
+            '.ds-metrics-*',
+            '.ds-events-*',
+            '.ds-synthetics-*',
+          ],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -121,7 +121,16 @@ export async function setupFleet(
       cluster: ['monitor', 'manage_api_key'],
       indices: [
         {
-          names: ['logs-*', 'metrics-*', 'events-*', '.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          names: [
+            'logs-*',
+            'metrics-*',
+            'events-*',
+            'synthetics-*',
+            '.ds-logs-*',
+            '.ds-metrics-*',
+            '.ds-events-*',
+            '.ds-synthetics-*',
+          ],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],


### PR DESCRIPTION
## Summary


This PR adds the `synthetics-*` and the `.ds-synthetics` permissions for
for the uptime application.


cc @andrewvc You will need this in Kibana to generate api keys with the appripriate permissions.
