### PR TITLE
[Security Solution][Detections] Rule Form: prevent creation of invalid scheduling parameters

### DIFF
--- a/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/create_new_rule.ts
@@ -190,16 +190,16 @@ export const fillDefineCustomRuleWithImportedQueryAndContinue = (
 ) => {
   cy.get(IMPORT_QUERY_FROM_SAVED_TIMELINE_LINK).click();
   cy.get(TIMELINE(rule.timelineId)).click();
-  cy.get(CUSTOM_QUERY_INPUT).invoke('text').should('eq', rule.customQuery);
+  cy.get(CUSTOM_QUERY_INPUT).should('have.text', rule.customQuery);
   cy.get(DEFINE_CONTINUE_BUTTON).should('exist').click({ force: true });
 
   cy.get(CUSTOM_QUERY_INPUT).should('not.exist');
 };
 
 export const fillScheduleRuleAndContinue = (rule: CustomRule | MachineLearningRule) => {
-  cy.get(RUNS_EVERY_INTERVAL).clear().type(rule.runsEvery.interval);
+  cy.get(RUNS_EVERY_INTERVAL).type('{selectall}').type(rule.runsEvery.interval);
   cy.get(RUNS_EVERY_TIME_TYPE).select(rule.runsEvery.timeType);
-  cy.get(LOOK_BACK_INTERVAL).clear().type(rule.lookBack.interval);
+  cy.get(LOOK_BACK_INTERVAL).type('{selectAll}').type(rule.lookBack.interval);
   cy.get(LOOK_BACK_TIME_TYPE).select(rule.lookBack.timeType);
 };
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -62,6 +62,15 @@ const MyEuiSelect = styled(EuiSelect)`
   width: auto;
 `;
 
+const getNumberFromUserInput = (input: string): number => {
+  const number = parseInt(input, 10);
+  if (Number.isNaN(number)) {
+    return 0;
+  } else {
+    return Math.min(number, Number.MAX_SAFE_INTEGER);
+  }
+};
+
 export const ScheduleItem = ({
   dataTestSubj,
   field,
@@ -84,7 +93,7 @@ export const ScheduleItem = ({
 
   const onChangeTimeVal = useCallback(
     (e) => {
-      const sanitizedValue: number = parseInt(e.target.value, 10);
+      const sanitizedValue = getNumberFromUserInput(e.target.value);
       setTimeVal(sanitizedValue);
       setValue(`${sanitizedValue}${timeType}`);
     },
@@ -155,6 +164,7 @@ export const ScheduleItem = ({
         <EuiFieldNumber
           fullWidth
           min={minimumValue}
+          max={Number.MAX_SAFE_INTEGER}
           onChange={onChangeTimeVal}
           value={timeVal}
           data-test-subj="interval"

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -21,7 +21,7 @@ import { FieldHook, getFieldValidityAndErrorMessage } from '../../../../shared_i
 import * as I18n from './translations';
 
 interface ScheduleItemProps {
-  field: FieldHook;
+  field: FieldHook<string>;
   dataTestSubj: string;
   idAria: string;
   isDisabled: boolean;
@@ -72,30 +72,29 @@ export const ScheduleItem = ({
   const [timeType, setTimeType] = useState('s');
   const [timeVal, setTimeVal] = useState<number>(0);
   const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
+  const { value, setValue } = field;
 
   const onChangeTimeType = useCallback(
     (e) => {
       setTimeType(e.target.value);
-      field.setValue(`${timeVal}${e.target.value}`);
+      setValue(`${timeVal}${e.target.value}`);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [timeVal]
+    [setValue, timeVal]
   );
 
   const onChangeTimeVal = useCallback(
     (e) => {
       const sanitizedValue: number = parseInt(e.target.value, 10);
       setTimeVal(sanitizedValue);
-      field.setValue(`${sanitizedValue}${timeType}`);
+      setValue(`${sanitizedValue}${timeType}`);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [timeType]
+    [setValue, timeType]
   );
 
   useEffect(() => {
-    if (field.value !== `${timeVal}${timeType}`) {
-      const filterTimeVal = (field.value as string).match(/\d+/g);
-      const filterTimeType = (field.value as string).match(/[a-zA-Z]+/g);
+    if (value !== `${timeVal}${timeType}`) {
+      const filterTimeVal = value.match(/\d+/g);
+      const filterTimeType = value.match(/[a-zA-Z]+/g);
       if (
         !isEmpty(filterTimeVal) &&
         filterTimeVal != null &&
@@ -113,8 +112,7 @@ export const ScheduleItem = ({
         setTimeType(filterTimeType[0]);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [field.value]);
+  }, [timeType, timeVal, value]);
 
   // EUI missing some props
   const rest = { disabled: isDisabled };

--- a/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/schedule_item_form/index.tsx
@@ -62,10 +62,10 @@ const MyEuiSelect = styled(EuiSelect)`
   width: auto;
 `;
 
-const getNumberFromUserInput = (input: string): number => {
+const getNumberFromUserInput = (input: string, defaultValue = 0): number => {
   const number = parseInt(input, 10);
   if (Number.isNaN(number)) {
-    return 0;
+    return defaultValue;
   } else {
     return Math.min(number, Number.MAX_SAFE_INTEGER);
   }
@@ -93,11 +93,11 @@ export const ScheduleItem = ({
 
   const onChangeTimeVal = useCallback(
     (e) => {
-      const sanitizedValue = getNumberFromUserInput(e.target.value);
+      const sanitizedValue = getNumberFromUserInput(e.target.value, minimumValue);
       setTimeVal(sanitizedValue);
       setValue(`${sanitizedValue}${timeType}`);
     },
-    [setValue, timeType]
+    [minimumValue, setValue, timeType]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Addresses a bug where users could enter very large numbers on the numeric inputs in the Schedule step that, causing the rule to store them in scientific notation and ultimately generating an error when the rule attempts to parse these fields. While https://github.com/elastic/kibana/pull/73379 addressed the latter issue, this PR prevents those errant values from being generated via the UI. API users are still able to set an arbitrary date math expression.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
