### PR TITLE
[APM] environments overlap w/ sparklines if labels are too long

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/__test__/__snapshots__/ServiceOverview.test.tsx.snap
@@ -223,30 +223,21 @@ NodeList [
         class="euiTableCellContent euiTableCellContent--overflowingContent"
       >
         <span
-          class="euiBadge euiBadge--hollow euiBadge--iconLeft"
-          title="test"
+          class="euiToolTipAnchor"
         >
           <span
-            class="euiBadge__content"
+            class="euiBadge euiBadge--iconLeft"
+            style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+            title="2 environments"
           >
             <span
-              class="euiBadge__text"
+              class="euiBadge__content"
             >
-              test
-            </span>
-          </span>
-        </span>
-        <span
-          class="euiBadge euiBadge--hollow euiBadge--iconLeft"
-          title="dev"
-        >
-          <span
-            class="euiBadge__content"
-          >
-            <span
-              class="euiBadge__text"
-            >
-              dev
+              <span
+                class="euiBadge__text"
+              >
+                2 environments
+              </span>
             </span>
           </span>
         </span>

--- a/x-pack/plugins/apm/public/components/shared/EnvironmentBadge/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentBadge/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   environments: string[];
 }
 export function EnvironmentBadge({ environments = [] }: Props) {
-  if (environments.length < 3) {
+  if (environments.length < 2) {
     return (
       <>
         {environments.map((env) => (


### PR DESCRIPTION
closes #77742

<img width="919" alt="Screenshot 2020-09-21 at 12 48 05" src="https://user-images.githubusercontent.com/55978943/93758814-66556880-fc09-11ea-89d4-819888de2285.png">
<img width="925" alt="Screenshot 2020-09-21 at 12 48 54" src="https://user-images.githubusercontent.com/55978943/93758819-67869580-fc09-11ea-91f0-814fc9dbb766.png">
<img width="808" alt="Screenshot 2020-09-21 at 12 49 23" src="https://user-images.githubusercontent.com/55978943/93758821-681f2c00-fc09-11ea-86df-c8d49dc0ba29.png">
