### PR TITLE
Register the 'Visualize field' action of OSS on plugin setup

### DIFF
--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -49,7 +49,7 @@ import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
 import { SavedObjectsStart } from '../../saved_objects/public';
 import { EmbeddableStart } from '../../embeddable/public';
 import { DashboardStart } from '../../dashboard/public';
-import { UiActionsStart, VISUALIZE_FIELD_TRIGGER } from '../../ui_actions/public';
+import { UiActionsSetup, VISUALIZE_FIELD_TRIGGER } from '../../ui_actions/public';
 import {
   setUISettings,
   setApplication,
@@ -69,7 +69,6 @@ export interface VisualizePluginStartDependencies {
   urlForwarding: UrlForwardingStart;
   savedObjects: SavedObjectsStart;
   dashboard: DashboardStart;
-  uiActions: UiActionsStart;
 }
 
 export interface VisualizePluginSetupDependencies {
@@ -77,6 +76,7 @@ export interface VisualizePluginSetupDependencies {
   urlForwarding: UrlForwardingSetup;
   data: DataPublicPluginSetup;
   share?: SharePluginSetup;
+  uiActions: UiActionsSetup;
 }
 
 export class VisualizePlugin
@@ -90,7 +90,7 @@ export class VisualizePlugin
 
   public async setup(
     core: CoreSetup<VisualizePluginStartDependencies>,
-    { home, urlForwarding, data, share }: VisualizePluginSetupDependencies
+    { home, urlForwarding, data, share, uiActions }: VisualizePluginSetupDependencies
   ) {
     const {
       appMounted,
@@ -135,6 +135,7 @@ export class VisualizePlugin
       );
     }
     setUISettings(core.uiSettings);
+    uiActions.addTriggerAction(VISUALIZE_FIELD_TRIGGER, visualizeFieldAction);
 
     core.application.register({
       id: 'visualize',
@@ -236,7 +237,6 @@ export class VisualizePlugin
     if (plugins.share) {
       setShareService(plugins.share);
     }
-    plugins.uiActions.addTriggerAction(VISUALIZE_FIELD_TRIGGER, visualizeFieldAction);
   }
 
   stop() {


### PR DESCRIPTION
## Summary

Closes #80435. 
This test fails due to a race condition that happens when the visualize plugin action is registered after Lens unregisters it. So we are moving the visualize plugin action registration to the plugin setup. So Lens will unregister the action on start and there will be no possibility to have both actions.
