### PR TITLE
POC: Explore full-width tables in Management apps

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_create/component_template_create.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_create/component_template_create.tsx
@@ -57,7 +57,7 @@ export const ComponentTemplateCreate: React.FunctionComponent<RouteComponentProp
   }, [breadcrumbs]);
 
   return (
-    <EuiPageBody>
+    <div className="indNarrowContainer">
       <EuiPageContent>
         <EuiTitle size="l">
           <h1 data-test-subj="pageTitle">
@@ -78,6 +78,6 @@ export const ComponentTemplateCreate: React.FunctionComponent<RouteComponentProp
           clearSaveError={clearSaveError}
         />
       </EuiPageContent>
-    </EuiPageBody>
+    </div>
   );
 };

--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_edit/component_template_edit.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_wizard/component_template_edit/component_template_edit.tsx
@@ -102,7 +102,7 @@ export const ComponentTemplateEdit: React.FunctionComponent<RouteComponentProps<
   }
 
   return (
-    <EuiPageBody>
+    <div className="indNarrowContainer">
       <EuiPageContent>
         <EuiTitle size="l">
           <h1 data-test-subj="pageTitle">
@@ -116,6 +116,6 @@ export const ComponentTemplateEdit: React.FunctionComponent<RouteComponentProps<
         <EuiSpacer size="l" />
         {content}
       </EuiPageContent>
-    </EuiPageBody>
+    </div>
   );
 };

--- a/x-pack/plugins/index_management/public/application/sections/template_clone/template_clone.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/template_clone/template_clone.tsx
@@ -116,8 +116,8 @@ export const TemplateClone: React.FunctionComponent<RouteComponentProps<MatchPar
   }
 
   return (
-    <EuiPageBody>
+    <div className="indNarrowContainer">
       <EuiPageContent>{content}</EuiPageContent>
-    </EuiPageBody>
+    </div>
   );
 };

--- a/x-pack/plugins/index_management/public/application/sections/template_create/template_create.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/template_create/template_create.tsx
@@ -49,7 +49,7 @@ export const TemplateCreate: React.FunctionComponent<RouteComponentProps> = ({ h
   }, []);
 
   return (
-    <EuiPageBody>
+    <div className="indNarrowContainer">
       <EuiPageContent>
         <TemplateForm
           title={
@@ -76,6 +76,6 @@ export const TemplateCreate: React.FunctionComponent<RouteComponentProps> = ({ h
           isLegacy={isLegacy}
         />
       </EuiPageContent>
-    </EuiPageBody>
+    </div>
   );
 };

--- a/x-pack/plugins/index_management/public/application/sections/template_edit/template_edit.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/template_edit/template_edit.tsx
@@ -158,8 +158,8 @@ export const TemplateEdit: React.FunctionComponent<RouteComponentProps<MatchPara
   }
 
   return (
-    <EuiPageBody>
+    <div className="indNarrowContainer">
       <EuiPageContent>{content}</EuiPageContent>
-    </EuiPageBody>
+    </div>
   );
 };

--- a/x-pack/plugins/index_management/public/index.scss
+++ b/x-pack/plugins/index_management/public/index.scss
@@ -24,3 +24,13 @@
 .indDetail__codeBlock {
   background: transparent;
 }
+
+.indNarrowContainer {
+  max-width: map-get($euiBreakpoints, 'xl');
+  margin: 0 auto;
+}
+
+// Override enclosing container width.
+.mgtPage__body {
+  max-width: 100% !important;
+}

--- a/x-pack/plugins/watcher/public/application/sections/watch_edit/components/watch_edit.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_edit/components/watch_edit.tsx
@@ -185,7 +185,9 @@ export const WatchEdit = ({
 
   return (
     <WatchContext.Provider value={{ watch, setWatchProperty, addAction }}>
-      <EditComponent pageTitle={pageTitle} />
+      <div className="watcherNarrowContainer">
+        <EditComponent pageTitle={pageTitle} />
+      </div>
     </WatchContext.Provider>
   );
 };

--- a/x-pack/plugins/watcher/public/application/sections/watch_status/components/watch_status.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_status/components/watch_status.tsx
@@ -155,97 +155,99 @@ export const WatchStatus = ({
 
     return (
       <WatchDetailsContext.Provider value={{ watchDetailError, watchDetail, isWatchDetailLoading }}>
-        <EuiPageContent>
-          <DeleteWatchesModal
-            callback={(deleted?: string[]) => {
-              if (deleted) {
-                goToWatchList();
-              }
-              setWatchesToDelete([]);
-            }}
-            watchesToDelete={watchesToDelete}
-          />
-          <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-            <EuiFlexItem grow={false}>
-              <EuiTitle size="m">
-                <h1 data-test-subj="pageTitle">
-                  <FormattedMessage
-                    id="xpack.watcher.sections.watchDetail.header"
-                    defaultMessage="Current status for '{watch}'"
-                    values={{
-                      watch: watchName ? watchName : watchId,
-                    }}
-                  />
-                </h1>
-              </EuiTitle>
-            </EuiFlexItem>
-            {isSystemWatch ? (
+        <div className="watcherNarrowContainer">
+          <EuiPageContent>
+            <DeleteWatchesModal
+              callback={(deleted?: string[]) => {
+                if (deleted) {
+                  goToWatchList();
+                }
+                setWatchesToDelete([]);
+              }}
+              watchesToDelete={watchesToDelete}
+            />
+            <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
               <EuiFlexItem grow={false}>
-                <EuiToolTip
-                  content={
+                <EuiTitle size="m">
+                  <h1 data-test-subj="pageTitle">
                     <FormattedMessage
-                      id="xpack.watcher.sections.watchDetail.headerBadgeToolipText"
-                      defaultMessage="You cannot deactivate or delete a system watch."
-                    />
-                  }
-                >
-                  <EuiBadge color="hollow">
-                    <FormattedMessage
-                      id="xpack.watcher.sections.watchDetail.headerBadgeText"
-                      defaultMessage="System watch"
-                    />
-                  </EuiBadge>
-                </EuiToolTip>
-              </EuiFlexItem>
-            ) : (
-              <EuiFlexItem>
-                <EuiFlexGroup justifyContent="flexEnd">
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      data-test-subj="toggleWatchActivationButton"
-                      onClick={() => toggleWatchActivation()}
-                      isLoading={isTogglingActivation}
-                    >
-                      {activationButtonText}
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      data-test-subj="deleteWatchButton"
-                      onClick={() => {
-                        setWatchesToDelete([watchId]);
+                      id="xpack.watcher.sections.watchDetail.header"
+                      defaultMessage="Current status for '{watch}'"
+                      values={{
+                        watch: watchName ? watchName : watchId,
                       }}
-                      color="danger"
-                      disabled={false}
-                    >
-                      <FormattedMessage
-                        id="xpack.watcher.sections.watchHistory.deleteWatchButtonLabel"
-                        defaultMessage="Delete"
-                      />
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
+                    />
+                  </h1>
+                </EuiTitle>
               </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-          <EuiSpacer size="s" />
-          <EuiTabs>
-            {WATCH_STATUS_TABS.map((tab, index) => (
-              <EuiTab
-                onClick={() => {
-                  setSelectedTab(tab.id);
-                }}
-                isSelected={tab.id === selectedTab}
-                key={index}
-                data-test-subj="tab"
-              >
-                {tab.name}
-              </EuiTab>
-            ))}
-          </EuiTabs>
-          <EuiSpacer size="l" />
-          {selectedTab === WATCH_ACTIONS_TAB ? <WatchDetail /> : <WatchHistory />}
-        </EuiPageContent>
+              {isSystemWatch ? (
+                <EuiFlexItem grow={false}>
+                  <EuiToolTip
+                    content={
+                      <FormattedMessage
+                        id="xpack.watcher.sections.watchDetail.headerBadgeToolipText"
+                        defaultMessage="You cannot deactivate or delete a system watch."
+                      />
+                    }
+                  >
+                    <EuiBadge color="hollow">
+                      <FormattedMessage
+                        id="xpack.watcher.sections.watchDetail.headerBadgeText"
+                        defaultMessage="System watch"
+                      />
+                    </EuiBadge>
+                  </EuiToolTip>
+                </EuiFlexItem>
+              ) : (
+                <EuiFlexItem>
+                  <EuiFlexGroup justifyContent="flexEnd">
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        data-test-subj="toggleWatchActivationButton"
+                        onClick={() => toggleWatchActivation()}
+                        isLoading={isTogglingActivation}
+                      >
+                        {activationButtonText}
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        data-test-subj="deleteWatchButton"
+                        onClick={() => {
+                          setWatchesToDelete([watchId]);
+                        }}
+                        color="danger"
+                        disabled={false}
+                      >
+                        <FormattedMessage
+                          id="xpack.watcher.sections.watchHistory.deleteWatchButtonLabel"
+                          defaultMessage="Delete"
+                        />
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+            <EuiTabs>
+              {WATCH_STATUS_TABS.map((tab, index) => (
+                <EuiTab
+                  onClick={() => {
+                    setSelectedTab(tab.id);
+                  }}
+                  isSelected={tab.id === selectedTab}
+                  key={index}
+                  data-test-subj="tab"
+                >
+                  {tab.name}
+                </EuiTab>
+              ))}
+            </EuiTabs>
+            <EuiSpacer size="l" />
+            {selectedTab === WATCH_ACTIONS_TAB ? <WatchDetail /> : <WatchHistory />}
+          </EuiPageContent>
+        </div>
       </WatchDetailsContext.Provider>
     );
   }

--- a/x-pack/plugins/watcher/public/index.scss
+++ b/x-pack/plugins/watcher/public/index.scss
@@ -20,3 +20,13 @@
 .watcherThresholdAlertAggFieldContainer {
   width: 300px;
 }
+
+.watcherNarrowContainer {
+  max-width: map-get($euiBreakpoints, 'xl');
+  margin: 0 auto;
+}
+
+// Override enclosing container width.
+.mgtPage__body {
+  max-width: 100% !important;
+}


### PR DESCRIPTION
It's bugged me for awhile that our tables are artificially limited in width, which means users can't take advantage of wider monitors to see more of the content in each table cell. Over the years there have been similar complaints from the community and other Elasticians: https://github.com/elastic/kibana/issues/19384, https://github.com/elastic/kibana/issues/18442, https://github.com/elastic/kibana/issues/18371. I'm putting this together to gather feedback from the team. What do people think of this? Is this change to the UX a net improvement? If we decide this is worth moving forward I'll pass this by other teams that maintain management apps and work with the appropriate owner to design a solution that's minimally invasive.

## Index Management

![image](https://user-images.githubusercontent.com/1238659/96825108-360a1100-13e5-11eb-8589-910f42724108.png)

![image](https://user-images.githubusercontent.com/1238659/96825096-330f2080-13e5-11eb-9346-8b11e723bf9b.png)

![image](https://user-images.githubusercontent.com/1238659/96825087-2f7b9980-13e5-11eb-9e7c-1474cdc337ae.png)

## ILM

![image](https://user-images.githubusercontent.com/1238659/96825069-2a1e4f00-13e5-11eb-9149-50b46d9d9012.png)

## Watcher

![image](https://user-images.githubusercontent.com/1238659/96825082-2d193f80-13e5-11eb-9bef-87166c897e29.png)
