### PR TITLE
[Ingest Manager] filter out non-upgradeable agents when user bulk upgrades

### DIFF
--- a/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.test.ts
+++ b/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.test.ts
@@ -6,7 +6,17 @@
 import { isAgentUpgradeable } from './is_agent_upgradeable';
 import { Agent } from '../types/models/agent';
 
-const getAgent = (version: string, upgradeable: boolean): Agent => {
+const getAgent = ({
+  version,
+  upgradeable = false,
+  unenrolling = false,
+  unenrolled = false,
+}: {
+  version: string;
+  upgradeable?: boolean;
+  unenrolling?: boolean;
+  unenrolled?: boolean;
+}): Agent => {
   const agent: Agent = {
     id: 'de9006e1-54a7-4320-b24e-927e6fe518a8',
     active: true,
@@ -76,25 +86,53 @@ const getAgent = (version: string, upgradeable: boolean): Agent => {
   if (upgradeable) {
     agent.local_metadata.elastic.agent.upgradeable = true;
   }
+  if (unenrolling) {
+    agent.unenrollment_started_at = '2020-10-01T14:43:27.255Z';
+  }
+  if (unenrolled) {
+    agent.unenrolled_at = '2020-10-01T14:43:27.255Z';
+  }
   return agent;
 };
 describe('Ingest Manager - isAgentUpgradeable', () => {
   it('returns false if agent reports not upgradeable with agent version < kibana version', () => {
-    expect(isAgentUpgradeable(getAgent('7.9.0', false), '8.0.0')).toBe(false);
+    expect(isAgentUpgradeable(getAgent({ version: '7.9.0' }), '8.0.0')).toBe(false);
   });
   it('returns false if agent reports not upgradeable with agent version > kibana version', () => {
-    expect(isAgentUpgradeable(getAgent('8.0.0', false), '7.9.0')).toBe(false);
+    expect(isAgentUpgradeable(getAgent({ version: '8.0.0' }), '7.9.0')).toBe(false);
   });
   it('returns false if agent reports not upgradeable with agent version === kibana version', () => {
-    expect(isAgentUpgradeable(getAgent('8.0.0', false), '8.0.0')).toBe(false);
+    expect(isAgentUpgradeable(getAgent({ version: '8.0.0' }), '8.0.0')).toBe(false);
   });
   it('returns false if agent reports upgradeable, with agent version === kibana version', () => {
-    expect(isAgentUpgradeable(getAgent('8.0.0', true), '8.0.0')).toBe(false);
+    expect(isAgentUpgradeable(getAgent({ version: '8.0.0', upgradeable: true }), '8.0.0')).toBe(
+      false
+    );
   });
   it('returns false if agent reports upgradeable, with agent version > kibana version', () => {
-    expect(isAgentUpgradeable(getAgent('8.0.0', true), '7.9.0')).toBe(false);
+    expect(isAgentUpgradeable(getAgent({ version: '8.0.0', upgradeable: true }), '7.9.0')).toBe(
+      false
+    );
+  });
+  it('returns false if agent reports upgradeable, but agent is unenrolling', () => {
+    expect(
+      isAgentUpgradeable(
+        getAgent({ version: '7.9.0', upgradeable: true, unenrolling: true }),
+        '8.0.0'
+      )
+    ).toBe(false);
+  });
+  it('returns false if agent reports upgradeable, but agent is unenrolled', () => {
+    expect(
+      isAgentUpgradeable(
+        getAgent({ version: '7.9.0', upgradeable: true, unenrolled: true }),
+        '8.0.0'
+      )
+    ).toBe(false);
   });
   it('returns true if agent reports upgradeable, with agent version < kibana version', () => {
-    expect(isAgentUpgradeable(getAgent('7.9.0', true), '8.0.0')).toBe(true);
+    expect(isAgentUpgradeable(getAgent({ version: '7.9.0', upgradeable: true }), '8.0.0')).toBe(
+      true
+    );
   });
 });

--- a/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.ts
+++ b/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.ts
@@ -13,6 +13,7 @@ export function isAgentUpgradeable(agent: Agent, kibanaVersion: string) {
   } else {
     return false;
   }
+  if (agent.unenrollment_started_at || agent.unenrolled_at) return false;
   const kibanaVersionParsed = semver.parse(kibanaVersion);
   const agentVersionParsed = semver.parse(agentVersion);
   if (!agentVersionParsed || !kibanaVersionParsed) return false;

--- a/x-pack/plugins/ingest_manager/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/upgrade.ts
@@ -9,6 +9,8 @@ import { AgentSOAttributes, AgentAction, AgentActionSOAttributes } from '../../t
 import { AGENT_ACTION_SAVED_OBJECT_TYPE, AGENT_SAVED_OBJECT_TYPE } from '../../constants';
 import { bulkCreateAgentActions, createAgentAction } from './actions';
 import { getAgents, listAllAgents } from './crud';
+import { isAgentUpgradeable } from '../../../common/services';
+import { appContextService } from '../app_context';
 
 export async function sendUpgradeAgentAction({
   soClient,
@@ -69,7 +71,8 @@ export async function sendUpgradeAgentsActions(
         version: string;
       }
 ) {
-  // Filter out agents currently unenrolling, agents unenrolled
+  const kibanaVersion = appContextService.getKibanaVersion();
+  // Filter out agents currently unenrolling, agents unenrolled, and agents not upgradeable
   const agents =
     'agentIds' in options
       ? await getAgents(soClient, options.agentIds)
@@ -80,7 +83,10 @@ export async function sendUpgradeAgentsActions(
           })
         ).agents;
   const agentsToUpdate = agents.filter(
-    (agent) => !agent.unenrollment_started_at && !agent.unenrolled_at
+    (agent) =>
+      !agent.unenrollment_started_at &&
+      !agent.unenrolled_at &&
+      isAgentUpgradeable(agent, kibanaVersion)
   );
   const now = new Date().toISOString();
   const data = {

--- a/x-pack/plugins/ingest_manager/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/upgrade.ts
@@ -82,12 +82,7 @@ export async function sendUpgradeAgentsActions(
             showInactive: false,
           })
         ).agents;
-  const agentsToUpdate = agents.filter(
-    (agent) =>
-      !agent.unenrollment_started_at &&
-      !agent.unenrolled_at &&
-      isAgentUpgradeable(agent, kibanaVersion)
-  );
+  const agentsToUpdate = agents.filter((agent) => isAgentUpgradeable(agent, kibanaVersion));
   const now = new Date().toISOString();
   const data = {
     version: options.version,

--- a/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
@@ -121,9 +121,24 @@ export default function (providerContext: FtrProviderContext) {
       expect(res.body.message).to.equal('agent agent1 is not upgradeable');
     });
 
-    it('should respond 200 to bulk upgrade agents and update the agent SOs', async () => {
+    it('should respond 200 to bulk upgrade upgradeable agents and update the agent SOs', async () => {
       const kibanaVersion = await kibanaServer.version.get();
-
+      await kibanaServer.savedObjects.update({
+        id: 'agent1',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+        },
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent2',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: {
+            elastic: { agent: { upgradeable: true, version: semver.inc(kibanaVersion, 'patch') } },
+          },
+        },
+      });
       await supertest
         .post(`/api/fleet/agents/bulk_upgrade`)
         .set('kbn-xsrf', 'xxx')
@@ -138,11 +153,27 @@ export default function (providerContext: FtrProviderContext) {
         supertest.get(`/api/fleet/agents/agent2`).set('kbn-xsrf', 'xxx'),
       ]);
       expect(typeof agent1data.body.item.upgrade_started_at).to.be('string');
-      expect(typeof agent2data.body.item.upgrade_started_at).to.be('string');
+      expect(typeof agent2data.body.item.upgrade_started_at).to.be('undefined');
     });
 
-    it('should allow to upgrade multiple agents by kuery', async () => {
+    it('should allow to upgrade multiple upgradeable agents by kuery', async () => {
       const kibanaVersion = await kibanaServer.version.get();
+      await kibanaServer.savedObjects.update({
+        id: 'agent1',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+        },
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent2',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: {
+            elastic: { agent: { upgradeable: true, version: semver.inc(kibanaVersion, 'patch') } },
+          },
+        },
+      });
       await supertest
         .post(`/api/fleet/agents/bulk_upgrade`)
         .set('kbn-xsrf', 'xxx')
@@ -156,13 +187,29 @@ export default function (providerContext: FtrProviderContext) {
         supertest.get(`/api/fleet/agents/agent2`).set('kbn-xsrf', 'xxx'),
       ]);
       expect(typeof agent1data.body.item.upgrade_started_at).to.be('string');
-      expect(typeof agent2data.body.item.upgrade_started_at).to.be('string');
+      expect(typeof agent2data.body.item.upgrade_started_at).to.be('undefined');
     });
 
     it('should not upgrade an unenrolling agent during bulk_upgrade', async () => {
       const kibanaVersion = await kibanaServer.version.get();
       await supertest.post(`/api/fleet/agents/agent1/unenroll`).set('kbn-xsrf', 'xxx').send({
         force: true,
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent1',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+        },
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent2',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: {
+            elastic: { agent: { upgradeable: true, version: '0.0.0' } },
+          },
+        },
       });
       await supertest
         .post(`/api/fleet/agents/bulk_upgrade`)
@@ -183,7 +230,19 @@ export default function (providerContext: FtrProviderContext) {
       kibanaServer.savedObjects.update({
         id: 'agent1',
         type: AGENT_SAVED_OBJECT_TYPE,
-        attributes: { unenrolled_at: new Date().toISOString() },
+        attributes: {
+          unenrolled_at: new Date().toISOString(),
+          local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+        },
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent2',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: {
+            elastic: { agent: { upgradeable: true, version: '0.0.0' } },
+          },
+        },
       });
       await supertest
         .post(`/api/fleet/agents/bulk_upgrade`)
@@ -198,6 +257,47 @@ export default function (providerContext: FtrProviderContext) {
       ]);
       expect(typeof agent1data.body.item.upgrade_started_at).to.be('undefined');
       expect(typeof agent2data.body.item.upgrade_started_at).to.be('string');
+    });
+    it('should not upgrade an non upgradeable agent during bulk_upgrade', async () => {
+      const kibanaVersion = await kibanaServer.version.get();
+      await kibanaServer.savedObjects.update({
+        id: 'agent1',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+        },
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent2',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: {
+            elastic: { agent: { upgradeable: true, version: semver.inc(kibanaVersion, 'patch') } },
+          },
+        },
+      });
+      await kibanaServer.savedObjects.update({
+        id: 'agent3',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: false, version: '0.0.0' } } },
+        },
+      });
+      await supertest
+        .post(`/api/fleet/agents/bulk_upgrade`)
+        .set('kbn-xsrf', 'xxx')
+        .send({
+          agents: ['agent1', 'agent2', 'agent3'],
+          version: kibanaVersion,
+        });
+      const [agent1data, agent2data, agent3data] = await Promise.all([
+        supertest.get(`/api/fleet/agents/agent1`).set('kbn-xsrf', 'xxx'),
+        supertest.get(`/api/fleet/agents/agent2`).set('kbn-xsrf', 'xxx'),
+        supertest.get(`/api/fleet/agents/agent3`).set('kbn-xsrf', 'xxx'),
+      ]);
+      expect(typeof agent1data.body.item.upgrade_started_at).to.be('string');
+      expect(typeof agent2data.body.item.upgrade_started_at).to.be('undefined');
+      expect(typeof agent3data.body.item.upgrade_started_at).to.be('undefined');
     });
   });
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/80070

When a user uses bulk actions to upgrade agents, it was not filtering out agents that were not upgradeable.   This change will filter them out so the action never gets sent to the non-upgradeable agent.

