### PR TITLE
[Ingest Manager] Fix for comparing versions with -SNAPSHOT suffix

### DIFF
--- a/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.test.ts
+++ b/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.test.ts
@@ -135,4 +135,35 @@ describe('Ingest Manager - isAgentUpgradeable', () => {
       true
     );
   });
+  it('returns false if agent reports upgradeable, with agent snapshot version === kibana version', () => {
+    expect(
+      isAgentUpgradeable(getAgent({ version: '7.9.0-SNAPSHOT', upgradeable: true }), '7.9.0')
+    ).toBe(false);
+  });
+  it('returns false if agent reports upgradeable, with agent version === kibana snapshot version', () => {
+    expect(
+      isAgentUpgradeable(getAgent({ version: '7.9.0', upgradeable: true }), '7.9.0-SNAPSHOT')
+    ).toBe(false);
+  });
+  it('returns true if agent reports upgradeable, with agent snapshot version < kibana snapshot version', () => {
+    expect(
+      isAgentUpgradeable(
+        getAgent({ version: '7.9.0-SNAPSHOT', upgradeable: true }),
+        '8.0.0-SNAPSHOT'
+      )
+    ).toBe(true);
+  });
+  it('returns false if agent reports upgradeable, with agent snapshot version === kibana snapshot version', () => {
+    expect(
+      isAgentUpgradeable(
+        getAgent({ version: '8.0.0-SNAPSHOT', upgradeable: true }),
+        '8.0.0-SNAPSHOT'
+      )
+    ).toBe(false);
+  });
+  it('returns true if agent reports upgradeable, with agent version < kibana snapshot version', () => {
+    expect(
+      isAgentUpgradeable(getAgent({ version: '7.9.0', upgradeable: true }), '8.0.0-SNAPSHOT')
+    ).toBe(true);
+  });
 });

--- a/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.ts
+++ b/x-pack/plugins/ingest_manager/common/services/is_agent_upgradeable.ts
@@ -14,9 +14,12 @@ export function isAgentUpgradeable(agent: Agent, kibanaVersion: string) {
     return false;
   }
   if (agent.unenrollment_started_at || agent.unenrolled_at) return false;
-  const kibanaVersionParsed = semver.parse(kibanaVersion);
-  const agentVersionParsed = semver.parse(agentVersion);
-  if (!agentVersionParsed || !kibanaVersionParsed) return false;
   if (!agent.local_metadata.elastic.agent.upgradeable) return false;
-  return semver.lt(agentVersionParsed, kibanaVersionParsed);
+
+  // make sure versions are only the number before comparison
+  const agentVersionNumber = semver.coerce(agentVersion);
+  if (!agentVersionNumber) throw new Error('agent version is invalid');
+  const kibanaVersionNumber = semver.coerce(kibanaVersion);
+  if (!kibanaVersionNumber) throw new Error('kibana version is invalid');
+  return semver.lt(agentVersionNumber, kibanaVersionNumber);
 }

--- a/x-pack/plugins/ingest_manager/server/routes/agent/upgrade_handler.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/agent/upgrade_handler.ts
@@ -69,7 +69,7 @@ export const postAgentUpgradeHandler: RequestHandler<
     await AgentService.sendUpgradeAgentAction({
       soClient,
       agentId: request.params.agentId,
-      version: versionToUpgradeNumber,
+      version,
       sourceUri,
     });
 
@@ -109,13 +109,13 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
       await AgentService.sendUpgradeAgentsActions(soClient, {
         agentIds: agents,
         sourceUri,
-        version: versionToUpgradeNumber,
+        version,
       });
     } else {
       await AgentService.sendUpgradeAgentsActions(soClient, {
         kuery: agents,
         sourceUri,
-        version: versionToUpgradeNumber,
+        version,
       });
     }
 

--- a/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
@@ -11,6 +11,10 @@ import { setupIngest } from './services';
 import { skipIfNoDockerRegistry } from '../../../helpers';
 import { AGENT_SAVED_OBJECT_TYPE } from '../../../../../plugins/ingest_manager/common';
 
+const makeSnapshotVersion = (version: string) => {
+  return version.endsWith('-SNAPSHOT') ? version : `${version}-SNAPSHOT`;
+};
+
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
@@ -50,7 +54,7 @@ export default function (providerContext: FtrProviderContext) {
     });
     it('should respond 400 if upgrading agent with version the same as snapshot version', async () => {
       const kibanaVersion = await kibanaServer.version.get();
-      const kibanaVersionSnapshot = `${kibanaVersion}-SNAPSHOT`;
+      const kibanaVersionSnapshot = makeSnapshotVersion(kibanaVersion);
       await kibanaServer.savedObjects.update({
         id: 'agent1',
         type: AGENT_SAVED_OBJECT_TYPE,
@@ -68,7 +72,8 @@ export default function (providerContext: FtrProviderContext) {
     });
     it('should respond 200 if upgrading agent with version less than kibana snapshot version', async () => {
       const kibanaVersion = await kibanaServer.version.get();
-      const kibanaVersionSnapshot = `${kibanaVersion}-SNAPSHOT`;
+      const kibanaVersionSnapshot = makeSnapshotVersion(kibanaVersion);
+
       await kibanaServer.savedObjects.update({
         id: 'agent1',
         type: AGENT_SAVED_OBJECT_TYPE,

--- a/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
@@ -48,6 +48,42 @@ export default function (providerContext: FtrProviderContext) {
       const res = await supertest.get(`/api/fleet/agents/agent1`).set('kbn-xsrf', 'xxx');
       expect(typeof res.body.item.upgrade_started_at).to.be('string');
     });
+    it('should respond 400 if upgrading agent with version the same as snapshot version', async () => {
+      const kibanaVersion = await kibanaServer.version.get();
+      const kibanaVersionSnapshot = `${kibanaVersion}-SNAPSHOT`;
+      await kibanaServer.savedObjects.update({
+        id: 'agent1',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: true, version: kibanaVersion } } },
+        },
+      });
+      await supertest
+        .post(`/api/fleet/agents/agent1/upgrade`)
+        .set('kbn-xsrf', 'xxx')
+        .send({
+          version: kibanaVersionSnapshot,
+        })
+        .expect(400);
+    });
+    it('should respond 200 if upgrading agent with version less than kibana snapshot version', async () => {
+      const kibanaVersion = await kibanaServer.version.get();
+      const kibanaVersionSnapshot = `${kibanaVersion}-SNAPSHOT`;
+      await kibanaServer.savedObjects.update({
+        id: 'agent1',
+        type: AGENT_SAVED_OBJECT_TYPE,
+        attributes: {
+          local_metadata: { elastic: { agent: { upgradeable: true, version: '0.0.0' } } },
+        },
+      });
+      await supertest
+        .post(`/api/fleet/agents/agent1/upgrade`)
+        .set('kbn-xsrf', 'xxx')
+        .send({
+          version: kibanaVersionSnapshot,
+        })
+        .expect(200);
+    });
     it('should respond 200 to upgrade agent and update the agent SO without source_uri', async () => {
       const kibanaVersion = await kibanaServer.version.get();
       await kibanaServer.savedObjects.update({


### PR DESCRIPTION
Fleet uses the Kibana version to determine which version the agent can upgrade to.  If Kibana is running as a snapshot, the version will have the `-SNAPSHOT` prefix in it.  When comparing versions we should not include the `-SNAPSHOT`.