### PR TITLE
[Ingest Manager] Remove dupe code between two unpack*ToCache fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "markdown-it": "^10.0.0",
     "md5": "^2.1.0",
     "mime": "^2.4.4",
+    "mime-types": "^2.1.27",
     "mini-css-extract-plugin": "0.8.0",
     "minimatch": "^3.0.4",
     "moment": "^2.24.0",

--- a/x-pack/plugins/ingest_manager/server/services/epm/archive/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/archive/index.ts
@@ -53,7 +53,7 @@ export async function unpackArchiveToCache(
     await bufferExtractor(archiveBuffer, filter, (entry: ArchiveEntry) => {
       const { path, buffer } = entry;
       // skip directories
-      if (path.slice(-1) === '/') return;
+      if (path.endsWith('/')) return;
       if (buffer) {
         cacheSet(path, buffer);
         paths.push(path);

--- a/x-pack/plugins/ingest_manager/server/services/epm/archive/index.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/archive/index.ts
@@ -61,7 +61,7 @@ export async function unpackArchiveToCache(
     });
   } catch (error) {
     throw new PackageInvalidArchiveError(
-      `Error during extraction of uploaded package: ${error}. Assumed content type was ${contentType}, check if this matches the archive type.`
+      `Error during extraction of package: ${error}. Assumed content type was ${contentType}, check if this matches the archive type.`
     );
   }
 
@@ -69,7 +69,7 @@ export async function unpackArchiveToCache(
   // unpacking a zip file with untarBuffer() just results in nothing.
   if (paths.length === 0) {
     throw new PackageInvalidArchiveError(
-      `Uploaded archive seems empty. Assumed content type was ${contentType}, check if this matches the archive type.`
+      `Archive seems empty. Assumed content type was ${contentType}, check if this matches the archive type.`
     );
   }
   return paths;

--- a/x-pack/test/ingest_manager_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/ingest_manager_api_integration/apis/epm/install_by_upload.ts
@@ -92,7 +92,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Uploaded archive seems empty. Assumed content type was application/gzip, check if this matches the archive type."}'
+        '{"statusCode":400,"error":"Bad Request","message":"Archive seems empty. Assumed content type was application/gzip, check if this matches the archive type."}'
       );
     });
 
@@ -105,7 +105,7 @@ export default function (providerContext: FtrProviderContext) {
         .send(buf)
         .expect(400);
       expect(res.error.text).to.equal(
-        '{"statusCode":400,"error":"Bad Request","message":"Error during extraction of uploaded package: Error: end of central directory record signature not found. Assumed content type was application/zip, check if this matches the archive type."}'
+        '{"statusCode":400,"error":"Bad Request","message":"Error during extraction of package: Error: end of central directory record signature not found. Assumed content type was application/zip, check if this matches the archive type."}'
       );
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20577,7 +20577,7 @@ mime-db@1.44.0, mime-db@1.x.x, "mime-db@>= 1.40.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.26, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.26, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==


### PR DESCRIPTION
## Summary

Update `unpackRegistryPackageToCache` to call `unpackArchiveToCache` instead of duplicating much of it.

Now an archive is iterated & put in cache via the same function regardless of its initial source.