### PR TITLE
[APM] Add correlations API

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Correlations/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import url from 'url';
+import { useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { EuiTitle, EuiListGroup } from '@elastic/eui';
+import { useUrlParams } from '../../../hooks/useUrlParams';
+import { useApmPluginContext } from '../../../hooks/useApmPluginContext';
+
+const SESSION_STORAGE_KEY = 'apm.debug.show_correlations';
+
+export function Correlations() {
+  const location = useLocation();
+  const { serviceName } = useParams<{ serviceName?: string }>();
+  const { urlParams, uiFilters } = useUrlParams();
+  const { core } = useApmPluginContext();
+  const { transactionName, transactionType, start, end } = urlParams;
+
+  if (
+    !location.search.includes('&_show_correlations') &&
+    sessionStorage.getItem(SESSION_STORAGE_KEY) !== 'true'
+  ) {
+    return null;
+  }
+
+  sessionStorage.setItem(SESSION_STORAGE_KEY, 'true');
+
+  const query = {
+    serviceName,
+    transactionName,
+    transactionType,
+    start,
+    end,
+    uiFilters: JSON.stringify(uiFilters),
+    fieldNames:
+      'user.username,user.id,host.ip,user_agent.name,kubernetes.pod.uuid,url.domain,container.id,service.node.name',
+  };
+
+  const listItems = [
+    {
+      label: 'Show correlations between two ranges',
+      href: url.format({
+        query: {
+          ...query,
+          gap: 24,
+        },
+        pathname: core.http.basePath.prepend(`/api/apm/correlations/ranges`),
+      }),
+      isDisabled: false,
+      iconType: 'tokenRange',
+      size: 's' as const,
+    },
+
+    {
+      label: 'Show correlations for slow transactions',
+      href: url.format({
+        query: {
+          ...query,
+          durationPercentile: 95,
+        },
+        pathname: core.http.basePath.prepend(
+          `/api/apm/correlations/slow_durations`
+        ),
+      }),
+      isDisabled: false,
+      iconType: 'clock',
+      size: 's' as const,
+    },
+  ];
+
+  return (
+    <>
+      <EuiTitle size="m">
+        <h2>Correlations</h2>
+      </EuiTitle>
+
+      <EuiListGroup listItems={listItems} />
+    </>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/index.tsx
@@ -21,6 +21,7 @@ import { useApmPluginContext } from '../../../hooks/useApmPluginContext';
 import { MLCallout } from './ServiceList/MLCallout';
 import { useLocalStorage } from '../../../hooks/useLocalStorage';
 import { useAnomalyDetectionJobs } from '../../../hooks/useAnomalyDetectionJobs';
+import { Correlations } from '../Correlations';
 
 const initialData = {
   items: [],
@@ -117,6 +118,9 @@ export function ServiceOverview() {
   return (
     <>
       <EuiSpacer />
+
+      <Correlations />
+
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>
           <LocalUIFilters {...localFiltersConfig} />

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/index.tsx
@@ -31,6 +31,7 @@ import { fromQuery, toQuery } from '../../shared/Links/url_helpers';
 import { useUrlParams } from '../../../hooks/useUrlParams';
 import { LocalUIFilters } from '../../shared/LocalUIFilters';
 import { HeightRetainer } from '../../shared/HeightRetainer';
+import { Correlations } from '../Correlations';
 
 interface Sample {
   traceId: string;
@@ -110,6 +111,8 @@ export function TransactionDetails({
           <h1>{transactionName}</h1>
         </EuiTitle>
       </ApmHeader>
+
+      <Correlations />
 
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/index.tsx
@@ -37,6 +37,7 @@ import { TransactionList } from './TransactionList';
 import { useRedirect } from './useRedirect';
 import { TRANSACTION_PAGE_LOAD } from '../../../../common/transaction_types';
 import { UserExperienceCallout } from './user_experience_callout';
+import { Correlations } from '../Correlations';
 
 function getRedirectLocation({
   urlParams,
@@ -117,6 +118,7 @@ export function TransactionOverview({ serviceName }: TransactionOverviewProps) {
 
   return (
     <>
+      <Correlations />
       <EuiSpacer />
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.ts
@@ -49,7 +49,15 @@ export interface SetupTimeRange {
 interface SetupRequestParams {
   query?: {
     _debug?: boolean;
+
+    /**
+     * Timestamp in ms since epoch
+     */
     start?: string;
+
+    /**
+     * Timestamp in ms since epoch
+     */
     end?: string;
     uiFilters?: string;
     processorEvent?: ProcessorEvent;

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_ranges.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_ranges.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { rangeFilter } from '../../../../common/utils/range_filter';
+import {
+  SERVICE_NAME,
+  TRANSACTION_NAME,
+  TRANSACTION_TYPE,
+} from '../../../../common/elasticsearch_fieldnames';
+import { ProcessorEvent } from '../../../../common/processor_event';
+import { Setup, SetupTimeRange } from '../../helpers/setup_request';
+import {
+  getSignificantTermsAgg,
+  formatAggregationResponse,
+} from './get_significant_terms_agg';
+
+export async function getCorrelationsForRanges({
+  serviceName,
+  transactionType,
+  transactionName,
+  gapBetweenRanges,
+  fieldNames,
+  setup,
+}: {
+  serviceName: string | undefined;
+  transactionType: string | undefined;
+  transactionName: string | undefined;
+  gapBetweenRanges: number;
+  fieldNames: string[];
+  setup: Setup & SetupTimeRange;
+}) {
+  const { start, end, esFilter, apmEventClient } = setup;
+
+  const baseFilters = [...esFilter];
+
+  if (serviceName) {
+    baseFilters.push({ term: { [SERVICE_NAME]: serviceName } });
+  }
+
+  if (transactionType) {
+    baseFilters.push({ term: { [TRANSACTION_TYPE]: transactionType } });
+  }
+
+  if (transactionName) {
+    baseFilters.push({ term: { [TRANSACTION_NAME]: transactionName } });
+  }
+
+  const diff = end - start + gapBetweenRanges;
+  const baseRangeStart = start - diff;
+  const baseRangeEnd = end - diff;
+  const backgroundFilters = [
+    ...baseFilters,
+    { range: rangeFilter(baseRangeStart, baseRangeEnd) },
+  ];
+
+  const params = {
+    apm: { events: [ProcessorEvent.transaction] },
+    body: {
+      size: 0,
+      query: {
+        bool: { filter: [...baseFilters, { range: rangeFilter(start, end) }] },
+      },
+      aggs: getSignificantTermsAgg(fieldNames, backgroundFilters),
+    },
+  };
+
+  const response = await apmEventClient.search(params);
+
+  return {
+    message: `Showing significant fields between the ranges`,
+    firstRange: `${new Date(baseRangeStart).toISOString()} - ${new Date(
+      baseRangeEnd
+    ).toISOString()}`,
+    lastRange: `${new Date(start).toISOString()} - ${new Date(
+      end
+    ).toISOString()}`,
+    response: formatAggregationResponse(response.aggregations),
+  };
+}

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_ranges.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_ranges.ts
@@ -16,11 +16,13 @@ import {
   getSignificantTermsAgg,
   formatAggregationResponse,
 } from './get_significant_terms_agg';
+import { SignificantTermsScoring } from './scoring_rt';
 
 export async function getCorrelationsForRanges({
   serviceName,
   transactionType,
   transactionName,
+  scoring,
   gapBetweenRanges,
   fieldNames,
   setup,
@@ -28,6 +30,7 @@ export async function getCorrelationsForRanges({
   serviceName: string | undefined;
   transactionType: string | undefined;
   transactionName: string | undefined;
+  scoring: SignificantTermsScoring;
   gapBetweenRanges: number;
   fieldNames: string[];
   setup: Setup & SetupTimeRange;
@@ -67,6 +70,7 @@ export async function getCorrelationsForRanges({
         fieldNames,
         backgroundFilters,
         backgroundIsSuperset: false,
+        scoring,
       }),
     },
   };

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_ranges.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_ranges.ts
@@ -63,7 +63,11 @@ export async function getCorrelationsForRanges({
       query: {
         bool: { filter: [...baseFilters, { range: rangeFilter(start, end) }] },
       },
-      aggs: getSignificantTermsAgg(fieldNames, backgroundFilters),
+      aggs: getSignificantTermsAgg({
+        fieldNames,
+        backgroundFilters,
+        backgroundIsSuperset: false,
+      }),
     },
   };
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_slow_transactions.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_slow_transactions.ts
@@ -20,6 +20,7 @@ import {
   formatAggregationResponse,
   getSignificantTermsAgg,
 } from './get_significant_terms_agg';
+import { SignificantTermsScoring } from './scoring_rt';
 
 export async function getCorrelationsForSlowTransactions({
   serviceName,
@@ -27,11 +28,13 @@ export async function getCorrelationsForSlowTransactions({
   transactionName,
   durationPercentile,
   fieldNames,
+  scoring,
   setup,
 }: {
   serviceName: string | undefined;
   transactionType: string | undefined;
   transactionName: string | undefined;
+  scoring: SignificantTermsScoring;
   durationPercentile: number;
   fieldNames: string[];
   setup: Setup & SetupTimeRange;
@@ -76,7 +79,7 @@ export async function getCorrelationsForSlowTransactions({
           ],
         },
       },
-      aggs: getSignificantTermsAgg({ fieldNames, backgroundFilters }),
+      aggs: getSignificantTermsAgg({ fieldNames, backgroundFilters, scoring }),
     },
   };
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_slow_transactions.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_slow_transactions.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { asDuration } from '../../../../common/utils/formatters';
+import { ESFilter } from '../../../../typings/elasticsearch';
+import { rangeFilter } from '../../../../common/utils/range_filter';
+import {
+  SERVICE_NAME,
+  TRANSACTION_DURATION,
+  TRANSACTION_NAME,
+  TRANSACTION_TYPE,
+} from '../../../../common/elasticsearch_fieldnames';
+import { ProcessorEvent } from '../../../../common/processor_event';
+import { Setup, SetupTimeRange } from '../../helpers/setup_request';
+import { getDurationForPercentile } from './get_duration_for_percentile';
+import {
+  formatAggregationResponse,
+  getSignificantTermsAgg,
+} from './get_significant_terms_agg';
+
+export async function getCorrelationsForSlowTransactions({
+  serviceName,
+  transactionType,
+  transactionName,
+  durationPercentile,
+  fieldNames,
+  setup,
+}: {
+  serviceName: string | undefined;
+  transactionType: string | undefined;
+  transactionName: string | undefined;
+  durationPercentile: number;
+  fieldNames: string[];
+  setup: Setup & SetupTimeRange;
+}) {
+  const { start, end, esFilter, apmEventClient } = setup;
+
+  const backgroundFilters: ESFilter[] = [
+    ...esFilter,
+    { range: rangeFilter(start, end) },
+  ];
+
+  if (serviceName) {
+    backgroundFilters.push({ term: { [SERVICE_NAME]: serviceName } });
+  }
+
+  if (transactionType) {
+    backgroundFilters.push({ term: { [TRANSACTION_TYPE]: transactionType } });
+  }
+
+  if (transactionName) {
+    backgroundFilters.push({ term: { [TRANSACTION_NAME]: transactionName } });
+  }
+
+  const durationForPercentile = await getDurationForPercentile({
+    durationPercentile,
+    backgroundFilters,
+    setup,
+  });
+
+  const params = {
+    apm: { events: [ProcessorEvent.transaction] },
+    body: {
+      size: 0,
+      query: {
+        bool: {
+          // foreground filters
+          filter: [
+            ...backgroundFilters,
+            {
+              range: { [TRANSACTION_DURATION]: { gte: durationForPercentile } },
+            },
+          ],
+        },
+      },
+      aggs: getSignificantTermsAgg(fieldNames, backgroundFilters),
+    },
+  };
+
+  const response = await apmEventClient.search(params);
+
+  return {
+    message: `Showing significant fields for transactions slower than ${durationPercentile}th percentile (${asDuration(
+      durationForPercentile
+    )})`,
+    response: formatAggregationResponse(response.aggregations),
+  };
+}

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_slow_transactions.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_correlations_for_slow_transactions.ts
@@ -76,7 +76,7 @@ export async function getCorrelationsForSlowTransactions({
           ],
         },
       },
-      aggs: getSignificantTermsAgg(fieldNames, backgroundFilters),
+      aggs: getSignificantTermsAgg({ fieldNames, backgroundFilters }),
     },
   };
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_duration_for_percentile.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_duration_for_percentile.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ESFilter } from '../../../../typings/elasticsearch';
+import { TRANSACTION_DURATION } from '../../../../common/elasticsearch_fieldnames';
+import { ProcessorEvent } from '../../../../common/processor_event';
+import { Setup, SetupTimeRange } from '../../helpers/setup_request';
+
+export async function getDurationForPercentile({
+  durationPercentile,
+  backgroundFilters,
+  setup,
+}: {
+  durationPercentile: number;
+  backgroundFilters: ESFilter[];
+  setup: Setup & SetupTimeRange;
+}) {
+  const { apmEventClient } = setup;
+  const res = await apmEventClient.search({
+    apm: {
+      events: [ProcessorEvent.transaction],
+    },
+    body: {
+      size: 0,
+      query: {
+        bool: { filter: backgroundFilters },
+      },
+      aggs: {
+        percentile: {
+          percentiles: {
+            field: TRANSACTION_DURATION,
+            percents: [durationPercentile],
+          },
+        },
+      },
+    },
+  });
+
+  return Object.values(res.aggregations?.percentile.values || {})[0];
+}

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_significant_terms_agg.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_significant_terms_agg.ts
@@ -5,15 +5,18 @@
  */
 
 import { ESFilter } from '../../../../typings/elasticsearch';
+import { SignificantTermsScoring } from './scoring_rt';
 
 export function getSignificantTermsAgg({
   fieldNames,
   backgroundFilters,
   backgroundIsSuperset = true,
+  scoring = 'percentage',
 }: {
   fieldNames: string[];
   backgroundFilters: ESFilter[];
   backgroundIsSuperset?: boolean;
+  scoring: SignificantTermsScoring;
 }) {
   return fieldNames.reduce((acc, fieldName) => {
     return {
@@ -24,11 +27,11 @@ export function getSignificantTermsAgg({
           field: fieldName,
           background_filter: { bool: { filter: backgroundFilters } },
 
-          // range comparison is not a superset
-          background_is_superset: backgroundIsSuperset,
+          // indicate whether background is a superset of the foreground
+          mutual_information: { background_is_superset: backgroundIsSuperset },
 
-          // percentage calculation https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html#_percentage
-          percentage: {},
+          // different scorings https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html#significantterms-aggregation-parameters
+          [scoring]: {},
           min_doc_count: 5,
           shard_min_doc_count: 5,
         },

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_significant_terms_agg.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_significant_terms_agg.ts
@@ -6,10 +6,15 @@
 
 import { ESFilter } from '../../../../typings/elasticsearch';
 
-export function getSignificantTermsAgg(
-  fieldNames: string[],
-  backgroundFilters: ESFilter[]
-) {
+export function getSignificantTermsAgg({
+  fieldNames,
+  backgroundFilters,
+  backgroundIsSuperset = true,
+}: {
+  fieldNames: string[];
+  backgroundFilters: ESFilter[];
+  backgroundIsSuperset?: boolean;
+}) {
   return fieldNames.reduce((acc, fieldName) => {
     return {
       ...acc,
@@ -18,6 +23,14 @@ export function getSignificantTermsAgg(
           size: 10,
           field: fieldName,
           background_filter: { bool: { filter: backgroundFilters } },
+
+          // range comparison is not a superset
+          background_is_superset: backgroundIsSuperset,
+
+          // percentage calculation https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html#_percentage
+          percentage: {},
+          min_doc_count: 5,
+          shard_min_doc_count: 5,
         },
       },
       [`cardinality-${fieldName}`]: {

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_significant_terms_agg.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/get_significant_terms_agg.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ESFilter } from '../../../../typings/elasticsearch';
+
+export function getSignificantTermsAgg(
+  fieldNames: string[],
+  backgroundFilters: ESFilter[]
+) {
+  return fieldNames.reduce((acc, fieldName) => {
+    return {
+      ...acc,
+      [fieldName]: {
+        significant_terms: {
+          size: 10,
+          field: fieldName,
+          background_filter: { bool: { filter: backgroundFilters } },
+        },
+      },
+      [`cardinality-${fieldName}`]: {
+        cardinality: { field: fieldName },
+      },
+    };
+  }, {} as Record<string, any>);
+}
+
+export function formatAggregationResponse(aggs?: Record<string, any>) {
+  if (!aggs) {
+    return;
+  }
+
+  return Object.entries(aggs).reduce((acc, [key, value]) => {
+    if (key.startsWith('cardinality-')) {
+      if (value.value > 0) {
+        const fieldName = key.slice(12);
+        acc[fieldName] = {
+          ...acc[fieldName],
+          cardinality: value.value,
+        };
+      }
+    } else if (value.buckets.length > 0) {
+      acc[key] = {
+        ...acc[key],
+        value,
+      };
+    }
+    return acc;
+  }, {} as Record<string, { cardinality: number; value: any }>);
+}

--- a/x-pack/plugins/apm/server/lib/transaction_groups/correlations/scoring_rt.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/correlations/scoring_rt.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as t from 'io-ts';
+
+export const scoringRt = t.union([
+  t.literal('jlh'),
+  t.literal('chi_square'),
+  t.literal('gnd'),
+  t.literal('percentage'),
+]);
+
+export type SignificantTermsScoring = t.TypeOf<typeof scoringRt>;

--- a/x-pack/plugins/apm/server/routes/correlations.ts
+++ b/x-pack/plugins/apm/server/routes/correlations.ts
@@ -8,6 +8,7 @@ import * as t from 'io-ts';
 import { rangeRt } from './default_api_types';
 import { getCorrelationsForSlowTransactions } from '../lib/transaction_groups/correlations/get_correlations_for_slow_transactions';
 import { getCorrelationsForRanges } from '../lib/transaction_groups/correlations/get_correlations_for_ranges';
+import { scoringRt } from '../lib/transaction_groups/correlations/scoring_rt';
 import { createRoute } from './create_route';
 import { setupRequest } from '../lib/helpers/setup_request';
 
@@ -19,6 +20,7 @@ export const correlationsForSlowTransactionsRoute = createRoute(() => ({
         serviceName: t.string,
         transactionName: t.string,
         transactionType: t.string,
+        scoring: scoringRt,
       }),
       t.type({
         durationPercentile: t.string,
@@ -36,6 +38,7 @@ export const correlationsForSlowTransactionsRoute = createRoute(() => ({
       transactionName,
       durationPercentile,
       fieldNames,
+      scoring = 'percentage',
     } = context.params.query;
 
     return getCorrelationsForSlowTransactions({
@@ -44,6 +47,7 @@ export const correlationsForSlowTransactionsRoute = createRoute(() => ({
       transactionName,
       durationPercentile: parseInt(durationPercentile, 10),
       fieldNames: fieldNames.split(','),
+      scoring,
       setup,
     });
   },
@@ -57,6 +61,7 @@ export const correlationsForRangesRoute = createRoute(() => ({
         serviceName: t.string,
         transactionName: t.string,
         transactionType: t.string,
+        scoring: scoringRt,
         gap: t.string,
       }),
       t.type({
@@ -73,6 +78,7 @@ export const correlationsForRangesRoute = createRoute(() => ({
       serviceName,
       transactionType,
       transactionName,
+      scoring = 'percentage',
       gap,
       fieldNames,
     } = context.params.query;
@@ -86,6 +92,7 @@ export const correlationsForRangesRoute = createRoute(() => ({
       serviceName,
       transactionType,
       transactionName,
+      scoring,
       gapBetweenRanges,
       fieldNames: fieldNames.split(','),
       setup,

--- a/x-pack/plugins/apm/server/routes/correlations.ts
+++ b/x-pack/plugins/apm/server/routes/correlations.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as t from 'io-ts';
+import { rangeRt } from './default_api_types';
+import { getCorrelationsForSlowTransactions } from '../lib/transaction_groups/correlations/get_correlations_for_slow_transactions';
+import { getCorrelationsForRanges } from '../lib/transaction_groups/correlations/get_correlations_for_ranges';
+import { createRoute } from './create_route';
+import { setupRequest } from '../lib/helpers/setup_request';
+
+export const correlationsForSlowTransactionsRoute = createRoute(() => ({
+  path: '/api/apm/correlations/slow_durations',
+  params: {
+    query: t.intersection([
+      t.partial({
+        serviceName: t.string,
+        transactionName: t.string,
+        transactionType: t.string,
+      }),
+      t.type({
+        durationPercentile: t.string,
+        fieldNames: t.string,
+      }),
+      t.partial({ uiFilters: t.string }),
+      rangeRt,
+    ]),
+  },
+  handler: async ({ context, request }) => {
+    const setup = await setupRequest(context, request);
+    const {
+      serviceName,
+      transactionType,
+      transactionName,
+      durationPercentile,
+      fieldNames,
+    } = context.params.query;
+
+    return getCorrelationsForSlowTransactions({
+      serviceName,
+      transactionType,
+      transactionName,
+      durationPercentile: parseInt(durationPercentile, 10),
+      fieldNames: fieldNames.split(','),
+      setup,
+    });
+  },
+}));
+
+export const correlationsForRangesRoute = createRoute(() => ({
+  path: '/api/apm/correlations/ranges',
+  params: {
+    query: t.intersection([
+      t.partial({
+        serviceName: t.string,
+        transactionName: t.string,
+        transactionType: t.string,
+        gap: t.string,
+      }),
+      t.type({
+        fieldNames: t.string,
+      }),
+      t.partial({ uiFilters: t.string }),
+      rangeRt,
+    ]),
+  },
+  handler: async ({ context, request }) => {
+    const setup = await setupRequest(context, request);
+
+    const {
+      serviceName,
+      transactionType,
+      transactionName,
+      gap,
+      fieldNames,
+    } = context.params.query;
+
+    const gapBetweenRanges = parseInt(gap || '0', 10) * 3600 * 1000;
+    if (gapBetweenRanges < 0) {
+      throw new Error('gap must be 0 or positive');
+    }
+
+    return getCorrelationsForRanges({
+      serviceName,
+      transactionType,
+      transactionName,
+      gapBetweenRanges,
+      fieldNames: fieldNames.split(','),
+      setup,
+    });
+  },
+}));

--- a/x-pack/plugins/apm/server/routes/create_apm_api.ts
+++ b/x-pack/plugins/apm/server/routes/create_apm_api.ts
@@ -42,6 +42,10 @@ import { serviceNodesRoute } from './service_nodes';
 import { tracesRoute, tracesByIdRoute } from './traces';
 import { transactionByTraceIdRoute } from './transaction';
 import {
+  correlationsForRangesRoute,
+  correlationsForSlowTransactionsRoute,
+} from './correlations';
+import {
   transactionGroupsBreakdownRoute,
   transactionGroupsChartsRoute,
   transactionGroupsDistributionRoute,
@@ -121,6 +125,10 @@ const createApmApi = () => {
     .add(listAgentConfigurationEnvironmentsRoute)
     .add(listAgentConfigurationServicesRoute)
     .add(createOrUpdateAgentConfigurationRoute)
+
+    // Correlations
+    .add(correlationsForSlowTransactionsRoute)
+    .add(correlationsForRangesRoute)
 
     // APM indices
     .add(apmIndexSettingsRoute)

--- a/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
+++ b/x-pack/plugins/apm/typings/elasticsearch/aggregations.ts
@@ -158,6 +158,11 @@ export interface AggregationOptionsByType {
     from?: number;
     size?: number;
   };
+  significant_terms: {
+    size?: number;
+    field?: string;
+    background_filter?: Record<string, any>;
+  } & AggregationSourceOptions;
 }
 
 type AggregationType = keyof AggregationOptionsByType;
@@ -333,6 +338,17 @@ interface AggregationResponsePart<
     }
       ? Array<{ key: number; value: number }>
       : Record<string, number>;
+  };
+  significant_terms: {
+    doc_count: number;
+    bg_count: number;
+    buckets: Array<
+      {
+        bg_count: number;
+        doc_count: number;
+        key: string | number;
+      } & SubAggregationResponseOf<TAggregationOptionsMap['aggs'], TDocument>
+    >;
   };
   bucket_sort: undefined;
 }

--- a/x-pack/test/apm_api_integration/basic/tests/correlations/ranges.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/correlations/ranges.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import expect from '@kbn/expect';
+import { format } from 'url';
+import { expectSnapshot } from '../../../common/match_snapshot';
+import { PromiseReturnType } from '../../../../../plugins/apm/typings/common';
+import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import archives_metadata from '../../../common/archives_metadata';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const esArchiver = getService('esArchiver');
+  const archiveName = 'apm_8.0.0';
+  const range = archives_metadata[archiveName];
+
+  // url parameters
+  const start = '2020-09-29T14:45:00.000Z';
+  const end = range.end;
+  const fieldNames =
+    'user.username,user.id,host.ip,user_agent.name,kubernetes.pod.uuid,url.domain,container.id,service.node.name';
+
+  describe('Ranges', () => {
+    const url = format({
+      pathname: `/api/apm/correlations/ranges`,
+      query: { start, end, fieldNames },
+    });
+
+    describe('when data is not loaded ', () => {
+      it('handles the empty state', async () => {
+        const response = await supertest.get(url);
+        expect(response.status).to.be(200);
+        expect(response.body.response).to.be(undefined);
+      });
+    });
+
+    describe('when data is loaded', () => {
+      let response: PromiseReturnType<typeof supertest.get>;
+      before(async () => {
+        await esArchiver.load(archiveName);
+        response = await supertest.get(url);
+      });
+
+      after(() => esArchiver.unload(archiveName));
+
+      it('returns successfully', () => {
+        expect(response.status).to.eql(200);
+      });
+
+      it('returns fields in response', () => {
+        expectSnapshot(Object.keys(response.body.response)).toMatchInline(`
+          Array [
+            "service.node.name",
+            "host.ip",
+            "user.id",
+            "user_agent.name",
+            "container.id",
+            "url.domain",
+          ]
+        `);
+      });
+
+      it('returns cardinality for each field', () => {
+        const cardinalitys = Object.values(response.body.response).map(
+          (field: any) => field.cardinality
+        );
+
+        expectSnapshot(cardinalitys).toMatchInline(`
+          Array [
+            5,
+            6,
+            20,
+            6,
+            5,
+            4,
+          ]
+        `);
+      });
+
+      it('returns buckets', () => {
+        const { buckets } = response.body.response['user.id'].value;
+        expectSnapshot(buckets[0]).toMatchInline(`
+          Object {
+            "bg_count": 2,
+            "doc_count": 7,
+            "key": "20",
+            "score": 3.5,
+          }
+        `);
+      });
+    });
+  });
+}

--- a/x-pack/test/apm_api_integration/basic/tests/correlations/slow_durations.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/correlations/slow_durations.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import expect from '@kbn/expect';
+import { format } from 'url';
+import { PromiseReturnType } from '../../../../../plugins/apm/typings/common';
+import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import { expectSnapshot } from '../../../common/match_snapshot';
+import archives_metadata from '../../../common/archives_metadata';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const esArchiver = getService('esArchiver');
+  const archiveName = 'apm_8.0.0';
+  const range = archives_metadata[archiveName];
+
+  // url parameters
+  const start = range.start;
+  const end = range.end;
+  const durationPercentile = 95;
+  const fieldNames =
+    'user.username,user.id,host.ip,user_agent.name,kubernetes.pod.uuid,url.domain,container.id,service.node.name';
+
+  describe('Slow durations', () => {
+    const url = format({
+      pathname: `/api/apm/correlations/slow_durations`,
+      query: { start, end, durationPercentile, fieldNames },
+    });
+
+    describe('when data is not loaded ', () => {
+      it('handles the empty state', async () => {
+        const response = await supertest.get(url);
+
+        expect(response.status).to.be(200);
+        expect(response.body.response).to.be(undefined);
+      });
+    });
+
+    describe('with default scoring', () => {
+      let response: PromiseReturnType<typeof supertest.get>;
+      before(async () => {
+        await esArchiver.load(archiveName);
+        response = await supertest.get(url);
+      });
+
+      after(() => esArchiver.unload(archiveName));
+
+      it('returns successfully', () => {
+        expect(response.status).to.eql(200);
+      });
+
+      it('returns fields in response', () => {
+        expectSnapshot(Object.keys(response.body.response)).toMatchInline(`
+          Array [
+            "service.node.name",
+            "host.ip",
+            "user.id",
+            "user_agent.name",
+            "container.id",
+            "url.domain",
+          ]
+        `);
+      });
+
+      it('returns cardinality for each field', () => {
+        const cardinalitys = Object.values(response.body.response).map(
+          (field: any) => field.cardinality
+        );
+
+        expectSnapshot(cardinalitys).toMatchInline(`
+          Array [
+            5,
+            6,
+            3,
+            5,
+            5,
+            4,
+          ]
+        `);
+      });
+
+      it('returns buckets', () => {
+        const { buckets } = response.body.response['user.id'].value;
+        expectSnapshot(buckets[0]).toMatchInline(`
+          Object {
+            "bg_count": 32,
+            "doc_count": 6,
+            "key": "2",
+            "score": 0.1875,
+          }
+        `);
+      });
+    });
+
+    describe('with different scoring', () => {
+      before(async () => esArchiver.load(archiveName));
+      after(() => esArchiver.unload(archiveName));
+
+      it(`returns buckets for each score`, async () => {
+        const promises = ['percentage', 'jlh', 'chi_square', 'gnd'].map(async (scoring) => {
+          const response = await supertest.get(
+            format({
+              pathname: `/api/apm/correlations/slow_durations`,
+              query: { start, end, durationPercentile, fieldNames, scoring },
+            })
+          );
+
+          return { name: scoring, value: response.body.response['user.id'].value.buckets[0].score };
+        });
+
+        const res = await Promise.all(promises);
+        expectSnapshot(res).toMatchInline(`
+          Array [
+            Object {
+              "name": "percentage",
+              "value": 0.1875,
+            },
+            Object {
+              "name": "jlh",
+              "value": 3.33506905769659,
+            },
+            Object {
+              "name": "chi_square",
+              "value": 219.192006524483,
+            },
+            Object {
+              "name": "gnd",
+              "value": 0.671406580688819,
+            },
+          ]
+        `);
+      });
+    });
+  });
+}

--- a/x-pack/test/apm_api_integration/basic/tests/index.ts
+++ b/x-pack/test/apm_api_integration/basic/tests/index.ts
@@ -56,5 +56,10 @@ export default function apmApiIntegrationTests({ loadTestFile }: FtrProviderCont
     describe('Metrics', function () {
       loadTestFile(require.resolve('./metrics_charts/metrics_charts'));
     });
+
+    describe('Correlations', function () {
+      loadTestFile(require.resolve('./correlations/slow_durations'));
+      loadTestFile(require.resolve('./correlations/ranges'));
+    });
   });
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/74168

**Slow durations API**
```
/api/apm/correlations/slow_durations?serviceName=elastic-co-frontend&transactionName=%2Fblog%2F%3Aid&transactionType=page-load&start=2020-10-13T22%3A36%3A40.590Z&end=2020-10-13T23%3A36%3A40.590Z&fieldNames=user.username%2Cuser.id%2Chost.ip%2Cuser_agent.name%2Ckubernetes.pod.uuid%2Curl.domain%2Ccontainer.id%2Cservice.node.name&durationPercentile=95
```

**Compare ranges API**
```
/api/apm/correlations/ranges?serviceName=&transactionName=&transactionType=page-load&start=2020-10-13T22%3A24%3A24.210Z&end=2020-10-13T23%3A23%3A43.792Z&fieldNames=user.username%2Cuser.id%2Chost.ip%2Cuser_agent.name%2Ckubernetes.pod.uuid%2Curl.domain%2Ccontainer.id%2Cservice.node.name&gap=0
```