### PR TITLE
[Enterprise Search] Add missing Enterprise Search Overview telemetry collectors/schema

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.tsx
@@ -7,10 +7,12 @@
 import React from 'react';
 import { EuiPage, EuiPageContent } from '@elastic/eui';
 
+import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { ErrorStatePrompt } from '../../../shared/error_state';
 
 export const ErrorConnecting: React.FC = () => (
   <EuiPage restrictWidth>
+    <SendTelemetry action="error" metric="cannot_connect" />
     <EuiPageContent>
       <ErrorStatePrompt />
     </EuiPageContent>

--- a/x-pack/plugins/enterprise_search/server/collectors/enterprise_search/telemetry.test.ts
+++ b/x-pack/plugins/enterprise_search/server/collectors/enterprise_search/telemetry.test.ts
@@ -20,6 +20,8 @@ describe('Enterprise Search Telemetry Usage Collector', () => {
     get: () => ({
       attributes: {
         'ui_viewed.overview': 10,
+        'ui_viewed.setup_guide': 5,
+        'ui_error.cannot_connect': 1,
         'ui_clicked.app_search': 2,
         'ui_clicked.workplace_search': 3,
       },
@@ -53,6 +55,10 @@ describe('Enterprise Search Telemetry Usage Collector', () => {
       expect(savedObjectsCounts).toEqual({
         ui_viewed: {
           overview: 10,
+          setup_guide: 5,
+        },
+        ui_error: {
+          cannot_connect: 1,
         },
         ui_clicked: {
           app_search: 2,
@@ -74,6 +80,10 @@ describe('Enterprise Search Telemetry Usage Collector', () => {
       expect(savedObjectsCounts).toEqual({
         ui_viewed: {
           overview: 0,
+          setup_guide: 0,
+        },
+        ui_error: {
+          cannot_connect: 0,
         },
         ui_clicked: {
           app_search: 0,

--- a/x-pack/plugins/enterprise_search/server/collectors/enterprise_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/collectors/enterprise_search/telemetry.ts
@@ -13,6 +13,10 @@ import { getSavedObjectAttributesFromRepo } from '../lib/telemetry';
 interface ITelemetry {
   ui_viewed: {
     overview: number;
+    setup_guide: number;
+  };
+  ui_error: {
+    cannot_connect: number;
   };
   ui_clicked: {
     app_search: number;
@@ -38,6 +42,10 @@ export const registerTelemetryUsageCollector = (
     schema: {
       ui_viewed: {
         overview: { type: 'long' },
+        setup_guide: { type: 'long' },
+      },
+      ui_error: {
+        cannot_connect: { type: 'long' },
       },
       ui_clicked: {
         app_search: { type: 'long' },
@@ -63,6 +71,10 @@ const fetchTelemetryMetrics = async (savedObjects: SavedObjectsServiceStart, log
   const defaultTelemetrySavedObject: ITelemetry = {
     ui_viewed: {
       overview: 0,
+      setup_guide: 0,
+    },
+    ui_error: {
+      cannot_connect: 0,
     },
     ui_clicked: {
       app_search: 0,
@@ -78,6 +90,10 @@ const fetchTelemetryMetrics = async (savedObjects: SavedObjectsServiceStart, log
   return {
     ui_viewed: {
       overview: get(savedObjectAttributes, 'ui_viewed.overview', 0),
+      setup_guide: get(savedObjectAttributes, 'ui_viewed.setup_guide', 0),
+    },
+    ui_error: {
+      cannot_connect: get(savedObjectAttributes, 'ui_error.cannot_connect', 0),
     },
     ui_clicked: {
       app_search: get(savedObjectAttributes, 'ui_clicked.app_search', 0),

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -1706,6 +1706,16 @@
           "properties": {
             "overview": {
               "type": "long"
+            },
+            "setup_guide": {
+              "type": "long"
+            }
+          }
+        },
+        "ui_error": {
+          "properties": {
+            "cannot_connect": {
+              "type": "long"
             }
           }
         },


### PR DESCRIPTION
## Summary

I was doing some telemetry work and realized we had missed capturing the following telemetry for the new Enterprise Search Overview plugin:

- The Setup Guide was registering a "viewed" telemetry action but hadn't actually set up a collector for it
- We should be collecting data for how often users encounter the error connecting view

@elastic/telemetry - I'm hoping to backport this in before BC5 so would super appreciate a quick look 🙏 Thanks so much, apologies for the rush!

## QA

- Checkout branch, and go to http://localhost:5601/api/stats?extended=true (must be logged in as `elastic`)
- Look for `enterprise_search` (3rd result on page)
  - [x] Confirm that the nested `ui_viewed.setup_guide` metric is present 
  - [x] Confirm the nested `ui_error.cannot_connect` metric is present
- Go to http://localhost:5601/app/enterprise_search/overview/setup_guide
  - [x] Go back to the api stats endpoint and confirm `ui_viewed.setup_guide` has incremented by one
- Stop your Enterprise Search instance if running and go to http://localhost:5601/app/enterprise_search/overview
  - [x] Go back to the api stats endpoint and confirm `ui_error.cannot_connect` has incremented by one

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios