### PR TITLE
[Enterprise Search] Rename "telemetry" to "stats"

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.test.tsx
@@ -33,7 +33,7 @@ describe('Shared Telemetry Helpers', () => {
         metric: 'setup_guide',
       });
 
-      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/telemetry', {
+      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
         headers,
         body: '{"product":"enterprise_search","action":"viewed","metric":"setup_guide"}',
       });
@@ -54,7 +54,7 @@ describe('Shared Telemetry Helpers', () => {
         http: httpMock,
       });
 
-      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/telemetry', {
+      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
         headers,
         body: '{"product":"enterprise_search","action":"viewed","metric":"page"}',
       });
@@ -65,7 +65,7 @@ describe('Shared Telemetry Helpers', () => {
         http: httpMock,
       });
 
-      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/telemetry', {
+      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
         headers,
         body: '{"product":"app_search","action":"clicked","metric":"button"}',
       });
@@ -76,7 +76,7 @@ describe('Shared Telemetry Helpers', () => {
         http: httpMock,
       });
 
-      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/telemetry', {
+      expect(httpMock.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
         headers,
         body: '{"product":"workplace_search","action":"error","metric":"not_found"}',
       });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.tsx
@@ -27,7 +27,7 @@ interface ISendTelemetry extends ISendTelemetryProps {
 export const sendTelemetry = async ({ http, product, action, metric }: ISendTelemetry) => {
   try {
     const body = JSON.stringify({ product, action, metric });
-    await http.put('/api/enterprise_search/telemetry', { headers, body });
+    await http.put('/api/enterprise_search/stats', { headers, body });
   } catch (error) {
     throw new Error('Unable to send telemetry');
   }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.test.ts
@@ -35,7 +35,7 @@ describe('Enterprise Search Telemetry API', () => {
     });
   });
 
-  describe('PUT /api/enterprise_search/telemetry', () => {
+  describe('PUT /api/enterprise_search/stats', () => {
     it('increments the saved objects counter for App Search', async () => {
       (incrementUICounter as jest.Mock).mockImplementation(jest.fn(() => successResponse));
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
@@ -25,7 +25,7 @@ export function registerTelemetryRoute({
 }: IRouteDependencies) {
   router.put(
     {
-      path: '/api/enterprise_search/telemetry',
+      path: '/api/enterprise_search/stats',
       validate: {
         body: schema.object({
           product: schema.oneOf([


### PR DESCRIPTION
## Summary

Rename `telemetry` to `stats` to avoid confusion in support and users.

We've had a few open requests asking why they could see requests to endpoints named after "telemetry" when they explicitly set `telemetry.enabled: false` or `telemetry.optIn: false`.

To avoid annoying users, let's use an alternative name when naming related plugins-owned endpoints.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
