### PR TITLE
[test/new_visualize_flow] fix config

### DIFF
--- a/scripts/functional_tests.js
+++ b/scripts/functional_tests.js
@@ -22,7 +22,7 @@ const alwaysImportedTests = [
   require.resolve('../test/functional/config.js'),
   require.resolve('../test/plugin_functional/config.ts'),
   require.resolve('../test/ui_capabilities/newsfeed_err/config.ts'),
-  require.resolve('../test/new_visualize_flow/config.js'),
+  require.resolve('../test/new_visualize_flow/config.ts'),
   require.resolve('../test/security_functional/config.ts'),
 ];
 // eslint-disable-next-line no-restricted-syntax

--- a/tasks/function_test_groups.js
+++ b/tasks/function_test_groups.js
@@ -42,7 +42,7 @@ const getDefaultArgs = (tag) => {
     '--bail',
     '--debug',
     '--config',
-    'test/new_visualize_flow/config.js',
+    'test/new_visualize_flow/config.ts',
     '--config',
     'test/security_functional/config.ts',
   ];

--- a/test/new_visualize_flow/config.ts
+++ b/test/new_visualize_flow/config.ts
@@ -17,18 +17,16 @@
  * under the License.
  */
 
-import { pageObjects } from '../functional/page_objects';
-import { services } from '../functional/services';
+import { FtrConfigProviderContext } from '@kbn/test/types/ftr';
 
-export default async function ({ readConfigFile }) {
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const commonConfig = await readConfigFile(require.resolve('../functional/config.js'));
 
   return {
-    testFiles: [require.resolve('./dashboard_embedding')],
-    pageObjects,
-    services,
+    testFiles: [require.resolve('./index.ts')],
+    pageObjects: commonConfig.get('pageObjects'),
+    services: commonConfig.get('services'),
     servers: commonConfig.get('servers'),
-
     esTestCluster: commonConfig.get('esTestCluster'),
 
     kbnTestServer: {
@@ -37,6 +35,7 @@ export default async function ({ readConfigFile }) {
         ...commonConfig.get('kbnTestServer.serverArgs'),
         '--oss',
         '--telemetry.optIn=false',
+        '--dashboard.allowByValueEmbeddables=true',
       ],
     },
 
@@ -105,7 +104,7 @@ export default async function ({ readConfigFile }) {
           },
           kibana: [],
         },
-        //for sample data - can remove but not add sample data
+        // for sample data - can remove but not add sample data
         kibana_sample_admin: {
           elasticsearch: {
             cluster: [],

--- a/test/new_visualize_flow/dashboard_embedding.ts
+++ b/test/new_visualize_flow/dashboard_embedding.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { FtrProviderContext } from 'test/functional/ftr_provider_context';
 import expect from '@kbn/expect';
 
 /**
@@ -27,7 +28,8 @@ import expect from '@kbn/expect';
  * broke?).  The upside is that this offers very good coverage with a minimal time investment.
  */
 
-export default function ({ getService, getPageObjects }) {
+// eslint-disable-next-line import/no-default-export
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const dashboardExpect = getService('dashboardExpect');


### PR DESCRIPTION
## Summary

Fixes config to run new_visualize_flow on CI:

```
info Running /dev/shm/workspace/parallel/7/kibana/test/new_visualize_flow/config.ts
 │ debg Loading config file from "/dev/shm/workspace/parallel/7/kibana/test/new_visualize_flow/config.ts"
 │ info Config loaded
...
...
       └-: New Visualize Flow
         └-> "before all" hook
         └-: Dashboard Embedding
           └-> "before all" hook
           └-> "before all" hook
             │ proc [kibana]   log   [15:59:30.017] [info][savedobjects-service] Creating index .kibana_2.
             │ proc [kibana]   log   [15:59:30.094] [info][savedobjects-service] Migrating .kibana_1 saved objects to .kibana_2
             │ proc [kibana]   log   [15:59:30.542] [info][savedobjects-service] Pointing alias .kibana to .kibana_2.
             │ proc [kibana]   log   [15:59:30.605] [info][savedobjects-service] Finished in 591ms.
             │ERROR browser[SEVERE] http://localhost:6171/37794/bundles/core/core.entry.js 12:192226 TypeError: Failed to fetch
             │          at _callee3$ (http://localhost:6171/37794/bundles/core/core.entry.js:6:43940)
             │          at l (http://localhost:6171/37794/bundles/kbn-ui-shared-deps/kbn-ui-shared-deps.js:321:1751401)
             │          at Generator._invoke (http://localhost:6171/37794/bundles/kbn-ui-shared-deps/kbn-ui-shared-deps.js:321:1751154)
             │          at Generator.forEach.e.<computed> [as throw] (http://localhost:6171/37794/bundles/kbn-ui-shared-deps/kbn-ui-shared-deps.js:321:1751758)
             │          at fetch_asyncGeneratorStep (http://localhost:6171/37794/bundles/core/core.entry.js:6:38998)
             │          at _throw (http://localhost:6171/37794/bundles/core/core.entry.js:6:39406)
           └-> adding a metric visualization
             └-> "before each" hook: global before each
             └- ✓ pass  (17.8s) "New Visualize Flow Dashboard Embedding adding a metric visualization"
           └-> adding a markdown
             └-> "before each" hook: global before each
             └- ✓ pass  (18.0s) "New Visualize Flow Dashboard Embedding adding a markdown"
           └-> "after all" hook
         └-> "after all" hook
     │
     │2 passing (1.0m)
```
