### PR TITLE
[Lens] Break long titles into multiple lines

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
@@ -50,6 +50,7 @@
   width: 100%;
   padding: $euiSizeS;
   min-height: $euiSizeXXL - 2;
+  word-break: break-word;
 
   &:focus {
     background-color: transparent !important; // sass-lint:disable-line no-important

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.tsx
@@ -229,6 +229,13 @@ export function onDrop(props: DatasourceDimensionDropHandlerProps<IndexPatternPr
   return true;
 }
 
+function wrapOnDot(str?: string) {
+  // u200B is a non-width white-space character, which allows
+  // the browser to efficiently word-wrap right after the dot
+  // without us having to draw a lot of extra DOM elements, etc
+  return str ? str.replace(/\./g, '.\u200B') : '';
+}
+
 export const IndexPatternDimensionTriggerComponent = function IndexPatternDimensionTrigger(
   props: IndexPatternDimensionTriggerProps
 ) {
@@ -249,6 +256,7 @@ export const IndexPatternDimensionTriggerComponent = function IndexPatternDimens
   if (!selectedColumn) {
     return null;
   }
+  const formattedLabel = wrapOnDot(uniqueLabel);
 
   const triggerLinkA11yText = i18n.translate('xpack.lens.configure.editConfig', {
     defaultMessage: 'Click to edit configuration or drag to move',
@@ -299,7 +307,7 @@ export const IndexPatternDimensionTriggerComponent = function IndexPatternDimens
       aria-label={triggerLinkA11yText}
       title={triggerLinkA11yText}
     >
-      {uniqueLabel}
+      {formattedLabel}
     </EuiLink>
   );
 };


### PR DESCRIPTION
This fixes a bug where the delete button was sometimes hidden because of text length issues. The dimension triggers on the right side of Lens are now receiving the same handling as the field names on the left side of Lens, which we are happy with.

Screenshot:

<img width="305" alt="Screen Shot 2020-10-05 at 5 36 35 PM" src="https://user-images.githubusercontent.com/666475/95135027-d5ff4380-0731-11eb-8a60-a620f29a83a1.png">


Fixes https://github.com/elastic/kibana/issues/79573
