### PR TITLE
[Ingest Manager] Combine related `getBuffer*` functions & add tests

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/registry/index.test.ts
@@ -82,14 +82,38 @@ describe('splitPkgKey tests', () => {
   });
 });
 
-describe('getBufferExtractor', () => {
-  it('returns unzipBuffer if the archive key ends in .zip', () => {
-    const extractor = getBufferExtractor('.zip');
+describe('getBufferExtractor called with { archivePath }', () => {
+  it('returns unzipBuffer if `archivePath` ends in .zip', () => {
+    const extractor = getBufferExtractor({ archivePath: '.zip' });
     expect(extractor).toBe(unzipBuffer);
   });
 
-  it('returns untarBuffer if the key ends in anything else', () => {
-    const extractor = getBufferExtractor('.xyz');
+  it('returns untarBuffer if `archivePath` ends in .gz', () => {
+    const extractor = getBufferExtractor({ archivePath: '.gz' });
     expect(extractor).toBe(untarBuffer);
+    const extractor2 = getBufferExtractor({ archivePath: '.tar.gz' });
+    expect(extractor2).toBe(untarBuffer);
+  });
+
+  it('returns `undefined` if `archivePath` ends in anything else', () => {
+    const extractor = getBufferExtractor({ archivePath: '.xyz' });
+    expect(extractor).toEqual(undefined);
+  });
+});
+
+describe('getBufferExtractor called with { contentType }', () => {
+  it('returns unzipBuffer if `contentType` is `application/zip`', () => {
+    const extractor = getBufferExtractor({ contentType: 'application/zip' });
+    expect(extractor).toBe(unzipBuffer);
+  });
+
+  it('returns untarBuffer if `contentType` is `application/gzip`', () => {
+    const extractor = getBufferExtractor({ contentType: 'application/gzip' });
+    expect(extractor).toBe(untarBuffer);
+  });
+
+  it('returns `undefined` if `contentType` ends in anything else', () => {
+    const extractor = getBufferExtractor({ contentType: '.xyz' });
+    expect(extractor).toEqual(undefined);
   });
 });


### PR DESCRIPTION
## Summary
Move logic from `getBufferExtractorForContentType` into `getBufferExtractor` & change the interface so one function can be used.

### Diff showing old vs new call
```diff
-  getBufferExtractorForContentType(contentType);
+  getBufferExtractor({ contentType });
```
```diff
-  getBufferExtractor(archivePath);
+  getBufferExtractor({ archivePath });
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
