### PR TITLE
index pattern server api simpler dependency

### DIFF
--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.indexpatternsservice.start.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.indexpatternsservice.start.md
@@ -8,7 +8,7 @@
 
 ```typescript
 start(core: CoreStart, { fieldFormats, logger }: IndexPatternsServiceStartDeps): {
-        indexPatternsServiceFactory: (kibanaRequest: KibanaRequest) => Promise<IndexPatternsCommonService>;
+        indexPatternsServiceFactory: (savedObjectsClient: SavedObjectsClientContract) => Promise<IndexPatternsCommonService>;
     };
 ```
 
@@ -22,6 +22,6 @@ start(core: CoreStart, { fieldFormats, logger }: IndexPatternsServiceStartDeps):
 <b>Returns:</b>
 
 `{
-        indexPatternsServiceFactory: (kibanaRequest: KibanaRequest) => Promise<IndexPatternsCommonService>;
+        indexPatternsServiceFactory: (savedObjectsClient: SavedObjectsClientContract) => Promise<IndexPatternsCommonService>;
     }`
 

--- a/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.plugin.start.md
+++ b/docs/development/plugins/data/server/kibana-plugin-plugins-data-server.plugin.start.md
@@ -12,7 +12,7 @@ start(core: CoreStart): {
             fieldFormatServiceFactory: (uiSettings: import("../../../core/server").IUiSettingsClient) => Promise<import("../common").FieldFormatsRegistry>;
         };
         indexPatterns: {
-            indexPatternsServiceFactory: (kibanaRequest: import("../../../core/server").KibanaRequest<unknown, unknown, unknown, any>) => Promise<import("../public").IndexPatternsService>;
+            indexPatternsServiceFactory: (savedObjectsClient: Pick<import("../../../core/server").SavedObjectsClient, "update" | "find" | "get" | "delete" | "errors" | "create" | "bulkCreate" | "checkConflicts" | "bulkGet" | "addToNamespaces" | "deleteFromNamespaces" | "bulkUpdate">) => Promise<import("../public").IndexPatternsService>;
         };
         search: ISearchStart<import("./search").IEsSearchRequest, import("./search").IEsSearchResponse<any>>;
     };
@@ -31,7 +31,7 @@ start(core: CoreStart): {
             fieldFormatServiceFactory: (uiSettings: import("../../../core/server").IUiSettingsClient) => Promise<import("../common").FieldFormatsRegistry>;
         };
         indexPatterns: {
-            indexPatternsServiceFactory: (kibanaRequest: import("../../../core/server").KibanaRequest<unknown, unknown, unknown, any>) => Promise<import("../public").IndexPatternsService>;
+            indexPatternsServiceFactory: (savedObjectsClient: Pick<import("../../../core/server").SavedObjectsClient, "update" | "find" | "get" | "delete" | "errors" | "create" | "bulkCreate" | "checkConflicts" | "bulkGet" | "addToNamespaces" | "deleteFromNamespaces" | "bulkUpdate">) => Promise<import("../public").IndexPatternsService>;
         };
         search: ISearchStart<import("./search").IEsSearchRequest, import("./search").IEsSearchResponse<any>>;
     }`

--- a/src/plugins/data/server/index_patterns/index_patterns_service.ts
+++ b/src/plugins/data/server/index_patterns/index_patterns_service.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { CoreSetup, CoreStart, Plugin, KibanaRequest, Logger } from 'kibana/server';
+import { CoreSetup, CoreStart, Plugin, Logger, SavedObjectsClientContract } from 'kibana/server';
 import { registerRoutes } from './routes';
 import { indexPatternSavedObjectType } from '../saved_objects';
 import { capabilitiesProvider } from './capabilities_provider';
@@ -29,7 +29,7 @@ import { SavedObjectsClientServerToCommon } from './saved_objects_client_wrapper
 
 export interface IndexPatternsServiceStart {
   indexPatternsServiceFactory: (
-    kibanaRequest: KibanaRequest
+    savedObjectsClient: SavedObjectsClientContract
   ) => Promise<IndexPatternsCommonService>;
 }
 
@@ -47,11 +47,11 @@ export class IndexPatternsService implements Plugin<void, IndexPatternsServiceSt
   }
 
   public start(core: CoreStart, { fieldFormats, logger }: IndexPatternsServiceStartDeps) {
-    const { uiSettings, savedObjects } = core;
+    const { uiSettings } = core;
 
     return {
-      indexPatternsServiceFactory: async (kibanaRequest: KibanaRequest) => {
-        const savedObjectsClient = savedObjects.getScopedClient(kibanaRequest);
+      // indexPatternsServiceFactory: async (kibanaRequest: KibanaRequest) => {
+      indexPatternsServiceFactory: async (savedObjectsClient: SavedObjectsClientContract) => {
         const uiSettingsClient = uiSettings.asScopedToClient(savedObjectsClient);
         const formats = await fieldFormats.fieldFormatServiceFactory(uiSettingsClient);
 

--- a/src/plugins/data/server/index_patterns/index_patterns_service.ts
+++ b/src/plugins/data/server/index_patterns/index_patterns_service.ts
@@ -50,7 +50,6 @@ export class IndexPatternsService implements Plugin<void, IndexPatternsServiceSt
     const { uiSettings } = core;
 
     return {
-      // indexPatternsServiceFactory: async (kibanaRequest: KibanaRequest) => {
       indexPatternsServiceFactory: async (savedObjectsClient: SavedObjectsClientContract) => {
         const uiSettingsClient = uiSettings.asScopedToClient(savedObjectsClient);
         const formats = await fieldFormats.fieldFormatServiceFactory(uiSettingsClient);

--- a/src/plugins/data/server/search/search_service.ts
+++ b/src/plugins/data/server/search/search_service.ts
@@ -162,7 +162,9 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
         asScoped: async (request: KibanaRequest) => {
           const esClient = elasticsearch.client.asScoped(request);
           const savedObjectsClient = savedObjects.getScopedClient(request);
-          const scopedIndexPatterns = await indexPatterns.indexPatternsServiceFactory(request);
+          const scopedIndexPatterns = await indexPatterns.indexPatternsServiceFactory(
+            savedObjectsClient
+          );
           const uiSettingsClient = uiSettings.asScopedToClient(savedObjectsClient);
 
           // cache ui settings, only including items which are explicitly needed by SearchSource

--- a/src/plugins/data/server/server.api.md
+++ b/src/plugins/data/server/server.api.md
@@ -23,7 +23,6 @@ import { ExpressionsServerSetup } from 'src/plugins/expressions/server';
 import { ISearchOptions as ISearchOptions_2 } from 'src/plugins/data/public';
 import { ISearchSource } from 'src/plugins/data/public';
 import { KibanaRequest } from 'src/core/server';
-import { KibanaRequest as KibanaRequest_2 } from 'kibana/server';
 import { LegacyAPICaller } from 'kibana/server';
 import { Logger } from 'kibana/server';
 import { LoggerFactory } from '@kbn/logging';
@@ -42,6 +41,7 @@ import { RequestHandlerContext } from 'src/core/server';
 import { RequestStatistics } from 'src/plugins/inspector/common';
 import { SavedObject } from 'src/core/server';
 import { SavedObjectsClientContract } from 'src/core/server';
+import { SavedObjectsClientContract as SavedObjectsClientContract_2 } from 'kibana/server';
 import { Search } from '@elastic/elasticsearch/api/requestParams';
 import { SearchResponse } from 'elasticsearch';
 import { SerializedFieldFormat as SerializedFieldFormat_2 } from 'src/plugins/expressions/common';
@@ -675,7 +675,7 @@ export class IndexPatternsService implements Plugin_3<void, IndexPatternsService
     //
     // (undocumented)
     start(core: CoreStart_2, { fieldFormats, logger }: IndexPatternsServiceStartDeps): {
-        indexPatternsServiceFactory: (kibanaRequest: KibanaRequest_2) => Promise<IndexPatternsService_2>;
+        indexPatternsServiceFactory: (savedObjectsClient: SavedObjectsClientContract_2) => Promise<IndexPatternsService_2>;
     };
 }
 
@@ -879,7 +879,7 @@ export class Plugin implements Plugin_2<PluginSetup, PluginStart, DataPluginSetu
             fieldFormatServiceFactory: (uiSettings: import("../../../core/server").IUiSettingsClient) => Promise<import("../common").FieldFormatsRegistry>;
         };
         indexPatterns: {
-            indexPatternsServiceFactory: (kibanaRequest: import("../../../core/server").KibanaRequest<unknown, unknown, unknown, any>) => Promise<import("../public").IndexPatternsService>;
+            indexPatternsServiceFactory: (savedObjectsClient: Pick<import("../../../core/server").SavedObjectsClient, "update" | "find" | "get" | "delete" | "errors" | "create" | "bulkCreate" | "checkConflicts" | "bulkGet" | "addToNamespaces" | "deleteFromNamespaces" | "bulkUpdate">) => Promise<import("../public").IndexPatternsService>;
         };
         search: ISearchStart<import("./search").IEsSearchRequest, import("./search").IEsSearchResponse<any>>;
     };

--- a/src/plugins/vis_type_timeseries/server/lib/get_fields.ts
+++ b/src/plugins/vis_type_timeseries/server/lib/get_fields.ts
@@ -62,8 +62,11 @@ export async function getFields(
   let indexPatternString = indexPattern;
 
   if (!indexPatternString) {
-    const [, { data }] = await framework.core.getStartServices();
-    const indexPatternsService = await data.indexPatterns.indexPatternsServiceFactory(request);
+    const [{ savedObjects }, { data }] = await framework.core.getStartServices();
+    const savedObjectsClient = savedObjects.getScopedClient(request);
+    const indexPatternsService = await data.indexPatterns.indexPatternsServiceFactory(
+      savedObjectsClient
+    );
     const defaultIndexPattern = await indexPatternsService.getDefault();
     indexPatternString = get(defaultIndexPattern, 'title', '');
   }

--- a/test/plugin_functional/plugins/data_search/server/plugin.ts
+++ b/test/plugin_functional/plugins/data_search/server/plugin.ts
@@ -58,12 +58,15 @@ export class DataSearchTestPlugin
         },
       },
       async (context, req, res) => {
-        const [, { data }] = await core.getStartServices();
+        const [{ savedObjects }, { data }] = await core.getStartServices();
         const service = await data.search.searchSource.asScoped(req);
+        const savedObjectsClient = savedObjects.getScopedClient(req);
 
         // Since the index pattern ID can change on each test run, we need
         // to look it up on the fly and insert it into the request.
-        const indexPatterns = await data.indexPatterns.indexPatternsServiceFactory(req);
+        const indexPatterns = await data.indexPatterns.indexPatternsServiceFactory(
+          savedObjectsClient
+        );
         const ids = await indexPatterns.getIds();
         // @ts-expect-error Force overwriting the request
         req.body.index = ids[0];

--- a/test/plugin_functional/plugins/index_patterns/server/plugin.ts
+++ b/test/plugin_functional/plugins/index_patterns/server/plugin.ts
@@ -39,8 +39,9 @@ export class IndexPatternsTestPlugin
     router.get(
       { path: '/api/index-patterns-plugin/get-all', validate: false },
       async (context, req, res) => {
-        const [, { data }] = await core.getStartServices();
-        const service = await data.indexPatterns.indexPatternsServiceFactory(req);
+        const [{ savedObjects }, { data }] = await core.getStartServices();
+        const savedObjectsClient = savedObjects.getScopedClient(req);
+        const service = await data.indexPatterns.indexPatternsServiceFactory(savedObjectsClient);
         const ids = await service.getIds();
         return res.ok({ body: ids });
       }
@@ -57,8 +58,9 @@ export class IndexPatternsTestPlugin
       },
       async (context, req, res) => {
         const id = (req.params as Record<string, string>).id;
-        const [, { data }] = await core.getStartServices();
-        const service = await data.indexPatterns.indexPatternsServiceFactory(req);
+        const [{ savedObjects }, { data }] = await core.getStartServices();
+        const savedObjectsClient = savedObjects.getScopedClient(req);
+        const service = await data.indexPatterns.indexPatternsServiceFactory(savedObjectsClient);
         const ip = await service.get(id);
         return res.ok({ body: ip.toSpec() });
       }
@@ -74,9 +76,10 @@ export class IndexPatternsTestPlugin
         },
       },
       async (context, req, res) => {
-        const [, { data }] = await core.getStartServices();
+        const [{ savedObjects }, { data }] = await core.getStartServices();
         const id = (req.params as Record<string, string>).id;
-        const service = await data.indexPatterns.indexPatternsServiceFactory(req);
+        const savedObjectsClient = savedObjects.getScopedClient(req);
+        const service = await data.indexPatterns.indexPatternsServiceFactory(savedObjectsClient);
         const ip = await service.get(id);
         await service.updateSavedObject(ip);
         return res.ok();
@@ -93,9 +96,10 @@ export class IndexPatternsTestPlugin
         },
       },
       async (context, req, res) => {
-        const [, { data }] = await core.getStartServices();
+        const [{ savedObjects }, { data }] = await core.getStartServices();
         const id = (req.params as Record<string, string>).id;
-        const service = await data.indexPatterns.indexPatternsServiceFactory(req);
+        const savedObjectsClient = savedObjects.getScopedClient(req);
+        const service = await data.indexPatterns.indexPatternsServiceFactory(savedObjectsClient);
         await service.delete(id);
         return res.ok();
       }


### PR DESCRIPTION
## Summary

Server side index pattern api should use the scoped object client instead of the kibana request because its a simpler dependency and sufficient for its use.
