### PR TITLE
[7.x] oss tests: replace grunt task with node script (#82371)

### DIFF
--- a/tasks/config/run.js
+++ b/tasks/config/run.js
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-import { getFunctionalTestGroupRunConfigs } from '../function_test_groups';
-
 const { version } = require('../../package.json');
 const KIBANA_INSTALL_DIR =
   process.env.KIBANA_INSTALL_DIR ||
@@ -238,9 +236,5 @@ module.exports = function () {
       'test:jest_integration'
     ),
     test_projects: gruntTaskWithGithubChecks('Project tests', 'test:projects'),
-
-    ...getFunctionalTestGroupRunConfigs({
-      kibanaInstallDir: KIBANA_INSTALL_DIR,
-    }),
   };
 };

--- a/tasks/function_test_groups.js
+++ b/tasks/function_test_groups.js
@@ -29,39 +29,6 @@ const TEST_TAGS = safeLoad(JOBS_YAML)
   .JOB.filter((id) => id.startsWith('kibana-ciGroup'))
   .map((id) => id.replace(/^kibana-/, ''));
 
-export function getFunctionalTestGroupRunConfigs({ kibanaInstallDir } = {}) {
-  return {
-    // include a run task for each test group
-    ...TEST_TAGS.reduce(
-      (acc, tag) => ({
-        ...acc,
-        [`functionalTests_${tag}`]: {
-          cmd: process.execPath,
-          args: [
-            'scripts/functional_tests',
-            '--include-tag',
-            tag,
-            '--config',
-            'test/functional/config.js',
-            '--config',
-            'test/ui_capabilities/newsfeed_err/config.ts',
-            '--config',
-            'test/new_visualize_flow/config.ts',
-            '--config',
-            'test/security_functional/config.ts',
-            // '--config', 'test/functional/config.firefox.js',
-            '--bail',
-            '--debug',
-            '--kibana-install-dir',
-            kibanaInstallDir,
-          ],
-        },
-      }),
-      {}
-    ),
-  };
-}
-
 grunt.registerTask(
   'functionalTests:ensureAllTestsInCiGroup',
   'Check that all of the functional tests are in a CI group',

--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -2,7 +2,11 @@
 
 source test/scripts/jenkins_test_setup_oss.sh
 
-checks-reporter-with-killswitch "Functional tests / Group ${CI_GROUP}" yarn run grunt "run:functionalTests_ciGroup${CI_GROUP}";
+checks-reporter-with-killswitch "Functional tests / Group ${CI_GROUP}" \
+  node scripts/functional_tests \
+    --debug --bail \
+    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+    --include-tag "ciGroup$CI_GROUP"
 
 if [[ ! "$TASK_QUEUE_PROCESS_ID" && "$CI_GROUP" == "1" ]]; then
   source test/scripts/jenkins_build_kbn_sample_panel_action.sh


### PR DESCRIPTION
Backports the following commits to 7.x:
 - oss tests: replace grunt task with node script (#82371)