### PR TITLE
[Ingest Manager] Restrict direct package upload to Enterprise license

### DIFF
--- a/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/epm/handlers.ts
@@ -43,6 +43,7 @@ import {
 } from '../../services/epm/packages';
 import { defaultIngestErrorHandler, ingestErrorToResponseOptions } from '../../errors';
 import { splitPkgKey } from '../../services/epm/registry';
+import { licenseService } from '../../services';
 
 export const getCategoriesHandler: RequestHandler<
   undefined,
@@ -212,6 +213,12 @@ export const installPackageByUploadHandler: RequestHandler<
   undefined,
   TypeOf<typeof InstallPackageByUploadRequestSchema.body>
 > = async (context, request, response) => {
+  if (!licenseService.isEnterprise()) {
+    return response.customError({
+      statusCode: 403,
+      body: { message: 'Requires Enterprise license' },
+    });
+  }
   const savedObjectsClient = context.core.savedObjects.client;
   const callCluster = context.core.elasticsearch.legacy.client.callAsCurrentUser;
   const contentType = request.headers['content-type'] as string; // from types it could also be string[] or undefined but this is checked later


### PR DESCRIPTION
## Summary

Restricts the direct package upload feature to Enterprise license, as discussed in https://github.com/elastic/kibana/issues/70582#issuecomment-703679135

### How to test this

* Start elasticsearch locally with `yarn es snapshot --license basic OTHER_OPTIONS` (or find any other way to run with a `basic` license).
* Start kibana locally.
* `export KIBANA_HOME=/path/to/your/kibana/project/directory`
* `curl -X POST -u elastic:changeme http://localhost:5601/api/ingest_manager/epm/packages --data-binary @$KIBANA_HOME/x-pack/test/ingest_manager_api_integration/apis/fixtures/direct_upload_packages/apache_0.1.4.zip -H 'kbn-xsrf: xyz' -H 'Content-Type: application/zip'`

This should result in the response `{"statusCode":403,"error":"Forbidden","message":"Requires Enterprise license"}`.

Do the same with a `trial` license. The installation should work.