### PR TITLE
Remove unused elasticsearch.preserverHost setting

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -27,11 +27,6 @@
 # The URLs of the Elasticsearch instances to use for all your queries.
 #elasticsearch.hosts: ["http://localhost:9200"]
 
-# When this setting's value is true Kibana uses the hostname specified in the server.host
-# setting. When the value of this setting is false, Kibana uses the hostname of the host
-# that connects to this Kibana instance.
-#elasticsearch.preserveHost: true
-
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations and
 # dashboards. Kibana creates a new index if the index doesn't already exist.
 #kibana.index: ".kibana"

--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -76,9 +76,6 @@
 # Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable.
 #elasticsearch.shardTimeout: 30000
 
-# Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying.
-#elasticsearch.startupTimeout: 5000
-
 # Logs queries sent to Elasticsearch. Requires logging.verbose set to true.
 #elasticsearch.logQueries: false
 

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -68,11 +68,6 @@ currently do not have an inspector, for example Timelion and Monitoring.
  | Time in milliseconds to wait for {es} to respond to pings.
 *Default: the value of the <<elasticsearch-requestTimeout, `elasticsearch.requestTimeout`>> setting*
 
-| `elasticsearch.preserveHost:`
- | When the value is `true`, {kib} uses the hostname specified in the
-<<server-host, `server.host`>> setting. When the value is `false`, {kib} uses
-the hostname of the host that connects to this {kib} instance. *Default: `true`*
-
 |[[elasticsearch-requestHeadersWhitelist]] `elasticsearch.requestHeadersWhitelist:`
  | List of {kib} client-side headers to send to {es}. To send *no* client-side
 headers, set this value to [] (an empty list). Removing the `authorization`

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -199,10 +199,6 @@ making an outbound SSL/TLS connection to {es}. Valid values are `"full"`,
 using `"certificate"` skips hostname verification, and using `"none"` skips
 verification entirely. *Default: `"full"`*
 
-| `elasticsearch.startupTimeout:`
- | Time in milliseconds to wait for {es} at {kib} startup before retrying.
-*Default: `5000`*
-
 |[[elasticsearch-user-passwd]] `elasticsearch.username:` and `elasticsearch.password:`
  | If your {es} is protected with basic authentication, these settings provide
 the username and password that the {kib} server uses to perform maintenance

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -136,6 +136,7 @@ export const coreDeprecationProvider: ConfigDeprecationProvider = ({ rename, unu
   unusedFromRoot('optimize.workers'),
   unusedFromRoot('optimize.profile'),
   unusedFromRoot('optimize.validateSyntaxOfNodeModules'),
+  unusedFromRoot('elasticsearch.preserveHost'),
   rename('cpu.cgroup.path.override', 'ops.cGroupOverrides.cpuPath'),
   rename('cpuacct.cgroup.path.override', 'ops.cGroupOverrides.cpuAcctPath'),
   configPathDeprecation,

--- a/src/core/server/config/deprecation/core_deprecations.ts
+++ b/src/core/server/config/deprecation/core_deprecations.ts
@@ -137,6 +137,7 @@ export const coreDeprecationProvider: ConfigDeprecationProvider = ({ rename, unu
   unusedFromRoot('optimize.profile'),
   unusedFromRoot('optimize.validateSyntaxOfNodeModules'),
   unusedFromRoot('elasticsearch.preserveHost'),
+  unusedFromRoot('elasticsearch.startupTimeout'),
   rename('cpu.cgroup.path.override', 'ops.cGroupOverrides.cpuPath'),
   rename('cpuacct.cgroup.path.override', 'ops.cGroupOverrides.cpuAcctPath'),
   configPathDeprecation,

--- a/src/core/server/elasticsearch/elasticsearch_config.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.ts
@@ -45,7 +45,6 @@ export const configSchema = schema.object({
   hosts: schema.oneOf([hostURISchema, schema.arrayOf(hostURISchema, { minSize: 1 })], {
     defaultValue: 'http://localhost:9200',
   }),
-  preserveHost: schema.boolean({ defaultValue: true }),
   username: schema.maybe(
     schema.conditional(
       schema.contextRef('dist'),

--- a/src/core/server/elasticsearch/elasticsearch_config.ts
+++ b/src/core/server/elasticsearch/elasticsearch_config.ts
@@ -70,7 +70,6 @@ export const configSchema = schema.object({
   shardTimeout: schema.duration({ defaultValue: '30s' }),
   requestTimeout: schema.duration({ defaultValue: '30s' }),
   pingTimeout: schema.duration({ defaultValue: schema.siblingRef('requestTimeout') }),
-  startupTimeout: schema.duration({ defaultValue: '5s' }),
   logQueries: schema.boolean({ defaultValue: false }),
   ssl: schema.object(
     {

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -67,7 +67,6 @@ export function pluginInitializerContextConfigMock<T>(config: T) {
       shardTimeout: duration('30s'),
       requestTimeout: duration('30s'),
       pingTimeout: duration('30s'),
-      startupTimeout: duration('30s'),
     },
     path: { data: '/tmp' },
     savedObjects: {

--- a/src/core/server/plugins/plugin_context.test.ts
+++ b/src/core/server/plugins/plugin_context.test.ts
@@ -91,7 +91,6 @@ describe('createPluginInitializerContext', () => {
         shardTimeout: duration(30, 's'),
         requestTimeout: duration(30, 's'),
         pingTimeout: duration(30, 's'),
-        startupTimeout: duration(5, 's'),
       },
       path: { data: fromRoot('data') },
       savedObjects: { maxImportPayloadBytes: new ByteSizeValue(10485760) },

--- a/src/core/server/plugins/types.ts
+++ b/src/core/server/plugins/types.ts
@@ -262,7 +262,7 @@ export interface Plugin<
 export const SharedGlobalConfigKeys = {
   // We can add more if really needed
   kibana: ['index', 'autocompleteTerminateAfter', 'autocompleteTimeout'] as const,
-  elasticsearch: ['shardTimeout', 'requestTimeout', 'pingTimeout', 'startupTimeout'] as const,
+  elasticsearch: ['shardTimeout', 'requestTimeout', 'pingTimeout'] as const,
   path: ['data'] as const,
   savedObjects: ['maxImportPayloadBytes'] as const,
 };

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -355,7 +355,6 @@ export const config: {
             shardTimeout: Type<import("moment").Duration>;
             requestTimeout: Type<import("moment").Duration>;
             pingTimeout: Type<import("moment").Duration>;
-            startupTimeout: Type<import("moment").Duration>;
             logQueries: Type<boolean>;
             ssl: import("@kbn/config-schema").ObjectType<{
                 verificationMode: Type<"none" | "certificate" | "full">;

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -348,7 +348,6 @@ export const config: {
             sniffInterval: Type<false | import("moment").Duration>;
             sniffOnConnectionFault: Type<boolean>;
             hosts: Type<string | string[]>;
-            preserveHost: Type<boolean>;
             username: Type<string | undefined>;
             password: Type<string | undefined>;
             requestHeadersWhitelist: Type<string | string[]>;

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker
@@ -8,11 +8,11 @@
 #
 # eg. Setting the environment variable:
 #
-#       ELASTICSEARCH_STARTUPTIMEOUT=60
+#       ELASTICSEARCH_LOGQUERIES=true
 #
 # will cause Kibana to be invoked with:
 #
-#       --elasticsearch.startupTimeout=60
+#       --elasticsearch.logQueries=true
 
 kibana_vars=(
     console.enabled
@@ -46,7 +46,6 @@ kibana_vars=(
     elasticsearch.ssl.truststore.path
     elasticsearch.ssl.truststore.password
     elasticsearch.ssl.verificationMode
-    elasticsearch.startupTimeout
     elasticsearch.username
     i18n.locale
     interpreter.enableInVisualize

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker
@@ -30,7 +30,6 @@ kibana_vars=(
     elasticsearch.logQueries
     elasticsearch.password
     elasticsearch.pingTimeout
-    elasticsearch.preserveHost
     elasticsearch.requestHeadersWhitelist
     elasticsearch.requestTimeout
     elasticsearch.shardTimeout

--- a/x-pack/plugins/monitoring/server/config.test.ts
+++ b/x-pack/plugins/monitoring/server/config.test.ts
@@ -72,7 +72,6 @@ describe('config schema', () => {
             "logFetchCount": 10,
             "logQueries": false,
             "pingTimeout": "PT30S",
-            "preserveHost": true,
             "requestHeadersWhitelist": Array [
               "authorization",
             ],

--- a/x-pack/plugins/monitoring/server/config.test.ts
+++ b/x-pack/plugins/monitoring/server/config.test.ts
@@ -86,7 +86,6 @@ describe('config schema', () => {
               "truststore": Object {},
               "verificationMode": "full",
             },
-            "startupTimeout": "PT5S",
           },
           "enabled": true,
           "logs": Object {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/17242

I've also removed `elasticsearch.startupTimeout` which was unused. Since Kibana will keep on trying to connect to Elasticsearch until it manages to connect, I don't think there's any value in having such a setting.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
