### PR TITLE
[App Search] Implement initial Engine routing/navigation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/constants.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+// TODO: It's very likely that we'll move these i18n constants to their respective component
+// folders once those are migrated over. This is a temporary way of DRYing them out for now.
+
+export const ENGINES_TITLE = i18n.translate('xpack.enterpriseSearch.appSearch.engines.title', {
+  defaultMessage: 'Engines',
+});
+
+export const OVERVIEW_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.overview.title',
+  { defaultMessage: 'Overview' }
+);
+export const ANALYTICS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.analytics.title',
+  { defaultMessage: 'Analytics' }
+);
+export const DOCUMENTS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.documents.title',
+  { defaultMessage: 'Documents' }
+);
+export const SCHEMA_TITLE = i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.title', {
+  defaultMessage: 'Schema',
+});
+export const CRAWLER_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.crawler.title',
+  { defaultMessage: 'Crawler' }
+);
+export const RELEVANCE_TUNING_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.relevanceTuning.title',
+  { defaultMessage: 'Relevance Tuning' }
+);
+export const SYNONYMS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.synonyms.title',
+  { defaultMessage: 'Synonyms' }
+);
+export const CURATIONS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.curations.title',
+  { defaultMessage: 'Curations' }
+);
+export const RESULT_SETTINGS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.resultSettings.title',
+  { defaultMessage: 'Result Settings' }
+);
+export const SEARCH_UI_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.searchUI.title',
+  { defaultMessage: 'Search UI' }
+);
+export const API_LOGS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.apiLogs.title',
+  { defaultMessage: 'API Logs' }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.scss
@@ -4,5 +4,14 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export { Layout } from './layout';
-export { SideNav, SideNavLink, SideNavItem } from './side_nav';
+.appSearchNavEngineLabel {
+  padding-top: $euiSizeS;
+  padding-bottom: $euiSizeS;
+
+  .euiText {
+    font-weight: $euiFontWeightMedium;
+  }
+  .euiBadge {
+    margin-top: $euiSizeXS;
+  }
+}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../__mocks__/react_router_history.mock';
+import { setMockValues } from '../../../__mocks__/kea.mock';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Switch, useParams } from 'react-router-dom';
+
+import { EngineRouter, EngineNav } from './';
+
+describe('EngineRouter', () => {
+  it('renders a default engine overview', () => {
+    setMockValues({ myRole: {} });
+    const wrapper = shallow(<EngineRouter />);
+
+    expect(wrapper.find(Switch)).toHaveLength(1);
+    expect(wrapper.find('[data-test-subj="EngineOverviewTODO"]')).toHaveLength(1);
+  });
+
+  it('renders an analytics view', () => {
+    setMockValues({ myRole: { canViewEngineAnalytics: true } });
+    const wrapper = shallow(<EngineRouter />);
+
+    expect(wrapper.find('[data-test-subj="AnalyticsTODO"]')).toHaveLength(1);
+  });
+});
+
+describe('EngineNav', () => {
+  beforeEach(() => {
+    (useParams as jest.Mock).mockReturnValue({ engineName: 'some-engine' });
+  });
+
+  it('does not render without an engine name', () => {
+    setMockValues({ myRole: {} });
+    (useParams as jest.Mock).mockReturnValue({ engineName: '' });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('renders a default engine overview link', () => {
+    setMockValues({ myRole: {} });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineOverviewLink"]')).toHaveLength(1);
+  });
+
+  it('renders an analytics link', () => {
+    setMockValues({ myRole: { canViewEngineAnalytics: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineAnalyticsLink"]')).toHaveLength(1);
+  });
+
+  it('renders a documents link', () => {
+    setMockValues({ myRole: { canViewEngineDocuments: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineDocumentsLink"]')).toHaveLength(1);
+  });
+
+  it('renders a schema link', () => {
+    setMockValues({ myRole: { canViewEngineSchema: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineSchemaLink"]')).toHaveLength(1);
+
+    // TODO: Schema warning icon
+  });
+
+  // TODO: Unskip when EngineLogic is migrated
+  it.skip('renders a crawler link', () => {
+    setMockValues({ myRole: { canViewEngineCrawler: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineCrawlerLink"]')).toHaveLength(1);
+
+    // TODO: Test that the crawler link does NOT show up for meta/sample engines
+  });
+
+  // TODO: Unskip when EngineLogic is migrated
+  it.skip('renders a meta engine source engines link', () => {
+    setMockValues({ myRole: { canViewMetaEngineSourceEngines: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="MetaEngineEnginesLink"]')).toHaveLength(1);
+
+    // TODO: Test that the crawler link does NOT show up for non-meta engines
+  });
+
+  it('renders a relevance tuning link', () => {
+    setMockValues({ myRole: { canManageEngineRelevanceTuning: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineRelevanceTuningLink"]')).toHaveLength(1);
+
+    // TODO: Boost error icon
+  });
+
+  it('renders a synonyms link', () => {
+    setMockValues({ myRole: { canManageEngineSynonyms: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineSynonymsLink"]')).toHaveLength(1);
+  });
+
+  it('renders a curations link', () => {
+    setMockValues({ myRole: { canManageEngineCurations: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineCurationsLink"]')).toHaveLength(1);
+  });
+
+  it('renders a results settings link', () => {
+    setMockValues({ myRole: { canManageEngineResultSettings: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineResultSettingsLink"]')).toHaveLength(1);
+  });
+
+  it('renders a Search UI link', () => {
+    setMockValues({ myRole: { canManageEngineSearchUi: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineSearchUILink"]')).toHaveLength(1);
+  });
+
+  it('renders an API logs link', () => {
+    setMockValues({ myRole: { canViewEngineApiLogs: true } });
+    const wrapper = shallow(<EngineNav />);
+    expect(wrapper.find('[data-test-subj="EngineAPILogsLink"]')).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -8,8 +8,9 @@ import '../../../__mocks__/react_router_history.mock';
 import { setMockValues } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Switch, useParams } from 'react-router-dom';
+import { EuiBadge } from '@elastic/eui';
 
 import { EngineRouter, EngineNav } from './';
 
@@ -40,6 +41,17 @@ describe('EngineNav', () => {
     (useParams as jest.Mock).mockReturnValue({ engineName: '' });
     const wrapper = shallow(<EngineNav />);
     expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('renders an engine label', () => {
+    setMockValues({ myRole: {} });
+    const wrapper = mount(<EngineNav />);
+
+    const label = wrapper.find('[data-test-subj="EngineLabel"]').last();
+    expect(label.text()).toEqual(expect.stringContaining('SOME-ENGINE'));
+
+    // TODO: Test sample & meta engine conditional rendering
+    expect(label.find(EuiBadge).text()).toEqual('SAMPLE ENGINE');
   });
 
   it('renders a default engine overview link', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { Route, Switch, useParams } from 'react-router-dom';
+import { useValues } from 'kea';
+import { i18n } from '@kbn/i18n';
+
+import { SideNavLink } from '../../../shared/layout';
+import { AppLogic } from '../../app_logic';
+import {
+  getEngineRoute,
+  ENGINE_PATH,
+  ENGINE_ANALYTICS_PATH,
+  ENGINE_DOCUMENTS_PATH,
+  ENGINE_SCHEMA_PATH,
+  ENGINE_CRAWLER_PATH,
+  META_ENGINE_SOURCE_ENGINES_PATH,
+  ENGINE_RELEVANCE_TUNING_PATH,
+  ENGINE_SYNONYMS_PATH,
+  ENGINE_CURATIONS_PATH,
+  ENGINE_RESULT_SETTINGS_PATH,
+  ENGINE_SEARCH_UI_PATH,
+  ENGINE_API_LOGS_PATH,
+} from '../../routes';
+import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
+
+export const EngineRouter: React.FC = () => {
+  const {
+    myRole: { canViewEngineAnalytics },
+  } = useValues(AppLogic);
+
+  // TODO: EngineLogic
+
+  return (
+    // TODO: Add more routes as we migrate them
+    <Switch>
+      {canViewEngineAnalytics && (
+        <Route path={ENGINE_PATH + ENGINE_ANALYTICS_PATH}>
+          <div data-test-subj="AnalyticsTODO">Just testing right now</div>
+        </Route>
+      )}
+      <Route>
+        <div data-test-subj="EngineOverviewTODO">Overview</div>
+      </Route>
+    </Switch>
+  );
+};
+
+export const EngineNav: React.FC = () => {
+  const {
+    myRole: {
+      canViewEngineAnalytics,
+      canViewEngineDocuments,
+      canViewEngineSchema,
+      canViewEngineCrawler,
+      canViewMetaEngineSourceEngines,
+      canManageEngineSynonyms,
+      canManageEngineCurations,
+      canManageEngineRelevanceTuning,
+      canManageEngineResultSettings,
+      canManageEngineSearchUi,
+      canViewEngineApiLogs,
+    },
+  } = useValues(AppLogic);
+
+  // TODO: Use EngineLogic
+  const isSampleEngine = true;
+  const isMetaEngine = false;
+  const { engineName } = useParams() as { engineName: string };
+  const engineRoute = engineName && getEngineRoute(engineName);
+
+  if (!engineName) return null;
+
+  return (
+    <>
+      <SideNavLink to={engineRoute} data-test-subj="EngineOverviewLink">
+        {i18n.translate('xpack.enterpriseSearch.appSearch.engine.overview.title', {
+          defaultMessage: 'Overview',
+        })}
+      </SideNavLink>
+      {canViewEngineAnalytics && (
+        <SideNavLink to={engineRoute + ENGINE_ANALYTICS_PATH} data-test-subj="EngineAnalyticsLink">
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.analytics.title', {
+            defaultMessage: 'Analytics',
+          })}
+        </SideNavLink>
+      )}
+      {canViewEngineDocuments && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_DOCUMENTS_PATH)}
+          data-test-subj="EngineDocumentsLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.documents.title', {
+            defaultMessage: 'Documents',
+          })}
+        </SideNavLink>
+      )}
+      {canViewEngineSchema && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_SCHEMA_PATH)}
+          data-test-subj="EngineSchemaLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.title', {
+            defaultMessage: 'Schema',
+          })}
+          {/* TODO: Engine schema warning icon */}
+        </SideNavLink>
+      )}
+      {canViewEngineCrawler && !isMetaEngine && !isSampleEngine && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_CRAWLER_PATH)}
+          data-test-subj="EngineCrawlerLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.crawler.title', {
+            defaultMessage: 'Crawler',
+          })}
+        </SideNavLink>
+      )}
+      {canViewMetaEngineSourceEngines && isMetaEngine && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + META_ENGINE_SOURCE_ENGINES_PATH)}
+          data-test-subj="MetaEngineEnginesLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.metaEngine.navLink', {
+            defaultMessage: 'Engines',
+          })}
+        </SideNavLink>
+      )}
+      {canManageEngineRelevanceTuning && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_RELEVANCE_TUNING_PATH)}
+          data-test-subj="EngineRelevanceTuningLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.relevanceTuning.title', {
+            defaultMessage: 'Relevance Tuning',
+          })}
+          {/* TODO: invalid boosts error icon */}
+        </SideNavLink>
+      )}
+      {canManageEngineSynonyms && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_SYNONYMS_PATH)}
+          data-test-subj="EngineSynonymsLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.synonyms.title', {
+            defaultMessage: 'Synonyms',
+          })}
+        </SideNavLink>
+      )}
+      {canManageEngineCurations && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_CURATIONS_PATH)}
+          data-test-subj="EngineCurationsLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.curations.title', {
+            defaultMessage: 'Curations',
+          })}
+        </SideNavLink>
+      )}
+      {canManageEngineResultSettings && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_RESULT_SETTINGS_PATH)}
+          data-test-subj="EngineResultSettingsLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.resultSettings.title', {
+            defaultMessage: 'Result Settings',
+          })}
+        </SideNavLink>
+      )}
+      {canManageEngineSearchUi && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_SEARCH_UI_PATH)}
+          data-test-subj="EngineSearchUILink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.searchUI.title', {
+            defaultMessage: 'Search UI',
+          })}
+        </SideNavLink>
+      )}
+      {canViewEngineApiLogs && (
+        <SideNavLink
+          isExternal
+          to={getAppSearchUrl(engineRoute + ENGINE_API_LOGS_PATH)}
+          data-test-subj="EngineAPILogsLink"
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.apiLogs.title', {
+            defaultMessage: 'API Logs',
+          })}
+        </SideNavLink>
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -7,9 +7,11 @@
 import React from 'react';
 import { Route, Switch, useParams } from 'react-router-dom';
 import { useValues } from 'kea';
+
+import { EuiText, EuiBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { SideNavLink } from '../../../shared/layout';
+import { SideNavLink, SideNavItem } from '../../../shared/layout';
 import { AppLogic } from '../../app_logic';
 import {
   getEngineRoute,
@@ -27,6 +29,8 @@ import {
   ENGINE_API_LOGS_PATH,
 } from '../../routes';
 import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
+
+import './engine_nav.scss';
 
 export const EngineRouter: React.FC = () => {
   const {
@@ -77,6 +81,25 @@ export const EngineNav: React.FC = () => {
 
   return (
     <>
+      <SideNavItem className="appSearchNavEngineLabel" data-test-subj="EngineLabel">
+        <EuiText color="subdued" size="s">
+          <div className="eui-textTruncate">{engineName.toUpperCase()}</div>
+          {isSampleEngine && (
+            <EuiBadge>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.engine.sampleEngineBadge', {
+                defaultMessage: 'SAMPLE ENGINE',
+              })}
+            </EuiBadge>
+          )}
+          {isMetaEngine && (
+            <EuiBadge>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.engine.metaEngineBadge', {
+                defaultMessage: 'META ENGINE',
+              })}
+            </EuiBadge>
+          )}
+        </EuiText>
+      </SideNavItem>
       <SideNavLink to={engineRoute} data-test-subj="EngineOverviewLink">
         {i18n.translate('xpack.enterpriseSearch.appSearch.engine.overview.title', {
           defaultMessage: 'Overview',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -30,6 +30,20 @@ import {
   ENGINE_API_LOGS_PATH,
 } from '../../routes';
 import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
+import {
+  ENGINES_TITLE,
+  OVERVIEW_TITLE,
+  ANALYTICS_TITLE,
+  DOCUMENTS_TITLE,
+  SCHEMA_TITLE,
+  CRAWLER_TITLE,
+  RELEVANCE_TUNING_TITLE,
+  SYNONYMS_TITLE,
+  CURATIONS_TITLE,
+  RESULT_SETTINGS_TITLE,
+  SEARCH_UI_TITLE,
+  API_LOGS_TITLE,
+} from './constants';
 
 import './engine_nav.scss';
 
@@ -41,38 +55,19 @@ export const EngineRouter: React.FC = () => {
   // TODO: EngineLogic
 
   const { engineName } = useParams() as { engineName: string };
-  const engineBreadcrumb = [
-    i18n.translate('xpack.enterpriseSearch.appSearch.engines.title', {
-      defaultMessage: 'Engines',
-    }),
-    engineName,
-  ];
+  const engineBreadcrumb = [ENGINES_TITLE, engineName];
 
   return (
     // TODO: Add more routes as we migrate them
     <Switch>
       {canViewEngineAnalytics && (
         <Route path={ENGINE_PATH + ENGINE_ANALYTICS_PATH}>
-          <SetPageChrome
-            trail={[
-              ...engineBreadcrumb,
-              i18n.translate('xpack.enterpriseSearch.appSearch.engine.analytics.title', {
-                defaultMessage: 'Analytics',
-              }),
-            ]}
-          />
+          <SetPageChrome trail={[...engineBreadcrumb, ANALYTICS_TITLE]} />
           <div data-test-subj="AnalyticsTODO">Just testing right now</div>
         </Route>
       )}
       <Route>
-        <SetPageChrome
-          trail={[
-            ...engineBreadcrumb,
-            i18n.translate('xpack.enterpriseSearch.appSearch.engine.overview.title', {
-              defaultMessage: 'Overview',
-            }),
-          ]}
-        />
+        <SetPageChrome trail={[...engineBreadcrumb, OVERVIEW_TITLE]} />
         <div data-test-subj="EngineOverviewTODO">Overview</div>
       </Route>
     </Switch>
@@ -126,15 +121,11 @@ export const EngineNav: React.FC = () => {
         </EuiText>
       </SideNavItem>
       <SideNavLink to={engineRoute} data-test-subj="EngineOverviewLink">
-        {i18n.translate('xpack.enterpriseSearch.appSearch.engine.overview.title', {
-          defaultMessage: 'Overview',
-        })}
+        {OVERVIEW_TITLE}
       </SideNavLink>
       {canViewEngineAnalytics && (
         <SideNavLink to={engineRoute + ENGINE_ANALYTICS_PATH} data-test-subj="EngineAnalyticsLink">
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.analytics.title', {
-            defaultMessage: 'Analytics',
-          })}
+          {ANALYTICS_TITLE}
         </SideNavLink>
       )}
       {canViewEngineDocuments && (
@@ -143,9 +134,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_DOCUMENTS_PATH)}
           data-test-subj="EngineDocumentsLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.documents.title', {
-            defaultMessage: 'Documents',
-          })}
+          {DOCUMENTS_TITLE}
         </SideNavLink>
       )}
       {canViewEngineSchema && (
@@ -154,9 +143,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_SCHEMA_PATH)}
           data-test-subj="EngineSchemaLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.schema.title', {
-            defaultMessage: 'Schema',
-          })}
+          {SCHEMA_TITLE}
           {/* TODO: Engine schema warning icon */}
         </SideNavLink>
       )}
@@ -166,9 +153,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_CRAWLER_PATH)}
           data-test-subj="EngineCrawlerLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.crawler.title', {
-            defaultMessage: 'Crawler',
-          })}
+          {CRAWLER_TITLE}
         </SideNavLink>
       )}
       {canViewMetaEngineSourceEngines && isMetaEngine && (
@@ -177,9 +162,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + META_ENGINE_SOURCE_ENGINES_PATH)}
           data-test-subj="MetaEngineEnginesLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.metaEngine.navLink', {
-            defaultMessage: 'Engines',
-          })}
+          {ENGINES_TITLE}
         </SideNavLink>
       )}
       {canManageEngineRelevanceTuning && (
@@ -188,9 +171,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_RELEVANCE_TUNING_PATH)}
           data-test-subj="EngineRelevanceTuningLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.relevanceTuning.title', {
-            defaultMessage: 'Relevance Tuning',
-          })}
+          {RELEVANCE_TUNING_TITLE}
           {/* TODO: invalid boosts error icon */}
         </SideNavLink>
       )}
@@ -200,9 +181,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_SYNONYMS_PATH)}
           data-test-subj="EngineSynonymsLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.synonyms.title', {
-            defaultMessage: 'Synonyms',
-          })}
+          {SYNONYMS_TITLE}
         </SideNavLink>
       )}
       {canManageEngineCurations && (
@@ -211,9 +190,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_CURATIONS_PATH)}
           data-test-subj="EngineCurationsLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.curations.title', {
-            defaultMessage: 'Curations',
-          })}
+          {CURATIONS_TITLE}
         </SideNavLink>
       )}
       {canManageEngineResultSettings && (
@@ -222,9 +199,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_RESULT_SETTINGS_PATH)}
           data-test-subj="EngineResultSettingsLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.resultSettings.title', {
-            defaultMessage: 'Result Settings',
-          })}
+          {RESULT_SETTINGS_TITLE}
         </SideNavLink>
       )}
       {canManageEngineSearchUi && (
@@ -233,9 +208,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_SEARCH_UI_PATH)}
           data-test-subj="EngineSearchUILink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.searchUI.title', {
-            defaultMessage: 'Search UI',
-          })}
+          {SEARCH_UI_TITLE}
         </SideNavLink>
       )}
       {canViewEngineApiLogs && (
@@ -244,9 +217,7 @@ export const EngineNav: React.FC = () => {
           to={getAppSearchUrl(engineRoute + ENGINE_API_LOGS_PATH)}
           data-test-subj="EngineAPILogsLink"
         >
-          {i18n.translate('xpack.enterpriseSearch.appSearch.engine.apiLogs.title', {
-            defaultMessage: 'API Logs',
-          })}
+          {API_LOGS_TITLE}
         </SideNavLink>
       )}
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -12,6 +12,7 @@ import { EuiText, EuiBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { SideNavLink, SideNavItem } from '../../../shared/layout';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { AppLogic } from '../../app_logic';
 import {
   getEngineRoute,
@@ -39,15 +40,39 @@ export const EngineRouter: React.FC = () => {
 
   // TODO: EngineLogic
 
+  const { engineName } = useParams() as { engineName: string };
+  const engineBreadcrumb = [
+    i18n.translate('xpack.enterpriseSearch.appSearch.engines.title', {
+      defaultMessage: 'Engines',
+    }),
+    engineName,
+  ];
+
   return (
     // TODO: Add more routes as we migrate them
     <Switch>
       {canViewEngineAnalytics && (
         <Route path={ENGINE_PATH + ENGINE_ANALYTICS_PATH}>
+          <SetPageChrome
+            trail={[
+              ...engineBreadcrumb,
+              i18n.translate('xpack.enterpriseSearch.appSearch.engine.analytics.title', {
+                defaultMessage: 'Analytics',
+              }),
+            ]}
+          />
           <div data-test-subj="AnalyticsTODO">Just testing right now</div>
         </Route>
       )}
       <Route>
+        <SetPageChrome
+          trail={[
+            ...engineBreadcrumb,
+            i18n.translate('xpack.enterpriseSearch.appSearch.engine.overview.title', {
+              defaultMessage: 'Overview',
+            }),
+          ]}
+        />
         <div data-test-subj="EngineOverviewTODO">Overview</div>
       </Route>
     </Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { EngineRouter, EngineNav } from './engine_nav';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.test.tsx
@@ -9,7 +9,8 @@ import '../../../__mocks__/enterprise_search_url.mock';
 import { mockTelemetryActions, mountWithIntl } from '../../../__mocks__/';
 
 import React from 'react';
-import { EuiBasicTable, EuiPagination, EuiButtonEmpty, EuiLink } from '@elastic/eui';
+import { EuiBasicTable, EuiPagination, EuiButtonEmpty } from '@elastic/eui';
+import { EuiLink } from '../../../shared/react_router_helpers';
 
 import { EngineTable } from './engine_table';
 
@@ -52,7 +53,7 @@ describe('EngineTable', () => {
     const engineLinks = wrapper.find(EuiLink);
 
     engineLinks.forEach((link) => {
-      expect(link.prop('href')).toEqual('http://localhost:3002/as/engines/test-engine');
+      expect(link.prop('to')).toEqual('/engines/test-engine');
       link.simulate('click');
 
       expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalledWith({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
@@ -6,12 +6,12 @@
 
 import React from 'react';
 import { useActions } from 'kea';
-import { EuiBasicTable, EuiBasicTableColumn, EuiLink } from '@elastic/eui';
+import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
 import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { TelemetryLogic } from '../../../shared/telemetry';
-import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
+import { EuiLink } from '../../../shared/react_router_helpers';
 import { getEngineRoute } from '../../routes';
 
 import { ENGINES_PAGE_SIZE } from '../../../../../common/constants';
@@ -44,8 +44,7 @@ export const EngineTable: React.FC<IEngineTableProps> = ({
   const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
 
   const engineLinkProps = (name: string) => ({
-    href: getAppSearchUrl(getEngineRoute(name)),
-    target: '_blank',
+    to: getEngineRoute(name),
     onClick: () =>
       sendAppSearchTelemetry({
         action: 'clicked',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
@@ -17,6 +17,7 @@ import { Layout, SideNav, SideNavLink } from '../shared/layout';
 import { SetupGuide } from './components/setup_guide';
 import { ErrorConnecting } from './components/error_connecting';
 import { EngineOverview } from './components/engine_overview';
+import { EngineRouter } from './components/engine';
 import { AppSearch, AppSearchUnconfigured, AppSearchConfigured, AppSearchNav } from './';
 
 describe('AppSearch', () => {
@@ -54,9 +55,10 @@ describe('AppSearchConfigured', () => {
   it('renders with layout', () => {
     const wrapper = shallow(<AppSearchConfigured />);
 
-    expect(wrapper.find(Layout)).toHaveLength(1);
-    expect(wrapper.find(Layout).prop('readOnlyMode')).toBeFalsy();
+    expect(wrapper.find(Layout)).toHaveLength(2);
+    expect(wrapper.find(Layout).last().prop('readOnlyMode')).toBeFalsy();
     expect(wrapper.find(EngineOverview)).toHaveLength(1);
+    expect(wrapper.find(EngineRouter)).toHaveLength(1);
   });
 
   it('initializes app data with passed props', () => {
@@ -91,7 +93,7 @@ describe('AppSearchConfigured', () => {
 
     const wrapper = shallow(<AppSearchConfigured />);
 
-    expect(wrapper.find(Layout).prop('readOnlyMode')).toEqual(true);
+    expect(wrapper.find(Layout).first().prop('readOnlyMode')).toEqual(true);
   });
 
   describe('ability checks', () => {
@@ -106,6 +108,13 @@ describe('AppSearchNav', () => {
 
     expect(wrapper.find(SideNav)).toHaveLength(1);
     expect(wrapper.find(SideNavLink).prop('to')).toEqual('/engines');
+  });
+
+  it('renders an Engine subnav if passed', () => {
+    const wrapper = shallow(<AppSearchNav subNav={<div data-test-subj="subnav">Testing</div>} />);
+    const link = wrapper.find(SideNavLink).dive();
+
+    expect(link.find('[data-test-subj="subnav"]')).toHaveLength(1);
   });
 
   it('renders the Settings link', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
@@ -18,6 +18,7 @@ import { IInitialAppData } from '../../../common/types';
 
 import { APP_SEARCH_PLUGIN } from '../../../common/constants';
 import { Layout, SideNav, SideNavLink } from '../shared/layout';
+import { EngineNav, EngineRouter } from './components/engine';
 
 import {
   ROOT_PATH,
@@ -26,6 +27,7 @@ import {
   CREDENTIALS_PATH,
   ROLE_MAPPINGS_PATH,
   ENGINES_PATH,
+  ENGINE_PATH,
 } from './routes';
 
 import { SetupGuide } from './components/setup_guide';
@@ -65,6 +67,11 @@ export const AppSearchConfigured: React.FC<IInitialAppData> = (props) => {
       <Route exact path={SETUP_GUIDE_PATH}>
         <SetupGuide />
       </Route>
+      <Route path={ENGINE_PATH}>
+        <Layout navigation={<AppSearchNav subNav={<EngineNav />} />} readOnlyMode={readOnlyMode}>
+          <EngineRouter />
+        </Layout>
+      </Route>
       <Route>
         <Layout navigation={<AppSearchNav />} readOnlyMode={readOnlyMode}>
           {errorConnecting ? (
@@ -94,14 +101,18 @@ export const AppSearchConfigured: React.FC<IInitialAppData> = (props) => {
   );
 };
 
-export const AppSearchNav: React.FC = () => {
+interface IAppSearchNavProps {
+  subNav?: React.ReactNode;
+}
+
+export const AppSearchNav: React.FC<IAppSearchNavProps> = ({ subNav }) => {
   const {
     myRole: { canViewSettings, canViewAccountCredentials, canViewRoleMappings },
   } = useValues(AppLogic);
 
   return (
     <SideNav product={APP_SEARCH_PLUGIN}>
-      <SideNavLink to={ENGINES_PATH} isRoot>
+      <SideNavLink to={ENGINES_PATH} subNav={subNav} isRoot>
         {i18n.translate('xpack.enterpriseSearch.appSearch.nav.engines', {
           defaultMessage: 'Engines',
         })}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { generatePath } from 'react-router-dom';
+
 export const ROOT_PATH = '/';
 export const SETUP_GUIDE_PATH = '/setup_guide';
 export const SETTINGS_PATH = '/settings/account';
@@ -14,4 +16,28 @@ export const ENGINES_PATH = '/engines';
 export const CREATE_ENGINES_PATH = `${ENGINES_PATH}/new`;
 
 export const ENGINE_PATH = '/engines/:engineName';
-export const getEngineRoute = (engineName: string) => `${ENGINES_PATH}/${engineName}`;
+export const SAMPLE_ENGINE_PATH = '/engines/national-parks-demo';
+export const getEngineRoute = (engineName: string) => generatePath(ENGINE_PATH, { engineName });
+
+export const ENGINE_ANALYTICS_PATH = '/analytics';
+// TODO: Analytics sub-pages
+
+export const ENGINE_DOCUMENTS_PATH = '/documents';
+export const ENGINE_DOCUMENT_DETAIL_PATH = `${ENGINE_DOCUMENTS_PATH}/:documentId`;
+
+export const ENGINE_SCHEMA_PATH = '/schema/edit';
+export const ENGINE_REINDEX_JOB_PATH = '/reindex-job/:activeReindexJobId';
+
+export const ENGINE_CRAWLER_PATH = '/crawler';
+// TODO: Crawler sub-pages
+
+export const META_ENGINE_SOURCE_ENGINES_PATH = '/engines';
+
+export const ENGINE_RELEVANCE_TUNING_PATH = '/search-settings';
+export const ENGINE_SYNONYMS_PATH = '/synonyms';
+export const ENGINE_CURATIONS_PATH = '/curations';
+// TODO: Curations sub-pages
+export const ENGINE_RESULT_SETTINGS_PATH = '/result-settings';
+
+export const ENGINE_SEARCH_UI_PATH = '/reference_application/new';
+export const ENGINE_API_LOGS_PATH = '/api-logs';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.test.ts
@@ -43,7 +43,7 @@ describe('getRoleAbilities', () => {
       canManageEngineCredentials: false,
       canManageEngineCurations: false,
       canManageEngineRelevanceTuning: false,
-      canManageEngineReferenceUi: false,
+      canManageEngineSearchUi: false,
       canManageEngineResultSettings: false,
       canManageEngineSchema: false,
       canManageMetaEngineSourceEngines: false,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.ts
@@ -38,9 +38,9 @@ export interface IRole {
   canManageEngineCredentials: boolean;
   canManageEngineCurations: boolean;
   canManageEngineRelevanceTuning: boolean;
-  canManageEngineReferenceUi: boolean;
   canManageEngineResultSettings: boolean;
   canManageEngineSchema: boolean;
+  canManageEngineSearchUi: boolean;
   canManageMetaEngineSourceEngines: boolean;
 }
 
@@ -94,9 +94,9 @@ export const getRoleAbilities = (role: IAccount['role']): IRole => {
     canManageEngineCredentials: myRole.can('manage', 'engine_credentials'),
     canManageEngineCurations: myRole.can('manage', 'engine_curations'),
     canManageEngineRelevanceTuning: myRole.can('manage', 'engine_relevance_tuning'),
-    canManageEngineReferenceUi: myRole.can('manage', 'engine_reference_ui'),
     canManageEngineResultSettings: myRole.can('manage', 'engine_result_settings'),
     canManageEngineSchema: myRole.can('manage', 'engine_schema'),
+    canManageEngineSearchUi: myRole.can('manage', 'engine_reference_ui'),
     canManageMetaEngineSourceEngines: myRole.can('manage', 'meta_engine_source_engines'),
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.test.tsx
@@ -14,7 +14,7 @@ import { EuiLink as EuiLinkExternal } from '@elastic/eui';
 import { EuiLink } from '../react_router_helpers';
 import { ENTERPRISE_SEARCH_PLUGIN, APP_SEARCH_PLUGIN } from '../../../../common/constants';
 
-import { SideNav, SideNavLink } from './';
+import { SideNav, SideNavLink, SideNavItem } from './';
 
 describe('SideNav', () => {
   it('renders link children', () => {
@@ -104,5 +104,35 @@ describe('SideNavLink', () => {
 
     expect(wrapper.find('.enterpriseSearchNavLinks__subNav')).toHaveLength(1);
     expect(wrapper.find('[data-test-subj="subNav"]')).toHaveLength(1);
+  });
+});
+
+describe('SideNavItem', () => {
+  it('renders', () => {
+    const wrapper = shallow(<SideNavItem>Test</SideNavItem>);
+
+    expect(wrapper.type()).toEqual('li');
+    expect(wrapper.find('.enterpriseSearchNavLinks__item')).toHaveLength(1);
+  });
+
+  it('renders children', () => {
+    const wrapper = shallow(
+      <SideNavItem>
+        <span data-test-subj="hello">World</span>
+      </SideNavItem>
+    );
+
+    expect(wrapper.find('[data-test-subj="hello"]').text()).toEqual('World');
+  });
+
+  it('passes down custom classes and props', () => {
+    const wrapper = shallow(
+      <SideNavItem className="testing" data-test-subj="testing">
+        Test
+      </SideNavItem>
+    );
+
+    expect(wrapper.find('.testing')).toHaveLength(1);
+    expect(wrapper.find('[data-test-subj="testing"]')).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.tsx
@@ -109,3 +109,20 @@ export const SideNavLink: React.FC<ISideNavLinkProps> = ({
     </li>
   );
 };
+
+/**
+ * Side navigation non-link item
+ */
+
+interface ISideNavItemProps {
+  className?: string;
+}
+
+export const SideNavItem: React.FC<ISideNavItemProps> = ({ children, className, ...rest }) => {
+  const classes = classNames('enterpriseSearchNavLinks__item', className);
+  return (
+    <li {...rest} className={classes}>
+      {children}
+    </li>
+  );
+};


### PR DESCRIPTION
## Summary

This PR adds the engine sub-nav & routing to App Search, based on Davey's initial Figma mocks (there is some deviation and re-ordering from ent-search as a note.)

It adds two dummy "routes" (Engine Overview and Analytics), mostly to confirm that routing and breadcrumbs work. There are still a **lot** of TODOs in the code (mostly around EngineLogic).

I recommend following along by commit if possible.

## Screencaps

<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/98055178-b96a3000-1df1-11eb-87ab-bcfa588fdb7a.png"> <img width="400" alt="" src="https://user-images.githubusercontent.com/549407/98055179-ba02c680-1df1-11eb-8970-051cb3fb3507.png">

![screencap](https://user-images.githubusercontent.com/549407/98055175-b7a06c80-1df1-11eb-992d-63dc0badaaae.gif)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)