### PR TITLE
[APM] Fix anomaly detection setup header link for environment: All

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Links/apm/AnomalyDetectionSetupLink.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/AnomalyDetectionSetupLink.tsx
@@ -9,7 +9,10 @@ import { i18n } from '@kbn/i18n';
 import { useApmPluginContext } from '../../../../hooks/useApmPluginContext';
 import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { APMLink } from './APMLink';
-import { getEnvironmentLabel } from '../../../../../common/environment_filter_values';
+import {
+  ENVIRONMENT_ALL,
+  getEnvironmentLabel,
+} from '../../../../../common/environment_filter_values';
 import { useUrlParams } from '../../../../hooks/useUrlParams';
 import { useFetcher, FETCH_STATUS } from '../../../../hooks/useFetcher';
 import { useLicense } from '../../../../hooks/useLicense';
@@ -57,7 +60,8 @@ export function MissingJobsAlert({ environment }: { environment?: string }) {
     return null;
   }
 
-  const isEnvironmentSelected = !!environment;
+  const isEnvironmentSelected =
+    environment && environment !== ENVIRONMENT_ALL.value;
 
   // there are jobs for at least one environment
   if (!isEnvironmentSelected && data.jobs.length > 0) {
@@ -80,7 +84,7 @@ export function MissingJobsAlert({ environment }: { environment?: string }) {
 }
 
 function getTooltipText(environment?: string) {
-  if (!environment) {
+  if (!environment || environment === ENVIRONMENT_ALL.value) {
     return i18n.translate('xpack.apm.anomalyDetectionSetup.notEnabledText', {
       defaultMessage: `Anomaly detection is not yet enabled. Click to continue setup.`,
     });

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/anomaly_detection_setup_link.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/anomaly_detection_setup_link.test.tsx
@@ -96,4 +96,15 @@ describe('MissingJobsAlert', () => {
       expect(toolTipText).toBe(undefined);
     });
   });
+
+  describe('when at least one job exists and all environments are selected', () => {
+    it('does not show a warning', async () => {
+      const { toolTipAnchor, toolTipText } = await renderTooltipAnchor({
+        jobs: [{ environment: 'ENVIRONMENT_ALL', job_id: 'my_job_id' }],
+      });
+
+      expect(toolTipAnchor).not.toBeInTheDocument();
+      expect(toolTipText).toBe(undefined);
+    });
+  });
 });


### PR DESCRIPTION
Closes #79796. Fixes bug in the anomaly detection setup header link showing an alert when environment: All was selected even when there were anomaly detection jobs
