### PR TITLE
[Monitoring] Ensure some data is returned

### DIFF
--- a/x-pack/plugins/monitoring/public/views/elasticsearch/nodes/index.js
+++ b/x-pack/plugins/monitoring/public/views/elasticsearch/nodes/index.js
@@ -63,7 +63,7 @@ uiRoutes.when('/elasticsearch/nodes', {
 
         const promise = globalState.cluster_uuid
           ? getNodes()
-          : new Promise((resolve) => resolve({}));
+          : new Promise((resolve) => resolve({ data: {} }));
         return promise
           .then((response) => response.data)
           .catch((err) => {


### PR DESCRIPTION
Fixes #81343 

I'm not sure what's going on. Between this and https://github.com/elastic/kibana/pull/81200, I wonder if something happened to the underlying `$http` angular service. Perhaps we need to switch to the Kibana core http service.

To reproduce, simply load the Stack Monitoring UI without any monitoring data and click the button to setup with Metricbeat. It should load the Elasticsearch nodes listing page