### PR TITLE
[Usage Collection] [schema] `reporting` + add `MappedType` support

### DIFF
--- a/packages/kbn-telemetry-tools/src/tools/serializer.test.ts
+++ b/packages/kbn-telemetry-tools/src/tools/serializer.test.ts
@@ -124,4 +124,18 @@ describe('getDescriptor', () => {
       '@@INDEX@@': { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
     });
   });
+
+  it('serializes MappedTypes', () => {
+    const usageInterface = usageInterfaces.get('MappedTypes')!;
+    const descriptor = getDescriptor(usageInterface, tsProgram);
+    expect(descriptor).toEqual({
+      mappedTypeWithExternallyDefinedProps: {
+        prop1: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+        prop2: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+      },
+      mappedTypeWithOneInlineProp: {
+        prop3: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+      },
+    });
+  });
 });

--- a/packages/kbn-telemetry-tools/src/tools/utils.ts
+++ b/packages/kbn-telemetry-tools/src/tools/utils.ts
@@ -124,7 +124,9 @@ export function getVariableValue(node: ts.Node, program: ts.Program): string | R
   }
 
   throw Error(
-    `Unsupported Node: cannot get value of node (${node.getText()}) of kind ${node.kind}`
+    `Unsupported Node: cannot get value of node (${node.getText()}) of kind ${node.kind} [${
+      ts.SyntaxKind[node.kind]
+    }]`
   );
 }
 

--- a/src/fixtures/telemetry_collectors/constants.ts
+++ b/src/fixtures/telemetry_collectors/constants.ts
@@ -55,3 +55,14 @@ export const externallyDefinedSchema: MakeSchemaFrom<{ locale: string }> = {
 export type TypeAliasWithUnion = Usage & WithUnion;
 
 export type TypeAliasWithRecord = Usage & Record<string, number>;
+
+export type MappedTypeProps = 'prop1' | 'prop2';
+
+export interface MappedTypes {
+  mappedTypeWithExternallyDefinedProps: {
+    [key in MappedTypeProps]: number;
+  };
+  mappedTypeWithOneInlineProp: {
+    [key in 'prop3']: number;
+  };
+}

--- a/x-pack/.telemetryrc.json
+++ b/x-pack/.telemetryrc.json
@@ -6,7 +6,6 @@
     "plugins/alerts/server/usage/alerts_usage_collector.ts",
     "plugins/apm/server/lib/apm_telemetry/index.ts",
     "plugins/infra/server/usage/usage_collector.ts",
-    "plugins/reporting/server/usage/reporting_usage_collector.ts",
     "plugins/maps/server/maps_telemetry/collectors/register.ts"
   ]
 }

--- a/x-pack/plugins/reporting/server/usage/reporting_usage_collector.test.ts
+++ b/x-pack/plugins/reporting/server/usage/reporting_usage_collector.test.ts
@@ -467,6 +467,575 @@ describe('Ready for collection observable', () => {
         "fetch": [Function],
         "formatForBulkUpload": [Function],
         "isReady": [Function],
+        "schema": Object {
+          "PNG": Object {
+            "available": Object {
+              "type": "boolean",
+            },
+            "total": Object {
+              "type": "long",
+            },
+          },
+          "_all": Object {
+            "type": "long",
+          },
+          "available": Object {
+            "type": "boolean",
+          },
+          "browser_type": Object {
+            "type": "keyword",
+          },
+          "csv": Object {
+            "available": Object {
+              "type": "boolean",
+            },
+            "total": Object {
+              "type": "long",
+            },
+          },
+          "enabled": Object {
+            "type": "boolean",
+          },
+          "last7Days": Object {
+            "PNG": Object {
+              "available": Object {
+                "type": "boolean",
+              },
+              "total": Object {
+                "type": "long",
+              },
+            },
+            "_all": Object {
+              "type": "long",
+            },
+            "csv": Object {
+              "available": Object {
+                "type": "boolean",
+              },
+              "total": Object {
+                "type": "long",
+              },
+            },
+            "printable_pdf": Object {
+              "app": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "available": Object {
+                "type": "boolean",
+              },
+              "layout": Object {
+                "preserve_layout": Object {
+                  "type": "long",
+                },
+                "print": Object {
+                  "type": "long",
+                },
+              },
+              "total": Object {
+                "type": "long",
+              },
+            },
+            "status": Object {
+              "cancelled": Object {
+                "type": "long",
+              },
+              "completed": Object {
+                "type": "long",
+              },
+              "completed_with_warnings": Object {
+                "type": "long",
+              },
+              "failed": Object {
+                "type": "long",
+              },
+              "pending": Object {
+                "type": "long",
+              },
+              "processing": Object {
+                "type": "long",
+              },
+            },
+            "statuses": Object {
+              "cancelled": Object {
+                "PNG": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "csv": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "printable_pdf": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+              },
+              "completed": Object {
+                "PNG": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "csv": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "printable_pdf": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+              },
+              "completed_with_warnings": Object {
+                "PNG": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "csv": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "printable_pdf": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+              },
+              "failed": Object {
+                "PNG": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "csv": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "printable_pdf": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+              },
+              "pending": Object {
+                "PNG": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "csv": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "printable_pdf": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+              },
+              "processing": Object {
+                "PNG": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "csv": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+                "printable_pdf": Object {
+                  "canvas workpad": Object {
+                    "type": "long",
+                  },
+                  "dashboard": Object {
+                    "type": "long",
+                  },
+                  "visualization": Object {
+                    "type": "long",
+                  },
+                },
+              },
+            },
+          },
+          "printable_pdf": Object {
+            "app": Object {
+              "canvas workpad": Object {
+                "type": "long",
+              },
+              "dashboard": Object {
+                "type": "long",
+              },
+              "visualization": Object {
+                "type": "long",
+              },
+            },
+            "available": Object {
+              "type": "boolean",
+            },
+            "layout": Object {
+              "preserve_layout": Object {
+                "type": "long",
+              },
+              "print": Object {
+                "type": "long",
+              },
+            },
+            "total": Object {
+              "type": "long",
+            },
+          },
+          "status": Object {
+            "cancelled": Object {
+              "type": "long",
+            },
+            "completed": Object {
+              "type": "long",
+            },
+            "completed_with_warnings": Object {
+              "type": "long",
+            },
+            "failed": Object {
+              "type": "long",
+            },
+            "pending": Object {
+              "type": "long",
+            },
+            "processing": Object {
+              "type": "long",
+            },
+          },
+          "statuses": Object {
+            "cancelled": Object {
+              "PNG": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "csv": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "printable_pdf": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+            },
+            "completed": Object {
+              "PNG": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "csv": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "printable_pdf": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+            },
+            "completed_with_warnings": Object {
+              "PNG": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "csv": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "printable_pdf": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+            },
+            "failed": Object {
+              "PNG": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "csv": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "printable_pdf": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+            },
+            "pending": Object {
+              "PNG": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "csv": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "printable_pdf": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+            },
+            "processing": Object {
+              "PNG": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "csv": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+              "printable_pdf": Object {
+                "canvas workpad": Object {
+                  "type": "long",
+                },
+                "dashboard": Object {
+                  "type": "long",
+                },
+                "visualization": Object {
+                  "type": "long",
+                },
+              },
+            },
+          },
+        },
         "type": "reporting",
       }
     `);

--- a/x-pack/plugins/reporting/server/usage/reporting_usage_collector.ts
+++ b/x-pack/plugins/reporting/server/usage/reporting_usage_collector.ts
@@ -13,6 +13,7 @@ import { ReportingSetupDeps } from '../types';
 import { GetLicense } from './';
 import { getReportingUsage } from './get_reporting_usage';
 import { ReportingUsageType } from './types';
+import { reportingSchema } from './schema';
 
 // places the reporting data as kibana stats
 const METATYPE = 'kibana_stats';
@@ -41,6 +42,7 @@ export function getReportingUsageCollector(
       return getReportingUsage(config, getLicense, callCluster, exportTypesRegistry);
     },
     isReady,
+    schema: reportingSchema,
     /*
      * Format the response data into a model for internal upload
      * 1. Make this data part of the "kibana_stats" type

--- a/x-pack/plugins/reporting/server/usage/schema.ts
+++ b/x-pack/plugins/reporting/server/usage/schema.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MakeSchemaFrom } from 'src/plugins/usage_collection/server';
+import { AppCounts, AvailableTotal, JobTypes, RangeStats, ReportingUsageType } from './types';
+
+const appCountsSchema: MakeSchemaFrom<AppCounts> = {
+  'canvas workpad': { type: 'long' },
+  dashboard: { type: 'long' },
+  visualization: { type: 'long' },
+};
+
+const byAppCountsSchema: MakeSchemaFrom<RangeStats['statuses']['cancelled']> = {
+  csv: appCountsSchema,
+  PNG: appCountsSchema,
+  printable_pdf: appCountsSchema,
+};
+
+const availableTotalSchema: MakeSchemaFrom<AvailableTotal> = {
+  available: { type: 'boolean' },
+  total: { type: 'long' },
+};
+
+const jobTypesSchema: MakeSchemaFrom<JobTypes> = {
+  csv: availableTotalSchema,
+  PNG: availableTotalSchema,
+  printable_pdf: {
+    ...availableTotalSchema,
+    app: appCountsSchema,
+    layout: {
+      print: { type: 'long' },
+      preserve_layout: { type: 'long' },
+    },
+  },
+};
+
+const rangeStatsSchema: MakeSchemaFrom<RangeStats> = {
+  ...jobTypesSchema,
+  _all: { type: 'long' },
+  status: {
+    cancelled: { type: 'long' },
+    completed: { type: 'long' },
+    completed_with_warnings: { type: 'long' },
+    failed: { type: 'long' },
+    pending: { type: 'long' },
+    processing: { type: 'long' },
+  },
+  statuses: {
+    cancelled: byAppCountsSchema,
+    completed: byAppCountsSchema,
+    completed_with_warnings: byAppCountsSchema,
+    failed: byAppCountsSchema,
+    pending: byAppCountsSchema,
+    processing: byAppCountsSchema,
+  },
+};
+
+export const reportingSchema: MakeSchemaFrom<ReportingUsageType> = {
+  ...rangeStatsSchema,
+  available: { type: 'boolean' },
+  browser_type: { type: 'keyword' },
+  enabled: { type: 'boolean' },
+  last7Days: rangeStatsSchema,
+};

--- a/x-pack/plugins/reporting/server/usage/types.ts
+++ b/x-pack/plugins/reporting/server/usage/types.ts
@@ -162,8 +162,3 @@ export interface SearchResponse {
     };
   };
 }
-
-export interface AvailableTotal {
-  available: boolean;
-  total: number;
-}

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -754,6 +754,703 @@
         }
       }
     },
+    "reporting": {
+      "properties": {
+        "csv": {
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "total": {
+              "type": "long"
+            }
+          }
+        },
+        "PNG": {
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "total": {
+              "type": "long"
+            }
+          }
+        },
+        "printable_pdf": {
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "total": {
+              "type": "long"
+            },
+            "app": {
+              "properties": {
+                "canvas workpad": {
+                  "type": "long"
+                },
+                "dashboard": {
+                  "type": "long"
+                },
+                "visualization": {
+                  "type": "long"
+                }
+              }
+            },
+            "layout": {
+              "properties": {
+                "print": {
+                  "type": "long"
+                },
+                "preserve_layout": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
+        "_all": {
+          "type": "long"
+        },
+        "status": {
+          "properties": {
+            "cancelled": {
+              "type": "long"
+            },
+            "completed": {
+              "type": "long"
+            },
+            "completed_with_warnings": {
+              "type": "long"
+            },
+            "failed": {
+              "type": "long"
+            },
+            "pending": {
+              "type": "long"
+            },
+            "processing": {
+              "type": "long"
+            }
+          }
+        },
+        "statuses": {
+          "properties": {
+            "cancelled": {
+              "properties": {
+                "csv": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "PNG": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "printable_pdf": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "completed": {
+              "properties": {
+                "csv": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "PNG": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "printable_pdf": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "completed_with_warnings": {
+              "properties": {
+                "csv": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "PNG": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "printable_pdf": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "failed": {
+              "properties": {
+                "csv": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "PNG": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "printable_pdf": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "pending": {
+              "properties": {
+                "csv": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "PNG": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "printable_pdf": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "processing": {
+              "properties": {
+                "csv": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "PNG": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "printable_pdf": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "available": {
+          "type": "boolean"
+        },
+        "browser_type": {
+          "type": "keyword"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "last7Days": {
+          "properties": {
+            "csv": {
+              "properties": {
+                "available": {
+                  "type": "boolean"
+                },
+                "total": {
+                  "type": "long"
+                }
+              }
+            },
+            "PNG": {
+              "properties": {
+                "available": {
+                  "type": "boolean"
+                },
+                "total": {
+                  "type": "long"
+                }
+              }
+            },
+            "printable_pdf": {
+              "properties": {
+                "available": {
+                  "type": "boolean"
+                },
+                "total": {
+                  "type": "long"
+                },
+                "app": {
+                  "properties": {
+                    "canvas workpad": {
+                      "type": "long"
+                    },
+                    "dashboard": {
+                      "type": "long"
+                    },
+                    "visualization": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "layout": {
+                  "properties": {
+                    "print": {
+                      "type": "long"
+                    },
+                    "preserve_layout": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
+            "_all": {
+              "type": "long"
+            },
+            "status": {
+              "properties": {
+                "cancelled": {
+                  "type": "long"
+                },
+                "completed": {
+                  "type": "long"
+                },
+                "completed_with_warnings": {
+                  "type": "long"
+                },
+                "failed": {
+                  "type": "long"
+                },
+                "pending": {
+                  "type": "long"
+                },
+                "processing": {
+                  "type": "long"
+                }
+              }
+            },
+            "statuses": {
+              "properties": {
+                "cancelled": {
+                  "properties": {
+                    "csv": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "PNG": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "printable_pdf": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "completed": {
+                  "properties": {
+                    "csv": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "PNG": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "printable_pdf": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "completed_with_warnings": {
+                  "properties": {
+                    "csv": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "PNG": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "printable_pdf": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "failed": {
+                  "properties": {
+                    "csv": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "PNG": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "printable_pdf": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "pending": {
+                  "properties": {
+                    "csv": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "PNG": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "printable_pdf": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "processing": {
+                  "properties": {
+                    "csv": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "PNG": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "printable_pdf": {
+                      "properties": {
+                        "canvas workpad": {
+                          "type": "long"
+                        },
+                        "dashboard": {
+                          "type": "long"
+                        },
+                        "visualization": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "rollups": {
       "properties": {
         "index_patterns": {


### PR DESCRIPTION
## Summary

- Add `schema` definition to the collector `reporting`.
- Add support to `MappedType`: `{ [key in 'prop1' | 'prop2']: OtherType }`

Related to #70180.

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

