### PR TITLE
[APM] Fix link to trace

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TraceLink/get_redirect_to_transaction_detail_page_url.test.ts
+++ b/x-pack/plugins/apm/public/components/app/TraceLink/get_redirect_to_transaction_detail_page_url.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { roundToNearestMinute } from './get_redirect_to_transaction_detail_page_url';
+
+describe('roundToNearestMinute', () => {
+  it('should round up to nearest 5 minute', () => {
+    expect(
+      roundToNearestMinute({
+        timestamp: '2020-01-01T00:00:40.000Z',
+        direction: 'up',
+      })
+    ).toBe('2020-01-01T00:05:00.000Z');
+  });
+
+  it('should round down to nearest 5 minute', () => {
+    expect(
+      roundToNearestMinute({
+        timestamp: '2020-01-01T00:00:40.000Z',
+        direction: 'down',
+      })
+    ).toBe('2020-01-01T00:00:00.000Z');
+  });
+
+  it('should add diff and round up', () => {
+    expect(
+      roundToNearestMinute({
+        timestamp: '2020-01-01T00:00:40.000Z',
+        diff: 1000 * 60 * 7, // 7 minutes
+        direction: 'up',
+      })
+    ).toBe('2020-01-01T00:10:00.000Z');
+  });
+
+  it('should add diff and round down', () => {
+    expect(
+      roundToNearestMinute({
+        timestamp: '2020-01-01T00:00:40.000Z',
+        diff: 1000 * 60 * 7, // 7 minutes
+        direction: 'down',
+      })
+    ).toBe('2020-01-01T00:05:00.000Z');
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/TraceLink/get_redirect_to_transaction_detail_page_url.ts
+++ b/x-pack/plugins/apm/public/components/app/TraceLink/get_redirect_to_transaction_detail_page_url.ts
@@ -39,7 +39,7 @@ export const getRedirectToTransactionDetailPageUrl = ({
   });
 };
 
-export function roundToNearestMinute({
+function roundToNearestMinute({
   timestamp,
   diff = 0,
   direction = 'up',

--- a/x-pack/plugins/apm/public/components/app/TraceLink/get_redirect_to_transaction_detail_page_url.ts
+++ b/x-pack/plugins/apm/public/components/app/TraceLink/get_redirect_to_transaction_detail_page_url.ts
@@ -14,15 +14,48 @@ export const getRedirectToTransactionDetailPageUrl = ({
   transaction: Transaction;
   rangeFrom?: string;
   rangeTo?: string;
-}) =>
-  format({
+}) => {
+  return format({
     pathname: `/services/${transaction.service.name}/transactions/view`,
     query: {
       traceId: transaction.trace.id,
       transactionId: transaction.transaction.id,
       transactionName: transaction.transaction.name,
       transactionType: transaction.transaction.type,
-      rangeFrom,
-      rangeTo,
+      rangeFrom:
+        rangeFrom ||
+        roundToNearestMinute({
+          timestamp: transaction['@timestamp'],
+          direction: 'down',
+        }),
+      rangeTo:
+        rangeTo ||
+        roundToNearestMinute({
+          timestamp: transaction['@timestamp'],
+          diff: transaction.transaction.duration.us / 1000,
+          direction: 'up',
+        }),
     },
   });
+};
+
+export function roundToNearestMinute({
+  timestamp,
+  diff = 0,
+  direction = 'up',
+}: {
+  timestamp: string;
+  diff?: number;
+  direction?: 'up' | 'down';
+}) {
+  const date = new Date(timestamp);
+  const fiveMinutes = 1000 * 60 * 5; // round to 5 min
+
+  const ms = date.getTime() + diff;
+
+  return new Date(
+    direction === 'down'
+      ? Math.floor(ms / fiveMinutes) * fiveMinutes
+      : Math.ceil(ms / fiveMinutes) * fiveMinutes
+  ).toISOString();
+}


### PR DESCRIPTION
Currently when linking to a trace without specifying a date range the request fails:
```
/app/apm/link-to/trace/83af721165c610328b0b62d0977caf72
```


<img width="700" src="https://user-images.githubusercontent.com/209966/96464427-18437d00-1228-11eb-83d2-8b455bdb6d92.png" />


This PR changes that so if no date range is specified we'll use the timestamp of the trace being linked to rounded up/down to nearest 5 minutes (tests explain this better :) )