### PR TITLE
Update console.asciidoc

### DIFF
--- a/docs/dev-tools/console/console.asciidoc
+++ b/docs/dev-tools/console/console.asciidoc
@@ -46,6 +46,8 @@ curl -XGET "http://localhost:9200/_search" -d'
 When you paste the command into Console, {kib} automatically converts it
 to Console syntax.  Alternatively, if you want to see Console syntax in cURL, 
 click the action icon (image:dev-tools/console/images/wrench.png[]) and select *Copy as cURL*.
+Please note that once copied, the url will need to be replaced and the username and password will 
+need to be provided for the calls to work from external environments.
 
 [float]
 [[console-autocomplete]]


### PR DESCRIPTION
## Summary

Customer opened an SFDC case, saying that `copy as cUrl` does not construct a fully formatted url. I have added a brief note that for external calls to work, the url and un/pw will need to be provided. 

Pre-change: 
![Screen Shot 2020-10-26 at 11 01 53 AM](https://user-images.githubusercontent.com/66258065/97189165-ab296d80-177a-11eb-9369-292609b58c73.png)

Post-change: 
It will include a short notice that the url and un/pw will need to be provided for the calls to work. 



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
