### PR TITLE
Fix APM header wrapping

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/ApmHeader/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/ApmHeader/index.tsx
@@ -6,25 +6,15 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import React, { ReactNode } from 'react';
-import styled from 'styled-components';
 import { DatePicker } from '../DatePicker';
 import { EnvironmentFilter } from '../EnvironmentFilter';
 import { KueryBar } from '../KueryBar';
 
-// Header titles with long, unbroken words, like you would see for a long URL in
-// a transaction name, with the default `work-break`, don't break, and that ends
-// up pushing the date picker off of the screen. Setting `break-all` here lets
-// it wrap even if it has a long, unbroken work. The wrapped result is not great
-// looking, since it wraps, but it doesn't push any controls off of the screen.
-const ChildrenContainerFlexItem = styled(EuiFlexItem)`
-  word-break: break-all;
-`;
-
 export function ApmHeader({ children }: { children: ReactNode }) {
   return (
     <>
-      <EuiFlexGroup alignItems="center" gutterSize="s">
-        <ChildrenContainerFlexItem>{children}</ChildrenContainerFlexItem>
+      <EuiFlexGroup alignItems="center" gutterSize="s" wrap={true}>
+        <EuiFlexItem>{children}</EuiFlexItem>
         <EuiFlexItem grow={false}>
           <DatePicker />
         </EuiFlexItem>


### PR DESCRIPTION
Add `wrap` to the flex group for the APM header and remove the `break-all` CSS.

Makes it so the date picker doesn't get cut off on narrow screens and the header text does not wrap unnecessarily.

# Home 

## Before

![image](https://user-images.githubusercontent.com/9912/94602373-62a19180-025a-11eb-9593-476176eceb9d.png)

## After

![image](https://user-images.githubusercontent.com/9912/94602416-70571700-025a-11eb-96ab-512bb1336319.png)

# Transaction (with breakable characters)

## Before

![image](https://user-images.githubusercontent.com/9912/94602488-8a90f500-025a-11eb-8594-e26011c12ebb.png)

## After

![image](https://user-images.githubusercontent.com/9912/94602550-a5636980-025a-11eb-9165-3ae43d689a2d.png)

## Transaction (without breakable characters)

## Before

![image](https://user-images.githubusercontent.com/9912/94602689-d479db00-025a-11eb-9ed6-a6431bc49f00.png)

## After

![image](https://user-images.githubusercontent.com/9912/94602798-f6735d80-025a-11eb-95c1-6bff0db958a9.png)

note that in this last case the transaction name may be cut off but is still visible elsewhere on the page and we don't lose the use of the date picker.