### PR TITLE
[Upgrade Assistant] Rename "telemetry" to "stats"

### DIFF
--- a/x-pack/plugins/upgrade_assistant/public/application/components/tabs.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/tabs.tsx
@@ -239,7 +239,7 @@ export class UpgradeAssistantTabs extends React.Component<Props, TabsState> {
 
     this.setState({ telemetryState: TelemetryState.Running });
 
-    await this.props.http.fetch('/api/upgrade_assistant/telemetry/ui_open', {
+    await this.props.http.fetch('/api/upgrade_assistant/stats/ui_open', {
       method: 'PUT',
       body: JSON.stringify(set({}, tabName, true)),
     });

--- a/x-pack/plugins/upgrade_assistant/public/application/components/tabs/checkup/deprecations/reindex/button.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/tabs/checkup/deprecations/reindex/button.tsx
@@ -239,7 +239,7 @@ export class ReindexButton extends React.Component<ReindexButtonProps, ReindexBu
   };
 
   private async sendUIReindexTelemetryInfo(uiReindexAction: UIReindexOption) {
-    await this.props.http.fetch('/api/upgrade_assistant/telemetry/ui_reindex', {
+    await this.props.http.fetch('/api/upgrade_assistant/stats/ui_reindex', {
       method: 'PUT',
       body: JSON.stringify(set({}, uiReindexAction, true)),
     });

--- a/x-pack/plugins/upgrade_assistant/server/routes/telemetry.test.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/telemetry.test.ts
@@ -39,7 +39,7 @@ describe('Upgrade Assistant Telemetry API', () => {
   });
   afterEach(() => jest.clearAllMocks());
 
-  describe('PUT /api/upgrade_assistant/telemetry/ui_open', () => {
+  describe('PUT /api/upgrade_assistant/stats/ui_open', () => {
     it('returns correct payload with single option', async () => {
       const returnPayload = {
         overview: true,
@@ -51,7 +51,7 @@ describe('Upgrade Assistant Telemetry API', () => {
 
       const resp = await routeDependencies.router.getHandler({
         method: 'put',
-        pathPattern: '/api/upgrade_assistant/telemetry/ui_open',
+        pathPattern: '/api/upgrade_assistant/stats/ui_open',
       })(
         routeHandlerContextMock,
         createRequestMock({ body: returnPayload }),
@@ -72,7 +72,7 @@ describe('Upgrade Assistant Telemetry API', () => {
 
       const resp = await routeDependencies.router.getHandler({
         method: 'put',
-        pathPattern: '/api/upgrade_assistant/telemetry/ui_open',
+        pathPattern: '/api/upgrade_assistant/stats/ui_open',
       })(
         routeHandlerContextMock,
         createRequestMock({
@@ -93,7 +93,7 @@ describe('Upgrade Assistant Telemetry API', () => {
 
       const resp = await routeDependencies.router.getHandler({
         method: 'put',
-        pathPattern: '/api/upgrade_assistant/telemetry/ui_open',
+        pathPattern: '/api/upgrade_assistant/stats/ui_open',
       })(
         routeHandlerContextMock,
         createRequestMock({
@@ -108,7 +108,7 @@ describe('Upgrade Assistant Telemetry API', () => {
     });
   });
 
-  describe('PUT /api/upgrade_assistant/telemetry/ui_reindex', () => {
+  describe('PUT /api/upgrade_assistant/stats/ui_reindex', () => {
     it('returns correct payload with single option', async () => {
       const returnPayload = {
         close: false,
@@ -121,7 +121,7 @@ describe('Upgrade Assistant Telemetry API', () => {
 
       const resp = await routeDependencies.router.getHandler({
         method: 'put',
-        pathPattern: '/api/upgrade_assistant/telemetry/ui_reindex',
+        pathPattern: '/api/upgrade_assistant/stats/ui_reindex',
       })(
         routeHandlerContextMock,
         createRequestMock({
@@ -147,7 +147,7 @@ describe('Upgrade Assistant Telemetry API', () => {
 
       const resp = await routeDependencies.router.getHandler({
         method: 'put',
-        pathPattern: '/api/upgrade_assistant/telemetry/ui_reindex',
+        pathPattern: '/api/upgrade_assistant/stats/ui_reindex',
       })(
         routeHandlerContextMock,
         createRequestMock({
@@ -169,7 +169,7 @@ describe('Upgrade Assistant Telemetry API', () => {
 
       const resp = await routeDependencies.router.getHandler({
         method: 'put',
-        pathPattern: '/api/upgrade_assistant/telemetry/ui_reindex',
+        pathPattern: '/api/upgrade_assistant/stats/ui_reindex',
       })(
         routeHandlerContextMock,
         createRequestMock({

--- a/x-pack/plugins/upgrade_assistant/server/routes/telemetry.ts
+++ b/x-pack/plugins/upgrade_assistant/server/routes/telemetry.ts
@@ -12,7 +12,7 @@ import { RouteDependencies } from '../types';
 export function registerTelemetryRoutes({ router, getSavedObjectsService }: RouteDependencies) {
   router.put(
     {
-      path: '/api/upgrade_assistant/telemetry/ui_open',
+      path: '/api/upgrade_assistant/stats/ui_open',
       validate: {
         body: schema.object({
           overview: schema.boolean({ defaultValue: false }),
@@ -40,7 +40,7 @@ export function registerTelemetryRoutes({ router, getSavedObjectsService }: Rout
 
   router.put(
     {
-      path: '/api/upgrade_assistant/telemetry/ui_reindex',
+      path: '/api/upgrade_assistant/stats/ui_reindex',
       validate: {
         body: schema.object({
           close: schema.boolean({ defaultValue: false }),


### PR DESCRIPTION
## Summary

Rename `telemetry` to `stats` to avoid confusion in support and users.

We've had a few open requests asking why they could see requests to endpoints named after "telemetry" when they explicitly set `telemetry.enabled: false` or `telemetry.optIn: false`.

To avoid annoying users, let's use an alternative name when naming related plugins-owned endpoints.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
