### PR TITLE
[Security Solution] Changes rule details default stack-by value

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -88,6 +88,7 @@ import { timelineDefaults } from '../../../../../timelines/store/timeline/defaul
 import { TimelineModel } from '../../../../../timelines/store/timeline/model';
 import { useSourcererScope } from '../../../../../common/containers/sourcerer';
 import { SourcererScopeName } from '../../../../../common/store/sourcerer/model';
+import { AlertsHistogramOption } from '../../../../components/alerts_histogram_panel/types';
 
 enum RuleDetailTabs {
   alerts = 'alerts',
@@ -345,6 +346,11 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
     return null;
   }
 
+  const defaultRuleStackByOption: AlertsHistogramOption = {
+    text: 'event.category',
+    value: 'event.category',
+  };
+
   return (
     <>
       {hasIndexWrite != null && !hasIndexWrite && <NoWriteAlertsCallOut />}
@@ -480,6 +486,7 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
                     signalIndexName={signalIndexName}
                     setQuery={setQuery}
                     stackByOptions={alertsHistogramOptions}
+                    defaultStackByOption={defaultRuleStackByOption}
                     to={to}
                     updateDateRange={updateDateRangeCallback}
                   />


### PR DESCRIPTION
## Summary

The current rule detail stack by value in the histogram is `signal.rule.name` which isn't useful given that all the alerts under a single rule will all have the same value for that field. This changes the default field to `event.category`

### Screenshots
Previous default value and histogram
![image](https://user-images.githubusercontent.com/56367316/94072093-490fce00-fdb2-11ea-9dd2-dc1f20234753.png)


Current default value and histogram
<img width="1069" alt="Screen Shot 2020-09-23 at 3 29 18 PM" src="https://user-images.githubusercontent.com/56367316/94072082-4319ed00-fdb2-11ea-9940-ce100c1a169f.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
