### PR TITLE
Expressions timings in the browser console

### DIFF
--- a/src/plugins/expressions/common/execution/execution.ts
+++ b/src/plugins/expressions/common/execution/execution.ts
@@ -237,8 +237,8 @@ export class Execution<
             success: true,
             fn: fn.name,
             input,
-            args: resolvedArgs,
-            output,
+            // args: resolvedArgs,
+            // output,
             duration: timeEnd - timeStart,
           };
         }

--- a/src/plugins/expressions/common/executor/executor.ts
+++ b/src/plugins/expressions/common/executor/executor.ts
@@ -165,8 +165,13 @@ export class Executor<Context extends Record<string, unknown> = Record<string, u
     Input,
     Output,
     ExtraContext extends Record<string, unknown> = Record<string, unknown>
-  >(ast: string | ExpressionAstExpression, input: Input, context?: ExtraContext) {
-    const execution = this.createExecution(ast, context);
+  >(
+    ast: string | ExpressionAstExpression,
+    input: Input,
+    context?: ExtraContext,
+    options?: ExpressionExecOptions
+  ) {
+    const execution = this.createExecution(ast, context, options);
     execution.start(input);
     return (await execution.result) as Output;
   }

--- a/src/plugins/expressions/common/service/expressions_services.ts
+++ b/src/plugins/expressions/common/service/expressions_services.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Executor } from '../executor';
+import { Executor, ExpressionExecOptions } from '../executor';
 import { ExpressionRendererRegistry } from '../expression_renderers';
 import { ExpressionAstExpression } from '../ast';
 import { ExecutionContract } from '../execution/execution_contract';
@@ -169,8 +169,10 @@ export class ExpressionsService {
   >(
     ast: string | ExpressionAstExpression,
     input: Input,
-    context?: ExtraContext
-  ): Promise<Output> => this.executor.run<Input, Output, ExtraContext>(ast, input, context);
+    context?: ExtraContext,
+    options?: ExpressionExecOptions
+  ): Promise<Output> =>
+    this.executor.run<Input, Output, ExtraContext>(ast, input, context, options);
 
   /**
    * Get a registered `ExpressionFunction` by its name, which was registered
@@ -232,9 +234,14 @@ export class ExpressionsService {
     ast: string | ExpressionAstExpression,
     // This any is for legacy reasons.
     input: Input = { type: 'null' } as any,
-    context?: ExtraContext
+    context?: ExtraContext,
+    options?: ExpressionExecOptions
   ): ExecutionContract<ExtraContext, Input, Output> => {
-    const execution = this.executor.createExecution<ExtraContext, Input, Output>(ast, context);
+    const execution = this.executor.createExecution<ExtraContext, Input, Output>(
+      ast,
+      context,
+      options
+    );
     execution.start(input);
     return execution.contract;
   };

--- a/src/plugins/expressions/public/loader.ts
+++ b/src/plugins/expressions/public/loader.ts
@@ -145,11 +145,18 @@ export class ExpressionLoader {
       this.execution.cancel();
     }
     this.setParams(params);
-    this.execution = getExpressionsService().execute(expression, params.context, {
-      search: params.searchContext,
-      variables: params.variables || {},
-      inspectorAdapters: params.inspectorAdapters,
-    });
+    this.execution = getExpressionsService().execute(
+      expression,
+      params.context,
+      {
+        search: params.searchContext,
+        variables: params.variables || {},
+        inspectorAdapters: params.inspectorAdapters,
+      },
+      {
+        debug: params.debug,
+      }
+    );
 
     const prevDataHandler = this.execution;
     const data = await prevDataHandler.getData();
@@ -181,6 +188,7 @@ export class ExpressionLoader {
     if (params.variables && this.params) {
       this.params.variables = params.variables;
     }
+    this.params.debug = Boolean(params.debug);
 
     this.params.inspectorAdapters = (params.inspectorAdapters ||
       this.execution?.inspect()) as Adapters;

--- a/src/plugins/expressions/public/types/index.ts
+++ b/src/plugins/expressions/public/types/index.ts
@@ -45,6 +45,8 @@ export interface IExpressionLoaderParams {
   searchContext?: ExecutionContextSearch;
   context?: ExpressionValue;
   variables?: Record<string, any>;
+  // Enables debug tracking on each expression in the AST
+  debug?: boolean;
   disableCaching?: boolean;
   customFunctions?: [];
   customRenderers?: [];

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -295,6 +295,7 @@ export class VisualizeEmbeddable
       onRenderError: (element: HTMLElement, error: ExpressionRenderError) => {
         this.onContainerError(error);
       },
+      debug: true,
     });
 
     this.subscriptions.push(
@@ -376,6 +377,7 @@ export class VisualizeEmbeddable
       },
       uiState: this.vis.uiState,
       inspectorAdapters: this.inspectorAdapters,
+      debug: true,
     };
     if (this.abortController) {
       this.abortController.abort();

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -281,6 +281,7 @@ export function InnerWorkspacePanel({
           searchContext={context}
           reload$={autoRefreshFetch$}
           onEvent={onEvent}
+          debug={true}
           renderError={(errorMessage?: string | null) => {
             return (
               <EuiFlexGroup direction="column" alignItems="center">

--- a/x-pack/plugins/lens/public/editor_frame_service/embeddable/expression_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/embeddable/expression_wrapper.tsx
@@ -52,6 +52,7 @@ export function ExpressionWrapper({
             searchContext={searchContext}
             renderError={(error) => <div data-test-subj="expression-renderer-error">{error}</div>}
             onEvent={handleEvent}
+            debug={true}
           />
         </div>
       )}


### PR DESCRIPTION
This is a PR that lets you see how many milliseconds each expression function takes, for visualize, lens, and canvas. For example:

<img width="734" alt="Screen Shot 2020-09-29 at 6 40 04 PM" src="https://user-images.githubusercontent.com/666475/94624299-1cf9be80-0284-11eb-9d48-0b9e5a4c9d77.png">
