### PR TITLE
[Enterprise Search] Fix missing initial data

### DIFF
--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -59,11 +59,11 @@ export class EnterpriseSearchPlugin implements Plugin {
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
         const kibanaDeps = await this.getKibanaDeps(core, params);
-        const pluginData = this.getPluginData();
-
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(ENTERPRISE_SEARCH_PLUGIN.NAME);
+
         await this.getInitialData(http);
+        const pluginData = this.getPluginData();
 
         const { renderApp } = await import('./applications');
         const { EnterpriseSearch } = await import('./applications/enterprise_search');
@@ -80,11 +80,11 @@ export class EnterpriseSearchPlugin implements Plugin {
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
         const kibanaDeps = await this.getKibanaDeps(core, params);
-        const pluginData = this.getPluginData();
-
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(APP_SEARCH_PLUGIN.NAME);
+
         await this.getInitialData(http);
+        const pluginData = this.getPluginData();
 
         const { renderApp } = await import('./applications');
         const { AppSearch } = await import('./applications/app_search');
@@ -101,11 +101,11 @@ export class EnterpriseSearchPlugin implements Plugin {
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
         const kibanaDeps = await this.getKibanaDeps(core, params);
-        const pluginData = this.getPluginData();
-
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(APP_SEARCH_PLUGIN.NAME);
+
         await this.getInitialData(http);
+        const pluginData = this.getPluginData();
 
         const { renderApp, renderHeaderActions } = await import('./applications');
         const { WorkplaceSearch } = await import('./applications/workplace_search');


### PR DESCRIPTION
## Summary

I broke this in https://github.com/elastic/kibana/pull/78231/commits/450c6b7d48b64e9f8b2a59695bc52ecfc8a7b207, sorry everyone 🤦‍♀️ I did notice the buggy behavior while developing locally but was a few branches/PRs ahead but didn't stop to QA it because I assumed (🐴) for some reason that it was already in master / [this commit](https://github.com/elastic/kibana/pull/78091/commits/5670e0b2447ce597eddcf9f263dc557c2056845d#diff-67d8fcacf71e1350d15de7fb5cde33c6R42). Totally my bad!

### QA/repro steps

#### Before

<img width="291" alt="" src="https://user-images.githubusercontent.com/549407/94172310-33001d00-fe47-11ea-8557-74c5193c67ee.png">

- [x] As the `elastic` user, go to http://localhost:5601/app/enterprise_search/app_search/engines and confirm that routes/nav links locked behind access checks are unavailable for some reason

#### After

<img width="375" alt="" src="https://user-images.githubusercontent.com/549407/94171999-cab13b80-fe46-11ea-8f9a-ba758b09d682.png">

- [x] As the elastic user, refresh http://localhost:5601/app/enterprise_search/app_search/engines and confirm all navigation links now show up correctly

### Fix / cause

- Moving the definition of `const pluginData` to after we've run `this.getInitialData()` fixes the issue.
  - The underlying cause for the bug was because I assumed (for some misguided reason) that the reference to `this.data` would also update when we updated it later. But I was 100% wrong; because we replaced it with a totally new obj, the reference was still to the old obj sans `initialData`, and that's what we were passing to `renderApp`.