### PR TITLE
[Lens] Distinct icons for XY and pie chart value labels toolbar

### DIFF
--- a/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/toolbar.tsx
@@ -125,7 +125,7 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
         title={i18n.translate('xpack.lens.pieChart.valuesLabel', {
           defaultMessage: 'Labels',
         })}
-        type="values"
+        type="labels"
         groupPosition="left"
         buttonDataTestSubj="lnsLabelsButton"
       >

--- a/x-pack/plugins/lens/public/shared_components/toolbar_popover.tsx
+++ b/x-pack/plugins/lens/public/shared_components/toolbar_popover.tsx
@@ -11,7 +11,8 @@ import { EuiIconLegend } from '../assets/legend';
 
 const typeToIconMap: { [type: string]: string | IconType } = {
   legend: EuiIconLegend as IconType,
-  values: 'number',
+  values: 'visText',
+  numeric: 'number',
 };
 
 export interface ToolbarPopoverProps {

--- a/x-pack/plugins/lens/public/shared_components/toolbar_popover.tsx
+++ b/x-pack/plugins/lens/public/shared_components/toolbar_popover.tsx
@@ -11,8 +11,8 @@ import { EuiIconLegend } from '../assets/legend';
 
 const typeToIconMap: { [type: string]: string | IconType } = {
   legend: EuiIconLegend as IconType,
-  values: 'visText',
-  numeric: 'number',
+  labels: 'visText',
+  values: 'number',
 };
 
 export interface ToolbarPopoverProps {

--- a/x-pack/plugins/lens/public/xy_visualization/xy_config_panel.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_config_panel.tsx
@@ -262,7 +262,7 @@ export function XyToolbar(props: VisualizationToolbarProps<State>) {
               title={i18n.translate('xpack.lens.xyChart.valuesLabel', {
                 defaultMessage: 'Values',
               })}
-              type="values"
+              type="numeric"
               groupPosition="left"
               buttonDataTestSubj="lnsValuesButton"
               isDisabled={!isValueLabelsEnabled && !isFittingEnabled}

--- a/x-pack/plugins/lens/public/xy_visualization/xy_config_panel.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/xy_config_panel.tsx
@@ -262,7 +262,7 @@ export function XyToolbar(props: VisualizationToolbarProps<State>) {
               title={i18n.translate('xpack.lens.xyChart.valuesLabel', {
                 defaultMessage: 'Values',
               })}
-              type="numeric"
+              type="values"
               groupPosition="left"
               buttonDataTestSubj="lnsValuesButton"
               isDisabled={!isValueLabelsEnabled && !isFittingEnabled}


### PR DESCRIPTION
## Summary

This PR addresses an unintentional change in the pie chart toolbar, adding distinct icon types.

<img width="802" alt="Screenshot 2020-11-09 at 10 29 40" src="https://user-images.githubusercontent.com/924948/98523715-83580080-2276-11eb-8b90-668a15d45334.png">
<img width="810" alt="Screenshot 2020-11-09 at 10 29 47" src="https://user-images.githubusercontent.com/924948/98523721-84892d80-2276-11eb-9434-65fc43d4ff97.png">

Fixes #82893 
