### PR TITLE
[Ingest Manager] Better validation of registry urls

### DIFF
--- a/x-pack/plugins/ingest_manager/server/index.ts
+++ b/x-pack/plugins/ingest_manager/server/index.ts
@@ -30,8 +30,8 @@ export const config: PluginConfigDescriptor = {
   ],
   schema: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
-    registryUrl: schema.maybe(schema.uri()),
-    registryProxyUrl: schema.maybe(schema.uri()),
+    registryUrl: schema.maybe(schema.uri({ scheme: ['http', 'https'] })),
+    registryProxyUrl: schema.maybe(schema.uri({ scheme: ['http', 'https'] })),
     agents: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
       tlsCheckDisabled: schema.boolean({ defaultValue: false }),


### PR DESCRIPTION
## Summary

currently it's possible to set invalid values as registry url like:
```
xpack.ingestManager.registryUrl: 'htttttttttps://epr-staging.elastic.co/'
```

this result in this error during ingest manager setup:
```
TypeError: only HTTPS protocol supported
```

This PR fix it by validating the url scheme