### PR TITLE
[Enterprise Search] Fix/update MockRouter helper to return specific routes/paths 

### DIFF
--- a/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts
+++ b/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts
@@ -51,9 +51,12 @@ export class MockRouter {
 
   public callRoute = async (request: TMockRouterRequest) => {
     const routerCalls = this.router[this.method].mock.calls as any[];
-    const route = routerCalls.find(([router]: any) => router.path === this.path);
-    const [, handler] = route;
+    if (!routerCalls.length) throw new Error('No routes registered.');
 
+    const route = routerCalls.find(([router]: any) => router.path === this.path);
+    if (!route) throw new Error('No matching registered routes found - check method/path keys');
+
+    const [, handler] = route;
     const context = {} as jest.Mocked<RequestHandlerContext>;
     await handler(context, httpServerMock.createKibanaRequest(request as any), this.response);
   };

--- a/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts
+++ b/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts
@@ -21,6 +21,7 @@ type PayloadType = 'params' | 'query' | 'body';
 
 interface IMockRouterProps {
   method: MethodType;
+  path: string;
   payload?: PayloadType;
 }
 interface IMockRouterRequest {
@@ -33,12 +34,14 @@ type TMockRouterRequest = KibanaRequest | IMockRouterRequest;
 export class MockRouter {
   public router!: jest.Mocked<IRouter>;
   public method: MethodType;
+  public path: string;
   public payload?: PayloadType;
   public response = httpServerMock.createResponseFactory();
 
-  constructor({ method, payload }: IMockRouterProps) {
+  constructor({ method, path, payload }: IMockRouterProps) {
     this.createRouter();
     this.method = method;
+    this.path = path;
     this.payload = payload;
   }
 
@@ -47,7 +50,9 @@ export class MockRouter {
   };
 
   public callRoute = async (request: TMockRouterRequest) => {
-    const [, handler] = this.router[this.method].mock.calls[0];
+    const routerCalls = this.router[this.method].mock.calls as any[];
+    const route = routerCalls.find(([router]: any) => router.path === this.path);
+    const [, handler] = route;
 
     const context = {} as jest.Mocked<RequestHandlerContext>;
     await handler(context, httpServerMock.createKibanaRequest(request as any), this.response);
@@ -81,7 +86,11 @@ export class MockRouter {
 /**
  * Example usage:
  */
-// const mockRouter = new MockRouter({ method: 'get', payload: 'body' });
+// const mockRouter = new MockRouter({
+//   method: 'get',
+//   path: '/api/app_search/test',
+//   payload: 'body'
+// });
 //
 // beforeEach(() => {
 //   jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.test.ts
@@ -14,7 +14,11 @@ describe('credentials routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'get', payload: 'query' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/credentials',
+        payload: 'query',
+      });
 
       registerCredentialsRoutes({
         ...mockDependencies,
@@ -46,7 +50,11 @@ describe('credentials routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'post', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/app_search/credentials',
+        payload: 'body',
+      });
 
       registerCredentialsRoutes({
         ...mockDependencies,
@@ -155,7 +163,11 @@ describe('credentials routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'get', payload: 'query' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/credentials/details',
+        payload: 'query',
+      });
 
       registerCredentialsRoutes({
         ...mockDependencies,
@@ -175,7 +187,11 @@ describe('credentials routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'put', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/app_search/credentials/{name}',
+        payload: 'body',
+      });
 
       registerCredentialsRoutes({
         ...mockDependencies,
@@ -292,7 +308,11 @@ describe('credentials routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'delete', payload: 'params' });
+      mockRouter = new MockRouter({
+        method: 'delete',
+        path: '/api/app_search/credentials/{name}',
+        payload: 'params',
+      });
 
       registerCredentialsRoutes({
         ...mockDependencies,

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/engines.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/engines.test.ts
@@ -25,7 +25,11 @@ describe('engine routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'get', payload: 'query' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/engines',
+        payload: 'query',
+      });
 
       registerEnginesRoute({
         ...mockDependencies,

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/settings.test.ts
@@ -14,7 +14,10 @@ describe('log settings routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'get' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/log_settings',
+      });
 
       registerSettingsRoutes({
         ...mockDependencies,
@@ -36,7 +39,11 @@ describe('log settings routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'put', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/app_search/log_settings',
+        payload: 'body',
+      });
 
       registerSettingsRoutes({
         ...mockDependencies,

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.test.ts
@@ -18,7 +18,10 @@ describe('Enterprise Search Config Data API', () => {
   let mockRouter: MockRouter;
 
   beforeEach(() => {
-    mockRouter = new MockRouter({ method: 'get' });
+    mockRouter = new MockRouter({
+      method: 'get',
+      path: '/api/enterprise_search/config_data',
+    });
 
     registerConfigDataRoute({
       ...mockDependencies,

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.test.ts
@@ -25,7 +25,11 @@ describe('Enterprise Search Telemetry API', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockRouter = new MockRouter({ method: 'put', payload: 'body' });
+    mockRouter = new MockRouter({
+      method: 'put',
+      path: '/api/enterprise_search/stats',
+      payload: 'body',
+    });
 
     registerTelemetryRoute({
       ...mockDependencies,

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -25,7 +25,11 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      mockRouter = new MockRouter({ method: 'get', payload: 'query' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/groups',
+        payload: 'query',
+      });
 
       registerGroupsRoute({
         ...mockDependencies,
@@ -43,7 +47,11 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'post', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/groups',
+        payload: 'body',
+      });
 
       registerGroupsRoute({
         ...mockDependencies,
@@ -71,7 +79,11 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'post', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/groups/search',
+        payload: 'body',
+      });
 
       registerSearchGroupsRoute({
         ...mockDependencies,
@@ -141,7 +153,11 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      mockRouter = new MockRouter({ method: 'get', payload: 'params' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/groups/{id}',
+        payload: 'params',
+      });
 
       registerGroupRoute({
         ...mockDependencies,
@@ -176,7 +192,11 @@ describe('groups routes', () => {
     };
 
     it('creates a request handler', () => {
-      mockRouter = new MockRouter({ method: 'put', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/groups/{id}',
+        payload: 'body',
+      });
 
       registerGroupRoute({
         ...mockDependencies,
@@ -204,7 +224,11 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'delete', payload: 'params' });
+      mockRouter = new MockRouter({
+        method: 'delete',
+        path: '/api/workplace_search/groups/{id}',
+        payload: 'params',
+      });
 
       registerGroupRoute({
         ...mockDependencies,
@@ -227,7 +251,7 @@ describe('groups routes', () => {
     });
   });
 
-  describe('GET /api/workplace_search/groups/{id}/users', () => {
+  describe('GET /api/workplace_search/groups/{id}/group_users', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
@@ -235,7 +259,11 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      mockRouter = new MockRouter({ method: 'get', payload: 'params' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/groups/{id}/group_users',
+        payload: 'params',
+      });
 
       registerGroupUsersRoute({
         ...mockDependencies,
@@ -261,7 +289,11 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'post', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/groups/{id}/share',
+        payload: 'body',
+      });
 
       registerShareGroupRoute({
         ...mockDependencies,
@@ -291,7 +323,11 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'post', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/groups/{id}/assign',
+        payload: 'body',
+      });
 
       registerAssignGroupRoute({
         ...mockDependencies,
@@ -330,7 +366,11 @@ describe('groups routes', () => {
     };
 
     it('creates a request handler', () => {
-      mockRouter = new MockRouter({ method: 'put', payload: 'body' });
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/groups/{id}/boosts',
+        payload: 'body',
+      });
 
       registerBoostsGroupRoute({
         ...mockDependencies,

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/overview.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/overview.test.ts
@@ -14,7 +14,11 @@ describe('Overview route', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockRouter = new MockRouter({ method: 'get', payload: 'query' });
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/overview',
+        payload: 'query',
+      });
 
       registerOverviewRoute({
         ...mockDependencies,


### PR DESCRIPTION
## Summary

I realized while doing some server API refactoring/testing that our MockRouter helper would fail/produce a false negative in the following example scenario:

```js
export function registerSomeRoutes(...) {
  router.get(
    {
      path: '/api/app_search/example_one',
      validate: false,
    },
    enterpriseSearchRequestHandler.createRequest({
      path: '/as/example_one',
    })
  };

  router.get(
    {
      path: '/api/app_search/example_two',
      validate: false,
    },
    enterpriseSearchRequestHandler.createRequest({
      path: '/as/example_two',
    })
  };
}
```

Specifically, calling `MockRouter.callRoute()` would never actually call the 2nd `router.get` handler because of this line in the code:

https://github.com/elastic/kibana/blob/f065191a750639179a63b77df0cc95261c920812/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts#L50

Each `router.get` registration creates another array item in `mock.calls`, so the static `[0]` index meant only the 1st of each type of router method in a single `registerSomeRoute` function was ever getting called 😬 

My solution/approach to this was adding a `path` param to the MockRouter initialization, and searching the array for the correct/specific route path. This has the benefit of being more explicit about exactly which route we're testing in our test code - I'll admit there have been a few times when I've been writing tests where I'm like, "how does this mock router know what route I'm testing??" so hopefully this helps answer that.
 
### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios