### PR TITLE
[Search] Use async es client endpoints

### DIFF
--- a/x-pack/plugins/data_enhanced/server/search/es_search_strategy.test.ts
+++ b/x-pack/plugins/data_enhanced/server/search/es_search_strategy.test.ts
@@ -91,9 +91,9 @@ describe('ES search strategy', () => {
 
     expect(mockGetCaller).toBeCalled();
     const request = mockGetCaller.mock.calls[0][0];
-    expect(request).toEqual({
-      id: 'foo',
-    });
+    expect(request.id).toEqual('foo');
+    expect(request).toHaveProperty('wait_for_completion_timeout');
+    expect(request).toHaveProperty('keep_alive');
   });
 
   it('calls the rollup API if the index is a rollup type', async () => {

--- a/x-pack/plugins/data_enhanced/server/search/es_search_strategy.test.ts
+++ b/x-pack/plugins/data_enhanced/server/search/es_search_strategy.test.ts
@@ -35,12 +35,24 @@ const mockRollupResponse = {
 
 describe('ES search strategy', () => {
   const mockApiCaller = jest.fn();
+  const mockGetCaller = jest.fn();
+  const mockSubmitCaller = jest.fn();
   const mockLogger: any = {
     debug: () => {},
   };
   const mockContext = {
     core: {
-      elasticsearch: { client: { asCurrentUser: { transport: { request: mockApiCaller } } } },
+      elasticsearch: {
+        client: {
+          asCurrentUser: {
+            asyncSearch: {
+              get: mockGetCaller,
+              submit: mockSubmitCaller,
+            },
+            transport: { request: mockApiCaller },
+          },
+        },
+      },
     },
   };
   const mockConfig$ = pluginInitializerContextConfigMock<any>({}).legacy.globalConfig$;
@@ -56,47 +68,32 @@ describe('ES search strategy', () => {
   });
 
   it('makes a POST request to async search with params when no ID is provided', async () => {
-    mockApiCaller.mockResolvedValueOnce(mockAsyncResponse);
+    mockSubmitCaller.mockResolvedValueOnce(mockAsyncResponse);
 
     const params = { index: 'logstash-*', body: { query: {} } };
     const esSearch = await enhancedEsSearchStrategyProvider(mockConfig$, mockLogger);
 
     await esSearch.search((mockContext as unknown) as RequestHandlerContext, { params });
 
-    expect(mockApiCaller).toBeCalled();
-    const { method, path, body } = mockApiCaller.mock.calls[0][0];
-    expect(method).toBe('POST');
-    expect(path).toBe('/logstash-*/_async_search');
-    expect(body).toEqual({ query: {} });
+    expect(mockSubmitCaller).toBeCalled();
+    const request = mockSubmitCaller.mock.calls[0][0];
+    expect(request.index).toEqual(params.index);
+    expect(request.body).toEqual(params.body);
   });
 
   it('makes a GET request to async search with ID when ID is provided', async () => {
-    mockApiCaller.mockResolvedValueOnce(mockAsyncResponse);
+    mockGetCaller.mockResolvedValueOnce(mockAsyncResponse);
 
     const params = { index: 'logstash-*', body: { query: {} } };
     const esSearch = await enhancedEsSearchStrategyProvider(mockConfig$, mockLogger);
 
     await esSearch.search((mockContext as unknown) as RequestHandlerContext, { id: 'foo', params });
 
-    expect(mockApiCaller).toBeCalled();
-    const { method, path, body } = mockApiCaller.mock.calls[0][0];
-    expect(method).toBe('GET');
-    expect(path).toBe('/_async_search/foo');
-    expect(body).toEqual(undefined);
-  });
-
-  it('encodes special characters in the path', async () => {
-    mockApiCaller.mockResolvedValueOnce(mockAsyncResponse);
-
-    const params = { index: 'foo-程', body: {} };
-    const esSearch = await enhancedEsSearchStrategyProvider(mockConfig$, mockLogger);
-
-    await esSearch.search((mockContext as unknown) as RequestHandlerContext, { params });
-
-    expect(mockApiCaller).toBeCalled();
-    const { method, path } = mockApiCaller.mock.calls[0][0];
-    expect(method).toBe('POST');
-    expect(path).toBe('/foo-%E7%A8%8B/_async_search');
+    expect(mockGetCaller).toBeCalled();
+    const request = mockGetCaller.mock.calls[0][0];
+    expect(request).toEqual({
+      id: 'foo',
+    });
   });
 
   it('calls the rollup API if the index is a rollup type', async () => {
@@ -117,16 +114,16 @@ describe('ES search strategy', () => {
   });
 
   it('sets wait_for_completion_timeout and keep_alive in the request', async () => {
-    mockApiCaller.mockResolvedValueOnce(mockAsyncResponse);
+    mockSubmitCaller.mockResolvedValueOnce(mockAsyncResponse);
 
     const params = { index: 'foo-*', body: {} };
     const esSearch = await enhancedEsSearchStrategyProvider(mockConfig$, mockLogger);
 
     await esSearch.search((mockContext as unknown) as RequestHandlerContext, { params });
 
-    expect(mockApiCaller).toBeCalled();
-    const { querystring } = mockApiCaller.mock.calls[0][0];
-    expect(querystring).toHaveProperty('wait_for_completion_timeout');
-    expect(querystring).toHaveProperty('keep_alive');
+    expect(mockSubmitCaller).toBeCalled();
+    const request = mockSubmitCaller.mock.calls[0][0];
+    expect(request).toHaveProperty('wait_for_completion_timeout');
+    expect(request).toHaveProperty('keep_alive');
   });
 });

--- a/x-pack/plugins/data_enhanced/server/search/es_search_strategy.ts
+++ b/x-pack/plugins/data_enhanced/server/search/es_search_strategy.ts
@@ -84,13 +84,18 @@ async function asyncSearch(
   options?: ISearchOptions
 ): Promise<IEsSearchResponse> {
   let esResponse;
+
+  const asyncOptions = {
+    waitForCompletionTimeout: '100ms', // Wait up to 100ms for the response to return
+    keepAlive: '1m', // Extend the TTL for this search request by one minute
+  };
+
   // If we have an ID, then just poll for that ID, otherwise send the entire request body
   if (!request.id) {
     const submitOptions = toSnakeCase({
       batchedReduceSize: 64, // Only report partial results every 64 shards; this should be reduced when we actually display partial results
       trackTotalHits: true, // Get the exact count of hits
-      waitForCompletionTimeout: '100ms', // Wait up to 100ms for the response to return
-      keepAlive: '1m', // Extend the TTL for this search request by one minute
+      ...asyncOptions,
       ...request.params,
     });
 
@@ -98,6 +103,7 @@ async function asyncSearch(
   } else {
     esResponse = await client.asyncSearch.get({
       id: request.id,
+      ...toSnakeCase(asyncOptions),
     });
   }
 

--- a/x-pack/plugins/data_enhanced/server/search/es_search_strategy.ts
+++ b/x-pack/plugins/data_enhanced/server/search/es_search_strategy.ts
@@ -100,7 +100,7 @@ async function asyncSearch(
     keepAlive: '1m', // Extend the TTL for this search request by one minute
   };
 
-  const querystring = toSnakeCase({
+  const queryOptions = toSnakeCase({
     ...asyncOptions,
     ...(batchedReduceSize && { batchedReduceSize }),
     ...queryParams,
@@ -110,7 +110,7 @@ async function asyncSearch(
   if (!request.id) {
     esResponse = await client.asyncSearch.submit({
       body,
-      ...querystring,
+      ...queryOptions,
     });
   } else {
     esResponse = await client.asyncSearch.get({

--- a/x-pack/plugins/data_enhanced/server/search/es_search_strategy.ts
+++ b/x-pack/plugins/data_enhanced/server/search/es_search_strategy.ts
@@ -70,9 +70,8 @@ export const enhancedEsSearchStrategyProvider = (
 
   const cancel = async (context: RequestHandlerContext, id: string) => {
     logger.debug(`cancel ${id}`);
-    await context.core.elasticsearch.client.asCurrentUser.transport.request({
-      method: 'DELETE',
-      path: encodeURI(`/_async_search/${id}`),
+    await context.core.elasticsearch.client.asCurrentUser.asyncSearch.delete({
+      id,
     });
   };
 


### PR DESCRIPTION
## Summary

Use the `ESClient` `asyncSearch` routes, instead of `request.transport`.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
