### PR TITLE
Use new date_histogram intervals in timelion

### DIFF
--- a/src/plugins/vis_type_timelion/server/series_functions/es/es.test.js
+++ b/src/plugins/vis_type_timelion/server/series_functions/es/es.test.js
@@ -100,9 +100,17 @@ describe('es', () => {
       expect(agg.time_buckets.date_histogram.time_zone).to.equal('Etc/UTC');
     });
 
-    it('sets the field and interval', () => {
+    it('sets the field', () => {
       expect(agg.time_buckets.date_histogram.field).to.equal('@timestamp');
-      expect(agg.time_buckets.date_histogram.interval).to.equal('1y');
+    });
+
+    it('sets the interval for calendar_interval correctly', () => {
+      expect(agg.time_buckets.date_histogram).to.have.property('calendar_interval', '1y');
+    });
+
+    it('sets the interval for fixed_interval correctly', () => {
+      const a = createDateAgg({ timefield: '@timestamp', interval: '24h' }, tlConfig);
+      expect(a.time_buckets.date_histogram).to.have.property('fixed_interval', '24h');
     });
 
     it('sets min_doc_count to 0', () => {

--- a/src/plugins/vis_type_timelion/server/series_functions/es/lib/create_date_agg.js
+++ b/src/plugins/vis_type_timelion/server/series_functions/es/lib/create_date_agg.js
@@ -19,6 +19,8 @@
 
 import _ from 'lodash';
 import { buildAggBody } from './agg_body';
+import { search } from '../../../../../../plugins/data/server';
+const { dateHistogramInterval } = search.aggs;
 
 export default function createDateAgg(config, tlConfig, scriptedFields) {
   const dateAgg = {
@@ -26,13 +28,13 @@ export default function createDateAgg(config, tlConfig, scriptedFields) {
       meta: { type: 'time_buckets' },
       date_histogram: {
         field: config.timefield,
-        interval: config.interval,
         time_zone: tlConfig.time.timezone,
         extended_bounds: {
           min: tlConfig.time.from,
           max: tlConfig.time.to,
         },
         min_doc_count: 0,
+        ...dateHistogramInterval(config.interval),
       },
     },
   };


### PR DESCRIPTION
## Summary

Makes sure to uses the `fixed_interval` and `calendar_interval` in `date_histogram` in Timelion.

Part of https://github.com/elastic/kibana/issues/27410

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
