### PR TITLE
[Ingest Manger] Agent policy names must be unique across Fleet

### DIFF
--- a/x-pack/test/ingest_manager_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/agent_policy/agent_policy.ts
@@ -225,7 +225,9 @@ export default function ({ getService }: FtrProviderContext) {
           .post(`/api/fleet/agent_policies`)
           .set('kbn-xsrf', 'xxxx')
           .send(sharedBody)
-          .expect(200);
+          .expect(409);
+
+        expect(body.message).to.match(/already exists?/);
       });
     });
   });


### PR DESCRIPTION
## Summary

fixes #79903

Agent policy names are unique across all Fleet, not scoped by namespace.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
