### PR TITLE
[Security Solution][Detection Engine] Fixes date time errors when source index does not have date time stamps  

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
@@ -544,5 +544,23 @@ describe('rules_notification_alert_type', () => {
       expect(logger.error.mock.calls[0][0]).toContain('An error occurred during rule execution');
       expect(ruleStatusService.error).toHaveBeenCalled();
     });
+
+    it('should not do throws when the date time is "invalid"', async () => {
+      const result: SearchAfterAndBulkCreateReturnType = {
+        success: false,
+        searchAfterTimes: [],
+        bulkCreateTimes: [],
+        lastLookBackDate: new Date('undefined'), // This will do a throw if you do new Date('undefined').toISOString() and we can get this from the alerting froma
+        createdSignalsCount: 0,
+        errors: ['Error that bubbled up.'],
+      };
+      (searchAfterAndBulkCreate as jest.Mock).mockResolvedValue(result);
+      await alert.executor(payload);
+      expect(logger.error).toHaveBeenCalled();
+      expect(logger.error.mock.calls[0][0]).toContain(
+        'Bulk Indexing of signals failed: Error that bubbled up. name: "Detect Root/Admin Users" id: "04128c15-0d1b-4716-a4c5-46997ac7f3bd" rule id: "rule-1" signals index: ".siem-signals"'
+      );
+      expect(ruleStatusService.error).toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.test.ts
@@ -544,23 +544,5 @@ describe('rules_notification_alert_type', () => {
       expect(logger.error.mock.calls[0][0]).toContain('An error occurred during rule execution');
       expect(ruleStatusService.error).toHaveBeenCalled();
     });
-
-    it('should not do throws when the date time is "invalid"', async () => {
-      const result: SearchAfterAndBulkCreateReturnType = {
-        success: false,
-        searchAfterTimes: [],
-        bulkCreateTimes: [],
-        lastLookBackDate: new Date('undefined'), // This will do a throw if you do new Date('undefined').toISOString() and we can get this from the alerting froma
-        createdSignalsCount: 0,
-        errors: ['Error that bubbled up.'],
-      };
-      (searchAfterAndBulkCreate as jest.Mock).mockResolvedValue(result);
-      await alert.executor(payload);
-      expect(logger.error).toHaveBeenCalled();
-      expect(logger.error.mock.calls[0][0]).toContain(
-        'Bulk Indexing of signals failed: Error that bubbled up. name: "Detect Root/Admin Users" id: "04128c15-0d1b-4716-a4c5-46997ac7f3bd" rule id: "rule-1" signals index: ".siem-signals"'
-      );
-      expect(ruleStatusService.error).toHaveBeenCalled();
-    });
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -8,6 +8,7 @@
 
 import { Logger, KibanaRequest } from 'src/core/server';
 
+import moment from 'moment';
 import {
   SIGNALS_ID,
   DEFAULT_SEARCH_AFTER_PAGE_SIZE,
@@ -525,7 +526,9 @@ export const signalRulesAlertType = ({
             await ruleStatusService.success('succeeded', {
               bulkCreateTimeDurations: result.bulkCreateTimes,
               searchAfterTimeDurations: result.searchAfterTimes,
-              lastLookBackDate: result.lastLookBackDate?.toISOString(),
+              lastLookBackDate: moment(result.lastLookBackDate).isValid()
+                ? result.lastLookBackDate?.toISOString()
+                : undefined,
             });
           }
         } else {
@@ -537,7 +540,9 @@ export const signalRulesAlertType = ({
           await ruleStatusService.error(errorMessage, {
             bulkCreateTimeDurations: result.bulkCreateTimes,
             searchAfterTimeDurations: result.searchAfterTimes,
-            lastLookBackDate: result.lastLookBackDate?.toISOString(),
+            lastLookBackDate: moment(result.lastLookBackDate).isValid()
+              ? result.lastLookBackDate?.toISOString()
+              : undefined,
           });
         }
       } catch (error) {
@@ -551,7 +556,9 @@ export const signalRulesAlertType = ({
         await ruleStatusService.error(message, {
           bulkCreateTimeDurations: result.bulkCreateTimes,
           searchAfterTimeDurations: result.searchAfterTimes,
-          lastLookBackDate: result.lastLookBackDate?.toISOString(),
+          lastLookBackDate: moment(result.lastLookBackDate).isValid()
+            ? result.lastLookBackDate?.toISOString()
+            : undefined,
         });
       }
     },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -8,7 +8,6 @@
 
 import { Logger, KibanaRequest } from 'src/core/server';
 
-import moment from 'moment';
 import {
   SIGNALS_ID,
   DEFAULT_SEARCH_AFTER_PAGE_SIZE,
@@ -526,9 +525,7 @@ export const signalRulesAlertType = ({
             await ruleStatusService.success('succeeded', {
               bulkCreateTimeDurations: result.bulkCreateTimes,
               searchAfterTimeDurations: result.searchAfterTimes,
-              lastLookBackDate: moment(result.lastLookBackDate).isValid()
-                ? result.lastLookBackDate?.toISOString()
-                : undefined,
+              lastLookBackDate: result.lastLookBackDate?.toISOString(),
             });
           }
         } else {
@@ -540,9 +537,7 @@ export const signalRulesAlertType = ({
           await ruleStatusService.error(errorMessage, {
             bulkCreateTimeDurations: result.bulkCreateTimes,
             searchAfterTimeDurations: result.searchAfterTimes,
-            lastLookBackDate: moment(result.lastLookBackDate).isValid()
-              ? result.lastLookBackDate?.toISOString()
-              : undefined,
+            lastLookBackDate: result.lastLookBackDate?.toISOString(),
           });
         }
       } catch (error) {
@@ -556,9 +551,7 @@ export const signalRulesAlertType = ({
         await ruleStatusService.error(message, {
           bulkCreateTimeDurations: result.bulkCreateTimes,
           searchAfterTimeDurations: result.searchAfterTimes,
-          lastLookBackDate: moment(result.lastLookBackDate).isValid()
-            ? result.lastLookBackDate?.toISOString()
-            : undefined,
+          lastLookBackDate: result.lastLookBackDate?.toISOString(),
         });
       }
     },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
@@ -15,6 +15,9 @@ import { getListArrayMock } from '../../../../common/detection_engine/schemas/ty
 import { getExceptionListItemSchemaMock } from '../../../../../lists/common/schemas/response/exception_list_item_schema.mock';
 import { parseScheduleDates } from '../../../../common/detection_engine/parse_schedule_dates';
 
+// @ts-expect-error
+moment.suppressDeprecationWarnings = true;
+
 import {
   generateId,
   parseInterval,
@@ -32,6 +35,7 @@ import {
   createSearchAfterReturnType,
   mergeReturns,
   createTotalHitsFromSearchResult,
+  lastValidDate,
 } from './utils';
 import { BulkResponseErrorAggregation, SearchAfterAndBulkCreateReturnType } from './types';
 import {
@@ -981,6 +985,43 @@ describe('utils', () => {
       (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = null;
       const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({ searchResult });
       expect(lastLookBackDate).toEqual(null);
+    });
+
+    test('It will not set an invalid date time stamp from an invalid @timestamp string', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = 'invalid';
+      const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({ searchResult });
+      expect(lastLookBackDate).toEqual(null);
+    });
+  });
+
+  describe('lastValidDate', () => {
+    test('It returns undefined if the search result contains a null timestamp', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = null;
+      const date = lastValidDate(searchResult);
+      expect(date).toEqual(undefined);
+    });
+
+    test('It returns undefined if the search result contains a undefined timestamp', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = undefined;
+      const date = lastValidDate(searchResult);
+      expect(date).toEqual(undefined);
+    });
+
+    test('It returns undefined if the search result contains an invalid string value', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = 'invalid value';
+      const date = lastValidDate(searchResult);
+      expect(date).toEqual(undefined);
+    });
+
+    test('It returns correct date time stamp if the search result contains an invalid string value', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = 'invalid value';
+      const date = lastValidDate(searchResult);
+      expect(date).toEqual(undefined);
     });
   });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.test.ts
@@ -45,6 +45,7 @@ import {
   sampleEmptyDocSearchResults,
   sampleDocSearchResultsNoSortIdNoHits,
   repeatedSearchResultsWithSortId,
+  sampleDocSearchResultsNoSortId,
 } from './__mocks__/es_results';
 import { ShardError } from '../../types';
 
@@ -966,6 +967,20 @@ describe('utils', () => {
       searchResult._shards.failed = 0;
       const { success } = createSearchAfterReturnTypeFromResponse({ searchResult });
       expect(success).toEqual(true);
+    });
+
+    test('It will not set an invalid date time stamp from a non-existent @timestamp when the index is not 100% ECS compliant', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = undefined;
+      const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({ searchResult });
+      expect(lastLookBackDate).toEqual(null);
+    });
+
+    test('It will not set an invalid date time stamp from a null @timestamp when the index is not 100% ECS compliant', () => {
+      const searchResult = sampleDocSearchResultsNoSortId();
+      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = null;
+      const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({ searchResult });
+      expect(lastLookBackDate).toEqual(null);
     });
   });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -523,13 +523,12 @@ export const lastValidDate = (result: SignalSearchResponse): Date | undefined =>
   if (result.hits.hits.length === 0) {
     return undefined;
   } else {
-    const lastElementTimeStamp =
-      result.hits.hits[result.hits.hits.length - 1]._source['@timestamp'];
-    const isValid = lastElementTimeStamp != null && moment(lastElementTimeStamp).isValid();
+    const lastTimestamp = result.hits.hits[result.hits.hits.length - 1]._source['@timestamp'];
+    const isValid = lastTimestamp != null && moment(lastTimestamp).isValid();
     if (!isValid) {
       return undefined;
     } else {
-      return new Date(lastElementTimeStamp);
+      return new Date(lastTimestamp);
     }
   }
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -514,6 +514,26 @@ export const createErrorsFromShard = ({ errors }: { errors: ShardError[] }): str
   });
 };
 
+/**
+ * Given a SignalSearchResponse this will return a valid last date if it can find one, otherwise it
+ * will return undefined.
+ * @param result The result to try and parse out the timestamp.
+ */
+export const lastValidDate = (result: SignalSearchResponse): Date | undefined => {
+  if (result.hits.hits.length === 0) {
+    return undefined;
+  } else {
+    const lastElementTimeStamp =
+      result.hits.hits[result.hits.hits.length - 1]._source['@timestamp'];
+    const isValid = lastElementTimeStamp != null && moment(lastElementTimeStamp).isValid();
+    if (!isValid) {
+      return undefined;
+    } else {
+      return new Date(lastElementTimeStamp);
+    }
+  }
+};
+
 export const createSearchAfterReturnTypeFromResponse = ({
   searchResult,
 }: {
@@ -521,11 +541,7 @@ export const createSearchAfterReturnTypeFromResponse = ({
 }): SearchAfterAndBulkCreateReturnType => {
   return createSearchAfterReturnType({
     success: searchResult._shards.failed === 0,
-    lastLookBackDate:
-      searchResult.hits.hits.length > 0 &&
-      searchResult.hits.hits[searchResult.hits.hits.length - 1]?._source['@timestamp'] != null
-        ? new Date(searchResult.hits.hits[searchResult.hits.hits.length - 1]._source['@timestamp'])
-        : undefined,
+    lastLookBackDate: lastValidDate(searchResult),
   });
 };
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/utils.ts
@@ -522,8 +522,9 @@ export const createSearchAfterReturnTypeFromResponse = ({
   return createSearchAfterReturnType({
     success: searchResult._shards.failed === 0,
     lastLookBackDate:
-      searchResult.hits.hits.length > 0
-        ? new Date(searchResult.hits.hits[searchResult.hits.hits.length - 1]?._source['@timestamp'])
+      searchResult.hits.hits.length > 0 &&
+      searchResult.hits.hits[searchResult.hits.hits.length - 1]?._source['@timestamp'] != null
+        ? new Date(searchResult.hits.hits[searchResult.hits.hits.length - 1]._source['@timestamp'])
         : undefined,
   });
 };


### PR DESCRIPTION
## Summary

Right now even though it is not 100% ECS compliant a user can create a source index that has records which do not have the `@timestamp` but rather utilizes their own timestamp data and then within the detection engine they do an "override" to utilize that other timestamp.

To reproduce this simply add a lot of data records to an index and omit the `@timestamp` and then use the detection engine override to choose a different date timestamp. Before this fix you will see errors showing up during rule run even though it still does produce valid signals.

After this fix, you will not get errors showing up as we do not allow unusual things such as:

```ts
new Date(undefined).toISOString()
```

To occur which is what does the range throw. If you are on the estc server you can use the mapping I created called:

```ts
delme-alert-customer
```

With the override of `triggered`

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios