### PR TITLE
[Metrics UI] Inventory shows * node when there are no results

### DIFF
--- a/x-pack/plugins/infra/server/lib/metrics/constants.ts
+++ b/x-pack/plugins/infra/server/lib/metrics/constants.ts
@@ -4,13 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 export const EMPTY_RESPONSE = {
-  series: [
-    {
-      id: '*',
-      keys: ['*'],
-      columns: [],
-      rows: [],
-    },
-  ],
+  series: [],
   info: { total: 0, afterKey: null, interval: 0 },
 };

--- a/x-pack/test/api_integration/apis/metrics_ui/metrics_explorer.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/metrics_explorer.ts
@@ -239,13 +239,7 @@ export default function ({ getService }: FtrProviderContext) {
           .send(postBody)
           .expect(200);
         const body = decodeOrThrow(metricsExplorerResponseRT)(response.body);
-        expect(body.series).length(1);
-        expect(body.series[0]!).to.have.property('rows');
-        expect(body.series[0]!.rows).length(0);
-        expect(body.pageInfo).to.eql({
-          afterKey: null,
-          total: 0,
-        });
+        expect(body.series).length(0);
       });
       it('should work when there is no data with groupBy', async () => {
         const postBody = {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the UI returns a node with the id `*` when the search return ZERO results (or the metricbeat-* index is empty). That's the default behavior of the Metrics API but is being translated to the Inventory view incorrectly.

#### Before

![image](https://user-images.githubusercontent.com/41702/94087240-21286680-fdc2-11ea-9d56-2240a7604f16.png)

#### After

![image](https://user-images.githubusercontent.com/41702/94087062-9f383d80-fdc1-11ea-8579-24b023c212bf.png)
