### PR TITLE
[Timelion] Migrate hiding logic to the app instead of the vis

### DIFF
--- a/src/plugins/timelion/config.ts
+++ b/src/plugins/timelion/config.ts
@@ -19,14 +19,10 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 
-export const configSchema = {
-  schema: schema.object({
-    graphiteUrls: schema.maybe(schema.arrayOf(schema.string())),
-    enabled: schema.boolean({ defaultValue: true }),
-    ui: schema.object({
-      enabled: schema.boolean({ defaultValue: true }),
-    }),
-  }),
-};
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: true }),
+  ui: schema.object({ enabled: schema.boolean({ defaultValue: false }) }),
+  graphiteUrls: schema.maybe(schema.arrayOf(schema.string())),
+});
 
-export type TimelionConfigType = TypeOf<typeof configSchema.schema>;
+export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/src/plugins/timelion/public/plugin.ts
+++ b/src/plugins/timelion/public/plugin.ts
@@ -28,6 +28,7 @@ import {
   AppMountParameters,
   AppUpdater,
   ScopedHistory,
+  AppNavLinkStatus,
 } from '../../../core/public';
 import { Panel } from './panels/panel';
 import { initAngularBootstrap, KibanaLegacyStart } from '../../kibana_legacy/public';
@@ -36,6 +37,7 @@ import { DataPublicPluginStart, esFilters, DataPublicPluginSetup } from '../../d
 import { NavigationPublicPluginStart } from '../../navigation/public';
 import { VisualizationsStart } from '../../visualizations/public';
 import { VisTypeTimelionPluginStart } from '../../vis_type_timelion/public';
+import { ConfigSchema } from '../config';
 
 export interface TimelionPluginDependencies {
   data: DataPublicPluginStart;
@@ -50,9 +52,12 @@ export class TimelionPlugin implements Plugin<void, void> {
   private appStateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
   private stopUrlTracking: (() => void) | undefined = undefined;
   private currentHistory: ScopedHistory | undefined = undefined;
+  private uiConfig: ConfigSchema['ui'];
 
-  constructor(initializerContext: PluginInitializerContext) {
+  constructor(initializerContext: PluginInitializerContext<ConfigSchema>) {
     this.initializerContext = initializerContext;
+    const { ui } = initializerContext.config.get<ConfigSchema>();
+    this.uiConfig = ui;
   }
 
   public setup(core: CoreSetup, { data }: { data: DataPublicPluginSetup }) {
@@ -124,6 +129,9 @@ export class TimelionPlugin implements Plugin<void, void> {
 
   public start(core: CoreStart, { kibanaLegacy }: { kibanaLegacy: KibanaLegacyStart }) {
     kibanaLegacy.loadFontAwesome();
+    if (this.uiConfig.enabled === false) {
+      this.appStateUpdater.next(() => ({ navLinkStatus: AppNavLinkStatus.hidden }));
+    }
   }
 
   public stop(): void {

--- a/src/plugins/timelion/server/index.ts
+++ b/src/plugins/timelion/server/index.ts
@@ -18,11 +18,13 @@
  */
 import { PluginInitializerContext, PluginConfigDescriptor } from 'src/core/server';
 import { TimelionPlugin } from './plugin';
-import { configSchema, TimelionConfigType } from './config';
+import { configSchema, ConfigSchema } from '../config';
 
-export const config: PluginConfigDescriptor<TimelionConfigType> = {
-  schema: configSchema.schema,
+export const config: PluginConfigDescriptor<ConfigSchema> = {
+  schema: configSchema,
+  exposeToBrowser: {
+    ui: true,
+  },
 };
-
-export const plugin = (context: PluginInitializerContext<TimelionConfigType>) =>
+export const plugin = (context: PluginInitializerContext<ConfigSchema>) =>
   new TimelionPlugin(context);

--- a/src/plugins/timelion/server/plugin.ts
+++ b/src/plugins/timelion/server/plugin.ts
@@ -20,7 +20,7 @@
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext, Logger } from 'src/core/server';
 import { i18n } from '@kbn/i18n';
 import { schema } from '@kbn/config-schema';
-import { TimelionConfigType } from './config';
+import { ConfigSchema } from '../config';
 import { timelionSheetSavedObjectType } from './saved_objects';
 
 /**
@@ -50,7 +50,7 @@ const showWarningMessageIfTimelionSheetWasFound = (core: CoreStart, logger: Logg
 export class TimelionPlugin implements Plugin {
   private logger: Logger;
 
-  constructor(context: PluginInitializerContext<TimelionConfigType>) {
+  constructor(context: PluginInitializerContext<ConfigSchema>) {
     this.logger = context.logger.get();
   }
 

--- a/src/plugins/vis_type_timelion/public/plugin.ts
+++ b/src/plugins/vis_type_timelion/public/plugin.ts
@@ -94,9 +94,6 @@ export class TimelionVisPlugin
   public start(core: CoreStart, plugins: TimelionVisStartDependencies) {
     setIndexPatterns(plugins.data.indexPatterns);
     setSavedObjectsClient(core.savedObjects.client);
-    if (this.initializerContext.config.get().ui.enabled === false) {
-      core.chrome.navLinks.update('timelion', { hidden: true });
-    }
 
     return {
       getArgValueSuggestions,

--- a/src/plugins/vis_type_timelion/server/index.ts
+++ b/src/plugins/vis_type_timelion/server/index.ts
@@ -32,6 +32,7 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     renameFromRoot('timelion_vis.enabled', 'vis_type_timelion.enabled'),
     renameFromRoot('timelion.enabled', 'vis_type_timelion.enabled'),
     renameFromRoot('timelion.graphiteUrls', 'vis_type_timelion.graphiteUrls'),
+    renameFromRoot('timelion.ui.enabled', 'vis_type_timelion.ui.enabled', true),
   ],
 };
 export const plugin = (initializerContext: PluginInitializerContext) =>

--- a/src/plugins/vis_type_timelion/server/index.ts
+++ b/src/plugins/vis_type_timelion/server/index.ts
@@ -32,7 +32,6 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
     renameFromRoot('timelion_vis.enabled', 'vis_type_timelion.enabled'),
     renameFromRoot('timelion.enabled', 'vis_type_timelion.enabled'),
     renameFromRoot('timelion.graphiteUrls', 'vis_type_timelion.graphiteUrls'),
-    renameFromRoot('timelion.ui.enabled', 'vis_type_timelion.ui.enabled', true),
   ],
 };
 export const plugin = (initializerContext: PluginInitializerContext) =>


### PR DESCRIPTION
## Summary

Closes #77681.
This PR closes the bug of Timelion appearing on search results although it is disabled. 

The setting to disable it is `timelion.ui.enabled`. I have moved the config to the app, I have removed the hiding logic from the visualization to the app and also used the app.updater$ in order to work properly on search results.
