### PR TITLE
[Workplace Search] Consolidate groups routes

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -14,6 +14,7 @@ import {
   registerShareGroupRoute,
   registerAssignGroupRoute,
   registerBoostsGroupRoute,
+  registerGroupsRoutes,
 } from './groups';
 
 describe('groups routes', () => {
@@ -390,6 +391,13 @@ describe('groups routes', () => {
         path: '/ws/org/groups/123/update_source_boosts',
         body: mockPayload,
       });
+    });
+  });
+
+  describe('registerGroupsRoutes', () => {
+    it('runs without errors', () => {
+      const mockRouter = new MockRouter({} as any);
+      registerGroupsRoutes({ ...mockDependencies, router: mockRouter.router });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -14,7 +14,6 @@ import {
   registerShareGroupRoute,
   registerAssignGroupRoute,
   registerBoostsGroupRoute,
-  registerGroupsRoutes,
 } from './groups';
 
 describe('groups routes', () => {
@@ -391,13 +390,6 @@ describe('groups routes', () => {
         path: '/ws/org/groups/123/update_source_boosts',
         body: mockPayload,
       });
-    });
-  });
-
-  describe('registerGroupsRoutes', () => {
-    it('runs without errors', () => {
-      const mockRouter = new MockRouter({} as any);
-      registerGroupsRoutes({ ...mockDependencies, router: mockRouter.router });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
@@ -223,3 +223,13 @@ export function registerBoostsGroupRoute({
     }
   );
 }
+
+export const registerGroupsRoutes = (dependencies: IRouteDependencies) => {
+  registerGroupsRoute(dependencies);
+  registerSearchGroupsRoute(dependencies);
+  registerGroupRoute(dependencies);
+  registerGroupUsersRoute(dependencies);
+  registerShareGroupRoute(dependencies);
+  registerAssignGroupRoute(dependencies);
+  registerBoostsGroupRoute(dependencies);
+};

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -7,23 +7,9 @@
 import { IRouteDependencies } from '../../plugin';
 
 import { registerOverviewRoute } from './overview';
-import {
-  registerGroupsRoute,
-  registerSearchGroupsRoute,
-  registerGroupRoute,
-  registerGroupUsersRoute,
-  registerShareGroupRoute,
-  registerAssignGroupRoute,
-  registerBoostsGroupRoute,
-} from './groups';
+import { registerGroupsRoutes } from './groups';
 
 export const registerWorkplaceSearchRoutes = (dependencies: IRouteDependencies) => {
   registerOverviewRoute(dependencies);
-  registerGroupsRoute(dependencies);
-  registerSearchGroupsRoute(dependencies);
-  registerGroupRoute(dependencies);
-  registerGroupUsersRoute(dependencies);
-  registerShareGroupRoute(dependencies);
-  registerAssignGroupRoute(dependencies);
-  registerBoostsGroupRoute(dependencies);
+  registerGroupsRoutes(dependencies);
 };


### PR DESCRIPTION
This PR consolidates all of the groups route registration functions into a single export so that the `registerWorkplaceSearchRoutes` function only has to call the top-level routes and is easier to read and maintain.
