### PR TITLE
[Fleet] Show beta message without scrolling

### DIFF
--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
@@ -18,7 +18,9 @@ interface Props {
 }
 
 const Container = styled.div`
-  min-height: calc(100vh - ${(props) => parseFloat(props.theme.eui.euiHeaderChildSize) * 2}px);
+  min-height: calc(
+    100vh - ${(props) => parseFloat(props.theme.eui.euiHeaderHeightCompensation) * 2}px
+  );
   background: ${(props) => props.theme.eui.euiColorEmptyShade};
   display: flex;
   flex-direction: column;

--- a/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
+++ b/x-pack/plugins/ingest_manager/public/applications/ingest_manager/layouts/default.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const Container = styled.div`
-  min-height: calc(100vh - ${(props) => props.theme.eui.euiHeaderChildSize});
+  min-height: calc(100vh - ${(props) => parseFloat(props.theme.eui.euiHeaderChildSize) * 2}px);
   background: ${(props) => props.theme.eui.euiColorEmptyShade};
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Fixes #81314. This PR adjust the CSS related to the beta messaging so that it shows at the bottom of the page without having scroll. This was caused by the new stacked headers in Kibana (#72331), added for 7.10.

![image](https://user-images.githubusercontent.com/1965714/96799514-22948100-13b8-11eb-87e7-6d4c5132c660.png)
