### PR TITLE
[Security Solution] Fixes an issue where zoom controls were overlaid by the Timeline flyout button when "analyze event" is in full screen mode

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { waitFor } from '@testing-library/react';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { useFullScreen } from '../../../common/containers/use_full_screen';
+import { mockTimelineModel, TestProviders } from '../../../common/mock';
+import { TimelineId, TimelineType } from '../../../../common/types/timeline';
+
+import { GraphOverlay } from '.';
+
+jest.mock('../../../common/hooks/use_selector', () => ({
+  useShallowEqualSelector: jest.fn().mockReturnValue(mockTimelineModel),
+}));
+
+jest.mock('../../../common/containers/use_full_screen', () => ({
+  useFullScreen: jest.fn(),
+}));
+
+describe('GraphOverlay', () => {
+  beforeEach(() => {
+    (useFullScreen as jest.Mock).mockReturnValue({
+      timelineFullScreen: false,
+      setTimelineFullScreen: jest.fn(),
+      globalFullScreen: false,
+      setGlobalFullScreen: jest.fn(),
+    });
+  });
+
+  describe('when used in an events viewer (i.e. in the Detections view, or the Host > Events view)', () => {
+    const isEventViewer = true;
+    const timelineId = 'used-as-an-events-viewer';
+
+    test('it has 100% width when isEventViewer is true and NOT in full screen mode', async () => {
+      const wrapper = mount(
+        <TestProviders>
+          <GraphOverlay
+            timelineId={timelineId}
+            graphEventId="abcd"
+            isEventViewer={isEventViewer}
+            timelineType={TimelineType.default}
+          />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        const overlayContainer = wrapper.find('[data-test-subj="overlayContainer"]').first();
+        expect(overlayContainer).toHaveStyleRule('width', '100%');
+      });
+    });
+
+    test('it has a calculated width that makes room for the Timeline flyout button when isEventViewer is true in full screen mode', async () => {
+      (useFullScreen as jest.Mock).mockReturnValue({
+        timelineFullScreen: false,
+        setTimelineFullScreen: jest.fn(),
+        globalFullScreen: true, // <-- true when an events viewer is in full screen mode
+        setGlobalFullScreen: jest.fn(),
+      });
+
+      const wrapper = mount(
+        <TestProviders>
+          <GraphOverlay
+            timelineId={timelineId}
+            graphEventId="abcd"
+            isEventViewer={isEventViewer}
+            timelineType={TimelineType.default}
+          />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        const overlayContainer = wrapper.find('[data-test-subj="overlayContainer"]').first();
+        expect(overlayContainer).toHaveStyleRule('width', 'calc(100% - 36px)');
+      });
+    });
+  });
+
+  describe('when used in the active timeline', () => {
+    const isEventViewer = false;
+    const timelineId = TimelineId.active;
+
+    test('it has 100% width when isEventViewer is false and NOT in full screen mode', async () => {
+      const wrapper = mount(
+        <TestProviders>
+          <GraphOverlay
+            timelineId={timelineId}
+            graphEventId="abcd"
+            isEventViewer={isEventViewer}
+            timelineType={TimelineType.default}
+          />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        const overlayContainer = wrapper.find('[data-test-subj="overlayContainer"]').first();
+        expect(overlayContainer).toHaveStyleRule('width', '100%');
+      });
+    });
+
+    test('it has 100% width when isEventViewer is false and the active timeline is in full screen mode', async () => {
+      (useFullScreen as jest.Mock).mockReturnValue({
+        timelineFullScreen: true, // <-- true when the active timeline is in full screen mode
+        setTimelineFullScreen: jest.fn(),
+        globalFullScreen: false,
+        setGlobalFullScreen: jest.fn(),
+      });
+
+      const wrapper = mount(
+        <TestProviders>
+          <GraphOverlay
+            timelineId={timelineId}
+            graphEventId="abcd"
+            isEventViewer={isEventViewer}
+            timelineType={TimelineType.default}
+          />
+        </TestProviders>
+      );
+
+      await waitFor(() => {
+        const overlayContainer = wrapper.find('[data-test-subj="overlayContainer"]').first();
+        expect(overlayContainer).toHaveStyleRule('width', '100%');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -38,10 +38,13 @@ import { useUiSetting$ } from '../../../common/lib/kibana';
 import { useSignalIndex } from '../../../detections/containers/detection_engine/alerts/use_signal_index';
 
 const OverlayContainer = styled.div`
-  height: 100%;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
+  ${({ $restrictWidth }: { $restrictWidth: boolean }) =>
+    `
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: ${$restrictWidth ? 'calc(100% - 36px)' : '100%'};
+    `}
 `;
 
 const StyledResolver = styled(Resolver)`
@@ -54,6 +57,7 @@ const FullScreenButtonIcon = styled(EuiButtonIcon)`
 
 interface OwnProps {
   graphEventId?: string;
+  isEventViewer: boolean;
   timelineId: string;
   timelineType: TimelineType;
 }
@@ -100,6 +104,7 @@ const Navigation = ({
 
 const GraphOverlayComponent = ({
   graphEventId,
+  isEventViewer,
   status,
   timelineId,
   title,
@@ -151,7 +156,10 @@ const GraphOverlayComponent = ({
   }, [signalIndexName, siemDefaultIndices]);
 
   return (
-    <OverlayContainer>
+    <OverlayContainer
+      data-test-subj="overlayContainer"
+      $restrictWidth={isEventViewer && fullScreen}
+    >
       <EuiHorizontalRule margin="none" />
       <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/index.tsx
@@ -134,6 +134,7 @@ export const Body = React.memo<BodyProps>(
         {graphEventId && (
           <GraphOverlay
             graphEventId={graphEventId}
+            isEventViewer={isEventViewer}
             timelineId={timelineId}
             timelineType={timelineType}
           />


### PR DESCRIPTION
## Fixes an issue where zoom controls were overlaid by the Timeline flyout button when "analyze event" is in full screen mode

This PR implements a fix for [Zoom-in Zoom-out widget is overlaid on the Timeline flyout button after clicking on full-screen icon under "analyze event" #80309](https://github.com/elastic/kibana/issues/80309)

**Steps to Reproduce**

From the issue above:

1. Navigate to Detections under the security tab.
2. Click on the "analyze event" icon of alert that triggered in preconditions under the alert table.
3. Now click on the "Fullscreen" icon.
4. Observe that the Zoom-in Zoom-out widget is overlaid on the Timeline flyout button after clicking on full-screen icon under "analyze event". 

**Actual Result**
Zoom-in Zoom-out widget is overlaid on the Timeline flyout button after clicking on full-screen icon under "analyze event".

![UI_overlaid_events](https://user-images.githubusercontent.com/61860752/95853499-277f8200-0d73-11eb-8d17-6da7e37b0b14.jpg)

**Expected Result**
Zoom-in Zoom-out widget should not be overlaid on Timeline flyout button after clicking on full screen icon under "analyze event".

Screenshots of the fix:

### Chrome `85.0.4183.121` 

<img width="1708" alt="after-chrome" src="https://user-images.githubusercontent.com/4459398/95923597-13d41b80-0d73-11eb-9447-6ffcaeb12360.png">

### Firefox `81.0.1 `

<img width="1708" alt="safari-after" src="https://user-images.githubusercontent.com/4459398/95923622-24849180-0d73-11eb-859d-31c654588072.png">

### Safari `14.0`

<img width="1708" alt="safari-after" src="https://user-images.githubusercontent.com/4459398/95923656-36fecb00-0d73-11eb-881e-531208cce5fc.png">
