### PR TITLE
[Security Solution][Case] Fix bug when changing connectors

### DIFF
--- a/x-pack/plugins/case/server/routes/api/cases/post_case.ts
+++ b/x-pack/plugins/case/server/routes/api/cases/post_case.ts
@@ -66,7 +66,7 @@ export function initPostCaseApi({
               actionAt: createdDate,
               actionBy: { username, full_name, email },
               caseId: newCase.id,
-              fields: ['description', 'status', 'tags', 'title'],
+              fields: ['description', 'status', 'tags', 'title', 'connector'],
               newValue: JSON.stringify(query),
             }),
           ],

--- a/x-pack/plugins/security_solution/public/cases/containers/use_get_case_user_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/cases/containers/use_get_case_user_actions.test.tsx
@@ -111,6 +111,7 @@ describe('useGetCaseUserActions', () => {
       });
     });
   });
+
   describe('getPushedInfo', () => {
     it('Correctly marks first/last index - hasDataToPush: false', () => {
       const userActions = [...caseUserActions, getUserAction(['pushed'], 'push-to-service')];
@@ -226,7 +227,7 @@ describe('useGetCaseUserActions', () => {
       });
     });
 
-    it('Does not count connector_id update as a reason to push', () => {
+    it('Does not count connector update as a reason to push', () => {
       const userActions = [
         ...caseUserActions,
         getUserAction(['pushed'], 'push-to-service'),
@@ -246,6 +247,7 @@ describe('useGetCaseUserActions', () => {
         },
       });
     });
+
     it('Correctly handles multiple push actions', () => {
       const userActions = [
         ...caseUserActions,
@@ -267,6 +269,7 @@ describe('useGetCaseUserActions', () => {
         },
       });
     });
+
     it('Correctly handles comment update with multiple push actions', () => {
       const userActions = [
         ...caseUserActions,
@@ -298,6 +301,7 @@ describe('useGetCaseUserActions', () => {
         connector_name: 'other connector name',
         external_id: 'other_external_id',
       };
+
       const pushAction456 = {
         ...getUserAction(['pushed'], 'push-to-service'),
         newValue: JSON.stringify(push456),
@@ -309,7 +313,9 @@ describe('useGetCaseUserActions', () => {
         getUserAction(['comment'], 'create'),
         pushAction456,
       ];
+
       const result = getPushedInfo(userActions, '123');
+
       expect(result).toEqual({
         hasDataToPush: true,
         caseServices: {
@@ -342,6 +348,7 @@ describe('useGetCaseUserActions', () => {
         connector_name: 'other connector name',
         external_id: 'other_external_id',
       };
+
       const pushAction456 = {
         ...getUserAction(['pushed'], 'push-to-service'),
         newValue: JSON.stringify(push456),
@@ -353,6 +360,7 @@ describe('useGetCaseUserActions', () => {
         getUserAction(['comment'], 'create'),
         pushAction456,
       ];
+
       const result = getPushedInfo(userActions, '456');
       expect(result).toEqual({
         hasDataToPush: false,
@@ -371,6 +379,326 @@ describe('useGetCaseUserActions', () => {
             externalId: 'other_external_id',
             firstPushIndex: 5,
             lastPushIndex: 5,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+        },
+      });
+    });
+
+    it('Change fields of current connector - hasDataToPush: true', () => {
+      const userActions = [
+        ...caseUserActions,
+        getUserAction(['pushed'], 'push-to-service'),
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: true,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 3,
+            lastPushIndex: 3,
+            commentsToUpdate: [],
+            hasDataToPush: true,
+          },
+        },
+      });
+    });
+
+    it('Change current connector - hasDataToPush: true', () => {
+      const userActions = [
+        ...caseUserActions,
+        getUserAction(['pushed'], 'push-to-service'),
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: false,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 3,
+            lastPushIndex: 3,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+        },
+      });
+    });
+
+    it('Change connector and back - hasDataToPush: true', () => {
+      const userActions = [
+        ...caseUserActions,
+        getUserAction(['pushed'], 'push-to-service'),
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: false,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 3,
+            lastPushIndex: 3,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+        },
+      });
+    });
+
+    it('Change fields and connector after push - hasDataToPush: true', () => {
+      const userActions = [
+        ...caseUserActions,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+        getUserAction(['pushed'], 'push-to-service'),
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'Low' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: true,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 4,
+            lastPushIndex: 4,
+            commentsToUpdate: [],
+            hasDataToPush: true,
+          },
+        },
+      });
+    });
+
+    it('Change only connector after push - hasDataToPush: false', () => {
+      const userActions = [
+        ...caseUserActions,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+        getUserAction(['pushed'], 'push-to-service'),
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: false,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 4,
+            lastPushIndex: 4,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+        },
+      });
+    });
+
+    it('Change connectors and fields - multiple pushes', () => {
+      const pushAction123 = getUserAction(['pushed'], 'push-to-service');
+      const push456 = {
+        ...basicPushSnake,
+        connector_id: '456',
+        connector_name: 'other connector name',
+        external_id: 'other_external_id',
+      };
+
+      const pushAction456 = {
+        ...getUserAction(['pushed'], 'push-to-service'),
+        newValue: JSON.stringify(push456),
+      };
+
+      const userActions = [
+        ...caseUserActions,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+        pushAction123,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        pushAction456,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'Low' } }),
+        },
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'Low' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'Low' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: true,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 4,
+            lastPushIndex: 4,
+            commentsToUpdate: [],
+            hasDataToPush: true,
+          },
+          '456': {
+            ...basicPush,
+            connectorId: '456',
+            connectorName: 'other connector name',
+            externalId: 'other_external_id',
+            firstPushIndex: 6,
+            lastPushIndex: 6,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+        },
+      });
+    });
+
+    it('pushing other connectors does not count as an update', () => {
+      const pushAction123 = getUserAction(['pushed'], 'push-to-service');
+      const push456 = {
+        ...basicPushSnake,
+        connector_id: '456',
+        connector_name: 'other connector name',
+        external_id: 'other_external_id',
+      };
+
+      const pushAction456 = {
+        ...getUserAction(['pushed'], 'push-to-service'),
+        newValue: JSON.stringify(push456),
+      };
+      const userActions = [
+        ...caseUserActions,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+        pushAction123,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        pushAction456,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: false,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 4,
+            lastPushIndex: 4,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+          '456': {
+            ...basicPush,
+            connectorId: '456',
+            connectorName: 'other connector name',
+            externalId: 'other_external_id',
+            firstPushIndex: 6,
+            lastPushIndex: 6,
+            commentsToUpdate: [],
+            hasDataToPush: false,
+          },
+        },
+      });
+    });
+
+    it('Changing other connectors fields does not count as an update', () => {
+      const userActions = [
+        ...caseUserActions,
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: null } }),
+          newValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+        },
+        getUserAction(['pushed'], 'push-to-service'),
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '123', fields: { issueType: '10006', priority: 'High' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+        },
+        {
+          ...getUserAction(['connector'], 'update'),
+          oldValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '6' } }),
+          newValue: JSON.stringify({ id: '456', fields: { issueTypes: ['10'], severity: '3' } }),
+        },
+      ];
+
+      const result = getPushedInfo(userActions, '123');
+      expect(result).toEqual({
+        hasDataToPush: false,
+        caseServices: {
+          '123': {
+            ...basicPush,
+            firstPushIndex: 4,
+            lastPushIndex: 4,
             commentsToUpdate: [],
             hasDataToPush: false,
           },

--- a/x-pack/test/case_api_integration/basic/tests/cases/user_actions/get_all_user_actions.ts
+++ b/x-pack/test/case_api_integration/basic/tests/cases/user_actions/get_all_user_actions.ts
@@ -35,7 +35,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await actionsRemover.removeAll();
     });
 
-    it(`on new case, user action: 'create' should be called with actionFields: ['description', 'status', 'tags', 'title']`, async () => {
+    it(`on new case, user action: 'create' should be called with actionFields: ['description', 'status', 'tags', 'title', 'connector']`, async () => {
       const { body: postedCase } = await supertest
         .post(CASES_URL)
         .set('kbn-xsrf', 'true')
@@ -48,7 +48,7 @@ export default ({ getService }: FtrProviderContext): void => {
         .expect(200);
       expect(body.length).to.eql(1);
 
-      expect(body[0].action_field).to.eql(['description', 'status', 'tags', 'title']);
+      expect(body[0].action_field).to.eql(['description', 'status', 'tags', 'title', 'connector']);
       expect(body[0].action).to.eql('create');
       expect(body[0].old_value).to.eql(null);
       expect(body[0].new_value).to.eql(JSON.stringify(postCaseReq));


### PR DESCRIPTION
## Summary

This PR closes https://github.com/elastic/kibana/issues/79833.

When you change a connector and at the same time you change a field you cannot push the new changes to the connector. You need to do it in two steps, first, change the connector and then change the field.

This PR fixes this issue.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
