### PR TITLE
[Ingest Manager] Rename Fleet setup and requirement, Fleet => Central…

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -81,7 +81,7 @@ export const ManagedInstructions = React.memo<Props>(({ agentPolicies }) => {
                 <EuiLink href={getHref('fleet')}>
                   <FormattedMessage
                     id="xpack.ingestManager.agentEnrollment.setUpAgentsLink"
-                    defaultMessage="set up Agents"
+                    defaultMessage="set up central management for Elastic Agents"
                   />
                 </EuiLink>
               ),

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -95,7 +95,7 @@ export const SetupPage: React.FunctionComponent<{
             <EuiText color="subdued">
               <FormattedMessage
                 id="xpack.ingestManager.setupPage.enableText"
-                defaultMessage="Central management for Elastic Agents requires an Elastic user who can create API keys and write to logs-* and metrics-*."
+                defaultMessage="Central management requires an Elastic user who can create API keys and write to logs-* and metrics-*."
               />
             </EuiText>
             <EuiSpacer size="l" />
@@ -127,7 +127,7 @@ export const SetupPage: React.FunctionComponent<{
           >
             <FormattedMessage
               id="xpack.ingestManager.setupPage.missingRequirementsCalloutDescription"
-              defaultMessage="In order to use central management for Elastic Agents, you must enable the following Elasticsearch and Kibana security features."
+              defaultMessage="To use central management for Elastic Agents, enable the following Elasticsearch and Kibana security features."
             />
           </EuiCallOut>
           <EuiSpacer size="m" />

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -73,7 +73,7 @@ export const SetupPage: React.FunctionComponent<{
   ) {
     return (
       <WithoutHeaderLayout>
-        <EuiPageBody restrictWidth={548}>
+        <EuiPageBody restrictWidth={648}>
           <EuiPageContent
             verticalPosition="center"
             horizontalPosition="center"
@@ -87,7 +87,7 @@ export const SetupPage: React.FunctionComponent<{
               <h2>
                 <FormattedMessage
                   id="xpack.ingestManager.setupPage.enableTitle"
-                  defaultMessage="Enable Fleet"
+                  defaultMessage="Enable central management for Elastic Agents"
                 />
               </h2>
             </EuiTitle>
@@ -95,15 +95,15 @@ export const SetupPage: React.FunctionComponent<{
             <EuiText color="subdued">
               <FormattedMessage
                 id="xpack.ingestManager.setupPage.enableText"
-                defaultMessage="Fleet requires an Elastic user who can create API keys and write to logs-* and metrics-*."
+                defaultMessage="Central management for Elastic Agents requires an Elastic user who can create API keys and write to logs-* and metrics-*."
               />
             </EuiText>
             <EuiSpacer size="l" />
             <EuiForm>
               <EuiButton onClick={onSubmit} fill isLoading={isFormLoading} type="submit">
                 <FormattedMessage
-                  id="xpack.ingestManager.setupPage.enableFleet"
-                  defaultMessage="Create user and enable Fleet"
+                  id="xpack.ingestManager.setupPage.enableCentralManagement"
+                  defaultMessage="Create user and enable Agents"
                 />
               </EuiButton>
             </EuiForm>
@@ -127,7 +127,7 @@ export const SetupPage: React.FunctionComponent<{
           >
             <FormattedMessage
               id="xpack.ingestManager.setupPage.missingRequirementsCalloutDescription"
-              defaultMessage="In order to use Fleet, you must enable the following Elasticsearch and Kibana security features."
+              defaultMessage="In order to use central management for Elastic Agents, you must enable the following Elasticsearch and Kibana security features."
             />
           </EuiCallOut>
           <EuiSpacer size="m" />

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -103,7 +103,7 @@ export const SetupPage: React.FunctionComponent<{
               <EuiButton onClick={onSubmit} fill isLoading={isFormLoading} type="submit">
                 <FormattedMessage
                   id="xpack.ingestManager.setupPage.enableCentralManagement"
-                  defaultMessage="Create user and enable Agents"
+                  defaultMessage="Create user and enable central management"
                 />
               </EuiButton>
             </EuiForm>

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -9246,7 +9246,6 @@
     "xpack.ingestManager.setupPage.elasticsearchApiKeyFlagText": "{apiKeyLink}.{apiKeyFlag}を{true}に設定します。",
     "xpack.ingestManager.setupPage.elasticsearchSecurityFlagText": "{esSecurityLink}.{securityFlag}を{true}に設定します。",
     "xpack.ingestManager.setupPage.elasticsearchSecurityLink": "Elasticsearchセキュリティ",
-    "xpack.ingestManager.setupPage.enableFleet": "ユーザーを作成してフリートを有効にます",
     "xpack.ingestManager.setupPage.enableText": "フリートを使用するには、Elasticユーザーを作成する必要があります。このユーザーは、APIキーを作成して、logs-*およびmetrics-*に書き込むことができます。",
     "xpack.ingestManager.setupPage.enableTitle": "フリートを有効にする",
     "xpack.ingestManager.setupPage.encryptionKeyFlagText": "{encryptionKeyLink}.{keyFlag}を32文字以上の英数字に設定します。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -9252,7 +9252,6 @@
     "xpack.ingestManager.setupPage.elasticsearchApiKeyFlagText": "{apiKeyLink}。将 {apiKeyFlag} 设置为 {true}。",
     "xpack.ingestManager.setupPage.elasticsearchSecurityFlagText": "{esSecurityLink}。将 {securityFlag} 设置为 {true}。",
     "xpack.ingestManager.setupPage.elasticsearchSecurityLink": "Elasticsearch 安全",
-    "xpack.ingestManager.setupPage.enableFleet": "创建用户并启用 Fleet",
     "xpack.ingestManager.setupPage.enableText": "要使用 Fleet，必须创建 Elastic 用户。此用户可以创建 API 密钥并写入到 logs-* and metrics-*。",
     "xpack.ingestManager.setupPage.enableTitle": "启用 Fleet",
     "xpack.ingestManager.setupPage.encryptionKeyFlagText": "{encryptionKeyLink}。将 {keyFlag} 设置为至少 32 个字符的字母数字值。",


### PR DESCRIPTION
## Description 

In our effort to rename the Ingest Manager plugin Fleet, we are doing a few renaming through the whole plugin.
The Fleet tab is now the Agents tab, and to setup that tab we are now talking about enabling **Central management for Elastic Agent** instead of Fleet

## UI Change

<img width="1634" alt="Screen Shot 2020-10-02 at 9 12 40 AM" src="https://user-images.githubusercontent.com/1336873/94927954-f9579380-0490-11eb-8286-f966bca62a49.png">
<img width="1110" alt="Screen Shot 2020-10-02 at 9 14 04 AM" src="https://user-images.githubusercontent.com/1336873/94927957-f9f02a00-0490-11eb-8967-3f004ccfd5b1.png">
<img width="1349" alt="Screen Shot 2020-10-02 at 9 18 04 AM" src="https://user-images.githubusercontent.com/1336873/94927959-f9f02a00-0490-11eb-934b-fea10508701a.png">
 

## How to tests

* If you want to see the setup page just start with a fresh elastic search
* if you want to see the restrictions page you can run ES without api keys enabled ```yarn es snapshot --license trial --password changeme```