### PR TITLE
[APM] Use `history.replace` to preserve back-button functionality

### DIFF
--- a/x-pack/plugins/apm/public/hooks/useTransactionDistribution.ts
+++ b/x-pack/plugins/apm/public/hooks/useTransactionDistribution.ts
@@ -75,7 +75,7 @@ export function useTransactionDistribution(urlParams: IUrlParams) {
 
           const preferredSample = maybe(bucketsSortedByCount[0]?.samples[0]);
 
-          history.push({
+          history.replace({
             ...history.location,
             search: fromQuery({
               ...omit(toQuery(history.location.search), [


### PR DESCRIPTION
Clicking on a transaction in the transactions table takes the user to the transactions details page. However, it also breaks the backbutton. Clicking "back" should take the user to the table again, but it does not.