### PR TITLE
Fix error rate sorting in services list

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/index.tsx
@@ -153,7 +153,7 @@ export const SERVICE_COLUMNS: Array<ITableColumn<ServiceListItem>> = [
     width: px(unit * 10),
   },
   {
-    field: 'errorsPerMinute',
+    field: 'transactionErrorRate',
     name: i18n.translate('xpack.apm.servicesTable.transactionErrorRate', {
       defaultMessage: 'Error rate %',
     }),
@@ -222,13 +222,15 @@ export function ServiceList({ items, noItemsMessage }: Props) {
               itemsToSort,
               (item) => {
                 switch (sortField) {
+                  // Use `?? -1` here so `undefined` will appear after/before `0`.
+                  // In the table this will make the "N/A" items always at the
+                  // bottom/top.
                   case 'avgResponseTime':
-                    return item.avgResponseTime?.value ?? 0;
+                    return item.avgResponseTime?.value ?? -1;
                   case 'transactionsPerMinute':
-                    return item.transactionsPerMinute?.value ?? 0;
+                    return item.transactionsPerMinute?.value ?? -1;
                   case 'transactionErrorRate':
-                    return item.transactionErrorRate?.value ?? 0;
-
+                    return item.transactionErrorRate?.value ?? -1;
                   default:
                     return item[sortField as keyof typeof item];
                 }

--- a/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/service_list.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceOverview/ServiceList/service_list.test.tsx
@@ -35,8 +35,6 @@ describe('ServiceList', () => {
 
   it('renders with data', () => {
     expect(() =>
-      // Types of property 'avgResponseTime' are incompatible.
-      // Type 'null' is not assignable to type '{ value: number | null; timeseries: { x: number; y: number | null; }[]; } | undefined'.ts(2322)
       renderWithTheme(
         <ServiceList items={props.items as ServiceListAPIResponse['items']} />,
         { wrapper: Wrapper }


### PR DESCRIPTION
The field was incorrectly labeled `errorsPerMinute` instead of `transactionErrorRate` (probably left over from before when we switched to using error rate.)

Use `-1` for the fallback sort so "N/A" appears after "0%"

Fixes #80473.
