### PR TITLE
Set new data on elements after fetch.

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Cytoscape.tsx
@@ -84,6 +84,11 @@ function CytoscapeComponent({
       cy.elements().forEach((element) => {
         if (!elementIds.includes(element.data('id'))) {
           cy.remove(element);
+        } else {
+          // Doing an "add" with an element with the same id will keep the original
+          // element. Set the data with the new element data.
+          const newElement = elements.find((el) => el.data.id === element.id());
+          element.data(newElement?.data ?? element.data());
         }
       });
       cy.trigger('custom:data', [fit]);


### PR DESCRIPTION
When `add`ing an element with an already existing ID, it will use the already existing data instead of setting new data. This made it so when you change the time picker the element health statuses would not update.

When we get new elements, replace the existing data for existing elements.

Fixes #80335.
