### PR TITLE
[App Search] Misc credentials key UI enhancements

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.test.tsx
@@ -204,7 +204,11 @@ describe('Credentials', () => {
           copy: expect.any(Function),
           toggleIsHidden: expect.any(Function),
           isHidden: expect.any(Boolean),
-          text: <span aria-label="Hidden text">•••••••</span>,
+          text: (
+            <span aria-label="Hidden text">
+              <span aria-hidden={true}>•••••••</span>
+            </span>
+          ),
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
@@ -61,6 +61,10 @@ export const CredentialsList: React.FC = () => {
           </EuiCopy>
         );
       },
+      mobileOptions: {
+        // @ts-ignore - EUI's type definitions need to be updated
+        width: '100%',
+      },
     },
     {
       name: 'Modes',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
@@ -40,6 +40,7 @@ export const CredentialsList: React.FC = () => {
     {
       name: 'Key',
       width: '36%',
+      className: 'eui-textBreakAll',
       render: (token: ApiToken) => {
         const { key } = token;
         if (!key) return null;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/key.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/key.tsx
@@ -39,6 +39,7 @@ export const Key: React.FC<Props> = ({ copy, toggleIsHidden, isHidden, text }) =
         iconType={hideIcon}
         aria-label={hideIconLabel}
         aria-pressed={!isHidden}
+        style={{ marginRight: '0.25em' }}
       />
       {text}
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.tsx
@@ -25,7 +25,9 @@ export const HiddenText: React.FC<Props> = ({ text, children }) => {
     defaultMessage: 'Hidden text',
   });
   const hiddenText = isHidden ? (
-    <span aria-label={hiddenLabel}>{text.replace(/./g, '•')}</span>
+    <span aria-label={hiddenLabel}>
+      <span aria-hidden={true}>{text.replace(/./g, '•')}</span>
+    </span>
   ) : (
     text
   );


### PR DESCRIPTION
## Summary

When I was doing a final QA pass of the credentials view, I noticed some minor UI/UX things that were bugging me a little, so I tackled them in a separate commit 😅 Screencaps will be listed below on individual commits.

This is a Draft PR because the last commit is still waiting to use a recent EUI change. I'll un-draft the PR once Kibana updates to it. @JasonStoltz I'm assigning to you mostly as an FYI and to get your early eyes on it in case you have any thoughts!

### Checklist

- [x] Tested on screenreader: MacOS VoiceOver in Chrome
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)