### PR TITLE
[Ingest Manager] send path as separate property in Full Agent Policy

### DIFF
--- a/x-pack/plugins/ingest_manager/common/services/full_agent_policy_kibana_config.test.ts
+++ b/x-pack/plugins/ingest_manager/common/services/full_agent_policy_kibana_config.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { getFullAgentPolicyKibanaConfig } from './full_agent_policy_kibana_config';
+
+describe('Fleet - getFullAgentPolicyKibanaConfig', () => {
+  it('should return no path when there is no path', () => {
+    expect(getFullAgentPolicyKibanaConfig(['http://localhost:5601'])).toEqual({
+      hosts: ['localhost:5601'],
+      protocol: 'http',
+    });
+  });
+  it('should return correct config when there is a path', () => {
+    expect(getFullAgentPolicyKibanaConfig(['http://localhost:5601/ssg'])).toEqual({
+      hosts: ['localhost:5601'],
+      protocol: 'http',
+      path: '/ssg/',
+    });
+  });
+  it('should return correct config when there is a path that ends in a slash', () => {
+    expect(getFullAgentPolicyKibanaConfig(['http://localhost:5601/ssg/'])).toEqual({
+      hosts: ['localhost:5601'],
+      protocol: 'http',
+      path: '/ssg/',
+    });
+  });
+  it('should return correct config when there are multiple hosts', () => {
+    expect(
+      getFullAgentPolicyKibanaConfig(['http://localhost:5601/ssg/', 'http://localhost:3333/ssg/'])
+    ).toEqual({
+      hosts: ['localhost:5601', 'localhost:3333'],
+      protocol: 'http',
+      path: '/ssg/',
+    });
+  });
+});

--- a/x-pack/plugins/ingest_manager/common/services/full_agent_policy_kibana_config.ts
+++ b/x-pack/plugins/ingest_manager/common/services/full_agent_policy_kibana_config.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { FullAgentPolicyKibanaConfig } from '../types';
+
+export function getFullAgentPolicyKibanaConfig(kibanaUrls: string[]): FullAgentPolicyKibanaConfig {
+  // paths and protocol are validated to be the same for all urls, so use the first to get them
+  const firstUrlParsed = new URL(kibanaUrls[0]);
+  const config: FullAgentPolicyKibanaConfig = {
+    // remove the : from http:
+    protocol: firstUrlParsed.protocol.replace(':', ''),
+    hosts: kibanaUrls.map((url) => new URL(url).host),
+  };
+
+  // add path if user provided one
+  if (firstUrlParsed.pathname !== '/') {
+    // make sure the path ends with /
+    config.path = firstUrlParsed.pathname.endsWith('/')
+      ? firstUrlParsed.pathname
+      : `${firstUrlParsed.pathname}/`;
+  }
+  return config;
+}

--- a/x-pack/plugins/ingest_manager/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/common/types/models/agent_policy.ts
@@ -62,10 +62,7 @@ export interface FullAgentPolicy {
     };
   };
   fleet?: {
-    kibana: {
-      hosts: string[];
-      protocol: string;
-    };
+    kibana: FullAgentPolicyKibanaConfig;
   };
   inputs: FullAgentPolicyInput[];
   revision?: number;
@@ -77,4 +74,10 @@ export interface FullAgentPolicy {
       logs: boolean;
     };
   };
+}
+
+export interface FullAgentPolicyKibanaConfig {
+  hosts: string[];
+  protocol: string;
+  path?: string;
 }

--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
@@ -33,6 +33,7 @@ import { outputService } from './output';
 import { agentPolicyUpdateEventHandler } from './agent_policy_update';
 import { getSettings } from './settings';
 import { normalizeKuery, escapeSearchQueryPhrase } from './saved_object';
+import { getFullAgentPolicyKibanaConfig } from '../../common/services/full_agent_policy_kibana_config';
 
 const SAVED_OBJECT_TYPE = AGENT_POLICY_SAVED_OBJECT_TYPE;
 
@@ -537,18 +538,11 @@ class AgentPolicyService {
       }
       if (!settings.kibana_urls || !settings.kibana_urls.length)
         throw new Error('kibana_urls is missing');
-      const hostsWithoutProtocol = settings.kibana_urls.map((url) => {
-        const parsedURL = new URL(url);
-        return `${parsedURL.host}${parsedURL.pathname !== '/' ? parsedURL.pathname : ''}`;
-      });
+
       fullAgentPolicy.fleet = {
-        kibana: {
-          protocol: new URL(settings.kibana_urls[0]).protocol.replace(':', ''),
-          hosts: hostsWithoutProtocol,
-        },
+        kibana: getFullAgentPolicyKibanaConfig(settings.kibana_urls),
       };
     }
-
     return fullAgentPolicy;
   }
 }


### PR DESCRIPTION
As part of the Fleet Kibana config in the FullAgentPolicy,  path should not be sent as part of host property, taken from the user's Settings for kibana urls.  Path, if it exists, will be sent as `path` otherwise no property will be sent as part of the config.  Path will no longer be part of `hosts` . 

Related:
https://github.com/elastic/beats/pull/21804
https://github.com/elastic/beats/issues/21601