### PR TITLE
[APM] Disable incremental builds for APM-only type check

### DIFF
--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/optimize.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/optimize.js
@@ -11,6 +11,7 @@ const { promisify } = require('util');
 const path = require('path');
 const json5 = require('json5');
 const execa = require('execa');
+const { omit } = require('lodash');
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -27,6 +28,7 @@ function prepareParentTsConfigs() {
   return Promise.all(
     [
       path.resolve(xpackRoot, 'tsconfig.json'),
+      path.resolve(kibanaRoot, 'tsconfig.base.json'),
       path.resolve(kibanaRoot, 'tsconfig.json'),
     ].map(async (filename) => {
       const config = json5.parse(await readFile(filename, 'utf-8'));
@@ -35,7 +37,11 @@ function prepareParentTsConfigs() {
         filename,
         JSON.stringify(
           {
-            ...config,
+            ...omit(config, 'references'),
+            compilerOptions: {
+              ...config.compilerOptions,
+              incremental: false,
+            },
             include: [],
           },
           null,

--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
@@ -13,6 +13,7 @@ const tsconfigTpl = path.resolve(__dirname, './tsconfig.json');
 const filesToIgnore = [
   path.resolve(xpackRoot, 'tsconfig.json'),
   path.resolve(kibanaRoot, 'tsconfig.json'),
+  path.resolve(kibanaRoot, 'tsconfig.base.json'),
 ];
 
 module.exports = {

--- a/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/lib/traces/get_trace_items.ts
@@ -88,7 +88,7 @@ export async function getTraceItems(
     // explicit intermediary types to avoid TS "excessively deep" error
     PromiseValueType<typeof errorResponsePromise>,
     PromiseValueType<typeof traceResponsePromise>
-  ] = await Promise.all([errorResponsePromise, traceResponsePromise]);
+  ] = (await Promise.all([errorResponsePromise, traceResponsePromise])) as any;
 
   const exceedsMax = traceResponse.hits.total.value > maxTraceItems;
 


### PR DESCRIPTION
With project references being enabled now, the CLI check broke when the APM type-check optimization was applied (TS in the editor works fine because it's not using project references). 

This change disables incremental builds/references on all configurations used by the APM-only type-check for that reason.

Some numbers:
- Building the whole project takes about ~5m
- Building x-pack only (after building the whole project) takes about ~2.5m
- Type-checking only code used by APM takes about ~45s
