### PR TITLE
Re-style and re-order top menu buttons

### DIFF
--- a/src/plugins/dashboard/public/application/top_nav/get_top_nav_config.ts
+++ b/src/plugins/dashboard/public/application/top_nav/get_top_nav_config.ts
@@ -48,12 +48,12 @@ export function getTopNavConfig(
           ];
     case ViewMode.EDIT:
       return [
-        getCreateNewConfig(actions[TopNavIds.VISUALIZE]),
-        getSaveConfig(actions[TopNavIds.SAVE]),
-        getViewConfig(actions[TopNavIds.EXIT_EDIT_MODE]),
-        getAddConfig(actions[TopNavIds.ADD_EXISTING]),
         getOptionsConfig(actions[TopNavIds.OPTIONS]),
         getShareConfig(actions[TopNavIds.SHARE]),
+        getAddConfig(actions[TopNavIds.ADD_EXISTING]),
+        getViewConfig(actions[TopNavIds.EXIT_EDIT_MODE]),
+        getSaveConfig(actions[TopNavIds.SAVE]),
+        getCreateNewConfig(actions[TopNavIds.VISUALIZE]),
       ];
     default:
       return [];
@@ -79,7 +79,9 @@ function getFullScreenConfig(action: NavAction) {
  */
 function getEditConfig(action: NavAction) {
   return {
+    emphasize: true,
     id: 'edit',
+    iconType: 'pencil',
     label: i18n.translate('dashboard.topNave.editButtonAriaLabel', {
       defaultMessage: 'edit',
     }),
@@ -168,7 +170,7 @@ function getAddConfig(action: NavAction) {
 function getCreateNewConfig(action: NavAction) {
   return {
     emphasize: true,
-    iconType: 'plusInCircle',
+    iconType: 'plusInCircleFilled',
     id: 'addNew',
     label: i18n.translate('dashboard.topNave.addNewButtonAriaLabel', {
       defaultMessage: 'Create new',

--- a/src/plugins/navigation/public/top_nav_menu/__snapshots__/top_nav_menu_item.test.tsx.snap
+++ b/src/plugins/navigation/public/top_nav_menu/__snapshots__/top_nav_menu_item.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`TopNavMenu Should render emphasized item which should be clickable 1`] = `
 <EuiButton
-  fill={true}
   iconSide="right"
   iconType="beaker"
   isDisabled={false}

--- a/src/plugins/navigation/public/top_nav_menu/_index.scss
+++ b/src/plugins/navigation/public/top_nav_menu/_index.scss
@@ -1,3 +1,7 @@
+.kbnTopNavMenu {
+  margin-right: $euiSizeXS;
+}
+
 .kbnTopNavMenu > * > * {
   // TEMP fix to adjust spacing between EuiHeaderList__list items
   margin: 0 $euiSizeXS;

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -48,7 +48,7 @@ export function TopNavMenuItem(props: TopNavMenuData) {
   };
 
   const btn = props.emphasize ? (
-    <EuiButton size="s" fill {...commonButtonProps}>
+    <EuiButton size="s" {...commonButtonProps}>
       {upperFirst(props.label || props.id!)}
     </EuiButton>
   ) : (

--- a/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualize/public/application/utils/get_top_nav_config.tsx
@@ -175,54 +175,61 @@ export const getTopNavConfig = (
   };
 
   const topNavMenu: TopNavMenuData[] = [
-    ...(originatingApp && ((savedVis && savedVis.id) || embeddableId)
-      ? [
-          {
-            id: 'saveAndReturn',
-            label: i18n.translate('visualize.topNavMenu.saveAndReturnVisualizationButtonLabel', {
-              defaultMessage: 'Save and return',
-            }),
-            emphasize: true,
-            iconType: 'check',
-            description: i18n.translate(
-              'visualize.topNavMenu.saveAndReturnVisualizationButtonAriaLabel',
-              {
-                defaultMessage: 'Finish editing visualization and return to the last app',
-              }
-            ),
-            testId: 'visualizesaveAndReturnButton',
-            disableButton: hasUnappliedChanges,
-            tooltip() {
-              if (hasUnappliedChanges) {
-                return i18n.translate(
-                  'visualize.topNavMenu.saveAndReturnVisualizationDisabledButtonTooltip',
-                  {
-                    defaultMessage: 'Apply or Discard your changes before finishing',
-                  }
-                );
-              }
+    {
+      id: 'inspector',
+      label: i18n.translate('visualize.topNavMenu.openInspectorButtonLabel', {
+        defaultMessage: 'inspect',
+      }),
+      description: i18n.translate('visualize.topNavMenu.openInspectorButtonAriaLabel', {
+        defaultMessage: 'Open Inspector for visualization',
+      }),
+      testId: 'openInspectorButton',
+      disableButton() {
+        return !embeddableHandler.hasInspector || !embeddableHandler.hasInspector();
+      },
+      run: openInspector,
+      tooltip() {
+        if (!embeddableHandler.hasInspector || !embeddableHandler.hasInspector()) {
+          return i18n.translate('visualize.topNavMenu.openInspectorDisabledButtonTooltip', {
+            defaultMessage: `This visualization doesn't support any inspectors.`,
+          });
+        }
+      },
+    },
+    {
+      id: 'share',
+      label: i18n.translate('visualize.topNavMenu.shareVisualizationButtonLabel', {
+        defaultMessage: 'share',
+      }),
+      description: i18n.translate('visualize.topNavMenu.shareVisualizationButtonAriaLabel', {
+        defaultMessage: 'Share Visualization',
+      }),
+      testId: 'shareTopNavButton',
+      run: (anchorElement) => {
+        if (share && !embeddableId) {
+          // TODO: support sharing in by-value mode
+          share.toggleShareContextMenu({
+            anchorElement,
+            allowEmbed: true,
+            allowShortUrl: visualizeCapabilities.createShortUrl,
+            shareableUrl: unhashUrl(window.location.href),
+            objectId: savedVis?.id,
+            objectType: 'visualization',
+            sharingData: {
+              title: savedVis?.title,
             },
-            run: async () => {
-              const saveOptions = {
-                confirmOverwrite: false,
-                returnToOrigin: true,
-              };
-              if (
-                originatingApp === 'dashboards' &&
-                dashboard.dashboardFeatureFlagConfig.allowByValueEmbeddables &&
-                !savedVis
-              ) {
-                return createVisReference();
-              }
-              return doSave(saveOptions);
-            },
-          },
-        ]
-      : []),
+            isDirty: hasUnappliedChanges || hasUnsavedChanges,
+          });
+        }
+      },
+      // disable the Share button if no action specified
+      disableButton: !share || !!embeddableId,
+    },
     ...(visualizeCapabilities.save && !embeddableId
       ? [
           {
             id: 'save',
+            iconType: savedVis?.id && originatingApp ? undefined : 'save',
             label:
               savedVis?.id && originatingApp
                 ? i18n.translate('visualize.topNavMenu.saveVisualizationAsButtonLabel', {
@@ -303,56 +310,50 @@ export const getTopNavConfig = (
           },
         ]
       : []),
-    {
-      id: 'share',
-      label: i18n.translate('visualize.topNavMenu.shareVisualizationButtonLabel', {
-        defaultMessage: 'share',
-      }),
-      description: i18n.translate('visualize.topNavMenu.shareVisualizationButtonAriaLabel', {
-        defaultMessage: 'Share Visualization',
-      }),
-      testId: 'shareTopNavButton',
-      run: (anchorElement) => {
-        if (share && !embeddableId) {
-          // TODO: support sharing in by-value mode
-          share.toggleShareContextMenu({
-            anchorElement,
-            allowEmbed: true,
-            allowShortUrl: visualizeCapabilities.createShortUrl,
-            shareableUrl: unhashUrl(window.location.href),
-            objectId: savedVis?.id,
-            objectType: 'visualization',
-            sharingData: {
-              title: savedVis?.title,
+    ...(originatingApp && ((savedVis && savedVis.id) || embeddableId)
+      ? [
+          {
+            id: 'saveAndReturn',
+            label: i18n.translate('visualize.topNavMenu.saveAndReturnVisualizationButtonLabel', {
+              defaultMessage: 'Save and return',
+            }),
+            emphasize: true,
+            iconType: 'checkInCircleFilled',
+            description: i18n.translate(
+              'visualize.topNavMenu.saveAndReturnVisualizationButtonAriaLabel',
+              {
+                defaultMessage: 'Finish editing visualization and return to the last app',
+              }
+            ),
+            testId: 'visualizesaveAndReturnButton',
+            disableButton: hasUnappliedChanges,
+            tooltip() {
+              if (hasUnappliedChanges) {
+                return i18n.translate(
+                  'visualize.topNavMenu.saveAndReturnVisualizationDisabledButtonTooltip',
+                  {
+                    defaultMessage: 'Apply or Discard your changes before finishing',
+                  }
+                );
+              }
             },
-            isDirty: hasUnappliedChanges || hasUnsavedChanges,
-          });
-        }
-      },
-      // disable the Share button if no action specified
-      disableButton: !share || !!embeddableId,
-    },
-    {
-      id: 'inspector',
-      label: i18n.translate('visualize.topNavMenu.openInspectorButtonLabel', {
-        defaultMessage: 'inspect',
-      }),
-      description: i18n.translate('visualize.topNavMenu.openInspectorButtonAriaLabel', {
-        defaultMessage: 'Open Inspector for visualization',
-      }),
-      testId: 'openInspectorButton',
-      disableButton() {
-        return !embeddableHandler.hasInspector || !embeddableHandler.hasInspector();
-      },
-      run: openInspector,
-      tooltip() {
-        if (!embeddableHandler.hasInspector || !embeddableHandler.hasInspector()) {
-          return i18n.translate('visualize.topNavMenu.openInspectorDisabledButtonTooltip', {
-            defaultMessage: `This visualization doesn't support any inspectors.`,
-          });
-        }
-      },
-    },
+            run: async () => {
+              const saveOptions = {
+                confirmOverwrite: false,
+                returnToOrigin: true,
+              };
+              if (
+                originatingApp === 'dashboards' &&
+                dashboard.dashboardFeatureFlagConfig.allowByValueEmbeddables &&
+                !savedVis
+              ) {
+                return createVisReference();
+              }
+              return doSave(saveOptions);
+            },
+          },
+        ]
+      : []),
   ];
 
   return topNavMenu;

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -30,33 +30,6 @@ export function getLensTopNavConfig(options: {
         defaultMessage: 'Save',
       });
 
-  if (showSaveAndReturn) {
-    topNavMenu.push({
-      label: i18n.translate('xpack.lens.app.saveAndReturn', {
-        defaultMessage: 'Save and return',
-      }),
-      emphasize: true,
-      iconType: 'check',
-      run: actions.saveAndReturn,
-      testId: 'lnsApp_saveAndReturnButton',
-      disableButton: !savingPermitted,
-      description: i18n.translate('xpack.lens.app.saveAndReturnButtonAriaLabel', {
-        defaultMessage: 'Save the current lens visualization and return to the last app',
-      }),
-    });
-  }
-
-  topNavMenu.push({
-    label: saveButtonLabel,
-    emphasize: !showSaveAndReturn,
-    run: actions.showSaveModal,
-    testId: 'lnsApp_saveButton',
-    description: i18n.translate('xpack.lens.app.saveButtonAriaLabel', {
-      defaultMessage: 'Save the current lens visualization',
-    }),
-    disableButton: !savingPermitted,
-  });
-
   if (showCancel) {
     topNavMenu.push({
       label: i18n.translate('xpack.lens.app.cancel', {
@@ -69,5 +42,34 @@ export function getLensTopNavConfig(options: {
       }),
     });
   }
+
+  topNavMenu.push({
+    label: saveButtonLabel,
+    iconType: !showSaveAndReturn ? 'save' : undefined,
+    emphasize: !showSaveAndReturn,
+    run: actions.showSaveModal,
+    testId: 'lnsApp_saveButton',
+    description: i18n.translate('xpack.lens.app.saveButtonAriaLabel', {
+      defaultMessage: 'Save the current lens visualization',
+    }),
+    disableButton: !savingPermitted,
+  });
+
+  if (showSaveAndReturn) {
+    topNavMenu.push({
+      label: i18n.translate('xpack.lens.app.saveAndReturn', {
+        defaultMessage: 'Save and return',
+      }),
+      emphasize: true,
+      iconType: 'checkInCircleFilled',
+      run: actions.saveAndReturn,
+      testId: 'lnsApp_saveAndReturnButton',
+      disableButton: !savingPermitted,
+      description: i18n.translate('xpack.lens.app.saveAndReturnButtonAriaLabel', {
+        defaultMessage: 'Save the current lens visualization and return to the last app',
+      }),
+    });
+  }
+
   return topNavMenu;
 }

--- a/x-pack/plugins/maps/public/routing/routes/maps_app/top_nav_config.tsx
+++ b/x-pack/plugins/maps/public/routing/routes/maps_app/top_nav_config.tsx
@@ -123,28 +123,6 @@ export function getTopNavConfig({
     return { id: savedObjectId };
   }
 
-  if (hasSaveAndReturnConfig) {
-    topNavConfigs.push({
-      id: 'saveAndReturn',
-      label: i18n.translate('xpack.maps.topNav.saveAndReturnButtonLabel', {
-        defaultMessage: 'Save and return',
-      }),
-      emphasize: true,
-      iconType: 'checkInCircleFilled',
-      run: () => {
-        onSave({
-          newTitle: savedMap.title ? savedMap.title : '',
-          newDescription: savedMap.description ? savedMap.description : '',
-          newCopyOnSave: false,
-          isTitleDuplicateConfirmed: false,
-          returnToOrigin: true,
-          onTitleDuplicate: () => {},
-        });
-      },
-      testId: 'mapSaveAndReturnButton',
-    });
-  }
-
   topNavConfigs.push(
     {
       id: 'mapSettings',
@@ -194,7 +172,7 @@ export function getTopNavConfig({
   if (hasWritePermissions) {
     topNavConfigs.push({
       id: 'save',
-      iconType: 'save',
+      iconType: hasSaveAndReturnConfig ? undefined : 'save',
       label: hasSaveAndReturnConfig
         ? i18n.translate('xpack.maps.topNav.saveAsButtonLabel', {
             defaultMessage: 'Save as',
@@ -236,6 +214,28 @@ export function getTopNavConfig({
         );
         showSaveModal(saveModal, getCoreI18n().Context);
       },
+    });
+  }
+
+  if (hasSaveAndReturnConfig) {
+    topNavConfigs.push({
+      id: 'saveAndReturn',
+      label: i18n.translate('xpack.maps.topNav.saveAndReturnButtonLabel', {
+        defaultMessage: 'Save and return',
+      }),
+      emphasize: true,
+      iconType: 'checkInCircleFilled',
+      run: () => {
+        onSave({
+          newTitle: savedMap.title ? savedMap.title : '',
+          newDescription: savedMap.description ? savedMap.description : '',
+          newCopyOnSave: false,
+          isTitleDuplicateConfirmed: false,
+          returnToOrigin: true,
+          onTitleDuplicate: () => {},
+        });
+      },
+      testId: 'mapSaveAndReturnButton',
     });
   }
 

--- a/x-pack/plugins/maps/public/routing/routes/maps_app/top_nav_config.tsx
+++ b/x-pack/plugins/maps/public/routing/routes/maps_app/top_nav_config.tsx
@@ -130,7 +130,7 @@ export function getTopNavConfig({
         defaultMessage: 'Save and return',
       }),
       emphasize: true,
-      iconType: 'check',
+      iconType: 'checkInCircleFilled',
       run: () => {
         onSave({
           newTitle: savedMap.title ? savedMap.title : '',
@@ -142,53 +142,6 @@ export function getTopNavConfig({
         });
       },
       testId: 'mapSaveAndReturnButton',
-    });
-  }
-
-  if (hasWritePermissions) {
-    topNavConfigs.push({
-      id: 'save',
-      label: hasSaveAndReturnConfig
-        ? i18n.translate('xpack.maps.topNav.saveAsButtonLabel', {
-            defaultMessage: 'Save as',
-          })
-        : i18n.translate('xpack.maps.topNav.saveMapButtonLabel', {
-            defaultMessage: `save`,
-          }),
-      description: i18n.translate('xpack.maps.topNav.saveMapDescription', {
-        defaultMessage: `Save map`,
-      }),
-      emphasize: !hasSaveAndReturnConfig,
-      testId: 'mapSaveButton',
-      disableButton() {
-        return isSaveDisabled;
-      },
-      tooltip() {
-        if (isSaveDisabled) {
-          return i18n.translate('xpack.maps.topNav.saveMapDisabledButtonTooltip', {
-            defaultMessage: 'Confirm or Cancel your layer changes before saving',
-          });
-        }
-      },
-      run: () => {
-        const saveModal = (
-          <SavedObjectSaveModalOrigin
-            originatingApp={originatingApp}
-            getAppNameFromId={stateTransfer?.getAppNameFromId}
-            onSave={onSave}
-            onClose={() => {}}
-            documentInfo={{
-              description: savedMap.description,
-              id: savedMap.id,
-              title: savedMap.title,
-            }}
-            objectType={i18n.translate('xpack.maps.topNav.saveModalType', {
-              defaultMessage: 'map',
-            })}
-          />
-        );
-        showSaveModal(saveModal, getCoreI18n().Context);
-      },
     });
   }
 
@@ -237,6 +190,54 @@ export function getTopNavConfig({
       },
     }
   );
+
+  if (hasWritePermissions) {
+    topNavConfigs.push({
+      id: 'save',
+      iconType: 'save',
+      label: hasSaveAndReturnConfig
+        ? i18n.translate('xpack.maps.topNav.saveAsButtonLabel', {
+            defaultMessage: 'Save as',
+          })
+        : i18n.translate('xpack.maps.topNav.saveMapButtonLabel', {
+            defaultMessage: `save`,
+          }),
+      description: i18n.translate('xpack.maps.topNav.saveMapDescription', {
+        defaultMessage: `Save map`,
+      }),
+      emphasize: !hasSaveAndReturnConfig,
+      testId: 'mapSaveButton',
+      disableButton() {
+        return isSaveDisabled;
+      },
+      tooltip() {
+        if (isSaveDisabled) {
+          return i18n.translate('xpack.maps.topNav.saveMapDisabledButtonTooltip', {
+            defaultMessage: 'Confirm or Cancel your layer changes before saving',
+          });
+        }
+      },
+      run: () => {
+        const saveModal = (
+          <SavedObjectSaveModalOrigin
+            originatingApp={originatingApp}
+            getAppNameFromId={stateTransfer?.getAppNameFromId}
+            onSave={onSave}
+            onClose={() => {}}
+            documentInfo={{
+              description: savedMap.description,
+              id: savedMap.id,
+              title: savedMap.title,
+            }}
+            objectType={i18n.translate('xpack.maps.topNav.saveModalType', {
+              defaultMessage: 'map',
+            })}
+          />
+        );
+        showSaveModal(saveModal, getCoreI18n().Context);
+      },
+    });
+  }
 
   return topNavConfigs;
 }


### PR DESCRIPTION
Relates to ﻿https://github.com/elastic/kibana/pull/72331#issuecomment-687214556

## Summary

With the [new stacked header design](https://github.com/elastic/kibana/pull/72331), 'top menus' (in the legacy Kibana apps) were moved from the app level to the chrome/header level. For some (author included :) ), this has resulted in an [undesirable visual design/UX](https://github.com/elastic/kibana/pull/72331#issuecomment-686536185) outcome for apps that used filled buttons in their menu. For example:

#### Competing buttons in Dashboard
<img width="673" alt="Screen Shot 2020-09-23 at 12 59 14 PM" src="https://user-images.githubusercontent.com/446285/94051157-c3cdee80-fd9c-11ea-842a-1fa0082ce6d3.png">

#### Competing buttons in Lens
<img width="672" alt="Screen Shot 2020-09-23 at 12 59 02 PM" src="https://user-images.githubusercontent.com/446285/94051208-d516fb00-fd9c-11ea-9fee-173604ef0838.png">


## Proposed 7.10 solution introduced by this PR
- Replace the filled (emphasized) buttons with a hollow/bordered + icon button and make it the last item on the right.
- For Dashboard, make 'Edit' the last item and add an icon even though it was previously not emphasized.
- Where possible, use a filled-style icon for additional emphasis (e.g. `checkInCircleFilled` and `plusInCircleFilled`)
- Apps that did not have an emphasized button (Discover, Graph) remain unchanged.

### Affected apps (Dashboard, Lens, Visualize, Maps)

#### Dashboard (edit mode)
<img width="603" alt="Screen Shot 2020-10-01 at 3 19 58 PM" src="https://user-images.githubusercontent.com/446285/94859322-f65d9400-03f9-11eb-8b50-34c57862e81b.png">

#### Dashboard (view mode)
<img width="603" alt="Screen Shot 2020-10-01 at 3 19 42 PM" src="https://user-images.githubusercontent.com/446285/94859336-fa89b180-03f9-11eb-8a21-946d969e95c0.png">

#### Lens
<img width="605" alt="Screen Shot 2020-10-01 at 3 21 42 PM" src="https://user-images.githubusercontent.com/446285/94859381-0d9c8180-03fa-11eb-8584-91fa147d4023.png">

#### Visualize
<img width="602" alt="Screen Shot 2020-10-01 at 3 24 35 PM" src="https://user-images.githubusercontent.com/446285/94859506-4177a700-03fa-11eb-867d-6e2be331c9e3.png">

#### Visualize (from Dashboard)
<img width="605" alt="Screen Shot 2020-10-01 at 3 20 31 PM" src="https://user-images.githubusercontent.com/446285/94859418-1bea9d80-03fa-11eb-99af-cd25fec871aa.png">

#### Maps
<img width="604" alt="Screen Shot 2020-10-01 at 3 25 25 PM" src="https://user-images.githubusercontent.com/446285/94859572-5a805800-03fa-11eb-8b18-e93fac8cd223.png">

## Looking ahead
The recommended approach gets even more 'bold' when viewed in the Amsterdam theme. With the changes proposed by this PR, it would look as follows when the theme is enabled. Additionally, the plan is for this new theme to become the default later in the 7.x series.

<img width="602" alt="Screen Shot 2020-10-01 at 3 29 51 PM" src="https://user-images.githubusercontent.com/446285/94859955-fca04000-03fa-11eb-8300-f77ce84c4bb5.png">

<img width="605" alt="Screen Shot 2020-10-01 at 3 27 21 PM" src="https://user-images.githubusercontent.com/446285/94859846-d24e8280-03fa-11eb-92b6-ca8f13e1e088.png">

In addition to the top menu, teams may begin exploring additional UI enhancements if they desire to further emphasize core actions. For example, the Dashboard team is exploring adding a toolbar within their UI (for this and other reasons):

<img width="588" alt="Screen Shot 2020-09-04 at 10 08 40 AM" src="https://user-images.githubusercontent.com/446285/92254552-af31c100-ee96-11ea-852a-289887c37e57.png">

-------

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
