### PR TITLE
[Enterprise Search] Fix default Workplace Search plugin document title

### DIFF
--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -100,7 +100,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       mount: async (params: AppMountParameters) => {
         const kibanaDeps = await this.getKibanaDeps(core, params);
         const { chrome, http } = kibanaDeps.core;
-        chrome.docTitle.change(APP_SEARCH_PLUGIN.NAME);
+        chrome.docTitle.change(WORKPLACE_SEARCH_PLUGIN.NAME);
 
         await this.getInitialData(http);
         const pluginData = this.getPluginData();


### PR DESCRIPTION
## Summary

This was borked from a sloppy copy and paste job in https://github.com/elastic/kibana/pull/78231/commits/450c6b7d48b64e9f8b2a59695bc52ecfc8a7b207. I mean, uhh, my subliminal App Search advertising attempt was foiled again by @scottybollinger!

## QA

- [x] Confirm Workplace Search shows the correct product name when the app is loading in