### PR TITLE
[Enterprise Search] Refactor product server route registrations to their own files/folders

### DIFF
--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -39,14 +39,11 @@ import { registerConfigDataRoute } from './routes/enterprise_search/config_data'
 
 import { appSearchTelemetryType } from './saved_objects/app_search/telemetry';
 import { registerTelemetryUsageCollector as registerASTelemetryUsageCollector } from './collectors/app_search/telemetry';
-import { registerEnginesRoute } from './routes/app_search/engines';
-import { registerCredentialsRoutes } from './routes/app_search/credentials';
-import { registerSettingsRoutes } from './routes/app_search/settings';
+import { registerAppSearchRoutes } from './routes/app_search';
 
 import { workplaceSearchTelemetryType } from './saved_objects/workplace_search/telemetry';
 import { registerTelemetryUsageCollector as registerWSTelemetryUsageCollector } from './collectors/workplace_search/telemetry';
-import { registerWSOverviewRoute } from './routes/workplace_search/overview';
-import { registerWSGroupRoutes } from './routes/workplace_search/groups';
+import { registerWorkplaceSearchRoutes } from './routes/workplace_search';
 
 export interface PluginsSetup {
   usageCollection?: UsageCollectionSetup;
@@ -127,11 +124,8 @@ export class EnterpriseSearchPlugin implements Plugin {
     const dependencies = { router, config, log, enterpriseSearchRequestHandler };
 
     registerConfigDataRoute(dependencies);
-    registerEnginesRoute(dependencies);
-    registerCredentialsRoutes(dependencies);
-    registerSettingsRoutes(dependencies);
-    registerWSOverviewRoute(dependencies);
-    registerWSGroupRoutes(dependencies);
+    registerAppSearchRoutes(dependencies);
+    registerWorkplaceSearchRoutes(dependencies);
 
     /**
      * Bootstrap the routes, saved objects, and collector for telemetry

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/index.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/index.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { mockDependencies, MockRouter } from '../../__mocks__';
+
+import { registerAppSearchRoutes } from './';
+
+describe('registerAppSearchRoutes', () => {
+  it('runs without errors', () => {
+    const mockRouter = new MockRouter({} as any);
+    registerAppSearchRoutes({ ...mockDependencies, router: mockRouter.router });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { IRouteDependencies } from '../../plugin';
+
+import { registerEnginesRoute } from './engines';
+import { registerCredentialsRoutes } from './credentials';
+import { registerSettingsRoutes } from './settings';
+
+export const registerAppSearchRoutes = (dependencies: IRouteDependencies) => {
+  registerEnginesRoute(dependencies);
+  registerCredentialsRoutes(dependencies);
+  registerSettingsRoutes(dependencies);
+};

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
@@ -244,13 +244,3 @@ export function registerBoostsGroupRoute({
     }
   );
 }
-
-export function registerGroupRoutes(dependencies: IRouteDependencies) {
-  registerGroupsRoute(dependencies);
-  registerSearchGroupsRoute(dependencies);
-  registerGroupRoute(dependencies);
-  registerGroupUsersRoute(dependencies);
-  registerShareGroupRoute(dependencies);
-  registerAssignGroupRoute(dependencies);
-  registerBoostsGroupRoute(dependencies);
-}

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
@@ -245,7 +245,7 @@ export function registerBoostsGroupRoute({
   );
 }
 
-export function registerWSGroupRoutes(dependencies: IRouteDependencies) {
+export function registerGroupRoutes(dependencies: IRouteDependencies) {
   registerGroupsRoute(dependencies);
   registerSearchGroupsRoute(dependencies);
   registerGroupRoute(dependencies);

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { mockDependencies, MockRouter } from '../../__mocks__';
+
+import { registerWorkplaceSearchRoutes } from './';
+
+describe('registerWorkplaceSearchRoutes', () => {
+  it('runs without errors', () => {
+    const mockRouter = new MockRouter({} as any);
+    registerWorkplaceSearchRoutes({ ...mockDependencies, router: mockRouter.router });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -6,10 +6,10 @@
 
 import { IRouteDependencies } from '../../plugin';
 
-import { registerWSOverviewRoute } from './overview';
-import { registerWSGroupRoutes } from './groups';
+import { registerOverviewRoute } from './overview';
+import { registerGroupRoutes } from './groups';
 
 export const registerWorkplaceSearchRoutes = (dependencies: IRouteDependencies) => {
-  registerWSOverviewRoute(dependencies);
-  registerWSGroupRoutes(dependencies);
+  registerOverviewRoute(dependencies);
+  registerGroupRoutes(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -7,9 +7,23 @@
 import { IRouteDependencies } from '../../plugin';
 
 import { registerOverviewRoute } from './overview';
-import { registerGroupRoutes } from './groups';
+import {
+  registerGroupsRoute,
+  registerSearchGroupsRoute,
+  registerGroupRoute,
+  registerGroupUsersRoute,
+  registerShareGroupRoute,
+  registerAssignGroupRoute,
+  registerBoostsGroupRoute,
+} from './groups';
 
 export const registerWorkplaceSearchRoutes = (dependencies: IRouteDependencies) => {
   registerOverviewRoute(dependencies);
-  registerGroupRoutes(dependencies);
+  registerGroupsRoute(dependencies);
+  registerSearchGroupsRoute(dependencies);
+  registerGroupRoute(dependencies);
+  registerGroupUsersRoute(dependencies);
+  registerShareGroupRoute(dependencies);
+  registerAssignGroupRoute(dependencies);
+  registerBoostsGroupRoute(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { IRouteDependencies } from '../../plugin';
+
+import { registerWSOverviewRoute } from './overview';
+import { registerWSGroupRoutes } from './groups';
+
+export const registerWorkplaceSearchRoutes = (dependencies: IRouteDependencies) => {
+  registerWSOverviewRoute(dependencies);
+  registerWSGroupRoutes(dependencies);
+};

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/overview.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/overview.test.ts
@@ -6,7 +6,7 @@
 
 import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
 
-import { registerWSOverviewRoute } from './overview';
+import { registerOverviewRoute } from './overview';
 
 describe('Overview route', () => {
   describe('GET /api/workplace_search/overview', () => {
@@ -16,7 +16,7 @@ describe('Overview route', () => {
       jest.clearAllMocks();
       mockRouter = new MockRouter({ method: 'get', payload: 'query' });
 
-      registerWSOverviewRoute({
+      registerOverviewRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/overview.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/overview.ts
@@ -6,7 +6,7 @@
 
 import { IRouteDependencies } from '../../plugin';
 
-export function registerWSOverviewRoute({
+export function registerOverviewRoute({
   router,
   enterpriseSearchRequestHandler,
 }: IRouteDependencies) {


### PR DESCRIPTION
## Summary

I was adding a new Engine server route to App Search and noticed our `server/plugin.ts` was getting a little bloated/unwieldy. I decided to refactor/move all App Search and Workplace Search server route registrations to their own individual files (e.g. `server/routes/index.ts`) rather than being at the top level of `server/plugin.ts`.

Benefits:

1. Our import list at the top of plugin.ts doesn't grow larger and larger, making the actual file/logic harder to read
2. Products can scale to any size without affecting one another
3. No need to namespace route registrations internally within the product folders (48019ca)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios