### PR TITLE
[Security Solution] [Detections] Disable edit button when user does not have actions privileges w/ rule + actions

### DIFF
--- a/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
@@ -22,7 +22,7 @@ export const canEditRuleWithActions = (
   if (rule == null) {
     return true;
   }
-  if (rule.actions != null && rule.actions.length > 0 && isBoolean(privileges)) {
+  if (rule.actions?.length > 0 && isBoolean(privileges)) {
     return privileges;
   }
   return true;

--- a/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
@@ -9,6 +9,8 @@ import * as i18n from '../../../detections/pages/detection_engine/rules/translat
 import { isMlRule } from '../../../../common/machine_learning/helpers';
 import * as detectionI18n from '../../../detections/pages/detection_engine/translations';
 
+export const isBoolean = (obj: unknown): obj is boolean => typeof obj === 'boolean';
+
 export const canEditRule = (
   rule: Rule | null | undefined,
   privileges:
@@ -20,8 +22,8 @@ export const canEditRule = (
   if (rule == null) {
     return true;
   }
-  if (rule.actions != null && rule.actions.length > 0) {
-    return privileges as boolean;
+  if (rule.actions != null && rule.actions.length > 0 && isBoolean(privileges)) {
+    return privileges;
   }
   return true;
 };
@@ -29,7 +31,11 @@ export const canEditRule = (
 export const getToolTipContent = (
   rule: Rule | null | undefined,
   hasMlPermissions: boolean,
-  hasReadActionsPrivileges: boolean
+  hasReadActionsPrivileges:
+    | boolean
+    | Readonly<{
+        [x: string]: boolean;
+      }>
 ): string | undefined => {
   if (rule == null) {
     return undefined;

--- a/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
@@ -11,7 +11,7 @@ import * as detectionI18n from '../../../detections/pages/detection_engine/trans
 
 export const isBoolean = (obj: unknown): obj is boolean => typeof obj === 'boolean';
 
-export const canEditRule = (
+export const canEditRuleWithActions = (
   rule: Rule | null | undefined,
   privileges:
     | boolean
@@ -41,7 +41,7 @@ export const getToolTipContent = (
     return undefined;
   } else if (isMlRule(rule.type) && !hasMlPermissions) {
     return detectionI18n.ML_RULES_DISABLED_MESSAGE;
-  } else if (!canEditRule(rule, hasReadActionsPrivileges)) {
+  } else if (!canEditRuleWithActions(rule, hasReadActionsPrivileges)) {
     return i18n.EDIT_RULE_SETTINGS_TOOLTIP;
   } else {
     return undefined;

--- a/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/privileges/index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { Rule } from '../../../detections/containers/detection_engine/rules';
+import * as i18n from '../../../detections/pages/detection_engine/rules/translations';
+import { isMlRule } from '../../../../common/machine_learning/helpers';
+import * as detectionI18n from '../../../detections/pages/detection_engine/translations';
+
+export const canEditRule = (
+  rule: Rule | null | undefined,
+  privileges:
+    | boolean
+    | Readonly<{
+        [x: string]: boolean;
+      }>
+): boolean => {
+  if (rule == null) {
+    return true;
+  }
+  if (rule.actions != null && rule.actions.length > 0) {
+    return privileges as boolean;
+  }
+  return true;
+};
+
+export const getToolTipContent = (
+  rule: Rule | null | undefined,
+  hasMlPermissions: boolean,
+  hasReadActionsPrivileges: boolean
+): string | undefined => {
+  if (rule == null) {
+    return undefined;
+  } else if (isMlRule(rule.type) && !hasMlPermissions) {
+    return detectionI18n.ML_RULES_DISABLED_MESSAGE;
+  } else if (!canEditRule(rule, hasReadActionsPrivileges)) {
+    return i18n.EDIT_RULE_SETTINGS_TOOLTIP;
+  } else {
+    return undefined;
+  }
+};

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/__snapshots__/index.test.tsx.snap
@@ -34,14 +34,19 @@ exports[`RuleActionsOverflow snapshots renders correctly against snapshot 1`] = 
       hasFocus={true}
       items={
         Array [
-          <EuiContextMenuItem
-            data-test-subj="rules-details-duplicate-rule"
-            disabled={false}
-            icon="copy"
-            onClick={[Function]}
+          <EuiToolTip
+            delay="regular"
+            position="left"
           >
-            Duplicate rule
-          </EuiContextMenuItem>,
+            <EuiContextMenuItem
+              data-test-subj="rules-details-duplicate-rule"
+              disabled={false}
+              icon="copy"
+              onClick={[Function]}
+            >
+              Duplicate rule
+            </EuiContextMenuItem>
+          </EuiToolTip>,
           <EuiContextMenuItem
             data-test-subj="rules-details-export-rule"
             disabled={false}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/__snapshots__/index.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/__snapshots__/index.test.tsx.snap
@@ -34,19 +34,21 @@ exports[`RuleActionsOverflow snapshots renders correctly against snapshot 1`] = 
       hasFocus={true}
       items={
         Array [
-          <EuiToolTip
-            delay="regular"
-            position="left"
+          <EuiContextMenuItem
+            data-test-subj="rules-details-duplicate-rule"
+            disabled={false}
+            icon="copy"
+            onClick={[Function]}
           >
-            <EuiContextMenuItem
-              data-test-subj="rules-details-duplicate-rule"
-              disabled={false}
-              icon="copy"
-              onClick={[Function]}
+            <EuiToolTip
+              delay="regular"
+              position="left"
             >
-              Duplicate rule
-            </EuiContextMenuItem>
-          </EuiToolTip>,
+              <React.Fragment>
+                Duplicate rule
+              </React.Fragment>
+            </EuiToolTip>
+          </EuiContextMenuItem>,
           <EuiContextMenuItem
             data-test-subj="rules-details-export-rule"
             disabled={false}

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.test.tsx
@@ -29,7 +29,11 @@ describe('RuleActionsOverflow', () => {
   describe('snapshots', () => {
     test('renders correctly against snapshot', () => {
       const wrapper = shallow(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       expect(wrapper).toMatchSnapshot();
     });
@@ -38,7 +42,11 @@ describe('RuleActionsOverflow', () => {
   describe('rules details menu panel', () => {
     test('there is at least one item when there is a rule within the rules-details-menu-panel', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -51,7 +59,13 @@ describe('RuleActionsOverflow', () => {
     });
 
     test('items are empty when there is a null rule within the rules-details-menu-panel', () => {
-      const wrapper = mount(<RuleActionsOverflow rule={null} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={null}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       expect(
@@ -60,7 +74,13 @@ describe('RuleActionsOverflow', () => {
     });
 
     test('items are empty when there is an undefined rule within the rules-details-menu-panel', () => {
-      const wrapper = mount(<RuleActionsOverflow rule={null} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={null}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       expect(
@@ -70,7 +90,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it opens the popover when rules-details-popover-button-icon is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -83,7 +107,11 @@ describe('RuleActionsOverflow', () => {
   describe('rules details pop over button icon', () => {
     test('it does not open the popover when rules-details-popover-button-icon is clicked when the user does not have permission', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={true} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={true}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -96,7 +124,13 @@ describe('RuleActionsOverflow', () => {
   describe('rules details duplicate rule', () => {
     test('it does not open the popover when rules-details-popover-button-icon is clicked and the user does not have permission', () => {
       const rule = mockRule('id');
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={true} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={true}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       expect(wrapper.find('[data-test-subj="rules-details-delete-rule"] button').exists()).toEqual(
@@ -106,7 +140,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it opens the popover when rules-details-popover-button-icon is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -117,7 +155,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it closes the popover when rules-details-duplicate-rule is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -130,7 +172,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it calls duplicateRulesAction when rules-details-duplicate-rule is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -141,7 +187,13 @@ describe('RuleActionsOverflow', () => {
 
     test('it calls duplicateRulesAction with the rule and rule.id when rules-details-duplicate-rule is clicked', () => {
       const rule = mockRule('id');
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       wrapper.find('[data-test-subj="rules-details-duplicate-rule"] button').simulate('click');
@@ -158,7 +210,13 @@ describe('RuleActionsOverflow', () => {
   describe('rules details export rule', () => {
     test('it does not open the popover when rules-details-popover-button-icon is clicked and the user does not have permission', () => {
       const rule = mockRule('id');
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={true} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={true}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       expect(wrapper.find('[data-test-subj="rules-details-export-rule"] button').exists()).toEqual(
@@ -168,7 +226,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it closes the popover when rules-details-export-rule is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -181,7 +243,13 @@ describe('RuleActionsOverflow', () => {
 
     test('it sets the rule.rule_id on the generic downloader when rules-details-export-rule is clicked', () => {
       const rule = mockRule('id');
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
@@ -194,7 +262,13 @@ describe('RuleActionsOverflow', () => {
     test('it does not close the pop over on rules-details-export-rule when the rule is an immutable rule and the user does a click', () => {
       const rule = mockRule('id');
       rule.immutable = true;
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
@@ -207,7 +281,13 @@ describe('RuleActionsOverflow', () => {
     test('it does not set the rule.rule_id on rules-details-export-rule when the rule is an immutable rule', () => {
       const rule = mockRule('id');
       rule.immutable = true;
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       wrapper.find('[data-test-subj="rules-details-export-rule"] button').simulate('click');
@@ -221,7 +301,13 @@ describe('RuleActionsOverflow', () => {
   describe('rules details delete rule', () => {
     test('it does not open the popover when rules-details-popover-button-icon is clicked and the user does not have permission', () => {
       const rule = mockRule('id');
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={true} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={true}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       expect(wrapper.find('[data-test-subj="rules-details-delete-rule"] button').exists()).toEqual(
@@ -231,7 +317,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it closes the popover when rules-details-delete-rule is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -244,7 +334,11 @@ describe('RuleActionsOverflow', () => {
 
     test('it calls deleteRulesAction when rules-details-delete-rule is clicked', () => {
       const wrapper = mount(
-        <RuleActionsOverflow rule={mockRule('id')} userHasNoPermissions={false} />
+        <RuleActionsOverflow
+          rule={mockRule('id')}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
       );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
@@ -255,7 +349,13 @@ describe('RuleActionsOverflow', () => {
 
     test('it calls deleteRulesAction with the rule.id when rules-details-delete-rule is clicked', () => {
       const rule = mockRule('id');
-      const wrapper = mount(<RuleActionsOverflow rule={rule} userHasNoPermissions={false} />);
+      const wrapper = mount(
+        <RuleActionsOverflow
+          rule={rule}
+          userHasNoPermissions={false}
+          canDuplicateRuleWithActions={true}
+        />
+      );
       wrapper.find('[data-test-subj="rules-details-popover-button-icon"] button').simulate('click');
       wrapper.update();
       wrapper.find('[data-test-subj="rules-details-delete-rule"] button').simulate('click');

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
@@ -41,6 +41,7 @@ const MyEuiButtonIcon = styled(EuiButtonIcon)`
 interface RuleActionsOverflowComponentProps {
   rule: Rule | null;
   userHasNoPermissions: boolean;
+  canDuplicateRuleWithActions: boolean;
 }
 
 /**
@@ -49,6 +50,7 @@ interface RuleActionsOverflowComponentProps {
 const RuleActionsOverflowComponent = ({
   rule,
   userHasNoPermissions,
+  canDuplicateRuleWithActions,
 }: RuleActionsOverflowComponentProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [rulesToExport, setRulesToExport] = useState<string[]>([]);
@@ -66,7 +68,7 @@ const RuleActionsOverflowComponent = ({
             <EuiContextMenuItem
               key={i18nActions.DUPLICATE_RULE}
               icon="copy"
-              disabled={userHasNoPermissions}
+              disabled={!canDuplicateRuleWithActions || userHasNoPermissions}
               data-test-subj="rules-details-duplicate-rule"
               onClick={async () => {
                 setIsPopoverOpen(false);

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
@@ -66,23 +66,23 @@ const RuleActionsOverflowComponent = ({
     () =>
       rule != null
         ? [
-            <EuiToolTip
-              position="left"
-              content={getToolTipContent(rule, true, canDuplicateRuleWithActions)}
+            <EuiContextMenuItem
+              key={i18nActions.DUPLICATE_RULE}
+              icon="copy"
+              disabled={!canDuplicateRuleWithActions || userHasNoPermissions}
+              data-test-subj="rules-details-duplicate-rule"
+              onClick={async () => {
+                setIsPopoverOpen(false);
+                await duplicateRulesAction([rule], [rule.id], noop, dispatchToaster);
+              }}
             >
-              <EuiContextMenuItem
-                key={i18nActions.DUPLICATE_RULE}
-                icon="copy"
-                disabled={!canDuplicateRuleWithActions || userHasNoPermissions}
-                data-test-subj="rules-details-duplicate-rule"
-                onClick={async () => {
-                  setIsPopoverOpen(false);
-                  await duplicateRulesAction([rule], [rule.id], noop, dispatchToaster);
-                }}
+              <EuiToolTip
+                position="left"
+                content={getToolTipContent(rule, true, canDuplicateRuleWithActions)}
               >
-                {i18nActions.DUPLICATE_RULE}
-              </EuiContextMenuItem>
-            </EuiToolTip>,
+                <>{i18nActions.DUPLICATE_RULE}</>
+              </EuiToolTip>
+            </EuiContextMenuItem>,
             <EuiContextMenuItem
               key={i18nActions.EXPORT_RULE}
               icon="exportAction"

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_actions_overflow/index.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../pages/detection_engine/rules/all/actions';
 import { GenericDownloader } from '../../../../common/components/generic_downloader';
 import { getRulesUrl } from '../../../../common/components/link_to/redirect_to_detection_engine';
+import { getToolTipContent } from '../../../../common/utils/privileges';
 
 const MyEuiButtonIcon = styled(EuiButtonIcon)`
   &.euiButtonIcon {
@@ -65,18 +66,23 @@ const RuleActionsOverflowComponent = ({
     () =>
       rule != null
         ? [
-            <EuiContextMenuItem
-              key={i18nActions.DUPLICATE_RULE}
-              icon="copy"
-              disabled={!canDuplicateRuleWithActions || userHasNoPermissions}
-              data-test-subj="rules-details-duplicate-rule"
-              onClick={async () => {
-                setIsPopoverOpen(false);
-                await duplicateRulesAction([rule], [rule.id], noop, dispatchToaster);
-              }}
+            <EuiToolTip
+              position="left"
+              content={getToolTipContent(rule, true, canDuplicateRuleWithActions)}
             >
-              {i18nActions.DUPLICATE_RULE}
-            </EuiContextMenuItem>,
+              <EuiContextMenuItem
+                key={i18nActions.DUPLICATE_RULE}
+                icon="copy"
+                disabled={!canDuplicateRuleWithActions || userHasNoPermissions}
+                data-test-subj="rules-details-duplicate-rule"
+                onClick={async () => {
+                  setIsPopoverOpen(false);
+                  await duplicateRulesAction([rule], [rule.id], noop, dispatchToaster);
+                }}
+              >
+                {i18nActions.DUPLICATE_RULE}
+              </EuiContextMenuItem>
+            </EuiToolTip>,
             <EuiContextMenuItem
               key={i18nActions.EXPORT_RULE}
               icon="exportAction"

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/batch_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/batch_actions.tsx
@@ -71,40 +71,40 @@ export const getBatchItems = ({
   });
 
   return [
-    <EuiToolTip
-      position="right"
-      content={!canBulkActivateRulesWithActions ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined}
+    <EuiContextMenuItem
+      key={i18n.BATCH_ACTION_ACTIVATE_SELECTED}
+      icon="checkInCircleFilled"
+      disabled={!canBulkActivateRulesWithActions || containsLoading || !containsDisabled}
+      onClick={async () => {
+        closePopover();
+        const deactivatedIds = selectedRuleIds.filter(
+          (id) => !rules.find((r) => r.id === id)?.enabled ?? false
+        );
+
+        const deactivatedIdsNoML = deactivatedIds.filter(
+          (id) => !isMlRule(rules.find((r) => r.id === id)?.type)
+        );
+
+        const mlRuleCount = deactivatedIds.length - deactivatedIdsNoML.length;
+        if (!hasMlPermissions && mlRuleCount > 0) {
+          displayWarningToast(detectionI18n.ML_RULES_UNAVAILABLE(mlRuleCount), dispatchToaster);
+        }
+
+        await enableRulesAction(
+          hasMlPermissions ? deactivatedIds : deactivatedIdsNoML,
+          true,
+          dispatch,
+          dispatchToaster
+        );
+      }}
     >
-      <EuiContextMenuItem
-        key={i18n.BATCH_ACTION_ACTIVATE_SELECTED}
-        icon="checkInCircleFilled"
-        disabled={!canBulkActivateRulesWithActions || containsLoading || !containsDisabled}
-        onClick={async () => {
-          closePopover();
-          const deactivatedIds = selectedRuleIds.filter(
-            (id) => !rules.find((r) => r.id === id)?.enabled ?? false
-          );
-
-          const deactivatedIdsNoML = deactivatedIds.filter(
-            (id) => !isMlRule(rules.find((r) => r.id === id)?.type)
-          );
-
-          const mlRuleCount = deactivatedIds.length - deactivatedIdsNoML.length;
-          if (!hasMlPermissions && mlRuleCount > 0) {
-            displayWarningToast(detectionI18n.ML_RULES_UNAVAILABLE(mlRuleCount), dispatchToaster);
-          }
-
-          await enableRulesAction(
-            hasMlPermissions ? deactivatedIds : deactivatedIdsNoML,
-            true,
-            dispatch,
-            dispatchToaster
-          );
-        }}
+      <EuiToolTip
+        position="right"
+        content={!canBulkActivateRulesWithActions ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined}
       >
-        {i18n.BATCH_ACTION_ACTIVATE_SELECTED}
-      </EuiContextMenuItem>
-    </EuiToolTip>,
+        <>{i18n.BATCH_ACTION_ACTIVATE_SELECTED}</>
+      </EuiToolTip>
+    </EuiContextMenuItem>,
     <EuiContextMenuItem
       key={i18n.BATCH_ACTION_DEACTIVATE_SELECTED}
       icon="crossInACircleFilled"
@@ -117,7 +117,12 @@ export const getBatchItems = ({
         await enableRulesAction(activatedIds, false, dispatch, dispatchToaster);
       }}
     >
-      {i18n.BATCH_ACTION_DEACTIVATE_SELECTED}
+      <EuiToolTip
+        position="right"
+        content={!canBulkActivateRulesWithActions ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined}
+      >
+        <>{i18n.BATCH_ACTION_DEACTIVATE_SELECTED}</>
+      </EuiToolTip>
     </EuiContextMenuItem>,
     <EuiContextMenuItem
       key={i18n.BATCH_ACTION_EXPORT_SELECTED}
@@ -133,30 +138,29 @@ export const getBatchItems = ({
     >
       {i18n.BATCH_ACTION_EXPORT_SELECTED}
     </EuiContextMenuItem>,
-    <EuiToolTip
-      position="right"
-      content={!canBulkActivateRulesWithActions ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined}
+
+    <EuiContextMenuItem
+      key={i18n.BATCH_ACTION_DUPLICATE_SELECTED}
+      icon="copy"
+      disabled={!canBulkActivateRulesWithActions || containsLoading || selectedRuleIds.length === 0}
+      onClick={async () => {
+        closePopover();
+        await duplicateRulesAction(
+          rules.filter((r) => selectedRuleIds.includes(r.id)),
+          selectedRuleIds,
+          dispatch,
+          dispatchToaster
+        );
+        reFetchRules(true);
+      }}
     >
-      <EuiContextMenuItem
-        key={i18n.BATCH_ACTION_DUPLICATE_SELECTED}
-        icon="copy"
-        disabled={
-          !canBulkActivateRulesWithActions || containsLoading || selectedRuleIds.length === 0
-        }
-        onClick={async () => {
-          closePopover();
-          await duplicateRulesAction(
-            rules.filter((r) => selectedRuleIds.includes(r.id)),
-            selectedRuleIds,
-            dispatch,
-            dispatchToaster
-          );
-          reFetchRules(true);
-        }}
+      <EuiToolTip
+        position="right"
+        content={!canBulkActivateRulesWithActions ? i18n.EDIT_RULE_SETTINGS_TOOLTIP : undefined}
       >
-        {i18n.BATCH_ACTION_DUPLICATE_SELECTED}
-      </EuiContextMenuItem>
-    </EuiToolTip>,
+        <>{i18n.BATCH_ACTION_DUPLICATE_SELECTED}</>
+      </EuiToolTip>
+    </EuiContextMenuItem>,
     <EuiContextMenuItem
       data-test-subj="deleteRuleBulk"
       key={i18n.BATCH_ACTION_DELETE_SELECTED}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.test.tsx
@@ -52,7 +52,8 @@ describe('AllRulesTable Columns', () => {
         dispatch,
         dispatchToaster,
         history,
-        reFetchRules
+        reFetchRules,
+        true
       )[1];
       await duplicateRulesActionObject.onClick(rule);
       expect(results).toEqual(['duplicateRulesAction', 'reFetchRules']);
@@ -73,7 +74,8 @@ describe('AllRulesTable Columns', () => {
         dispatch,
         dispatchToaster,
         history,
-        reFetchRules
+        reFetchRules,
+        true
       )[3];
       await deleteRulesActionObject.onClick(rule);
       expect(results).toEqual(['deleteRulesAction', 'reFetchRules']);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -67,8 +67,14 @@ export const getActions = (
   {
     'data-test-subj': 'editRuleAction',
     description: i18n.EDIT_RULE_SETTINGS,
+    name: actionsPrivileges ? (
+      <EuiToolTip position="top" content={i18n.EDIT_RULE_SETTINGS_TOOLTIP}>
+        <>{i18n.EDIT_RULE_SETTINGS}</>
+      </EuiToolTip>
+    ) : (
+      i18n.EDIT_RULE_SETTINGS
+    ),
     icon: 'controlsHorizontal',
-    name: i18n.EDIT_RULE_SETTINGS,
     onClick: (rowItem: Rule) => editRuleAction(rowItem, history),
     enabled: (rowItem: Rule) => canEditRule(rowItem, actionsPrivileges),
   },

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -35,23 +35,9 @@ import {
 } from './actions';
 import { Action } from './reducer';
 import { LocalizedDateTooltip } from '../../../../../common/components/localized_date_tooltip';
-import * as detectionI18n from '../../translations';
 import { LinkAnchor } from '../../../../../common/components/links';
+import { getToolTipContent, canEditRule } from '../../../../../common/utils/privileges';
 import { TagsDisplay } from './tag_display';
-
-const canEditRule = (
-  rule: Rule,
-  privileges:
-    | boolean
-    | Readonly<{
-        [x: string]: boolean;
-      }>
-) => {
-  if (rule.actions != null && rule.actions.length > 0) {
-    return privileges;
-  }
-  return true;
-};
 
 export const getActions = (
   dispatch: React.Dispatch<Action>,
@@ -259,11 +245,7 @@ export const getColumns = ({
       render: (value: Rule['enabled'], item: Rule) => (
         <EuiToolTip
           position="top"
-          content={
-            isMlRule(item.type) && !hasMlPermissions
-              ? detectionI18n.ML_RULES_DISABLED_MESSAGE
-              : undefined
-          }
+          content={getToolTipContent(item, hasMlPermissions, hasReadActionsPrivileges as boolean)}
         >
           <RuleSwitch
             data-test-subj="enabled"
@@ -271,7 +253,9 @@ export const getColumns = ({
             id={item.id}
             enabled={item.enabled}
             isDisabled={
-              hasNoPermissions || (isMlRule(item.type) && !hasMlPermissions && !item.enabled)
+              !canEditRule(item, hasReadActionsPrivileges) ||
+              hasNoPermissions ||
+              (isMlRule(item.type) && !hasMlPermissions && !item.enabled)
             }
             isLoading={loadingRuleIds.includes(item.id)}
           />

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -36,7 +36,7 @@ import {
 import { Action } from './reducer';
 import { LocalizedDateTooltip } from '../../../../../common/components/localized_date_tooltip';
 import { LinkAnchor } from '../../../../../common/components/links';
-import { getToolTipContent, canEditRule } from '../../../../../common/utils/privileges';
+import { getToolTipContent, canEditRuleWithActions } from '../../../../../common/utils/privileges';
 import { TagsDisplay } from './tag_display';
 
 export const getActions = (
@@ -62,12 +62,13 @@ export const getActions = (
     ),
     icon: 'controlsHorizontal',
     onClick: (rowItem: Rule) => editRuleAction(rowItem, history),
-    enabled: (rowItem: Rule) => canEditRule(rowItem, actionsPrivileges),
+    enabled: (rowItem: Rule) => canEditRuleWithActions(rowItem, actionsPrivileges),
   },
   {
     description: i18n.DUPLICATE_RULE,
     icon: 'copy',
     name: i18n.DUPLICATE_RULE,
+    enabled: (rowItem: Rule) => canEditRuleWithActions(rowItem, actionsPrivileges),
     onClick: async (rowItem: Rule) => {
       await duplicateRulesAction([rowItem], [rowItem.id], dispatch, dispatchToaster);
       await reFetchRules(true);
@@ -253,7 +254,7 @@ export const getColumns = ({
             id={item.id}
             enabled={item.enabled}
             isDisabled={
-              !canEditRule(item, hasReadActionsPrivileges) ||
+              !canEditRuleWithActions(item, hasReadActionsPrivileges) ||
               hasNoPermissions ||
               (isMlRule(item.type) && !hasMlPermissions && !item.enabled)
             }

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -245,7 +245,7 @@ export const getColumns = ({
       render: (value: Rule['enabled'], item: Rule) => (
         <EuiToolTip
           position="top"
-          content={getToolTipContent(item, hasMlPermissions, hasReadActionsPrivileges as boolean)}
+          content={getToolTipContent(item, hasMlPermissions, hasReadActionsPrivileges)}
         >
           <RuleSwitch
             data-test-subj="enabled"

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -39,11 +39,30 @@ import * as detectionI18n from '../../translations';
 import { LinkAnchor } from '../../../../../common/components/links';
 import { TagsDisplay } from './tag_display';
 
+const canEditRule = (
+  rule: Rule,
+  privileges:
+    | boolean
+    | Readonly<{
+        [x: string]: boolean;
+      }>
+) => {
+  if (rule.actions != null && rule.actions.length > 0) {
+    return privileges;
+  }
+  return true;
+};
+
 export const getActions = (
   dispatch: React.Dispatch<Action>,
   dispatchToaster: Dispatch<ActionToaster>,
   history: H.History,
-  reFetchRules: (refreshPrePackagedRule?: boolean) => void
+  reFetchRules: (refreshPrePackagedRule?: boolean) => void,
+  actionsPrivileges:
+    | boolean
+    | Readonly<{
+        [x: string]: boolean;
+      }>
 ) => [
   {
     'data-test-subj': 'editRuleAction',
@@ -51,6 +70,7 @@ export const getActions = (
     icon: 'controlsHorizontal',
     name: i18n.EDIT_RULE_SETTINGS,
     onClick: (rowItem: Rule) => editRuleAction(rowItem, history),
+    enabled: (rowItem: Rule) => canEditRule(rowItem, actionsPrivileges),
   },
   {
     description: i18n.DUPLICATE_RULE,
@@ -97,6 +117,11 @@ interface GetColumns {
   hasNoPermissions: boolean;
   loadingRuleIds: string[];
   reFetchRules: (refreshPrePackagedRule?: boolean) => void;
+  hasReadActionsPrivileges:
+    | boolean
+    | Readonly<{
+        [x: string]: boolean;
+      }>;
 }
 
 export const getColumns = ({
@@ -108,6 +133,7 @@ export const getColumns = ({
   hasNoPermissions,
   loadingRuleIds,
   reFetchRules,
+  hasReadActionsPrivileges,
 }: GetColumns): RulesColumns[] => {
   const cols: RulesColumns[] = [
     {
@@ -251,7 +277,13 @@ export const getColumns = ({
   ];
   const actions: RulesColumns[] = [
     {
-      actions: getActions(dispatch, dispatchToaster, history, reFetchRules),
+      actions: getActions(
+        dispatch,
+        dispatchToaster,
+        history,
+        reFetchRules,
+        hasReadActionsPrivileges
+      ),
       width: '40px',
     } as EuiTableActionsColumnType<Rule>,
   ];

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/columns.tsx
@@ -53,8 +53,8 @@ export const getActions = (
   {
     'data-test-subj': 'editRuleAction',
     description: i18n.EDIT_RULE_SETTINGS,
-    name: actionsPrivileges ? (
-      <EuiToolTip position="top" content={i18n.EDIT_RULE_SETTINGS_TOOLTIP}>
+    name: !actionsPrivileges ? (
+      <EuiToolTip position="left" content={i18n.EDIT_RULE_SETTINGS_TOOLTIP}>
         <>{i18n.EDIT_RULE_SETTINGS}</>
       </EuiToolTip>
     ) : (
@@ -67,7 +67,13 @@ export const getActions = (
   {
     description: i18n.DUPLICATE_RULE,
     icon: 'copy',
-    name: i18n.DUPLICATE_RULE,
+    name: !actionsPrivileges ? (
+      <EuiToolTip position="left" content={i18n.EDIT_RULE_SETTINGS_TOOLTIP}>
+        <>{i18n.DUPLICATE_RULE}</>
+      </EuiToolTip>
+    ) : (
+      i18n.DUPLICATE_RULE
+    ),
     enabled: (rowItem: Rule) => canEditRuleWithActions(rowItem, actionsPrivileges),
     onClick: async (rowItem: Rule) => {
       await duplicateRulesAction([rowItem], [rowItem.id], dispatch, dispatchToaster);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
@@ -12,6 +12,7 @@ import '../../../../../common/mock/formatted_relative';
 import { TestProviders } from '../../../../../common/mock';
 import { waitFor } from '@testing-library/react';
 import { AllRules } from './index';
+import { useKibana } from '../../../../../common/lib/kibana';
 
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
@@ -24,25 +25,9 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('../../../../../common/lib/kibana', () => ({
-  useKibana: jest.fn().mockReturnValue({
-    services: {
-      application: {
-        getUrlForApp: jest.fn(),
-        capabilities: {
-          siem: {
-            crud: true,
-          },
-          actions: {
-            read: true,
-          },
-        },
-      },
-    },
-  }),
-}));
+jest.mock('../../../../../common/lib/kibana');
 
-jest.mock('../../../../../common/components/link_to');
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
 jest.mock('./reducer', () => {
   return {
@@ -178,6 +163,14 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('AllRules', () => {
+  beforeEach(() => {
+    useKibanaMock().services.application.capabilities = {
+      navLinks: {},
+      management: {},
+      catalogue: {},
+      actions: { show: true },
+    };
+  });
   it('renders correctly', () => {
     const wrapper = shallow(
       <AllRules

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
@@ -25,6 +25,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../../../../common/components/link_to');
 jest.mock('../../../../../common/lib/kibana');
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.test.tsx
@@ -24,6 +24,24 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../../../../common/lib/kibana', () => ({
+  useKibana: jest.fn().mockReturnValue({
+    services: {
+      application: {
+        getUrlForApp: jest.fn(),
+        capabilities: {
+          siem: {
+            crud: true,
+          },
+          actions: {
+            read: true,
+          },
+        },
+      },
+    },
+  }),
+}));
+
 jest.mock('../../../../../common/components/link_to');
 
 jest.mock('./reducer', () => {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
@@ -54,6 +54,7 @@ import { hasMlAdminPermissions } from '../../../../../../common/machine_learning
 import { hasMlLicense } from '../../../../../../common/machine_learning/has_ml_license';
 import { SecurityPageName } from '../../../../../app/types';
 import { useFormatUrl } from '../../../../../common/components/link_to';
+import { isBoolean } from '../../../../../common/utils/privileges';
 
 const INITIAL_SORT_FIELD = 'enabled';
 const initialState: State = {
@@ -180,6 +181,17 @@ export const AllRules = React.memo<AllRulesProps>(
       rulesNotInstalled,
       rulesNotUpdated
     );
+    const {
+      services: {
+        application: {
+          capabilities: { actions },
+        },
+      },
+    } = useKibana();
+
+    const hasActionsPrivileges = useMemo(() => (isBoolean(actions.show) ? actions.show : true), [
+      actions,
+    ]);
 
     const getBatchItemsPopoverContent = useCallback(
       (closePopover: () => void) => (
@@ -189,6 +201,7 @@ export const AllRules = React.memo<AllRulesProps>(
             dispatch,
             dispatchToaster,
             hasMlPermissions,
+            hasActionsPrivileges,
             loadingRuleIds,
             selectedRuleIds,
             reFetchRules: reFetchRulesData,
@@ -204,6 +217,7 @@ export const AllRules = React.memo<AllRulesProps>(
         reFetchRulesData,
         rules,
         selectedRuleIds,
+        hasActionsPrivileges,
       ]
     );
 
@@ -231,14 +245,6 @@ export const AllRules = React.memo<AllRulesProps>(
       [dispatch]
     );
 
-    const {
-      services: {
-        application: {
-          capabilities: { actions },
-        },
-      },
-    } = useKibana();
-
     const rulesColumns = useMemo(() => {
       return getColumns({
         dispatch,
@@ -253,7 +259,7 @@ export const AllRules = React.memo<AllRulesProps>(
             ? loadingRuleIds
             : [],
         reFetchRules: reFetchRulesData,
-        hasReadActionsPrivileges: actions.show,
+        hasReadActionsPrivileges: hasActionsPrivileges,
       });
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/all/index.tsx
@@ -34,6 +34,7 @@ import {
   UtilityBarSection,
   UtilityBarText,
 } from '../../../../../common/components/utility_bar';
+import { useKibana } from '../../../../../common/lib/kibana';
 import { useStateToaster } from '../../../../../common/components/toasters';
 import { Loader } from '../../../../../common/components/loader';
 import { Panel } from '../../../../../common/components/panel';
@@ -230,6 +231,14 @@ export const AllRules = React.memo<AllRulesProps>(
       [dispatch]
     );
 
+    const {
+      services: {
+        application: {
+          capabilities: { actions },
+        },
+      },
+    } = useKibana();
+
     const rulesColumns = useMemo(() => {
       return getColumns({
         dispatch,
@@ -244,6 +253,7 @@ export const AllRules = React.memo<AllRulesProps>(
             ? loadingRuleIds
             : [],
         reFetchRules: reFetchRulesData,
+        hasReadActionsPrivileges: actions.show,
       });
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -89,7 +89,7 @@ import { timelineDefaults } from '../../../../../timelines/store/timeline/defaul
 import { TimelineModel } from '../../../../../timelines/store/timeline/model';
 import { useSourcererScope } from '../../../../../common/containers/sourcerer';
 import { SourcererScopeName } from '../../../../../common/store/sourcerer/model';
-import { getToolTipContent, canEditRule } from '../../../../../common/utils/privileges';
+import { getToolTipContent, canEditRule, isBoolean } from '../../../../../common/utils/privileges';
 
 import { AlertsHistogramOption } from '../../../../components/alerts_histogram_panel/types';
 
@@ -177,8 +177,8 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
     },
   } = useKibana();
   const hasActionsPrivileges = useMemo(() => {
-    if (rule?.actions != null && rule?.actions.length > 0) {
-      return actions.show as boolean;
+    if (rule?.actions != null && rule?.actions.length > 0 && isBoolean(actions.show)) {
+      return actions.show;
     }
     return true;
   }, [actions, rule?.actions]);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -311,6 +311,33 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
     [history, ruleId]
   );
 
+  const canEditRule = useMemo(() => {
+    if (!hasActionsPrivileges) {
+      return (
+        <EuiToolTip position="top" content={ruleI18n.EDIT_RULE_SETTINGS_TOOLTIP}>
+          <LinkButton
+            onClick={goToEditRule}
+            iconType="controlsHorizontal"
+            isDisabled={true}
+            href={formatUrl(getEditRuleUrl(ruleId ?? ''))}
+          >
+            {ruleI18n.EDIT_RULE_SETTINGS}
+          </LinkButton>
+        </EuiToolTip>
+      );
+    }
+    return (
+      <LinkButton
+        onClick={goToEditRule}
+        iconType="controlsHorizontal"
+        isDisabled={userHasNoPermissions(canUserCRUD) ?? true}
+        href={formatUrl(getEditRuleUrl(ruleId ?? ''))}
+      >
+        {ruleI18n.EDIT_RULE_SETTINGS}
+      </LinkButton>
+    );
+  }, [canUserCRUD, formatUrl, goToEditRule, hasActionsPrivileges, ruleId]);
+
   const onShowBuildingBlockAlertsChangedCallback = useCallback(
     (newShowBuildingBlockAlerts: boolean) => {
       setShowBuildingBlockAlerts(newShowBuildingBlockAlerts);
@@ -424,16 +451,7 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
 
                   <EuiFlexItem grow={false}>
                     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-                      <EuiFlexItem grow={false}>
-                        <LinkButton
-                          onClick={goToEditRule}
-                          iconType="controlsHorizontal"
-                          isDisabled={!hasActionsPrivileges || userHasNoPermissions(canUserCRUD)}
-                          href={formatUrl(getEditRuleUrl(ruleId ?? ''))}
-                        >
-                          {ruleI18n.EDIT_RULE_SETTINGS}
-                        </LinkButton>
-                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>{canEditRule}</EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <RuleActionsOverflow
                           rule={rule}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -89,7 +89,11 @@ import { timelineDefaults } from '../../../../../timelines/store/timeline/defaul
 import { TimelineModel } from '../../../../../timelines/store/timeline/model';
 import { useSourcererScope } from '../../../../../common/containers/sourcerer';
 import { SourcererScopeName } from '../../../../../common/store/sourcerer/model';
-import { getToolTipContent, canEditRule, isBoolean } from '../../../../../common/utils/privileges';
+import {
+  getToolTipContent,
+  canEditRuleWithActions,
+  isBoolean,
+} from '../../../../../common/utils/privileges';
 
 import { AlertsHistogramOption } from '../../../../components/alerts_histogram_panel/types';
 
@@ -438,7 +442,7 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
                       <RuleSwitch
                         id={rule?.id ?? '-1'}
                         isDisabled={
-                          !canEditRule(rule, hasActionsPrivileges) ||
+                          !canEditRuleWithActions(rule, hasActionsPrivileges) ||
                           userHasNoPermissions(canUserCRUD) ||
                           (!hasMlPermissions && !rule?.enabled)
                         }
@@ -456,6 +460,10 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
                         <RuleActionsOverflow
                           rule={rule}
                           userHasNoPermissions={userHasNoPermissions(canUserCRUD)}
+                          canDuplicateRuleWithActions={canEditRuleWithActions(
+                            rule,
+                            hasActionsPrivileges
+                          )}
                         />
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/details/index.tsx
@@ -23,6 +23,7 @@ import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'reac
 import { useParams, useHistory } from 'react-router-dom';
 import { connect, ConnectedProps } from 'react-redux';
 
+import { useKibana } from '../../../../../common/lib/kibana';
 import { TimelineId } from '../../../../../../common/types/timeline';
 import { UpdateDateRange } from '../../../../../common/components/charts/common';
 import { FiltersGlobal } from '../../../../../common/components/filters_global';
@@ -166,6 +167,19 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
   // TODO: Refactor license check + hasMlAdminPermissions to common check
   const hasMlPermissions = hasMlLicense(mlCapabilities) && hasMlAdminPermissions(mlCapabilities);
   const ruleDetailTabs = getRuleDetailsTabs(rule);
+  const {
+    services: {
+      application: {
+        capabilities: { actions },
+      },
+    },
+  } = useKibana();
+  const hasActionsPrivileges = useMemo(() => {
+    if (rule?.actions != null && rule?.actions.length > 0) {
+      return actions.show;
+    }
+    return true;
+  }, [actions, rule?.actions]);
 
   // persist rule until refresh is complete
   useEffect(() => {
@@ -414,7 +428,7 @@ export const RuleDetailsPageComponent: FC<PropsFromRedux> = ({
                         <LinkButton
                           onClick={goToEditRule}
                           iconType="controlsHorizontal"
-                          isDisabled={userHasNoPermissions(canUserCRUD) ?? true}
+                          isDisabled={!hasActionsPrivileges || userHasNoPermissions(canUserCRUD)}
                           href={formatUrl(getEditRuleUrl(ruleId ?? ''))}
                         >
                           {ruleI18n.EDIT_RULE_SETTINGS}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -214,6 +214,13 @@ export const EDIT_RULE_SETTINGS = i18n.translate(
   }
 );
 
+export const EDIT_RULE_SETTINGS_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.detectionEngine.rules.allRules.actions.editRuleSettingsToolTip',
+  {
+    defaultMessage: 'You are missing actions privileges',
+  }
+);
+
 export const DUPLICATE = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.actions.duplicateTitle',
   {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/translations.ts
@@ -217,7 +217,7 @@ export const EDIT_RULE_SETTINGS = i18n.translate(
 export const EDIT_RULE_SETTINGS_TOOLTIP = i18n.translate(
   'xpack.securitySolution.detectionEngine.rules.allRules.actions.editRuleSettingsToolTip',
   {
-    defaultMessage: 'You are missing actions privileges',
+    defaultMessage: 'You do not have Kibana Actions privileges',
   }
 );
 


### PR DESCRIPTION
## Summary

When a user with no actions privileges visits the rule details page of a rule with actions, the following capabilities will be disabled on the UI:

### Edit Rule Settings button

"Edit Rule Settings" button will be greyed out similarly to when the a user does not have CRUD privileges for SIEM.

<img width="335" alt="Screen Shot 2020-10-13 at 3 41 41 PM" src="https://user-images.githubusercontent.com/915763/95908907-abce0700-0d6b-11eb-8794-67601dd2cabe.png">


and on the all rules table:

<img width="342" alt="Screen Shot 2020-10-13 at 4 46 20 PM" src="https://user-images.githubusercontent.com/915763/95914424-aeccf580-0d73-11eb-9739-518b9014e3b2.png">

### Activate switch

Disabling the activate switch on rules with actions on all rules table

<img width="287" alt="Screen Shot 2020-10-14 at 9 56 07 AM" src="https://user-images.githubusercontent.com/915763/95999180-a8865a00-0e03-11eb-9a12-b302b9869123.png">

Disabling the activate switch on rules with actions on rule details page

<img width="311" alt="Screen Shot 2020-10-14 at 10 14 04 AM" src="https://user-images.githubusercontent.com/915763/96001477-129ffe80-0e06-11eb-8e81-8182f147f540.png">


### Duplicate rule

Disable duplicate ability on all rules table

<img width="558" alt="Screen Shot 2020-10-14 at 11 07 30 AM" src="https://user-images.githubusercontent.com/915763/96009504-b7bed500-0e0e-11eb-828e-4bed90dca68d.png">

Disable duplicate ability on rule details page

<img width="578" alt="Screen Shot 2020-10-14 at 11 15 52 AM" src="https://user-images.githubusercontent.com/915763/96009528-c0171000-0e0e-11eb-9297-f5f163541ce0.png">



### Bulk actions

Disable the bulk functionality of duplicate, activate, deactivate

<img width="551" alt="Screen Shot 2020-10-14 at 6 42 30 PM" src="https://user-images.githubusercontent.com/915763/96053383-697cf680-0e4d-11eb-9a4a-3ac0c0d7e9d4.png">


 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
