### PR TITLE
Allow Custom Titles on Visualize Embeddables in Canvas

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -243,12 +243,6 @@ export class VisualizeEmbeddable
       dirty = true;
     }
 
-    // propagate the title to the output embeddable
-    // but only when the visualization is in edit/Visualize mode
-    if (!this.parent && this.vis.title !== this.output.title) {
-      this.updateOutput({ title: this.vis.title });
-    }
-
     if (this.vis.description && this.domNode) {
       this.domNode.setAttribute('data-description', this.vis.description);
     }

--- a/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
@@ -267,6 +267,7 @@ export const getTopNavConfig = (
                 }
                 const currentTitle = savedVis.title;
                 savedVis.title = newTitle;
+                embeddableHandler.updateInput({ title: newTitle });
                 savedVis.copyOnSave = newCopyOnSave;
                 savedVis.description = newDescription;
                 const saveOptions = {


### PR DESCRIPTION
## Summary

Changes the visualize editor and visualize embeddable to no longer overwrite the output title. This should allow a custom panel title to be added in canvas.

Closes https://github.com/elastic/kibana/issues/78189

The original change in visualize_embeddable was created to fix this issue: https://github.com/elastic/kibana/issues/72406. It did this by propagating the title from the saved visualization into the embeddable output any time the embeddable was not in an embeddable container. Canvas is currently not considered an embeddable container, so propagating the title there overwrote any custom titles that were added.

I believe I have fixed the original issue here in a way that does not break the canvas custom title by updating the visualize embeddable's input with the new title on save in the editor.

**Canvas Panel Title** 
![Panel Title Canvas](https://user-images.githubusercontent.com/14276393/93933228-5617b900-fcef-11ea-835f-9e9cc434d554.gif)

**Inspector Filename after save**
![Sep-22-2020 16-22-00](https://user-images.githubusercontent.com/14276393/93933556-d6d6b500-fcef-11ea-96ac-1116b924640f.gif)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
