### PR TITLE
[Ingest Manager] Fix condition for filtering to installed packages

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/packages/get.ts
@@ -51,14 +51,14 @@ export async function getPackages(
 }
 
 // Get package names for packages which cannot have more than one package policy on an agent policy
-// Assume packages only export one config template for now
+// Assume packages only export one policy template for now
 export async function getLimitedPackages(options: {
   savedObjectsClient: SavedObjectsClientContract;
 }): Promise<string[]> {
   const { savedObjectsClient } = options;
   const allPackages = await getPackages({ savedObjectsClient, experimental: true });
   const installedPackages = allPackages.filter(
-    (pkg) => (pkg.status = InstallationStatus.installed)
+    (pkg) => pkg.status === InstallationStatus.installed
   );
   const installedPackagesInfo = await Promise.all(
     installedPackages.map((pkgInstall) => {


### PR DESCRIPTION
## Summary

Resolves #71289. Fixes a silly typo in the condition where we check for installed packages, before checking if the package is limited. The typo caused us to fetch _all_ packages rather than just installed packages 🤦🏻‍♀️ 

I happened to run into this due to getting an error about a missing package after I switched between remote and local registries. Fortunately, this didn't have any consequences on our releases apart from slowing the loading of `Add integration` selection step.