### PR TITLE
[App Search] Credentials: Add final Logic and server routes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.test.tsx
@@ -18,6 +18,7 @@ describe('CredentialsFlyoutFooter', () => {
   };
   const actions = {
     hideCredentialsForm: jest.fn(),
+    onApiTokenChange: jest.fn(),
   };
 
   beforeEach(() => {
@@ -59,6 +60,6 @@ describe('CredentialsFlyoutFooter', () => {
     const button = wrapper.find('[data-test-subj="APIKeyActionButton"]');
     button.simulate('click');
 
-    // TODO: Expect onApiTokenChange to have been called
+    expect(actions.onApiTokenChange).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.tsx
@@ -18,7 +18,7 @@ import { i18n } from '@kbn/i18n';
 import { CredentialsLogic } from '../credentials_logic';
 
 export const CredentialsFlyoutFooter: React.FC = () => {
-  const { hideCredentialsForm } = useActions(CredentialsLogic);
+  const { hideCredentialsForm, onApiTokenChange } = useActions(CredentialsLogic);
   const { activeApiTokenExists } = useValues(CredentialsLogic);
 
   return (
@@ -33,7 +33,7 @@ export const CredentialsFlyoutFooter: React.FC = () => {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButton
-            onClick={() => window.alert('submit')}
+            onClick={onApiTokenChange}
             fill={true}
             color="secondary"
             iconType="check"

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -54,6 +54,7 @@ describe('CredentialsLogic', () => {
     meta: {},
     nameInputBlurred: false,
     shouldShowCredentialsForm: false,
+    fullEngineAccessChecked: false,
   };
 
   const mount = (defaults?: object) => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -1179,6 +1179,36 @@ describe('CredentialsLogic', () => {
         }
       });
     });
+
+    describe('onEngineSelect', () => {
+      it('calls addEngineName if the engine is not selected', () => {
+        mount({
+          activeApiToken: {
+            ...DEFAULT_VALUES.activeApiToken,
+            engines: [],
+          },
+        });
+        jest.spyOn(CredentialsLogic.actions, 'addEngineName');
+
+        CredentialsLogic.actions.onEngineSelect('engine1');
+        expect(CredentialsLogic.actions.addEngineName).toHaveBeenCalledWith('engine1');
+        expect(CredentialsLogic.values.activeApiToken.engines).toEqual(['engine1']);
+      });
+
+      it('calls removeEngineName if the engine is already selected', () => {
+        mount({
+          activeApiToken: {
+            ...DEFAULT_VALUES.activeApiToken,
+            engines: ['engine1', 'engine2'],
+          },
+        });
+        jest.spyOn(CredentialsLogic.actions, 'removeEngineName');
+
+        CredentialsLogic.actions.onEngineSelect('engine1');
+        expect(CredentialsLogic.actions.removeEngineName).toHaveBeenCalledWith('engine1');
+        expect(CredentialsLogic.values.activeApiToken.engines).toEqual(['engine2']);
+      });
+    });
   });
 
   describe('selectors', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -6,13 +6,11 @@
 
 import { resetContext } from 'kea';
 
-import { CredentialsLogic } from './credentials_logic';
-import { ApiTokenTypes } from './constants';
-
+import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: { http: { get: jest.fn(), delete: jest.fn() } } },
+  HttpLogic: { values: mockHttpValues },
 }));
-import { HttpLogic } from '../../../shared/http';
+const { http } = mockHttpValues;
 
 jest.mock('../../../shared/flash_messages', () => ({
   FlashMessagesLogic: { actions: { clearFlashMessages: jest.fn() } },
@@ -31,6 +29,9 @@ jest.mock('../../app_logic', () => ({
   },
 }));
 import { AppLogic } from '../../app_logic';
+
+import { ApiTokenTypes } from './constants';
+import { CredentialsLogic } from './credentials_logic';
 
 describe('CredentialsLogic', () => {
   const DEFAULT_VALUES = {
@@ -1089,10 +1090,10 @@ describe('CredentialsLogic', () => {
         mount();
         jest.spyOn(CredentialsLogic.actions, 'setCredentialsData').mockImplementationOnce(() => {});
         const promise = Promise.resolve({ meta, results });
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         CredentialsLogic.actions.fetchCredentials(2);
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith('/api/app_search/credentials', {
+        expect(http.get).toHaveBeenCalledWith('/api/app_search/credentials', {
           query: {
             'page[current]': 2,
           },
@@ -1104,7 +1105,7 @@ describe('CredentialsLogic', () => {
       it('handles errors', async () => {
         mount();
         const promise = Promise.reject('An error occured');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         CredentialsLogic.actions.fetchCredentials();
         try {
@@ -1122,12 +1123,10 @@ describe('CredentialsLogic', () => {
           .spyOn(CredentialsLogic.actions, 'setCredentialsDetails')
           .mockImplementationOnce(() => {});
         const promise = Promise.resolve(credentialsDetails);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         CredentialsLogic.actions.fetchDetails();
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
-          '/api/app_search/credentials/details'
-        );
+        expect(http.get).toHaveBeenCalledWith('/api/app_search/credentials/details');
         await promise;
         expect(CredentialsLogic.actions.setCredentialsDetails).toHaveBeenCalledWith(
           credentialsDetails
@@ -1137,7 +1136,7 @@ describe('CredentialsLogic', () => {
       it('handles errors', async () => {
         mount();
         const promise = Promise.reject('An error occured');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         CredentialsLogic.actions.fetchDetails();
         try {
@@ -1155,12 +1154,10 @@ describe('CredentialsLogic', () => {
         mount();
         jest.spyOn(CredentialsLogic.actions, 'onApiKeyDelete').mockImplementationOnce(() => {});
         const promise = Promise.resolve();
-        (HttpLogic.values.http.delete as jest.Mock).mockReturnValue(promise);
+        http.delete.mockReturnValue(promise);
 
         CredentialsLogic.actions.deleteApiKey(tokenName);
-        expect(HttpLogic.values.http.delete).toHaveBeenCalledWith(
-          `/api/app_search/credentials/${tokenName}`
-        );
+        expect(http.delete).toHaveBeenCalledWith(`/api/app_search/credentials/${tokenName}`);
         await promise;
         expect(CredentialsLogic.actions.onApiKeyDelete).toHaveBeenCalledWith(tokenName);
         expect(setSuccessMessage).toHaveBeenCalled();
@@ -1169,7 +1166,7 @@ describe('CredentialsLogic', () => {
       it('handles errors', async () => {
         mount();
         const promise = Promise.reject('An error occured');
-        (HttpLogic.values.http.delete as jest.Mock).mockReturnValue(promise);
+        http.delete.mockReturnValue(promise);
 
         CredentialsLogic.actions.deleteApiKey(tokenName);
         try {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -13,6 +13,7 @@ jest.mock('../../../shared/http', () => ({
   HttpLogic: { values: { http: { get: jest.fn(), delete: jest.fn() } } },
 }));
 import { HttpLogic } from '../../../shared/http';
+
 jest.mock('../../../shared/flash_messages', () => ({
   FlashMessagesLogic: { actions: { clearFlashMessages: jest.fn() } },
   setSuccessMessage: jest.fn(),
@@ -23,6 +24,13 @@ import {
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
+
+jest.mock('../../app_logic', () => ({
+  AppLogic: {
+    selectors: { myRole: jest.fn(() => ({})) },
+  },
+}));
+import { AppLogic } from '../../app_logic';
 
 describe('CredentialsLogic', () => {
   const DEFAULT_VALUES = {
@@ -1174,6 +1182,50 @@ describe('CredentialsLogic', () => {
   });
 
   describe('selectors', () => {
+    describe('fullEngineAccessChecked', () => {
+      it('should be true if active token is set to access all engines and the user can access all engines', () => {
+        (AppLogic.selectors.myRole as jest.Mock).mockReturnValueOnce({
+          canAccessAllEngines: true,
+        });
+        mount({
+          activeApiToken: {
+            ...DEFAULT_VALUES.activeApiToken,
+            access_all_engines: true,
+          },
+        });
+
+        expect(CredentialsLogic.values.fullEngineAccessChecked).toEqual(true);
+      });
+
+      it('should be false if the token is not set to access all engines', () => {
+        (AppLogic.selectors.myRole as jest.Mock).mockReturnValueOnce({
+          canAccessAllEngines: true,
+        });
+        mount({
+          activeApiToken: {
+            ...DEFAULT_VALUES.activeApiToken,
+            access_all_engines: false,
+          },
+        });
+
+        expect(CredentialsLogic.values.fullEngineAccessChecked).toEqual(false);
+      });
+
+      it('should be false if the user cannot acess all engines', () => {
+        (AppLogic.selectors.myRole as jest.Mock).mockReturnValueOnce({
+          canAccessAllEngines: false,
+        });
+        mount({
+          activeApiToken: {
+            ...DEFAULT_VALUES.activeApiToken,
+            access_all_engines: true,
+          },
+        });
+
+        expect(CredentialsLogic.values.fullEngineAccessChecked).toEqual(false);
+      });
+    });
+
     describe('activeApiTokenExists', () => {
       it('should be false if the token has no id', () => {
         mount({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
@@ -211,7 +211,8 @@ export const CredentialsLogic = kea<
   selectors: ({ selectors }) => ({
     fullEngineAccessChecked: [
       () => [AppLogic.selectors.myRole, selectors.activeApiToken],
-      (myRole, activeApiToken) => myRole.canAccessAllEngines && !!activeApiToken.access_all_engines,
+      (myRole, activeApiToken) =>
+        !!(myRole.canAccessAllEngines && activeApiToken.access_all_engines),
     ],
     dataLoading: [
       () => [selectors.isCredentialsDetailsComplete, selectors.isCredentialsDataComplete],
@@ -264,16 +265,7 @@ export const CredentialsLogic = kea<
       }
     },
     onApiTokenChange: async () => {
-      const { myRole } = AppLogic.values;
-      const {
-        id,
-        name,
-        engines,
-        type,
-        read,
-        write,
-        access_all_engines: accessAllEngines,
-      } = values.activeApiToken;
+      const { id, name, engines, type, read, write } = values.activeApiToken;
 
       const data: IApiToken = {
         name,
@@ -284,7 +276,7 @@ export const CredentialsLogic = kea<
         data.write = write;
       }
       if (type !== ApiTokenTypes.Admin) {
-        data.access_all_engines = !!(accessAllEngines && myRole.canAccessAllEngines);
+        data.access_all_engines = values.fullEngineAccessChecked;
         data.engines = engines;
       }
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
@@ -50,6 +50,7 @@ interface ICredentialsLogicActions {
   fetchCredentials(page?: number): number;
   fetchDetails(): { value: boolean };
   deleteApiKey(tokenName: string): string;
+  onEngineSelect(engineName: string): string;
 }
 
 interface ICredentialsLogicValues {
@@ -93,6 +94,7 @@ export const CredentialsLogic = kea<
     fetchCredentials: (page) => page,
     fetchDetails: true,
     deleteApiKey: (tokenName) => tokenName,
+    onEngineSelect: (engineName) => engineName,
   }),
   reducers: () => ({
     apiTokens: [
@@ -260,6 +262,12 @@ export const CredentialsLogic = kea<
       }
     },
     // TODO onApiTokenChange from ent-search
-    // TODO onEngineSelect from ent-search
+    onEngineSelect: (engineName: string) => {
+      if (values.activeApiToken?.engines?.includes(engineName)) {
+        actions.removeEngineName(engineName);
+      } else {
+        actions.addEngineName(engineName);
+      }
+    },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
@@ -15,6 +15,7 @@ import {
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
+import { AppLogic } from '../../app_logic';
 
 import { IMeta } from '../../../../../common/types';
 import { IEngine } from '../../types';
@@ -204,7 +205,10 @@ export const CredentialsLogic = kea<
     ],
   }),
   selectors: ({ selectors }) => ({
-    // TODO fullEngineAccessChecked from ent-search
+    fullEngineAccessChecked: [
+      () => [AppLogic.selectors.myRole, selectors.activeApiToken],
+      (myRole, activeApiToken) => myRole.canAccessAllEngines && !!activeApiToken.access_all_engines,
+    ],
     dataLoading: [
       () => [selectors.isCredentialsDetailsComplete, selectors.isCredentialsDataComplete],
       (isCredentialsDetailsComplete, isCredentialsDataComplete) => {

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.test.ts
@@ -41,6 +41,115 @@ describe('credentials routes', () => {
     });
   });
 
+  describe('POST /api/app_search/credentials', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({ method: 'post', payload: 'body' });
+
+      registerCredentialsRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/as/credentials/collection',
+      });
+    });
+
+    describe('validates', () => {
+      describe('admin keys', () => {
+        it('correctly', () => {
+          const request = {
+            body: {
+              name: 'admin-key',
+              type: 'admin',
+            },
+          };
+          mockRouter.shouldValidate(request);
+        });
+
+        it('throws on unnecessary properties', () => {
+          const request = {
+            body: {
+              name: 'admin-key',
+              type: 'admin',
+              read: true,
+              access_all_engines: true,
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+      });
+
+      describe('private keys', () => {
+        it('correctly', () => {
+          const request = {
+            body: {
+              name: 'private-key',
+              type: 'private',
+              read: true,
+              write: false,
+              access_all_engines: false,
+              engines: ['engine1', 'engine2'],
+            },
+          };
+          mockRouter.shouldValidate(request);
+        });
+
+        it('throws on missing keys', () => {
+          const request = {
+            body: {
+              name: 'private-key',
+              type: 'private',
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+      });
+
+      describe('search keys', () => {
+        it('correctly', () => {
+          const request = {
+            body: {
+              name: 'search-key',
+              type: 'search',
+              access_all_engines: true,
+            },
+          };
+          mockRouter.shouldValidate(request);
+        });
+
+        it('throws on missing keys', () => {
+          const request = {
+            body: {
+              name: 'search-key',
+              type: 'search',
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+
+        it('throws on extra keys', () => {
+          const request = {
+            body: {
+              name: 'search-key',
+              type: 'search',
+              read: true,
+              write: false,
+              access_all_engines: false,
+              engines: ['engine1', 'engine2'],
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+      });
+    });
+  });
+
   describe('GET /api/app_search/credentials/details', () => {
     let mockRouter: MockRouter;
 
@@ -57,6 +166,123 @@ describe('credentials routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/as/credentials/details',
+      });
+    });
+  });
+
+  describe('PUT /api/app_search/credentials/{name}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({ method: 'put', payload: 'body' });
+
+      registerCredentialsRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request to enterprise search', () => {
+      const mockRequest = {
+        params: {
+          name: 'abc123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/as/credentials/abc123',
+      });
+    });
+
+    describe('validates', () => {
+      describe('admin keys', () => {
+        it('correctly', () => {
+          const request = {
+            body: {
+              name: 'admin-key',
+              type: 'admin',
+            },
+          };
+          mockRouter.shouldValidate(request);
+        });
+
+        it('throws on unnecessary properties', () => {
+          const request = {
+            body: {
+              name: 'admin-key',
+              type: 'admin',
+              read: true,
+              access_all_engines: true,
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+      });
+
+      describe('private keys', () => {
+        it('correctly', () => {
+          const request = {
+            body: {
+              name: 'private-key',
+              type: 'private',
+              read: true,
+              write: false,
+              access_all_engines: false,
+              engines: ['engine1', 'engine2'],
+            },
+          };
+          mockRouter.shouldValidate(request);
+        });
+
+        it('throws on missing keys', () => {
+          const request = {
+            body: {
+              name: 'private-key',
+              type: 'private',
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+      });
+
+      describe('search keys', () => {
+        it('correctly', () => {
+          const request = {
+            body: {
+              name: 'search-key',
+              type: 'search',
+              access_all_engines: true,
+            },
+          };
+          mockRouter.shouldValidate(request);
+        });
+
+        it('throws on missing keys', () => {
+          const request = {
+            body: {
+              name: 'search-key',
+              type: 'search',
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
+
+        it('throws on extra keys', () => {
+          const request = {
+            body: {
+              name: 'search-key',
+              type: 'search',
+              read: true,
+              write: false,
+              access_all_engines: false,
+              engines: ['engine1', 'engine2'],
+            },
+          };
+          mockRouter.shouldThrow(request);
+        });
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.ts
@@ -8,10 +8,32 @@ import { schema } from '@kbn/config-schema';
 
 import { IRouteDependencies } from '../../plugin';
 
+const tokenSchema = schema.oneOf([
+  schema.object({
+    name: schema.string(),
+    type: schema.literal('admin'),
+  }),
+  schema.object({
+    name: schema.string(),
+    type: schema.literal('private'),
+    read: schema.boolean(),
+    write: schema.boolean(),
+    access_all_engines: schema.boolean(),
+    engines: schema.maybe(schema.arrayOf(schema.string())),
+  }),
+  schema.object({
+    name: schema.string(),
+    type: schema.literal('search'),
+    access_all_engines: schema.boolean(),
+    engines: schema.maybe(schema.arrayOf(schema.string())),
+  }),
+]);
+
 export function registerCredentialsRoutes({
   router,
   enterpriseSearchRequestHandler,
 }: IRouteDependencies) {
+  // Credentials API
   router.get(
     {
       path: '/api/app_search/credentials',
@@ -25,6 +47,19 @@ export function registerCredentialsRoutes({
       path: '/as/credentials/collection',
     })
   );
+  router.post(
+    {
+      path: '/api/app_search/credentials',
+      validate: {
+        body: tokenSchema,
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/as/credentials/collection',
+    })
+  );
+
+  // TODO: It would be great to remove this someday
   router.get(
     {
       path: '/api/app_search/credentials/details',
@@ -33,6 +68,24 @@ export function registerCredentialsRoutes({
     enterpriseSearchRequestHandler.createRequest({
       path: '/as/credentials/details',
     })
+  );
+
+  // Single credential API
+  router.put(
+    {
+      path: '/api/app_search/credentials/{name}',
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+        body: tokenSchema,
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/as/credentials/${request.params.name}`,
+      })(context, request, response);
+    }
   );
   router.delete(
     {


### PR DESCRIPTION
## PR sequence

This PR is part of a set of 3 PRs that implements the Credentials flyout form + functionality. It's broken up into PRs in the 400-800 line range so as not to open a 1700~ line PR.

List of all PRs (may be helpful for obtaining more context / QAing the entire final feature)
- [PR 1 - FlashMessages & flyout stub](https://github.com/elastic/kibana/pull/81391)
- [PR 2 - Logic & server routes](https://github.com/elastic/kibana/pull/81519) (you are here)
- [PR 3 - All working credential form views](https://github.com/elastic/kibana/pull/81541)

## Summary

This PR achieves:

- Adding `CredentialsLogic.values.fullEngineAccessChecked`
- Adding `CredentialsLogic.actions.onEngineSelect`
- Adding `CredentialsLogic.actions.onApiTokenChange`
- Adding server API routes that `CredentialsLogic.actions.onApiTokenChange` calls:
  - POST `/api/app_search/credentials`
  - PUT `/api/app_search/credentials/{name}`

## QA

This PR does not have easily testable changes in and of itself. It's easier to QA this against the `credentials-flyout-3` branch.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios