### PR TITLE
fix lazy loading for dashboard plugin

### DIFF
--- a/src/plugins/dashboard/public/application/index.ts
+++ b/src/plugins/dashboard/public/application/index.ts
@@ -19,4 +19,4 @@
 
 export * from './embeddable';
 export * from './actions';
-export { RenderDeps } from './application';
+export type { RenderDeps } from './application';


### PR DESCRIPTION
Plugin entry bundle size 569.3KB --> 350.6KB


