### PR TITLE
Chore: add log statement when deleting transform

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/install.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/install.ts
@@ -17,6 +17,7 @@ import { CallESAsCurrentUser } from '../../../../types';
 import { getInstallation } from '../../packages';
 import { deleteTransforms, deleteTransformRefs } from './remove';
 import { getAsset } from './common';
+import { appContextService } from '../../../app_context';
 
 interface TransformInstallation {
   installationName: string;
@@ -29,6 +30,7 @@ export const installTransform = async (
   callCluster: CallESAsCurrentUser,
   savedObjectsClient: SavedObjectsClientContract
 ) => {
+  const logger = appContextService.getLogger();
   const installation = await getInstallation({
     savedObjectsClient,
     pkgName: installablePackage.name,
@@ -37,6 +39,9 @@ export const installTransform = async (
   if (installation) {
     previousInstalledTransformEsAssets = installation.installed_es.filter(
       ({ type, id }) => type === ElasticsearchAssetType.transform
+    );
+    logger.info(
+      `Found previous transform references:\n ${JSON.stringify(previousInstalledTransformEsAssets)}`
     );
   }
 

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/remove.ts
@@ -24,6 +24,8 @@ export const deleteTransforms = async (
   callCluster: CallESAsCurrentUser,
   transformIds: string[]
 ) => {
+  const logger = appContextService.getLogger();
+  logger.info(`Deleting currently installed transform ids ${transformIds}`);
   await Promise.all(
     transformIds.map(async (transformId) => {
       // get the index the transform
@@ -47,7 +49,7 @@ export const deleteTransforms = async (
         path: `/_transform/${transformId}`,
         ignore: [404],
       });
-
+      logger.info(`Deleted: ${transformId}`);
       if (transformResponse?.transforms) {
         // expect this to be 1
         for (const transform of transformResponse.transforms) {
@@ -58,7 +60,7 @@ export const deleteTransforms = async (
           });
         }
       } else {
-        appContextService.getLogger().warn(`cannot find transform for ${transformId}`);
+        logger.warn(`cannot find transform for ${transformId}`);
       }
     })
   );

--- a/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { createAppContextStartContractMock } from '../../../../mocks';
+
 jest.mock('../../packages/get', () => {
   return { getInstallation: jest.fn(), getInstallationObject: jest.fn() };
 });
@@ -21,11 +23,13 @@ import { getInstallation, getInstallationObject } from '../../packages';
 import { getAsset } from './common';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { savedObjectsClientMock } from '../../../../../../../../src/core/server/saved_objects/service/saved_objects_client.mock';
+import { appContextService } from '../../../app_context';
 
 describe('test transform install', () => {
   let legacyScopedClusterClient: jest.Mocked<ILegacyScopedClusterClient>;
   let savedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
   beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
     legacyScopedClusterClient = {
       callAsInternalUser: jest.fn(),
       callAsCurrentUser: jest.fn(),


### PR DESCRIPTION
## Summary

- [x] add more logs to the transform deletions. 
- [x] the image below comes from the siem server and we want to see the state of the installation reference as well as how many times the installation is restarted. We have tested in cloud instance and have not been able to reproduce this. 

![image](https://user-images.githubusercontent.com/56361221/97475600-d69b8c00-1923-11eb-9f03-ad606b5d284e.png)


### Checklist

Delete any items that are not applicable to this PR.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
