### PR TITLE
Remove kibana-core-ui-designers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -370,13 +370,6 @@ x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json @elastic/kib
 **/*.scss  @elastic/kibana-design
 #CC# /packages/kbn-ui-framework/ @elastic/kibana-design
 
-# Core UI design
-/src/plugins/dashboard/**/*.scss @elastic/kibana-core-ui-designers
-/src/plugins/embeddable/**/*.scss @elastic/kibana-core-ui-designers
-/x-pack/plugins/canvas/**/*.scss @elastic/kibana-core-ui-designers
-/x-pack/plugins/spaces/**/*.scss @elastic/kibana-core-ui-designers
-/x-pack/plugins/security/**/*.scss @elastic/kibana-core-ui-designers
-
 # Observability design
 /x-pack/plugins/apm/**/*.scss @elastic/observability-design
 /x-pack/plugins/infra/**/*.scss @elastic/observability-design


### PR DESCRIPTION
The members of `kibana-core-ui-designers` have been rolled into the `kibana-design` team.

All `.scss` changes will now notify `kibana-design` since the `kibana-core-ui-designers` entries were overrides occurring later in this file.
