### PR TITLE
[Security Solution][Detections] Fix EQL search request filter when built with exceptions

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/get_query_filter.test.ts
@@ -1105,11 +1105,17 @@ describe('get_filter', () => {
           size: 100,
           query: 'process where true',
           filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-5m',
-                lte: 'now',
-              },
+            bool: {
+              filter: [
+                {
+                  range: {
+                    '@timestamp': {
+                      gte: 'now-5m',
+                      lte: 'now',
+                    },
+                  },
+                },
+              ],
             },
           },
         },
@@ -1135,11 +1141,17 @@ describe('get_filter', () => {
           size: 100,
           query: 'process where true',
           filter: {
-            range: {
-              'event.ingested': {
-                gte: 'now-5m',
-                lte: 'now',
-              },
+            bool: {
+              filter: [
+                {
+                  range: {
+                    'event.ingested': {
+                      gte: 'now-5m',
+                      lte: 'now',
+                    },
+                  },
+                },
+              ],
             },
           },
         },
@@ -1164,44 +1176,52 @@ describe('get_filter', () => {
           size: 100,
           query: 'process where true',
           filter: {
-            range: {
-              '@timestamp': {
-                gte: 'now-5m',
-                lte: 'now',
-              },
-            },
             bool: {
-              must_not: {
-                bool: {
-                  should: [
-                    {
+              filter: [
+                {
+                  range: {
+                    '@timestamp': {
+                      gte: 'now-5m',
+                      lte: 'now',
+                    },
+                  },
+                },
+                {
+                  bool: {
+                    must_not: {
                       bool: {
-                        filter: [
-                          {
-                            nested: {
-                              path: 'some.parentField',
-                              query: {
-                                bool: {
-                                  minimum_should_match: 1,
-                                  should: [
-                                    {
-                                      match_phrase: {
-                                        'some.parentField.nested.field': 'some value',
-                                      },
-                                    },
-                                  ],
-                                },
-                              },
-                              score_mode: 'none',
-                            },
-                          },
+                        should: [
                           {
                             bool: {
-                              minimum_should_match: 1,
-                              should: [
+                              filter: [
                                 {
-                                  match_phrase: {
-                                    'some.not.nested.field': 'some value',
+                                  nested: {
+                                    path: 'some.parentField',
+                                    query: {
+                                      bool: {
+                                        minimum_should_match: 1,
+                                        should: [
+                                          {
+                                            match_phrase: {
+                                              'some.parentField.nested.field': 'some value',
+                                            },
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    score_mode: 'none',
+                                  },
+                                },
+                                {
+                                  bool: {
+                                    minimum_should_match: 1,
+                                    should: [
+                                      {
+                                        match_phrase: {
+                                          'some.not.nested.field': 'some value',
+                                        },
+                                      },
+                                    ],
                                   },
                                 },
                               ],
@@ -1210,9 +1230,9 @@ describe('get_filter', () => {
                         ],
                       },
                     },
-                  ],
+                  },
                 },
-              },
+              ],
             },
           },
         },


### PR DESCRIPTION
## Summary

The ES query DSL does not support multiple objects within a `filter` object, which is how we were attempting to build the query. Instead, `filter` needs to be an array of objects. The EQL search API does not allow the top level `filter` to be an array so we have to nest the `filter` array within another `bool` object.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
