### PR TITLE
[Enterprise Search] Fix cross-application links & breadcrumbs

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
@@ -6,7 +6,10 @@
 
 import { resetContext } from 'kea';
 
-import { mockKibanaValues } from '../../__mocks__';
+import { mockKibanaValues, mockHttpValues } from '../../__mocks__';
+jest.mock('../http', () => ({
+  HttpLogic: { values: { http: mockHttpValues.http } },
+}));
 
 import { KibanaLogic, mountKibanaLogic } from './kibana_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -10,6 +10,7 @@ import { FC } from 'react';
 import { History } from 'history';
 import { ApplicationStart, ChromeBreadcrumb } from 'src/core/public';
 
+import { HttpLogic } from '../http';
 import { createHref, ICreateHrefOptions } from '../react_router_helpers';
 
 interface IKibanaLogicProps {
@@ -31,7 +32,8 @@ export const KibanaLogic = kea<MakeLogicType<IKibanaValues>>({
     history: [props.history, {}],
     navigateToUrl: [
       (url: string, options?: ICreateHrefOptions) => {
-        const href = createHref(url, props.history, options);
+        const deps = { history: props.history, http: HttpLogic.values.http };
+        const href = createHref(url, deps, options);
         return props.navigateToUrl(href);
       },
       {},

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -7,7 +7,8 @@
 import { useValues } from 'kea';
 import { EuiBreadcrumb } from '@elastic/eui';
 
-import { KibanaLogic } from '../../shared/kibana';
+import { KibanaLogic } from '../kibana';
+import { HttpLogic } from '../http';
 
 import {
   ENTERPRISE_SEARCH_PLUGIN,
@@ -66,12 +67,13 @@ export const useGenerateBreadcrumbs = (trail: TBreadcrumbTrail): TBreadcrumbs =>
 
 export const useEuiBreadcrumbs = (breadcrumbs: TBreadcrumbs): EuiBreadcrumb[] => {
   const { navigateToUrl, history } = useValues(KibanaLogic);
+  const { http } = useValues(HttpLogic);
 
   return breadcrumbs.map(({ text, path, shouldNotCreateHref }) => {
     const breadcrumb: EuiBreadcrumb = { text };
 
     if (path) {
-      breadcrumb.href = createHref(path, history, { shouldNotCreateHref });
+      breadcrumb.href = createHref(path, { history, http }, { shouldNotCreateHref });
       breadcrumb.onClick = (event) => {
         if (letBrowserHandleEvent(event)) return;
         event.preventDefault();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.test.ts
@@ -4,16 +4,33 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { httpServiceMock } from 'src/core/public/mocks';
 import { mockHistory } from '../../__mocks__';
 
 import { createHref } from './';
 
 describe('createHref', () => {
+  const dependencies = {
+    history: mockHistory,
+    http: httpServiceMock.createSetupContract(),
+  };
+
   it('generates a path with the React Router basename included', () => {
-    expect(createHref('/test', mockHistory)).toEqual('/app/enterprise_search/test');
+    expect(createHref('/test', dependencies)).toEqual('/app/enterprise_search/test');
   });
 
-  it('does not include the basename if shouldNotCreateHref is passed', () => {
-    expect(createHref('/test', mockHistory, { shouldNotCreateHref: true })).toEqual('/test');
+  describe('shouldNotCreateHref', () => {
+    const options = { shouldNotCreateHref: true };
+
+    it('does not include the router basename,', () => {
+      expect(createHref('/test', dependencies, options)).toEqual('/test');
+    });
+
+    it('does include the Kibana basepath,', () => {
+      const http = httpServiceMock.createSetupContract({ basePath: '/xyz/s/custom-space' });
+      const basePathDeps = { ...dependencies, http };
+
+      expect(createHref('/test', basePathDeps, options)).toEqual('/xyz/s/custom-space/test');
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.ts
@@ -5,23 +5,35 @@
  */
 
 import { History } from 'history';
+import { HttpSetup } from 'src/core/public';
 
 /**
- * This helper uses React Router's createHref function to generate links with router basenames accounted for.
+ * This helper uses React Router's createHref function to generate links with router basenames included.
  * For example, if we perform navigateToUrl('/engines') within App Search, we expect the app basename
- * to be taken into account to be intelligently routed to '/app/enterprise_search/app_search/engines'.
+ * to be taken into account & intelligently routed to '/app/enterprise_search/app_search/engines'.
  *
  * This helper accomplishes that, while still giving us an escape hatch for navigation *between* apps.
  * For example, if we want to navigate the user from App Search to Enterprise Search we could
  * navigateToUrl('/app/enterprise_search', { shouldNotCreateHref: true })
+ *
+ * Said escape hatch should still contain all of Kibana's basepaths - for example,
+ * 'localhost:5601/xyz' when developing locally, or '/s/some-custom-space/' for space basepaths.
+ * See: https://www.elastic.co/guide/en/kibana/master/kibana-navigation.html
+ *
+ * Links completely outside of Kibana should not use our React Router helpers or navigateToUrl.
  */
+interface ICreateHrefDeps {
+  history: History;
+  http: HttpSetup;
+}
 export interface ICreateHrefOptions {
   shouldNotCreateHref?: boolean;
 }
+
 export const createHref = (
   path: string,
-  history: History,
-  options?: ICreateHrefOptions
+  { history, http }: ICreateHrefDeps,
+  { shouldNotCreateHref }: ICreateHrefOptions = {}
 ): string => {
-  return options?.shouldNotCreateHref ? path : history.createHref({ pathname: path });
+  return shouldNotCreateHref ? http.basePath.prepend(path) : history.createHref({ pathname: path });
 };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_link.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_link.tsx
@@ -8,7 +8,8 @@ import React from 'react';
 import { useValues } from 'kea';
 import { EuiLink, EuiButton, EuiButtonProps, EuiLinkAnchorProps } from '@elastic/eui';
 
-import { KibanaLogic } from '../../shared/kibana';
+import { KibanaLogic } from '../kibana';
+import { HttpLogic } from '../http';
 import { letBrowserHandleEvent, createHref } from './';
 
 /**
@@ -33,9 +34,10 @@ export const EuiReactRouterHelper: React.FC<IEuiReactRouterProps> = ({
   children,
 }) => {
   const { navigateToUrl, history } = useValues(KibanaLogic);
+  const { http } = useValues(HttpLogic);
 
   // Generate the correct link href (with basename etc. accounted for)
-  const href = createHref(to, history, { shouldNotCreateHref });
+  const href = createHref(to, { history, http }, { shouldNotCreateHref });
 
   const reactRouterLinkClick = (event: React.MouseEvent) => {
     if (onClick) onClick(); // Run any passed click events (e.g. telemetry)


### PR DESCRIPTION
## Summary

I have no idea how I didn't notice this earlier or how this somehow wasn't broken for me locally until recently 🤦‍♀️ 

### Problem

Our cross-Kibana-app links (created **without** React Router's `history.createHref`) are broken on local dev and on custom spaces because they're missing Kibana's basePath:

#### Correctly formed URL example:

<img width="340" alt="" src="https://user-images.githubusercontent.com/549407/95115837-f3fd8180-06fa-11eb-99c4-47ebdf1d4f28.png">

#### Links missing basepath:
<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/95115715-c87a9700-06fa-11eb-94da-152e6c876e52.png">
<img width="528" alt="" src="https://user-images.githubusercontent.com/549407/95115671-b4cf3080-06fa-11eb-8f60-3fcebd0e6472.png">

### Solution

Updating our `createHref` helper to use `http.basePath.prepend()` [per Kibana's docs/recommendation](https://www.elastic.co/guide/en/kibana/master/kibana-navigation.html#navigating-between-kibana-apps) solves the issue:

<img width="411" alt="" src="https://user-images.githubusercontent.com/549407/95115787-e5af6580-06fa-11eb-99dc-8747fbc5e0ed.png">

## QA

- [x] ALL breadcrumb links (including cross-application ones) are now properly working
- [x] Enterprise Search Overview product card links are correctly working, including in custom spaces

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios