### PR TITLE
Copy `dateAsStringRt` to observability plugin

### DIFF
--- a/x-pack/plugins/observability/common/annotations.ts
+++ b/x-pack/plugins/observability/common/annotations.ts
@@ -5,7 +5,24 @@
  */
 
 import * as t from 'io-ts';
-import { dateAsStringRt } from '../../apm/common/runtime_types/date_as_string_rt';
+import { either } from 'fp-ts/lib/Either';
+
+/**
+ * Checks whether a string is a valid ISO timestamp,
+ * but doesn't convert it into a Date object when decoding.
+ *
+ * Copied from x-pack/plugins/apm/common/runtime_types/date_as_string_rt.ts.
+ */
+const dateAsStringRt = new t.Type<string, string, unknown>(
+  'DateAsString',
+  t.string.is,
+  (input, context) =>
+    either.chain(t.string.validate(input, context), (str) => {
+      const date = new Date(str);
+      return isNaN(date.getTime()) ? t.failure(input, context) : t.success(str);
+    }),
+  t.identity
+);
 
 export const createAnnotationRt = t.intersection([
   t.type({


### PR DESCRIPTION
Observability was importing `dateAsStringRt` from APM, which creates an implicit circular dependency between the two plugins.

Copy that function into where it was being used in observability to remove the dependency.

Related to #80508.
