### PR TITLE
[Lens] Use compressed input for label

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.tsx
@@ -78,7 +78,7 @@ export const FilterPopover = ({
           if (inputRef.current) inputRef.current.focus();
         }}
       />
-      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
       <LabelInput
         value={filter.label || ''}
         onChange={setFilterLabel}

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/advanced_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/advanced_editor.tsx
@@ -108,7 +108,7 @@ export const RangePopover = ({
       }
       data-test-subj="indexPattern-ranges-popover"
     >
-      <EuiFormRow>
+      <EuiFormRow compressed>
         <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
           <EuiFlexItem>
             <EuiFieldNumber
@@ -164,7 +164,7 @@ export const RangePopover = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFormRow>
-      <EuiFormRow>
+      <EuiFormRow compressed>
         <LabelInput
           value={label || ''}
           onChange={(newLabel) => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/shared_components/label_input.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/shared_components/label_input.tsx
@@ -43,6 +43,7 @@ export const LabelInput = ({
       value={inputValue}
       onChange={handleInputChange}
       fullWidth
+      compressed
       placeholder={placeholder || ''}
       inputRef={(node) => {
         if (inputRef && node) {


### PR DESCRIPTION
See https://github.com/elastic/kibana/pull/79628/files/051b93f35994b42e1956f9c19fc0d731aa6005c3#r504694006

This makes the custom label inputs compressed for both filters and ranges.

Now the only thing not compressed is the query input in filters as it's a text area.

Before
<img width="458" alt="Screenshot 2020-10-16 at 15 31 42" src="https://user-images.githubusercontent.com/1508364/96266991-99500980-0fc7-11eb-8762-0fcf4098469a.png">
<img width="999" alt="Screenshot 2020-10-16 at 15 31 32" src="https://user-images.githubusercontent.com/1508364/96266999-9b19cd00-0fc7-11eb-90b1-04571d8bb226.png">


After:
<img width="450" alt="Screenshot 2020-10-16 at 15 49 38" src="https://user-images.githubusercontent.com/1508364/96273182-56922f80-0fcf-11eb-9457-ecbd22f87fc0.png">
<img width="919" alt="Screenshot 2020-10-16 at 16 46 40" src="https://user-images.githubusercontent.com/1508364/96273059-319dbc80-0fcf-11eb-9d65-dcf17fb51ab3.png">
