### PR TITLE
Optimize charts plugin

### DIFF
--- a/src/plugins/charts/public/services/colors/color_palette.ts
+++ b/src/plugins/charts/public/services/colors/color_palette.ts
@@ -58,7 +58,7 @@ export function createColorPalette(num: number): string[] {
   const seedLength = seedColors.length;
 
   _.times(num - seedLength, function (i) {
-    colors.push(hsl((fraction(i + seedLength + 1) * 360 + offset) % 360, 0.5, 0.5).toString());
+    colors.push(hsl((fraction(i + seedLength + 1) * 360 + offset) % 360, 0.5, 0.5).hex());
   });
 
   return colors;

--- a/src/plugins/charts/public/services/colors/color_palette.ts
+++ b/src/plugins/charts/public/services/colors/color_palette.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import d3 from 'd3';
 import _ from 'lodash';
+import { hsl } from 'color';
 
 import { seedColors } from './seed_colors';
 
@@ -49,7 +49,7 @@ const fraction = function (goal: number) {
  * If the number is greater than the length of seed colors available,
  * new colors are generated up to the value of the input number.
  */
-export function createColorPalette(num?: any): string[] {
+export function createColorPalette(num: number): string[] {
   if (!_.isNumber(num)) {
     throw new TypeError('ColorPaletteUtilService expects a number');
   }
@@ -58,7 +58,7 @@ export function createColorPalette(num?: any): string[] {
   const seedLength = seedColors.length;
 
   _.times(num - seedLength, function (i) {
-    colors.push(d3.hsl((fraction(i + seedLength + 1) * 360 + offset) % 360, 0.5, 0.5).toString());
+    colors.push(hsl((fraction(i + seedLength + 1) * 360 + offset) % 360, 0.5, 0.5).toString());
   });
 
   return colors;

--- a/src/plugins/charts/public/services/colors/colors_palette.test.ts
+++ b/src/plugins/charts/public/services/colors/colors_palette.test.ts
@@ -37,26 +37,32 @@ describe('Color Palette', () => {
 
   it('should throw an error if input is not a number', () => {
     expect(() => {
+      // @ts-expect-error
       createColorPalette(string);
     }).toThrowError();
 
     expect(() => {
+      // @ts-expect-error
       createColorPalette(bool);
     }).toThrowError();
 
     expect(() => {
+      // @ts-expect-error
       createColorPalette(nullValue);
     }).toThrowError();
 
     expect(() => {
+      // @ts-expect-error
       createColorPalette(emptyArr);
     }).toThrowError();
 
     expect(() => {
+      // @ts-expect-error
       createColorPalette(emptyObject);
     }).toThrowError();
 
     expect(() => {
+      // @ts-expect-error
       createColorPalette();
     }).toThrowError();
   });

--- a/src/plugins/charts/public/services/colors/mapped_colors.test.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.test.ts
@@ -18,7 +18,9 @@
  */
 
 import _ from 'lodash';
-import { rgb } from 'color';
+import Color from 'color';
+
+import d3 from 'd3';
 
 import { coreMock } from '../../../../../core/public/mocks';
 import { COLOR_MAPPING_SETTING } from '../../../common';
@@ -61,7 +63,7 @@ describe('Mapped Colors', () => {
     mappedColors.mapKeys(arr);
 
     const colorValues = _(mappedColors.mapping).values();
-    expect(colorValues.includes(seedColors[0])).toBe(false);
+    expect(colorValues).not.toContain(seedColors[0]);
     expect(colorValues.uniq().size()).toBe(arr.length);
   });
 
@@ -78,8 +80,8 @@ describe('Mapped Colors', () => {
   });
 
   it('should treat different formats of colors as equal', () => {
-    const color = rgb(seedColors[0]);
-    const rgbColorString = `rgbColorString(${color.red}, ${color.green}, ${color.blue})`;
+    const color = new Color(seedColors[0]);
+    const rgbColorString = `rgb(${color.red()}, ${color.green()}, ${color.blue()})`;
     const newConfig = { bar: rgbColorString };
     config.set(COLOR_MAPPING_SETTING, newConfig);
 

--- a/src/plugins/charts/public/services/colors/mapped_colors.test.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.test.ts
@@ -20,8 +20,6 @@
 import _ from 'lodash';
 import Color from 'color';
 
-import d3 from 'd3';
-
 import { coreMock } from '../../../../../core/public/mocks';
 import { COLOR_MAPPING_SETTING } from '../../../common';
 import { seedColors } from './seed_colors';

--- a/src/plugins/charts/public/services/colors/mapped_colors.test.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.test.ts
@@ -18,7 +18,7 @@
  */
 
 import _ from 'lodash';
-import d3 from 'd3';
+import { rgb } from 'color';
 
 import { coreMock } from '../../../../../core/public/mocks';
 import { COLOR_MAPPING_SETTING } from '../../../common';
@@ -78,9 +78,9 @@ describe('Mapped Colors', () => {
   });
 
   it('should treat different formats of colors as equal', () => {
-    const color = d3.rgb(seedColors[0]);
-    const rgb = `rgb(${color.r}, ${color.g}, ${color.b})`;
-    const newConfig = { bar: rgb };
+    const color = rgb(seedColors[0]);
+    const rgbColorString = `rgbColorString(${color.red}, ${color.green}, ${color.blue})`;
+    const newConfig = { bar: rgbColorString };
     config.set(COLOR_MAPPING_SETTING, newConfig);
 
     const arr = ['foo', 'bar', 'baz', 'qux'];

--- a/src/plugins/charts/public/services/colors/mapped_colors.test.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.test.ts
@@ -79,8 +79,8 @@ describe('Mapped Colors', () => {
 
   it('should treat different formats of colors as equal', () => {
     const color = new Color(seedColors[0]);
-    const rgbColorString = `rgb(${color.red()}, ${color.green()}, ${color.blue()})`;
-    const newConfig = { bar: rgbColorString };
+    const rgb = `rgb(${color.red()}, ${color.green()}, ${color.blue()})`;
+    const newConfig = { bar: rgb };
     config.set(COLOR_MAPPING_SETTING, newConfig);
 
     const arr = ['foo', 'bar', 'baz', 'qux'];

--- a/src/plugins/charts/public/services/colors/mapped_colors.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.ts
@@ -18,14 +18,14 @@
  */
 
 import _ from 'lodash';
-import { rgb } from 'color';
+import Color from 'color';
 
 import { CoreSetup } from 'kibana/public';
 
 import { COLOR_MAPPING_SETTING } from '../../../common';
 import { createColorPalette } from './color_palette';
 
-const standardizeColor = (color: string) => rgb(color).toString();
+const standardizeColor = (color: string) => new Color(color).hex().toLowerCase();
 
 /**
  * Maintains a lookup table that associates the value (key) with a hex color (value)

--- a/src/plugins/charts/public/services/colors/mapped_colors.ts
+++ b/src/plugins/charts/public/services/colors/mapped_colors.ts
@@ -18,14 +18,14 @@
  */
 
 import _ from 'lodash';
-import d3 from 'd3';
+import { rgb } from 'color';
 
 import { CoreSetup } from 'kibana/public';
 
 import { COLOR_MAPPING_SETTING } from '../../../common';
 import { createColorPalette } from './color_palette';
 
-const standardizeColor = (color: string) => d3.rgb(color).toString();
+const standardizeColor = (color: string) => rgb(color).toString();
 
 /**
  * Maintains a lookup table that associates the value (key) with a hex color (value)


### PR DESCRIPTION
## Summary

This PR replaces the usage of `d3` in the `charts` plugin by usage of the `color` npm module instead. The goal is to reduce the page load bundle size of the `charts` plugin significantly, since `d3` has a significant larger size than the `color` module. We are also using that plugin across other parts of the code already.

**This PR should not change any functionallity.**

### Checklist

Delete any items that are not applicable to this PR.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- ~[ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)~
- ~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)~
- ~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- ~[ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
