### PR TITLE
[Security Solution][Detection Engine] Fixes critical bug with the same index being passed in

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.test.tsx
@@ -67,7 +67,7 @@ describe('Helpers', () => {
         type: 'mapping',
         value: 'some os',
       };
-      const output = getFormattedEntry(payloadIndexPattern, payloadItem, 0);
+      const output = getFormattedEntry(payloadIndexPattern, payloadIndexPattern, payloadItem, 0);
       const expected: FormattedEntry = {
         entryIndex: 0,
         field: {
@@ -88,15 +88,73 @@ describe('Helpers', () => {
   });
 
   describe('#getFormattedEntries', () => {
-    test('it returns formatted entry with fields undefined if it unable to find a matching index pattern field', () => {
-      const payloadIndexPattern: IndexPattern = getMockIndexPattern();
+    test('it returns formatted entry with field and value undefined if it unable to find a matching index pattern field', () => {
+      const payloadIndexPattern = getMockIndexPattern();
       const payloadItems: Entry[] = [{ field: 'field.one', type: 'mapping', value: 'field.one' }];
-      const output = getFormattedEntries(payloadIndexPattern, payloadItems);
+      const output = getFormattedEntries(payloadIndexPattern, payloadIndexPattern, payloadItems);
       const expected: FormattedEntry[] = [
         {
           entryIndex: 0,
           field: undefined,
           value: undefined,
+          type: 'mapping',
+        },
+      ];
+      expect(output).toEqual(expected);
+    });
+
+    test('it returns "undefined" value if cannot match a pattern field', () => {
+      const payloadIndexPattern = getMockIndexPattern();
+      const payloadItems: Entry[] = [{ field: 'machine.os', type: 'mapping', value: 'yolo' }];
+      const output = getFormattedEntries(payloadIndexPattern, payloadIndexPattern, payloadItems);
+      const expected: FormattedEntry[] = [
+        {
+          entryIndex: 0,
+          field: {
+            name: 'machine.os',
+            type: 'string',
+            esTypes: ['text'],
+            count: 0,
+            scripted: false,
+            searchable: true,
+            aggregatable: true,
+            readFromDocValues: false,
+          },
+          value: undefined,
+          type: 'mapping',
+        },
+      ];
+      expect(output).toEqual(expected);
+    });
+
+    test('it returns value and field when they match two independent index patterns', () => {
+      const payloadIndexPattern = getMockIndexPattern();
+      const threatIndexPattern = getMockIndexPattern();
+      const payloadItems: Entry[] = [{ field: 'machine.os', type: 'mapping', value: 'machine.os' }];
+      const output = getFormattedEntries(payloadIndexPattern, threatIndexPattern, payloadItems);
+      const expected: FormattedEntry[] = [
+        {
+          entryIndex: 0,
+          field: {
+            name: 'machine.os',
+            type: 'string',
+            esTypes: ['text'],
+            count: 0,
+            scripted: false,
+            searchable: true,
+            aggregatable: true,
+            readFromDocValues: false,
+          },
+          value: {
+            name: 'machine.os',
+            type: 'string',
+            esTypes: ['text'],
+            count: 0,
+            scripted: false,
+            searchable: true,
+            aggregatable: true,
+            readFromDocValues: false,
+          },
           type: 'mapping',
         },
       ];
@@ -109,7 +167,7 @@ describe('Helpers', () => {
         { field: 'machine.os', type: 'mapping', value: 'machine.os' },
         { field: 'ip', type: 'mapping', value: 'ip' },
       ];
-      const output = getFormattedEntries(payloadIndexPattern, payloadItems);
+      const output = getFormattedEntries(payloadIndexPattern, payloadIndexPattern, payloadItems);
       const expected: FormattedEntry[] = [
         {
           field: {

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/helpers.tsx
@@ -22,14 +22,16 @@ import { Entry, FormattedEntry, ThreatMapEntries, EmptyEntry } from './types';
  */
 export const getFormattedEntry = (
   indexPattern: IndexPattern,
+  threatIndexPatterns: IndexPattern,
   item: Entry,
   itemIndex: number
 ): FormattedEntry => {
   const { fields } = indexPattern;
+  const { fields: threatFields } = threatIndexPatterns;
   const field = item.field;
   const threatField = item.value;
   const [foundField] = fields.filter(({ name }) => field != null && field === name);
-  const [threatFoundField] = fields.filter(
+  const [threatFoundField] = threatFields.filter(
     ({ name }) => threatField != null && threatField === name
   );
   return {
@@ -48,10 +50,11 @@ export const getFormattedEntry = (
  */
 export const getFormattedEntries = (
   indexPattern: IndexPattern,
+  threatIndexPatterns: IndexPattern,
   entries: Entry[]
 ): FormattedEntry[] => {
   return entries.reduce<FormattedEntry[]>((acc, item, index) => {
-    const newItemEntry = getFormattedEntry(indexPattern, item, index);
+    const newItemEntry = getFormattedEntry(indexPattern, threatIndexPatterns, item, index);
     return [...acc, newItemEntry];
   }, []);
 };

--- a/x-pack/plugins/security_solution/public/common/components/threat_match/list_item.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/threat_match/list_item.tsx
@@ -72,9 +72,9 @@ export const ListItemComponent = React.memo<ListItemProps>(
     const entries = useMemo(
       (): FormattedEntry[] =>
         indexPattern != null && listItem.entries.length > 0
-          ? getFormattedEntries(indexPattern, listItem.entries)
+          ? getFormattedEntries(indexPattern, threatIndexPatterns, listItem.entries)
           : [],
-      [listItem.entries, indexPattern]
+      [listItem.entries, indexPattern, threatIndexPatterns]
     );
     return (
       <EuiFlexItem>


### PR DESCRIPTION
## Summary

If you had two different index patterns for threat and your query I was previously sending the same pattern in for both which was causing drop down boxes for threat match to null things out. Now, I set the two different indexes correctly. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
