### PR TITLE
[Ingest Manager] getInstallType type improvements

### DIFF
--- a/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
@@ -167,7 +167,7 @@ export const installPackageHandler: RequestHandler<
         await removeInstallation({ savedObjectsClient, pkgkey, callCluster });
       }
       if (installType === 'update') {
-        // @ts-ignore installType conditions already check for existence of installedPkg
+        // @ts-ignore getInstallType ensures we have installedPkg
         const prevVersion = `${pkgName}-${installedPkg.attributes.version}`;
         logger.error(`rolling back to ${prevVersion} after error installing ${pkgkey}`);
         await installPackage({

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.test.ts
@@ -45,6 +45,15 @@ describe('install', () => {
     it('should return correct type when installing and no other version is currently installed', () => {
       const installTypeInstall = getInstallType({ pkgVersion: '1.0.0', installedPkg: undefined });
       expect(installTypeInstall).toBe('install');
+
+      // @ts-expect-error can only be 'install' if no installedPkg given
+      expect(installTypeInstall === 'update').toBe(false);
+      // @ts-expect-error can only be 'install' if no installedPkg given
+      expect(installTypeInstall === 'reinstall').toBe(false);
+      // @ts-expect-error can only be 'install' if no installedPkg given
+      expect(installTypeInstall === 'reupdate').toBe(false);
+      // @ts-expect-error can only be 'install' if no installedPkg given
+      expect(installTypeInstall === 'rollback').toBe(false);
     });
 
     it('should return correct type when installing the same version', () => {
@@ -53,6 +62,9 @@ describe('install', () => {
         installedPkg: mockInstallation,
       });
       expect(installTypeReinstall).toBe('reinstall');
+
+      // @ts-expect-error cannot be 'install' if given installedPkg
+      expect(installTypeReinstall === 'install').toBe(false);
     });
 
     it('should return correct type when moving from one version to another', () => {
@@ -61,6 +73,9 @@ describe('install', () => {
         installedPkg: mockInstallation,
       });
       expect(installTypeUpdate).toBe('update');
+
+      // @ts-expect-error cannot be 'install' if given installedPkg
+      expect(installTypeUpdate === 'install').toBe(false);
     });
 
     it('should return correct type when update fails and trys again', () => {
@@ -69,6 +84,9 @@ describe('install', () => {
         installedPkg: mockInstallationUpdateFail,
       });
       expect(installTypeReupdate).toBe('reupdate');
+
+      // @ts-expect-error cannot be 'install' if given installedPkg
+      expect(installTypeReupdate === 'install').toBe(false);
     });
 
     it('should return correct type when attempting to rollback from a failed update', () => {
@@ -77,6 +95,9 @@ describe('install', () => {
         installedPkg: mockInstallationUpdateFail,
       });
       expect(installTypeRollback).toBe('rollback');
+
+      // @ts-expect-error cannot be 'install' if given installedPkg
+      expect(installTypeRollback === 'install').toBe(false);
     });
   });
 });

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.test.ts
@@ -42,36 +42,41 @@ const mockInstallationUpdateFail: SavedObject<Installation> = {
 };
 describe('install', () => {
   describe('getInstallType', () => {
-    it('should return correct type when installing and no other version is currently installed', () => {});
-    const installTypeInstall = getInstallType({ pkgVersion: '1.0.0', installedPkg: undefined });
-    expect(installTypeInstall).toBe('install');
-
-    it('should return correct type when installing the same version', () => {});
-    const installTypeReinstall = getInstallType({
-      pkgVersion: '1.0.0',
-      installedPkg: mockInstallation,
+    it('should return correct type when installing and no other version is currently installed', () => {
+      const installTypeInstall = getInstallType({ pkgVersion: '1.0.0', installedPkg: undefined });
+      expect(installTypeInstall).toBe('install');
     });
-    expect(installTypeReinstall).toBe('reinstall');
 
-    it('should return correct type when moving from one version to another', () => {});
-    const installTypeUpdate = getInstallType({
-      pkgVersion: '1.0.1',
-      installedPkg: mockInstallation,
+    it('should return correct type when installing the same version', () => {
+      const installTypeReinstall = getInstallType({
+        pkgVersion: '1.0.0',
+        installedPkg: mockInstallation,
+      });
+      expect(installTypeReinstall).toBe('reinstall');
     });
-    expect(installTypeUpdate).toBe('update');
 
-    it('should return correct type when update fails and trys again', () => {});
-    const installTypeReupdate = getInstallType({
-      pkgVersion: '1.0.1',
-      installedPkg: mockInstallationUpdateFail,
+    it('should return correct type when moving from one version to another', () => {
+      const installTypeUpdate = getInstallType({
+        pkgVersion: '1.0.1',
+        installedPkg: mockInstallation,
+      });
+      expect(installTypeUpdate).toBe('update');
     });
-    expect(installTypeReupdate).toBe('reupdate');
 
-    it('should return correct type when attempting to rollback from a failed update', () => {});
-    const installTypeRollback = getInstallType({
-      pkgVersion: '1.0.0',
-      installedPkg: mockInstallationUpdateFail,
+    it('should return correct type when update fails and trys again', () => {
+      const installTypeReupdate = getInstallType({
+        pkgVersion: '1.0.1',
+        installedPkg: mockInstallationUpdateFail,
+      });
+      expect(installTypeReupdate).toBe('reupdate');
     });
-    expect(installTypeRollback).toBe('rollback');
+
+    it('should return correct type when attempting to rollback from a failed update', () => {
+      const installTypeRollback = getInstallType({
+        pkgVersion: '1.0.0',
+        installedPkg: mockInstallationUpdateFail,
+      });
+      expect(installTypeRollback).toBe('rollback');
+    });
   });
 });

--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/install.ts
@@ -200,22 +200,20 @@ export async function installPackage({
   );
 
   // if this is an update or retrying an update, delete the previous version's pipelines
-  if (installType === 'update' || installType === 'reupdate') {
+  if ((installType === 'update' || installType === 'reupdate') && installedPkg) {
     await deletePreviousPipelines(
       callCluster,
       savedObjectsClient,
       pkgName,
-      // @ts-ignore installType conditions already check for existence of installedPkg
       installedPkg.attributes.version
     );
   }
   // pipelines from a different version may have installed during a failed update
-  if (installType === 'rollback') {
+  if (installType === 'rollback' && installedPkg) {
     await deletePreviousPipelines(
       callCluster,
       savedObjectsClient,
       pkgName,
-      // @ts-ignore installType conditions already check for existence of installedPkg
       installedPkg.attributes.install_version
     );
   }
@@ -354,17 +352,32 @@ export async function ensurePackagesCompletedInstall(
   return installingPackages;
 }
 
-export function getInstallType({
-  pkgVersion,
-  installedPkg,
-}: {
+interface NoPkgArgs {
   pkgVersion: string;
-  installedPkg: SavedObject<Installation> | undefined;
-}): InstallType {
-  const isInstalledPkg = !!installedPkg;
-  const currentPkgVersion = installedPkg?.attributes.version;
-  const lastStartedInstallVersion = installedPkg?.attributes.install_version;
-  if (!isInstalledPkg) return 'install';
+  installedPkg?: undefined;
+}
+
+interface HasPkgArgs {
+  pkgVersion: string;
+  installedPkg: SavedObject<Installation>;
+}
+
+type OnlyInstall = Extract<InstallType, 'install'>;
+type NotInstall = Exclude<InstallType, 'install'>;
+
+// overloads
+export function getInstallType(args: NoPkgArgs): OnlyInstall;
+export function getInstallType(args: HasPkgArgs): NotInstall;
+export function getInstallType(args: NoPkgArgs | HasPkgArgs): OnlyInstall | NotInstall;
+
+// implementation
+export function getInstallType(args: NoPkgArgs | HasPkgArgs): OnlyInstall | NotInstall {
+  const { pkgVersion, installedPkg } = args;
+  if (!installedPkg) return 'install';
+
+  const currentPkgVersion = installedPkg.attributes.version;
+  const lastStartedInstallVersion = installedPkg.attributes.install_version;
+
   if (pkgVersion === currentPkgVersion && pkgVersion !== lastStartedInstallVersion)
     return 'rollback';
   if (pkgVersion === currentPkgVersion) return 'reinstall';


### PR DESCRIPTION
## Summary

1. https://github.com/elastic/kibana/commit/66975f13397e45a75f9bbf0399b88db9aef725e8 Update `getInstallType` to express that:
   * if called without an `installedPkg`, the only result is `install`
   * if called with an `installedPkg`, the result cannot be `install`
     ```typescript
     function getInstallType(args: NoPkgArgs): OnlyInstall;
     function getInstallType(args: HasPkgArgs): NotInstall;
     function getInstallType(args: NoPkgArgs | HasPkgArgs): OnlyInstall | NotInstall;
     ```
1. https://github.com/elastic/kibana/commit/944cd607959c9c0a05d2c29746d4f5dd73d88976 Add some tests with `@ts-expect-error` to ensure (1) above


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

refs https://github.com/elastic/kibana/pull/76694#issuecomment-687611173

> e.g. no `installPkg` so can only be `install`
> <img width="952" alt="Screen Shot 2020-09-05 at 9 07 21 AM" src="https://user-images.githubusercontent.com/57655/92305770-47dc4580-ef58-11ea-8e86-a088c3c2e692.png">
>
> e.g. given `installPkg` so cannot be `install`
> <img width="769" alt="Screen Shot 2020-09-05 at 9 07 56 AM" src="https://user-images.githubusercontent.com/57655/92305771-4874dc00-ef58-11ea-9cd7-28ed7c4266b7.png">
