### PR TITLE
[APM] Filtering by "Type" on error overview sometimes causes an error

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/__test__/__snapshots__/List.test.tsx.snap
@@ -826,7 +826,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   query={
                     Object {
                       "end": "2018-01-10T10:06:41.050Z",
-                      "kuery": "error.exception.type:AssertionError",
+                      "kuery": "error.exception.type:\\"AssertionError\\"",
                       "page": 0,
                       "serviceName": "opbeans-python",
                       "start": "2018-01-10T09:51:41.050Z",
@@ -838,12 +838,12 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                 >
                   <EuiLink
                     className="c1"
-                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                     title="AssertionError"
                   >
                     <a
                       className="euiLink euiLink--primary c1"
-                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                       rel="noreferrer"
                       title="AssertionError"
                     >
@@ -1065,7 +1065,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   query={
                     Object {
                       "end": "2018-01-10T10:06:41.050Z",
-                      "kuery": "error.exception.type:AssertionError",
+                      "kuery": "error.exception.type:\\"AssertionError\\"",
                       "page": 0,
                       "serviceName": "opbeans-python",
                       "start": "2018-01-10T09:51:41.050Z",
@@ -1077,12 +1077,12 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                 >
                   <EuiLink
                     className="c1"
-                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                     title="AssertionError"
                   >
                     <a
                       className="euiLink euiLink--primary c1"
-                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                       rel="noreferrer"
                       title="AssertionError"
                     >
@@ -1304,7 +1304,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   query={
                     Object {
                       "end": "2018-01-10T10:06:41.050Z",
-                      "kuery": "error.exception.type:AssertionError",
+                      "kuery": "error.exception.type:\\"AssertionError\\"",
                       "page": 0,
                       "serviceName": "opbeans-python",
                       "start": "2018-01-10T09:51:41.050Z",
@@ -1316,12 +1316,12 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                 >
                   <EuiLink
                     className="c1"
-                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                     title="AssertionError"
                   >
                     <a
                       className="euiLink euiLink--primary c1"
-                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                       rel="noreferrer"
                       title="AssertionError"
                     >
@@ -1543,7 +1543,7 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                   query={
                     Object {
                       "end": "2018-01-10T10:06:41.050Z",
-                      "kuery": "error.exception.type:AssertionError",
+                      "kuery": "error.exception.type:\\"AssertionError\\"",
                       "page": 0,
                       "serviceName": "opbeans-python",
                       "start": "2018-01-10T09:51:41.050Z",
@@ -1555,12 +1555,12 @@ exports[`ErrorGroupOverview -> List should render with data 1`] = `
                 >
                   <EuiLink
                     className="c1"
-                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                    href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                     title="AssertionError"
                   >
                     <a
                       className="euiLink euiLink--primary c1"
-                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:AssertionError"
+                      href="/basepath/app/apm/services/opbeans-python/errors?page=0&serviceName=opbeans-python&transactionType=request&start=2018-01-10T09:51:41.050Z&end=2018-01-10T10:06:41.050Z&kuery=error.exception.type:%22AssertionError%22"
                       rel="noreferrer"
                       title="AssertionError"
                     >

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -107,7 +107,7 @@ function ErrorGroupList({ items, serviceName }: Props) {
               query={
                 {
                   ...urlParams,
-                  kuery: `error.exception.type:${type}`,
+                  kuery: `error.exception.type:"${type}"`,
                 } as APMQueryParams
               }
             >


### PR DESCRIPTION
closes #82386

![error_type_filter](https://user-images.githubusercontent.com/55978943/98272977-7f736800-1f70-11eb-8f54-6816df1078ac.gif)
