### PR TITLE
[Ingest Manager]Fix config renaming conflict with xpack.ingestManager and xpack.ingestManager.agents

### DIFF
--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -25,8 +25,8 @@ export const config: PluginConfigDescriptor = {
     agents: true,
   },
   deprecations: ({ renameFromRoot }) => [
-    renameFromRoot('xpack.ingestManager.fleet', 'xpack.fleet.agents'),
     renameFromRoot('xpack.ingestManager', 'xpack.fleet'),
+    renameFromRoot('xpack.fleet.fleet', 'xpack.fleet.agents'),
   ],
   schema: schema.object({
     enabled: schema.boolean({ defaultValue: true }),

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
@@ -31,7 +31,6 @@ const getDefaultRegistryUrl = (): string => {
 // Custom registry URL is currently only for internal Elastic development and is unsupported
 export const getRegistryUrl = (): string => {
   const customUrl = appContextService.getConfig()?.registryUrl;
-  console.log('REGISTRY URL', customUrl);
   const isEnterprise = licenseService.isEnterprise();
 
   if (customUrl && isEnterprise) {

--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
@@ -31,6 +31,7 @@ const getDefaultRegistryUrl = (): string => {
 // Custom registry URL is currently only for internal Elastic development and is unsupported
 export const getRegistryUrl = (): string => {
   const customUrl = appContextService.getConfig()?.registryUrl;
+  console.log('REGISTRY URL', customUrl);
   const isEnterprise = licenseService.isEnterprise();
 
   if (customUrl && isEnterprise) {


### PR DESCRIPTION
## Summary

The config for Fleet as been renamed from 
* `xpack.ingestManager` to `xpack.fleet.*`
* `xpack.ingestManager.fleet.*` to `xpack.fleet.agent.*`

The rename rule we are using where not working if both `xpack.ingestManager.*` and `xpack.ingestManager.fleet.*` where used.


## How to reproduce the bug

Configure both fleet and agents using the old key `ingestManager`

In kibana.dev.yml
```
xpack.ingestManager.registryUrl: 'http://localhost:8080/'
xpack.ingestManager.fleet.tlsCheckDisabled: true
```

It should not use your registry
and you should saw this when kibana start 
```log
server    log   [14:11:09.896] [warning][config][deprecation] "xpack.ingestManager.fleet" is deprecated and has been replaced by "xpack.fleet.agents"
server    log   [14:11:09.897] [warning][config][deprecation] "xpack.ingestManager" is deprecated and has been replaced by "xpack.fleet". However both key are present, ignoring "xpack.ingestManager"
```