### PR TITLE
[Workplace Search] Update Groups breadcrumb to new API

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -260,7 +260,7 @@ export const GroupOverview: React.FC = () => {
 
   return (
     <>
-      <SetPageChrome text="Group Overview" />
+      <SetPageChrome trail={['Group Overview']} />
       <SendTelemetry action="viewed" metric="group_overview" />
 
       <ViewContentHeader title={truncatedName} />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -123,7 +123,7 @@ export const Groups: React.FC = () => {
 
   return (
     <>
-      <SetPageChrome text="Groups" />
+      <SetPageChrome trail={['Groups']} />
       <SendTelemetry action="viewed" metric="groups" />
       <FlashMessages />
       <ViewContentHeader


### PR DESCRIPTION
## Summary

This updates #78679 with the new breadcrumbs trail API/prop added in #79231.

NOTE: This is a safer version of #79551 - just the change breaking Kibana's CI, no nested breadcrumbs/i18n/constants/routes refactors.