### PR TITLE
[Discover] Should not visualize unknown/conflict type fields

### DIFF
--- a/src/plugins/data/common/index_patterns/fields/index_pattern_field.test.ts
+++ b/src/plugins/data/common/index_patterns/fields/index_pattern_field.test.ts
@@ -91,6 +91,17 @@ describe('Field', function () {
     expect(fieldC.searchable).toEqual(false);
   });
 
+  it('calculates visualizable', () => {
+    const field = getField({ type: 'unknown' });
+    expect(field.visualizable).toEqual(false);
+
+    const fieldB = getField({ type: 'conflict' });
+    expect(fieldB.visualizable).toEqual(false);
+
+    const fieldC = getField({ aggregatable: false, scripted: false });
+    expect(fieldC.visualizable).toEqual(false);
+  });
+
   it('calculates aggregatable', () => {
     const field = getField({ aggregatable: true, scripted: false });
     expect(field.aggregatable).toEqual(true);

--- a/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
+++ b/src/plugins/data/common/index_patterns/fields/index_pattern_field.ts
@@ -18,6 +18,7 @@
  */
 
 import { KbnFieldType, getKbnFieldType } from '../../kbn_field_types';
+import { KBN_FIELD_TYPES } from '../../kbn_field_types/types';
 import { IFieldType } from './types';
 import { FieldSpec, IndexPattern } from '../..';
 
@@ -129,7 +130,8 @@ export class IndexPatternField implements IFieldType {
   }
 
   public get visualizable() {
-    return this.aggregatable;
+    const notVisualizableFieldTypes: string[] = [KBN_FIELD_TYPES.UNKNOWN, KBN_FIELD_TYPES.CONFLICT];
+    return this.aggregatable && !notVisualizableFieldTypes.includes(this.spec.type);
   }
 
   public toJSON() {

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_details.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_details.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { findTestSubject } from '@elastic/eui/lib/test';
+// @ts-ignore
+import stubbedLogstashFields from 'fixtures/logstash_fields';
+import { mountWithIntl } from 'test_utils/enzyme_helpers';
+import { DiscoverFieldDetails } from './discover_field_details';
+import { coreMock } from '../../../../../../core/public/mocks';
+import { IndexPatternField } from '../../../../../data/public';
+import { getStubIndexPattern } from '../../../../../data/public/test_utils';
+
+const indexPattern = getStubIndexPattern(
+  'logstash-*',
+  (cfg: any) => cfg,
+  'time',
+  stubbedLogstashFields(),
+  coreMock.createSetup()
+);
+
+describe('discover sidebar field details', function () {
+  const defaultProps = {
+    indexPattern,
+    details: { buckets: [], error: '', exists: 1, total: true, columns: [] },
+    onAddFilter: jest.fn(),
+  };
+
+  function mountComponent(field: IndexPatternField) {
+    const compProps = { ...defaultProps, field };
+    return mountWithIntl(<DiscoverFieldDetails {...compProps} />);
+  }
+
+  it('should enable the visualize link for a number field', function () {
+    const visualizableField = new IndexPatternField(
+      {
+        name: 'bytes',
+        type: 'number',
+        esTypes: ['long'],
+        count: 10,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'bytes'
+    );
+    const comp = mountComponent(visualizableField);
+    expect(findTestSubject(comp, 'fieldVisualize-bytes')).toBeTruthy();
+  });
+
+  it('should disable the visualize link for a conflict field', function () {
+    const conflictField = new IndexPatternField(
+      {
+        name: 'test',
+        type: 'conflict',
+        esTypes: ['double', 'geo_point'],
+        count: 0,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'test'
+    );
+    const comp = mountComponent(conflictField);
+    expect(findTestSubject(comp, 'fieldVisualize-test')).toEqual({});
+  });
+
+  it('should disable the visualize link for an unknown field', function () {
+    const unknownField = new IndexPatternField(
+      {
+        name: 'test',
+        type: 'unknown',
+        esTypes: ['double'],
+        count: 0,
+        scripted: false,
+        searchable: true,
+        aggregatable: true,
+        readFromDocValues: true,
+      },
+      'test'
+    );
+    const comp = mountComponent(unknownField);
+    expect(findTestSubject(comp, 'fieldVisualize-test')).toEqual({});
+  });
+});

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_details.test.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_details.test.tsx
@@ -65,12 +65,12 @@ describe('discover sidebar field details', function () {
     expect(findTestSubject(comp, 'fieldVisualize-bytes')).toBeTruthy();
   });
 
-  it('should disable the visualize link for a conflict field', function () {
+  it('should disable the visualize link for an _id field', function () {
     const conflictField = new IndexPatternField(
       {
-        name: 'test',
-        type: 'conflict',
-        esTypes: ['double', 'geo_point'],
+        name: '_id',
+        type: 'string',
+        esTypes: ['_id'],
         count: 0,
         scripted: false,
         searchable: true,
@@ -80,7 +80,7 @@ describe('discover sidebar field details', function () {
       'test'
     );
     const comp = mountComponent(conflictField);
-    expect(findTestSubject(comp, 'fieldVisualize-test')).toEqual({});
+    expect(findTestSubject(comp, 'fieldVisualize-_id')).toEqual({});
   });
 
   it('should disable the visualize link for an unknown field', function () {

--- a/src/plugins/discover/public/application/components/sidebar/lib/visualize_trigger_utils.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/visualize_trigger_utils.ts
@@ -95,14 +95,8 @@ export async function isFieldVisualizable(
   indexPatternId: string | undefined,
   contextualFields: string[]
 ) {
-  const notVisualizableFieldTypes: string[] = [KBN_FIELD_TYPES.UNKNOWN, KBN_FIELD_TYPES.CONFLICT];
-  if (
-    field.name === '_id' ||
-    notVisualizableFieldTypes.includes(field.spec.type) ||
-    !indexPatternId
-  ) {
+  if (field.name === '_id' || !indexPatternId) {
     // for first condition you'd get a 'Fielddata access on the _id field is disallowed' error on ES side.
-    // for second condition we can't visualize unknown and conflict type fields
     return false;
   }
   const trigger = getTriggerConstant(field.type);

--- a/src/plugins/discover/public/application/components/sidebar/lib/visualize_trigger_utils.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/visualize_trigger_utils.ts
@@ -95,8 +95,14 @@ export async function isFieldVisualizable(
   indexPatternId: string | undefined,
   contextualFields: string[]
 ) {
-  if (field.name === '_id' || !indexPatternId) {
+  const notVisualizableFieldTypes: string[] = [KBN_FIELD_TYPES.UNKNOWN, KBN_FIELD_TYPES.CONFLICT];
+  if (
+    field.name === '_id' ||
+    notVisualizableFieldTypes.includes(field.spec.type) ||
+    !indexPatternId
+  ) {
     // for first condition you'd get a 'Fielddata access on the _id field is disallowed' error on ES side.
+    // for second condition we can't visualize unknown and conflict type fields
     return false;
   }
   const trigger = getTriggerConstant(field.type);


### PR DESCRIPTION
## Summary

Closes #81292. Discover currently allows the user to visualize `unknown` and `conflict` type fields. We don't want this as it redirects the user to Lens or Visualize for OSS and this field can't be displayed. ~~With this fix, Discover identifies that the user wants to visualize this kind of fields and not displays the button.~~ With this fix, the field visualizable function returns false for these two types.

Before:
![96706214-94f46980-1396-11eb-8293-1461812400f1](https://user-images.githubusercontent.com/17003240/96719266-d8a89c80-13b1-11eb-9195-c95069c14c9b.png)

After the fix:
<img width="646" alt="Screenshot 2020-10-21 at 3 27 56 PM" src="https://user-images.githubusercontent.com/17003240/96719405-02fa5a00-13b2-11eb-99a8-3a8dd5eb7900.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios