### PR TITLE
[Enterprise Search] Migrate shared CredentialItem component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/credential_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/credential_item.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { EuiCopy, EuiButtonIcon, EuiFieldText } from '@elastic/eui';
+
+import { CredentialItem } from './';
+
+const label = 'Credential';
+const testSubj = 'CredentialItemTest';
+const value = 'foo';
+
+const props = { label, testSubj, value };
+
+describe('CredentialItem', () => {
+  const setState = jest.fn();
+  const useStateMock: any = (initState: any) => [initState, setState];
+
+  beforeEach(() => {
+    jest.spyOn(React, 'useState').mockImplementation(useStateMock);
+    setState(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(<CredentialItem {...props} />);
+
+    expect(wrapper.find(`[data-test-subj="${testSubj}"]`)).toHaveLength(1);
+  });
+
+  it('renders the copy button', () => {
+    const copyMock = jest.fn();
+    const wrapper = shallow(<CredentialItem {...props} />);
+
+    const copyEl = shallow(<div>{wrapper.find(EuiCopy).props().children(copyMock)}</div>);
+    expect(copyEl.find(EuiButtonIcon).props().onClick).toEqual(copyMock);
+  });
+
+  it('does not render copy button when hidden', () => {
+    const wrapper = shallow(<CredentialItem {...props} hideCopy />);
+
+    expect(wrapper.find(EuiCopy)).toHaveLength(0);
+  });
+
+  it('handles credential visible toggle click', () => {
+    const wrapper = shallow(<CredentialItem {...props} hideCopy />);
+    const button = wrapper.find(EuiButtonIcon).dive().find('button');
+    button.simulate('click');
+
+    expect(setState).toHaveBeenCalled();
+    expect(wrapper.find(EuiFieldText)).toHaveLength(1);
+  });
+
+  it('handles select all button click', () => {
+    const wrapper = shallow(<CredentialItem {...props} hideCopy />);
+    // Toggle isVisible before EuiFieldText is visible
+    const button = wrapper.find(EuiButtonIcon).dive().find('button');
+    button.simulate('click');
+
+    const simulatedEvent = {
+      button: 0,
+      target: { getAttribute: () => '_self' },
+      currentTarget: { select: jest.fn() },
+      preventDefault: jest.fn(),
+    };
+
+    const input = wrapper.find(EuiFieldText).dive().find('input');
+    input.simulate('click', simulatedEvent);
+
+    expect(simulatedEvent.currentTarget.select).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/credential_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/credential_item.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useState } from 'react';
+
+import { upperFirst } from 'lodash';
+
+import {
+  EuiButtonIcon,
+  EuiCopy,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiFieldPassword,
+  EuiToolTip,
+} from '@elastic/eui';
+
+interface ICredentialItemProps {
+  label: string;
+  value: string;
+  testSubj: string;
+  hideCopy?: boolean;
+}
+
+const inputSelectAll = (e: React.MouseEvent<HTMLInputElement>) => e.currentTarget.select();
+
+export const CredentialItem: React.FC<ICredentialItemProps> = ({
+  label,
+  value,
+  testSubj,
+  hideCopy,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="none"
+      responsive={false}
+      data-test-subj={testSubj}
+    >
+      <EuiFlexItem grow={1}>
+        <EuiText size="s">
+          <strong>{label}</strong>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={2}>
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          {!hideCopy && (
+            <EuiFlexItem grow={false}>
+              <EuiCopy beforeMessage="Copy to clipboard" afterMessage="Copied!" textToCopy={value}>
+                {(copy) => (
+                  <EuiButtonIcon
+                    aria-label="Copy to Clipboard"
+                    onClick={copy}
+                    iconType="copy"
+                    color="primary"
+                  />
+                )}
+              </EuiCopy>
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false}>
+            <EuiToolTip position="top" content={`Show ${label}`}>
+              <EuiButtonIcon
+                aria-label="Show credential"
+                data-test-subj={`Show${upperFirst(testSubj)}`}
+                onClick={() => setIsVisible(!isVisible)}
+                iconType={isVisible ? 'eyeClosed' : 'eye'}
+                color="primary"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {!isVisible ? (
+              <EuiFieldPassword
+                placeholder={label}
+                value={value}
+                readOnly
+                compressed={true}
+                disabled
+              />
+            ) : (
+              <EuiFieldText
+                readOnly={true}
+                placeholder="Compressed"
+                data-test-subj={`${testSubj}Input`}
+                value={value}
+                compressed={true}
+                onClick={inputSelectAll}
+              />
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { CredentialItem } from './credential_item';


### PR DESCRIPTION
## Summary

Migrates shared [CredentialItem](https://github.com/elastic/ent-search/blob/master/app/javascript/workplace_search/components/CredentialItem/CredentialItem.tsx) component from `ent-search`.

![image](https://user-images.githubusercontent.com/1869731/98027671-a3994280-1dd2-11eb-81b9-ba2ab841af3c.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
