### PR TITLE
[7.x] Make the actual Vislib import async (#78949)

### DIFF
--- a/src/plugins/vis_type_vislib/public/vis_controller.tsx
+++ b/src/plugins/vis_type_vislib/public/vis_controller.tsx
@@ -20,8 +20,6 @@
 import $ from 'jquery';
 import React, { RefObject } from 'react';
 
-// @ts-ignore
-import { Vis as Vislib } from './vislib/vis';
 import { Positions } from './utils/collections';
 import { VisTypeVislibDependencies } from './plugin';
 import { mountReactNode } from '../../../core/public/utils';
@@ -79,6 +77,9 @@ export const createVislibVisController = (deps: VisTypeVislibDependencies) => {
         if (this.el.clientWidth === 0 || this.el.clientHeight === 0) {
           return resolve();
         }
+
+        // @ts-expect-error
+        const { Vis: Vislib } = await import('./vislib/vis');
 
         this.vislibVis = new Vislib(this.chartEl, visParams, deps);
         this.vislibVis.on('brush', this.vis.API.events.brush);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make the actual Vislib import async (#78949)