### PR TITLE
[Ingest Manager] send protocol separately to agent as part of full agent policy

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/agent_policy.ts
@@ -64,6 +64,7 @@ export interface FullAgentPolicy {
   fleet?: {
     kibana: {
       hosts: string[];
+      protocol: string;
     };
   };
   inputs: FullAgentPolicyInput[];

--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.test.ts
@@ -81,7 +81,8 @@ describe('agent policy', () => {
         revision: 1,
         fleet: {
           kibana: {
-            hosts: ['http://localhost:5603'],
+            hosts: ['localhost:5603'],
+            protocol: 'http',
           },
         },
         agent: {
@@ -115,7 +116,8 @@ describe('agent policy', () => {
         revision: 1,
         fleet: {
           kibana: {
-            hosts: ['http://localhost:5603'],
+            hosts: ['localhost:5603'],
+            protocol: 'http',
           },
         },
         agent: {
@@ -150,7 +152,8 @@ describe('agent policy', () => {
         revision: 1,
         fleet: {
           kibana: {
-            hosts: ['http://localhost:5603'],
+            hosts: ['localhost:5603'],
+            protocol: 'http',
           },
         },
         agent: {

--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
@@ -532,10 +532,16 @@ class AgentPolicyService {
       } catch (error) {
         throw new Error('Default settings is not setup');
       }
-      if (!settings.kibana_urls) throw new Error('kibana_urls is missing');
+      if (!settings.kibana_urls || !settings.kibana_urls.length)
+        throw new Error('kibana_urls is missing');
+      const hostsWithoutProtocol = settings.kibana_urls.map((url) => {
+        const parsedURL = new URL(url);
+        return `${parsedURL.host}${parsedURL.pathname !== '/' ? parsedURL.pathname : ''}`;
+      });
       fullAgentPolicy.fleet = {
         kibana: {
-          hosts: settings.kibana_urls,
+          protocol: new URL(settings.kibana_urls[0]).protocol.replace(':', ''),
+          hosts: hostsWithoutProtocol,
         },
       };
     }

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/policy_details.ts
@@ -25,7 +25,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { protocol, hostname, port } = kbnTestServer;
 
   const kibanaUrl = Url.format({
-    protocol,
     hostname,
     port,
   });
@@ -237,6 +236,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           fleet: {
             kibana: {
               hosts: [kibanaUrl],
+              protocol,
             },
           },
           revision: 3,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/79740


### Summary
When the policy change is sent to the Elastic Agent it includes the `fleet.kibana.hosts` with the hosts having a prefix of `http://`. It should not send it in this format as that doesn't follow the same format shared by all beats.

It should send the hosts as:

```
fleet:
  kibana:
     protocol: 'http'
     hosts: ['localhost:5601']
```

It is currently sent as:

```
fleet:
  kibana:
     hosts: ['http://localhost:5601']
```

### Change
Separate the host from the url during creation of the full agent policy
