### PR TITLE
[7.x] [Security Solution] Unskips Alerts and Persistent timeline cypress tests (#81898)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/integration/alerts.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/alerts.spec.ts
@@ -30,8 +30,7 @@ import { loginAndWaitForPage } from '../tasks/login';
 
 import { DETECTIONS_URL } from '../urls/navigation';
 
-// FLAKY: https://github.com/elastic/kibana/issues/77957
-describe.skip('Alerts', () => {
+describe('Alerts', () => {
   context('Closing alerts', () => {
     beforeEach(() => {
       esArchiverLoad('alerts');

--- a/x-pack/plugins/security_solution/cypress/integration/timeline_local_storage.spec.ts
+++ b/x-pack/plugins/security_solution/cypress/integration/timeline_local_storage.spec.ts
@@ -13,8 +13,7 @@ import { TABLE_COLUMN_EVENTS_MESSAGE } from '../screens/hosts/external_events';
 import { waitsForEventsToBeLoaded, openEventsViewerFieldsBrowser } from '../tasks/hosts/events';
 import { removeColumn, resetFields } from '../tasks/timeline';
 
-// FLAKY: https://github.com/elastic/kibana/issues/75794
-describe.skip('persistent timeline', () => {
+describe('persistent timeline', () => {
   before(() => {
     loginAndWaitForPage(HOSTS_URL);
     openEvents();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Security Solution] Unskips Alerts and Persistent timeline cypress tests (#81898)