### PR TITLE
[Lens] Stabilize flaky unit test

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/embeddable/embeddable.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/embeddable/embeddable.test.tsx
@@ -28,6 +28,7 @@ import { IBasePath } from '../../../../../../src/core/public';
 import { AttributeService } from '../../../../../../src/plugins/embeddable/public';
 import { LensAttributeService } from '../../lens_attribute_service';
 import { OnSaveProps } from '../../../../../../src/plugins/saved_objects/public/save_modal';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('../../../../../../src/plugins/inspector/public/', () => ({
   isAvailable: false,
@@ -337,10 +338,12 @@ describe('embeddable', () => {
     } as LensEmbeddableInput);
     embeddable.render(mountpoint);
 
-    embeddable.updateInput({
-      timeRange,
-      query,
-      filters: [{ meta: { alias: 'test', negate: true, disabled: true } }],
+    act(() => {
+      embeddable.updateInput({
+        timeRange,
+        query,
+        filters: [{ meta: { alias: 'test', negate: true, disabled: true } }],
+      });
     });
 
     expect(expressionRenderer).toHaveBeenCalledTimes(1);
@@ -384,7 +387,9 @@ describe('embeddable', () => {
     } as LensEmbeddableInput);
     embeddable.render(mountpoint);
 
-    autoRefreshFetchSubject.next();
+    act(() => {
+      autoRefreshFetchSubject.next();
+    });
 
     expect(expressionRenderer).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/81432

In some embeddable tests, we relied on react calling a component in the component tree synchronously after invoking it indirectly.

As react may decide to render certain parts of the tree async, this can fail in some cases.

To fix it, I wrapped the problematic calls into `act` closures, so react knows to complete rendering before continuing the test.