### PR TITLE
Fix link to fleet docs

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/setup_page/index.tsx
@@ -239,7 +239,7 @@ xpack.security.authc.api_key.enabled: true`}
               values={{
                 encryptionKeyLink: (
                   <EuiLink
-                    href="https://www.elastic.co/guide/en/kibana/current/ingest-manager-settings-kb.html"
+                    href="https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html"
                     target="_blank"
                     external
                   >


### PR DESCRIPTION
## Summary

Updates link to Fleet settings documentation.

NOTE: This link won't be live until 7.10 is released. Creating draft PR to remind me to change it. 

