### PR TITLE
[Lens] fix grouping and value formatting option order

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -410,7 +410,22 @@ export function DimensionEditor(props: DimensionEditorProps) {
               }}
             />
           )}
-
+          {selectedColumn && selectedColumn.dataType === 'number' ? (
+            <FormatSelector
+              selectedColumn={selectedColumn}
+              onChange={(newFormat) => {
+                setState(
+                  updateColumnParam({
+                    state,
+                    layerId,
+                    currentColumn: selectedColumn,
+                    paramName: 'format',
+                    value: newFormat,
+                  })
+                );
+              }}
+            />
+          ) : null}
           {!hideGrouping && (
             <BucketNestingEditor
               fieldMap={fieldMap}
@@ -430,23 +445,6 @@ export function DimensionEditor(props: DimensionEditorProps) {
               }}
             />
           )}
-
-          {selectedColumn && selectedColumn.dataType === 'number' ? (
-            <FormatSelector
-              selectedColumn={selectedColumn}
-              onChange={(newFormat) => {
-                setState(
-                  updateColumnParam({
-                    state,
-                    layerId,
-                    currentColumn: selectedColumn,
-                    paramName: 'format',
-                    value: newFormat,
-                  })
-                );
-              }}
-            />
-          ) : null}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Seems like options 'grouping' and 'Value Format' are swapped when the two of them appear.
To reproduce it, create a visualization with top values on any numeric field and add any 'break down by'. (Same thing happens for ranges)

current state:
<img src="https://user-images.githubusercontent.com/4283304/94810688-a16b4f00-03f4-11eb-8a66-955c5927b2d4.png" data-canonical-src="https://user-images.githubusercontent.com/4283304/94810688-a16b4f00-03f4-11eb-8a66-955c5927b2d4.png" height="300"  />


Here's the outlook after this PR:
<img src="https://user-images.githubusercontent.com/4283304/94810777-c495fe80-03f4-11eb-869f-0b1c5b1ae87d.png" data-canonical-src="https://user-images.githubusercontent.com/4283304/94810777-c495fe80-03f4-11eb-869f-0b1c5b1ae87d.png" height="300"  />
