### PR TITLE
Add the Enterprise Search logo to the Overview search result

### DIFF
--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -53,6 +53,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     core.application.register({
       id: ENTERPRISE_SEARCH_PLUGIN.ID,
       title: ENTERPRISE_SEARCH_PLUGIN.NAV_TITLE,
+      euiIconType: ENTERPRISE_SEARCH_PLUGIN.LOGO,
       appRoute: ENTERPRISE_SEARCH_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {


### PR DESCRIPTION
## Summary

Adds the Enterprise Search logo for the new Overview page so that it appears in the search results like so:

Side note: we're working on adding some metadata below the page title that will signify which solution/category the result belongs too. In other words, this will soon show _Enterprise Search_ as a subtitle under the _Overview_ text.

#### Before
<img width="332" alt="Screen Shot 2020-09-15 at 9 38 12 AM" src="https://user-images.githubusercontent.com/446285/93238383-f8133080-f746-11ea-8418-5021a0dec999.png">

#### After
<img width="347" alt="Screen Shot 2020-09-15 at 11 26 00 AM" src="https://user-images.githubusercontent.com/446285/93238394-fea1a800-f746-11ea-98fe-0a7ec29a002c.png">


### Checklist

Delete any items that are not applicable to this PR.

N/A
