### PR TITLE
[Lens] fix add new dimension button click area

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -7,12 +7,14 @@ import './layer_panel.scss';
 
 import React, { useContext, useState, useEffect } from 'react';
 import {
+  EuiLink,
   EuiPanel,
   EuiSpacer,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiButtonEmpty,
+  EuiIcon,
   EuiFormRow,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -381,35 +383,40 @@ export function LayerPanel(
                       accessor={newId}
                       groupId={group.groupId}
                       trigger={
-                        <div className="lnsLayerPanel__triggerLink">
-                          <EuiButtonEmpty
-                            iconType="plusInCircleFilled"
-                            data-test-subj="lns-empty-dimension"
-                            aria-label={i18n.translate('xpack.lens.configure.addConfig', {
-                              defaultMessage: 'Add a configuration',
-                            })}
-                            title={i18n.translate('xpack.lens.configure.addConfig', {
-                              defaultMessage: 'Add a configuration',
-                            })}
-                            onClick={() => {
-                              if (dimensionContainerState.isOpen) {
-                                setDimensionContainerState(initialDimensionContainerState);
-                              } else {
-                                setDimensionContainerState({
-                                  isOpen: true,
-                                  openId: newId,
-                                  addingToGroupId: group.groupId,
-                                });
-                              }
-                            }}
-                            size="xs"
-                          >
-                            <FormattedMessage
-                              id="xpack.lens.configure.emptyConfig"
-                              defaultMessage="Drop a field here"
-                            />
-                          </EuiButtonEmpty>
-                        </div>
+                        <EuiLink
+                          className="lnsLayerPanel__triggerLink"
+                          data-test-subj="lns-empty-dimension"
+                          aria-label={i18n.translate('xpack.lens.configure.addConfig', {
+                            defaultMessage: 'Add a configuration',
+                          })}
+                          title={i18n.translate('xpack.lens.configure.addConfig', {
+                            defaultMessage: 'Add a configuration',
+                          })}
+                          onClick={() => {
+                            if (dimensionContainerState.isOpen) {
+                              setDimensionContainerState(initialDimensionContainerState);
+                            } else {
+                              setDimensionContainerState({
+                                isOpen: true,
+                                openId: newId,
+                                addingToGroupId: group.groupId,
+                              });
+                            }
+                          }}
+                        >
+                          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                            <EuiFlexItem grow={false}>{/* Empty for spacing */}</EuiFlexItem>
+                            <EuiFlexItem grow={false}>
+                              <EuiIcon size="m" type="plusInCircleFilled" />
+                            </EuiFlexItem>
+                            <EuiFlexItem grow={true}>
+                              <FormattedMessage
+                                id="xpack.lens.configure.emptyConfig"
+                                defaultMessage="Drop a field here"
+                              />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiLink>
                       }
                       panelTitle={i18n.translate('xpack.lens.configure.configurePanelTitle', {
                         defaultMessage: '{groupLabel} configuration',


### PR DESCRIPTION
## Summary

The 'drop a new field' button clickable area is quite small. This can cause accessibility problems and is not consistent  with other dimension triggers clicking areas:
<img src="https://user-images.githubusercontent.com/4283304/94802729-77139480-03e8-11eb-8ef4-50d2a727ec03.png" data-canonical-src="https://user-images.githubusercontent.com/4283304/94802729-77139480-03e8-11eb-8ef4-50d2a727ec03.png" height="50"  />
<img src="https://user-images.githubusercontent.com/4283304/94802745-7aa71b80-03e8-11eb-8814-b7b3225dbc88.png" data-canonical-src="https://user-images.githubusercontent.com/4283304/94802745-7aa71b80-03e8-11eb-8814-b7b3225dbc88.png" height="100"  />

This PR solves it:

<img src="https://user-images.githubusercontent.com/4283304/94803817-2dc44480-03ea-11eb-8abe-fbab015fc27f.png" data-canonical-src="https://user-images.githubusercontent.com/4283304/94803817-2dc44480-03ea-11eb-8abe-fbab015fc27f.png" height="60"  />