### PR TITLE
[Lens] Fix underlying data drilldown for Lens

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/embeddable/embeddable.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/embeddable/embeddable.test.tsx
@@ -139,6 +139,44 @@ describe('embeddable', () => {
 | expression`);
   });
 
+  it('should initialize output with deduped list of index patterns', async () => {
+    attributeService = attributeServiceMockFromSavedVis({
+      ...savedVis,
+      references: [
+        { type: 'index-pattern', id: '123', name: 'abc' },
+        { type: 'index-pattern', id: '123', name: 'def' },
+        { type: 'index-pattern', id: '456', name: 'ghi' },
+      ],
+    });
+    const embeddable = new Embeddable(
+      {
+        timefilter: dataPluginMock.createSetupContract().query.timefilter.timefilter,
+        attributeService,
+        expressionRenderer,
+        basePath,
+        indexPatternService: ({
+          get: (id: string) => Promise.resolve({ id }),
+        } as unknown) as IndexPatternsContract,
+        editable: true,
+        getTrigger,
+        documentToExpression: () =>
+          Promise.resolve({
+            type: 'expression',
+            chain: [
+              { type: 'function', function: 'my', arguments: {} },
+              { type: 'function', function: 'expression', arguments: {} },
+            ],
+          }),
+      },
+      {} as LensEmbeddableInput
+    );
+    await embeddable.initializeSavedVis({} as LensEmbeddableInput);
+    const outputIndexPatterns = embeddable.getOutput().indexPatterns!;
+    expect(outputIndexPatterns.length).toEqual(2);
+    expect(outputIndexPatterns[0].id).toEqual('123');
+    expect(outputIndexPatterns[1].id).toEqual('456');
+  });
+
   it('should re-render if new input is pushed', async () => {
     const timeRange: TimeRange = { from: 'now-15d', to: 'now' };
     const query: Query = { language: 'kquery', query: '' };

--- a/x-pack/plugins/lens/public/editor_frame_service/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/embeddable/embeddable.tsx
@@ -251,8 +251,10 @@ export class Embeddable
     if (!this.savedVis) {
       return;
     }
-    const promises = this.savedVis.references
-      .filter(({ type }) => type === 'index-pattern')
+    const promises = _.uniqBy(
+      this.savedVis.references.filter(({ type }) => type === 'index-pattern'),
+      'id'
+    )
       .map(async ({ id }) => {
         try {
           return await this.deps.indexPatternService.get(id);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/82657

This PR makes sure there are no duplicates in the index pattern in the Lens embeddable output. This broke the "Explore underlying data" drilldown on dashboard because this feature only works for a single index pattern per embeddable.