### PR TITLE
[Enterprise Search] Add flag to restrict width of layout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { EuiPageSideBar, EuiButton } from '@elastic/eui';
+import { EuiPageSideBar, EuiButton, EuiPageBody } from '@elastic/eui';
 
 import { Layout, INavContext } from './layout';
 
@@ -15,6 +15,13 @@ describe('Layout', () => {
     const wrapper = shallow(<Layout navigation={null} />);
 
     expect(wrapper.find('.enterpriseSearchLayout')).toHaveLength(1);
+    expect(wrapper.find(EuiPageBody).prop('restrictWidth')).toBeFalsy();
+  });
+
+  it('passes the restrictWidth prop', () => {
+    const wrapper = shallow(<Layout navigation={null} restrictWidth />);
+
+    expect(wrapper.find(EuiPageBody).prop('restrictWidth')).toEqual(true);
   });
 
   it('renders navigation', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.tsx
@@ -14,6 +14,7 @@ import './layout.scss';
 
 interface ILayoutProps {
   navigation: React.ReactNode;
+  restrictWidth?: boolean;
 }
 
 export interface INavContext {
@@ -21,7 +22,7 @@ export interface INavContext {
 }
 export const NavContext = React.createContext({});
 
-export const Layout: React.FC<ILayoutProps> = ({ children, navigation }) => {
+export const Layout: React.FC<ILayoutProps> = ({ children, navigation, restrictWidth }) => {
   const [isNavOpen, setIsNavOpen] = useState(false);
   const toggleNavigation = () => setIsNavOpen(!isNavOpen);
   const closeNavigation = () => setIsNavOpen(false);
@@ -54,7 +55,9 @@ export const Layout: React.FC<ILayoutProps> = ({ children, navigation }) => {
         </div>
         <NavContext.Provider value={{ closeNavigation }}>{navigation}</NavContext.Provider>
       </EuiPageSideBar>
-      <EuiPageBody className="enterpriseSearchLayout__body">{children}</EuiPageBody>
+      <EuiPageBody className="enterpriseSearchLayout__body" restrictWidth={restrictWidth}>
+        {children}
+      </EuiPageBody>
     </EuiPage>
   );
 };


### PR DESCRIPTION


## Summary

This PR adds a boolean flag to restrict the width of the Enterprise Search layout file for use in Workplace Search.

**Usage**
```JavaScript
<Layout navigation={<WorkplaceSearchNav />} restrictWidth>
  ...
</Layout>
```

**Before**
![_before](https://user-images.githubusercontent.com/1869731/93255480-9f9c5d00-f75f-11ea-9185-9fb9a264df30.png)

**After**
![_after](https://user-images.githubusercontent.com/1869731/93255624-c9ee1a80-f75f-11ea-8db8-1aaa06e70af8.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
