### PR TITLE
[DOC] Clarify TSVB support with rollup index patterns

### DIFF
--- a/docs/management/rollups/create_and_manage_rollups.asciidoc
+++ b/docs/management/rollups/create_and_manage_rollups.asciidoc
@@ -135,6 +135,7 @@ rollup index, or you can remove or archive it using <<creating-index-lifecycle-p
 
 Your next step is to visualize your rolled up data in a vertical bar chart.
 Most visualizations support rolled up data, with the exception of Timelion and Vega visualizations.
+TSVB visualizations support rolled up index patterns when they are not combined together with other index patterns.
 
 
 . Go to *Stack Management > {kib} > Index Patterns*.


### PR DESCRIPTION
## Summary

TSVB visualizations support traditional index patterns and rolled index patterns exclusively.
You cannot use `rolled_up_index_pattern,index_pattern`, nor you can use `rolled_up_index_pattern,index_pattern*`.
You can use `rolled_up_index_pattern` xor `index_pattern*`.

### For maintainers

- [ ] This has to be backported to all versions
- [ ] Suggest any better wording if necessary