### PR TITLE
[Telemetry Tools] Merge array of constraints

### DIFF
--- a/packages/kbn-telemetry-tools/src/tools/serializer.test.ts
+++ b/packages/kbn-telemetry-tools/src/tools/serializer.test.ts
@@ -148,6 +148,17 @@ describe('getDescriptor', () => {
     });
   });
 
+  it('serializes RecordWithKnownAllProps', () => {
+    const usageInterface = usageInterfaces.get('RecordWithKnownAllProps')!;
+    const descriptor = getDescriptor(usageInterface, tsProgram);
+    expect(descriptor).toEqual({
+      prop1: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+      prop2: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+      prop3: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+      prop4: { kind: ts.SyntaxKind.NumberKeyword, type: 'NumberKeyword' },
+    });
+  });
+
   it('serializes IndexedAccessType', () => {
     const usageInterface = usageInterfaces.get('IndexedAccessType')!;
     const descriptor = getDescriptor(usageInterface, tsProgram);

--- a/packages/kbn-telemetry-tools/src/tools/serializer.ts
+++ b/packages/kbn-telemetry-tools/src/tools/serializer.ts
@@ -88,7 +88,11 @@ export function getConstraints(node: ts.Node, program: ts.Program): any {
 
   if (ts.isUnionTypeNode(node)) {
     const types = node.types.filter(discardNullOrUndefined);
-    return types.map((typeNode) => getConstraints(typeNode, program));
+    return types.reduce<any>((acc, typeNode) => {
+      const constraints = getConstraints(typeNode, program);
+      const contraintsArray = Array.isArray(constraints) ? constraints : [constraints];
+      return [...acc, ...contraintsArray];
+    }, []);
   }
 
   if (ts.isLiteralTypeNode(node) && ts.isLiteralExpression(node.literal)) {

--- a/src/fixtures/telemetry_collectors/constants.ts
+++ b/src/fixtures/telemetry_collectors/constants.ts
@@ -58,6 +58,10 @@ export type TypeAliasWithRecord = Usage & Record<string, number>;
 
 export type MappedTypeProps = 'prop1' | 'prop2';
 
+export type MappedTypeExtraProps = 'prop3' | 'prop4';
+
+export type MappedTypeAllProps = MappedTypeProps | MappedTypeExtraProps;
+
 export interface MappedTypes {
   mappedTypeWithExternallyDefinedProps: {
     [key in MappedTypeProps]: number;
@@ -68,5 +72,6 @@ export interface MappedTypes {
 }
 
 export type RecordWithKnownProps = Record<MappedTypeProps, number>;
+export type RecordWithKnownAllProps = Record<MappedTypeAllProps, number>;
 
 export type IndexedAccessType = Pick<WithUnion, 'prop1' | 'prop2'>;


### PR DESCRIPTION
## Summary

When defining `Record<AllProps, SOMETHING>`, and `type AllProps = OneList | AnotherList`, the `getConstraints` method was returning an array of arrays instead of 1 flattened array of strings.

This PR fixes that behaviour.

Related to #79587

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
