### PR TITLE
[Enterprise Search] Prevent double encoding in enterprise_search_request_handler

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -116,14 +116,14 @@ describe('EnterpriseSearchRequestHandler', () => {
         );
       });
 
-      it('will correctly encode query string parameters', async () => {
+      it('correctly encodes paths and query string parameters', async () => {
         const requestHandler = enterpriseSearchRequestHandler.createRequest({
-          path: '/api/example',
+          path: '/api/some example',
         });
         await makeAPICall(requestHandler, { query: { 'page[current]': 1 } });
 
         EnterpriseSearchAPI.shouldHaveBeenCalledWith(
-          'http://localhost:3002/api/example?page%5Bcurrent%5D=1'
+          'http://localhost:3002/api/some%20example?page%5Bcurrent%5D=1'
         );
       });
     });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -93,6 +93,17 @@ describe('EnterpriseSearchRequestHandler', () => {
         });
       });
 
+      it('passes request params', async () => {
+        const requestHandler = enterpriseSearchRequestHandler.createRequest({
+          path: '/api/example',
+        });
+        await makeAPICall(requestHandler, { query: { someQuery: false } });
+
+        EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+          'http://localhost:3002/api/example?someQuery=false'
+        );
+      });
+
       it('passes custom params set by the handler, which override request params', async () => {
         const requestHandler = enterpriseSearchRequestHandler.createRequest({
           path: '/api/example',
@@ -102,6 +113,17 @@ describe('EnterpriseSearchRequestHandler', () => {
 
         EnterpriseSearchAPI.shouldHaveBeenCalledWith(
           'http://localhost:3002/api/example?someQuery=true'
+        );
+      });
+
+      it('will correctly encode query string parameters', async () => {
+        const requestHandler = enterpriseSearchRequestHandler.createRequest({
+          path: '/api/example',
+        });
+        await makeAPICall(requestHandler, { query: { 'page[current]': 1 } });
+
+        EnterpriseSearchAPI.shouldHaveBeenCalledWith(
+          'http://localhost:3002/api/example?page%5Bcurrent%5D=1'
         );
       });
     });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -69,7 +69,7 @@ export class EnterpriseSearchRequestHandler {
         const queryString = !this.isEmptyObj(queryParams)
           ? `?${querystring.stringify(queryParams)}`
           : '';
-        const url = this.enterpriseSearchUrl + path + queryString;
+        const url = encodeURI(this.enterpriseSearchUrl + path) + queryString;
 
         // Set up API options
         const { method } = request.route;

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -69,7 +69,7 @@ export class EnterpriseSearchRequestHandler {
         const queryString = !this.isEmptyObj(queryParams)
           ? `?${querystring.stringify(queryParams)}`
           : '';
-        const url = encodeURI(this.enterpriseSearchUrl + path + queryString);
+        const url = this.enterpriseSearchUrl + path + queryString;
 
         // Set up API options
         const { method } = request.route;


### PR DESCRIPTION
enterprise_search_request_handler was double encoding urls.

This is because `querystring.stringify` was already encoding, and
we were subsequentally calling `encodeURI` on the same url.

This resulted in something like "page[current]=2" to be converted
to "page%255Bcurrent%255D=2", rather than
"page%5Bcurrent%5D=2"; it was double encoded.

References: https://nodejs.org/api/querystring.html
See the `encodeURIComponent` option for the `stringify` method, which
defaults to `escape`.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
