### PR TITLE
[Ingest Manager] Remove package cache on package uninstall

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
@@ -14,6 +14,7 @@ import { deletePipeline } from '../elasticsearch/ingest_pipeline/';
 import { installIndexPatterns } from '../kibana/index_pattern/install';
 import { packagePolicyService, appContextService } from '../..';
 import { splitPkgKey } from '../registry';
+import { cacheDelete } from '../registry/cache';
 
 export async function removeInstallation(options: {
   savedObjectsClient: SavedObjectsClientContract;
@@ -49,6 +50,10 @@ export async function removeInstallation(options: {
   // Delete the manager saved object with references to the asset objects
   // could also update with [] or some other state
   await savedObjectsClient.delete(PACKAGES_SAVED_OBJECT_TYPE, pkgName);
+
+  // remove the package archive from the cache so that a reinstall fetches a fresh copy from the
+  // registry
+  cacheDelete(pkgkey);
 
   // successful delete's in SO client return {}. return something more useful
   return installedAssets;

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/remove.ts
@@ -13,9 +13,7 @@ import { getInstallation, savedObjectTypes } from './index';
 import { deletePipeline } from '../elasticsearch/ingest_pipeline/';
 import { installIndexPatterns } from '../kibana/index_pattern/install';
 import { packagePolicyService, appContextService } from '../..';
-import { splitPkgKey } from '../registry';
-import { deletePackageCache } from '../registry/cache';
-import * as Registry from '../registry';
+import { splitPkgKey, deletePackageCache, getArchiveInfo } from '../registry';
 
 export async function removeInstallation(options: {
   savedObjectsClient: SavedObjectsClientContract;
@@ -54,7 +52,7 @@ export async function removeInstallation(options: {
 
   // remove the package archive and its contents from the cache so that a reinstall fetches
   // a fresh copy from the registry
-  const paths = await Registry.getArchiveInfo(pkgName, pkgVersion);
+  const paths = await getArchiveInfo(pkgName, pkgVersion);
   deletePackageCache(pkgName, pkgVersion, paths);
 
   // successful delete's in SO client return {}. return something more useful

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/cache.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/cache.ts
@@ -21,18 +21,3 @@ export const setArchiveLocation = (name: string, version: string, location: stri
 
 export const deleteArchiveLocation = (name: string, version: string) =>
   archiveLocationCache.delete(pkgToPkgKey({ name, version }));
-
-export const deletePackageCache = (name: string, version: string, paths: string[]) => {
-  const archiveLocation = getArchiveLocation(name, version);
-  if (archiveLocation) {
-    // delete cached archive
-    cacheDelete(archiveLocation);
-
-    // delete cached archive location
-    deleteArchiveLocation(name, version);
-  }
-  // delete cached archive contents
-  // this has been populated in Registry.getArchiveInfo()
-  // TODO: move cache population and cache cleanup closer together?
-  paths.forEach((path) => cacheDelete(path));
-};

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/cache.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/cache.ts
@@ -18,3 +18,21 @@ export const getArchiveLocation = (name: string, version: string) =>
 
 export const setArchiveLocation = (name: string, version: string, location: string) =>
   archiveLocationCache.set(pkgToPkgKey({ name, version }), location);
+
+export const deleteArchiveLocation = (name: string, version: string) =>
+  archiveLocationCache.delete(pkgToPkgKey({ name, version }));
+
+export const deletePackageCache = (name: string, version: string, paths: string[]) => {
+  const archiveLocation = getArchiveLocation(name, version);
+  if (archiveLocation) {
+    // delete cached archive
+    cacheDelete(archiveLocation);
+
+    // delete cached archive location
+    deleteArchiveLocation(name, version);
+  }
+  // delete cached archive contents
+  // this has been populated in Registry.getArchiveInfo()
+  // TODO: move cache population and cache cleanup closer together?
+  paths.forEach((path) => cacheDelete(path));
+};

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/index.ts
@@ -17,7 +17,15 @@ import {
   RegistrySearchResults,
   RegistrySearchResult,
 } from '../../../types';
-import { cacheGet, cacheSet, cacheHas, getArchiveLocation, setArchiveLocation } from './cache';
+import {
+  cacheGet,
+  cacheSet,
+  cacheDelete,
+  cacheHas,
+  getArchiveLocation,
+  setArchiveLocation,
+  deleteArchiveLocation,
+} from './cache';
 import { ArchiveEntry, untarBuffer, unzipBuffer } from './extract';
 import { fetchUrl, getResponse, getResponseStream } from './requests';
 import { streamToBuffer } from './streams';
@@ -241,3 +249,17 @@ export function groupPathsByService(paths: string[]): AssetsGroupedByServiceByTy
     // elasticsearch: assets.elasticsearch,
   };
 }
+
+export const deletePackageCache = (name: string, version: string, paths: string[]) => {
+  const archiveLocation = getArchiveLocation(name, version);
+  if (archiveLocation) {
+    // delete cached archive
+    cacheDelete(archiveLocation);
+
+    // delete cached archive location
+    deleteArchiveLocation(name, version);
+  }
+  // delete cached archive contents
+  // this has been populated in Registry.getArchiveInfo()
+  paths.forEach((path) => cacheDelete(path));
+};


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/68890

This adds a function to the registry's cache handling that deletes the following from the cache:
* the archive downloaded from the registry, from the main cache
* the contents of that archive, from the main cache
* the path to the archive in the registry, from the archive location cache

### How to test this

* Run Kibana against a local registry.
* Install, then uninstall, then reinstall a package from Settings page of an integration, or with `curl`
* In the terminal output of the registry, observe that every reinstall of the same package triggers a request to the package archive (ending in `.tar.gz` (or `.zip` in a really new registry))
* Compare to `master`, where only the first install of a package triggers a request to the package archive
