### PR TITLE
80697: ignore 404, check if there are transforms in results.

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/common.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/common.ts
@@ -4,8 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { Logger } from 'src/core/server';
 import * as Registry from '../../registry';
+import { appContextService } from '../../../app_context';
 
 export const getAsset = (path: string): Buffer => {
   return Registry.getAsset(path);
+};
+
+export const getLogger = (): Logger => {
+  return appContextService.getLogger();
 };

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/common.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/common.ts
@@ -4,14 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { Logger } from 'src/core/server';
 import * as Registry from '../../registry';
-import { appContextService } from '../../../app_context';
 
 export const getAsset = (path: string): Buffer => {
   return Registry.getAsset(path);
-};
-
-export const getLogger = (): Logger => {
-  return appContextService.getLogger();
 };

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
@@ -28,7 +28,7 @@ export const deleteTransforms = async (
       // get the index the transform
       const transformResponse: {
         count: number;
-        transforms: Array<{
+        transforms?: Array<{
           dest: {
             index: string;
           };
@@ -36,6 +36,7 @@ export const deleteTransforms = async (
       } = await callCluster('transport.request', {
         method: 'GET',
         path: `/_transform/${transformId}`,
+        ignore: [404],
       });
 
       await stopTransforms([transformId], callCluster);
@@ -46,13 +47,15 @@ export const deleteTransforms = async (
         ignore: [404],
       });
 
-      // expect this to be 1
-      for (const transform of transformResponse.transforms) {
-        await callCluster('transport.request', {
-          method: 'DELETE',
-          path: `/${transform?.dest?.index}`,
-          ignore: [404],
-        });
+      if (transformResponse?.transforms) {
+        // expect this to be 1
+        for (const transform of transformResponse.transforms) {
+          await callCluster('transport.request', {
+            method: 'DELETE',
+            path: `/${transform?.dest?.index}`,
+            ignore: [404],
+          });
+        }
       }
     })
   );

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
@@ -8,6 +8,7 @@ import { SavedObjectsClientContract } from 'kibana/server';
 import { CallESAsCurrentUser, ElasticsearchAssetType, EsAssetReference } from '../../../../types';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../../../common/constants';
 import { getLogger } from './common';
+import { appContextService } from '../../../app_context';
 
 export const stopTransforms = async (transformIds: string[], callCluster: CallESAsCurrentUser) => {
   for (const transformId of transformIds) {
@@ -58,7 +59,7 @@ export const deleteTransforms = async (
           });
         }
       } else {
-        getLogger().warn(`cannot find transform for ${transformId}`);
+        appContextService.getLogger().warn(`cannot find transform for ${transformId}`);
       }
     })
   );

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
@@ -7,6 +7,7 @@
 import { SavedObjectsClientContract } from 'kibana/server';
 import { CallESAsCurrentUser, ElasticsearchAssetType, EsAssetReference } from '../../../../types';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../../../common/constants';
+import { getLogger } from './common';
 
 export const stopTransforms = async (transformIds: string[], callCluster: CallESAsCurrentUser) => {
   for (const transformId of transformIds) {
@@ -56,6 +57,8 @@ export const deleteTransforms = async (
             ignore: [404],
           });
         }
+      } else {
+        getLogger().warn(`cannot find transform for ${transformId}`);
       }
     })
   );

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
@@ -7,7 +7,6 @@
 import { SavedObjectsClientContract } from 'kibana/server';
 import { CallESAsCurrentUser, ElasticsearchAssetType, EsAssetReference } from '../../../../types';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../../../common/constants';
-import { getLogger } from './common';
 import { appContextService } from '../../../app_context';
 
 export const stopTransforms = async (transformIds: string[], callCluster: CallESAsCurrentUser) => {

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -160,6 +160,7 @@ describe('test transform install', () => {
         {
           method: 'GET',
           path: '/_transform/endpoint.metadata_current-default-0.15.0-dev.0',
+          ignore: [404],
         },
       ],
       [
@@ -446,6 +447,7 @@ describe('test transform install', () => {
         {
           method: 'GET',
           path: '/_transform/endpoint.metadata-current-default-0.15.0-dev.0',
+          ignore: [404],
         },
       ],
       [

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -11,6 +11,7 @@ jest.mock('../../packages/get', () => {
 jest.mock('./common', () => {
   return {
     getAsset: jest.fn(),
+    getLogger: jest.fn(),
   };
 });
 

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -11,7 +11,6 @@ jest.mock('../../packages/get', () => {
 jest.mock('./common', () => {
   return {
     getAsset: jest.fn(),
-    getLogger: jest.fn(),
   };
 });
 


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/80697
## Summary

- [x] ignore missing transform even when present in Fleet. 
- [x] check that there is transform in response before deleting index attached to transform. 

### Checklist


Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios