### PR TITLE
Add CSM paths for uptime team to path labeller

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -16,3 +16,11 @@
     - "x-pack/test/epm_api_integration/**/*.*"
   - "Team:uptime":
     - "x-pack/plugins/uptime/**/*.*"
+    - "x-pack/plugins/apm/e2e/cypress/support/step_definitions/csm/*.*"
+    - "x-pack/plugins/apm/public/application/csmApp.tsx"
+    - "x-pack/plugins/apm/public/components/app/RumDashboard/**/*.*"
+    - "x-pack/plugins/apm/public/components/app/RumDashboard/*.*"
+    - "x-pack/plugins/apm/server/lib/rum_client/**/*.*"
+    - "x-pack/plugins/apm/server/lib/rum_client/*.*"
+    - "x-pack/plugins/apm/server/routes/rum_client.ts"
+    - "x-pack/plugins/apm/server/projections/rum_overview.ts"


### PR DESCRIPTION
This should make it so labels are applied correctly to PRs for CSM.