### PR TITLE
[Fleet] Split unpacking an archive and caching its files into separate functions

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/index.ts
@@ -18,7 +18,7 @@ import { parseAndVerifyArchive } from './validation';
 
 export * from './cache';
 
-export async function loadArchivePackage({
+export async function getArchivePackage({
   archiveBuffer,
   contentType,
 }: {

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -15,12 +15,29 @@ import {
   RegistryVarsEntry,
 } from '../../../../common/types';
 import { PackageInvalidArchiveError } from '../../../errors';
-import { pkgToPkgKey } from '../registry';
-import { cacheGet } from './cache';
+import { ArchiveEntry, pkgToPkgKey } from '../registry';
+
+const MANIFESTS: Record<string, Buffer> = {};
+const MANIFEST_NAME = 'manifest.yml';
 
 // TODO: everything below performs verification of manifest.yml files, and hence duplicates functionality already implemented in the
 // package registry. At some point this should probably be replaced (or enhanced) with verification based on
 // https://github.com/elastic/package-spec/
+export async function parseAndVerifyArchiveEntries(
+  entries: ArchiveEntry[]
+): Promise<{ paths: string[]; archivePackageInfo: ArchivePackage }> {
+  const paths: string[] = [];
+  entries.forEach(({ path, buffer }) => {
+    paths.push(path);
+    if (path.endsWith(MANIFEST_NAME) && buffer) MANIFESTS[path] = buffer;
+  });
+
+  return {
+    archivePackageInfo: parseAndVerifyArchive(paths),
+    paths,
+  };
+}
+
 export function parseAndVerifyArchive(paths: string[]): ArchivePackage {
   // The top-level directory must match pkgName-pkgVersion, and no other top-level files or directories may be present
   const toplevelDir = paths[0].split('/')[0];
@@ -31,10 +48,10 @@ export function parseAndVerifyArchive(paths: string[]): ArchivePackage {
   });
 
   // The package must contain a manifest file ...
-  const manifestFile = `${toplevelDir}/manifest.yml`;
-  const manifestBuffer = cacheGet(manifestFile);
+  const manifestFile = `${toplevelDir}/${MANIFEST_NAME}`;
+  const manifestBuffer = MANIFESTS[manifestFile];
   if (!paths.includes(manifestFile) || !manifestBuffer) {
-    throw new PackageInvalidArchiveError('Package must contain a top-level manifest.yml file.');
+    throw new PackageInvalidArchiveError(`Package must contain a top-level ${MANIFEST_NAME} file.`);
   }
 
   // ... which must be valid YAML
@@ -97,8 +114,8 @@ function parseAndVerifyDataStreams(
   dataStreamPaths = uniq(dataStreamPaths);
 
   dataStreamPaths.forEach((dataStreamPath) => {
-    const manifestFile = `${pkgKey}/data_stream/${dataStreamPath}/manifest.yml`;
-    const manifestBuffer = cacheGet(manifestFile);
+    const manifestFile = `${pkgKey}/data_stream/${dataStreamPath}/${MANIFEST_NAME}`;
+    const manifestBuffer = MANIFESTS[manifestFile];
     if (!paths.includes(manifestFile) || !manifestBuffer) {
       throw new PackageInvalidArchiveError(
         `No manifest.yml file found for data stream '${dataStreamPath}'`

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -36,7 +36,7 @@ import {
 } from '../../../errors';
 import { getPackageSavedObjects } from './get';
 import { appContextService } from '../../app_context';
-import { loadArchivePackage } from '../archive';
+import { getArchivePackage } from '../archive';
 import { _installPackage } from './_install_package';
 
 export async function installLatestPackage(options: {
@@ -283,7 +283,7 @@ async function installPackageByUpload({
   archiveBuffer,
   contentType,
 }: InstallUploadedArchiveParams): Promise<AssetReference[]> {
-  const { paths, archivePackageInfo } = await loadArchivePackage({ archiveBuffer, contentType });
+  const { paths, archivePackageInfo } = await getArchivePackage({ archiveBuffer, contentType });
 
   const installedPkg = await getInstallationObject({
     savedObjectsClient,


### PR DESCRIPTION
## Summary

 * Separate unpacking an archive from caching it or other side-effects
 * Parse and validate an archive before caching it 
 * Validation has no coupling with caching side-effects or any other code outside the `validation.ts` file

```diff
-  const paths = await unpackArchiveToCache(archiveBuffer, contentType);
-  const archivePackageInfo = parseAndVerifyArchive(paths);
+  const entries = await unpackArchiveEntries(archiveBuffer, contentType);
+  const { archivePackageInfo } = await parseAndVerifyArchiveEntries(entries);
+  const paths = addEntriesToMemoryStore(entries);
```
### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
