### PR TITLE
[APM] Fix service map timeouts for longer time ranges

### DIFF
--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -21,7 +21,7 @@ export const config = {
     serviceMapFingerprintBucketSize: schema.number({ defaultValue: 100 }),
     serviceMapTraceIdBucketSize: schema.number({ defaultValue: 65 }),
     serviceMapFingerprintGlobalBucketSize: schema.number({
-      defaultValue: 1000,
+      defaultValue: 500,
     }),
     serviceMapTraceIdGlobalBucketSize: schema.number({ defaultValue: 6 }),
     serviceMapMaxTracesPerRequest: schema.number({ defaultValue: 50 }),


### PR DESCRIPTION
Fixes #80629 by changing the default value for `xpack.apm.serviceMapFingerprintGlobalBucketSize` from `1000` to `500`.