### PR TITLE
[Lens] remove test warnings about improper HTML structure

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -8,7 +8,15 @@ import React, { useState, useEffect, useMemo, useContext, useCallback } from 're
 import classNames from 'classnames';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiButtonEmpty, EuiLink } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiButtonEmpty,
+  EuiLink,
+  EuiSpacer,
+} from '@elastic/eui';
 import { CoreStart, CoreSetup } from 'kibana/public';
 import { ExecutionContextSearch } from 'src/plugins/expressions';
 import {
@@ -224,26 +232,25 @@ export function InnerWorkspacePanel({
         <DropIllustration aria-hidden={true} className="lnsWorkspacePanel__dropIllustration" />
         {expression === null && (
           <>
-            <p>
+            <EuiText textAlign="center" size="s">
               <FormattedMessage
                 id="xpack.lens.editorFrame.emptyWorkspaceHeading"
                 defaultMessage="Lens is a new tool for creating visualizations"
               />
-            </p>
-            <p>
-              <small>
-                <EuiLink
-                  href="https://www.elastic.co/products/kibana/feedback"
-                  target="_blank"
-                  external
-                >
-                  <FormattedMessage
-                    id="xpack.lens.editorFrame.goToForums"
-                    defaultMessage="Make requests and give feedback"
-                  />
-                </EuiLink>
-              </small>
-            </p>
+            </EuiText>
+            <EuiSpacer size="l" />
+            <EuiText textAlign="center" size="xs">
+              <EuiLink
+                href="https://www.elastic.co/products/kibana/feedback"
+                target="_blank"
+                external
+              >
+                <FormattedMessage
+                  id="xpack.lens.editorFrame.goToForums"
+                  defaultMessage="Make requests and give feedback"
+                />
+              </EuiLink>
+            </EuiText>
           </>
         )}
       </EuiText>

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -8,15 +8,7 @@ import React, { useState, useEffect, useMemo, useContext, useCallback } from 're
 import classNames from 'classnames';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiText,
-  EuiButtonEmpty,
-  EuiLink,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiButtonEmpty, EuiLink } from '@elastic/eui';
 import { CoreStart, CoreSetup } from 'kibana/public';
 import { ExecutionContextSearch } from 'src/plugins/expressions';
 import {
@@ -216,41 +208,36 @@ export function InnerWorkspacePanel({
       >
         <h2>
           <strong>
-            {expression === null ? (
-              <FormattedMessage
-                id="xpack.lens.editorFrame.emptyWorkspace"
-                defaultMessage="Drop some fields here to start"
-              />
-            ) : (
-              <FormattedMessage
-                id="xpack.lens.editorFrame.emptyWorkspaceSimple"
-                defaultMessage="Drop field here"
-              />
-            )}
+            {expression === null
+              ? i18n.translate('xpack.lens.editorFrame.emptyWorkspace', {
+                  defaultMessage: 'Drop some fields here to start',
+                })
+              : i18n.translate('xpack.lens.editorFrame.emptyWorkspaceSimple', {
+                  defaultMessage: 'Drop field here',
+                })}
           </strong>
         </h2>
         <DropIllustration aria-hidden={true} className="lnsWorkspacePanel__dropIllustration" />
         {expression === null && (
           <>
-            <EuiText textAlign="center" size="s">
-              <FormattedMessage
-                id="xpack.lens.editorFrame.emptyWorkspaceHeading"
-                defaultMessage="Lens is a new tool for creating visualizations"
-              />
-            </EuiText>
-            <EuiSpacer size="l" />
-            <EuiText textAlign="center" size="xs">
-              <EuiLink
-                href="https://www.elastic.co/products/kibana/feedback"
-                target="_blank"
-                external
-              >
-                <FormattedMessage
-                  id="xpack.lens.editorFrame.goToForums"
-                  defaultMessage="Make requests and give feedback"
-                />
-              </EuiLink>
-            </EuiText>
+            <p>
+              {i18n.translate('xpack.lens.editorFrame.emptyWorkspaceHeading', {
+                defaultMessage: 'Lens is a new tool for creating visualization',
+              })}
+            </p>
+            <p>
+              <small>
+                <EuiLink
+                  href="https://www.elastic.co/products/kibana/feedback"
+                  target="_blank"
+                  external
+                >
+                  {i18n.translate('xpack.lens.editorFrame.goToForums', {
+                    defaultMessage: 'Make requests and give feedback',
+                  })}
+                </EuiLink>
+              </small>
+            </p>
           </>
         )}
       </EuiText>


### PR DESCRIPTION
## Summary

Removes the warnings from the console when workspace_panel tests are running:
![image](https://user-images.githubusercontent.com/4283304/94893256-08d1df00-0487-11eb-8e59-a1bae3b4b9c9.png)
