### PR TITLE
[Fleet] Add loading spinner to page headers

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_policy/details_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_policy/details_page/index.tsx
@@ -75,14 +75,18 @@ export const AgentPolicyDetailsPage: React.FunctionComponent = () => {
         <EuiFlexItem>
           <EuiText className="eui-textBreakWord">
             <h1>
-              {(agentPolicy && agentPolicy.name) || (
-                <FormattedMessage
-                  id="xpack.ingestManager.policyDetails.policyDetailsTitle"
-                  defaultMessage="Policy '{id}'"
-                  values={{
-                    id: policyId,
-                  }}
-                />
+              {isLoading ? (
+                <Loading />
+              ) : (
+                (agentPolicy && agentPolicy.name) || (
+                  <FormattedMessage
+                    id="xpack.ingestManager.policyDetails.policyDetailsTitle"
+                    defaultMessage="Policy '{id}'"
+                    values={{
+                      id: policyId,
+                    }}
+                  />
+                )
               )}
             </h1>
           </EuiText>
@@ -98,7 +102,7 @@ export const AgentPolicyDetailsPage: React.FunctionComponent = () => {
         ) : null}
       </EuiFlexGroup>
     ),
-    [getHref, agentPolicy, policyId]
+    [getHref, isLoading, agentPolicy, policyId]
   );
 
   const enrollmentCancelClickHandler = useCallback(() => {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/index.tsx
@@ -97,8 +97,10 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         <EuiFlexItem>
           <EuiText>
             <h1>
-              {typeof agentData?.item?.local_metadata?.host === 'object' &&
-              typeof agentData?.item?.local_metadata?.host?.hostname === 'string' ? (
+              {isLoading ? (
+                <Loading />
+              ) : typeof agentData?.item?.local_metadata?.host === 'object' &&
+                typeof agentData?.item?.local_metadata?.host?.hostname === 'string' ? (
                 agentData.item.local_metadata.host.hostname
               ) : (
                 <FormattedMessage
@@ -114,8 +116,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         </EuiFlexItem>
       </EuiFlexGroup>
     ),
-    /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    [agentData, agentId, getHref]
+    [agentData?.item?.local_metadata?.host, agentId, getHref, isLoading]
   );
 
   const headerRightContent = useMemo(

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_details_page/index.tsx
@@ -97,7 +97,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         <EuiFlexItem>
           <EuiText>
             <h1>
-              {isLoading ? (
+              {isLoading && isInitialRequest ? (
                 <Loading />
               ) : typeof agentData?.item?.local_metadata?.host === 'object' &&
                 typeof agentData?.item?.local_metadata?.host?.hostname === 'string' ? (
@@ -116,7 +116,7 @@ export const AgentDetailsPage: React.FunctionComponent = () => {
         </EuiFlexItem>
       </EuiFlexGroup>
     ),
-    [agentData?.item?.local_metadata?.host, agentId, getHref, isLoading]
+    [agentData?.item?.local_metadata?.host, agentId, getHref, isInitialRequest, isLoading]
   );
 
   const headerRightContent = useMemo(


### PR DESCRIPTION
## Summary

Fixes #79449. Replaces `Policy {id}` with a loading spinner when agent policy details is being loaded. I found that the agent detail page had a similar issue, so applied the same to that page header.