### PR TITLE
[Monitoring] Remove license refresh from setup

### DIFF
--- a/x-pack/plugins/monitoring/server/plugin.test.ts
+++ b/x-pack/plugins/monitoring/server/plugin.test.ts
@@ -21,9 +21,7 @@ jest.mock('./es_client/instantiate_client', () => ({
 
 jest.mock('./license_service', () => ({
   LicenseService: jest.fn().mockImplementation(() => ({
-    setup: jest.fn().mockImplementation(() => ({
-      refresh: jest.fn(),
-    })),
+    setup: jest.fn().mockImplementation(() => ({})),
   })),
 }));
 

--- a/x-pack/plugins/monitoring/server/plugin.ts
+++ b/x-pack/plugins/monitoring/server/plugin.ts
@@ -119,7 +119,6 @@ export class Plugin {
       config,
       log: this.log,
     });
-    await this.licenseService.refresh();
 
     const serverInfo = core.http.getServerInfo();
     let kibanaUrl = `${serverInfo.protocol}://${serverInfo.hostname}:${serverInfo.port}`;


### PR DESCRIPTION
Fixes #79451

I don't know recall why we added this in the first place, but the code seems to still work without it.