### PR TITLE
[Fleet] Allow default packages to be deleted from the default agent policy

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agent_policy.ts
@@ -83,7 +83,12 @@ class AgentPolicyService {
     return (await this.get(soClient, id)) as AgentPolicy;
   }
 
-  public async ensureDefaultAgentPolicy(soClient: SavedObjectsClientContract) {
+  public async ensureDefaultAgentPolicy(
+    soClient: SavedObjectsClientContract
+  ): Promise<{
+    created: boolean;
+    defaultAgentPolicy: AgentPolicy;
+  }> {
     const agentPolicies = await soClient.find<AgentPolicySOAttributes>({
       type: AGENT_POLICY_SAVED_OBJECT_TYPE,
       searchFields: ['is_default'],
@@ -95,12 +100,18 @@ class AgentPolicyService {
         ...DEFAULT_AGENT_POLICY,
       };
 
-      return this.create(soClient, newDefaultAgentPolicy);
+      return {
+        created: true,
+        defaultAgentPolicy: await this.create(soClient, newDefaultAgentPolicy),
+      };
     }
 
     return {
-      id: agentPolicies.saved_objects[0].id,
-      ...agentPolicies.saved_objects[0].attributes,
+      created: false,
+      defaultAgentPolicy: {
+        id: agentPolicies.saved_objects[0].id,
+        ...agentPolicies.saved_objects[0].attributes,
+      },
     };
   }
 
@@ -404,7 +415,9 @@ class AgentPolicyService {
       throw new Error('Agent policy not found');
     }
 
-    const { id: defaultAgentPolicyId } = await this.ensureDefaultAgentPolicy(soClient);
+    const {
+      defaultAgentPolicy: { id: defaultAgentPolicyId },
+    } = await this.ensureDefaultAgentPolicy(soClient);
     if (id === defaultAgentPolicyId) {
       throw new Error('The default agent policy cannot be deleted');
     }

--- a/x-pack/plugins/ingest_manager/server/services/setup.ts
+++ b/x-pack/plugins/ingest_manager/server/services/setup.ts
@@ -49,7 +49,11 @@ async function createSetupSideEffects(
   soClient: SavedObjectsClientContract,
   callCluster: CallESAsCurrentUser
 ): Promise<SetupStatus> {
-  const [installedPackages, defaultOutput, defaultAgentPolicy] = await Promise.all([
+  const [
+    installedPackages,
+    defaultOutput,
+    { created: defaultAgentPolicyCreated, defaultAgentPolicy },
+  ] = await Promise.all([
     // packages installed by default
     ensureInstalledDefaultPackages(soClient, callCluster),
     outputService.ensureDefaultOutput(soClient),
@@ -66,44 +70,46 @@ async function createSetupSideEffects(
     }),
   ]);
 
-  // ensure default packages are added to the default conifg
-  const agentPolicyWithPackagePolicies = await agentPolicyService.get(
-    soClient,
-    defaultAgentPolicy.id,
-    true
-  );
-  if (!agentPolicyWithPackagePolicies) {
-    throw new Error('Policy not found');
-  }
-  if (
-    agentPolicyWithPackagePolicies.package_policies.length &&
-    typeof agentPolicyWithPackagePolicies.package_policies[0] === 'string'
-  ) {
-    throw new Error('Policy not found');
-  }
-
-  for (const installedPackage of installedPackages) {
-    const packageShouldBeInstalled = DEFAULT_AGENT_POLICIES_PACKAGES.some(
-      (packageName) => installedPackage.name === packageName
+  // If we just created the default policy, ensure default packages are added to it
+  if (defaultAgentPolicyCreated) {
+    const agentPolicyWithPackagePolicies = await agentPolicyService.get(
+      soClient,
+      defaultAgentPolicy.id,
+      true
     );
-    if (!packageShouldBeInstalled) {
-      continue;
+    if (!agentPolicyWithPackagePolicies) {
+      throw new Error('Policy not found');
+    }
+    if (
+      agentPolicyWithPackagePolicies.package_policies.length &&
+      typeof agentPolicyWithPackagePolicies.package_policies[0] === 'string'
+    ) {
+      throw new Error('Policy not found');
     }
 
-    const isInstalled = agentPolicyWithPackagePolicies.package_policies.some(
-      (d: PackagePolicy | string) => {
-        return typeof d !== 'string' && d.package?.name === installedPackage.name;
-      }
-    );
-
-    if (!isInstalled) {
-      await addPackageToAgentPolicy(
-        soClient,
-        callCluster,
-        installedPackage,
-        agentPolicyWithPackagePolicies,
-        defaultOutput
+    for (const installedPackage of installedPackages) {
+      const packageShouldBeInstalled = DEFAULT_AGENT_POLICIES_PACKAGES.some(
+        (packageName) => installedPackage.name === packageName
       );
+      if (!packageShouldBeInstalled) {
+        continue;
+      }
+
+      const isInstalled = agentPolicyWithPackagePolicies.package_policies.some(
+        (d: PackagePolicy | string) => {
+          return typeof d !== 'string' && d.package?.name === installedPackage.name;
+        }
+      );
+
+      if (!isInstalled) {
+        await addPackageToAgentPolicy(
+          soClient,
+          callCluster,
+          installedPackage,
+          agentPolicyWithPackagePolicies,
+          defaultOutput
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #74515. This PR allows default packages to be deleted from the default agent policy. Previously, if the user deletes `system` package (which is installed by default), it would get re-added to the default agent policy the next time Fleet runs setup. This PR adds a check so that we only add the default packages to the default agent policy when it is initially created.