### PR TITLE
[Ingest Manager] Add tests to verify field parsing behavior.

### DIFF
--- a/x-pack/plugins/ingest_manager/server/services/epm/fields/field.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/fields/field.test.ts
@@ -547,4 +547,51 @@ describe('processFields', () => {
     ];
     expect(processFields(nested)).toEqual(nestedExpected);
   });
+
+  test('ignores redefinitions of a field', () => {
+    const fields = [
+      {
+        name: 'a',
+        type: 'text',
+      },
+      {
+        name: 'a',
+        type: 'number',
+      },
+      {
+        name: 'b.c',
+        type: 'number',
+      },
+      {
+        name: 'b',
+        type: 'group',
+        fields: [
+          {
+            name: 'c',
+            type: 'text',
+          },
+        ],
+      },
+    ];
+
+    const fieldsExpected = [
+      {
+        name: 'a',
+        // should preserve the field that was parsed first which had type: text
+        type: 'text',
+      },
+      {
+        name: 'b',
+        type: 'group',
+        fields: [
+          {
+            name: 'c',
+            // should preserve the field that was parsed first which had type: number
+            type: 'number',
+          },
+        ],
+      },
+    ];
+    expect(processFields(fields)).toEqual(fieldsExpected);
+  });
 });

--- a/x-pack/plugins/ingest_manager/server/services/epm/fields/field.test.ts
+++ b/x-pack/plugins/ingest_manager/server/services/epm/fields/field.test.ts
@@ -594,4 +594,30 @@ describe('processFields', () => {
     ];
     expect(processFields(fields)).toEqual(fieldsExpected);
   });
+
+  test('ignores multiple redefinitions of a field', () => {
+    const fields = [
+      {
+        name: 'a',
+        type: 'text',
+      },
+      {
+        name: 'a',
+        type: 'number',
+      },
+      {
+        name: 'a',
+        type: 'keyword',
+      },
+    ];
+
+    const fieldsExpected = [
+      {
+        name: 'a',
+        // should preserve the field that was parsed first which had type: text
+        type: 'text',
+      },
+    ];
+    expect(processFields(fields)).toEqual(fieldsExpected);
+  });
 });


### PR DESCRIPTION
## Summary

When `fields.yml` files contain multiple definitions of the same field, the first definition wins and the following one(s) are silently discarded. This adds a test to explicitly verify this is the case.

