### PR TITLE
[Fleet] Show base breadcrumb when there is an error booting the app

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/constants/page_paths.ts
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/constants/page_paths.ts
@@ -5,6 +5,7 @@
  */
 
 export type StaticPage =
+  | 'base'
   | 'overview'
   | 'integrations'
   | 'integrations_all'
@@ -62,6 +63,7 @@ export const pagePathGetters: {
   {
     [key in DynamicPage]: (values: DynamicPagePathValues) => string;
   } = {
+  base: () => '/',
   overview: () => '/',
   integrations: () => '/integrations',
   integrations_all: () => '/integrations',

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/hooks/use_breadcrumbs.tsx
@@ -18,6 +18,7 @@ const BASE_BREADCRUMB: ChromeBreadcrumb = {
 const breadcrumbGetters: {
   [key in Page]: (values: DynamicPagePathValues) => ChromeBreadcrumb[];
 } = {
+  base: () => [BASE_BREADCRUMB],
   overview: () => [
     BASE_BREADCRUMB,
     {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/index.tsx
@@ -12,6 +12,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import styled from 'styled-components';
 import { EuiErrorBoundary, EuiPanel, EuiEmptyPrompt, EuiCode } from '@elastic/eui';
 import { CoreStart, AppMountParameters } from 'src/core/public';
+import { KibanaContextProvider } from '../../../../../../src/plugins/kibana_react/public';
 import { EuiThemeProvider } from '../../../../xpack_legacy/common';
 import {
   IngestManagerSetupDeps,
@@ -33,10 +34,9 @@ import {
   KibanaVersionContext,
 } from './hooks';
 import { PackageInstallProvider } from './sections/epm/hooks';
-import { FleetStatusProvider } from './hooks/use_fleet_status';
-import './index.scss';
-import { KibanaContextProvider } from '../../../../../../src/plugins/kibana_react/public';
+import { FleetStatusProvider, useBreadcrumbs } from './hooks';
 import { IntraAppStateProvider } from './hooks/use_intra_app_state';
+import './index.scss';
 
 export interface ProtectedRouteProps extends RouteProps {
   isAllowed?: boolean;
@@ -67,6 +67,7 @@ const ErrorLayout = ({ children }: { children: JSX.Element }) => (
 
 const IngestManagerRoutes = memo<{ history: AppMountParameters['history']; basepath: string }>(
   ({ history, ...rest }) => {
+    useBreadcrumbs('base');
     const { fleet } = useConfig();
     const { notifications } = useCore();
 


### PR DESCRIPTION
## Summary

Fixes #76920. When there was an error loading the app (permissions/setup/etc failure), the breadcrumb would not get updated from the user's previous page. This PR fixes that.
