### PR TITLE
[Security Solution] Fix redirect properly old SIEM App routes

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/url_compatibility.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/url_compatibility.spec.ts
@@ -19,7 +19,7 @@ const ABSOLUTE_DATE = {
 };
 
 // FLAKY: https://github.com/elastic/kibana/issues/75697
-describe.skip('URL compatibility', () => {
+describe('URL compatibility', () => {
   it('Redirects to Detection alerts from old Detections URL', () => {
     loginAndWaitForPage(DETECTIONS);
 

--- a/x-pack/plugins/security_solution/cypress/integration/url_compatibility.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/url_compatibility.spec.ts
@@ -18,7 +18,6 @@ const ABSOLUTE_DATE = {
   startTime: '2019-08-01T20:03:29.186Z',
 };
 
-// FLAKY: https://github.com/elastic/kibana/issues/75697
 describe('URL compatibility', () => {
   it('Redirects to Detection alerts from old Detections URL', () => {
     loginAndWaitForPage(DETECTIONS);

--- a/x-pack/plugins/security_solution/public/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/helpers.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { parseRoute } from './helpers';
+
+describe('public helpers parseRoute', () => {
+  it('should properly parse hash route', () => {
+    const hashSearch =
+      '?timerange=(global:(linkTo:!(timeline),timerange:(from:%272020-09-06T11:43:55.814Z%27,fromStr:now-24h,kind:relative,to:%272020-09-07T11:43:55.814Z%27,toStr:now)),timeline:(linkTo:!(global),timerange:(from:%272020-09-06T11:43:55.814Z%27,fromStr:now-24h,kind:relative,to:%272020-09-07T11:43:55.814Z%27,toStr:now)))';
+    const hashLocation = {
+      hash: `#/detections/rules/id/78acc090-bbaa-4a86-916b-ea44784324ae/edit${hashSearch}`,
+      pathname: '/app/siem',
+      search: '',
+    };
+
+    expect(parseRoute(hashLocation)).toEqual({
+      pageName: 'detections',
+      path: `/rules/id/78acc090-bbaa-4a86-916b-ea44784324ae/edit${hashSearch}`,
+      search: hashSearch,
+    });
+  });
+
+  it('should properly parse non-hash route', () => {
+    const nonHashLocation = {
+      hash: '',
+      pathname: '/app/security/detections/rules/id/78acc090-bbaa-4a86-916b-ea44784324ae/edit',
+      search:
+        '?timerange=(global:(linkTo:!(timeline),timerange:(from:%272020-09-06T11:43:55.814Z%27,fromStr:now-24h,kind:relative,to:%272020-09-07T11:43:55.814Z%27,toStr:now)),timeline:(linkTo:!(global),timerange:(from:%272020-09-06T11:43:55.814Z%27,fromStr:now-24h,kind:relative,to:%272020-09-07T11:43:55.814Z%27,toStr:now)))',
+    };
+
+    expect(parseRoute(nonHashLocation)).toEqual({
+      pageName: 'detections',
+      path: `/rules/id/78acc090-bbaa-4a86-916b-ea44784324ae/edit${nonHashLocation.search}`,
+      search: nonHashLocation.search,
+    });
+  });
+
+  it('should properly parse non-hash subplugin route', () => {
+    const nonHashLocation = {
+      hash: '',
+      pathname: '/app/security/detections',
+      search:
+        '?timerange=(global:(linkTo:!(timeline),timerange:(from:%272020-09-06T11:43:55.814Z%27,fromStr:now-24h,kind:relative,to:%272020-09-07T11:43:55.814Z%27,toStr:now)),timeline:(linkTo:!(global),timerange:(from:%272020-09-06T11:43:55.814Z%27,fromStr:now-24h,kind:relative,to:%272020-09-07T11:43:55.814Z%27,toStr:now)))',
+    };
+
+    expect(parseRoute(nonHashLocation)).toEqual({
+      pageName: 'detections',
+      path: `${nonHashLocation.search}`,
+      search: nonHashLocation.search,
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/helpers.ts
+++ b/x-pack/plugins/security_solution/public/helpers.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { isEmpty } from 'lodash/fp';
+
 import { CoreStart } from '../../../../src/core/public';
 import { APP_ID } from '../common/constants';
 import {
@@ -13,13 +15,37 @@ import {
 import { SecurityPageName } from './app/types';
 import { InspectResponse } from './types';
 
+export const parseRoute = (location: Pick<Location, 'hash' | 'pathname' | 'search'>) => {
+  if (!isEmpty(location.hash)) {
+    const hashPath = location.hash.split('?');
+    const search = hashPath.length >= 1 ? `?${hashPath[1]}` : '';
+    const pageRoute = hashPath.length > 0 ? hashPath[0].split('/') : [];
+    const pageName = pageRoute.length >= 1 ? pageRoute[1] : '';
+    const path = `/${pageRoute.slice(2).join('/') ?? ''}${search}`;
+
+    return {
+      pageName,
+      path,
+      search,
+    };
+  }
+
+  const search = location.search;
+  const pageRoute = location.pathname.split('/');
+  const pageName = pageRoute[3];
+  const subpluginPath = pageRoute.length > 4 ? `/${pageRoute.slice(4).join('/')}` : '';
+  const path = `${subpluginPath}${search}`;
+
+  return {
+    pageName,
+    path,
+    search,
+  };
+};
+
 export const manageOldSiemRoutes = async (coreStart: CoreStart) => {
   const { application } = coreStart;
-  const hashPath = window.location.hash.split('?');
-  const search = hashPath.length >= 1 ? hashPath[1] : '';
-  const pageRoute = hashPath.length > 0 ? hashPath[0].split('/') : [];
-  const pageName = pageRoute.length >= 1 ? pageRoute[1] : '';
-  const path = `/${pageRoute.slice(2).join('/') ?? ''}?${search}`;
+  const { pageName, path, search } = parseRoute(window.location);
 
   switch (pageName) {
     case SecurityPageName.overview:
@@ -73,7 +99,7 @@ export const manageOldSiemRoutes = async (coreStart: CoreStart) => {
     default:
       application.navigateToApp(`${APP_ID}:${SecurityPageName.overview}`, {
         replace: true,
-        path: `?${search}`,
+        path: `${search}`,
       });
       break;
   }


### PR DESCRIPTION
## Summary
The current solution doesn't cover a case where the user accesses `/app/siem/` url without a `#` at the end.
This PR adds support for that case and also some basic unit tests coverage for both cases.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios