### PR TITLE
Added brace import to vis_default_editor

### DIFF
--- a/src/plugins/vis_default_editor/public/default_editor.tsx
+++ b/src/plugins/vis_default_editor/public/default_editor.tsx
@@ -18,6 +18,7 @@
  */
 
 import './index.scss';
+import 'brace/mode/json';
 
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { EventEmitter } from 'events';


### PR DESCRIPTION
## Summary

Fix for the large number of `Uncaught SyntaxError: Unexpected token '<'` errors reported in CI.