### PR TITLE
[Enterprise Search] Migrate shared ApiKey component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/api_key.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/api_key.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { EuiCodeBlock, EuiFormLabel } from '@elastic/eui';
+
+import { ApiKey } from './';
+
+const key = '123abc';
+const label = 'foo';
+
+describe('ApiKey', () => {
+  it('renders', () => {
+    const wrapper = shallow(<ApiKey apiKey={key} />);
+
+    expect(wrapper.find(EuiCodeBlock)).toHaveLength(1);
+    expect(wrapper.find(EuiFormLabel)).toHaveLength(0);
+    expect(wrapper.find(EuiCodeBlock).prop('children')).toEqual(key);
+  });
+
+  it('renders label', () => {
+    const wrapper = shallow(<ApiKey apiKey={key} label={label} />);
+
+    expect(wrapper.find(EuiFormLabel)).toHaveLength(1);
+    expect(wrapper.find(EuiFormLabel).prop('children')).toEqual(label);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/api_key.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/api_key.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+
+import { EuiCodeBlock, EuiFormLabel, EuiSpacer } from '@elastic/eui';
+
+interface IApiKeyProps {
+  apiKey: string;
+  label?: string;
+}
+
+export const ApiKey: React.FC<IApiKeyProps> = ({ apiKey, label }) => (
+  <>
+    {label && (
+      <>
+        <EuiFormLabel>{label}</EuiFormLabel>
+        <EuiSpacer size="xs" />
+      </>
+    )}
+    <EuiCodeBlock language="bash" fontSize="m" paddingSize="m" color="dark" isCopyable>
+      {apiKey}
+    </EuiCodeBlock>
+  </>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { ApiKey } from './api_key';


### PR DESCRIPTION
## Summary

Migrates the shared [ApiKey](https://github.com/elastic/ent-search/blob/master/app/javascript/workplace_search/components/ApiKey.tsx) component from `ent-search`.

![image](https://user-images.githubusercontent.com/1869731/98040598-237cd800-1de6-11eb-8fef-25d1f3666002.png)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios