### PR TITLE
[Lens] Fix bug in terms formatting

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -34,6 +34,13 @@ export interface TermsIndexPatternColumn extends FieldBasedIndexPatternColumn {
     size: number;
     orderBy: { type: 'alphabetical' } | { type: 'column'; columnId: string };
     orderDirection: 'asc' | 'desc';
+    // Terms on numeric fields can be formatted
+    format?: {
+      id: string;
+      params?: {
+        decimals: number;
+      };
+    };
   };
 }
 
@@ -105,10 +112,16 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
     };
   },
   onFieldChange: (oldColumn, indexPattern, field) => {
+    const newParams = { ...oldColumn.params };
+    if ('format' in newParams && field.type !== 'number') {
+      delete newParams.format;
+    }
     return {
       ...oldColumn,
+      dataType: field.type as DataType,
       label: ofName(field.displayName),
       sourceField: field.name,
+      params: newParams,
     };
   },
   onOtherColumnChanged: (currentColumn, columns) => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -103,14 +103,40 @@ describe('terms', () => {
         },
       };
       const indexPattern = createMockedIndexPattern();
-      const newDateField = indexPattern.fields.find((i) => i.name === 'dest')!;
+      const newNumberField = indexPattern.fields.find((i) => i.name === 'bytes')!;
 
-      const column = termsOperation.onFieldChange(oldColumn, indexPattern, newDateField);
-      expect(column).toHaveProperty('sourceField', 'dest');
+      const column = termsOperation.onFieldChange(oldColumn, indexPattern, newNumberField);
+      expect(column).toHaveProperty('dataType', 'number');
+      expect(column).toHaveProperty('sourceField', 'bytes');
       expect(column).toHaveProperty('params.size', 5);
       expect(column).toHaveProperty('params.orderBy.type', 'alphabetical');
       expect(column).toHaveProperty('params.orderDirection', 'asc');
-      expect(column.label).toContain('dest');
+      expect(column.label).toContain('bytes');
+    });
+
+    it('should remove numeric parameters when changing away from number', () => {
+      const oldColumn: TermsIndexPatternColumn = {
+        operationType: 'terms',
+        sourceField: 'bytes',
+        label: 'Top values of bytes',
+        isBucketed: true,
+        dataType: 'number',
+        params: {
+          size: 5,
+          orderBy: {
+            type: 'alphabetical',
+          },
+          orderDirection: 'asc',
+          format: { id: 'number', params: { decimals: 0 } },
+        },
+      };
+      const indexPattern = createMockedIndexPattern();
+      const newStringField = indexPattern.fields.find((i) => i.name === 'source')!;
+
+      const column = termsOperation.onFieldChange(oldColumn, indexPattern, newStringField);
+      expect(column).toHaveProperty('dataType', 'string');
+      expect(column).toHaveProperty('sourceField', 'source');
+      expect(column.params.format).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
The Terms aggregation was not maintaining the link between its field and its dataType, which is important to get support for numeric formatting without formatting non-numeric fields.

Steps to validate:

1. Create an initial XY chart
2. Drag a numeric field onto the horizontal axis, which will create an Intervals aggregation
3. Switch the horizontal axis to Top Values
4. Choose a number formatter, anything but Default
5. Switch the field to any non-numeric field, and the number format will be removed and you will see correct data

Fixes https://github.com/elastic/kibana/issues/82771

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
