### PR TITLE
[Enterprise Search] Telemetry: refactor to Kea logic file

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
@@ -8,6 +8,7 @@ export { mockHistory, mockLocation } from './react_router_history.mock';
 export { mockKibanaValues } from './kibana_logic.mock';
 export { mockLicensingValues } from './licensing_logic.mock';
 export { mockHttpValues } from './http_logic.mock';
+export { mockTelemetryActions } from './telemetry_logic.mock';
 export { mockFlashMessagesValues, mockFlashMessagesActions } from './flash_messages_logic.mock';
 export { mockAllValues, mockAllActions, setMockValues, setMockActions } from './kea.mock';
 

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
@@ -13,6 +13,7 @@
 import { mockKibanaValues } from './kibana_logic.mock';
 import { mockLicensingValues } from './licensing_logic.mock';
 import { mockHttpValues } from './http_logic.mock';
+import { mockTelemetryActions } from './telemetry_logic.mock';
 import { mockFlashMessagesValues, mockFlashMessagesActions } from './flash_messages_logic.mock';
 
 export const mockAllValues = {
@@ -22,6 +23,7 @@ export const mockAllValues = {
   ...mockFlashMessagesValues,
 };
 export const mockAllActions = {
+  ...mockTelemetryActions,
   ...mockFlashMessagesActions,
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/telemetry_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/telemetry_logic.mock.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const mockTelemetryActions = {
+  sendTelemetry: jest.fn(),
+  sendEnterpriseSearchTelemetry: jest.fn(),
+  sendAppSearchTelemetry: jest.fn(),
+  sendWorkplaceSearchTelemetry: jest.fn(),
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/empty_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/empty_state.test.tsx
@@ -5,16 +5,11 @@
  */
 
 import '../../../../__mocks__/kea.mock';
+import { mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
 import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';
-
-jest.mock('../../../../shared/telemetry', () => ({
-  sendTelemetry: jest.fn(),
-  SendAppSearchTelemetry: jest.fn(),
-}));
-import { sendTelemetry } from '../../../../shared/telemetry';
 
 import { EmptyState } from './';
 
@@ -31,7 +26,6 @@ describe('EmptyState', () => {
     const button = prompt.find(EuiButton);
 
     button.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalled();
-    (sendTelemetry as jest.Mock).mockClear();
+    expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/empty_state.tsx
@@ -5,12 +5,11 @@
  */
 
 import React from 'react';
-import { useValues } from 'kea';
+import { useActions } from 'kea';
 import { EuiPageContent, EuiEmptyPrompt, EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { sendTelemetry } from '../../../../shared/telemetry';
-import { HttpLogic } from '../../../../shared/http';
+import { TelemetryLogic } from '../../../../shared/telemetry';
 import { getAppSearchUrl } from '../../../../shared/enterprise_search_url';
 import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
 import { CREATE_ENGINES_PATH } from '../../../routes';
@@ -20,15 +19,13 @@ import { EngineOverviewHeader } from './header';
 import './empty_state.scss';
 
 export const EmptyState: React.FC = () => {
-  const { http } = useValues(HttpLogic);
+  const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
 
   const buttonProps = {
     href: getAppSearchUrl(CREATE_ENGINES_PATH),
     target: '_blank',
     onClick: () =>
-      sendTelemetry({
-        http,
-        product: 'app_search',
+      sendAppSearchTelemetry({
         action: 'clicked',
         metric: 'create_first_engine_button',
       }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/header.test.tsx
@@ -6,12 +6,10 @@
 
 import '../../../../__mocks__/kea.mock';
 import '../../../../__mocks__/enterprise_search_url.mock';
+import { mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
-
-jest.mock('../../../../shared/telemetry', () => ({ sendTelemetry: jest.fn() }));
-import { sendTelemetry } from '../../../../shared/telemetry';
 
 import { EngineOverviewHeader } from './';
 
@@ -29,6 +27,6 @@ describe('EngineOverviewHeader', () => {
     expect(button.prop('isDisabled')).toBeFalsy();
 
     button.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalled();
+    expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/header.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { useValues } from 'kea';
+import { useActions } from 'kea';
 import {
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -16,12 +16,11 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { sendTelemetry } from '../../../../shared/telemetry';
-import { HttpLogic } from '../../../../shared/http';
+import { TelemetryLogic } from '../../../../shared/telemetry';
 import { getAppSearchUrl } from '../../../../shared/enterprise_search_url';
 
 export const EngineOverviewHeader: React.FC = () => {
-  const { http } = useValues(HttpLogic);
+  const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
 
   const buttonProps = {
     fill: true,
@@ -30,9 +29,7 @@ export const EngineOverviewHeader: React.FC = () => {
     href: getAppSearchUrl(),
     target: '_blank',
     onClick: () =>
-      sendTelemetry({
-        http,
-        product: 'app_search',
+      sendAppSearchTelemetry({
         action: 'clicked',
         metric: 'header_launch_button',
       }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.test.tsx
@@ -6,13 +6,10 @@
 
 import '../../../__mocks__/kea.mock';
 import '../../../__mocks__/enterprise_search_url.mock';
-import { mockHttpValues, mountWithIntl } from '../../../__mocks__/';
+import { mockTelemetryActions, mountWithIntl } from '../../../__mocks__/';
 
 import React from 'react';
 import { EuiBasicTable, EuiPagination, EuiButtonEmpty, EuiLink } from '@elastic/eui';
-
-jest.mock('../../../shared/telemetry', () => ({ sendTelemetry: jest.fn() }));
-import { sendTelemetry } from '../../../shared/telemetry';
 
 import { EngineTable } from './engine_table';
 
@@ -58,9 +55,7 @@ describe('EngineTable', () => {
       expect(link.prop('href')).toEqual('http://localhost:3002/as/engines/test-engine');
       link.simulate('click');
 
-      expect(sendTelemetry).toHaveBeenCalledWith({
-        http: mockHttpValues.http,
-        product: 'app_search',
+      expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalledWith({
         action: 'clicked',
         metric: 'engine_table_link',
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
@@ -5,13 +5,12 @@
  */
 
 import React from 'react';
-import { useValues } from 'kea';
+import { useActions } from 'kea';
 import { EuiBasicTable, EuiBasicTableColumn, EuiLink } from '@elastic/eui';
 import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
-import { sendTelemetry } from '../../../shared/telemetry';
-import { HttpLogic } from '../../../shared/http';
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
 import { getEngineRoute } from '../../routes';
 
@@ -42,15 +41,13 @@ export const EngineTable: React.FC<IEngineTableProps> = ({
   data,
   pagination: { totalEngines, pageIndex, onPaginate },
 }) => {
-  const { http } = useValues(HttpLogic);
+  const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
 
   const engineLinkProps = (name: string) => ({
     href: getAppSearchUrl(getEngineRoute(name)),
     target: '_blank',
     onClick: () =>
-      sendTelemetry({
-        http,
-        product: 'app_search',
+      sendAppSearchTelemetry({
         action: 'clicked',
         metric: 'engine_table_link',
       }),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import '../../../__mocks__/kea.mock';
+import { mockTelemetryActions } from '../../../__mocks__';
 
 import React from 'react';
 import { useValues } from 'kea';
@@ -13,11 +14,6 @@ import { shallow } from 'enzyme';
 import { EuiCard } from '@elastic/eui';
 import { EuiButton } from '../../../shared/react_router_helpers';
 import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
-
-jest.mock('../../../shared/telemetry', () => ({
-  sendTelemetry: jest.fn(),
-}));
-import { sendTelemetry } from '../../../shared/telemetry';
 
 import { ProductCard } from './';
 
@@ -38,7 +34,10 @@ describe('ProductCard', () => {
     expect(button.prop('children')).toEqual('Launch App Search');
 
     button.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalledWith(expect.objectContaining({ metric: 'app_search' }));
+    expect(mockTelemetryActions.sendEnterpriseSearchTelemetry).toHaveBeenCalledWith({
+      action: 'clicked',
+      metric: 'app_search',
+    });
   });
 
   it('renders a Workplace Search card', () => {
@@ -53,9 +52,10 @@ describe('ProductCard', () => {
     expect(button.prop('children')).toEqual('Launch Workplace Search');
 
     button.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalledWith(
-      expect.objectContaining({ metric: 'workplace_search' })
-    );
+    expect(mockTelemetryActions.sendEnterpriseSearchTelemetry).toHaveBeenCalledWith({
+      action: 'clicked',
+      metric: 'workplace_search',
+    });
   });
 
   it('renders correct button text when host not present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
@@ -5,14 +5,13 @@
  */
 
 import React from 'react';
-import { useValues } from 'kea';
+import { useValues, useActions } from 'kea';
 import { snakeCase } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { EuiCard, EuiTextColor } from '@elastic/eui';
 
 import { EuiButton } from '../../../shared/react_router_helpers';
-import { sendTelemetry } from '../../../shared/telemetry';
-import { HttpLogic } from '../../../shared/http';
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { KibanaLogic } from '../../../shared/kibana';
 
 import './product_card.scss';
@@ -29,7 +28,7 @@ interface IProductCard {
 }
 
 export const ProductCard: React.FC<IProductCard> = ({ product, image }) => {
-  const { http } = useValues(HttpLogic);
+  const { sendEnterpriseSearchTelemetry } = useActions(TelemetryLogic);
   const { config } = useValues(KibanaLogic);
 
   const LAUNCH_BUTTON_TEXT = i18n.translate(
@@ -69,9 +68,7 @@ export const ProductCard: React.FC<IProductCard> = ({ product, image }) => {
           to={product.URL}
           shouldNotCreateHref={true}
           onClick={() =>
-            sendTelemetry({
-              http,
-              product: 'enterprise_search',
+            sendEnterpriseSearchTelemetry({
               action: 'clicked',
               metric: snakeCase(product.ID),
             })

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/index.ts
@@ -5,7 +5,6 @@
  */
 
 export { TelemetryLogic } from './telemetry_logic';
-export { sendTelemetry } from './send_telemetry';
 export {
   SendEnterpriseSearchTelemetry,
   SendAppSearchTelemetry,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/index.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+export { TelemetryLogic } from './telemetry_logic';
 export { sendTelemetry } from './send_telemetry';
 export {
   SendEnterpriseSearchTelemetry,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.test.tsx
@@ -4,77 +4,50 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import '../../__mocks__/kea.mock';
 import '../../__mocks__/shallow_useeffect.mock';
-import { mockHttpValues } from '../../__mocks__';
+import { mockTelemetryActions } from '../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { JSON_HEADER as headers } from '../../../../common/constants';
-
 import {
-  sendTelemetry,
   SendEnterpriseSearchTelemetry,
   SendAppSearchTelemetry,
   SendWorkplaceSearchTelemetry,
 } from './';
 
-describe('Shared Telemetry Helpers', () => {
+describe('Telemetry component helpers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('sendTelemetry', () => {
-    it('successfully calls the server-side telemetry endpoint', () => {
-      sendTelemetry({
-        http: mockHttpValues.http,
-        product: 'enterprise_search',
-        action: 'viewed',
-        metric: 'setup_guide',
-      });
+  it('SendEnterpriseSearchTelemetry', () => {
+    shallow(<SendEnterpriseSearchTelemetry action="viewed" metric="page" />);
 
-      expect(mockHttpValues.http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
-        headers,
-        body: '{"product":"enterprise_search","action":"viewed","metric":"setup_guide"}',
-      });
-    });
-
-    it('throws an error if the telemetry endpoint fails', () => {
-      const httpRejectMock = sendTelemetry({
-        http: { put: () => Promise.reject() },
-      } as any);
-
-      expect(httpRejectMock).rejects.toThrow('Unable to send telemetry');
+    expect(mockTelemetryActions.sendTelemetry).toHaveBeenCalledWith({
+      action: 'viewed',
+      metric: 'page',
+      product: 'enterprise_search',
     });
   });
 
-  describe('React component helpers', () => {
-    it('SendEnterpriseSearchTelemetry component', () => {
-      shallow(<SendEnterpriseSearchTelemetry action="viewed" metric="page" />);
+  it('SendAppSearchTelemetry', () => {
+    shallow(<SendAppSearchTelemetry action="clicked" metric="button" />);
 
-      expect(mockHttpValues.http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
-        headers,
-        body: '{"product":"enterprise_search","action":"viewed","metric":"page"}',
-      });
+    expect(mockTelemetryActions.sendTelemetry).toHaveBeenCalledWith({
+      action: 'clicked',
+      metric: 'button',
+      product: 'app_search',
     });
+  });
 
-    it('SendAppSearchTelemetry component', () => {
-      shallow(<SendAppSearchTelemetry action="clicked" metric="button" />);
+  it('SendWorkplaceSearchTelemetry', () => {
+    shallow(<SendWorkplaceSearchTelemetry action="error" metric="not_found" />);
 
-      expect(mockHttpValues.http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
-        headers,
-        body: '{"product":"app_search","action":"clicked","metric":"button"}',
-      });
-    });
-
-    it('SendWorkplaceSearchTelemetry component', () => {
-      shallow(<SendWorkplaceSearchTelemetry action="error" metric="not_found" />);
-
-      expect(mockHttpValues.http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
-        headers,
-        body: '{"product":"workplace_search","action":"error","metric":"not_found"}',
-      });
+    expect(mockTelemetryActions.sendTelemetry).toHaveBeenCalledWith({
+      action: 'error',
+      metric: 'not_found',
+      product: 'workplace_search',
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.tsx
@@ -5,68 +5,40 @@
  */
 
 import React, { useEffect } from 'react';
-import { useValues } from 'kea';
+import { useActions } from 'kea';
 
-import { HttpSetup } from 'src/core/public';
-import { JSON_HEADER as headers } from '../../../../common/constants';
-import { HttpLogic } from '../http';
-
-interface ISendTelemetryProps {
-  action: 'viewed' | 'error' | 'clicked';
-  metric: string; // e.g., 'setup_guide'
-}
-
-interface ISendTelemetry extends ISendTelemetryProps {
-  http: HttpSetup;
-  product: 'app_search' | 'workplace_search' | 'enterprise_search';
-}
-
-/**
- * Base function - useful for non-component actions, e.g. clicks
- */
-
-export const sendTelemetry = async ({ http, product, action, metric }: ISendTelemetry) => {
-  try {
-    const body = JSON.stringify({ product, action, metric });
-    await http.put('/api/enterprise_search/stats', { headers, body });
-  } catch (error) {
-    throw new Error('Unable to send telemetry');
-  }
-};
+import { TelemetryLogic, TSendTelemetry } from './telemetry_logic';
 
 /**
  * React component helpers - useful for on-page-load/views
  */
 
-export const SendEnterpriseSearchTelemetry: React.FC<ISendTelemetryProps> = ({
-  action,
-  metric,
-}) => {
-  const { http } = useValues(HttpLogic);
+export const SendEnterpriseSearchTelemetry: React.FC<TSendTelemetry> = ({ action, metric }) => {
+  const { sendTelemetry } = useActions(TelemetryLogic);
 
   useEffect(() => {
-    sendTelemetry({ http, action, metric, product: 'enterprise_search' });
-  }, [action, metric, http]);
+    sendTelemetry({ action, metric, product: 'enterprise_search' });
+  }, [action, metric]);
 
   return null;
 };
 
-export const SendAppSearchTelemetry: React.FC<ISendTelemetryProps> = ({ action, metric }) => {
-  const { http } = useValues(HttpLogic);
+export const SendAppSearchTelemetry: React.FC<TSendTelemetry> = ({ action, metric }) => {
+  const { sendTelemetry } = useActions(TelemetryLogic);
 
   useEffect(() => {
-    sendTelemetry({ http, action, metric, product: 'app_search' });
-  }, [action, metric, http]);
+    sendTelemetry({ action, metric, product: 'app_search' });
+  }, [action, metric]);
 
   return null;
 };
 
-export const SendWorkplaceSearchTelemetry: React.FC<ISendTelemetryProps> = ({ action, metric }) => {
-  const { http } = useValues(HttpLogic);
+export const SendWorkplaceSearchTelemetry: React.FC<TSendTelemetry> = ({ action, metric }) => {
+  const { sendTelemetry } = useActions(TelemetryLogic);
 
   useEffect(() => {
-    sendTelemetry({ http, action, metric, product: 'workplace_search' });
-  }, [action, metric, http]);
+    sendTelemetry({ action, metric, product: 'workplace_search' });
+  }, [action, metric]);
 
   return null;
 };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { resetContext } from 'kea';
+
+import { JSON_HEADER as headers } from '../../../../common/constants';
+import { mockHttpValues } from '../../__mocks__';
+jest.mock('../http', () => ({
+  HttpLogic: { values: { http: mockHttpValues.http } },
+}));
+
+import { TelemetryLogic } from './';
+
+describe('Telemetry logic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetContext({});
+    TelemetryLogic.mount();
+  });
+
+  describe('sendTelemetry', () => {
+    it('successfully calls the server-side telemetry endpoint', () => {
+      TelemetryLogic.actions.sendTelemetry({
+        action: 'viewed',
+        metric: 'setup_guide',
+        product: 'enterprise_search',
+      });
+
+      expect(mockHttpValues.http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
+        headers,
+        body: '{"product":"enterprise_search","action":"viewed","metric":"setup_guide"}',
+      });
+    });
+
+    it('throws an error if the telemetry endpoint fails', () => {
+      mockHttpValues.http.put.mockImplementationOnce(() => Promise.reject());
+      try {
+        TelemetryLogic.actions.sendTelemetry({ action: '', metric: '', product: '' });
+      } catch (e) {
+        expect(e.message).toEqual('Unable to send telemetry');
+      }
+    });
+  });
+
+  describe('product helpers', () => {
+    const telemetryEvent = { action: 'viewed', metric: 'overview' };
+
+    beforeEach(() => {
+      jest.spyOn(TelemetryLogic.actions, 'sendTelemetry');
+    });
+
+    describe('sendEnterpriseSearchTelemetry', () => {
+      it('calls sendTelemetry with the product populated', () => {
+        TelemetryLogic.actions.sendEnterpriseSearchTelemetry(telemetryEvent);
+
+        expect(TelemetryLogic.actions.sendTelemetry).toHaveBeenCalledWith({
+          ...telemetryEvent,
+          product: 'enterprise_search',
+        });
+      });
+    });
+
+    describe('sendAppSearchTelemetry', () => {
+      it('calls sendTelemetry with the product populated', () => {
+        TelemetryLogic.actions.sendAppSearchTelemetry(telemetryEvent);
+
+        expect(TelemetryLogic.actions.sendTelemetry).toHaveBeenCalledWith({
+          ...telemetryEvent,
+          product: 'app_search',
+        });
+      });
+    });
+
+    describe('sendWorkplaceSearchTelemetry', () => {
+      it('calls sendTelemetry with the product populated', () => {
+        TelemetryLogic.actions.sendWorkplaceSearchTelemetry(telemetryEvent);
+
+        expect(TelemetryLogic.actions.sendTelemetry).toHaveBeenCalledWith({
+          ...telemetryEvent,
+          product: 'workplace_search',
+        });
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
@@ -35,13 +35,17 @@ describe('Telemetry logic', () => {
       });
     });
 
-    it('throws an error if the telemetry endpoint fails', () => {
+    it('throws an error if the telemetry endpoint fails', async () => {
       mockHttpValues.http.put.mockImplementationOnce(() => Promise.reject());
-      try {
-        TelemetryLogic.actions.sendTelemetry({ action: '', metric: '', product: '' });
-      } catch (e) {
-        expect(e.message).toEqual('Unable to send telemetry');
-      }
+
+      // To capture thrown errors, we have to call the listener fn directly
+      // instead of using `TelemetryLogic.actions.sendTelemetry` - this is
+      // due to how Kea invokes/wraps action fns by design.
+      const { sendTelemetry } = (TelemetryLogic.inputs[0] as any).listeners({ actions: {} });
+
+      await expect(sendTelemetry({ action: '', metric: '', product: '' })).rejects.toThrow(
+        'Unable to send telemetry'
+      );
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { JSON_HEADER as headers } from '../../../../common/constants';
+import { HttpLogic } from '../http';
+
+export interface ISendTelemetry {
+  action: 'viewed' | 'error' | 'clicked';
+  metric: string; // e.g., 'setup_guide'
+  product: 'enterprise_search' | 'app_search' | 'workplace_search';
+}
+export type TSendTelemetry = Omit<ISendTelemetry, 'product'>;
+
+interface ITelemetryActions {
+  sendTelemetry(args: ISendTelemetry): ISendTelemetry;
+  sendEnterpriseSearchTelemetry(args: TSendTelemetry): TSendTelemetry;
+  sendAppSearchTelemetry(args: TSendTelemetry): TSendTelemetry;
+  sendWorkplaceSearchTelemetry(args: TSendTelemetry): TSendTelemetry;
+}
+
+export const TelemetryLogic = kea<MakeLogicType<ITelemetryActions>>({
+  path: ['enterprise_search', 'telemetry_logic'],
+  actions: {
+    sendTelemetry: ({ action, metric, product }) => ({ action, metric, product }),
+    sendEnterpriseSearchTelemetry: ({ action, metric }) => ({ action, metric }),
+    sendAppSearchTelemetry: ({ action, metric }) => ({ action, metric }),
+    sendWorkplaceSearchTelemetry: ({ action, metric }) => ({ action, metric }),
+  },
+  listeners: ({ actions }) => ({
+    sendTelemetry: async ({ action, metric, product }: ISendTelemetry) => {
+      const { http } = HttpLogic.values;
+      try {
+        const body = JSON.stringify({ product, action, metric });
+        await http.put('/api/enterprise_search/stats', { headers, body });
+      } catch (error) {
+        throw new Error('Unable to send telemetry');
+      }
+    },
+    sendEnterpriseSearchTelemetry: ({ action, metric }: TSendTelemetry) =>
+      actions.sendTelemetry({ action, metric, product: 'enterprise_search' }),
+    sendAppSearchTelemetry: ({ action, metric }: TSendTelemetry) =>
+      actions.sendTelemetry({ action, metric, product: 'app_search' }),
+    sendWorkplaceSearchTelemetry: ({ action, metric }: TSendTelemetry) =>
+      actions.sendTelemetry({ action, metric, product: 'workplace_search' }),
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import '../../../../__mocks__/kea.mock';
+import { mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
@@ -12,12 +13,6 @@ import { EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 import { ProductButton } from './';
-
-jest.mock('../../../../shared/telemetry', () => ({
-  sendTelemetry: jest.fn(),
-  SendAppSearchTelemetry: jest.fn(),
-}));
-import { sendTelemetry } from '../../../../shared/telemetry';
 
 describe('ProductButton', () => {
   it('renders', () => {
@@ -32,7 +27,6 @@ describe('ProductButton', () => {
     const button = wrapper.find(EuiButton);
 
     button.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalled();
-    (sendTelemetry as jest.Mock).mockClear();
+    expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.tsx
@@ -5,17 +5,16 @@
  */
 
 import React from 'react';
-import { useValues } from 'kea';
+import { useActions } from 'kea';
 
 import { EuiButton, EuiButtonProps, EuiLinkProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { sendTelemetry } from '../../../../shared/telemetry';
-import { HttpLogic } from '../../../../shared/http';
+import { TelemetryLogic } from '../../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../../shared/enterprise_search_url';
 
 export const ProductButton: React.FC = () => {
-  const { http } = useValues(HttpLogic);
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
 
   const buttonProps = {
     fill: true,
@@ -25,9 +24,7 @@ export const ProductButton: React.FC = () => {
   buttonProps.href = getWorkplaceSearchUrl();
   buttonProps.target = '_blank';
   buttonProps.onClick = () =>
-    sendTelemetry({
-      http,
-      product: 'workplace_search',
+    sendWorkplaceSearchTelemetry({
       action: 'clicked',
       metric: 'header_launch_button',
     });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
@@ -6,6 +6,7 @@
 
 import { IOverviewValues } from '../overview_logic';
 
+import { setMockValues as setMockKeaValues, setMockActions } from '../../../../__mocks__/kea.mock';
 import { DEFAULT_INITIAL_APP_DATA } from '../../../../../../common/__mocks__';
 
 const { workplaceSearch: mockAppValues } = DEFAULT_INITIAL_APP_DATA;
@@ -29,14 +30,9 @@ export const mockActions = {
 
 const mockValues = { ...mockOverviewValues, ...mockAppValues, isFederatedAuth: true };
 
-jest.mock('kea', () => ({
-  ...(jest.requireActual('kea') as object),
-  useActions: jest.fn(() => ({ ...mockActions })),
-  useValues: jest.fn(() => ({ ...mockValues })),
-}));
-
-import { useValues } from 'kea';
+setMockActions({ ...mockActions });
+setMockKeaValues({ ...mockValues });
 
 export const setMockValues = (values: object) => {
-  (useValues as jest.Mock).mockImplementation(() => ({ ...mockValues, ...values }));
+  setMockKeaValues({ ...mockValues, ...values });
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.test.tsx
@@ -6,6 +6,7 @@
 
 import '../../../__mocks__/kea.mock';
 import '../../../__mocks__/enterprise_search_url.mock';
+import { mockTelemetryActions } from '../../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
@@ -13,9 +14,6 @@ import { shallow } from 'enzyme';
 import { EuiEmptyPrompt, EuiButton, EuiButtonEmpty } from '@elastic/eui';
 
 import { OnboardingCard } from './onboarding_card';
-
-jest.mock('../../../shared/telemetry', () => ({ sendTelemetry: jest.fn() }));
-import { sendTelemetry } from '../../../shared/telemetry';
 
 const cardProps = {
   title: 'My card',
@@ -42,7 +40,7 @@ describe('OnboardingCard', () => {
     expect(button.prop('href')).toBe('http://localhost:3002/ws/some_path');
 
     button.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalled();
+    expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
   });
 
   it('renders an empty button when onboarding is completed', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { useValues } from 'kea';
+import { useActions } from 'kea';
 
 import {
   EuiButton,
@@ -19,8 +19,7 @@ import {
   EuiLinkProps,
 } from '@elastic/eui';
 
-import { sendTelemetry } from '../../../shared/telemetry';
-import { HttpLogic } from '../../../shared/http';
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
 
 interface IOnboardingCardProps {
@@ -42,12 +41,10 @@ export const OnboardingCard: React.FC<IOnboardingCardProps> = ({
   actionPath,
   complete,
 }) => {
-  const { http } = useValues(HttpLogic);
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
 
   const onClick = () =>
-    sendTelemetry({
-      http,
-      product: 'workplace_search',
+    sendWorkplaceSearchTelemetry({
       action: 'clicked',
       metric: 'onboarding_card_button',
     });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { mockTelemetryActions } from '../../../__mocks__';
 import './__mocks__/overview_logic.mock';
 import { setMockValues } from './__mocks__';
 
@@ -11,9 +12,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { ORG_SOURCES_PATH, USERS_PATH } from '../../routes';
-
-jest.mock('../../../shared/telemetry', () => ({ sendTelemetry: jest.fn() }));
-import { sendTelemetry } from '../../../shared/telemetry';
 
 import { OnboardingSteps, OrgNameOnboarding } from './onboarding_steps';
 import { OnboardingCard } from './onboarding_card';
@@ -117,7 +115,7 @@ describe('OnboardingSteps', () => {
         .find('[data-test-subj="orgNameChangeButton"]');
 
       button.simulate('click');
-      expect(sendTelemetry).toHaveBeenCalled();
+      expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
     });
 
     it('hides card when name has been changed', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { useValues } from 'kea';
+import { useValues, useActions } from 'kea';
 
 import {
   EuiSpacer,
@@ -22,8 +22,7 @@ import {
   EuiLinkProps,
 } from '@elastic/eui';
 import sharedSourcesIcon from '../../components/shared/assets/share_circle.svg';
-import { sendTelemetry } from '../../../shared/telemetry';
-import { HttpLogic } from '../../../shared/http';
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
 import { ORG_SOURCES_PATH, USERS_PATH, ORG_SETTINGS_PATH } from '../../routes';
 
@@ -136,12 +135,10 @@ export const OnboardingSteps: React.FC = () => {
 };
 
 export const OrgNameOnboarding: React.FC = () => {
-  const { http } = useValues(HttpLogic);
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
 
   const onClick = () =>
-    sendTelemetry({
-      http,
-      product: 'workplace_search',
+    sendWorkplaceSearchTelemetry({
       action: 'clicked',
       metric: 'org_name_change_button',
     });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.test.tsx
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { mockTelemetryActions } from '../../../__mocks__';
 import './__mocks__/overview_logic.mock';
 import { setMockValues } from './__mocks__';
 
@@ -14,9 +15,6 @@ import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 import { RecentActivity, RecentActivityItem } from './recent_activity';
-
-jest.mock('../../../shared/telemetry', () => ({ sendTelemetry: jest.fn() }));
-import { sendTelemetry } from '../../../shared/telemetry';
 
 const organization = { name: 'foo', defaultOrgName: 'bar' };
 
@@ -50,7 +48,7 @@ describe('RecentActivity', () => {
 
     const link = activity.find('[data-test-subj="viewSourceDetailsLink"]');
     link.simulate('click');
-    expect(sendTelemetry).toHaveBeenCalled();
+    expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
   });
 
   it('renders activity item error state', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.tsx
@@ -7,14 +7,13 @@
 import React from 'react';
 
 import moment from 'moment';
-import { useValues } from 'kea';
+import { useValues, useActions } from 'kea';
 
 import { EuiEmptyPrompt, EuiLink, EuiPanel, EuiSpacer, EuiLinkProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 import { ContentSection } from '../../components/shared/content_section';
-import { sendTelemetry } from '../../../shared/telemetry';
-import { HttpLogic } from '../../../shared/http';
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
 import { SOURCE_DETAILS_PATH, getContentSourcePath } from '../../routes';
 
@@ -94,12 +93,10 @@ export const RecentActivityItem: React.FC<IFeedActivity> = ({
   timestamp,
   sourceId,
 }) => {
-  const { http } = useValues(HttpLogic);
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
 
   const onClick = () =>
-    sendTelemetry({
-      http,
-      product: 'workplace_search',
+    sendWorkplaceSearchTelemetry({
       action: 'clicked',
       metric: 'recent_activity_source_details_link',
     });


### PR DESCRIPTION
## Summary

This refactors our `sendTelemetry()` utility function (that we primarily used for onClick actions) into a logic action, which allows us to not have to import/pass the `http` dependency in every `sendTelemetry` call.
 
### Before:

```js
const { http } = useValues(HttpLogic);

sendTelemetry({
  http,
  product: 'app_search',
  action: 'clicked',
  metric: 'button',
});
```

### After:

```js
const { sendAppSearchTelemetry } = useActions(TelemetryLogic);

sendAppSearchTelemetry({
  action: 'clicked',
  metric: 'button',
});
```

Hopefully the code speaks for itself and feels clearer / closer to the `<SendTelemetry />` components. It also makes unit tests a little less verbose, as we have a lot more helpers in place for mocking Kea values/actions.

## Regression QA

All of the following telemetry actions/events should correctly send 200 XHR requests to `api/enterprise_search/stats`:
- App Search
  - [x] Header > clicking "Launch App Search" button
  - [x] Empty engine state > clicking the "Create engine" button
  - [x] Engine table > Clicking either the engine name link or "Manage" link
- Enterprise Search
  - [x] Clicking a product card's "Launch" button
- Workplace Search
  - [x] Header > Clicking "Launch Workplace Search" button
  - [x] Overview > Clicking the "Add sources" button
  - [x] Overview > Clicking the "Name your organization" link
  - [x] Overview > Clicking a recent activity link

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios