### PR TITLE
[Fleet] Fix empty agent table prompt when inactive and upgradeable filters are applied

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/sections/fleet/agent_list_page/index.tsx
@@ -173,6 +173,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   // Agent data states
   const [showInactive, setShowInactive] = useState<boolean>(false);
   const [showUpgradeable, setShowUpgradeable] = useState<boolean>(false);
+
   // Table and search states
   const [search, setSearch] = useState<string>(defaultKuery);
   const [selectionMode, setSelectionMode] = useState<SelectionMode>('manual');
@@ -188,11 +189,20 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
   const [isStatusFilterOpen, setIsStatutsFilterOpen] = useState<boolean>(false);
   const [selectedStatus, setSelectedStatus] = useState<string[]>([]);
 
+  const isUsingFilter =
+    search.trim() ||
+    selectedAgentPolicies.length ||
+    selectedStatus.length ||
+    showInactive ||
+    showUpgradeable;
+
   const clearFilters = useCallback(() => {
     setSearch('');
     setSelectedAgentPolicies([]);
     setSelectedStatus([]);
-  }, [setSearch, setSelectedAgentPolicies, setSelectedStatus]);
+    setShowInactive(false);
+    setShowUpgradeable(false);
+  }, [setSearch, setSelectedAgentPolicies, setSelectedStatus, setShowInactive, setShowUpgradeable]);
 
   // Add a agent policy id to current search
   const addAgentPolicyFilter = (policyId: string) => {
@@ -638,7 +648,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
               id="xpack.ingestManager.agentList.loadingAgentsMessage"
               defaultMessage="Loading agents…"
             />
-          ) : search.trim() || selectedAgentPolicies.length || selectedStatus.length ? (
+          ) : isUsingFilter ? (
             <FormattedMessage
               id="xpack.ingestManager.agentList.noFilteredAgentsPrompt"
               defaultMessage="No agents found. {clearFiltersLink}"


### PR DESCRIPTION
## Summary

Resolves #77328. This PR fixes the empty message in agents table when there are no agents and the inactive/upgradeable filters are applied. Previously, the table will show Add agent prompt. This PR fixes that so that the `No agents found` message appears instead, the same way it does when other filters applied to the table.

The `Clear filters` link was also adjusted to reset the inactive & upgradeable filters too.

![image](https://user-images.githubusercontent.com/1965714/96649468-03c5ba00-12e6-11eb-95c8-43af20cdf729.png)