### PR TITLE
[Enterprise Search] Update shared API request handler

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -70,6 +70,9 @@ export const WORKPLACE_SEARCH_PLUGIN = {
 
 export const LICENSED_SUPPORT_URL = 'https://support.elastic.co';
 
-export const JSON_HEADER = { 'Content-Type': 'application/json' }; // This needs specific casing or Chrome throws a 415 error
+export const JSON_HEADER = {
+  'Content-Type': 'application/json', // This needs specific casing or Chrome throws a 415 error
+  Accept: 'application/json', // Required for Enterprise Search APIs
+};
 
 export const ENGINES_PAGE_SIZE = 10;

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -150,18 +150,26 @@ describe('EnterpriseSearchRequestHandler', () => {
       );
     });
 
-    it('returns an error when user authentication to Enterprise Search fails', async () => {
-      EnterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/login' });
-      const requestHandler = enterpriseSearchRequestHandler.createRequest({
-        path: '/api/unauthenticated',
+    describe('user authentication errors', () => {
+      afterEach(async () => {
+        const requestHandler = enterpriseSearchRequestHandler.createRequest({
+          path: '/api/unauthenticated',
+        });
+        await makeAPICall(requestHandler);
+
+        EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/unauthenticated');
+        expect(responseMock.customError).toHaveBeenCalledWith({
+          body: 'Error connecting to Enterprise Search: Cannot authenticate Enterprise Search user',
+          statusCode: 502,
+        });
       });
 
-      await makeAPICall(requestHandler);
-      EnterpriseSearchAPI.shouldHaveBeenCalledWith('http://localhost:3002/api/unauthenticated');
+      it('errors when redirected to /login', async () => {
+        EnterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/login' });
+      });
 
-      expect(responseMock.customError).toHaveBeenCalledWith({
-        body: 'Error connecting to Enterprise Search: Cannot authenticate Enterprise Search user',
-        statusCode: 502,
+      it('errors when redirected to /ent/select', async () => {
+        EnterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/ent/select' });
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { mockConfig, mockLogger } from '../__mocks__';
+import { JSON_HEADER } from '../../common/constants';
 
 import { EnterpriseSearchRequestHandler } from './enterprise_search_request_handler';
 
@@ -193,7 +194,7 @@ const makeAPICall = (handler: Function, params = {}) => {
 const EnterpriseSearchAPI = {
   shouldHaveBeenCalledWith(expectedUrl: string, expectedParams = {}) {
     expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
-      headers: { Authorization: 'Basic 123' },
+      headers: { Authorization: 'Basic 123', ...JSON_HEADER },
       method: 'GET',
       body: undefined,
       ...expectedParams,

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -14,6 +14,7 @@ import {
   Logger,
 } from 'src/core/server';
 import { ConfigType } from '../index';
+import { JSON_HEADER } from '../../common/constants';
 
 interface IConstructorDependencies {
   config: ConfigType;
@@ -65,7 +66,7 @@ export class EnterpriseSearchRequestHandler {
 
         // Set up API options
         const { method } = request.route;
-        const headers = { Authorization: request.headers.authorization as string };
+        const headers = { Authorization: request.headers.authorization as string, ...JSON_HEADER };
         const body = !this.isEmptyObj(request.body as object)
           ? JSON.stringify(request.body)
           : undefined;

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -73,7 +73,7 @@ export class EnterpriseSearchRequestHandler {
         // Call the Enterprise Search API and pass back response to the front-end
         const apiResponse = await fetch(url, { method, headers, body });
 
-        if (apiResponse.url.endsWith('/login')) {
+        if (apiResponse.url.endsWith('/login') || apiResponse.url.endsWith('/ent/select')) {
           throw new Error('Cannot authenticate Enterprise Search user');
         }
 

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -25,7 +25,7 @@ interface IRequestParams<ResponseBody> {
   hasValidData?: (body?: ResponseBody) => boolean;
 }
 export interface IEnterpriseSearchRequestHandler {
-  createRequest(requestParams?: object): RequestHandler<unknown, Readonly<{}>, unknown>;
+  createRequest(requestParams?: object): RequestHandler<unknown, unknown, unknown>;
 }
 
 /**
@@ -52,12 +52,12 @@ export class EnterpriseSearchRequestHandler {
   }: IRequestParams<ResponseBody>) {
     return async (
       _context: RequestHandlerContext,
-      request: KibanaRequest<unknown, Readonly<{}>, unknown>,
+      request: KibanaRequest<unknown, unknown, unknown>,
       response: KibanaResponseFactory
     ) => {
       try {
         // Set up API URL
-        const queryParams = { ...request.query, ...params };
+        const queryParams = { ...(request.query as object), ...params };
         const queryString = !this.isEmptyObj(queryParams)
           ? `?${querystring.stringify(queryParams)}`
           : '';


### PR DESCRIPTION
## Summary

Updates our shared `enterpriseSearchRequestHandler` lib with the following changes that need to be made (primarily for future endpoints) due to recent Enterprise Search changes:

- Add user auth check for `/ent/select` redirects (was previously showing JSON token at 0 errors)
- Fix `request.query` typing (affects future endpoints with new queries)
- Add `Accept` and `Content-Type` JSON headers to Enterprise Search requests (affects future POST/PUT/DELETE endpoints & endpoints that send JSON bodies to Enterprise Search)

Thanks to @scottybollinger for finding these issues in his trailblazing Workplace Search efforts!

## QA/Regression Testing

- [x] Telemetry XHRs still work (in both Chrome and Firefox)
- [x] Current server-side API calls work as-is

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios