### PR TITLE
[Enterprise Search] Add helpers for flash messages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
@@ -6,7 +6,7 @@
 
 import { resetContext } from 'kea';
 
-import { FlashMessagesLogic, IFlashMessage, setSuccessMessage } from './flash_messages_logic';
+import { FlashMessagesLogic, IFlashMessage } from './flash_messages_logic';
 
 describe('FlashMessagesLogic', () => {
   const DEFAULT_VALUES = {
@@ -77,21 +77,6 @@ describe('FlashMessagesLogic', () => {
       FlashMessagesLogic.actions.clearQueuedMessages();
 
       expect(FlashMessagesLogic.values.queuedMessages).toEqual([]);
-    });
-  });
-
-  describe('setSuccessMessage()', () => {
-    it('sets a flash message', () => {
-      const message = 'I am a message';
-      FlashMessagesLogic.mount();
-      setSuccessMessage(message);
-
-      expect(FlashMessagesLogic.values.messages).toEqual([
-        {
-          message: 'I am a message',
-          type: 'success',
-        },
-      ]);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
@@ -6,7 +6,7 @@
 
 import { resetContext } from 'kea';
 
-import { FlashMessagesLogic, IFlashMessage } from './flash_messages_logic';
+import { FlashMessagesLogic, IFlashMessage, setSuccessMessage } from './flash_messages_logic';
 
 describe('FlashMessagesLogic', () => {
   const DEFAULT_VALUES = {
@@ -77,6 +77,21 @@ describe('FlashMessagesLogic', () => {
       FlashMessagesLogic.actions.clearQueuedMessages();
 
       expect(FlashMessagesLogic.values.queuedMessages).toEqual([]);
+    });
+  });
+
+  describe('setSuccessMessage()', () => {
+    it('sets a flash message', () => {
+      const message = 'I am a message';
+      FlashMessagesLogic.mount();
+      setSuccessMessage(message);
+
+      expect(FlashMessagesLogic.values.messages).toEqual([
+        {
+          message: 'I am a message',
+          type: 'success',
+        },
+      ]);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
@@ -80,10 +80,3 @@ export const FlashMessagesLogic = kea<MakeLogicType<IFlashMessagesValues, IFlash
     },
   }),
 });
-
-export const setSuccessMessage = (message: string) => {
-  FlashMessagesLogic.actions.setFlashMessages({
-    type: 'success',
-    message,
-  });
-};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
@@ -80,3 +80,10 @@ export const FlashMessagesLogic = kea<MakeLogicType<IFlashMessagesValues, IFlash
     },
   }),
 });
+
+export const setSuccessMessage = (message: string) => {
+  FlashMessagesLogic.actions.setFlashMessages({
+    type: 'success',
+    message,
+  });
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
@@ -13,3 +13,4 @@ export {
 } from './flash_messages_logic';
 export { FlashMessagesProvider } from './flash_messages_provider';
 export { flashAPIErrors } from './handle_api_errors';
+export { setSuccessMessage, setErrorMessage, setQueuedSuccessMessage } from './set_message_helpers';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -4,8 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
-
 import {
   FlashMessagesLogic,
   setSuccessMessage,
@@ -13,7 +11,7 @@ import {
   setQueuedSuccessMessage,
 } from './';
 
-describe('', () => {
+describe('Flash Message Helpers', () => {
   const message = 'I am a message';
 
   describe('setSuccessMessage()', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -17,7 +17,7 @@ describe('', () => {
   const message = 'I am a message';
 
   describe('setSuccessMessage()', () => {
-    it('sets a flash message', () => {
+    it('sets a success message', () => {
       FlashMessagesLogic.mount();
       setSuccessMessage(message);
 
@@ -31,7 +31,7 @@ describe('', () => {
   });
 
   describe('setErrorMessage()', () => {
-    it('sets a flash message', () => {
+    it('sets an error message', () => {
       FlashMessagesLogic.mount();
       setErrorMessage(message);
 
@@ -45,7 +45,7 @@ describe('', () => {
   });
 
   describe('setQueuedSuccessMessage()', () => {
-    it('sets a flash message', () => {
+    it('sets a queued success message', () => {
       FlashMessagesLogic.mount();
       setQueuedSuccessMessage(message);
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -14,45 +14,40 @@ import {
 describe('Flash Message Helpers', () => {
   const message = 'I am a message';
 
-  describe('setSuccessMessage()', () => {
-    it('sets a success message', () => {
-      FlashMessagesLogic.mount();
-      setSuccessMessage(message);
-
-      expect(FlashMessagesLogic.values.messages).toEqual([
-        {
-          message,
-          type: 'success',
-        },
-      ]);
-    });
+  beforeEach(() => {
+    FlashMessagesLogic.mount();
   });
 
-  describe('setErrorMessage()', () => {
-    it('sets an error message', () => {
-      FlashMessagesLogic.mount();
-      setErrorMessage(message);
+  it('etSuccessMessage()', () => {
+    setSuccessMessage(message);
 
-      expect(FlashMessagesLogic.values.messages).toEqual([
-        {
-          message,
-          type: 'error',
-        },
-      ]);
-    });
+    expect(FlashMessagesLogic.values.messages).toEqual([
+      {
+        message,
+        type: 'success',
+      },
+    ]);
   });
 
-  describe('setQueuedSuccessMessage()', () => {
-    it('sets a queued success message', () => {
-      FlashMessagesLogic.mount();
-      setQueuedSuccessMessage(message);
+  it('setErrorMessage()', () => {
+    setErrorMessage(message);
 
-      expect(FlashMessagesLogic.values.queuedMessages).toEqual([
-        {
-          message,
-          type: 'success',
-        },
-      ]);
-    });
+    expect(FlashMessagesLogic.values.messages).toEqual([
+      {
+        message,
+        type: 'error',
+      },
+    ]);
+  });
+
+  it('setQueuedSuccessMessage()', () => {
+    setQueuedSuccessMessage(message);
+
+    expect(FlashMessagesLogic.values.queuedMessages).toEqual([
+      {
+        message,
+        type: 'success',
+      },
+    ]);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -23,7 +23,7 @@ describe('', () => {
 
       expect(FlashMessagesLogic.values.messages).toEqual([
         {
-          message: 'I am a message',
+          message,
           type: 'success',
         },
       ]);
@@ -37,7 +37,7 @@ describe('', () => {
 
       expect(FlashMessagesLogic.values.messages).toEqual([
         {
-          message: 'I am a message',
+          message,
           type: 'error',
         },
       ]);
@@ -51,7 +51,7 @@ describe('', () => {
 
       expect(FlashMessagesLogic.values.queuedMessages).toEqual([
         {
-          message: 'I am a message',
+          message,
           type: 'success',
         },
       ]);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { resetContext } from 'kea';
+
+import {
+  FlashMessagesLogic,
+  setSuccessMessage,
+  setErrorMessage,
+  setQueuedSuccessMessage,
+} from './';
+
+describe('', () => {
+  const message = 'I am a message';
+
+  describe('setSuccessMessage()', () => {
+    it('sets a flash message', () => {
+      FlashMessagesLogic.mount();
+      setSuccessMessage(message);
+
+      expect(FlashMessagesLogic.values.messages).toEqual([
+        {
+          message: 'I am a message',
+          type: 'success',
+        },
+      ]);
+    });
+  });
+
+  describe('setErrorMessage()', () => {
+    it('sets a flash message', () => {
+      FlashMessagesLogic.mount();
+      setErrorMessage(message);
+
+      expect(FlashMessagesLogic.values.messages).toEqual([
+        {
+          message: 'I am a message',
+          type: 'error',
+        },
+      ]);
+    });
+  });
+
+  describe('setQueuedSuccessMessage()', () => {
+    it('sets a flash message', () => {
+      FlashMessagesLogic.mount();
+      setQueuedSuccessMessage(message);
+
+      expect(FlashMessagesLogic.values.queuedMessages).toEqual([
+        {
+          message: 'I am a message',
+          type: 'success',
+        },
+      ]);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -18,7 +18,7 @@ describe('Flash Message Helpers', () => {
     FlashMessagesLogic.mount();
   });
 
-  it('etSuccessMessage()', () => {
+  it('setSuccessMessage()', () => {
     setSuccessMessage(message);
 
     expect(FlashMessagesLogic.values.messages).toEqual([

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { FlashMessagesLogic } from './';
+
+export const setSuccessMessage = (message: string) => {
+  FlashMessagesLogic.actions.setFlashMessages({
+    type: 'success',
+    message,
+  });
+};
+
+export const setErrorMessage = (message: string) => {
+  FlashMessagesLogic.actions.setFlashMessages({
+    type: 'error',
+    message,
+  });
+};
+
+export const setQueuedSuccessMessage = (message: string) => {
+  FlashMessagesLogic.actions.setQueuedMessages({
+    type: 'success',
+    message,
+  });
+};


### PR DESCRIPTION
## Summary

With the current FlashMessages implementation, the setting of a simple message is quite verbose. This PR exposes simple methods that set single-string messages, which covers most use cases in the logic files.

**Before**
```JavaScript
FlashMessagesLogic.actions.setFlashMessages({
  type: 'success',
  message: 'Successfully created bird.',
});
```
**After**
```JavaScript
setSuccessMessage('Successfully created bird.');
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
