### PR TITLE
[App Search] Temporarily remove sidebar layout for 7.10 release

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { shallow } from 'enzyme';
 
-import { Layout, SideNav, SideNavLink } from '../shared/layout';
+import { SideNav, SideNavLink } from '../shared/layout';
 import { SetupGuide } from './components/setup_guide';
 import { ErrorConnecting } from './components/error_connecting';
 import { EngineOverview } from './components/engine_overview';
@@ -51,11 +51,9 @@ describe('AppSearchConfigured', () => {
     setMockActions({ initializeAppData: () => {} });
   });
 
-  it('renders with layout', () => {
+  it('renders', () => {
     const wrapper = shallow(<AppSearchConfigured />);
 
-    expect(wrapper.find(Layout)).toHaveLength(1);
-    expect(wrapper.find(Layout).prop('readOnlyMode')).toBeFalsy();
     expect(wrapper.find(EngineOverview)).toHaveLength(1);
   });
 
@@ -84,14 +82,6 @@ describe('AppSearchConfigured', () => {
     const wrapper = shallow(<AppSearchConfigured />);
 
     expect(wrapper.find(ErrorConnecting)).toHaveLength(1);
-  });
-
-  it('passes readOnlyMode state', () => {
-    setMockValues({ myRole: {}, readOnlyMode: true });
-
-    const wrapper = shallow(<AppSearchConfigured />);
-
-    expect(wrapper.find(Layout).prop('readOnlyMode')).toEqual(true);
   });
 
   describe('ability checks', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
@@ -8,6 +8,7 @@ import React, { useEffect } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 import { useActions, useValues } from 'kea';
 
+import { EuiPage, EuiPageBody } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { getAppSearchUrl } from '../shared/enterprise_search_url';
@@ -17,7 +18,7 @@ import { AppLogic } from './app_logic';
 import { IInitialAppData } from '../../../common/types';
 
 import { APP_SEARCH_PLUGIN } from '../../../common/constants';
-import { Layout, SideNav, SideNavLink } from '../shared/layout';
+import { SideNav, SideNavLink } from '../shared/layout';
 
 import {
   ROOT_PATH,
@@ -52,7 +53,7 @@ export const AppSearchUnconfigured: React.FC = () => (
 export const AppSearchConfigured: React.FC<IInitialAppData> = (props) => {
   const { initializeAppData } = useActions(AppLogic);
   const { hasInitialized } = useValues(AppLogic);
-  const { errorConnecting, readOnlyMode } = useValues(HttpLogic);
+  const { errorConnecting } = useValues(HttpLogic);
 
   useEffect(() => {
     if (!hasInitialized) initializeAppData(props);
@@ -64,23 +65,25 @@ export const AppSearchConfigured: React.FC<IInitialAppData> = (props) => {
         <SetupGuide />
       </Route>
       <Route>
-        <Layout navigation={<AppSearchNav />} readOnlyMode={readOnlyMode}>
-          {errorConnecting ? (
-            <ErrorConnecting />
-          ) : (
-            <Switch>
-              <Route exact path={ROOT_PATH}>
-                <Redirect to={ENGINES_PATH} />
-              </Route>
-              <Route exact path={ENGINES_PATH}>
-                <EngineOverview />
-              </Route>
-              <Route>
-                <NotFound product={APP_SEARCH_PLUGIN} />
-              </Route>
-            </Switch>
-          )}
-        </Layout>
+        <EuiPage>
+          <EuiPageBody restrictWidth>
+            {errorConnecting ? (
+              <ErrorConnecting />
+            ) : (
+              <Switch>
+                <Route exact path={ROOT_PATH}>
+                  <Redirect to={ENGINES_PATH} />
+                </Route>
+                <Route exact path={ENGINES_PATH}>
+                  <EngineOverview />
+                </Route>
+                <Route>
+                  <NotFound product={APP_SEARCH_PLUGIN} />
+                </Route>
+              </Switch>
+            )}
+          </EuiPageBody>
+        </EuiPage>
       </Route>
     </Switch>
   );


### PR DESCRIPTION
## Summary

Since our other top level pages (settings, credentials, role mappings) aren't yet ready, we're reverting to the 7.9 UI for 7.10 (i.e., only showing the Engines Overview to users).

### Screencaps

<img width="1438" alt="" src="https://user-images.githubusercontent.com/549407/95108868-aed45200-06f0-11eb-9188-da3e3118e12a.png">
<img width="1436" alt="" src="https://user-images.githubusercontent.com/549407/95108884-b136ac00-06f0-11eb-94a8-bf24fa5fecd4.png">
<img width="1437" alt="" src="https://user-images.githubusercontent.com/549407/95108891-b1cf4280-06f0-11eb-9c7a-a4d4b8928354.png">

## QA

- [x] Engines Overview looks functionally the same as 7.9
- [x] Setup Guide looks exactly the same as before

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Please note: this commit will **immediately** be reverted for 7.x/7.11 once the 7.10 branch is cut (tomorrow/FF). At that point, this PR should only exist in the 7.10 branch.