### PR TITLE
[Visualizations] Fix bad color mapping with multiple split series

### DIFF
--- a/src/plugins/charts/public/services/colors/color_palette.ts
+++ b/src/plugins/charts/public/services/colors/color_palette.ts
@@ -58,7 +58,7 @@ export function createColorPalette(num: number): string[] {
   const seedLength = seedColors.length;
 
   _.times(num - seedLength, function (i) {
-    colors.push(hsl((fraction(i + seedLength + 1) * 360 + offset) % 360, 0.5, 0.5).hex());
+    colors.push(hsl((fraction(i + seedLength + 1) * 360 + offset) % 360, 50, 50).hex());
   });
 
   return colors;

--- a/src/plugins/charts/public/services/colors/colors_palette.test.ts
+++ b/src/plugins/charts/public/services/colors/colors_palette.test.ts
@@ -90,4 +90,8 @@ describe('Color Palette', () => {
   it('should create new darker colors when input is greater than 72', () => {
     expect(createColorPalette(num3)[72]).not.toEqual(seedColors[0]);
   });
+
+  it('should create new colors and convert them correctly', () => {
+    expect(createColorPalette(num3)[72]).toEqual('#404ABF');
+  });
 });


### PR DESCRIPTION
## Summary

- [x] Missing unit test

Fixes #80760. It fixes the wrong color mapping when multiple split series were applied on the visualizations.

Before:
<img width="1772" alt="Screenshot 2020-10-16 at 11 35 18 AM" src="https://user-images.githubusercontent.com/17003240/96237345-defbda80-0fa5-11eb-8ebb-e964166bccc2.png">

After the fix: 
<img width="1327" alt="Screenshot 2020-10-16 at 11 35 08 AM" src="https://user-images.githubusercontent.com/17003240/96237928-8842d080-0fa6-11eb-8cd7-c58985498982.png">

The problem was that the hsl function with 0.5 round it to 0 which results to black

<img width="600" alt="Screenshot 2020-10-16 at 11 52 21 AM" src="https://user-images.githubusercontent.com/17003240/96237522-15395a00-0fa6-11eb-8d71-8df8f6777a50.png">
<img width="600" alt="Screenshot 2020-10-16 at 11 52 12 AM" src="https://user-images.githubusercontent.com/17003240/96237539-18cce100-0fa6-11eb-8a51-068f6a46b03a.png">
