### PR TITLE
[7.x] [Metrics UI] Fix EC2 Query to only include aws.ec2 nodes (#78236)

### DIFF
--- a/x-pack/plugins/infra/common/inventory_models/aws_ec2/index.ts
+++ b/x-pack/plugins/infra/common/inventory_models/aws_ec2/index.ts
@@ -31,4 +31,5 @@ export const awsEC2: InventoryModel = {
   },
   requiredMetrics: ['awsEC2CpuUtilization', 'awsEC2NetworkTraffic', 'awsEC2DiskIOBytes'],
   tooltipMetrics: ['cpu', 'rx', 'tx'],
+  nodeFilter: [{ term: { 'event.dataset': 'aws.ec2' } }],
 };

--- a/x-pack/plugins/infra/common/inventory_models/types.ts
+++ b/x-pack/plugins/infra/common/inventory_models/types.ts
@@ -371,4 +371,5 @@ export interface InventoryModel {
   metrics: InventoryMetrics;
   requiredMetrics: InventoryMetric[];
   tooltipMetrics: SnapshotMetricType[];
+  nodeFilter?: object[];
 }

--- a/x-pack/plugins/infra/server/routes/snapshot/lib/transform_request_to_metrics_api_request.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/transform_request_to_metrics_api_request.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { findInventoryFields } from '../../../../common/inventory_models';
+import { findInventoryFields, findInventoryModel } from '../../../../common/inventory_models';
 import { MetricsAPIRequest, SnapshotRequest } from '../../../../common/http_api';
 import { ESSearchClient } from '../../../lib/metrics/types';
 import { InfraSource } from '../../../lib/sources';
@@ -50,6 +50,11 @@ export const transformRequestToMetricsAPIRequest = async (
 
   if (snapshotRequest.region) {
     filters.push({ term: { 'cloud.region': snapshotRequest.region } });
+  }
+
+  const inventoryModel = findInventoryModel(snapshotRequest.nodeType);
+  if (inventoryModel && inventoryModel.nodeFilter) {
+    inventoryModel.nodeFilter?.forEach((f) => filters.push(f));
   }
 
   const inventoryFields = findInventoryFields(


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Fix EC2 Query to only include aws.ec2 nodes (#78236)