### PR TITLE
[Monitoring] Prevent edit/create for Stack Monitoring alerts in Alerts Management

### DIFF
--- a/x-pack/plugins/monitoring/public/alerts/cpu_usage_alert/cpu_usage_alert.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/cpu_usage_alert/cpu_usage_alert.tsx
@@ -23,6 +23,6 @@ export function createCpuUsageAlertType(): AlertTypeModel {
     ),
     validate,
     defaultActionMessage: '{{context.internalFullMessage}}',
-    requiresAppContext: false,
+    requiresAppContext: true,
   };
 }

--- a/x-pack/plugins/monitoring/public/alerts/legacy_alert/legacy_alert.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/legacy_alert/legacy_alert.tsx
@@ -33,7 +33,7 @@ export function createLegacyAlertTypes(): AlertTypeModel[] {
       ),
       defaultActionMessage: '{{context.internalFullMessage}}',
       validate: () => ({ errors: {} }),
-      requiresAppContext: false,
+      requiresAppContext: true,
     };
   });
 }


### PR DESCRIPTION
Resolves #75414

This prevents the creation and editing of Stack Monitoring-specific alerts in the Alerts Management UI since the creation creates a broken UX. The alerting team will follow up in a future version with support for editing but not creation and at that point, we can revert this.