### PR TITLE
[APM] Enable spaces for UI indices

### DIFF
--- a/x-pack/plugins/apm/server/saved_objects/apm_indices.ts
+++ b/x-pack/plugins/apm/server/saved_objects/apm_indices.ts
@@ -8,7 +8,7 @@ import { SavedObjectsType } from 'src/core/server';
 export const apmIndices: SavedObjectsType = {
   name: 'apm-indices',
   hidden: false,
-  namespaceType: 'agnostic',
+  namespaceType: 'single',
   mappings: {
     properties: {
       /* eslint-disable @typescript-eslint/naming-convention */


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/49647

This makes UI indices settings specific per space. Previously it was global (shared across all spaces).
This will allow users to view different APM data per space.

TODO:
 - [ ] Figure out what the migration implications of this change are. How will an existing cluster with `namespaceType:agnostic` (previous setting) react to it being changed to `namespaceType: 'single'`?
 - [ ] Is ML space-aware?