### PR TITLE
[Graph] Fix problem with duplicate ids

### DIFF
--- a/x-pack/plugins/graph/public/components/field_manager/field_editor.tsx
+++ b/x-pack/plugins/graph/public/components/field_manager/field_editor.tsx
@@ -116,7 +116,7 @@ export function FieldEditor({
 
   return (
     <EuiPopover
-      id="graphFieldEditor"
+      id={`graphFieldEditor-${initialField.name}`}
       anchorPosition="downLeft"
       ownFocus
       panelPaddingSize="none"


### PR DESCRIPTION
## Summary

Closes #75211

There was the accessibility problem with duplicate ids in graph plugin. It has been solved by adding the field name in the id.

<img width="1842" alt="Screenshot 2020-10-30 at 11 48 20 AM" src="https://user-images.githubusercontent.com/17003240/97691412-0030f080-1aa7-11eb-9ed5-8e3b68144c0a.png">