### PR TITLE
[Enterprise Search] Migrate shared ComponentLoader component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.scss
@@ -4,14 +4,16 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export * from '../../../common/types/workplace_search';
+.componentLoader {
+  display: flex;
+  justify-content: center;
+  margin: auto;
+  align-items: center;
+  min-height: 200px;
+  border-radius: 4px;
+  background-color: #FAFBFD;
 
-export type TSpacerSize = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
-
-export interface ISourcePriority {
-  [id: string]: number;
-}
-
-export interface IComponentLoader {
-  text?: string;
+  .componentLoaderText {
+    margin-left: 10px;
+  }
 }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { EuiLoadingSpinner, EuiTextColor } from '@elastic/eui';
+
+import { ComponentLoader } from './';
+
+describe('ComponentLoader', () => {
+  it('renders', () => {
+    const wrapper = shallow(<ComponentLoader />);
+
+    expect(wrapper.find(EuiLoadingSpinner)).toHaveLength(1);
+    expect(wrapper.find(EuiTextColor)).toHaveLength(1);
+    expect(wrapper.find(EuiTextColor).prop('children')).toEqual('Loading...');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+
+import { EuiLoadingSpinner, EuiTextColor } from '@elastic/eui';
+
+import { IComponentLoader } from '../../../types';
+
+import './component_loader.scss';
+
+export const ComponentLoader: React.FC<IComponentLoader> = ({ text = 'Loading...' }) => (
+  <div className="componentLoader">
+    <EuiLoadingSpinner size="l" />
+    <EuiTextColor className="componentLoaderText" color="subdued">
+      {text}
+    </EuiTextColor>
+  </div>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/index.ts
@@ -4,14 +4,4 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export * from '../../../common/types/workplace_search';
-
-export type TSpacerSize = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
-
-export interface ISourcePriority {
-  [id: string]: number;
-}
-
-export interface IComponentLoader {
-  text?: string;
-}
+export { ComponentLoader } from './component_loader';


### PR DESCRIPTION
## Summary

Migrates the shared [ComponentLoader](https://github.com/elastic/ent-search/blob/master/app/javascript/workplace_search/components/ComponentLoader/ComponentLoader.tsx) component
![image](https://user-images.githubusercontent.com/1869731/98039659-a69d2e80-1de4-11eb-87fa-555f30bd4561.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios