### PR TITLE
Extracts newsfeed plugin to ts project refs

### DIFF
--- a/src/plugins/newsfeed/tsconfig.json
+++ b/src/plugins/newsfeed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./target/types",
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": [
+    "public/**/*",
+    "server/**/*",
+    "common/*",
+    "../../../typings/**/*"
+  ],
+  "references": [
+    { "path": "../../core/tsconfig.json" }
+  ]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "../src/plugins/kibana_react/tsconfig.json" },
     { "path": "../src/plugins/usage_collection/tsconfig.json" },
     { "path": "../src/plugins/telemetry_collection_manager/tsconfig.json" },
-    { "path": "../src/plugins/telemetry/tsconfig.json" }
+    { "path": "../src/plugins/telemetry/tsconfig.json" },
+    { "path": "../src/plugins/newsfeed/tsconfig.json" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "src/plugins/kibana_react/**/*",
     "src/plugins/usage_collection/**/*",
     "src/plugins/telemetry_collection_manager/**/*",
-    "src/plugins/telemetry/**/*"
+    "src/plugins/telemetry/**/*",
+    "src/plugins/newsfeed/**/*"
     // In the build we actually exclude **/public/**/* from this config so that
     // we can run the TSC on both this and the .browser version of this config
     // file, but if we did it during development IDEs would not be able to find
@@ -27,6 +28,7 @@
     { "path": "./src/plugins/kibana_react/tsconfig.json" },
     { "path": "./src/plugins/usage_collection/tsconfig.json" },
     { "path": "./src/plugins/telemetry_collection_manager/tsconfig.json" },
-    { "path": "./src/plugins/telemetry/tsconfig.json" }
+    { "path": "./src/plugins/telemetry/tsconfig.json" },
+    { "path": "./src/plugins/newsfeed/tsconfig.json" }
   ]
 }

--- a/tsconfig.refs.json
+++ b/tsconfig.refs.json
@@ -8,5 +8,6 @@
     { "path": "./src/plugins/usage_collection/tsconfig.json" },
     { "path": "./src/plugins/telemetry_collection_manager/tsconfig.json" },
     { "path": "./src/plugins/telemetry/tsconfig.json" },
+    { "path": "./src/plugins/newsfeed/tsconfig.json" },
   ]
 }

--- a/x-pack/test/tsconfig.json
+++ b/x-pack/test/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "../plugins/global_search/tsconfig.json" },
     { "path": "../../src/plugins/usage_collection/tsconfig.json" },
     { "path": "../../src/plugins/telemetry_collection_manager/tsconfig.json" },
-    { "path": "../../src/plugins/telemetry/tsconfig.json" }
+    { "path": "../../src/plugins/telemetry/tsconfig.json" },
+    { "path": "../../src/plugins/newsfeed/tsconfig.json" }
   ]
 }

--- a/x-pack/tsconfig.json
+++ b/x-pack/tsconfig.json
@@ -36,6 +36,7 @@
     { "path": "./plugins/global_search/tsconfig.json" },
     { "path": "../src/plugins/usage_collection/tsconfig.json" },
     { "path": "../src/plugins/telemetry_collection_manager/tsconfig.json" },
-    { "path": "../src/plugins/telemetry/tsconfig.json" }
+    { "path": "../src/plugins/telemetry/tsconfig.json" },
+    { "path": "../src/plugins/newsfeed/tsconfig.json" },
   ]
 }


### PR DESCRIPTION
Extracts newsfeed plugin to a separate ts project.
Part of #81017

Condensed output from node --max-old-space-size=4096 ./node_modules/.bin/tsc -p tsconfig.json --extendedDiagnostics --noEmit given in the after section for each plugin.

**Before**:
Files: 5289
Lines: 707035

**After extracting newsfeed**:
Files: 5262
Lines: 705287