### PR TITLE
[Security Solution] [Detections] Remove file validation on import route

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.test.ts
@@ -55,6 +55,18 @@ describe('import_rules_route', () => {
       expect(response.status).toEqual(200);
     });
 
+    test('returns 500 if more than 10,000 rules are imported', async () => {
+      const ruleIds = new Array(10001).fill(undefined).map((_, index) => `rule-${index}`);
+      const multiRequest = getImportRulesRequest(buildHapiStream(ruleIdsToNdJsonString(ruleIds)));
+      const response = await server.inject(multiRequest, context);
+
+      expect(response.status).toEqual(500);
+      expect(response.body).toEqual({
+        message: "Can't import more than 10000 rules",
+        status_code: 500,
+      });
+    });
+
     test('returns 404 if alertClient is not available on the route', async () => {
       context.alerting!.getAlertsClient = jest.fn();
       const response = await server.inject(request, context);
@@ -226,6 +238,19 @@ describe('import_rules_route', () => {
         errors: [],
         success: true,
         success_count: 2,
+      });
+    });
+
+    test('returns 200 if many rules are imported successfully', async () => {
+      const ruleIds = new Array(9999).fill(undefined).map((_, index) => `rule-${index}`);
+      const multiRequest = getImportRulesRequest(buildHapiStream(ruleIdsToNdJsonString(ruleIds)));
+      const response = await server.inject(multiRequest, context);
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        errors: [],
+        success: true,
+        success_count: 9999,
       });
     });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.ts
@@ -47,7 +47,7 @@ import { PartialFilter } from '../../types';
 
 type PromiseFromStreams = ImportRulesSchemaDecoded | Error;
 
-const CHUNK_PARSED_OBJECT_SIZE = 300;
+const CHUNK_PARSED_OBJECT_SIZE = 50;
 
 export const importRulesRoute = (router: IRouter, config: ConfigType, ml: SetupPlugins['ml']) => {
   router.post(

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.ts
@@ -6,14 +6,12 @@
 
 import { chunk } from 'lodash/fp';
 import { extname } from 'path';
+import { schema } from '@kbn/config-schema';
 
 import { validate } from '../../../../../common/validate';
 import {
   importRulesQuerySchema,
   ImportRulesQuerySchemaDecoded,
-  importRulesPayloadSchema,
-  ImportRulesPayloadSchemaDecoded,
-  ImportRulesSchemaDecoded,
 } from '../../../../../common/detection_engine/schemas/request/import_rules_schema';
 import {
   ImportRulesSchema as ImportRulesResponseSchema,
@@ -48,7 +46,7 @@ import { PartialFilter } from '../../types';
 
 type PromiseFromStreams = ImportRulesSchemaDecoded | Error;
 
-const CHUNK_PARSED_OBJECT_SIZE = 10;
+const CHUNK_PARSED_OBJECT_SIZE = 300;
 
 export const importRulesRoute = (router: IRouter, config: ConfigType, ml: SetupPlugins['ml']) => {
   router.post(
@@ -58,10 +56,7 @@ export const importRulesRoute = (router: IRouter, config: ConfigType, ml: SetupP
         query: buildRouteValidation<typeof importRulesQuerySchema, ImportRulesQuerySchemaDecoded>(
           importRulesQuerySchema
         ),
-        body: buildRouteValidation<
-          typeof importRulesPayloadSchema,
-          ImportRulesPayloadSchemaDecoded
-        >(importRulesPayloadSchema),
+        body: schema.any(), // validation on file object is accomplished later in the handler.
       },
       options: {
         tags: ['access:securitySolution'],

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/import_rules_route.ts
@@ -12,6 +12,7 @@ import { validate } from '../../../../../common/validate';
 import {
   importRulesQuerySchema,
   ImportRulesQuerySchemaDecoded,
+  ImportRulesSchemaDecoded,
 } from '../../../../../common/detection_engine/schemas/request/import_rules_schema';
 import {
   ImportRulesSchema as ImportRulesResponseSchema,

--- a/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
@@ -192,7 +192,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
-      // import is still very slow due to the alerts client find api
+      // import is very slow in 7.10+ due to the alerts client find api
       // when importing 100 rules it takes about 30 seconds for this
       // test to complete so at 10 rules completing in about 10 seconds
       // I figured this is enough to make sure the import route is doing its job.
@@ -212,6 +212,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       // uncomment the below test once we speed up the alerts client find api
+      // in another PR.
       // it('should be able to import 10000 rules', async () => {
       //   const ruleIds = new Array(10000).fill(undefined).map((_, index) => `rule-${index}`);
       //   const { body } = await supertest

--- a/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
@@ -192,8 +192,12 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
-      it('should be able to import 9999 rules', async () => {
-        const ruleIds = new Array(9999).fill(undefined).map((_, index) => `rule-${index}`);
+      // import is still very slow due to the alerts client find api
+      // when importing 100 rules it takes about 30 seconds for this
+      // test to complete so at 10 rules completing in about 10 seconds
+      // I figured this is enough to make sure the import route is doing its job.
+      it('should be able to import 10 rules', async () => {
+        const ruleIds = new Array(10).fill(undefined).map((_, index) => `rule-${index}`);
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
@@ -203,9 +207,25 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(body).to.eql({
           errors: [],
           success: true,
-          success_count: 9999,
+          success_count: 10,
         });
       });
+
+      // uncomment the below test once we speed up the alerts client find api
+      // it('should be able to import 10000 rules', async () => {
+      //   const ruleIds = new Array(10000).fill(undefined).map((_, index) => `rule-${index}`);
+      //   const { body } = await supertest
+      //     .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+      //     .set('kbn-xsrf', 'true')
+      //     .attach('file', getSimpleRuleAsNdjson(ruleIds, false), 'rules.ndjson')
+      //     .expect(200);
+
+      //   expect(body).to.eql({
+      //     errors: [],
+      //     success: true,
+      //     success_count: 10000,
+      //   });
+      // });
 
       it('should NOT be able to import more than 10,000 rules', async () => {
         const ruleIds = new Array(10001).fill(undefined).map((_, index) => `rule-${index}`);

--- a/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
@@ -129,7 +129,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
+          .attach('file', getSimpleRuleAsNdjson(['rule-1'], true), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
@@ -330,7 +330,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
+          .attach('file', getSimpleRuleAsNdjson(['rule-1'], true), 'rules.ndjson')
           .expect(200);
 
         const simpleRule = getSimpleRule('rule-1');
@@ -422,13 +422,17 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
+          .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2'], true), 'rules.ndjson')
           .expect(200);
 
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
+          .attach(
+            'file',
+            getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3'], true),
+            'rules.ndjson'
+          )
           .expect(200);
 
         const { body: bodyOfRule1 } = await supertest

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
@@ -129,7 +129,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
+          .attach('file', getSimpleRuleAsNdjson(['rule-1'], true), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
@@ -243,7 +243,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
+          .attach('file', getSimpleRuleAsNdjson(['rule-1'], true), 'rules.ndjson')
           .expect(200);
 
         const simpleRule = getSimpleRule('rule-1');
@@ -335,13 +335,17 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
+          .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2'], true), 'rules.ndjson')
           .expect(200);
 
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
-          .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
+          .attach(
+            'file',
+            getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3'], true),
+            'rules.ndjson'
+          )
           .expect(200);
 
         const { body: bodyOfRule1 } = await supertest

--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -58,7 +58,7 @@ export const removeServerGeneratedPropertiesIncludingRuleId = (
  * @param ruleId
  * @param enabled Enables the rule on creation or not. Defaulted to false to enable it on import
  */
-export const getSimpleRule = (ruleId = 'rule-1', enabled = false): CreateRulesSchema => ({
+export const getSimpleRule = (ruleId = 'rule-1', enabled = true): CreateRulesSchema => ({
   name: 'Simple Rule Query',
   description: 'Simple Rule Query',
   enabled,

--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -56,10 +56,12 @@ export const removeServerGeneratedPropertiesIncludingRuleId = (
 /**
  * This is a typical simple rule for testing that is easy for most basic testing
  * @param ruleId
+ * @param enabled Enables the rule on creation or not. Defaulted to false to enable it on import
  */
-export const getSimpleRule = (ruleId = 'rule-1'): CreateRulesSchema => ({
+export const getSimpleRule = (ruleId = 'rule-1', enabled = false): CreateRulesSchema => ({
   name: 'Simple Rule Query',
   description: 'Simple Rule Query',
+  enabled,
   risk_score: 1,
   rule_id: ruleId,
   severity: 'high',
@@ -360,12 +362,9 @@ export const deleteSignalsIndex = async (
  * for testing uploads.
  * @param ruleIds Array of strings of rule_ids
  */
-export const getSimpleRuleAsNdjson = (ruleIds: string[], enabled?: boolean): Buffer => {
+export const getSimpleRuleAsNdjson = (ruleIds: string[], enabled = false): Buffer => {
   const stringOfRules = ruleIds.map((ruleId) => {
-    const simpleRule = getSimpleRule(ruleId);
-    if (enabled != null) {
-      return JSON.stringify({ enabled, ...simpleRule });
-    }
+    const simpleRule = getSimpleRule(ruleId, enabled);
     return JSON.stringify(simpleRule);
   });
   return Buffer.from(stringOfRules.join('\n'));

--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -360,9 +360,12 @@ export const deleteSignalsIndex = async (
  * for testing uploads.
  * @param ruleIds Array of strings of rule_ids
  */
-export const getSimpleRuleAsNdjson = (ruleIds: string[]): Buffer => {
+export const getSimpleRuleAsNdjson = (ruleIds: string[], enabled?: boolean): Buffer => {
   const stringOfRules = ruleIds.map((ruleId) => {
     const simpleRule = getSimpleRule(ruleId);
+    if (enabled != null) {
+      return JSON.stringify({ enabled, ...simpleRule });
+    }
     return JSON.stringify(simpleRule);
   });
   return Buffer.from(stringOfRules.join('\n'));


### PR DESCRIPTION
## Summary

io-ts validation on the rule import file object was creating performance issues. We replace this validation with `kbn schema.any()` since the validation on the rules occurs later in the route handler.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
