### PR TITLE
Fix anomaly alert selection text

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/TransactionDurationAnomalyAlertTrigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/TransactionDurationAnomalyAlertTrigger/index.tsx
@@ -17,7 +17,7 @@ import { PopoverExpression } from '../ServiceAlertTrigger/PopoverExpression';
 import {
   AnomalySeverity,
   SelectAnomalySeverity,
-} from './SelectAnomalySeverity';
+} from './select_anomaly_severity';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import {
   EnvironmentField,

--- a/x-pack/plugins/apm/public/components/alerting/TransactionDurationAnomalyAlertTrigger/select_anomaly_severity.test.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/TransactionDurationAnomalyAlertTrigger/select_anomaly_severity.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { render } from '@testing-library/react';
+import React, { ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+import { ANOMALY_SEVERITY } from '../../../../../ml/common';
+import { SelectAnomalySeverity } from './select_anomaly_severity';
+
+function Wrapper({ children }: { children?: ReactNode }) {
+  return <IntlProvider locale="en">{children}</IntlProvider>;
+}
+
+describe('SelectAnomalySeverity', () => {
+  it('shows the correct text for each item', async () => {
+    const result = render(
+      <SelectAnomalySeverity
+        onChange={() => {}}
+        value={ANOMALY_SEVERITY.CRITICAL}
+      />,
+      { wrapper: Wrapper }
+    );
+    const button = (await result.findAllByText('critical'))[1];
+
+    button.click();
+
+    const options = await result.findAllByTestId(
+      'SelectAnomalySeverity option text'
+    );
+
+    expect(
+      options.map((option) => (option.firstChild as HTMLElement)?.innerHTML)
+    ).toEqual([
+      'score critical ', // Trailing space is intentional here, to keep the i18n simple
+      'score major and above',
+      'score minor and above',
+      'score warning and above',
+    ]);
+  });
+});

--- a/x-pack/plugins/apm/public/components/alerting/TransactionDurationAnomalyAlertTrigger/select_anomaly_severity.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/TransactionDurationAnomalyAlertTrigger/select_anomaly_severity.tsx
@@ -45,11 +45,14 @@ export function SelectAnomalySeverity({ onChange, value }: Props) {
             <AnomalySeverity type={option.type} />
             <EuiSpacer size="xs" />
             <EuiText size="xs" color="subdued">
-              <p className="euiTextColor--subdued">
+              <p
+                className="euiTextColor--subdued"
+                data-test-subj="SelectAnomalySeverity option text"
+              >
                 <FormattedMessage
                   id="xpack.apm.alerts.anomalySeverity.scoreDetailsDescription"
-                  defaultMessage="score {value} and above"
-                  values={{ value }}
+                  defaultMessage="score {value} {value, select, critical {} other {and above}}"
+                  values={{ value: option.type }}
                 />
               </p>
             </EuiText>


### PR DESCRIPTION
Was using the incorrect value. Add a case to leave out "and above" when on "critical."

Add a test and rename files to snake case.

Fixes #80441.

# Before

![image](https://user-images.githubusercontent.com/9912/96182383-05b10700-0efb-11eb-91c3-81f9b7d5d180.png)

# After

![image](https://user-images.githubusercontent.com/9912/96182438-18c3d700-0efb-11eb-9941-33208913a94c.png)
