### PR TITLE
[Metrics UI] Add timerange and sorting to node detail metadata request

### DIFF
--- a/x-pack/plugins/infra/server/routes/metadata/index.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/index.ts
@@ -58,7 +58,14 @@ export const initMetadataRoute = (libs: InfraBackendLibs) => {
           nameToFeature('metrics')
         );
 
-        const info = await getNodeInfo(framework, requestContext, configuration, nodeId, nodeType);
+        const info = await getNodeInfo(
+          framework,
+          requestContext,
+          configuration,
+          nodeId,
+          nodeType,
+          timeRange
+        );
         const cloudInstanceId = get(info, 'cloud.instance.id');
 
         const cloudMetricsMetadata = cloudInstanceId

--- a/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
+++ b/x-pack/plugins/infra/server/routes/metadata/lib/get_node_info.ts
@@ -20,7 +20,8 @@ export const getNodeInfo = async (
   requestContext: RequestHandlerContext,
   sourceConfiguration: InfraSourceConfiguration,
   nodeId: string,
-  nodeType: InventoryItemType
+  nodeType: InventoryItemType,
+  timeRange: { from: number; to: number }
 ): Promise<InfraMetadataInfo> => {
   // If the nodeType is a Kubernetes pod then we need to get the node info
   // from a host record instead of a pod. This is due to the fact that any host
@@ -33,7 +34,8 @@ export const getNodeInfo = async (
       requestContext,
       sourceConfiguration,
       nodeId,
-      nodeType
+      nodeType,
+      timeRange
     );
     if (kubernetesNodeName) {
       return getNodeInfo(
@@ -41,12 +43,14 @@ export const getNodeInfo = async (
         requestContext,
         sourceConfiguration,
         kubernetesNodeName,
-        'host'
+        'host',
+        timeRange
       );
     }
     return {};
   }
   const fields = findInventoryFields(nodeType, sourceConfiguration.fields);
+  const timestampField = sourceConfiguration.fields.timestamp;
   const params = {
     allowNoIndices: true,
     ignoreUnavailable: true,
@@ -55,9 +59,21 @@ export const getNodeInfo = async (
     body: {
       size: 1,
       _source: ['host.*', 'cloud.*'],
+      sort: [{ [timestampField]: 'desc' }],
       query: {
         bool: {
-          filter: [{ match: { [fields.id]: nodeId } }],
+          filter: [
+            { match: { [fields.id]: nodeId } },
+            {
+              range: {
+                [timestampField]: {
+                  gte: timeRange.from,
+                  lte: timeRange.to,
+                  format: 'epoch_millis',
+                },
+              },
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
## Summary

This PR fixes #79643 by adding a range filter to the node info and pod name queries along with sorting by the timestamp field. This ensures that we are pulling the latest metadata for the specified time range. 