### PR TITLE
[Fleet] add force flag to upgrade agents api

### DIFF
--- a/x-pack/plugins/ingest_manager/server/routes/agent/upgrade_handler.ts
+++ b/x-pack/plugins/ingest_manager/server/routes/agent/upgrade_handler.ts
@@ -26,7 +26,7 @@ export const postAgentUpgradeHandler: RequestHandler<
   TypeOf<typeof PostAgentUpgradeRequestSchema.body>
 > = async (context, request, response) => {
   const soClient = context.core.savedObjects.client;
-  const { version, source_uri: sourceUri } = request.body;
+  const { version, source_uri: sourceUri, force } = request.body;
   const kibanaVersion = appContextService.getKibanaVersion();
   try {
     checkVersionIsSame(version, kibanaVersion);
@@ -53,7 +53,7 @@ export const postAgentUpgradeHandler: RequestHandler<
   }
 
   const agent = savedObjectToAgent(agentSO);
-  if (!isAgentUpgradeable(agent, kibanaVersion)) {
+  if (!force && !isAgentUpgradeable(agent, kibanaVersion)) {
     return response.customError({
       statusCode: 400,
       body: {
@@ -83,7 +83,7 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
   TypeOf<typeof PostBulkAgentUpgradeRequestSchema.body>
 > = async (context, request, response) => {
   const soClient = context.core.savedObjects.client;
-  const { version, source_uri: sourceUri, agents } = request.body;
+  const { version, source_uri: sourceUri, agents, force } = request.body;
   const kibanaVersion = appContextService.getKibanaVersion();
   try {
     checkVersionIsSame(version, kibanaVersion);
@@ -102,12 +102,14 @@ export const postBulkAgentsUpgradeHandler: RequestHandler<
         agentIds: agents,
         sourceUri,
         version,
+        force,
       });
     } else {
       await AgentService.sendUpgradeAgentsActions(soClient, {
         kuery: agents,
         sourceUri,
         version,
+        force,
       });
     }
 

--- a/x-pack/plugins/ingest_manager/server/services/agents/upgrade.ts
+++ b/x-pack/plugins/ingest_manager/server/services/agents/upgrade.ts
@@ -64,11 +64,13 @@ export async function sendUpgradeAgentsActions(
         agentIds: string[];
         sourceUri: string | undefined;
         version: string;
+        force?: boolean;
       }
     | {
         kuery: string;
         sourceUri: string | undefined;
         version: string;
+        force?: boolean;
       }
 ) {
   const kibanaVersion = appContextService.getKibanaVersion();
@@ -82,7 +84,9 @@ export async function sendUpgradeAgentsActions(
             showInactive: false,
           })
         ).agents;
-  const agentsToUpdate = agents.filter((agent) => isAgentUpgradeable(agent, kibanaVersion));
+  const agentsToUpdate = options.force
+    ? agents
+    : agents.filter((agent) => isAgentUpgradeable(agent, kibanaVersion));
   const now = new Date().toISOString();
   const data = {
     version: options.version,

--- a/x-pack/plugins/ingest_manager/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/ingest_manager/server/types/rest_spec/agent.ts
@@ -188,6 +188,7 @@ export const PostAgentUpgradeRequestSchema = {
   body: schema.object({
     source_uri: schema.maybe(schema.string()),
     version: schema.string(),
+    force: schema.maybe(schema.boolean()),
   }),
 };
 
@@ -196,6 +197,7 @@ export const PostBulkAgentUpgradeRequestSchema = {
     agents: schema.oneOf([schema.arrayOf(schema.string()), schema.string()]),
     source_uri: schema.maybe(schema.string()),
     version: schema.string(),
+    force: schema.maybe(schema.boolean()),
   }),
 };
 

--- a/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/fleet/agents/upgrade.ts
@@ -402,8 +402,6 @@ export default function (providerContext: FtrProviderContext) {
       expect(typeof agent3data.body.item.upgrade_started_at).to.be('string');
     });
     it('should respond 400 if trying to bulk upgrade to a version that does not match installed kibana version', async () => {
-      const kibanaVersion = await kibanaServer.version.get();
-      const higherVersion = semver.inc(kibanaVersion, 'patch');
       await kibanaServer.savedObjects.update({
         id: 'agent1',
         type: AGENT_SAVED_OBJECT_TYPE,
@@ -423,7 +421,7 @@ export default function (providerContext: FtrProviderContext) {
         .set('kbn-xsrf', 'xxx')
         .send({
           agents: ['agent1', 'agent2'],
-          version: higherVersion,
+          version: '1.0.0',
           force: true,
         })
         .expect(400);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/81845

- Adds a `force` option to `/agents/{agentId}/upgrade` and `/agents/bulk_upgrade` endpoints that bypasses the restriction that you must upgrade the agent to a higher version that the currently installed agent.  This can be used for testing when versions are the same but are different builds, so someone can upgrade a version to the same version.  
- Adds a missing test to cover when attempting to bulk upgrade agents to a version that does not match the installed kibana version