### PR TITLE
[Discover] Make _source field not clickable

### DIFF
--- a/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
@@ -172,6 +172,19 @@ export function DiscoverField({
     );
   }
 
+  if (field.type === '_source') {
+    return (
+      <FieldButton
+        size="s"
+        className="dscSidebarItem"
+        dataTestSubj={`field-${field.name}-showDetails`}
+        fieldIcon={dscFieldIcon}
+        fieldAction={actionButton}
+        fieldName={fieldName}
+      />
+    );
+  }
+
   return (
     <EuiPopover
       ownFocus
@@ -184,7 +197,7 @@ export function DiscoverField({
           onClick={() => {
             togglePopover();
           }}
-          buttonProps={{ 'data-test-subj': `field-${field.name}-showDetails` }}
+          dataTestSubj={`field-${field.name}-showDetails`}
           fieldIcon={dscFieldIcon}
           fieldAction={actionButton}
           fieldName={fieldName}

--- a/src/plugins/kibana_react/public/field_button/field_button.tsx
+++ b/src/plugins/kibana_react/public/field_button/field_button.tsx
@@ -19,8 +19,7 @@
 
 import './field_button.scss';
 import classNames from 'classnames';
-import React, { ReactNode, HTMLAttributes, ButtonHTMLAttributes } from 'react';
-import { CommonProps } from '@elastic/eui';
+import React, { ReactNode, HTMLAttributes } from 'react';
 
 export interface FieldButtonProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -54,13 +53,10 @@ export interface FieldButtonProps extends HTMLAttributes<HTMLDivElement> {
   size?: ButtonSize;
   className?: string;
   /**
-   * The component always renders a `<button>` and therefore will always need an `onClick`
+   * The component will render a `<button>` when provided an `onClick`
    */
-  onClick: () => void;
-  /**
-   * Pass more button props to the actual `<button>` element
-   */
-  buttonProps?: ButtonHTMLAttributes<HTMLButtonElement> & CommonProps;
+  onClick?: () => void;
+  dataTestSubj?: string;
 }
 
 const sizeToClassNameMap = {
@@ -82,8 +78,7 @@ export function FieldButton({
   className,
   isDraggable = false,
   onClick,
-  buttonProps,
-  ...rest
+  dataTestSubj,
 }: FieldButtonProps) {
   const classes = classNames(
     'kbnFieldButton',
@@ -93,27 +88,31 @@ export function FieldButton({
     className
   );
 
-  const buttonClasses = classNames(
-    'kbn-resetFocusState kbnFieldButton__button',
-    buttonProps && buttonProps.className
-  );
-
   return (
-    <div className={classes} {...rest}>
-      <button
-        onClick={(e) => {
-          if (e.type === 'click') {
-            e.currentTarget.focus();
-          }
-          onClick();
-        }}
-        {...buttonProps}
-        className={buttonClasses}
-      >
-        {fieldIcon && <span className="kbnFieldButton__fieldIcon">{fieldIcon}</span>}
-        {fieldName && <span className="kbnFieldButton__name">{fieldName}</span>}
-        {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
-      </button>
+    <div className={classes}>
+      {onClick ? (
+        <button
+          onClick={(e) => {
+            if (e.type === 'click') {
+              e.currentTarget.focus();
+            }
+            onClick();
+          }}
+          data-test-subj={dataTestSubj}
+          className={'kbn-resetFocusState kbnFieldButton__button'}
+        >
+          {fieldIcon && <span className="kbnFieldButton__fieldIcon">{fieldIcon}</span>}
+          {fieldName && <span className="kbnFieldButton__name">{fieldName}</span>}
+          {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
+        </button>
+      ) : (
+        <div className={'kbn-resetFocusState kbnFieldButton__button'} data-test-subj={dataTestSubj}>
+          {fieldIcon && <span className="kbnFieldButton__fieldIcon">{fieldIcon}</span>}
+          {fieldName && <span className="kbnFieldButton__name">{fieldName}</span>}
+          {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
+        </div>
+      )}
+
       {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
     </div>
   );


### PR DESCRIPTION
The _source field was showing a confusing error message when clicked, so the solution is to make the _source field even more "special" than it already is by removing all clickability.

![discover without clickable _source](https://user-images.githubusercontent.com/666475/94489748-0afc1b00-01b3-11eb-8a53-ab8b9e1bd152.gif)

Fixes https://github.com/elastic/kibana/issues/8415

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
