### PR TITLE
[Security Solution][Endpoint] Update host.os.family to match what endpoint sends

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
@@ -67,7 +67,7 @@ const Windows: OSFields[] = [
     full: 'Windows 10',
     version: '10.0',
     platform: 'Windows',
-    family: 'Windows',
+    family: 'windows',
     Ext: {
       variant: 'Windows Pro',
     },
@@ -77,7 +77,7 @@ const Windows: OSFields[] = [
     full: 'Windows Server 2016',
     version: '10.0',
     platform: 'Windows',
-    family: 'Windows',
+    family: 'windows',
     Ext: {
       variant: 'Windows Server',
     },
@@ -87,7 +87,7 @@ const Windows: OSFields[] = [
     full: 'Windows Server 2012',
     version: '6.2',
     platform: 'Windows',
-    family: 'Windows',
+    family: 'windows',
     Ext: {
       variant: 'Windows Server',
     },
@@ -97,7 +97,7 @@ const Windows: OSFields[] = [
     full: 'Windows Server 2012R2',
     version: '6.3',
     platform: 'Windows',
-    family: 'Windows',
+    family: 'windows',
     Ext: {
       variant: 'Windows Server Release 2',
     },


### PR DESCRIPTION
## Summary

The endpoint sends `host.os.family` lowercased as `windows`. This PR updates the data generator to match the endpoint. `host.os.family` is used when creating endpoint exceptions and is expected to be lowercased there as well.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
