### PR TITLE
[Security Solution] [Detections] useMemo for conditional rendering of actions step and bug fix

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_about_rule/index.tsx
@@ -122,9 +122,13 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
   }, [onSubmit]);
 
   useEffect(() => {
-    if (setForm) {
+    let didCancel = false;
+    if (setForm && !didCancel) {
       setForm(RuleStep.aboutRule, getData);
     }
+    return () => {
+      didCancel = true;
+    };
   }, [getData, setForm]);
 
   return isReadOnlyView ? (

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -191,9 +191,13 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
   }, [getFormData, submit]);
 
   useEffect(() => {
-    if (setForm) {
+    let didCancel = false;
+    if (setForm && !didCancel) {
       setForm(RuleStep.defineRule, getData);
     }
+    return () => {
+      didCancel = true;
+    };
   }, [getData, setForm]);
 
   const handleResetIndices = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -120,9 +120,13 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
   }, [getFormData, submit]);
 
   useEffect(() => {
-    if (setForm) {
+    let didCancel = false;
+    if (setForm && !didCancel) {
       setForm(RuleStep.ruleActions, getData);
     }
+    return () => {
+      didCancel = true;
+    };
   }, [getData, setForm]);
 
   const throttleOptions = useMemo(() => {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_rule_actions/index.tsx
@@ -142,6 +142,52 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     [isLoading, throttleOptions]
   );
 
+  const displayActionsOptions = useMemo(
+    () =>
+      throttle !== stepActionsDefaultValue.throttle ? (
+        <>
+          <EuiSpacer />
+          <UseField
+            path="actions"
+            component={RuleActionsField}
+            componentProps={{
+              messageVariables: actionMessageParams,
+            }}
+          />
+        </>
+      ) : (
+        <UseField path="actions" component={GhostFormField} />
+      ),
+    [throttle, actionMessageParams]
+  );
+  // only display the actions dropdown if the user has "read" privileges for actions
+  const displayActionsDropDown = useMemo(() => {
+    return application.capabilities.actions.show ? (
+      <>
+        <UseField
+          path="throttle"
+          component={ThrottleSelectField}
+          componentProps={throttleFieldComponentProps}
+        />
+        {displayActionsOptions}
+        <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
+        <UseField path="enabled" component={GhostFormField} />
+      </>
+    ) : (
+      <>
+        <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
+        <UseField
+          path="throttle"
+          componentProps={throttleFieldComponentProps}
+          component={GhostFormField}
+        />
+        <UseField path="actions" component={GhostFormField} />
+        <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
+        <UseField path="enabled" component={GhostFormField} />
+      </>
+    );
+  }, [application.capabilities.actions.show, displayActionsOptions, throttleFieldComponentProps]);
+
   if (isReadOnlyView) {
     return (
       <StepContentWrapper addPadding={addPadding}>
@@ -149,48 +195,6 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
       </StepContentWrapper>
     );
   }
-
-  const displayActionsOptions =
-    throttle !== stepActionsDefaultValue.throttle ? (
-      <>
-        <EuiSpacer />
-        <UseField
-          path="actions"
-          component={RuleActionsField}
-          componentProps={{
-            messageVariables: actionMessageParams,
-          }}
-        />
-      </>
-    ) : (
-      <UseField path="actions" component={GhostFormField} />
-    );
-
-  // only display the actions dropdown if the user has "read" privileges for actions
-  const displayActionsDropDown = application.capabilities.actions.show ? (
-    <>
-      <UseField
-        path="throttle"
-        component={ThrottleSelectField}
-        componentProps={throttleFieldComponentProps}
-      />
-      {displayActionsOptions}
-      <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
-      <UseField path="enabled" component={GhostFormField} />
-    </>
-  ) : (
-    <>
-      <EuiText>{I18n.NO_ACTIONS_READ_PERMISSIONS}</EuiText>
-      <UseField
-        path="throttle"
-        componentProps={throttleFieldComponentProps}
-        component={GhostFormField}
-      />
-      <UseField path="actions" component={GhostFormField} />
-      <UseField path="kibanaSiemAppUrl" component={GhostFormField} />
-      <UseField path="enabled" component={GhostFormField} />
-    </>
-  );
 
   return (
     <>

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_schedule_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_schedule_rule/index.tsx
@@ -64,9 +64,13 @@ const StepScheduleRuleComponent: FC<StepScheduleRuleProps> = ({
   }, [getFormData, submit]);
 
   useEffect(() => {
-    if (setForm) {
+    let didCancel = false;
+    if (setForm && !didCancel) {
       setForm(RuleStep.scheduleRule, getData);
     }
+    return () => {
+      didCancel = true;
+    };
   }, [getData, setForm]);
 
   return isReadOnlyView ? (


### PR DESCRIPTION
## Summary

Updates the conditional rendering to use useMemo. This PR also fixes a bug where when switching between tabs on the edit rules page, a React error would be thrown because we were updating the state of the form before the components on that step were rendered (thanks @XavierM  for the fix 👍 )

### Checklist

Delete any items that are not applicable to this PR.


- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
