### PR TITLE
[Enterprise Search] Update CODEOWNERS and README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -329,16 +329,6 @@ x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json @elastic/kib
 # Shared
 /x-pack/plugins/enterprise_search/ @elastic/enterprise-search-frontend
 /x-pack/test/functional_enterprise_search/ @elastic/enterprise-search-frontend
-# App Search
-/x-pack/plugins/enterprise_search/public/applications/app_search @elastic/app-search-frontend
-/x-pack/plugins/enterprise_search/server/routes/app_search @elastic/app-search-frontend
-/x-pack/plugins/enterprise_search/server/collectors/app_search @elastic/app-search-frontend
-/x-pack/plugins/enterprise_search/server/saved_objects/app_search @elastic/app-search-frontend
-# Workplace Search
-/x-pack/plugins/enterprise_search/public/applications/workplace_search @elastic/workplace-search-frontend
-/x-pack/plugins/enterprise_search/server/routes/workplace_search @elastic/workplace-search-frontend
-/x-pack/plugins/enterprise_search/server/collectors/workplace_search @elastic/workplace-search-frontend
-/x-pack/plugins/enterprise_search/server/saved_objects/workplace_search @elastic/workplace-search-frontend
 
 # Elasticsearch UI
 /src/plugins/dev_tools/ @elastic/es-ui

--- a/x-pack/plugins/enterprise_search/README.md
+++ b/x-pack/plugins/enterprise_search/README.md
@@ -17,6 +17,10 @@ This plugin's goal is to provide a Kibana user interface to the Enterprise Searc
 
 Enterprise Search uses [Kea.js](https://github.com/keajs/kea) to manage our React/Redux state for us. Kea state is handled in our `*Logic` files and exposes [values](https://kea.js.org/docs/guide/concepts#values) and [actions](https://kea.js.org/docs/guide/concepts#actions) for our components to get and set state with.
 
+#### Advanced Kea usage
+
+For the most part, we stick to the functionality described in Kea's [core concepts](https://kea.js.org/docs/guide/concepts). However, in some files, we also take advantage of [props](https://kea.js.org/docs/guide/additional#props) and [events](https://kea.js.org/docs/guide/additional#events), as well as [manually mounting](https://kea.js.org/docs/guide/advanced#mounting-and-unmounting) some shared logic files on plugin init outside of React.
+
 #### Debugging Kea
 
 To debug Kea state in-browser, Kea recommends [Redux Devtools](https://kea.js.org/docs/guide/debugging). To facilitate debugging, we use the [path](https://kea.js.org/docs/guide/debugging/#setting-the-path-manually) key with `snake_case`d paths. The path key should always end with the logic filename (e.g. `['enterprise_search', 'some_logic']`) to make it easy for devs to quickly find/jump to files via IDE tooling.


### PR DESCRIPTION
## Summary

Two small chores:

- CODEOWNERS:
  - Temporarily remove team-specific review requirements. The App Search and Workplace Search teams are currently too small in size (+ only a few are focused on Kibana work) to justify requiring 2 reviews (1 from each team) vs just 1 review from either team.
- README:
  - Adds additional Kea documentation links to help intro advanced concepts & usage of Kea to new developers.