### PR TITLE
[Lens] Fix console error by passing I18nProvider to metric vis

### DIFF
--- a/x-pack/plugins/lens/public/metric_visualization/expression.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/expression.tsx
@@ -5,7 +5,7 @@
  */
 
 import './expression.scss';
-
+import { I18nProvider } from '@kbn/i18n/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {
@@ -93,7 +93,9 @@ export const getMetricChartRenderer = (
   ) => {
     const resolvedFormatFactory = await formatFactory;
     ReactDOM.render(
-      <MetricChart {...config} formatFactory={resolvedFormatFactory} />,
+      <I18nProvider>
+        <MetricChart {...config} formatFactory={resolvedFormatFactory} />,
+      </I18nProvider>,
       domNode,
       () => {
         handlers.done();

--- a/x-pack/plugins/lens/public/metric_visualization/expression.tsx
+++ b/x-pack/plugins/lens/public/metric_visualization/expression.tsx
@@ -94,7 +94,7 @@ export const getMetricChartRenderer = (
     const resolvedFormatFactory = await formatFactory;
     ReactDOM.render(
       <I18nProvider>
-        <MetricChart {...config} formatFactory={resolvedFormatFactory} />,
+        <MetricChart {...config} formatFactory={resolvedFormatFactory} />
       </I18nProvider>,
       domNode,
       () => {


### PR DESCRIPTION
## Summary

Removes this console error:
![image](https://user-images.githubusercontent.com/4283304/97876890-b6e9d680-1d1c-11eb-9bf0-a633aa420498.png)
