### PR TITLE
[Fleet] Emit info log when using custom registry URL

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/registry_url.ts
@@ -28,12 +28,14 @@ const getDefaultRegistryUrl = (): string => {
   }
 };
 
-// Custom registry URL is currently only for internal Elastic development and is unsupported
 export const getRegistryUrl = (): string => {
   const customUrl = appContextService.getConfig()?.registryUrl;
   const isEnterprise = licenseService.isEnterprise();
 
   if (customUrl && isEnterprise) {
+    appContextService
+      .getLogger()
+      .info('Custom registry url is an experimental feature and is unsupported.');
     return customUrl;
   }
 


### PR DESCRIPTION
## Summary

Per discussion in https://github.com/elastic/kibana/pull/79204#issuecomment-706896834, emit info logging about experimental nature of custom registry URL usage.