### PR TITLE
[APM] Bug: Set minimum scale to 1% for the Transaction error rate chart

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/ErroneousTransactionsRateChart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/ErroneousTransactionsRateChart/index.tsx
@@ -6,6 +6,7 @@
 import { EuiPanel, EuiSpacer, EuiTitle } from '@elastic/eui';
 import theme from '@elastic/eui/dist/eui_theme_light.json';
 import { i18n } from '@kbn/i18n';
+import { max } from 'lodash';
 import React, { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { asPercent } from '../../../../../common/utils/formatters';
@@ -56,6 +57,7 @@ export function ErroneousTransactionsRateChart() {
   );
 
   const errorRates = data?.erroneousTransactionsRate || [];
+  const maxRate = max(errorRates.map((errorRate) => errorRate.y));
 
   return (
     <EuiPanel>
@@ -70,7 +72,7 @@ export function ErroneousTransactionsRateChart() {
       <CustomPlot
         {...syncedChartsProps}
         noHits={data?.noHits}
-        yMax={1}
+        yMax={maxRate === 0 ? 1 : undefined}
         series={[
           {
             color: theme.euiColorVis7,


### PR DESCRIPTION
closes #77741

<img width="789" alt="Screenshot 2020-09-18 at 11 29 26" src="https://user-images.githubusercontent.com/55978943/93582636-0eb5c380-f9a3-11ea-93b6-9431cc67ac37.png">
<img width="801" alt="Screenshot 2020-09-18 at 11 29 41" src="https://user-images.githubusercontent.com/55978943/93582644-107f8700-f9a3-11ea-8bd7-4f2674859722.png">
