### PR TITLE
add copy trace link to clipboard to APM transaction detail view

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
@@ -18,7 +18,7 @@ import { useKibana } from '../../../../../../../../src/plugins/kibana_react/publ
 import { Transaction } from '../../../../../typings/es_schemas/ui/transaction';
 import { getAPMHref } from '../../../shared/Links/apm/APMLink';
 
-export function CopyTraceLink({ transaction }: { transaction: ITransaction }) {
+export function CopyTraceLink({ transaction }: { transaction: Transaction }) {
   const { core } = useApmPluginContext();
   const { basePath } = core.http;
   const toasts = useKibana().services.notifications?.toasts;

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
@@ -15,7 +15,7 @@ import { i18n } from '@kbn/i18n';
 import React, { useCallback } from 'react';
 import { useApmPluginContext } from '../../../../hooks/useApmPluginContext';
 import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
-import { Transaction as ITransaction } from '../../../../../typings/es_schemas/ui/transaction';
+import { Transaction } from '../../../../../typings/es_schemas/ui/transaction';
 import { getAPMHref } from '../../../shared/Links/apm/APMLink';
 
 export function CopyTraceLink({ transaction }: { transaction: ITransaction }) {
@@ -37,7 +37,7 @@ export function CopyTraceLink({ transaction }: { transaction: ITransaction }) {
             title: i18n.translate(
               'xpack.apm.transactionDetails.copyTraceSampleFailureTitle',
               {
-                defaultMessage: 'Copy Failure',
+                defaultMessage: 'Unable to copy trace url to clipboard',
               }
             ),
           });

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useCallback } from 'react';
+import { useApmPluginContext } from '../../../../hooks/useApmPluginContext';
+import { useKibana } from '../../../../../../../../src/plugins/kibana_react/public';
+import { Transaction as ITransaction } from '../../../../../typings/es_schemas/ui/transaction';
+import { getAPMHref } from '../../../shared/Links/apm/APMLink';
+
+export function CopyTraceLink({ transaction }: { transaction: ITransaction }) {
+  const { core } = useApmPluginContext();
+  const { basePath } = core.http;
+  const toasts = useKibana().services.notifications?.toasts;
+  const textToCopy = getAPMHref({
+    basePath,
+    path: `/link-to/trace/${transaction.trace.id}`,
+  });
+
+  const onClick = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      try {
+        await navigator.clipboard.writeText(textToCopy);
+      } catch (error) {
+        if (toasts) {
+          toasts.addError(error, {
+            title: i18n.translate(
+              'xpack.apm.transactionDetails.copyTraceSampleFailureTitle',
+              {
+                defaultMessage: 'Copy Failure',
+              }
+            ),
+          });
+        }
+      }
+    },
+    [textToCopy, toasts]
+  );
+
+  return (
+    <EuiFlexGroup>
+      <EuiFlexItem style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <EuiText size="xs">{transaction.trace.id.substring(0, 10)}</EuiText>
+        <EuiToolTip
+          content={i18n.translate(
+            'xpack.apm.transactionDetails.traceLinkCopyToClipboard',
+            {
+              defaultMessage: 'Copy Trace Link to Clipboard',
+            }
+          )}
+        >
+          <EuiButtonIcon
+            aria-label={i18n.translate(
+              'xpack.apm.transactionDetails.traceLinkCopyToClipboard',
+              {
+                defaultMessage: 'Copy Trace Link to Clipboard',
+              }
+            )}
+            color="text"
+            iconType="copyClipboard"
+            onClick={onClick}
+          />
+        </EuiToolTip>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/CopyTraceLink.tsx
@@ -22,10 +22,11 @@ export function CopyTraceLink({ transaction }: { transaction: Transaction }) {
   const { core } = useApmPluginContext();
   const { basePath } = core.http;
   const toasts = useKibana().services.notifications?.toasts;
-  const textToCopy = getAPMHref({
+  const href = getAPMHref({
     basePath,
     path: `/link-to/trace/${transaction.trace.id}`,
   });
+  const textToCopy = `${window.location.protocol}//${window.location.host}${href}`;
 
   const onClick = useCallback(
     async (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/index.tsx
@@ -25,6 +25,7 @@ import { LoadingStatePrompt } from '../../../shared/LoadingStatePrompt';
 import { TransactionSummary } from '../../../shared/Summary/TransactionSummary';
 import { TransactionActionMenu } from '../../../shared/TransactionActionMenu/TransactionActionMenu';
 import { MaybeViewTraceLink } from './MaybeViewTraceLink';
+import { CopyTraceLink } from './CopyTraceLink';
 import { TransactionTabs } from './TransactionTabs';
 import { IWaterfall } from './WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers';
 
@@ -106,6 +107,7 @@ export function WaterfallWithSummmary({
               compressed
             />
           )}
+          <CopyTraceLink transaction={entryTransaction} />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFlexGroup justifyContent="flexEnd">


### PR DESCRIPTION
## Summary

Add "add copy trace link" to clipboard to APM transaction detail view.

<img width="454" alt="image" src="https://user-images.githubusercontent.com/83483/97052046-48538e80-154e-11eb-8342-b37e25e69a8a.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

closes #76794
