### PR TITLE
[Enterprise Search] Move renderHeaderActions back into mount useEffect

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -76,6 +76,7 @@ describe('WorkplaceSearchConfigured', () => {
     shallow(<WorkplaceSearchConfigured />);
 
     expect(initializeAppData).not.toHaveBeenCalled();
+    expect(mockKibanaValues.renderHeaderActions).not.toHaveBeenCalled();
   });
 
   it('renders ErrorState', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -38,10 +38,9 @@ export const WorkplaceSearchConfigured: React.FC<IInitialAppData> = (props) => {
   useEffect(() => {
     if (!hasInitialized) {
       initializeAppData(props);
+      renderHeaderActions(WorkplaceSearchHeaderActions);
     }
   }, [hasInitialized]);
-
-  renderHeaderActions(WorkplaceSearchHeaderActions);
 
   return (
     <Switch>


### PR DESCRIPTION
## Summary

We originally moved `renderHeaderActions()` outside of useEffect (https://github.com/elastic/kibana/pull/78679/commits/3254c6277e44a2f1de4ea84155a4f287d7fbd270) because it was disappearing between in-app navigation within Workplace Search. However, it turns out this was an issue with Kibana's internal `navigateToApp` API which has now been fixed (https://github.com/elastic/kibana/pull/80809).

We can now move `renderHeaderActions()` back into our on-mount useEffect, which incidentally also solves the issue of our header actions not correctly unmounting when navigating  _outside_ the Workplace Search app.

## QA

- Navigate directly to http://localhost:5601/app/enterprise_search/workplace_search/groups
- [x] Confirm that navigating within WS (groups, group overview, source prioritization) via links, breadcrumbs, nav & side nav does not cause the Header Action menu to disappear
- [x] Navigate from Workplace Search to Enterprise Search via breadcrumbs. Confirm the header correctly disappears
- [x] Navigate from Workplace Search to the Maps plugin via side nav. Confirm the header correctly renders Maps' header actions
- [x] Test the above on both dev `yarn start` and 'prod' (`yarn start --no-base-path`)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios