### PR TITLE
[Telemetry] Synchronous `setup` and `start` methods

### DIFF
--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -18,7 +18,7 @@
  */
 
 import moment from 'moment';
-import { Observable } from 'rxjs';
+import { Observable, Subscription, timer } from 'rxjs';
 import { take } from 'rxjs/operators';
 // @ts-ignore
 import fetch from 'node-fetch';
@@ -58,7 +58,7 @@ export class FetcherTask {
   private readonly config$: Observable<TelemetryConfigType>;
   private readonly currentKibanaVersion: string;
   private readonly logger: Logger;
-  private intervalId?: NodeJS.Timeout;
+  private intervalId?: Subscription;
   private lastReported?: number;
   private isSending = false;
   private internalRepository?: SavedObjectsClientContract;
@@ -79,15 +79,14 @@ export class FetcherTask {
     this.telemetryCollectionManager = telemetryCollectionManager;
     this.elasticsearchClient = elasticsearch.legacy.createClient('telemetry-fetcher');
 
-    setTimeout(() => {
-      this.sendIfDue();
-      this.intervalId = setInterval(() => this.sendIfDue(), this.checkIntervalMs);
-    }, this.initialCheckDelayMs);
+    this.intervalId = timer(this.initialCheckDelayMs, this.checkIntervalMs).subscribe(() =>
+      this.sendIfDue()
+    );
   }
 
   public stop() {
     if (this.intervalId) {
-      clearInterval(this.intervalId);
+      this.intervalId.unsubscribe();
     }
     if (this.elasticsearchClient) {
       this.elasticsearchClient.close();

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -174,8 +174,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
     } catch (error) {
       this.logger.warn('Unable to update legacy telemetry configs.');
     }
-    // Set the mark in the ReplySubject so all the methods that require this method to be completed before working, can move on
-    this.oldUiSettingsHandled$.next(true);
+    // Set the mark in the AsyncSubject as complete so all the methods that require this method to be completed before working, can move on
     this.oldUiSettingsHandled$.complete();
   }
 

--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -148,7 +148,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
       getIsOptedIn: async () => {
         await this.oldUiSettingsHandled$.pipe(take(1)).toPromise(); // Wait for the old settings to be handled
         const internalRepository = new SavedObjectsClient(savedObjectsInternalRepository);
-        const telemetrySavedObject = await getTelemetrySavedObject(internalRepository!);
+        const telemetrySavedObject = await getTelemetrySavedObject(internalRepository);
         const config = await this.config$.pipe(take(1)).toPromise();
         const allowChangingOptInStatus = config.allowChangingOptInStatus;
         const configTelemetryOptIn = typeof config.optIn === 'undefined' ? null : config.optIn;


### PR DESCRIPTION
## Summary

Remove the `async` condition of the `setup` and `start` methods in the `telemetry` plugin.

Resolves #79452.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
