### PR TITLE
[Lens] Respect requested sub vis type for xy charts

### DIFF
--- a/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.test.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.test.ts
@@ -518,6 +518,22 @@ describe('xy_suggestions', () => {
     expect(suggestion.hide).toBeTruthy();
   });
 
+  test('respects requested sub visualization type if set', () => {
+    const [suggestion, ...rest] = getSuggestions({
+      table: {
+        isMultiRow: true,
+        columns: [numCol('price'), numCol('quantity'), dateCol('date'), strCol('product')],
+        layerId: 'first',
+        changeType: 'reduced',
+      },
+      keptLayerIds: [],
+      subVisualizationId: 'area',
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(suggestion.state.preferredSeriesType).toBe('area');
+  });
+
   test('keeps existing seriesType for initial tables', () => {
     const currentState: XYState = {
       legend: { isVisible: true, position: 'bottom' },

--- a/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.ts
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_suggestions.ts
@@ -35,6 +35,7 @@ export function getSuggestions({
   table,
   state,
   keptLayerIds,
+  subVisualizationId,
 }: SuggestionRequest<State>): Array<VisualizationSuggestion<State>> {
   if (
     // We only render line charts for multi-row queries. We require at least
@@ -66,7 +67,12 @@ export function getSuggestions({
     return [];
   }
 
-  const suggestions = getSuggestionForColumns(table, keptLayerIds, state);
+  const suggestions = getSuggestionForColumns(
+    table,
+    keptLayerIds,
+    state,
+    subVisualizationId as SeriesType | undefined
+  );
 
   if (suggestions && suggestions instanceof Array) {
     return suggestions;
@@ -78,7 +84,8 @@ export function getSuggestions({
 function getSuggestionForColumns(
   table: TableSuggestion,
   keptLayerIds: string[],
-  currentState?: State
+  currentState?: State,
+  seriesType?: SeriesType
 ): VisualizationSuggestion<State> | Array<VisualizationSuggestion<State>> | undefined {
   const [buckets, values] = partition(table.columns, (col) => col.operation.isBucketed);
 
@@ -93,6 +100,7 @@ function getSuggestionForColumns(
       currentState,
       tableLabel: table.label,
       keptLayerIds,
+      requestedSeriesType: seriesType,
     });
   } else if (buckets.length === 0) {
     const [x, ...yValues] = prioritizeColumns(values);
@@ -105,6 +113,7 @@ function getSuggestionForColumns(
       currentState,
       tableLabel: table.label,
       keptLayerIds,
+      requestedSeriesType: seriesType,
     });
   }
 }
@@ -190,6 +199,7 @@ function getSuggestionsForLayer({
   currentState,
   tableLabel,
   keptLayerIds,
+  requestedSeriesType,
 }: {
   layerId: string;
   changeType: TableChangeType;
@@ -199,9 +209,11 @@ function getSuggestionsForLayer({
   currentState?: State;
   tableLabel?: string;
   keptLayerIds: string[];
+  requestedSeriesType?: SeriesType;
 }): VisualizationSuggestion<State> | Array<VisualizationSuggestion<State>> {
   const title = getSuggestionTitle(yValues, xValue, tableLabel);
-  const seriesType: SeriesType = getSeriesType(currentState, layerId, xValue);
+  const seriesType: SeriesType =
+    requestedSeriesType || getSeriesType(currentState, layerId, xValue);
 
   const options = {
     currentState,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/80295

A suggestion request can contain a sub visualiation id (used by the chart switcher). So far the XY chart was not respecting this - this caused full data loss for some switches from other chart types (except for stacked bars, because that's the default and always has a suggestion)