### PR TITLE
[Ingest Manager] Don't error if editing the same agent_policy

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
@@ -128,25 +128,28 @@ class AgentPolicyService {
 
   public async requireUniqueName(
     soClient: SavedObjectsClientContract,
-    { name, namespace }: Pick<NewAgentPolicy, 'name' | 'namespace'>
+    givenPolicy: { id?: string; name: string; namespace: string }
   ) {
     const results = await soClient.find<AgentPolicySOAttributes>({
       type: SAVED_OBJECT_TYPE,
       searchFields: ['namespace', 'name'],
-      search: `${namespace} + ${escapeSearchQueryPhrase(name)}`,
+      search: `${givenPolicy.namespace} + ${escapeSearchQueryPhrase(givenPolicy.name)}`,
     });
 
     if (results.total) {
-      const policies = results.saved_objects;
-      const isSinglePolicy = policies.length === 1;
-      const policyList = isSinglePolicy ? policies[0].id : policies.map(({ id }) => id).join(',');
-      const existClause = isSinglePolicy
-        ? `Agent Policy '${policyList}' already exists`
-        : `Agent Policies '${policyList}' already exist`;
+      const existingPolicies = results.saved_objects;
+      const existingIds = existingPolicies.map(({ id }) => id);
+      const isSinglePolicy = existingIds.length === 1;
+      const policyList = isSinglePolicy ? existingIds[0] : existingIds.join(',');
+      if (givenPolicy.id && !existingIds.includes(givenPolicy.id)) {
+        const existClause = isSinglePolicy
+          ? `Agent Policy '${policyList}' already exists`
+          : `Agent Policies '${policyList}' already exist`;
 
-      throw new AgentPolicyNameExistsError(
-        `${existClause} in '${namespace}' namespace with name '${name}'`
-      );
+        throw new AgentPolicyNameExistsError(
+          `${existClause} in '${givenPolicy.namespace}' namespace with name '${givenPolicy.name}'`
+        );
+      }
     }
   }
 
@@ -237,6 +240,7 @@ class AgentPolicyService {
   ): Promise<AgentPolicy> {
     if (agentPolicy.name && agentPolicy.namespace) {
       await this.requireUniqueName(soClient, {
+        id,
         name: agentPolicy.name,
         namespace: agentPolicy.namespace,
       });

--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
@@ -135,16 +135,14 @@ class AgentPolicyService {
       searchFields: ['namespace', 'name'],
       search: `${givenPolicy.namespace} + ${escapeSearchQueryPhrase(givenPolicy.name)}`,
     });
-
-    if (results.total) {
-      const existingPolicies = results.saved_objects;
-      const existingIds = existingPolicies.map(({ id }) => id);
-      const isSinglePolicy = existingIds.length === 1;
-      const policyList = isSinglePolicy ? existingIds[0] : existingIds.join(',');
-      if (givenPolicy.id && !existingIds.includes(givenPolicy.id)) {
+    const idsWithName = results.total && results.saved_objects.map(({ id }) => id);
+    if (Array.isArray(idsWithName)) {
+      const isEditingSelf = givenPolicy.id && idsWithName.includes(givenPolicy.id);
+      if (!givenPolicy.id || !isEditingSelf) {
+        const isSinglePolicy = idsWithName.length === 1;
         const existClause = isSinglePolicy
-          ? `Agent Policy '${policyList}' already exists`
-          : `Agent Policies '${policyList}' already exist`;
+          ? `Agent Policy '${idsWithName[0]}' already exists`
+          : `Agent Policies '${idsWithName.join(',')}' already exist`;
 
         throw new AgentPolicyNameExistsError(
           `${existClause} in '${givenPolicy.namespace}' namespace with name '${givenPolicy.name}'`


### PR DESCRIPTION
## Summary

fixes #80136

Haven't added/updated tests yet but tested the various combinations in the UI and all worked as expected.

<details><summary>Screenshots</summary>
<h3>Policy listing</h3>
<img width="1302" alt="Screen Shot 2020-10-14 at 7 05 19 AM" src="https://user-images.githubusercontent.com/57655/95981056-1c1c6d00-0dec-11eb-9746-5e91043f3d19.png">

<h3>Update existing policy succeeds</h3>
<img width="1308" alt="Screen Shot 2020-10-14 at 7 05 49 AM" src="https://user-images.githubusercontent.com/57655/95981059-1cb50380-0dec-11eb-9e55-7a14b72085f9.png">
<h3>Creating new policy w/existing name fails</h3>
<img width="1308" alt="Screen Shot 2020-10-14 at 7 06 06 AM" src="https://user-images.githubusercontent.com/57655/95981062-1cb50380-0dec-11eb-833b-1ab6636a5c67.png">

<h3>Updating policy to existing name fails</h3>
<img width="1308" alt="Screen Shot 2020-10-14 at 7 08 05 AM" src="https://user-images.githubusercontent.com/57655/95981078-1f175d80-0dec-11eb-91d5-7ffd976da48e.png">

</details>
### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
