### PR TITLE
Cleanup/codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,10 +39,6 @@
 #CC# /src/legacy/core_plugins/vis_type_vislib/ @elastic/kibana-app
 #CC# /src/legacy/server/url_shortening/ @elastic/kibana-app
 #CC# /src/legacy/ui/public/state_management @elastic/kibana-app
-#CC# /src/plugins/advanced_settings/ @elastic/kibana-app
-#CC# /src/plugins/charts/ @elastic/kibana-app
-#CC# /src/plugins/index_pattern_management/public @elastic/kibana-app
-#CC# /src/plugins/vis_default_editor @elastic/kibana-app
 
 # App Architecture
 /examples/bfetch_explorer/ @elastic/kibana-app-arch
@@ -74,7 +70,7 @@
 /x-pack/plugins/embeddable_enhanced/ @elastic/kibana-app-arch
 /x-pack/plugins/ui_actions_enhanced/ @elastic/kibana-app-arch
 #CC# /src/plugins/bfetch/ @elastic/kibana-app-arch
-#CC# /src/plugins/index_pattern_management/public/service @elastic/kibana-app-arch
+#CC# /src/plugins/index_pattern_management/ @elastic/kibana-app-arch
 #CC# /src/plugins/inspector/ @elastic/kibana-app-arch
 #CC# /src/plugins/share/ @elastic/kibana-app-arch
 #CC# /x-pack/plugins/advanced_ui_actions/ @elastic/kibana-app-arch

--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -22,8 +22,10 @@ NOTE:
 |Description
 
 
-|{kib-repo}blob/{branch}/src/plugins/advanced_settings[advancedSettings]
-|WARNING: Missing README.
+|{kib-repo}blob/{branch}/src/plugins/advanced_settings/README.md[advancedSettings]
+|This plugin contains the advanced settings management section
+allowing users to configure their advanced settings, also known
+as uiSettings within the code.
 
 
 |{kib-repo}blob/{branch}/src/plugins/apm_oss[apmOss]
@@ -130,8 +132,10 @@ in Kibana, e.g. visualizations. It has the form of a flyout panel.
 |WARNING: Missing README.
 
 
-|{kib-repo}blob/{branch}/src/plugins/management[management]
-|WARNING: Missing README.
+|{kib-repo}blob/{branch}/src/plugins/management/README.md[management]
+|This plugins contains the "Stack Management" page framework. It offers navigation and an API
+to link individual managment section into it. This plugin does not contain any individual
+management section itself.
 
 
 |{kib-repo}blob/{branch}/src/plugins/maps_legacy/README.md[mapsLegacy]

--- a/src/plugins/advanced_settings/README.md
+++ b/src/plugins/advanced_settings/README.md
@@ -1,0 +1,5 @@
+# Advanced Settings
+
+This plugin contains the advanced settings management section
+allowing users to configure their advanced settings, also known
+as uiSettings within the code.

--- a/src/plugins/management/README.md
+++ b/src/plugins/management/README.md
@@ -1,4 +1,4 @@
-# Managament Plugin
+# Management Plugin
 
 This plugins contains the "Stack Management" page framework. It offers navigation and an API
 to link individual managment section into it. This plugin does not contain any individual

--- a/src/plugins/management/README.md
+++ b/src/plugins/management/README.md
@@ -1,0 +1,5 @@
+# Managament Plugin
+
+This plugins contains the "Stack Management" page framework. It offers navigation and an API
+to link individual managment section into it. This plugin does not contain any individual
+management section itself.


### PR DESCRIPTION
## Summary
This file adds our missing READMEs. It also removed redundant CC lines from CODEOWNERS (since we already have them under our regular CODEOWNERSHIP the additional CC line is not needed), also it moves the index pattern management plugin completely to App Arch (as we decided recently).