### PR TITLE
[Enterprise Search][tech debt] Add Kea logic paths for easier debugging/defaults

### DIFF
--- a/x-pack/plugins/enterprise_search/README.md
+++ b/x-pack/plugins/enterprise_search/README.md
@@ -13,6 +13,14 @@ This plugin's goal is to provide a Kibana user interface to the Enterprise Searc
 2. Update `config/kibana.dev.yml` with `enterpriseSearch.host: 'http://localhost:3002'`
 3. For faster QA/development, run Enterprise Search on [elasticsearch-native auth](https://www.elastic.co/guide/en/app-search/current/security-and-users.html#app-search-self-managed-security-and-user-management-elasticsearch-native-realm) and log in as the `elastic` superuser on Kibana.
 
+### Kea
+
+Enterprise Search uses [Kea.js](https://github.com/keajs/kea) to manage our React/Redux state for us. Kea state is handled in our `*Logic` files and exposes [values](https://kea.js.org/docs/guide/concepts#values) and [actions](https://kea.js.org/docs/guide/concepts#actions) for our components to get and set state with.
+
+#### Debugging Kea
+
+To debug Kea state in-browser, Kea recommends [Redux Devtools](https://kea.js.org/docs/guide/debugging). To facilitate debugging, we use the [path](https://kea.js.org/docs/guide/debugging/#setting-the-path-manually) key with `snake_case`d paths. The path key should always end with the logic filename (e.g. `['enterprise_search', 'some_logic']`) to make it easy for devs to quickly find/jump to files via IDE tooling.
+
 ## Testing
 
 ### Unit tests

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -16,6 +16,7 @@ export interface IAppActions {
 }
 
 export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
+  path: ['enterpriseSearch', 'appSearch', 'app'],
   actions: {
     initializeAppData: (props) => props,
   },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -16,7 +16,7 @@ export interface IAppActions {
 }
 
 export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
-  path: ['enterpriseSearch', 'appSearch', 'app'],
+  path: ['enterprise_search', 'app_search', 'app_logic'],
   actions: {
     initializeAppData: (props) => props,
   },

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
@@ -32,7 +32,7 @@ const convertToArray = (messages: IFlashMessage | IFlashMessage[]) =>
   !Array.isArray(messages) ? [messages] : messages;
 
 export const FlashMessagesLogic = kea<MakeLogicType<IFlashMessagesValues, IFlashMessagesActions>>({
-  path: ['enterpriseSearch', 'flashMessages'],
+  path: ['enterprise_search', 'flash_messages_logic'],
   actions: {
     setFlashMessages: (messages) => ({ messages: convertToArray(messages) }),
     clearFlashMessages: () => null,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
@@ -32,6 +32,7 @@ const convertToArray = (messages: IFlashMessage | IFlashMessage[]) =>
   !Array.isArray(messages) ? [messages] : messages;
 
 export const FlashMessagesLogic = kea<MakeLogicType<IFlashMessagesValues, IFlashMessagesActions>>({
+  path: ['enterpriseSearch', 'flashMessages'],
   actions: {
     setFlashMessages: (messages) => ({ messages: convertToArray(messages) }),
     clearFlashMessages: () => null,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/http/http_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/http/http_logic.ts
@@ -27,7 +27,7 @@ export interface IHttpActions {
 }
 
 export const HttpLogic = kea<MakeLogicType<IHttpValues, IHttpActions>>({
-  path: ['enterpriseSearch', 'http'],
+  path: ['enterprise_search', 'http_logic'],
   actions: {
     initializeHttp: ({ http, errorConnecting }) => ({ http, errorConnecting }),
     initializeHttpInterceptors: () => null,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/http/http_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/http/http_logic.ts
@@ -27,6 +27,7 @@ export interface IHttpActions {
 }
 
 export const HttpLogic = kea<MakeLogicType<IHttpValues, IHttpActions>>({
+  path: ['enterpriseSearch', 'http'],
   actions: {
     initializeHttp: ({ http, errorConnecting }) => ({ http, errorConnecting }),
     initializeHttpInterceptors: () => null,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -22,7 +22,7 @@ export interface IAppActions {
 }
 
 export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
-  path: ['enterpriseSearch', 'workplaceSearch', 'app'],
+  path: ['enterprise_search', 'workplace_search', 'app_logic'],
   actions: {
     initializeAppData: ({ workplaceSearch, isFederatedAuth }) => ({
       workplaceSearch,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -22,6 +22,7 @@ export interface IAppActions {
 }
 
 export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
+  path: ['enterpriseSearch', 'workplaceSearch', 'app'],
   actions: {
     initializeAppData: ({ workplaceSearch, isFederatedAuth }) => ({
       workplaceSearch,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
@@ -31,6 +31,7 @@ export interface IOverviewValues extends IOverviewServerData {
 }
 
 export const OverviewLogic = kea<MakeLogicType<IOverviewValues, IOverviewActions>>({
+  path: ['enterpriseSearch', 'workplaceSearch', 'overview'],
   actions: {
     setServerData: (serverData) => serverData,
     initializeOverview: () => null,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
@@ -31,7 +31,7 @@ export interface IOverviewValues extends IOverviewServerData {
 }
 
 export const OverviewLogic = kea<MakeLogicType<IOverviewValues, IOverviewActions>>({
-  path: ['enterpriseSearch', 'workplaceSearch', 'overview'],
+  path: ['enterprise_search', 'workplace_search', 'overview_logic'],
   actions: {
     setServerData: (serverData) => serverData,
     initializeOverview: () => null,


### PR DESCRIPTION
## Summary

Promise I'm not trying to steal your thunder @JasonStoltz - just want to keep commits as modular as possible, + this way it makes it easier for us to have a convo about this separately from the credentials logic :)

[Per Jason's explanation](https://github.com/elastic/kibana/pull/77626/files#r489532908) on what Kea paths accomplish, these changes should:

1. Make debugging w/ Redux DevTools: See https://kea.js.org/docs/guide/debugging/#logic-path
<img src="https://user-images.githubusercontent.com/1427475/93359135-417b8280-f810-11ea-8132-4b3b18a1c301.png" alt="">

2. Make initializing values via resetContext easier: https://kea.js.org/docs/api/context/#resetcontext

https://github.com/elastic/kibana/blob/b0fcf4a24ab33c8b39fc68a2162994c064b20eab/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts#L21-L33

### Checklist

- [x] All tests pass as before