### PR TITLE
[Dashboard] Maximize Panel Title Copy

### DIFF
--- a/src/plugins/dashboard/public/application/actions/expand_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/expand_panel_action.tsx
@@ -57,7 +57,7 @@ export class ExpandPanelAction implements ActionByType<typeof ACTION_EXPAND_PANE
           defaultMessage: 'Minimize',
         })
       : i18n.translate('dashboard.actions.toggleExpandPanelMenuItem.notExpandedDisplayName', {
-          defaultMessage: 'Full screen',
+          defaultMessage: 'Maximize panel',
         });
   }
 

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -502,7 +502,6 @@
     "core.status.redTitle": "赤",
     "core.status.yellowTitle": "黄色",
     "dashboard.actions.toggleExpandPanelMenuItem.expandedDisplayName": "最小化",
-    "dashboard.actions.toggleExpandPanelMenuItem.notExpandedDisplayName": "全画面",
     "dashboard.addExistingVisualizationLinkText": "既存のユーザーを追加",
     "dashboard.addNewVisualizationText": "またはこのダッシュボードに新規オブジェクトを追加",
     "dashboard.addPanel.noMatchingObjectsMessage": "一致するオブジェクトが見つかりませんでした。",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -502,6 +502,7 @@
     "core.status.redTitle": "赤",
     "core.status.yellowTitle": "黄色",
     "dashboard.actions.toggleExpandPanelMenuItem.expandedDisplayName": "最小化",
+    "dashboard.actions.toggleExpandPanelMenuItem.notExpandedDisplayName": "全画面",
     "dashboard.addExistingVisualizationLinkText": "既存のユーザーを追加",
     "dashboard.addNewVisualizationText": "またはこのダッシュボードに新規オブジェクトを追加",
     "dashboard.addPanel.noMatchingObjectsMessage": "一致するオブジェクトが見つかりませんでした。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -502,6 +502,7 @@
     "core.status.redTitle": "红",
     "core.status.yellowTitle": "黄",
     "dashboard.actions.toggleExpandPanelMenuItem.expandedDisplayName": "最小化",
+    "dashboard.actions.toggleExpandPanelMenuItem.notExpandedDisplayName": "全屏",
     "dashboard.addExistingVisualizationLinkText": "将现有",
     "dashboard.addNewVisualizationText": "或新对象添加到此仪表板",
     "dashboard.addPanel.noMatchingObjectsMessage": "未找到任何匹配对象。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -502,7 +502,6 @@
     "core.status.redTitle": "红",
     "core.status.yellowTitle": "黄",
     "dashboard.actions.toggleExpandPanelMenuItem.expandedDisplayName": "最小化",
-    "dashboard.actions.toggleExpandPanelMenuItem.notExpandedDisplayName": "全屏",
     "dashboard.addExistingVisualizationLinkText": "将现有",
     "dashboard.addNewVisualizationText": "或新对象添加到此仪表板",
     "dashboard.addPanel.noMatchingObjectsMessage": "未找到任何匹配对象。",


### PR DESCRIPTION
## Summary

Changes the copy for the dashboard 'expand panel' action to avoid confusion between the dashboard full screen mode and individual panel fullscreen modes. Fixes https://github.com/elastic/kibana/issues/78649

<img width="259" alt="Screen Shot 2020-09-28 at 5 09 03 PM" src="https://user-images.githubusercontent.com/14276393/94487194-92935b00-01ae-11eb-82ff-c7549bf49276.png">


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
