### PR TITLE
[Design] A couple fixes for 7.10

### DIFF
--- a/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/public/chrome/ui/header/__snapshots__/header.test.tsx.snap
@@ -1907,62 +1907,133 @@ exports[`Header renders 1`] = `
             Object {
               "borders": "none",
               "items": Array [
-                <HeaderNavControls
-                  navControls$={
-                    BehaviorSubject {
-                      "_isScalar": false,
-                      "_value": Array [],
-                      "closed": false,
-                      "hasError": false,
-                      "isStopped": false,
-                      "observers": Array [
-                        Subscriber {
-                          "_parentOrParents": null,
-                          "_subscriptions": Array [
-                            SubjectSubscription {
-                              "_parentOrParents": [Circular],
+                <EuiShowFor
+                  sizes={
+                    Array [
+                      "m",
+                      "l",
+                      "xl",
+                    ]
+                  }
+                >
+                  <HeaderNavControls
+                    navControls$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
                               "_subscriptions": null,
                               "closed": false,
-                              "subject": [Circular],
-                              "subscriber": [Circular],
-                            },
-                          ],
-                          "closed": false,
-                          "destination": SafeSubscriber {
-                            "_complete": undefined,
-                            "_context": [Circular],
-                            "_error": undefined,
-                            "_next": [Function],
-                            "_parentOrParents": null,
-                            "_parentSubscriber": [Circular],
-                            "_subscriptions": null,
-                            "closed": false,
-                            "destination": Object {
-                              "closed": true,
-                              "complete": [Function],
-                              "error": [Function],
-                              "next": [Function],
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
                             },
                             "isStopped": false,
-                            "syncErrorThrowable": false,
+                            "syncErrorThrowable": true,
                             "syncErrorThrown": false,
                             "syncErrorValue": null,
                           },
-                          "isStopped": false,
-                          "syncErrorThrowable": true,
-                          "syncErrorThrown": false,
-                          "syncErrorValue": null,
-                        },
-                      ],
-                      "thrownError": null,
+                        ],
+                        "thrownError": null,
+                      }
                     }
-                  }
-                />,
+                  />
+                </EuiShowFor>,
               ],
             },
             Object {
               "borders": "none",
               "items": Array [
+                <EuiHideFor
+                  sizes={
+                    Array [
+                      "m",
+                      "l",
+                      "xl",
+                    ]
+                  }
+                >
+                  <HeaderNavControls
+                    navControls$={
+                      BehaviorSubject {
+                        "_isScalar": false,
+                        "_value": Array [],
+                        "closed": false,
+                        "hasError": false,
+                        "isStopped": false,
+                        "observers": Array [
+                          Subscriber {
+                            "_parentOrParents": null,
+                            "_subscriptions": Array [
+                              SubjectSubscription {
+                                "_parentOrParents": [Circular],
+                                "_subscriptions": null,
+                                "closed": false,
+                                "subject": [Circular],
+                                "subscriber": [Circular],
+                              },
+                            ],
+                            "closed": false,
+                            "destination": SafeSubscriber {
+                              "_complete": undefined,
+                              "_context": [Circular],
+                              "_error": undefined,
+                              "_next": [Function],
+                              "_parentOrParents": null,
+                              "_parentSubscriber": [Circular],
+                              "_subscriptions": null,
+                              "closed": false,
+                              "destination": Object {
+                                "closed": true,
+                                "complete": [Function],
+                                "error": [Function],
+                                "next": [Function],
+                              },
+                              "isStopped": false,
+                              "syncErrorThrowable": false,
+                              "syncErrorThrown": false,
+                              "syncErrorValue": null,
+                            },
+                            "isStopped": false,
+                            "syncErrorThrowable": true,
+                            "syncErrorThrown": false,
+                            "syncErrorValue": null,
+                          },
+                        ],
+                        "thrownError": null,
+                      }
+                    }
+                  />
+                </EuiHideFor>,
                 <InjectIntl(HeaderHelpMenuUI)
                   helpExtension$={
                     BehaviorSubject {
@@ -3053,57 +3124,67 @@ exports[`Header renders 1`] = `
                 <div
                   className="euiHeaderSectionItem"
                 >
-                  <HeaderNavControls
-                    navControls$={
-                      BehaviorSubject {
-                        "_isScalar": false,
-                        "_value": Array [],
-                        "closed": false,
-                        "hasError": false,
-                        "isStopped": false,
-                        "observers": Array [
-                          Subscriber {
-                            "_parentOrParents": null,
-                            "_subscriptions": Array [
-                              SubjectSubscription {
-                                "_parentOrParents": [Circular],
+                  <EuiShowFor
+                    sizes={
+                      Array [
+                        "m",
+                        "l",
+                        "xl",
+                      ]
+                    }
+                  >
+                    <HeaderNavControls
+                      navControls$={
+                        BehaviorSubject {
+                          "_isScalar": false,
+                          "_value": Array [],
+                          "closed": false,
+                          "hasError": false,
+                          "isStopped": false,
+                          "observers": Array [
+                            Subscriber {
+                              "_parentOrParents": null,
+                              "_subscriptions": Array [
+                                SubjectSubscription {
+                                  "_parentOrParents": [Circular],
+                                  "_subscriptions": null,
+                                  "closed": false,
+                                  "subject": [Circular],
+                                  "subscriber": [Circular],
+                                },
+                              ],
+                              "closed": false,
+                              "destination": SafeSubscriber {
+                                "_complete": undefined,
+                                "_context": [Circular],
+                                "_error": undefined,
+                                "_next": [Function],
+                                "_parentOrParents": null,
+                                "_parentSubscriber": [Circular],
                                 "_subscriptions": null,
                                 "closed": false,
-                                "subject": [Circular],
-                                "subscriber": [Circular],
-                              },
-                            ],
-                            "closed": false,
-                            "destination": SafeSubscriber {
-                              "_complete": undefined,
-                              "_context": [Circular],
-                              "_error": undefined,
-                              "_next": [Function],
-                              "_parentOrParents": null,
-                              "_parentSubscriber": [Circular],
-                              "_subscriptions": null,
-                              "closed": false,
-                              "destination": Object {
-                                "closed": true,
-                                "complete": [Function],
-                                "error": [Function],
-                                "next": [Function],
+                                "destination": Object {
+                                  "closed": true,
+                                  "complete": [Function],
+                                  "error": [Function],
+                                  "next": [Function],
+                                },
+                                "isStopped": false,
+                                "syncErrorThrowable": false,
+                                "syncErrorThrown": false,
+                                "syncErrorValue": null,
                               },
                               "isStopped": false,
-                              "syncErrorThrowable": false,
+                              "syncErrorThrowable": true,
                               "syncErrorThrown": false,
                               "syncErrorValue": null,
                             },
-                            "isStopped": false,
-                            "syncErrorThrowable": true,
-                            "syncErrorThrown": false,
-                            "syncErrorValue": null,
-                          },
-                        ],
-                        "thrownError": null,
+                          ],
+                          "thrownError": null,
+                        }
                       }
-                    }
-                  />
+                    />
+                  </EuiShowFor>
                 </div>
               </EuiHeaderSectionItem>
             </div>
@@ -3117,6 +3198,24 @@ exports[`Header renders 1`] = `
               <EuiHeaderSectionItem
                 border="none"
                 key="0"
+              >
+                <div
+                  className="euiHeaderSectionItem"
+                >
+                  <EuiHideFor
+                    sizes={
+                      Array [
+                        "m",
+                        "l",
+                        "xl",
+                      ]
+                    }
+                  />
+                </div>
+              </EuiHeaderSectionItem>
+              <EuiHeaderSectionItem
+                border="none"
+                key="1"
               >
                 <div
                   className="euiHeaderSectionItem"
@@ -4786,7 +4885,7 @@ exports[`Header renders 1`] = `
               </EuiHeaderSectionItem>
               <EuiHeaderSectionItem
                 border="none"
-                key="1"
+                key="2"
               >
                 <div
                   className="euiHeaderSectionItem"
@@ -4897,13 +4996,6 @@ exports[`Header renders 1`] = `
                     </button>
                   </EuiHeaderSectionItemButton>
                 </div>
-              </EuiHeaderSectionItem>
-              <EuiHeaderSectionItem
-                border="right"
-              >
-                <div
-                  className="euiHeaderSectionItem euiHeaderSectionItem--borderRight"
-                />
               </EuiHeaderSectionItem>
               <HeaderNavControls
                 navControls$={

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -22,7 +22,9 @@ import {
   EuiHeaderSection,
   EuiHeaderSectionItem,
   EuiHeaderSectionItemButton,
+  EuiHideFor,
   EuiIcon,
+  EuiShowFor,
   htmlIdGenerator,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -117,12 +119,19 @@ export function Header({
               },
               {
                 ...(observables.navControlsCenter$ && {
-                  items: [<HeaderNavControls navControls$={observables.navControlsCenter$} />],
+                  items: [
+                    <EuiShowFor sizes={['m', 'l', 'xl']}>
+                      <HeaderNavControls navControls$={observables.navControlsCenter$} />
+                    </EuiShowFor>,
+                  ],
                 }),
                 borders: 'none',
               },
               {
                 items: [
+                  <EuiHideFor sizes={['m', 'l', 'xl']}>
+                    <HeaderNavControls navControls$={observables.navControlsCenter$} />
+                  </EuiHideFor>,
                   <HeaderHelpMenu
                     helpExtension$={observables.helpExtension$}
                     helpSupportUrl$={observables.helpSupportUrl$}

--- a/src/core/public/chrome/ui/header/header.tsx
+++ b/src/core/public/chrome/ui/header/header.tsx
@@ -163,8 +163,6 @@ export function Header({
                 </EuiHeaderSectionItemButton>
               </EuiHeaderSectionItem>
 
-              <EuiHeaderSectionItem border="right" />
-
               <HeaderNavControls side="left" navControls$={observables.navControlsLeft$} />
             </EuiHeaderSection>
 

--- a/src/plugins/advanced_settings/public/management_app/_advanced_settings.scss
+++ b/src/plugins/advanced_settings/public/management_app/_advanced_settings.scss
@@ -64,3 +64,7 @@
 .mgtAdvancedSettingsForm__button {
   width: 100%;
 }
+
+.kbnBody--mgtAdvancedSettingsHasBottomBar .mgtPage__body {
+  padding-bottom: $euiSizeXL * 2;
+}

--- a/src/plugins/advanced_settings/public/management_app/components/form/form.tsx
+++ b/src/plugins/advanced_settings/public/management_app/components/form/form.tsx
@@ -386,6 +386,13 @@ export class Form extends PureComponent<FormProps> {
     const { unsavedChanges } = this.state;
     const { visibleSettings, categories, categoryCounts, clearQuery } = this.props;
     const currentCategories: Category[] = [];
+    const hasUnsavedChanges = !isEmpty(unsavedChanges);
+
+    if (hasUnsavedChanges) {
+      document.body.classList.add('kbnBody--mgtAdvancedSettingsHasBottomBar');
+    } else {
+      document.body.classList.remove('kbnBody--mgtAdvancedSettingsHasBottomBar');
+    }
 
     categories.forEach((category) => {
       if (visibleSettings[category] && visibleSettings[category].length) {
@@ -406,7 +413,7 @@ export class Form extends PureComponent<FormProps> {
               })
             : this.maybeRenderNoSettings(clearQuery)}
         </div>
-        {!isEmpty(unsavedChanges) && this.renderBottomBar()}
+        {hasUnsavedChanges && this.renderBottomBar()}
       </Fragment>
     );
   }

--- a/src/plugins/data/public/ui/query_string_input/no_data_popover.tsx
+++ b/src/plugins/data/public/ui/query_string_input/no_data_popover.tsx
@@ -63,6 +63,7 @@ export function NoDataPopover({
       }
       minWidth={300}
       anchorPosition="downCenter"
+      anchorClassName="eui-displayBlock"
       step={1}
       stepsTotal={1}
       isStepOpen={noDataPopoverVisible}

--- a/src/plugins/data/public/ui/typeahead/suggestions_component.tsx
+++ b/src/plugins/data/public/ui/typeahead/suggestions_component.tsx
@@ -154,7 +154,7 @@ export class SuggestionsComponent extends Component<Props> {
 const StyledSuggestionsListDiv = styled.div`
   ${(props: { queryBarRect: DOMRect; verticalListPosition: string }) => `
       position: absolute;
-      z-index: 4001;
+      z-index: 999;
       left: ${props.queryBarRect.left}px;
       width: ${props.queryBarRect.width}px;
       ${props.verticalListPosition}`}

--- a/src/plugins/saved_objects/public/save_modal/__snapshots__/saved_object_save_modal.test.tsx.snap
+++ b/src/plugins/saved_objects/public/save_modal/__snapshots__/saved_object_save_modal.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`SavedObjectSaveModal should render matching snapshot 1`] = `
       </EuiModalHeader>
       <EuiModalBody>
         <EuiForm>
+          <EuiSpacer />
           <EuiFormRow
             describedByIds={Array []}
             display="row"

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -110,10 +110,13 @@ export class SavedObjectSaveModal extends React.Component<Props, SaveModalState>
 
               <EuiForm>
                 {!this.props.showDescription && this.props.description && (
-                  <EuiFormRow>
-                    <EuiText color="subdued">{this.props.description}</EuiText>
-                  </EuiFormRow>
+                  <EuiText size="s" color="subdued">
+                    {this.props.description}
+                  </EuiText>
                 )}
+
+                <EuiSpacer />
+
                 {this.renderCopyOnSave()}
 
                 <EuiFormRow

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -141,6 +141,9 @@ export function SearchBar({ globalSearch, navigateToUrl }: Props) {
       onChange={onChange}
       options={options}
       popoverButtonBreakpoints={['xs', 's']}
+      popoverProps={{
+        repositionOnScroll: true,
+      }}
       popoverButton={
         <EuiHeaderSectionItemButton
           aria-label={i18n.translate(

--- a/x-pack/plugins/ui_actions_enhanced/public/components/action_wizard/action_wizard.tsx
+++ b/x-pack/plugins/ui_actions_enhanced/public/components/action_wizard/action_wizard.tsx
@@ -250,7 +250,7 @@ const SelectedActionFactory: React.FC<SelectedActionFactoryProps> = ({
       data-test-subj={`${TEST_SUBJ_SELECTED_ACTION_FACTORY}-${actionFactory.id}`}
     >
       <header>
-        <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
           {actionFactory.getIconType(context) && (
             <EuiFlexItem grow={false}>
               <EuiIcon type={actionFactory.getIconType(context)!} size="m" />
@@ -342,7 +342,7 @@ const ActionFactorySelector: React.FC<ActionFactorySelectorProps> = ({
   };
 
   return (
-    <EuiFlexGroup gutterSize="m" wrap={true} style={firefoxBugFix}>
+    <EuiFlexGroup gutterSize="m" responsive={false} wrap={true} style={firefoxBugFix}>
       {ensureOrder(actionFactories).map((actionFactory) => (
         <EuiFlexItem grow={false} key={actionFactory.id}>
           <EuiToolTip

--- a/x-pack/plugins/ui_actions_enhanced/public/drilldowns/components/drilldown_hello_bar/drilldown_hello_bar.tsx
+++ b/x-pack/plugins/ui_actions_enhanced/public/drilldowns/components/drilldown_hello_bar/drilldown_hello_bar.tsx
@@ -31,11 +31,9 @@ export const DrilldownHelloBar: React.FC<DrilldownHelloBarProps> = ({
 }) => {
   return (
     <EuiCallOut data-test-subj={WELCOME_MESSAGE_TEST_SUBJ}>
-      <EuiFlexGroup>
+      <EuiFlexGroup responsive={false}>
         <EuiFlexItem grow={false}>
-          <div style={{ marginLeft: '8px' }}>
-            <EuiIcon type="help" />
-          </div>
+          <EuiIcon type="help" />
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <EuiText size={'s'}>

--- a/x-pack/plugins/ui_actions_enhanced/public/drilldowns/components/flyout_frame/flyout_frame.tsx
+++ b/x-pack/plugins/ui_actions_enhanced/public/drilldowns/components/flyout_frame/flyout_frame.tsx
@@ -64,7 +64,7 @@ export const FlyoutFrame: React.FC<FlyoutFrameProps> = ({
 
   const footerFragment = (onClose || footer) && (
     <EuiFlyoutFooter>
-      <EuiFlexGroup justifyContent="spaceBetween">
+      <EuiFlexGroup responsive={false} justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
           {onClose && (
             <EuiButtonEmpty

--- a/x-pack/plugins/watcher/public/application/sections/watch_edit/components/threshold_watch_edit/threshold_watch_action_dropdown.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_edit/components/threshold_watch_edit/threshold_watch_action_dropdown.tsx
@@ -103,7 +103,7 @@ export const WatchActionsDropdown: React.FunctionComponent<Props> = ({ settings,
                 setIsPopOverOpen(false);
               }}
             >
-              <EuiFlexGroup>
+              <EuiFlexGroup responsive={false}>
                 <EuiFlexItem grow={false} className="watcherThresholdWatchActionContextMenuItem">
                   <EuiIcon type={action.iconClass} />
                 </EuiFlexItem>


### PR DESCRIPTION
## Header

### 1. Fixed placement of mobile search button

![image](https://user-images.githubusercontent.com/549577/94577396-88bc3700-0244-11eb-9bef-63689ce00e86.png)

### 2. Fixed search popover from scrolling away with the page

![image](https://user-images.githubusercontent.com/549577/94577553-ba350280-0244-11eb-9cf2-ae73f07a4f39.png)

## KQL Bar

### 3. Fixed responsive size of date picker

![image](https://user-images.githubusercontent.com/549577/94578044-3cbdc200-0245-11eb-8b3a-b593c3b1b804.png)


### 4. Fixed suggestion popover from overlapping the header

![image](https://user-images.githubusercontent.com/549577/94578162-5fe87180-0245-11eb-8fa3-6e32942e4644.png)

## Discover

### 5. Fixed spacing in save popover

![image](https://user-images.githubusercontent.com/549577/94578258-84dce480-0245-11eb-82c8-bea7a42f2e9e.png)


## Other responsive fixes

### 6. Drilldowns flyout

![image](https://user-images.githubusercontent.com/549577/94578563-e3a25e00-0245-11eb-8aa7-a583a80c1523.png)

### 7. Alerts action menu

I don't have an after, because I don't know how to setup the TLS 🤷. But this is what it was before and I just removed the responsive layout.
 
![image](https://user-images.githubusercontent.com/549577/94578733-10ef0c00-0246-11eb-91ae-9a38a4e351e4.png)

## Management

### 8. Fix padding for bottom bar in Advanced Settings

The EuiBottomBar adds padding to the body element, but the way the Management layout is setup, this didn't actually add any affordance for the bottom bar, so I had to add a custom body class and padding via CSS.

![image](https://user-images.githubusercontent.com/549577/94579363-bbffc580-0246-11eb-952c-f9a91f8feb19.png)



### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
