### PR TITLE
[Enterprise Search] Minor flashAPIMessages update

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
@@ -52,6 +52,20 @@ describe('flashAPIErrors', () => {
     ]);
   });
 
+  it('falls back to the basic message for http responses without an errors array', () => {
+    flashAPIErrors({
+      body: {
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Not Found',
+      },
+    } as any);
+
+    expect(FlashMessagesLogic.actions.setFlashMessages).toHaveBeenCalledWith([
+      { type: 'error', message: 'Not Found' },
+    ]);
+  });
+
   it('displays a generic error message and re-throws non-API errors', () => {
     try {
       flashAPIErrors(Error('whatever') as any);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
@@ -40,7 +40,7 @@ export const flashAPIErrors = (
 
   const errorFlashMessages: IFlashMessage[] = Array.isArray(error?.body?.attributes?.errors)
     ? error.body!.attributes.errors.map((message) => ({ type: 'error', message }))
-    : [{ type: 'error', message: defaultErrorMessage }];
+    : [{ type: 'error', message: error?.body?.message || defaultErrorMessage }];
 
   if (isQueued) {
     FlashMessagesLogic.actions.setQueuedMessages(errorFlashMessages);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
@@ -12,3 +12,4 @@ export {
   IFlashMessagesActions,
 } from './flash_messages_logic';
 export { FlashMessagesProvider } from './flash_messages_provider';
+export { flashAPIErrors } from './handle_api_errors';


### PR DESCRIPTION
## Summary

Follow up to #77258 - I forgot to export the helper :dead_inside:

I also realized that we should add some kind of fallback for HTTP errors without an `attributes.errors` array/key (applies to HTTP errors that aren't ours, and some of our returned server errors). The `messages` key works really well for this purpose since it's required by Kibana's response factory.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios