### PR TITLE
Replace handlebars documentation link

### DIFF
--- a/docs/user/dashboard/url-drilldown.asciidoc
+++ b/docs/user/dashboard/url-drilldown.asciidoc
@@ -99,7 +99,7 @@ https://github.com/elastic/kibana/issues?q={{event.value}}
 
 A Handlebars expression is a `{{`, some contents, followed by a `}}`. When the drilldown is executed, these expressions are replaced by values from the dashboard and interaction context.
 
-Refer to Handlebars https://handlebarsjs.com/guide/expressions.html#expressions[documentation] to learn about advanced use cases.
+Refer to Handlebars https://ela.st/handlebars-docs#expressions[documentation] to learn about advanced use cases.
 
 [[helpers]]
 In addition to https://handlebarsjs.com/guide/builtin-helpers.html[built-in] Handlebars helpers, you can use the following custom helpers:

--- a/docs/user/dashboard/url-drilldown.asciidoc
+++ b/docs/user/dashboard/url-drilldown.asciidoc
@@ -102,7 +102,7 @@ A Handlebars expression is a `{{`, some contents, followed by a `}}`. When the d
 Refer to Handlebars https://ela.st/handlebars-docs#expressions[documentation] to learn about advanced use cases.
 
 [[helpers]]
-In addition to https://handlebarsjs.com/guide/builtin-helpers.html[built-in] Handlebars helpers, you can use the following custom helpers:
+In addition to https://ela.st/handlebars-helpers[built-in] Handlebars helpers, you can use the following custom helpers:
 
 
 |===

--- a/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
@@ -134,7 +134,7 @@ export class MarkdownEditor extends Component {
                 values={{
                   handlebarLink: (
                     <a
-                      href="https://handlebarsjs.com/guide/expressions.html"
+                      href="https://ela.st/handlebars-docs"
                       target="_BLANK"
                       rel="noreferrer noopener"
                     >

--- a/x-pack/plugins/canvas/canvas_plugin_src/elements/markdown/index.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/elements/markdown/index.ts
@@ -24,7 +24,7 @@ The data table contains
  **{{name}}**
 {{/each}}
 
-You can use standard Markdown in here, but you can also access your piped-in data using Handlebars. If you want to know more, check out the [Handlebars documentation](https://handlebarsjs.com/guide/expressions.html).
+You can use standard Markdown in here, but you can also access your piped-in data using Handlebars. If you want to know more, check out the [Handlebars documentation](https://ela.st/handlebars-docs).
 
 #### Enjoy!" | render`,
 });

--- a/x-pack/plugins/canvas/public/components/workpad_header/element_menu/__stories__/element_menu.stories.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/element_menu/__stories__/element_menu.stories.tsx
@@ -76,7 +76,7 @@ the following columns:
 **{{name}}**
 {{/each}}
 
-You can use standard Markdown in here, but you can also access your piped-in data using Handlebars. If you want to know more, check out the [Handlebars documentation](https://handlebarsjs.com/guide/expressions.html).
+You can use standard Markdown in here, but you can also access your piped-in data using Handlebars. If you want to know more, check out the [Handlebars documentation](https://ela.st/handlebars-docs).
 
 #### Enjoy!" | render`,
   },


### PR DESCRIPTION
## Summary

Closes #82032. 
This PR replaces the handlebars documentation link with a new one that can be handled by us in order to be able to update it easily if it changes again.

It replaces it on:
- Canvas
- TSVB markdown
- Drilldowns documentation

<img width="344" alt="Screenshot 2020-11-02 at 11 48 10 AM" src="https://user-images.githubusercontent.com/17003240/97853817-4e413080-1d01-11eb-81b5-17c78ab3f7b9.png">

<img width="1773" alt="Screenshot 2020-11-02 at 11 48 56 AM" src="https://user-images.githubusercontent.com/17003240/97853901-6a44d200-1d01-11eb-9e16-319497568b65.png">