### PR TITLE
[App Search] Added the log retention modal to the Settings page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { GenericConfirmationModal } from './generic_confirmation_modal';
+
+describe('GenericConfirmationModal', () => {
+  let wrapper: any;
+  const onClose = jest.fn();
+  const onSave = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    wrapper = shallow(
+      <GenericConfirmationModal
+        title="A title"
+        subheading="A subheading"
+        description="A description"
+        target="DISABLE"
+        onClose={onClose}
+        onSave={onSave}
+      />
+    );
+  });
+
+  it('calls onSave callback when save is pressed', () => {
+    const button = wrapper.find('[data-test-subj="GenericConfirmationModalSave"]');
+    button.simulate('click');
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('calls onClose callback when Cancel is pressed', () => {
+    const button = wrapper.find('[data-test-subj="GenericConfirmationModalCancel"]');
+    button.simulate('click');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables the Save button when the input is empty', () => {
+    const button = wrapper.find('[data-test-subj="GenericConfirmationModalSave"]');
+    expect(button.prop('disabled')).toEqual(true);
+  });
+
+  it('disables the Save button when the input is not equal to the target', () => {
+    const input = wrapper.find('[data-test-subj="GenericConfirmationModalInput"]');
+    input.prop('onChange')({
+      target: {
+        value: 'NOT_GOOD',
+      },
+    });
+
+    const button = wrapper.find('[data-test-subj="GenericConfirmationModalSave"]');
+    expect(button.prop('disabled')).toEqual(true);
+  });
+
+  it('enables the Save button when the current input equals the target prop', () => {
+    const input = wrapper.find('[data-test-subj="GenericConfirmationModalInput"]');
+    input.prop('onChange')({
+      target: {
+        value: 'DISABLE',
+      },
+    });
+    const button = wrapper.find('[data-test-subj="GenericConfirmationModalSave"]');
+    expect(button.prop('disabled')).toEqual(false);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { ReactNode, useState } from 'react';
+import { i18n } from '@kbn/i18n';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+
+interface IGenericConfirmationModalProps {
+  description: ReactNode;
+  subheading: ReactNode;
+  target: string;
+  title: ReactNode;
+  onClose(): void;
+  onSave(): void;
+}
+
+export const GenericConfirmationModal: React.FC<IGenericConfirmationModalProps> = ({
+  description,
+  onClose,
+  onSave,
+  subheading,
+  target,
+  title,
+}) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const onConfirm = () => {
+    setInputValue('');
+    onSave();
+  };
+
+  return (
+    <EuiModal onClose={onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiText>
+          <p>
+            <strong>{subheading}</strong>
+          </p>
+          <p>{description}</p>
+        </EuiText>
+        <EuiSpacer />
+        <EuiFormRow
+          label={i18n.translate(
+            'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.prompt',
+            {
+              defaultMessage: 'Type "{target}" to confirm.',
+              values: { target },
+            }
+          )}
+        >
+          <EuiFieldText
+            data-test-subj="GenericConfirmationModalInput"
+            name="engineName"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+          />
+        </EuiFormRow>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButtonEmpty data-test-subj="GenericConfirmationModalCancel" onClick={onClose}>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.modal.cancel', {
+            defaultMessage: 'Cancel',
+          })}
+        </EuiButtonEmpty>
+        <EuiButton
+          data-test-subj="GenericConfirmationModalSave"
+          onClick={onConfirm}
+          disabled={inputValue !== target}
+        >
+          {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.modal.save', {
+            defaultMessage: 'Save setting',
+          })}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../../__mocks__/kea.mock';
+import { setMockActions, setMockValues } from '../../../../__mocks__';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+
+import { LogRetentionConfirmationModal } from './log_retention_confirmation_modal';
+import { ELogRetentionOptions } from './types';
+import { GenericConfirmationModal } from './generic_confirmation_modal';
+
+describe('<LogRetentionConfirmationModal />', () => {
+  beforeAll(() => {
+    // LogRetentionConfirmationModal contains EuiModals, which utilize React Portals,
+    // so we must mock `createPortal` to get the rendered element directly,
+    // instead of letting it be placed normally elsewhere in DOM (outside of jest's domain)
+    // @ts-ignore
+    ReactDOM.createPortal = jest.fn((element) => {
+      return element;
+    });
+  });
+
+  const actions = {
+    closeModals: jest.fn(),
+    saveLogRetention: jest.fn(),
+  };
+
+  const values = {
+    openedModal: null,
+    logRetention: {
+      analytics: {
+        enabled: true,
+        retentionPolicy: {
+          isDefault: true,
+          minAgeDays: 180,
+        },
+      },
+      api: {
+        enabled: true,
+        retentionPolicy: {
+          isDefault: true,
+          minAgeDays: 7,
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockActions(actions);
+    setMockValues(values);
+  });
+
+  afterEach(() => {
+    // Remove the jest mock on createPortal
+    // @ts-ignore
+    ReactDOM.createPortal.mockClear();
+  });
+
+  it('renders nothing by default', () => {
+    const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+    expect(logRetentionPanel.isEmptyRender()).toBe(true);
+  });
+
+  describe('analytics', () => {
+    it('renders the Analytics panel when openedModal is set to Analytics', () => {
+      setMockValues({
+        ...values,
+        openedModal: ELogRetentionOptions.Analytics,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      expect(
+        logRetentionPanel.find('[data-test-subj="AnalyticsLogRetentionConfirmationModal"]').length
+      ).toBe(1);
+    });
+
+    it('calls saveLogRetention on save when showing analytics', () => {
+      setMockValues({
+        ...values,
+        openedModal: ELogRetentionOptions.Analytics,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      const genericConfirmationModal = logRetentionPanel.find(GenericConfirmationModal);
+      genericConfirmationModal.prop('onSave')();
+      expect(actions.saveLogRetention).toHaveBeenCalledWith(ELogRetentionOptions.Analytics, false);
+    });
+
+    it('calls closeModals on close', () => {
+      setMockValues({
+        ...values,
+        openedModal: ELogRetentionOptions.Analytics,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      const genericConfirmationModal = logRetentionPanel.find(GenericConfirmationModal);
+      genericConfirmationModal.prop('onClose')();
+      expect(actions.closeModals).toHaveBeenCalled();
+    });
+  });
+
+  describe('api', () => {
+    it('renders the API panel when openedModal is set to API', () => {
+      setMockValues({
+        ...values,
+        openedModal: ELogRetentionOptions.API,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      expect(
+        logRetentionPanel.find('[data-test-subj="APILogRetentionConfirmationModal"]').length
+      ).toBe(1);
+    });
+
+    it('calls saveLogRetention on save when showing api', () => {
+      setMockValues({
+        ...values,
+        openedModal: ELogRetentionOptions.API,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      const genericConfirmationModal = logRetentionPanel.find(GenericConfirmationModal);
+      genericConfirmationModal.prop('onSave')();
+      expect(actions.saveLogRetention).toHaveBeenCalledWith(ELogRetentionOptions.API, false);
+    });
+
+    it('calls closeModals on close', () => {
+      setMockValues({
+        ...values,
+        openedModal: ELogRetentionOptions.API,
+      });
+
+      const logRetentionPanel = shallow(<LogRetentionConfirmationModal />);
+      const genericConfirmationModal = logRetentionPanel.find(GenericConfirmationModal);
+      genericConfirmationModal.prop('onClose')();
+      expect(actions.closeModals).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+
+import { EuiTextColor, EuiOverlayMask } from '@elastic/eui';
+import { useActions, useValues } from 'kea';
+
+import { GenericConfirmationModal } from './generic_confirmation_modal';
+import { LogRetentionLogic } from './log_retention_logic';
+
+import { ELogRetentionOptions } from './types';
+
+export const LogRetentionConfirmationModal: React.FC = () => {
+  const CANNOT_BE_RECOVERED = i18n.translate(
+    'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.recovery',
+    {
+      defaultMessage: 'cannot be recovered',
+    }
+  );
+
+  const { closeModals, saveLogRetention } = useActions(LogRetentionLogic);
+
+  const { logRetention, openedModal } = useValues(LogRetentionLogic);
+
+  if (openedModal === null) {
+    return null;
+  }
+
+  return (
+    <EuiOverlayMask>
+      {openedModal === ELogRetentionOptions.Analytics && (
+        <GenericConfirmationModal
+          data-test-subj="AnalyticsLogRetentionConfirmationModal"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.analytics.title',
+            {
+              defaultMessage: 'Disable Analytics writes',
+            }
+          )}
+          subheading={
+            logRetention &&
+            logRetention[ELogRetentionOptions.Analytics].retentionPolicy?.minAgeDays &&
+            i18n.translate(
+              'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.analytics.subheading',
+              {
+                defaultMessage:
+                  'Your Analytics Logs are currently being stored for {minAgeDays} days.',
+                values: {
+                  minAgeDays:
+                    logRetention[ELogRetentionOptions.Analytics].retentionPolicy?.minAgeDays,
+                },
+              }
+            )
+          }
+          description={
+            <>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.analytics.description',
+                {
+                  defaultMessage:
+                    'When disabling Analytics Logs, all your engines will immediately stop indexing Analytics Logs. Your existing data will be deleted in accordance with the storage timeframes outlined above. Once your data has been removed, it',
+                }
+              )}{' '}
+              <strong>
+                <EuiTextColor color="danger">{CANNOT_BE_RECOVERED}</EuiTextColor>
+              </strong>
+              .
+            </>
+          }
+          target="DISABLE"
+          onClose={closeModals}
+          onSave={() => saveLogRetention(ELogRetentionOptions.Analytics, false)}
+        />
+      )}
+      {openedModal === ELogRetentionOptions.API && (
+        <GenericConfirmationModal
+          data-test-subj="APILogRetentionConfirmationModal"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.api.title',
+            {
+              defaultMessage: 'Disable API writes',
+            }
+          )}
+          subheading={
+            logRetention &&
+            logRetention?.[ELogRetentionOptions.API].retentionPolicy?.minAgeDays &&
+            i18n.translate(
+              'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.api.subheading',
+              {
+                defaultMessage: 'Your API Logs are currently being stored for {minAgeDays} days.',
+                values: {
+                  minAgeDays: logRetention?.[ELogRetentionOptions.API].retentionPolicy?.minAgeDays,
+                },
+              }
+            )
+          }
+          description={
+            <>
+              {i18n.translate(
+                'xpack.enterpriseSearch.appSearch.settings.logRetention.modal.api.description',
+                {
+                  defaultMessage:
+                    'When disabling API Logs, all your engines will immediately stop indexing API Logs. Your existing data will be deleted in accordance with the storage timeframes outlined above. Once your data has been removed, it',
+                }
+              )}{' '}
+              <strong>
+                <EuiTextColor color="danger">{CANNOT_BE_RECOVERED}</EuiTextColor>
+              </strong>
+              .
+            </>
+          }
+          target="DISABLE"
+          onClose={closeModals}
+          onSave={() => saveLogRetention(ELogRetentionOptions.API, false)}
+        />
+      )}
+    </EuiOverlayMask>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.test.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../../__mocks__/kea.mock';
+import '../../../../__mocks__/shallow_useeffect.mock';
+
+import { setMockActions, setMockValues } from '../../../../__mocks__';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { LogRetentionPanel } from './log_retention_panel';
+import { ILogRetention } from './types';
+
+describe('<LogRetentionPanel />', () => {
+  const actions = {
+    fetchLogRetention: jest.fn(),
+    toggleLogRetention: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockActions(actions);
+  });
+
+  it('renders', () => {
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    expect(logRetentionPanel.find('div[data-test-subj="LogRetentionPanel"]')).toHaveLength(1);
+  });
+
+  it('initializes data on mount', () => {
+    shallow(<LogRetentionPanel />);
+    expect(actions.fetchLogRetention).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Analytics switch off when analytics log retention is false in LogRetentionLogic ', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        analytics: {
+          enabled: false,
+        },
+      }),
+    });
+
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAnalyticsSwitch"]`).prop('checked')
+    ).toEqual(false);
+  });
+
+  it('renders Analytics switch on when analyticsLogRetention is true in LogRetentionLogic ', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        analytics: {
+          enabled: true,
+        },
+      }),
+    });
+
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAnalyticsSwitch"]`).prop('checked')
+    ).toEqual(true);
+  });
+
+  it('renders API switch off when apiLogRetention is false in LogRetentionLogic ', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        api: {
+          enabled: false,
+        },
+      }),
+    });
+
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAPISwitch"]`).prop('checked')
+    ).toEqual(false);
+  });
+
+  it('renders API switch on when apiLogRetention is true in LogRetentionLogic ', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        api: {
+          enabled: true,
+        },
+      }),
+    });
+
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAPISwitch"]`).prop('checked')
+    ).toEqual(true);
+  });
+
+  it('enables both switches when isLogRetentionUpdating is false', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({}),
+    });
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAnalyticsSwitch"]`).prop('disabled')
+    ).toEqual(false);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAPISwitch"]`).prop('disabled')
+    ).toEqual(false);
+  });
+
+  it('disables both switches when isLogRetentionUpdating is true', () => {
+    setMockValues({
+      isLogRetentionUpdating: true,
+      logRetention: mockLogRetention({}),
+    });
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAnalyticsSwitch"]`).prop('disabled')
+    ).toEqual(true);
+    expect(
+      logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAPISwitch"]`).prop('disabled')
+    ).toEqual(true);
+  });
+
+  it('calls toggleLogRetention when analytics log retention option is changed', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        analytics: {
+          enabled: false,
+        },
+      }),
+    });
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    logRetentionPanel
+      .find(`[data-test-subj="LogRetentionPanelAnalyticsSwitch"]`)
+      .simulate('change');
+    expect(actions.toggleLogRetention).toHaveBeenCalledWith('analytics');
+  });
+
+  it('calls toggleLogRetention when api log retention option is changed', () => {
+    setMockValues({
+      isLogRetentionUpdating: false,
+      logRetention: mockLogRetention({
+        analytics: {
+          enabled: false,
+        },
+      }),
+    });
+    const logRetentionPanel = shallow(<LogRetentionPanel />);
+    logRetentionPanel.find(`[data-test-subj="LogRetentionPanelAPISwitch"]`).simulate('change');
+    expect(actions.toggleLogRetention).toHaveBeenCalledWith('api');
+  });
+});
+
+function mockLogRetention(logRetention: Partial<ILogRetention>) {
+  const baseLogRetention = {
+    analytics: {
+      disabledAt: null,
+      enabled: true,
+      retentionPolicy: { isDefault: true, minAgeDays: 180 },
+    },
+    api: {
+      disabledAt: null,
+      enabled: true,
+      retentionPolicy: { isDefault: true, minAgeDays: 180 },
+    },
+  };
+
+  return {
+    analytics: {
+      ...baseLogRetention.analytics,
+      ...logRetention.analytics,
+    },
+    api: {
+      ...baseLogRetention.api,
+      ...logRetention.api,
+    },
+  };
+}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
@@ -30,11 +30,11 @@ export const LogRetentionPanel: React.FC = () => {
   return (
     <div data-test-subj="LogRetentionPanel">
       <EuiTitle size="s">
-        <h3>
+        <h2>
           {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.title', {
             defaultMessage: 'Log Retention',
           })}
-        </h3>
+        </h2>
       </EuiTitle>
       <EuiText>
         <p>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { i18n } from '@kbn/i18n';
 
 import { EuiLink, EuiSpacer, EuiSwitch, EuiText, EuiTextColor, EuiTitle } from '@elastic/eui';
 import { useActions, useValues } from 'kea';
@@ -29,16 +30,24 @@ export const LogRetentionPanel: React.FC = () => {
   return (
     <div data-test-subj="LogRetentionPanel">
       <EuiTitle size="s">
-        <h3>Log Retention</h3>
+        <h3>
+          {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.title', {
+            defaultMessage: 'Log Retention',
+          })}
+        </h3>
       </EuiTitle>
       <EuiText>
         <p>
-          Manage the default write settings for API Logs and Analytics.{' '}
+          {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.description', {
+            defaultMessage: 'Manage the default write settings for API Logs and Analytics.',
+          })}{' '}
           <EuiLink
             href="https://www.elastic.co/guide/en/app-search/current/logs.html"
             target="_blank"
           >
-            Learn more about retention settings.
+            {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.learnMore', {
+              defaultMessage: 'Learn more about retention settings.',
+            })}
           </EuiLink>
         </p>
       </EuiText>
@@ -47,7 +56,14 @@ export const LogRetentionPanel: React.FC = () => {
         <EuiSwitch
           label={
             <>
-              <strong>Analytics Logs</strong>{' '}
+              <strong>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.label',
+                  {
+                    defaultMessage: 'Analytics Logs',
+                  }
+                )}
+              </strong>{' '}
               {hasILM && (
                 <EuiTextColor color="subdued">
                   <AnalyticsLogRetentionMessage />
@@ -66,7 +82,14 @@ export const LogRetentionPanel: React.FC = () => {
         <EuiSwitch
           label={
             <>
-              <strong>API Logs</strong>{' '}
+              <strong>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.settings.logRetention.api.label',
+                  {
+                    defaultMessage: 'API Logs',
+                  }
+                )}
+              </strong>{' '}
               {logRetention !== null && (
                 <EuiTextColor color="subdued">
                   <ApiLogRetentionMessage />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useEffect } from 'react';
+
+import { EuiLink, EuiSpacer, EuiSwitch, EuiText, EuiTextColor, EuiTitle } from '@elastic/eui';
+import { useActions, useValues } from 'kea';
+
+import { LogRetentionLogic } from './log_retention_logic';
+import { AnalyticsLogRetentionMessage, ApiLogRetentionMessage } from './messaging';
+import { ELogRetentionOptions } from './types';
+
+export const LogRetentionPanel: React.FC = () => {
+  const { toggleLogRetention, fetchLogRetention } = useActions(LogRetentionLogic);
+
+  const { logRetention, isLogRetentionUpdating } = useValues(LogRetentionLogic);
+
+  const hasILM = logRetention !== null;
+  const analyticsLogRetentionSettings = logRetention?.[ELogRetentionOptions.Analytics];
+  const apiLogRetentionSettings = logRetention?.[ELogRetentionOptions.API];
+
+  useEffect(() => {
+    fetchLogRetention();
+  }, []);
+
+  return (
+    <div data-test-subj="LogRetentionPanel">
+      <EuiTitle size="s">
+        <h3>Log Retention</h3>
+      </EuiTitle>
+      <EuiText>
+        <p>
+          Manage the default write settings for API Logs and Analytics.{' '}
+          <EuiLink
+            href="https://www.elastic.co/guide/en/app-search/current/logs.html"
+            target="_blank"
+          >
+            Learn more about retention settings.
+          </EuiLink>
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <EuiText>
+        <EuiSwitch
+          label={
+            <>
+              <strong>Analytics Logs</strong>{' '}
+              {hasILM && (
+                <EuiTextColor color="subdued">
+                  <AnalyticsLogRetentionMessage />
+                </EuiTextColor>
+              )}
+            </>
+          }
+          checked={!!analyticsLogRetentionSettings?.enabled}
+          onChange={() => toggleLogRetention(ELogRetentionOptions.Analytics)}
+          disabled={isLogRetentionUpdating}
+          data-test-subj="LogRetentionPanelAnalyticsSwitch"
+        />
+      </EuiText>
+      <EuiSpacer size="m" />
+      <EuiText>
+        <EuiSwitch
+          label={
+            <>
+              <strong>API Logs</strong>{' '}
+              {logRetention !== null && (
+                <EuiTextColor color="subdued">
+                  <ApiLogRetentionMessage />
+                </EuiTextColor>
+              )}
+            </>
+          }
+          checked={!!apiLogRetentionSettings?.enabled}
+          onChange={() => toggleLogRetention(ELogRetentionOptions.API)}
+          disabled={isLogRetentionUpdating}
+          data-test-subj="LogRetentionPanelAPISwitch"
+        />
+      </EuiText>
+    </div>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/constants.ts
@@ -4,35 +4,116 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { i18n } from '@kbn/i18n';
+
 import { ILogRetentionMessages } from './types';
 import { renderLogRetentionDate } from '.';
 
+const ANALYTICS_NO_LOGGING = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.noLogging',
+  {
+    defaultMessage: 'Analytics collection has been disabled for all engines.',
+  }
+);
+
+const ANALYTICS_NO_LOGGING_COLLECTED = (disabledAt: string) =>
+  i18n.translate(
+    'xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.noLogging.collected',
+    {
+      defaultMessage: 'The last date analytics were collected was {disabledAt}.',
+      values: { disabledAt },
+    }
+  );
+
+const ANALYTICS_NO_LOGGING_NOT_COLLECTED = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.noLogging.notCollected',
+  {
+    defaultMessage: 'There are no analytics collected.',
+  }
+);
+
+const ANALYTICS_ILM_DISABLED = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.ilmDisabled',
+  {
+    defaultMessage: "App Search isn't managing analytics retention.",
+  }
+);
+
+const ANALYTICS_CUSTOM_POLICY = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.customPolicy',
+  {
+    defaultMessage: 'You have a custom analytics retention policy.',
+  }
+);
+
+const ANALYTICS_STORED = (minAgeDays: number | null | undefined) =>
+  i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.analytics.stored', {
+    defaultMessage: 'Your analytics are being stored for at least {minAgeDays} days.',
+    values: { minAgeDays },
+  });
+
+const API_NO_LOGGING = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.api.noLogging',
+  {
+    defaultMessage: 'API logging has been disabled for all engines.',
+  }
+);
+
+const API_NO_LOGGING_COLLECTED = (disabledAt: string) =>
+  i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.api.noLogging.collected', {
+    defaultMessage: 'The last date logs were collected was {disabledAt}.',
+    values: { disabledAt },
+  });
+
+const API_NO_LOGGING_NOT_COLLECTED = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.api.noLogging.notCollected',
+  {
+    defaultMessage: 'There are no logs collected.',
+  }
+);
+
+const API_ILM_DISABLED = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.api.ilmDisabled',
+  {
+    defaultMessage: "App Search isn't managing API log retention.",
+  }
+);
+
+const API_CUSTOM_POLICY = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.settings.logRetention.api.customPolicy',
+  {
+    defaultMessage: 'You have a custom API log retention policy.',
+  }
+);
+
+const API_STORED = (minAgeDays: number | null | undefined) =>
+  i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.api.stored', {
+    defaultMessage: 'Your logs are being stored for at least {minAgeDays} days.',
+    values: { minAgeDays },
+  });
+
 export const ANALYTICS_MESSAGES: ILogRetentionMessages = {
   noLogging: (_, logRetentionSettings) =>
-    `Analytics collection has been disabled for all engines. ${
+    `${ANALYTICS_NO_LOGGING} ${
       logRetentionSettings.disabledAt
-        ? `The last date analytics were collected was ${renderLogRetentionDate(
-            logRetentionSettings.disabledAt
-          )}.`
-        : 'There are no analytics collected.'
+        ? ANALYTICS_NO_LOGGING_COLLECTED(renderLogRetentionDate(logRetentionSettings.disabledAt))
+        : ANALYTICS_NO_LOGGING_NOT_COLLECTED
     }`,
-  ilmDisabled: "App Search isn't managing analytics retention.",
-  customPolicy: 'You have a custom analytics retention policy.',
+  ilmDisabled: ANALYTICS_ILM_DISABLED,
+  customPolicy: ANALYTICS_CUSTOM_POLICY,
   defaultPolicy: (_, logRetentionSettings) =>
-    `Your analytics are being stored for at least ${logRetentionSettings.retentionPolicy?.minAgeDays} days.`,
+    ANALYTICS_STORED(logRetentionSettings.retentionPolicy?.minAgeDays),
 };
 
 export const API_MESSAGES: ILogRetentionMessages = {
   noLogging: (_, logRetentionSettings) =>
-    `API logging has been disabled for all engines. ${
+    `${API_NO_LOGGING} ${
       logRetentionSettings.disabledAt
-        ? `The last date logs were collected was ${renderLogRetentionDate(
-            logRetentionSettings.disabledAt
-          )}.`
-        : 'There are no logs collected.'
+        ? API_NO_LOGGING_COLLECTED(renderLogRetentionDate(logRetentionSettings.disabledAt))
+        : API_NO_LOGGING_NOT_COLLECTED
     }`,
-  ilmDisabled: "App Search isn't managing API log retention.",
-  customPolicy: 'You have a custom API log retention policy.',
+  ilmDisabled: API_ILM_DISABLED,
+  customPolicy: API_CUSTOM_POLICY,
   defaultPolicy: (_, logRetentionSettings) =>
-    `Your logs are being stored for at least ${logRetentionSettings.retentionPolicy?.minAgeDays} days.`,
+    API_STORED(logRetentionSettings.retentionPolicy?.minAgeDays),
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/constants.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ILogRetentionMessages } from './types';
+import { renderLogRetentionDate } from '.';
+
+export const ANALYTICS_MESSAGES: ILogRetentionMessages = {
+  noLogging: (_, logRetentionSettings) =>
+    `Analytics collection has been disabled for all engines. ${
+      logRetentionSettings.disabledAt
+        ? `The last date analytics were collected was ${renderLogRetentionDate(
+            logRetentionSettings.disabledAt
+          )}.`
+        : 'There are no analytics collected.'
+    }`,
+  ilmDisabled: "App Search isn't managing analytics retention.",
+  customPolicy: 'You have a custom analytics retention policy.',
+  defaultPolicy: (_, logRetentionSettings) =>
+    `Your analytics are being stored for at least ${logRetentionSettings.retentionPolicy?.minAgeDays} days.`,
+};
+
+export const API_MESSAGES: ILogRetentionMessages = {
+  noLogging: (_, logRetentionSettings) =>
+    `API logging has been disabled for all engines. ${
+      logRetentionSettings.disabledAt
+        ? `The last date logs were collected was ${renderLogRetentionDate(
+            logRetentionSettings.disabledAt
+          )}.`
+        : 'There are no logs collected.'
+    }`,
+  ilmDisabled: "App Search isn't managing API log retention.",
+  customPolicy: 'You have a custom API log retention policy.',
+  defaultPolicy: (_, logRetentionSettings) =>
+    `Your logs are being stored for at least ${logRetentionSettings.retentionPolicy?.minAgeDays} days.`,
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/determine_tooltip_content.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/determine_tooltip_content.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { determineTooltipContent } from './determine_tooltip_content';
+import { ANALYTICS_MESSAGES, API_MESSAGES } from './constants';
+
+describe('determineTooltipContent', () => {
+  const BASE_SETTINGS = {
+    disabledAt: null,
+    enabled: true,
+    retentionPolicy: null,
+  };
+
+  it('will return nothing if settings are not provided', () => {
+    expect(determineTooltipContent(ANALYTICS_MESSAGES, true)).toBeUndefined();
+  });
+
+  describe('analytics messages', () => {
+    describe('when analytics logs are enabled', () => {
+      describe('and there using the default policy', () => {
+        it('will render a retention policy message', () => {
+          expect(
+            determineTooltipContent(ANALYTICS_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: true,
+              retentionPolicy: {
+                isDefault: true,
+                minAgeDays: 7,
+              },
+            })
+          ).toEqual('Your analytics are being stored for at least 7 days.');
+        });
+      });
+
+      describe('and there is a custom policy', () => {
+        it('will render a retention policy message', () => {
+          expect(
+            determineTooltipContent(ANALYTICS_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: true,
+              retentionPolicy: {
+                isDefault: false,
+                minAgeDays: 7,
+              },
+            })
+          ).toEqual('You have a custom analytics retention policy.');
+        });
+      });
+    });
+
+    describe('when analytics logs are disabled', () => {
+      describe('and there is no disabledAt date', () => {
+        it('will render a no logging message', () => {
+          expect(
+            determineTooltipContent(ANALYTICS_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: false,
+              disabledAt: null,
+            })
+          ).toEqual(
+            'Analytics collection has been disabled for all engines. There are no analytics collected.'
+          );
+        });
+      });
+
+      describe('and there is a disabledAt date', () => {
+        it('will render a no logging message', () => {
+          expect(
+            determineTooltipContent(ANALYTICS_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: false,
+              disabledAt: 'Thu, 05 Nov 2020 18:57:28 +0000',
+            })
+          ).toEqual(
+            'Analytics collection has been disabled for all engines. The last date analytics were collected was November 5, 2020.'
+          );
+        });
+      });
+    });
+
+    describe('when ilm is disabled entirely', () => {
+      it('will render a no logging message', () => {
+        expect(
+          determineTooltipContent(ANALYTICS_MESSAGES, false, {
+            ...BASE_SETTINGS,
+            enabled: true,
+          })
+        ).toEqual("App Search isn't managing analytics retention.");
+      });
+    });
+  });
+
+  describe('api messages', () => {
+    describe('when analytics logs are enabled', () => {
+      describe('and there using the default policy', () => {
+        it('will render a retention policy message', () => {
+          expect(
+            determineTooltipContent(API_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: true,
+              retentionPolicy: {
+                isDefault: true,
+                minAgeDays: 7,
+              },
+            })
+          ).toEqual('Your logs are being stored for at least 7 days.');
+        });
+      });
+
+      describe('and there is a custom policy', () => {
+        it('will render a retention policy message', () => {
+          expect(
+            determineTooltipContent(API_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: true,
+              retentionPolicy: {
+                isDefault: false,
+                minAgeDays: 7,
+              },
+            })
+          ).toEqual('You have a custom API log retention policy.');
+        });
+      });
+    });
+
+    describe('when analytics logs are disabled', () => {
+      describe('and there is no disabledAt date', () => {
+        it('will render a no logging message', () => {
+          expect(
+            determineTooltipContent(API_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: false,
+              disabledAt: null,
+            })
+          ).toEqual('API logging has been disabled for all engines. There are no logs collected.');
+        });
+      });
+
+      describe('and there is a disabledAt date', () => {
+        it('will render a no logging message', () => {
+          expect(
+            determineTooltipContent(API_MESSAGES, true, {
+              ...BASE_SETTINGS,
+              enabled: false,
+              disabledAt: 'Thu, 05 Nov 2020 18:57:28 +0000',
+            })
+          ).toEqual(
+            'API logging has been disabled for all engines. The last date logs were collected was November 5, 2020.'
+          );
+        });
+      });
+    });
+
+    describe('when ilm is disabled entirely', () => {
+      it('will render a no logging message', () => {
+        expect(
+          determineTooltipContent(API_MESSAGES, false, {
+            ...BASE_SETTINGS,
+            enabled: true,
+          })
+        ).toEqual("App Search isn't managing API log retention.");
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/determine_tooltip_content.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/determine_tooltip_content.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ILogRetentionSettings } from '../types';
+import { TMessageStringOrFunction, ILogRetentionMessages } from './types';
+
+export const determineTooltipContent = (
+  messages: ILogRetentionMessages,
+  ilmEnabled: boolean,
+  logRetentionSettings?: ILogRetentionSettings
+) => {
+  if (typeof logRetentionSettings === 'undefined') {
+    return;
+  }
+
+  const renderOrReturnMessage = (message: TMessageStringOrFunction) => {
+    if (typeof message === 'function') {
+      return message(ilmEnabled, logRetentionSettings);
+    }
+    return message;
+  };
+
+  if (!logRetentionSettings.enabled) {
+    return renderOrReturnMessage(messages.noLogging);
+  }
+  if (logRetentionSettings.enabled && !ilmEnabled) {
+    return renderOrReturnMessage(messages.ilmDisabled);
+  }
+  if (
+    logRetentionSettings.enabled &&
+    ilmEnabled &&
+    !logRetentionSettings.retentionPolicy?.isDefault
+  ) {
+    return renderOrReturnMessage(messages.customPolicy);
+  }
+  if (
+    logRetentionSettings.enabled &&
+    ilmEnabled &&
+    logRetentionSettings.retentionPolicy?.isDefault
+  ) {
+    return renderOrReturnMessage(messages.defaultPolicy);
+  }
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/index.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../../../__mocks__/kea.mock';
+import { setMockValues } from '../../../../../__mocks__';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { AnalyticsLogRetentionMessage, ApiLogRetentionMessage, renderLogRetentionDate } from '.';
+
+describe('LogRetentionMessaging', () => {
+  const LOG_RETENTION = {
+    analytics: {
+      disabledAt: null,
+      enabled: true,
+      retentionPolicy: { isDefault: true, minAgeDays: 180 },
+    },
+    api: {
+      disabledAt: null,
+      enabled: true,
+      retentionPolicy: { isDefault: true, minAgeDays: 180 },
+    },
+  };
+
+  describe('renderLogRetentionDate', () => {
+    it('renders a formatted date', () => {
+      expect(renderLogRetentionDate('Thu, 05 Nov 2020 18:57:28 +0000')).toEqual('November 5, 2020');
+    });
+  });
+
+  describe('AnalyticsLogRetentionMessage', () => {
+    it('renders', () => {
+      setMockValues({
+        ilmEnabled: true,
+        logRetention: LOG_RETENTION,
+      });
+      const wrapper = shallow(<AnalyticsLogRetentionMessage />);
+      expect(wrapper.text()).toEqual('Your analytics are being stored for at least 180 days.');
+    });
+
+    it('renders nothing if logRetention is null', () => {
+      setMockValues({
+        ilmEnabled: true,
+        logRetention: null,
+      });
+      const wrapper = shallow(<AnalyticsLogRetentionMessage />);
+      expect(wrapper.isEmptyRender()).toEqual(true);
+    });
+  });
+
+  describe('ApiLogRetentionMessage', () => {
+    it('renders', () => {
+      setMockValues({
+        ilmEnabled: true,
+        logRetention: LOG_RETENTION,
+      });
+      const wrapper = shallow(<ApiLogRetentionMessage />);
+      expect(wrapper.text()).toEqual('Your logs are being stored for at least 180 days.');
+    });
+
+    it('renders nothing if logRetention is null', () => {
+      setMockValues({
+        ilmEnabled: true,
+        logRetention: null,
+      });
+      const wrapper = shallow(<ApiLogRetentionMessage />);
+      expect(wrapper.isEmptyRender()).toEqual(true);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/index.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+import moment from 'moment';
+
+import { AppLogic } from '../../../../app_logic';
+import { LogRetentionLogic } from '../log_retention_logic';
+import { ELogRetentionOptions } from '../types';
+
+import { determineTooltipContent } from './determine_tooltip_content';
+import { ANALYTICS_MESSAGES, API_MESSAGES } from './constants';
+
+export const renderLogRetentionDate = (dateString: string) =>
+  moment(dateString).format('MMMM D, YYYY');
+
+export const AnalyticsLogRetentionMessage: React.FC = () => {
+  const { ilmEnabled } = useValues(AppLogic);
+  const { logRetention } = useValues(LogRetentionLogic);
+  if (!logRetention) return null;
+
+  return (
+    <>
+      {determineTooltipContent(
+        ANALYTICS_MESSAGES,
+        ilmEnabled,
+        logRetention[ELogRetentionOptions.Analytics]
+      )}
+    </>
+  );
+};
+
+export const ApiLogRetentionMessage: React.FC = () => {
+  const { ilmEnabled } = useValues(AppLogic);
+  const { logRetention } = useValues(LogRetentionLogic);
+  if (!logRetention) return null;
+
+  return (
+    <>{determineTooltipContent(API_MESSAGES, ilmEnabled, logRetention[ELogRetentionOptions.API])}</>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/messaging/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { ILogRetentionSettings } from '../types';
+
+export type TMessageStringOrFunction =
+  | string
+  | ((ilmEnabled: boolean, logRetentionSettings: ILogRetentionSettings) => string);
+
+export interface ILogRetentionMessages {
+  noLogging: TMessageStringOrFunction;
+  ilmDisabled: TMessageStringOrFunction;
+  customPolicy: TMessageStringOrFunction;
+  defaultPolicy: TMessageStringOrFunction;
+}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.tsx
@@ -5,8 +5,8 @@
  */
 
 import React from 'react';
-
 import { i18n } from '@kbn/i18n';
+
 import {
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -18,6 +18,7 @@ import {
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { FlashMessages } from '../../../shared/flash_messages';
 import { LogRetentionPanel } from './log_retention/log_retention_panel';
+import { LogRetentionConfirmationModal } from './log_retention/log_retention_confirmation_modal';
 
 export const Settings: React.FC = () => {
   return (
@@ -43,6 +44,7 @@ export const Settings: React.FC = () => {
       <EuiPageContent>
         <EuiPageContentBody>
           <FlashMessages />
+          <LogRetentionConfirmationModal />
           <LogRetentionPanel />
         </EuiPageContentBody>
       </EuiPageContent>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.tsx
@@ -7,10 +7,17 @@
 import React from 'react';
 
 import { i18n } from '@kbn/i18n';
-import { EuiPageHeader, EuiPageHeaderSection, EuiPageContentBody, EuiTitle } from '@elastic/eui';
+import {
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiPageContent,
+  EuiPageContentBody,
+  EuiTitle,
+} from '@elastic/eui';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { LogRetentionPanel } from './log_retention/log_retention_panel';
 
 export const Settings: React.FC = () => {
   return (
@@ -33,9 +40,12 @@ export const Settings: React.FC = () => {
           </EuiTitle>
         </EuiPageHeaderSection>
       </EuiPageHeader>
-      <EuiPageContentBody>
-        <FlashMessages />
-      </EuiPageContentBody>
+      <EuiPageContent>
+        <EuiPageContentBody>
+          <FlashMessages />
+          <LogRetentionPanel />
+        </EuiPageContentBody>
+      </EuiPageContent>
     </>
   );
 };


### PR DESCRIPTION
## Summary

This PR adds the confirmation modal for log retention settings to the App Search Settings page.

![screencapture-localhost-5601-app-enterprise-search-app-search-settings-account-2020-11-09-14_54_03](https://user-images.githubusercontent.com/1427475/98589547-73064c80-229b-11eb-89b7-9b55791a523d.png)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
