### PR TITLE
Remove isDeprecated flag on visType

### DIFF
--- a/src/plugins/region_map/public/region_map_type.js
+++ b/src/plugins/region_map/public/region_map_type.js
@@ -32,7 +32,6 @@ export function createRegionMapTypeDefinition(dependencies) {
 
   return {
     name: 'region_map',
-    isDeprecated: true,
     getDeprecationMessage,
     title: i18n.translate('regionMap.mapVis.regionMapTitle', { defaultMessage: 'Region Map' }),
     description: i18n.translate('regionMap.mapVis.regionMapDescription', {

--- a/src/plugins/tile_map/public/tile_map_type.js
+++ b/src/plugins/tile_map/public/tile_map_type.js
@@ -33,7 +33,6 @@ export function createTileMapTypeDefinition(dependencies) {
 
   return {
     name: 'tile_map',
-    isDeprecated: true,
     getDeprecationMessage,
     title: i18n.translate('tileMap.vis.mapTitle', {
       defaultMessage: 'Coordinate Map',

--- a/src/plugins/visualizations/public/vis_types/base_vis_type.ts
+++ b/src/plugins/visualizations/public/vis_types/base_vis_type.ts
@@ -44,7 +44,7 @@ interface CommonBaseVisTypeOptions {
   useCustomNoDataScreen?: boolean;
   inspectorAdapters?: Adapters | (() => Adapters);
   isDeprecated?: boolean;
-  getDeprecationMessage?: (vis: Vis) => ReactElement<any>;
+  getDeprecationMessage?: (vis: Vis) => ReactElement<{}>;
 }
 
 interface ExpressionBaseVisTypeOptions<TVisParams> extends CommonBaseVisTypeOptions {
@@ -84,8 +84,7 @@ export class BaseVisType<TVisParams = VisParams> {
   useCustomNoDataScreen: boolean;
   inspectorAdapters?: Adapters | (() => Adapters);
   toExpressionAst?: VisToExpressionAst<TVisParams>;
-  isDeprecated: boolean;
-  getDeprecationMessage?: (vis: Vis) => ReactElement<any>;
+  getDeprecationMessage?: (vis: Vis) => ReactElement<{}>;
 
   constructor(opts: BaseVisTypeOptions<TVisParams>) {
     if (!opts.icon && !opts.image) {
@@ -123,7 +122,6 @@ export class BaseVisType<TVisParams = VisParams> {
     this.useCustomNoDataScreen = opts.useCustomNoDataScreen || false;
     this.inspectorAdapters = opts.inspectorAdapters;
     this.toExpressionAst = opts.toExpressionAst;
-    this.isDeprecated = opts.isDeprecated || false;
     this.getDeprecationMessage = opts.getDeprecationMessage;
   }
 

--- a/src/plugins/visualize/public/application/components/visualize_editor_common.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_editor_common.tsx
@@ -79,34 +79,29 @@ export const VisualizeEditorCommon = ({
         />
       )}
       {visInstance?.vis?.type?.isExperimental && <ExperimentalVisInfo />}
-      {visInstance?.vis?.type?.isDeprecated &&
-        visInstance?.vis?.type?.getDeprecationMessage &&
-        visInstance.vis.type.getDeprecationMessage(visInstance?.vis)}
+      {visInstance?.vis?.type?.getDeprecationMessage?.(visInstance.vis)}
       {visInstance && (
         <EuiScreenReaderOnly>
           <h1>
-            {
-              // @ts-expect-error
-              'savedVis' in visInstance && visInstance.savedVis.id ? (
-                <FormattedMessage
-                  id="visualize.pageHeading"
-                  defaultMessage="{chartName} {chartType} visualization"
-                  values={{
-                    chartName: (visInstance as SavedVisInstance).savedVis.title,
-                    chartType: (visInstance as SavedVisInstance).vis.type.title,
-                  }}
-                />
-              ) : (
-                <FormattedMessage
-                  id="visualize.byValue_pageHeading"
-                  defaultMessage="Visualization of type {chartType} embedded into {originatingApp} app"
-                  values={{
-                    chartType: visInstance.vis.type.title,
-                    originatingApp: originatingApp || 'dashboards',
-                  }}
-                />
-              )
-            }
+            {'savedVis' in visInstance && visInstance.savedVis.id ? (
+              <FormattedMessage
+                id="visualize.pageHeading"
+                defaultMessage="{chartName} {chartType} visualization"
+                values={{
+                  chartName: (visInstance as SavedVisInstance).savedVis.title,
+                  chartType: (visInstance as SavedVisInstance).vis.type.title,
+                }}
+              />
+            ) : (
+              <FormattedMessage
+                id="visualize.byValue_pageHeading"
+                defaultMessage="Visualization of type {chartType} embedded into {originatingApp} app"
+                values={{
+                  chartType: visInstance.vis.type.title,
+                  originatingApp: originatingApp || 'dashboards',
+                }}
+              />
+            )}
           </h1>
         </EuiScreenReaderOnly>
       )}


### PR DESCRIPTION
## Summary

This is a follow up cleanup from #77683 and removes the introduced `isDeprecated` flag again.

The `isDeprecated` and `getDeprecationMessage` were titly coupled (so you always need to set both or neither), why we don't really need that flag and can just check on the `getDeprecationMessage` being set or not.

This PR also cleans up some unnice usage of `any` (we know exactly that we're not passing in any props to that component, so we can use an empty object). Also by shortening the implementation in the visualize_common_editor.tsx, the `@ts-expect-error` is actually not needed anymore (though don't ask me why :shrug:).

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
