### PR TITLE
[APM] Persist time range between APM and other apps

### DIFF
--- a/x-pack/plugins/apm/public/application/application.test.tsx
+++ b/x-pack/plugins/apm/public/application/application.test.tsx
@@ -42,6 +42,13 @@ describe('renderApp', () => {
       licensing: { license$: new Observable() },
       triggers_actions_ui: { actionTypeRegistry: {}, alertTypeRegistry: {} },
       usageCollection: { reportUiStats: () => {} },
+      data: {
+        query: {
+          timefilter: {
+            timefilter: { setTime: () => {}, getTime: () => ({}) },
+          },
+        },
+      },
     };
     const params = {
       element: document.createElement('div'),

--- a/x-pack/plugins/apm/public/components/app/Home/__snapshots__/Home.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/Home/__snapshots__/Home.test.tsx.snap
@@ -53,6 +53,16 @@ exports[`Home component should render services 1`] = `
         },
       },
       "plugins": Object {
+        "data": Object {
+          "query": Object {
+            "timefilter": Object {
+              "timefilter": Object {
+                "getTime": [Function],
+                "setTime": [Function],
+              },
+            },
+          },
+        },
         "ml": Object {
           "urlGenerator": MlUrlGenerator {
             "createUrl": [Function],
@@ -126,6 +136,16 @@ exports[`Home component should render traces 1`] = `
         },
       },
       "plugins": Object {
+        "data": Object {
+          "query": Object {
+            "timefilter": Object {
+              "timefilter": Object {
+                "getTime": [Function],
+                "setTime": [Function],
+              },
+            },
+          },
+        },
         "ml": Object {
           "urlGenerator": MlUrlGenerator {
             "createUrl": [Function],

--- a/x-pack/plugins/apm/public/context/ApmPluginContext/MockApmPluginContext.tsx
+++ b/x-pack/plugins/apm/public/context/ApmPluginContext/MockApmPluginContext.tsx
@@ -87,6 +87,11 @@ const mockPlugin = {
       useHash: false,
     }),
   },
+  data: {
+    query: {
+      timefilter: { timefilter: { setTime: () => {}, getTime: () => ({}) } },
+    },
+  },
 };
 export const mockApmPluginContextValue = {
   config: mockConfig,


### PR DESCRIPTION
This change ensures that the time range is persisted when switching between APM and other Kibana apps.

![persist-timerange](https://user-images.githubusercontent.com/209966/94798608-2436de80-03e2-11eb-8be7-85a555d45a00.gif)
