### PR TITLE
[Lens] Don't debounce visualization settings UI 

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -15,7 +15,14 @@ import {
   DatasourceMock,
   createMockFramePublicAPI,
 } from '../../mocks';
-import { InnerWorkspacePanel, WorkspacePanelProps } from './workspace_panel';
+
+jest.mock('../../../debounced_component', () => {
+  return {
+    debouncedComponent: (fn: unknown) => fn,
+  };
+});
+
+import { WorkspacePanel, WorkspacePanelProps } from './workspace_panel';
 import { mountWithIntl as mount } from 'test_utils/enzyme_helpers';
 import { ReactWrapper } from 'enzyme';
 import { DragDrop, ChildDragDropProvider } from '../../../drag_drop';
@@ -64,7 +71,7 @@ describe('workspace_panel', () => {
 
   it('should render an explanatory text if no visualization is active', () => {
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{}}
         datasourceMap={{}}
@@ -87,7 +94,7 @@ describe('workspace_panel', () => {
 
   it('should render an explanatory text if the visualization does not produce an expression', () => {
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{}}
         datasourceMap={{}}
@@ -110,7 +117,7 @@ describe('workspace_panel', () => {
 
   it('should render an explanatory text if the datasource does not produce an expression', () => {
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{}}
         datasourceMap={{}}
@@ -140,7 +147,7 @@ describe('workspace_panel', () => {
     mockDatasource.getLayers.mockReturnValue(['first']);
 
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{
           mock: {
@@ -213,7 +220,7 @@ describe('workspace_panel', () => {
     mockDatasource.getLayers.mockReturnValue(['first']);
 
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{
           mock: {
@@ -260,7 +267,7 @@ describe('workspace_panel', () => {
     mockDatasource2.getLayers.mockReturnValue(['second', 'third']);
 
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{
           mock: {
@@ -345,7 +352,7 @@ describe('workspace_panel', () => {
 
     await act(async () => {
       instance = mount(
-        <InnerWorkspacePanel
+        <WorkspacePanel
           activeDatasourceId={'mock'}
           datasourceStates={{
             mock: {
@@ -381,6 +388,7 @@ describe('workspace_panel', () => {
         },
       });
     });
+
     instance.update();
 
     expect(expressionRendererMock).toHaveBeenCalledTimes(2);
@@ -400,7 +408,7 @@ describe('workspace_panel', () => {
     expressionRendererMock = jest.fn((_arg) => <span />);
     await act(async () => {
       instance = mount(
-        <InnerWorkspacePanel
+        <WorkspacePanel
           activeDatasourceId={'mock'}
           datasourceStates={{
             mock: {
@@ -455,7 +463,7 @@ describe('workspace_panel', () => {
     };
 
     instance = mount(
-      <InnerWorkspacePanel
+      <WorkspacePanel
         activeDatasourceId={'mock'}
         datasourceStates={{
           mock: {
@@ -493,7 +501,7 @@ describe('workspace_panel', () => {
 
     await act(async () => {
       instance = mount(
-        <InnerWorkspacePanel
+        <WorkspacePanel
           activeDatasourceId={'mock'}
           datasourceStates={{
             mock: {
@@ -537,7 +545,7 @@ describe('workspace_panel', () => {
 
     await act(async () => {
       instance = mount(
-        <InnerWorkspacePanel
+        <WorkspacePanel
           activeDatasourceId={'mock'}
           datasourceStates={{
             mock: {
@@ -592,7 +600,7 @@ describe('workspace_panel', () => {
     function initComponent(draggingContext: unknown = draggedField) {
       instance = mount(
         <ChildDragDropProvider dragging={draggingContext} setDragging={() => {}}>
-          <InnerWorkspacePanel
+          <WorkspacePanel
             activeDatasourceId={'mock'}
             datasourceStates={{
               mock: {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useEffect, useMemo, useContext, useCallback } from 'react';
 import classNames from 'classnames';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { Ast } from '@kbn/interpreter/common';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiButtonEmpty, EuiLink } from '@elastic/eui';
 import { CoreStart, CoreSetup } from 'kibana/public';
@@ -33,7 +34,10 @@ import {
   VisualizeFieldContext,
 } from '../../../../../../../src/plugins/ui_actions/public';
 import { VIS_EVENT_TO_TRIGGER } from '../../../../../../../src/plugins/visualizations/public';
-import { DataPublicPluginStart } from '../../../../../../../src/plugins/data/public';
+import {
+  DataPublicPluginStart,
+  TimefilterContract,
+} from '../../../../../../../src/plugins/data/public';
 import { WorkspacePanelWrapper } from './workspace_panel_wrapper';
 import { DropIllustration } from '../../../assets/drop_illustration';
 
@@ -57,6 +61,11 @@ export interface WorkspacePanelProps {
   plugins: { uiActions?: UiActionsStart; data: DataPublicPluginStart };
   title?: string;
   visualizeTriggerFieldContext?: VisualizeFieldContext;
+}
+
+interface WorkspaceState {
+  expressionBuildError: string | undefined;
+  expandError: boolean;
 }
 
 // Exported for testing purposes only.
@@ -105,7 +114,7 @@ export function WorkspacePanel({
     [dragDropContext.dragging]
   );
 
-  const [localState, setLocalState] = useState({
+  const [localState, setLocalState] = useState<WorkspaceState>({
     expressionBuildError: undefined as string | undefined,
     expandError: false,
   });
@@ -158,28 +167,6 @@ export function WorkspacePanel({
       }
     },
     [plugins.uiActions]
-  );
-
-  const autoRefreshFetch$ = useMemo(
-    () => plugins.data.query.timefilter.timefilter.getAutoRefreshFetch$(),
-    [plugins.data.query.timefilter.timefilter]
-  );
-
-  const context: ExecutionContextSearch = useMemo(
-    () => ({
-      query: framePublicAPI.query,
-      timeRange: {
-        from: framePublicAPI.dateRange.fromDate,
-        to: framePublicAPI.dateRange.toDate,
-      },
-      filters: framePublicAPI.filters,
-    }),
-    [
-      framePublicAPI.query,
-      framePublicAPI.dateRange.fromDate,
-      framePublicAPI.dateRange.toDate,
-      framePublicAPI.filters,
-    ]
   );
 
   useEffect(() => {
@@ -253,33 +240,17 @@ export function WorkspacePanel({
     if (expression === null && !visualizeTriggerFieldContext) {
       return renderEmptyWorkspace();
     }
-
-    if (localState.expressionBuildError) {
-      return (
-        <EuiFlexGroup style={{ maxWidth: '100%' }} direction="column" alignItems="center">
-          <EuiFlexItem>
-            <EuiIcon type="alert" size="xl" color="danger" />
-          </EuiFlexItem>
-          <EuiFlexItem data-test-subj="expression-failure">
-            <FormattedMessage
-              id="xpack.lens.editorFrame.expressionFailure"
-              defaultMessage="An error occurred in the expression"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>{localState.expressionBuildError}</EuiFlexItem>
-        </EuiFlexGroup>
-      );
-    }
-    const props = {
-      expression,
-      context,
-      autoRefreshFetch$,
-      onEvent,
-      setLocalState,
-      localState,
-      ExpressionRendererComponent,
-    };
-    return <VisualizationWrapper {...props} />;
+    return (
+      <VisualizationWrapper
+        expression={expression}
+        framePublicAPI={framePublicAPI}
+        timefilter={plugins.data.query.timefilter.timefilter}
+        onEvent={onEvent}
+        setLocalState={setLocalState}
+        localState={localState}
+        ExpressionRendererComponent={ExpressionRendererComponent}
+      />
+    );
   }
 
   return (
@@ -310,16 +281,58 @@ export function WorkspacePanel({
   );
 }
 
-const InnerVisualizationWrapper = (props) => {
-  const {
-    expression,
-    context,
-    autoRefreshFetch$,
-    onEvent,
-    setLocalState,
-    localState,
-    ExpressionRendererComponent,
-  } = props;
+export const InnerVisualizationWrapper = ({
+  expression,
+  framePublicAPI,
+  timefilter,
+  onEvent,
+  setLocalState,
+  localState,
+  ExpressionRendererComponent,
+}: {
+  expression: Ast | null | undefined;
+  framePublicAPI: FramePublicAPI;
+  timefilter: TimefilterContract;
+  onEvent: (event: ExpressionRendererEvent) => void;
+  setLocalState: (dispatch: (prevState: WorkspaceState) => WorkspaceState) => void;
+  localState: WorkspaceState;
+  ExpressionRendererComponent: ReactExpressionRendererType;
+}) => {
+  const autoRefreshFetch$ = useMemo(() => timefilter.getAutoRefreshFetch$(), [timefilter]);
+
+  const context: ExecutionContextSearch = useMemo(
+    () => ({
+      query: framePublicAPI.query,
+      timeRange: {
+        from: framePublicAPI.dateRange.fromDate,
+        to: framePublicAPI.dateRange.toDate,
+      },
+      filters: framePublicAPI.filters,
+    }),
+    [
+      framePublicAPI.query,
+      framePublicAPI.dateRange.fromDate,
+      framePublicAPI.dateRange.toDate,
+      framePublicAPI.filters,
+    ]
+  );
+
+  if (localState.expressionBuildError) {
+    return (
+      <EuiFlexGroup style={{ maxWidth: '100%' }} direction="column" alignItems="center">
+        <EuiFlexItem>
+          <EuiIcon type="alert" size="xl" color="danger" />
+        </EuiFlexItem>
+        <EuiFlexItem data-test-subj="expression-failure">
+          <FormattedMessage
+            id="xpack.lens.editorFrame.expressionFailure"
+            defaultMessage="An error occurred in the expression"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>{localState.expressionBuildError}</EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
   return (
     <div className="lnsExpressionRenderer">
       <ExpressionRendererComponent
@@ -345,7 +358,7 @@ const InnerVisualizationWrapper = (props) => {
                 <EuiFlexItem className="eui-textBreakAll" grow={false}>
                   <EuiButtonEmpty
                     onClick={() => {
-                      setLocalState((prevState) => ({
+                      setLocalState((prevState: WorkspaceState) => ({
                         ...prevState,
                         expandError: !prevState.expandError,
                       }));

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -59,10 +59,8 @@ export interface WorkspacePanelProps {
   visualizeTriggerFieldContext?: VisualizeFieldContext;
 }
 
-export const WorkspacePanel = debouncedComponent(InnerWorkspacePanel);
-
 // Exported for testing purposes only.
-export function InnerWorkspacePanel({
+export function WorkspacePanel({
   activeDatasourceId,
   activeVisualizationId,
   visualizationMap,
@@ -272,52 +270,16 @@ export function InnerWorkspacePanel({
         </EuiFlexGroup>
       );
     }
-
-    return (
-      <div className="lnsExpressionRenderer">
-        <ExpressionRendererComponent
-          className="lnsExpressionRenderer__component"
-          padding="m"
-          expression={expression!}
-          searchContext={context}
-          reload$={autoRefreshFetch$}
-          onEvent={onEvent}
-          renderError={(errorMessage?: string | null) => {
-            return (
-              <EuiFlexGroup style={{ maxWidth: '100%' }} direction="column" alignItems="center">
-                <EuiFlexItem>
-                  <EuiIcon type="alert" size="xl" color="danger" />
-                </EuiFlexItem>
-                <EuiFlexItem data-test-subj="expression-failure">
-                  <FormattedMessage
-                    id="xpack.lens.editorFrame.dataFailure"
-                    defaultMessage="An error occurred when loading data."
-                  />
-                </EuiFlexItem>
-                {errorMessage ? (
-                  <EuiFlexItem className="eui-textBreakAll" grow={false}>
-                    <EuiButtonEmpty
-                      onClick={() => {
-                        setLocalState((prevState) => ({
-                          ...prevState,
-                          expandError: !prevState.expandError,
-                        }));
-                      }}
-                    >
-                      {i18n.translate('xpack.lens.editorFrame.expandRenderingErrorButton', {
-                        defaultMessage: 'Show details of error',
-                      })}
-                    </EuiButtonEmpty>
-
-                    {localState.expandError ? errorMessage : null}
-                  </EuiFlexItem>
-                ) : null}
-              </EuiFlexGroup>
-            );
-          }}
-        />
-      </div>
-    );
+    const props = {
+      expression,
+      context,
+      autoRefreshFetch$,
+      onEvent,
+      setLocalState,
+      localState,
+      ExpressionRendererComponent,
+    };
+    return <VisualizationWrapper {...props} />;
   }
 
   return (
@@ -347,3 +309,62 @@ export function InnerWorkspacePanel({
     </WorkspacePanelWrapper>
   );
 }
+
+const InnerVisualizationWrapper = (props) => {
+  const {
+    expression,
+    context,
+    autoRefreshFetch$,
+    onEvent,
+    setLocalState,
+    localState,
+    ExpressionRendererComponent,
+  } = props;
+  return (
+    <div className="lnsExpressionRenderer">
+      <ExpressionRendererComponent
+        className="lnsExpressionRenderer__component"
+        padding="m"
+        expression={expression!}
+        searchContext={context}
+        reload$={autoRefreshFetch$}
+        onEvent={onEvent}
+        renderError={(errorMessage?: string | null) => {
+          return (
+            <EuiFlexGroup style={{ maxWidth: '100%' }} direction="column" alignItems="center">
+              <EuiFlexItem>
+                <EuiIcon type="alert" size="xl" color="danger" />
+              </EuiFlexItem>
+              <EuiFlexItem data-test-subj="expression-failure">
+                <FormattedMessage
+                  id="xpack.lens.editorFrame.dataFailure"
+                  defaultMessage="An error occurred when loading data."
+                />
+              </EuiFlexItem>
+              {errorMessage ? (
+                <EuiFlexItem className="eui-textBreakAll" grow={false}>
+                  <EuiButtonEmpty
+                    onClick={() => {
+                      setLocalState((prevState) => ({
+                        ...prevState,
+                        expandError: !prevState.expandError,
+                      }));
+                    }}
+                  >
+                    {i18n.translate('xpack.lens.editorFrame.expandRenderingErrorButton', {
+                      defaultMessage: 'Show details of error',
+                    })}
+                  </EuiButtonEmpty>
+
+                  {localState.expandError ? errorMessage : null}
+                </EuiFlexItem>
+              ) : null}
+            </EuiFlexGroup>
+          );
+        }}
+      />
+    </div>
+  );
+};
+
+export const VisualizationWrapper = debouncedComponent(InnerVisualizationWrapper);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/79639

before screenshot of changing the legend from 'show' to 'hide':
<img width="230" alt="Screenshot 2020-10-06 at 13 47 09" src="https://user-images.githubusercontent.com/4283304/95197960-b07a4480-07da-11eb-91c9-dd42a9432315.png">


after:
<img width="205" alt="Screenshot 2020-10-06 at 13 44 19" src="https://user-images.githubusercontent.com/4283304/95197965-b2440800-07da-11eb-86e6-5862422ac3c8.png">

The problem: we are debouncing the whole InnerWorkspacePanel that consists of all menu items instead of just visualisation part. I've extracted VisualizationWrapper Component and surrounded only this component with `debouncedComponent()`. 
