### PR TITLE
[TSVB] Request validation error: [panels.0.series.0.metrics.0.percentiles.1.value]

### DIFF
--- a/src/plugins/vis_type_timeseries/common/vis_schema.ts
+++ b/src/plugins/vis_type_timeseries/common/vis_schema.ts
@@ -111,7 +111,7 @@ export const metricsItems = schema.object({
         field: stringOptionalNullable,
         mode: schema.oneOf([schema.literal('line'), schema.literal('band')]),
         shade: schema.oneOf([numberOptional, stringOptionalNullable]),
-        value: schema.oneOf([numberOptional, stringOptionalNullable]),
+        value: schema.maybe(schema.oneOf([numberOptional, stringOptionalNullable])),
         percentile: stringOptionalNullable,
       })
     )


### PR DESCRIPTION
Closes: #79006

## Summary

**Describe the bug:**
 Request validation error: [panels.0.series.0.metrics.0.percentiles.1.value]

`[warning][plugins][visTypeTimeseries][visTypeTimeseries] Request validation error: [panels.0.series.0.metrics.0.percentiles.1.value]: expected at least one defined value but got [undefined] (saved object id: unsaved). This most likely means your TSVB visualization contains outdated configuration. You can report this problem under https://github.com/elastic/kibana/issues/new?template=Bug_report.md`

**Root cause:**
This issue occurs when we add new percentile by pressing '+' button. We process that case as 0 value.
![image](https://user-images.githubusercontent.com/20072247/94736220-8fe26280-0374-11eb-9d5a-4487f2dec2de.png)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
