### PR TITLE
[Fleet] Show agent/package policy name on successful deletion

### DIFF
--- a/x-pack/plugins/ingest_manager/common/types/rest_spec/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/common/types/rest_spec/agent_policy.ts
@@ -63,6 +63,7 @@ export interface DeleteAgentPolicyRequest {
 
 export interface DeleteAgentPolicyResponse {
   id: string;
+  name: string;
 }
 
 export interface GetFullAgentPolicyRequest {

--- a/x-pack/plugins/ingest_manager/common/types/rest_spec/package_policy.ts
+++ b/x-pack/plugins/ingest_manager/common/types/rest_spec/package_policy.ts
@@ -52,5 +52,6 @@ export interface DeletePackagePoliciesRequest {
 
 export type DeletePackagePoliciesResponse = Array<{
   id: string;
+  name?: string;
   success: boolean;
 }>;

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_policy/components/agent_policy_delete_provider.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_policy/components/agent_policy_delete_provider.tsx
@@ -63,7 +63,7 @@ export const AgentPolicyDeleteProvider: React.FunctionComponent<Props> = ({ chil
         notifications.toasts.addSuccess(
           i18n.translate('xpack.ingestManager.deleteAgentPolicy.successSingleNotificationTitle', {
             defaultMessage: "Deleted agent policy '{id}'",
-            values: { id: agentPolicy },
+            values: { id: data.name || data.id },
           })
         );
         if (onSuccessCallback.current) {

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_policy/components/package_policy_delete_provider.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/agent_policy/components/package_policy_delete_provider.tsx
@@ -106,7 +106,7 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
                 'xpack.ingestManager.deletePackagePolicy.successSingleNotificationTitle',
                 {
                   defaultMessage: "Deleted integration '{id}'",
-                  values: { id: successfulResults[0].id },
+                  values: { id: successfulResults[0].name || successfulResults[0].id },
                 }
               );
           notifications.toasts.addSuccess(successMessage);

--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
@@ -426,6 +426,7 @@ class AgentPolicyService {
     await this.triggerAgentPolicyUpdatedEvent(soClient, 'deleted', id);
     return {
       id,
+      name: agentPolicy.name,
     };
   }
 

--- a/x-pack/plugins/ingest_manager/server/services/package_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/package_policy.ts
@@ -286,15 +286,15 @@ class PackagePolicyService {
 
     for (const id of ids) {
       try {
-        const oldPackagePolicy = await this.get(soClient, id);
-        if (!oldPackagePolicy) {
+        const packagePolicy = await this.get(soClient, id);
+        if (!packagePolicy) {
           throw new Error('Package policy not found');
         }
         if (!options?.skipUnassignFromAgentPolicies) {
           await agentPolicyService.unassignPackagePolicies(
             soClient,
-            oldPackagePolicy.policy_id,
-            [oldPackagePolicy.id],
+            packagePolicy.policy_id,
+            [packagePolicy.id],
             {
               user: options?.user,
             }
@@ -303,6 +303,7 @@ class PackagePolicyService {
         await soClient.delete(SAVED_OBJECT_TYPE, id);
         result.push({
           id,
+          name: packagePolicy.name,
           success: true,
         });
       } catch (e) {


### PR DESCRIPTION
## Summary

Resolves #80501. This PR replaces agent/package policy IDs with their names instead, in the toast messages after successful deletion.