### PR TITLE
[Enterprise Search] Fix users being logged out of Kibana if Enterprise Search returns a 401

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -325,6 +325,10 @@ describe('EnterpriseSearchRequestHandler', () => {
         expect(mockLogger.error).toHaveBeenCalled();
       });
 
+      it('errors when receiving a 401 response', async () => {
+        EnterpriseSearchAPI.mockReturn({}, { status: 401 });
+      });
+
       it('errors when redirected to /login', async () => {
         EnterpriseSearchAPI.mockReturn({}, { url: 'http://localhost:3002/login' });
       });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -84,8 +84,12 @@ export class EnterpriseSearchRequestHandler {
         // Handle response headers
         this.setResponseHeaders(apiResponse);
 
-        // Handle authentication redirects
-        if (apiResponse.url.endsWith('/login') || apiResponse.url.endsWith('/ent/select')) {
+        // Handle unauthenticated users / authentication redirects
+        if (
+          apiResponse.status === 401 ||
+          apiResponse.url.endsWith('/login') ||
+          apiResponse.url.endsWith('/ent/select')
+        ) {
           return this.handleAuthenticationError(response);
         }
 
@@ -213,6 +217,10 @@ export class EnterpriseSearchRequestHandler {
     return response.customError({ statusCode: 502, headers: this.headers, body: errorMessage });
   }
 
+  /**
+   * Note: Kibana auto logs users out when it receives a 401 response, so we want to catch and
+   * return 401 responses from Enterprise Search as a 502 so Kibana sessions aren't interrupted
+   */
   handleAuthenticationError(response: KibanaResponseFactory) {
     const errorMessage = 'Cannot authenticate Enterprise Search user';
 


### PR DESCRIPTION
## Summary

At some point between 7.9 and 7.10, Enterprise Search started returning 401 responses (instead of /login redirects) when users were unauthenticated or did not exist (e.g. standard auth).

We need to expand our `handleAuthenticationError` catch to check for 401 responses as well so we don't pass them back to Kibana - Kibana responds to 401 status codes by logging the user out of Kibana, which we don't want to do in this case.

## QA

- Start Enterprise Search on standard auth
- Log in to Kibana as the `elastic` user
- Attempt to access App Search or Workplace Search
- Confirm that you are:
  - [x] NOT logged out / see an error connecting screen
  - [x] See a `[error][enterpriseSearch][plugins] Cannot authenticate Enterprise Search user` message in the Kibana terminal logs

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios