### PR TITLE
[APM] docs: Add xpack.apm.searchAggregatedTransactions

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -59,11 +59,11 @@ Changing these settings may disable features of the APM App.
   | Maximum number of child items displayed when viewing trace details. Defaults to `1000`.
 
 | `xpack.observability.annotations.index`
+  | Index name where Observability annotations are stored. Defaults to `observability-annotations`.
+
+| `xpack.apm.searchAggregatedTransactions`
   | experimental[] Enables Transaction histogram metrics. Requires additional configuration in APM Server.
     See {apm-server-ref-v}/transaction-metrics.html[Configure transaction metrics] for more information.
-  
-| `xpack.apm.searchAggregatedTransactions`
-  | Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
 | `apm_oss.indexPattern` {ess-icon}
   | The index pattern used for integrations with Machine Learning and Query Bar.

--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -62,7 +62,7 @@ Changing these settings may disable features of the APM App.
   | Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
 | `xpack.apm.searchAggregatedTransactions`
-  | experimental[] Enables Transaction histogram metrics. Requires additional configuration in APM Server.
+  | experimental[] Enables Transaction histogram metrics. Defaults to `false`. When `true`, additional configuration in APM Server is required.
     See {apm-server-ref-v}/transaction-metrics.html[Configure transaction metrics] for more information.
 
 | `apm_oss.indexPattern` {ess-icon}

--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -59,6 +59,10 @@ Changing these settings may disable features of the APM App.
   | Maximum number of child items displayed when viewing trace details. Defaults to `1000`.
 
 | `xpack.observability.annotations.index`
+  | experimental[] Enables Transaction histogram metrics. Requires additional configuration in APM Server.
+    See {apm-server-ref-v}/transaction-metrics.html[Configure transaction metrics] for more information.
+  
+| `xpack.apm.searchAggregatedTransactions`
   | Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
 | `apm_oss.indexPattern` {ess-icon}


### PR DESCRIPTION
## Summary

Companion PR to https://github.com/elastic/apm-server/pull/4345. Adds a config description for `xpack.apm.searchAggregatedTransactions` and links to APM Server's (soon to exist) Transaction metrics page for more information. This setting is marked as experimental.

<img width="770" alt="Screen Shot 2020-11-02 at 1 38 31 PM" src="https://user-images.githubusercontent.com/5618806/97922051-b5b2ac80-1d10-11eb-8ddc-eb47fcd35791.png">


