### PR TITLE
[Enterprise Search] Fix various plugin states when app has error connecting to Enterprise Search

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
@@ -56,6 +56,15 @@ describe('AppLogic', () => {
         }),
       });
     });
+
+    it('gracefully handles missing initial data', () => {
+      AppLogic.actions.initializeAppData({});
+
+      expect(AppLogic.values).toEqual({
+        ...DEFAULT_VALUES,
+        hasInitialized: true,
+      });
+    });
   });
 
   describe('setOnboardingComplete()', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -39,7 +39,7 @@ export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
     account: [
       {},
       {
-        initializeAppData: (_, { appSearch: account }) => account,
+        initializeAppData: (_, { appSearch: account }) => account || {},
         setOnboardingComplete: (account) => ({
           ...account,
           onboardingComplete: true,
@@ -49,7 +49,7 @@ export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
     configuredLimits: [
       {},
       {
-        initializeAppData: (_, { configuredLimits }) => configuredLimits.appSearch,
+        initializeAppData: (_, { configuredLimits }) => configuredLimits?.appSearch || {},
       },
     ],
     ilmEnabled: [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.test.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ErrorStatePrompt } from '../../../shared/error_state';
+import { ErrorConnecting } from './';
+
+describe('ErrorConnecting', () => {
+  it('renders', () => {
+    const wrapper = shallow(<ErrorConnecting />);
+
+    expect(wrapper.find(ErrorStatePrompt)).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { EuiPage, EuiPageContent } from '@elastic/eui';
+
+import { ErrorStatePrompt } from '../../../shared/error_state';
+
+export const ErrorConnecting: React.FC = () => (
+  <EuiPage restrictWidth>
+    <EuiPageContent>
+      <ErrorStatePrompt />
+    </EuiPageContent>
+  </EuiPage>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { ErrorConnecting } from './error_connecting';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.test.tsx
@@ -6,13 +6,20 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import { EuiPage } from '@elastic/eui';
 
+import '../__mocks__/kea.mock';
+import { useValues } from 'kea';
+
 import { EnterpriseSearch } from './';
+import { ErrorConnecting } from './components/error_connecting';
 import { ProductCard } from './components/product_card';
 
 describe('EnterpriseSearch', () => {
+  beforeEach(() => {
+    (useValues as jest.Mock).mockReturnValue({ errorConnecting: false });
+  });
+
   it('renders the overview page and product cards', () => {
     const wrapper = shallow(
       <EnterpriseSearch access={{ hasAppSearchAccess: true, hasWorkplaceSearchAccess: true }} />
@@ -20,6 +27,14 @@ describe('EnterpriseSearch', () => {
 
     expect(wrapper.find(EuiPage).hasClass('enterpriseSearchOverview')).toBe(true);
     expect(wrapper.find(ProductCard)).toHaveLength(2);
+  });
+
+  it('renders the error connecting prompt', () => {
+    (useValues as jest.Mock).mockReturnValueOnce({ errorConnecting: true });
+    const wrapper = shallow(<EnterpriseSearch />);
+
+    expect(wrapper.find(ErrorConnecting)).toHaveLength(1);
+    expect(wrapper.find(EuiPage)).toHaveLength(0);
   });
 
   describe('access checks', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { useValues } from 'kea';
 import {
   EuiPage,
   EuiPageBody,
@@ -21,9 +22,11 @@ import { i18n } from '@kbn/i18n';
 import { IInitialAppData } from '../../../common/types';
 import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../../../common/constants';
 
+import { HttpLogic } from '../shared/http';
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../shared/kibana_chrome';
 import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../shared/telemetry';
 
+import { ErrorConnecting } from './components/error_connecting';
 import { ProductCard } from './components/product_card';
 
 import AppSearchImage from './assets/app_search.png';
@@ -31,9 +34,12 @@ import WorkplaceSearchImage from './assets/workplace_search.png';
 import './index.scss';
 
 export const EnterpriseSearch: React.FC<IInitialAppData> = ({ access = {} }) => {
+  const { errorConnecting } = useValues(HttpLogic);
   const { hasAppSearchAccess, hasWorkplaceSearchAccess } = access;
 
-  return (
+  return errorConnecting ? (
+    <ErrorConnecting />
+  ) : (
     <EuiPage restrictWidth className="enterpriseSearchOverview">
       <SetPageChrome isRoot />
       <SendTelemetry action="viewed" metric="overview" />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -50,5 +50,15 @@ describe('AppLogic', () => {
 
       expect(AppLogic.values).toEqual(expectedLogicValues);
     });
+
+    it('gracefully handles missing initial data', () => {
+      AppLogic.actions.initializeAppData({});
+
+      expect(AppLogic.values).toEqual({
+        ...DEFAULT_VALUES,
+        hasInitialized: true,
+        isFederatedAuth: false,
+      });
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -21,6 +21,9 @@ export interface IAppActions {
   initializeAppData(props: IInitialAppData): IInitialAppData;
 }
 
+const emptyOrg = {} as IOrganization;
+const emptyAccount = {} as IAccount;
+
 export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
   path: ['enterprise_search', 'workplace_search', 'app_logic'],
   actions: {
@@ -43,15 +46,15 @@ export const AppLogic = kea<MakeLogicType<IAppValues, IAppActions>>({
       },
     ],
     organization: [
-      {} as IOrganization,
+      emptyOrg,
       {
-        initializeAppData: (_, { workplaceSearch }) => workplaceSearch!.organization,
+        initializeAppData: (_, { workplaceSearch }) => workplaceSearch?.organization || emptyOrg,
       },
     ],
     account: [
-      {} as IAccount,
+      emptyAccount,
       {
-        initializeAppData: (_, { workplaceSearch }) => workplaceSearch!.account,
+        initializeAppData: (_, { workplaceSearch }) => workplaceSearch?.account || emptyAccount,
       },
     ],
   },


### PR DESCRIPTION
## Summary

When Enterprise Search is stopped/has errors connecting:

### Before

- App Search & Workplace Search were crashing w/ blank pages, due to AppLogic still being initialized w/ no fallbacks to empty objs
- The Enterprise Search Overview plugin was showing a blank page with no meaningful messaging

### After

- AS & WS should now show the Error Connecting prompts once more without crashes from AppLogic
- Enterprise Search Overview now shows shared error connecting prompt, like AS & WS

<img width="770" alt="" src="https://user-images.githubusercontent.com/549407/93824802-e7682c00-fc18-11ea-8afe-9de63412ae9c.png">

NOTE: The Setup Guide for Enterprise Search is NYI/will be discussed in sync tomorrow and implemented by @scottybollinger 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios