### PR TITLE
[7.x] [Metrics UI] Reduce the pagination size for snapshot request (#78051)

### DIFF
--- a/x-pack/plugins/infra/server/routes/snapshot/lib/transform_request_to_metrics_api_request.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/transform_request_to_metrics_api_request.ts
@@ -34,7 +34,7 @@ export const transformRequestToMetricsAPIRequest = async (
       interval: timeRangeWithIntervalApplied.interval,
     },
     metrics: transformSnapshotMetricsToMetricsAPIMetrics(snapshotRequest),
-    limit: snapshotRequest.overrideCompositeSize ? snapshotRequest.overrideCompositeSize : 10,
+    limit: snapshotRequest.overrideCompositeSize ? snapshotRequest.overrideCompositeSize : 5,
     alignDataToEnd: true,
   };
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Reduce the pagination size for snapshot request (#78051)