### PR TITLE
[Watcher] Retain search and pagination values when watch list refreshes

### DIFF
--- a/x-pack/plugins/watcher/__jest__/client_integration/helpers/watch_list.helpers.ts
+++ b/x-pack/plugins/watcher/__jest__/client_integration/helpers/watch_list.helpers.ts
@@ -95,4 +95,5 @@ export type TestSubjects =
   | 'createWatchButton'
   | 'emptyPrompt'
   | 'emptyPrompt.createWatchButton'
-  | 'editWatchButton';
+  | 'editWatchButton'
+  | 'watchesTableContainer';

--- a/x-pack/plugins/watcher/__jest__/client_integration/helpers/watch_list.helpers.ts
+++ b/x-pack/plugins/watcher/__jest__/client_integration/helpers/watch_list.helpers.ts
@@ -14,7 +14,7 @@ import {
   nextTick,
 } from '../../../../../test_utils';
 import { WatchList } from '../../../public/application/sections/watch_list/components/watch_list';
-import { ROUTES } from '../../../common/constants';
+import { ROUTES, REFRESH_INTERVALS } from '../../../common/constants';
 import { withAppContext } from './app_context.mock';
 
 const testBedConfig: TestBedConfig = {
@@ -31,6 +31,8 @@ export interface WatchListTestBed extends TestBed<WatchListTestSubjects> {
     selectWatchAt: (index: number) => void;
     clickWatchAt: (index: number) => void;
     clickWatchActionAt: (index: number, action: 'delete' | 'edit') => void;
+    searchWatches: (term: string) => void;
+    advanceTimeToTableRefresh: () => Promise<void>;
   };
 }
 
@@ -73,12 +75,35 @@ export const setup = async (): Promise<WatchListTestBed> => {
     });
   };
 
+  const searchWatches = (term: string) => {
+    const { find, component } = testBed;
+    const searchInput = find('watchesTableContainer').find('.euiFieldSearch');
+
+    // Enter input into the search box
+    // @ts-ignore
+    searchInput.instance().value = term;
+    searchInput.simulate('keyup', { key: 'Enter', keyCode: 13, which: 13 });
+
+    component.update();
+  };
+
+  const advanceTimeToTableRefresh = async () => {
+    const { component } = testBed;
+    await act(async () => {
+      // Advance timers to simulate another request
+      jest.advanceTimersByTime(REFRESH_INTERVALS.WATCH_LIST);
+    });
+    component.update();
+  };
+
   return {
     ...testBed,
     actions: {
       selectWatchAt,
       clickWatchAt,
       clickWatchActionAt,
+      searchWatches,
+      advanceTimeToTableRefresh,
     },
   };
 };

--- a/x-pack/plugins/watcher/__jest__/client_integration/watch_list.test.ts
+++ b/x-pack/plugins/watcher/__jest__/client_integration/watch_list.test.ts
@@ -90,6 +90,8 @@ describe('<WatchList />', () => {
 
           const searchInput = find('watchesTableContainer').find('.euiFieldSearch');
 
+          // Enter the name of "watch1" in the search box
+          // @ts-ignore
           searchInput.instance().value = watch1.name;
           searchInput.simulate('keyup', { key: 'Enter', keyCode: 13, which: 13 });
 
@@ -97,6 +99,7 @@ describe('<WatchList />', () => {
 
           const { tableCellsValues } = table.getMetaData('watchesTable');
 
+          // Expect "watch1" is only visible in the table
           expect(tableCellsValues.length).toEqual(1);
           const row = tableCellsValues[0];
           const { name, id, watchStatus } = watch1;
@@ -123,6 +126,7 @@ describe('<WatchList />', () => {
 
           const { tableCellsValues: updatedTableCellsValues } = table.getMetaData('watchesTable');
 
+          // Verify "watch1" is still the only watch visible in the table
           expect(updatedTableCellsValues.length).toEqual(1);
           const updatedRow = updatedTableCellsValues[0];
 

--- a/x-pack/plugins/watcher/public/application/sections/watch_list/components/watch_list.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_list/components/watch_list.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useMemo, useEffect, Fragment } from 'react';
 
 import {
+  CriteriaWithPagination,
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -57,7 +58,10 @@ export const WatchList = () => {
   // Filter out deleted watches on the client, because the API will return 200 even though some watches
   // may not really be deleted until after they're done firing and this could take some time.
   const [deletedWatches, setDeletedWatches] = useState<string[]>([]);
-  const [pagination, setPagination] = useState({ pageIndex: 0 });
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: PAGINATION.initialPageSize,
+  });
   const [query, setQuery] = useState('');
 
   useEffect(() => {
@@ -381,7 +385,7 @@ export const WatchList = () => {
           : '',
     };
 
-    const handleOnChange = (search) => {
+    const handleOnChange = (search: { queryText: string }) => {
       setQuery(search.queryText);
       return true;
     };
@@ -420,7 +424,7 @@ export const WatchList = () => {
     content = (
       <div data-test-subj="watchesTableContainer">
         <EuiInMemoryTable
-          onTableChange={({ page: { index, size } }) =>
+          onTableChange={({ page: { index, size } }: CriteriaWithPagination<never>) =>
             setPagination({ pageIndex: index, pageSize: size })
           }
           items={availableWatches}

--- a/x-pack/plugins/watcher/public/application/sections/watch_list/components/watch_list.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_list/components/watch_list.tsx
@@ -57,6 +57,8 @@ export const WatchList = () => {
   // Filter out deleted watches on the client, because the API will return 200 even though some watches
   // may not really be deleted until after they're done firing and this could take some time.
   const [deletedWatches, setDeletedWatches] = useState<string[]>([]);
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     setBreadcrumbs([listBreadcrumb]);
@@ -379,7 +381,14 @@ export const WatchList = () => {
           : '',
     };
 
+    const handleOnChange = (search) => {
+      setQuery(search.queryText);
+      return true;
+    };
+
     const searchConfig = {
+      query,
+      onChange: handleOnChange,
       box: {
         incremental: true,
       },
@@ -409,29 +418,43 @@ export const WatchList = () => {
     };
 
     content = (
-      <EuiInMemoryTable
-        items={availableWatches}
-        itemId="id"
-        columns={columns}
-        search={searchConfig}
-        pagination={PAGINATION}
-        sorting={true}
-        selection={selectionConfig}
-        isSelectable={true}
-        message={
-          <FormattedMessage
-            id="xpack.watcher.sections.watchList.watchTable.noWatchesMessage"
-            defaultMessage="No watches to show"
-          />
-        }
-        rowProps={() => ({
-          'data-test-subj': 'row',
-        })}
-        cellProps={() => ({
-          'data-test-subj': 'cell',
-        })}
-        data-test-subj="watchesTable"
-      />
+      <div data-test-subj="watchesTableContainer">
+        <EuiInMemoryTable
+          onTableChange={({ page: { index, size } }) =>
+            setPagination({ pageIndex: index, pageSize: size })
+          }
+          items={availableWatches}
+          itemId="id"
+          columns={columns}
+          search={searchConfig}
+          pagination={{
+            ...PAGINATION,
+            pageIndex: pagination.pageIndex,
+            pageSize: pagination.pageSize,
+          }}
+          sorting={{
+            sort: {
+              field: 'name',
+              direction: 'asc',
+            },
+          }}
+          selection={selectionConfig}
+          isSelectable={true}
+          message={
+            <FormattedMessage
+              id="xpack.watcher.sections.watchList.watchTable.noWatchesMessage"
+              defaultMessage="No watches to show"
+            />
+          }
+          rowProps={() => ({
+            'data-test-subj': 'row',
+          })}
+          cellProps={() => ({
+            'data-test-subj': 'cell',
+          })}
+          data-test-subj="watchesTable"
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/69606

### How to test
1. Create >10 watches with a variety of names.
2. Search for one of the watches. Wait one minute, check that another request was made to refresh the watch list, and verify the search input value along with the filtered results persists.
3. Navigate to page 2 of the results. Wait one minute, check that another request was made to refresh the watch list, and verify you are still on page 2.
4. Change the default page size. Wait one minute, check that another request was made to refresh the watch list, and verify the page size selected persists.

### Release note
This fixes a bug in the Watcher UI where the search input cleared after 1 minute of inactivity, causing a user to lose the filtered results. It also fixes a similar issue where if the user changed pages or the default page size and was inactive.
