### PR TITLE
[Security Solution] [Detections] Only display actions options if user has "read" privileges

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.test.tsx
@@ -14,6 +14,11 @@ jest.mock('../../../../common/lib/kibana', () => ({
     services: {
       application: {
         getUrlForApp: jest.fn(),
+        capabilities: {
+          siem: {
+            crud: true,
+          },
+        },
       },
       triggers_actions_ui: {
         actionTypeRegistry: jest.fn(),

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.test.tsx
@@ -18,6 +18,9 @@ jest.mock('../../../../common/lib/kibana', () => ({
           siem: {
             crud: true,
           },
+          actions: {
+            read: true,
+          },
         },
       },
       triggers_actions_ui: {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiButton,
   EuiSpacer,
+  EuiText,
 } from '@elastic/eui';
 import { findIndex } from 'lodash/fp';
 import React, { FC, memo, useCallback, useEffect, useMemo } from 'react';
@@ -34,6 +35,7 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { getSchema } from './schema';
 import * as I18n from './translations';
 import { APP_ID } from '../../../../../common/constants';
+import { useUserInfo } from '../../user_info';
 
 interface StepRuleActionsProps extends RuleStepProps {
   defaultValues?: ActionsStepRule | null;
@@ -141,6 +143,8 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     [isLoading, throttleOptions]
   );
 
+  const { canReadActions } = useUserInfo();
+
   return isReadOnlyView ? (
     <StepContentWrapper addPadding={addPadding}>
       <StepRuleDescription schema={schema} data={initialState} columns="single" />
@@ -148,31 +152,35 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
   ) : (
     <>
       <StepContentWrapper addPadding={!isUpdateView}>
-        <Form form={form} data-test-subj="stepRuleActions">
-          <EuiForm>
-            <UseField
-              path="throttle"
-              component={ThrottleSelectField}
-              componentProps={throttleFieldComponentProps}
-            />
-            {throttle !== stepActionsDefaultValue.throttle ? (
-              <>
-                <EuiSpacer />
-                <UseField
-                  path="actions"
-                  component={RuleActionsField}
-                  componentProps={{
-                    messageVariables: actionMessageParams,
-                  }}
-                />
-              </>
-            ) : (
-              <UseField path="actions" component={GhostFormField} />
-            )}
-            <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
-            <UseField path="enabled" component={GhostFormField} />
-          </EuiForm>
-        </Form>
+        {canReadActions ? (
+          <Form form={form} data-test-subj="stepRuleActions">
+            <EuiForm>
+              <UseField
+                path="throttle"
+                component={ThrottleSelectField}
+                componentProps={throttleFieldComponentProps}
+              />
+              {throttle !== stepActionsDefaultValue.throttle ? (
+                <>
+                  <EuiSpacer />
+                  <UseField
+                    path="actions"
+                    component={RuleActionsField}
+                    componentProps={{
+                      messageVariables: actionMessageParams,
+                    }}
+                  />
+                </>
+              ) : (
+                <UseField path="actions" component={GhostFormField} />
+              )}
+              <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
+              <UseField path="enabled" component={GhostFormField} />
+            </EuiForm>
+          </Form>
+        ) : (
+          <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
+        )}
       </StepContentWrapper>
 
       {!isUpdateView && (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -126,9 +126,14 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     }
   }, [getData, setForm]);
 
+  const { canReadActions } = useUserInfo();
+
   const throttleOptions = useMemo(() => {
-    return getThrottleOptions(throttle);
-  }, [throttle]);
+    if (canReadActions) {
+      return getThrottleOptions(throttle);
+    }
+    return [{ value: DEFAULT_THROTTLE_OPTION.value, text: I18n.NO_ACTIONS_READ_PERMISSIONS }];
+  }, [throttle, canReadActions]);
 
   const throttleFieldComponentProps = useMemo(
     () => ({
@@ -143,8 +148,6 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     [isLoading, throttleOptions]
   );
 
-  const { canReadActions } = useUserInfo();
-
   return isReadOnlyView ? (
     <StepContentWrapper addPadding={addPadding}>
       <StepRuleDescription schema={schema} data={initialState} columns="single" />
@@ -152,35 +155,31 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
   ) : (
     <>
       <StepContentWrapper addPadding={!isUpdateView}>
-        {canReadActions ? (
-          <Form form={form} data-test-subj="stepRuleActions">
-            <EuiForm>
-              <UseField
-                path="throttle"
-                component={ThrottleSelectField}
-                componentProps={throttleFieldComponentProps}
-              />
-              {throttle !== stepActionsDefaultValue.throttle ? (
-                <>
-                  <EuiSpacer />
-                  <UseField
-                    path="actions"
-                    component={RuleActionsField}
-                    componentProps={{
-                      messageVariables: actionMessageParams,
-                    }}
-                  />
-                </>
-              ) : (
-                <UseField path="actions" component={GhostFormField} />
-              )}
-              <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
-              <UseField path="enabled" component={GhostFormField} />
-            </EuiForm>
-          </Form>
-        ) : (
-          <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
-        )}
+        <Form form={form} data-test-subj="stepRuleActions">
+          <EuiForm>
+            <UseField
+              path="throttle"
+              component={ThrottleSelectField}
+              componentProps={throttleFieldComponentProps}
+            />
+            {throttle !== stepActionsDefaultValue.throttle ? (
+              <>
+                <EuiSpacer />
+                <UseField
+                  path="actions"
+                  component={RuleActionsField}
+                  componentProps={{
+                    messageVariables: actionMessageParams,
+                  }}
+                />
+              </>
+            ) : (
+              <UseField path="actions" component={GhostFormField} />
+            )}
+            <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
+            <UseField path="enabled" component={GhostFormField} />
+          </EuiForm>
+        </Form>
       </StepContentWrapper>
 
       {!isUpdateView && (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -34,7 +34,6 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { getSchema } from './schema';
 import * as I18n from './translations';
 import { APP_ID } from '../../../../../common/constants';
-import { useUserInfo } from '../../user_info';
 
 interface StepRuleActionsProps extends RuleStepProps {
   defaultValues?: ActionsStepRule | null;
@@ -125,14 +124,12 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     }
   }, [getData, setForm]);
 
-  const { canReadActions } = useUserInfo();
-
   const throttleOptions = useMemo(() => {
-    if (canReadActions) {
+    if (application.capabilities.actions.show) {
       return getThrottleOptions(throttle);
     }
     return [{ value: DEFAULT_THROTTLE_OPTION.value, text: I18n.NO_ACTIONS_READ_PERMISSIONS }];
-  }, [throttle, canReadActions]);
+  }, [throttle, application.capabilities.actions.show]);
 
   const throttleFieldComponentProps = useMemo(
     () => ({

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiButton,
   EuiSpacer,
+  EuiText,
 } from '@elastic/eui';
 import { findIndex } from 'lodash/fp';
 import React, { FC, memo, useCallback, useEffect, useMemo } from 'react';
@@ -125,11 +126,8 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
   }, [getData, setForm]);
 
   const throttleOptions = useMemo(() => {
-    if (application.capabilities.actions.show) {
-      return getThrottleOptions(throttle);
-    }
-    return [{ value: DEFAULT_THROTTLE_OPTION.value, text: I18n.NO_ACTIONS_READ_PERMISSIONS }];
-  }, [throttle, application.capabilities.actions.show]);
+    return getThrottleOptions(throttle);
+  }, [throttle]);
 
   const throttleFieldComponentProps = useMemo(
     () => ({
@@ -151,7 +149,11 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
   ) : (
     <>
       <StepContentWrapper addPadding={!isUpdateView}>
-        <Form form={form} data-test-subj="stepRuleActions">
+        <Form
+          form={form}
+          style={{ display: application.capabilities.actions.show ? 'block' : 'none' }}
+          data-test-subj="stepRuleActions"
+        >
           <EuiForm>
             <UseField
               path="throttle"
@@ -176,6 +178,9 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
             <UseField path="enabled" component={GhostFormField} />
           </EuiForm>
         </Form>
+        {!application.capabilities.actions.show && (
+          <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
+        )}
       </StepContentWrapper>
 
       {!isUpdateView && (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -142,45 +142,62 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     [isLoading, throttleOptions]
   );
 
-  return isReadOnlyView ? (
-    <StepContentWrapper addPadding={addPadding}>
-      <StepRuleDescription schema={schema} data={initialState} columns="single" />
-    </StepContentWrapper>
+  if (isReadOnlyView) {
+    return (
+      <StepContentWrapper addPadding={addPadding}>
+        <StepRuleDescription schema={schema} data={initialState} columns="single" />
+      </StepContentWrapper>
+    );
+  }
+
+  const displayActionsOptions =
+    throttle !== stepActionsDefaultValue.throttle ? (
+      <>
+        <EuiSpacer />
+        <UseField
+          path="actions"
+          component={RuleActionsField}
+          componentProps={{
+            messageVariables: actionMessageParams,
+          }}
+        />
+      </>
+    ) : (
+      <UseField path="actions" component={GhostFormField} />
+    );
+
+  // only display the actions dropdown if the user has "read" privileges for actions
+  const displayActionsDropDown = application.capabilities.actions.show ? (
+    <>
+      <UseField
+        path="throttle"
+        component={ThrottleSelectField}
+        componentProps={throttleFieldComponentProps}
+      />
+      {displayActionsOptions}
+      <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
+      <UseField path="enabled" component={GhostFormField} />
+    </>
   ) : (
     <>
+      <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
+      <UseField
+        path="throttle"
+        componentProps={throttleFieldComponentProps}
+        component={GhostFormField}
+      />
+      <UseField path="actions" component={GhostFormField} />
+      <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
+      <UseField path="enabled" component={GhostFormField} />
+    </>
+  );
+
+  return (
+    <>
       <StepContentWrapper addPadding={!isUpdateView}>
-        <Form
-          form={form}
-          style={{ display: application.capabilities.actions.show ? 'block' : 'none' }}
-          data-test-subj="stepRuleActions"
-        >
-          <EuiForm>
-            <UseField
-              path="throttle"
-              component={ThrottleSelectField}
-              componentProps={throttleFieldComponentProps}
-            />
-            {throttle !== stepActionsDefaultValue.throttle ? (
-              <>
-                <EuiSpacer />
-                <UseField
-                  path="actions"
-                  component={RuleActionsField}
-                  componentProps={{
-                    messageVariables: actionMessageParams,
-                  }}
-                />
-              </>
-            ) : (
-              <UseField path="actions" component={GhostFormField} />
-            )}
-            <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
-            <UseField path="enabled" component={GhostFormField} />
-          </EuiForm>
+        <Form form={form} data-test-subj="stepRuleActions">
+          <EuiForm>{displayActionsDropDown}</EuiForm>
         </Form>
-        {!application.capabilities.actions.show && (
-          <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
-        )}
       </StepContentWrapper>
 
       {!isUpdateView && (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -11,7 +11,6 @@ import {
   EuiFlexItem,
   EuiButton,
   EuiSpacer,
-  EuiText,
 } from '@elastic/eui';
 import { findIndex } from 'lodash/fp';
 import React, { FC, memo, useCallback, useEffect, useMemo } from 'react';

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/translations.tsx
@@ -28,6 +28,14 @@ export const NO_CONNECTOR_SELECTED = i18n.translate(
   }
 );
 
+export const NO_ACTIONS_READ_PERMISSIONS = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.noReadActionsPrivileges',
+  {
+    defaultMessage:
+      'Cannot create rule actions. You do not have "Read" permissions for the "Actions" plugin.',
+  }
+);
+
 export const INVALID_MUSTACHE_TEMPLATE = (paramKey: string) =>
   i18n.translate(
     'xpack.securitySolution.detectionEngine.createRule.stepRuleActions.invalidMustacheTemplateErrorMessage',

--- a/x-pack/plugins/security_solution/public/detections/components/user_info/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/user_info/index.tsx
@@ -20,7 +20,6 @@ export interface State {
   hasEncryptionKey: boolean | null;
   loading: boolean;
   signalIndexName: string | null;
-  canReadActions: boolean | null;
 }
 
 const initialState: State = {
@@ -32,7 +31,6 @@ const initialState: State = {
   hasEncryptionKey: null,
   loading: true,
   signalIndexName: null,
-  canReadActions: null,
 };
 
 export type Action =
@@ -155,7 +153,6 @@ export const useUserInfo = (): State => {
     hasEncryptionKey: isApiEncryptionKey,
     hasIndexManage: hasApiIndexManage,
     hasIndexWrite: hasApiIndexWrite,
-    canReadActions,
   } = usePrivilegeUser();
   const {
     loading: indexNameLoading,
@@ -242,6 +239,5 @@ export const useUserInfo = (): State => {
     hasIndexManage,
     hasIndexWrite,
     signalIndexName,
-    canReadActions,
   };
 };

--- a/x-pack/plugins/security_solution/public/detections/components/user_info/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/user_info/index.tsx
@@ -20,6 +20,7 @@ export interface State {
   hasEncryptionKey: boolean | null;
   loading: boolean;
   signalIndexName: string | null;
+  canReadActions: boolean | null;
 }
 
 const initialState: State = {
@@ -31,6 +32,7 @@ const initialState: State = {
   hasEncryptionKey: null,
   loading: true,
   signalIndexName: null,
+  canReadActions: null,
 };
 
 export type Action =
@@ -153,6 +155,7 @@ export const useUserInfo = (): State => {
     hasEncryptionKey: isApiEncryptionKey,
     hasIndexManage: hasApiIndexManage,
     hasIndexWrite: hasApiIndexWrite,
+    canReadActions,
   } = usePrivilegeUser();
   const {
     loading: indexNameLoading,
@@ -239,5 +242,6 @@ export const useUserInfo = (): State => {
     hasIndexManage,
     hasIndexWrite,
     signalIndexName,
+    canReadActions,
   };
 };

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
@@ -985,6 +985,7 @@ export const mockSignalIndex: AlertsIndex = {
 export const mockUserPrivilege: Privilege = {
   username: 'elastic',
   has_all_requested: false,
+  can_read_actions: true,
   cluster: {
     monitor_ml: true,
     manage_ccr: true,

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
@@ -985,7 +985,6 @@ export const mockSignalIndex: AlertsIndex = {
 export const mockUserPrivilege: Privilege = {
   username: 'elastic',
   has_all_requested: false,
-  can_read_actions: true,
   cluster: {
     monitor_ml: true,
     manage_ccr: true,

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/types.ts
@@ -97,5 +97,4 @@ export interface Privilege {
   };
   is_authenticated: boolean;
   has_encryption_key: boolean;
-  can_read_actions: boolean;
 }

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/types.ts
@@ -97,4 +97,5 @@ export interface Privilege {
   };
   is_authenticated: boolean;
   has_encryption_key: boolean;
+  can_read_actions: boolean;
 }

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.test.tsx
@@ -23,7 +23,6 @@ describe('usePrivilegeUser', () => {
         hasIndexWrite: null,
         isAuthenticated: null,
         loading: true,
-        canReadActions: null,
       });
     });
   });
@@ -41,7 +40,6 @@ describe('usePrivilegeUser', () => {
         hasIndexWrite: true,
         isAuthenticated: true,
         loading: false,
-        canReadActions: true,
       });
     });
   });
@@ -63,7 +61,6 @@ describe('usePrivilegeUser', () => {
         hasIndexWrite: false,
         isAuthenticated: false,
         loading: false,
-        canReadActions: false,
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.test.tsx
@@ -23,6 +23,7 @@ describe('usePrivilegeUser', () => {
         hasIndexWrite: null,
         isAuthenticated: null,
         loading: true,
+        canReadActions: null,
       });
     });
   });
@@ -40,6 +41,7 @@ describe('usePrivilegeUser', () => {
         hasIndexWrite: true,
         isAuthenticated: true,
         loading: false,
+        canReadActions: true,
       });
     });
   });
@@ -61,6 +63,7 @@ describe('usePrivilegeUser', () => {
         hasIndexWrite: false,
         isAuthenticated: false,
         loading: false,
+        canReadActions: false,
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.tsx
@@ -16,6 +16,7 @@ export interface ReturnPrivilegeUser {
   hasEncryptionKey: boolean | null;
   hasIndexManage: boolean | null;
   hasIndexWrite: boolean | null;
+  canReadActions: boolean | null;
 }
 /**
  * Hook to get user privilege from
@@ -26,13 +27,14 @@ export const usePrivilegeUser = (): ReturnPrivilegeUser => {
   const [privilegeUser, setPrivilegeUser] = useState<
     Pick<
       ReturnPrivilegeUser,
-      'isAuthenticated' | 'hasEncryptionKey' | 'hasIndexManage' | 'hasIndexWrite'
+      'isAuthenticated' | 'hasEncryptionKey' | 'hasIndexManage' | 'hasIndexWrite' | 'canReadActions'
     >
   >({
     isAuthenticated: null,
     hasEncryptionKey: null,
     hasIndexManage: null,
     hasIndexWrite: null,
+    canReadActions: null,
   });
   const [, dispatchToaster] = useStateToaster();
 
@@ -54,6 +56,7 @@ export const usePrivilegeUser = (): ReturnPrivilegeUser => {
               isAuthenticated: privilege.is_authenticated,
               hasEncryptionKey: privilege.has_encryption_key,
               hasIndexManage: privilege.index[indexName].manage,
+              canReadActions: privilege.can_read_actions,
               hasIndexWrite:
                 privilege.index[indexName].create ||
                 privilege.index[indexName].create_doc ||
@@ -69,6 +72,7 @@ export const usePrivilegeUser = (): ReturnPrivilegeUser => {
             hasEncryptionKey: false,
             hasIndexManage: false,
             hasIndexWrite: false,
+            canReadActions: false,
           });
           errorToToaster({ title: i18n.PRIVILEGE_FETCH_FAILURE, error, dispatchToaster });
         }

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/use_privilege_user.tsx
@@ -16,7 +16,6 @@ export interface ReturnPrivilegeUser {
   hasEncryptionKey: boolean | null;
   hasIndexManage: boolean | null;
   hasIndexWrite: boolean | null;
-  canReadActions: boolean | null;
 }
 /**
  * Hook to get user privilege from
@@ -27,14 +26,13 @@ export const usePrivilegeUser = (): ReturnPrivilegeUser => {
   const [privilegeUser, setPrivilegeUser] = useState<
     Pick<
       ReturnPrivilegeUser,
-      'isAuthenticated' | 'hasEncryptionKey' | 'hasIndexManage' | 'hasIndexWrite' | 'canReadActions'
+      'isAuthenticated' | 'hasEncryptionKey' | 'hasIndexManage' | 'hasIndexWrite'
     >
   >({
     isAuthenticated: null,
     hasEncryptionKey: null,
     hasIndexManage: null,
     hasIndexWrite: null,
-    canReadActions: null,
   });
   const [, dispatchToaster] = useStateToaster();
 
@@ -56,7 +54,6 @@ export const usePrivilegeUser = (): ReturnPrivilegeUser => {
               isAuthenticated: privilege.is_authenticated,
               hasEncryptionKey: privilege.has_encryption_key,
               hasIndexManage: privilege.index[indexName].manage,
-              canReadActions: privilege.can_read_actions,
               hasIndexWrite:
                 privilege.index[indexName].create ||
                 privilege.index[indexName].create_doc ||
@@ -72,7 +69,6 @@ export const usePrivilegeUser = (): ReturnPrivilegeUser => {
             hasEncryptionKey: false,
             hasIndexManage: false,
             hasIndexWrite: false,
-            canReadActions: false,
           });
           errorToToaster({ title: i18n.PRIVILEGE_FETCH_FAILURE, error, dispatchToaster });
         }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
@@ -20,9 +20,6 @@ describe('read_privileges route', () => {
 
     mockSecurity = securityMock.createSetup();
     mockSecurity.authc.isAuthenticated.mockReturnValue(false);
-    mockSecurity.authz.checkPrivilegesDynamicallyWithRequest.mockImplementation(() => () => ({
-      hasAllRequested: true,
-    }));
     clients.clusterClient.callAsCurrentUser.mockResolvedValue(getMockPrivilegesResult());
     readPrivilegesRoute(server.router, mockSecurity, false);
   });
@@ -39,7 +36,6 @@ describe('read_privileges route', () => {
         ...getMockPrivilegesResult(),
         is_authenticated: false,
         has_encryption_key: true,
-        can_read_actions: true,
       };
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(expectedBody);
@@ -51,7 +47,6 @@ describe('read_privileges route', () => {
         ...getMockPrivilegesResult(),
         is_authenticated: true,
         has_encryption_key: true,
-        can_read_actions: true,
       };
 
       const response = await server.inject(getPrivilegeRequest(), context);
@@ -90,7 +85,6 @@ describe('read_privileges route', () => {
         ...getMockPrivilegesResult(),
         is_authenticated: false,
         has_encryption_key: true,
-        can_read_actions: false,
       };
 
       const response = await server.inject(getPrivilegeRequest(), context);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.test.ts
@@ -20,6 +20,9 @@ describe('read_privileges route', () => {
 
     mockSecurity = securityMock.createSetup();
     mockSecurity.authc.isAuthenticated.mockReturnValue(false);
+    mockSecurity.authz.checkPrivilegesDynamicallyWithRequest.mockImplementation(() => () => ({
+      hasAllRequested: true,
+    }));
     clients.clusterClient.callAsCurrentUser.mockResolvedValue(getMockPrivilegesResult());
     readPrivilegesRoute(server.router, mockSecurity, false);
   });
@@ -36,6 +39,7 @@ describe('read_privileges route', () => {
         ...getMockPrivilegesResult(),
         is_authenticated: false,
         has_encryption_key: true,
+        can_read_actions: true,
       };
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(expectedBody);
@@ -47,6 +51,7 @@ describe('read_privileges route', () => {
         ...getMockPrivilegesResult(),
         is_authenticated: true,
         has_encryption_key: true,
+        can_read_actions: true,
       };
 
       const response = await server.inject(getPrivilegeRequest(), context);
@@ -85,6 +90,7 @@ describe('read_privileges route', () => {
         ...getMockPrivilegesResult(),
         is_authenticated: false,
         has_encryption_key: true,
+        can_read_actions: false,
       };
 
       const response = await server.inject(getPrivilegeRequest(), context);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
@@ -40,12 +40,6 @@ export const readPrivilegesRoute = (
         const clusterPrivileges = await readPrivileges(clusterClient.callAsCurrentUser, index);
         const privileges = merge(clusterPrivileges, {
           is_authenticated: security?.authc.isAuthenticated(request) ?? false,
-          can_read_actions:
-            (
-              await security?.authz?.checkPrivilegesDynamicallyWithRequest(request)({
-                kibana: [security?.authz?.actions.ui.get('actions', 'show')],
-              })
-            )?.hasAllRequested ?? false,
           has_encryption_key: !usingEphemeralEncryptionKey,
         });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
@@ -40,6 +40,12 @@ export const readPrivilegesRoute = (
         const clusterPrivileges = await readPrivileges(clusterClient.callAsCurrentUser, index);
         const privileges = merge(clusterPrivileges, {
           is_authenticated: security?.authc.isAuthenticated(request) ?? false,
+          can_read_actions:
+            (
+              await security?.authz?.checkPrivilegesDynamicallyWithRequest(request)({
+                kibana: [security?.authz?.actions.ui.get('actions', 'show')],
+              })
+            )?.hasAllRequested ?? false,
           has_encryption_key: !usingEphemeralEncryptionKey,
         });
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/74170

~~updates the detections privileges route to include checking for "read" privilege on actions.~~ Also updates the rule create / edit steps to display a message if the user is missing the actions privileges while still allowing the user to create and activate a rule.

testing:

This script will post a role with the necessary detections permissions

```
curl -H 'Content-Type: application/json' -H 'kbn-xsrf: 123'\
 -u ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} \
-XPUT ${KIBANA_URL}/api/security/role/my_detections_role \
-d '{
  "elasticsearch": {
    "cluster": ["manage"],
    "indices": [
      {
        "names": ["auditbeat-*", "packetbeat-*", ".siem-signals-*", ".lists*", ".items*"],
        "privileges": ["manage", "write", "read"]
      }
    ]
  },
  "kibana": [
    {
      "feature": {
        "siem": ["all"],
        "actions": ["read"], // change this to "none" to see the rule actions dropdown change
        "builtInAlerts": ["all"],
        "dev_tools": ["all"],
        "savedObjectsManagement": ["all"]
      },
      "spaces": ["*"]
    }
  ]
}'
```

This is what the "Rule Actions" step on the rule creation form looks like if the user does not have "read" privileges for actions:

<img width="964" alt="Screen Shot 2020-10-01 at 11 48 54 AM" src="https://user-images.githubusercontent.com/915763/94832702-3dd52780-03dc-11eb-898a-22a1b4cca973.png">

And here it is on the edit page


<img width="747" alt="Screen Shot 2020-10-01 at 11 49 11 AM" src="https://user-images.githubusercontent.com/915763/94832724-46c5f900-03dc-11eb-8205-3b80cdfcf449.png">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
