### PR TITLE
[Lens] Rename "telemetry" to "stats"

### DIFF
--- a/x-pack/plugins/lens/public/lens_ui_telemetry/factory.test.ts
+++ b/x-pack/plugins/lens/public/lens_ui_telemetry/factory.test.ts
@@ -83,7 +83,7 @@ describe('Lens UI telemetry', () => {
 
     jest.runOnlyPendingTimers();
 
-    expect(http.post).toHaveBeenCalledWith(`/api/lens/telemetry`, {
+    expect(http.post).toHaveBeenCalledWith(`/api/lens/stats`, {
       body: JSON.stringify({
         events: {
           '2019-10-23': {

--- a/x-pack/plugins/lens/public/lens_ui_telemetry/factory.ts
+++ b/x-pack/plugins/lens/public/lens_ui_telemetry/factory.ts
@@ -86,7 +86,7 @@ export class LensReportManager {
     this.readFromStorage();
     if (Object.keys(this.events).length || Object.keys(this.suggestionEvents).length) {
       try {
-        await this.http.post(`${BASE_API_URL}/telemetry`, {
+        await this.http.post(`${BASE_API_URL}/stats`, {
           body: JSON.stringify({
             events: this.events,
             suggestionEvents: this.suggestionEvents,

--- a/x-pack/plugins/lens/server/routes/telemetry.ts
+++ b/x-pack/plugins/lens/server/routes/telemetry.ts
@@ -15,7 +15,7 @@ export async function initLensUsageRoute(setup: CoreSetup) {
   const router = setup.http.createRouter();
   router.post(
     {
-      path: `${BASE_API_URL}/telemetry`,
+      path: `${BASE_API_URL}/stats`,
       validate: {
         body: schema.object({
           events: schema.mapOf(schema.string(), schema.mapOf(schema.string(), schema.number())),

--- a/x-pack/test/api_integration/apis/lens/telemetry.ts
+++ b/x-pack/test/api_integration/apis/lens/telemetry.ts
@@ -60,7 +60,7 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should do nothing on empty post', async () => {
       await supertest
-        .post('/api/lens/telemetry')
+        .post('/api/lens/stats')
         .set(COMMON_HEADERS)
         .send({
           events: {},
@@ -73,7 +73,7 @@ export default ({ getService }: FtrProviderContext) => {
 
     it('should write a document per results', async () => {
       await supertest
-        .post('/api/lens/telemetry')
+        .post('/api/lens/stats')
         .set(COMMON_HEADERS)
         .send({
           events: {


### PR DESCRIPTION
## Summary

Rename `telemetry` to `stats` to avoid confusion in support and users.

We've had a few open requests asking why they could see requests to endpoints named after "telemetry" when they explicitly set `telemetry.enabled: false` or `telemetry.optIn: false`.

To avoid annoying users, let's use an alternative name when naming related plugins-owned endpoints.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
