### PR TITLE
[7.x] [Metrics UI] Fix Metrics Explorer API to return empty results when field is missing from aggregation (#80919)

### DIFF
--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_metric_to_metrics_api_metric.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_metric_to_metrics_api_metric.ts
@@ -9,7 +9,7 @@ import { MetricsAPIMetric, MetricsExplorerMetric } from '../../../../common/http
 export const convertMetricToMetricsAPIMetric = (
   metric: MetricsExplorerMetric,
   index: number
-): MetricsAPIMetric => {
+): MetricsAPIMetric | undefined => {
   const id = `metric_${index}`;
   if (metric.aggregation === 'rate' && metric.field) {
     return {
@@ -44,19 +44,21 @@ export const convertMetricToMetricsAPIMetric = (
     };
   }
 
-  return {
-    id,
-    aggregations: {
-      [id]: {
-        bucket_script: {
-          buckets_path: { count: '_count' },
-          script: {
-            source: 'count * 1',
-            lang: 'expression',
+  if (metric.aggregation === 'count') {
+    return {
+      id,
+      aggregations: {
+        [id]: {
+          bucket_script: {
+            buckets_path: { count: '_count' },
+            script: {
+              source: 'count * 1',
+              lang: 'expression',
+            },
+            gap_policy: 'skip',
           },
-          gap_policy: 'skip',
         },
       },
-    },
-  };
+    };
+  }
 };

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_request_to_metrics_api_options.test.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_request_to_metrics_api_options.test.ts
@@ -120,4 +120,16 @@ describe('convertRequestToMetricsAPIOptions', () => {
       metrics: [],
     });
   });
+
+  it('should work with empty field', () => {
+    expect(
+      convertRequestToMetricsAPIOptions({
+        ...BASE_REQUEST,
+        metrics: [{ aggregation: 'avg' }],
+      })
+    ).toEqual({
+      ...BASE_METRICS_UI_OPTIONS,
+      metrics: [],
+    });
+  });
 });

--- a/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_request_to_metrics_api_options.ts
+++ b/x-pack/plugins/infra/server/routes/metrics_explorer/lib/convert_request_to_metrics_api_options.ts
@@ -15,7 +15,9 @@ import { convertMetricToMetricsAPIMetric } from './convert_metric_to_metrics_api
 export const convertRequestToMetricsAPIOptions = (
   options: MetricsExplorerRequestBody
 ): MetricsAPIRequest => {
-  const metrics = options.metrics.map(convertMetricToMetricsAPIMetric);
+  const metrics = options.metrics
+    .map(convertMetricToMetricsAPIMetric)
+    .filter(<M>(m: M): m is NonNullable<M> => !!m);
   const { limit, timerange, indexPattern } = options;
 
   const metricsApiOptions: MetricsAPIRequest = {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Fix Metrics Explorer API to return empty results when field is missing from aggregation (#80919)