### PR TITLE
Remove trailing comma in example

### DIFF
--- a/docs/user/security/api-keys/index.asciidoc
+++ b/docs/user/security/api-keys/index.asciidoc
@@ -53,7 +53,7 @@ to authenticate to a <<api, Kibana API>>.
 [source,js]
 POST /_security/api_key
 {
-  "name": "kibana_api_key",
+  "name": "kibana_api_key"
 }
 
 This creates an API key with the


### PR DESCRIPTION
Removing trailing comma from example so that it works correctly within the Dev Tools Console.

## Summary

Removing trailing comma from example so that it works correctly within the Dev Tools Console.

The original example had a trailing comma which meant if folks copy/paste this into Dev tools it wouldn't work. This PR fixes it by removing the trailing comma.

### Checklist


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
