### PR TITLE
Explicitly add permission for every single feature

### DIFF
--- a/x-pack/plugins/apm/scripts/kibana-security/setup-custom-kibana-user-role.ts
+++ b/x-pack/plugins/apm/scripts/kibana-security/setup-custom-kibana-user-role.ts
@@ -122,11 +122,69 @@ async function init() {
   });
   await createRole({
     roleName: KIBANA_READ_ROLE,
-    kibanaPrivileges: { base: ['read'] },
+    kibanaPrivileges: {
+      feature: {
+        // core
+        discover: ['read'],
+        dashboard: ['read'],
+        canvas: ['read'],
+        ml: ['read'],
+        maps: ['read'],
+        graph: ['read'],
+        visualize: ['read'],
+
+        // observability
+        logs: ['read'],
+        infrastructure: ['read'],
+        apm: ['read'],
+        uptime: ['read'],
+
+        // security
+        siem: ['read'],
+
+        // management
+        dev_tools: ['read'],
+        advancedSettings: ['read'],
+        indexPatterns: ['read'],
+        savedObjectsManagement: ['read'],
+        stackAlerts: ['read'],
+        ingestManager: ['read'],
+        actions: ['read'],
+      },
+    },
   });
   await createRole({
     roleName: KIBANA_WRITE_ROLE,
-    kibanaPrivileges: { base: ['all'] },
+    kibanaPrivileges: {
+      feature: {
+        // core
+        discover: ['all'],
+        dashboard: ['all'],
+        canvas: ['all'],
+        ml: ['all'],
+        maps: ['all'],
+        graph: ['all'],
+        visualize: ['all'],
+
+        // observability
+        logs: ['all'],
+        infrastructure: ['all'],
+        apm: ['all'],
+        uptime: ['all'],
+
+        // security
+        siem: ['all'],
+
+        // management
+        dev_tools: ['all'],
+        advancedSettings: ['all'],
+        indexPatterns: ['all'],
+        savedObjectsManagement: ['all'],
+        stackAlerts: ['all'],
+        ingestManager: ['all'],
+        actions: ['all'],
+      },
+    },
   });
 
   // read access only to APM + apm index access


### PR DESCRIPTION
Specifying `"base": ["all"]` should give permissions to all features but doesn't include ML. It's therefore necessary to explicitly specify every single feature that the role should have access to.