### PR TITLE
[Lens] Maintain order of operations in dimension panel

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -960,12 +960,12 @@ describe('IndexPatternDimensionEditorPanel', () => {
       const items: EuiListGroupItemProps[] = wrapper.find(EuiListGroup).prop('listItems') || [];
 
       expect(items.map(({ label }: { label: React.ReactNode }) => label)).toEqual([
-        'Unique count',
         'Average',
         'Count',
         'Maximum',
         'Minimum',
         'Sum',
+        'Unique count',
       ]);
     });
 


### PR DESCRIPTION
This PR maintains all the existing behavior except that operations are now displayed in the same order regardless of whether they are considered "compatible" or not. This results in the following behavior:

![configuration with consistent order](https://user-images.githubusercontent.com/666475/94611271-81f6e980-026f-11eb-9a57-83378958866e.gif)

Closes https://github.com/elastic/kibana/issues/78153

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
