### PR TITLE
[Workplace Search] Add routes for Sources

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -14,6 +14,7 @@ import {
   registerShareGroupRoute,
   registerAssignGroupRoute,
   registerBoostsGroupRoute,
+  registerGroupsRoutes,
 } from './groups';
 
 describe('groups routes', () => {
@@ -390,6 +391,13 @@ describe('groups routes', () => {
         path: '/ws/org/groups/123/update_source_boosts',
         body: mockPayload,
       });
+    });
+  });
+
+  describe('registerGroupsRoutes', () => {
+    it('runs without errors', () => {
+      const mockRouter = new MockRouter({} as any);
+      registerGroupsRoutes({ ...mockDependencies, router: mockRouter.router });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -14,7 +14,6 @@ import {
   registerShareGroupRoute,
   registerAssignGroupRoute,
   registerBoostsGroupRoute,
-  registerGroupsRoutes,
 } from './groups';
 
 describe('groups routes', () => {
@@ -391,13 +390,6 @@ describe('groups routes', () => {
         path: '/ws/org/groups/123/update_source_boosts',
         body: mockPayload,
       });
-    });
-  });
-
-  describe('registerGroupsRoutes', () => {
-    it('runs without errors', () => {
-      const mockRouter = new MockRouter({} as any);
-      registerGroupsRoutes({ ...mockDependencies, router: mockRouter.router });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -8,8 +8,10 @@ import { RouteDependencies } from '../../plugin';
 
 import { registerOverviewRoute } from './overview';
 import { registerGroupsRoutes } from './groups';
+import { registerSourcesRoutes } from './sources';
 
 export const registerWorkplaceSearchRoutes = (dependencies: RouteDependencies) => {
   registerOverviewRoute(dependencies);
   registerGroupsRoutes(dependencies);
+  registerSourcesRoutes(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -1,0 +1,828 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
+
+import {
+  registerAccountSourceRoute,
+  registerAccountCreateSourceRoute,
+  registerAccountSourceDocumentsRoute,
+  registerAccountSourceFederatedSummaryRoute,
+  registerAccountSourceReauthPrepareRoute,
+  registerAccountSourceSettingsRoute,
+  registerAccountPreSourceRoute,
+  registerAccountPrepareSourcesRoute,
+  registerOrgSourceRoute,
+  registerOrgCreateSourceRoute,
+  registerOrgSourceDocumentsRoute,
+  registerOrgSourceFederatedSummaryRoute,
+  registerOrgSourceReauthPrepareRoute,
+  registerOrgSourceSettingsRoute,
+  registerOrgPreSourceRoute,
+  registerOrgPrepareSourcesRoute,
+  registerOrgSourceOauthConfigurationsRoute,
+  registerOrgSourceOauthConfigurationRoute,
+} from './sources';
+
+const mockConfig = {
+  base_url: 'http://search',
+  client_id: 'asd',
+  client_secret: '234KKDFksdf22',
+  service_type: 'zendesk',
+  private_key: 'gsdfgsdfg',
+  public_key: 'gadfgsdfgss',
+  consumer_key: 'sf44argsr',
+};
+
+describe('sources routes', () => {
+  describe('GET /api/workplace_search/account/sources/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/account/sources/{id}',
+        payload: 'params',
+      });
+
+      registerAccountSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/123',
+      });
+    });
+  });
+
+  describe('DELETE /api/workplace_search/account/sources/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'delete',
+        path: '/api/workplace_search/account/sources/{id}',
+        payload: 'params',
+      });
+
+      registerAccountSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/123',
+      });
+    });
+  });
+
+  describe('POST /api/workplace_search/account/create_source', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/account/create_source',
+        payload: 'body',
+      });
+
+      registerAccountCreateSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        body: {
+          service_type: 'google',
+          name: 'Google',
+          login: 'user',
+          password: 'changeme',
+          organizations: 'swiftype',
+          indexPermissions: true,
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/form_create',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('POST /api/workplace_search/account/sources/{id}/documents', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/account/sources/{id}/documents',
+        payload: 'body',
+      });
+
+      registerAccountSourceDocumentsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        params: { id: '123' },
+        body: {
+          query: 'foo',
+          page: {
+            current: 1,
+            size: 10,
+            total_pages: 1,
+            total_results: 10,
+          },
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/123/documents',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/account/sources/{id}/federated_summary', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/account/sources/{id}/federated_summary',
+        payload: 'params',
+      });
+
+      registerAccountSourceFederatedSummaryRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/123/federated_summary',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/account/sources/{id}/reauth_prepare', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/account/sources/{id}/reauth_prepare',
+        payload: 'params',
+      });
+
+      registerAccountSourceReauthPrepareRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/123/reauth_prepare',
+      });
+    });
+  });
+
+  describe('PATCH /api/workplace_search/account/sources/{id}/settings', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'patch',
+        path: '/api/workplace_search/account/sources/{id}/settings',
+        payload: 'body',
+      });
+
+      registerAccountSourceSettingsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        params: { id: '123' },
+        body: {
+          query: {
+            content_source: {
+              name: 'foo',
+            },
+          },
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/123/settings',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/account/pre_sources/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/account/pre_sources/{id}',
+        payload: 'params',
+      });
+
+      registerAccountPreSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/pre_content_sources/123',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/account/sources/{service_type}/prepare', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/account/sources/{service_type}/prepare',
+        payload: 'params',
+      });
+
+      registerAccountPrepareSourcesRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          service_type: 'zendesk',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/pre_content_sources/zendesk',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/sources/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/sources/{id}',
+        payload: 'params',
+      });
+
+      registerOrgSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/123',
+      });
+    });
+  });
+
+  describe('DELETE /api/workplace_search/org/sources/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'delete',
+        path: '/api/workplace_search/org/sources/{id}',
+        payload: 'params',
+      });
+
+      registerOrgSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/123',
+      });
+    });
+  });
+
+  describe('POST /api/workplace_search/org/create_source', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/org/create_source',
+        payload: 'body',
+      });
+
+      registerOrgCreateSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        body: {
+          service_type: 'google',
+          name: 'Google',
+          login: 'user',
+          password: 'changeme',
+          organizations: 'swiftype',
+          indexPermissions: true,
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/form_create',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('POST /api/workplace_search/org/sources/{id}/documents', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/org/sources/{id}/documents',
+        payload: 'body',
+      });
+
+      registerOrgSourceDocumentsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        params: { id: '123' },
+        body: {
+          query: 'foo',
+          page: {
+            current: 1,
+            size: 10,
+            total_pages: 1,
+            total_results: 10,
+          },
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/123/documents',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/sources/{id}/federated_summary', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/sources/{id}/federated_summary',
+        payload: 'params',
+      });
+
+      registerOrgSourceFederatedSummaryRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/123/federated_summary',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/sources/{id}/reauth_prepare', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/sources/{id}/reauth_prepare',
+        payload: 'params',
+      });
+
+      registerOrgSourceReauthPrepareRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/123/reauth_prepare',
+      });
+    });
+  });
+
+  describe('PATCH /api/workplace_search/org/sources/{id}/settings', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'patch',
+        path: '/api/workplace_search/org/sources/{id}/settings',
+        payload: 'body',
+      });
+
+      registerOrgSourceSettingsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      const mockRequest = {
+        params: { id: '123' },
+        body: {
+          query: {
+            content_source: {
+              name: 'foo',
+            },
+          },
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/123/settings',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/pre_sources/{id}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/pre_sources/{id}',
+        payload: 'params',
+      });
+
+      registerOrgPreSourceRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          id: '123',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/pre_content_sources/123',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/sources/{service_type}/prepare', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/sources/{service_type}/prepare',
+        payload: 'params',
+      });
+
+      registerOrgPrepareSourcesRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          service_type: 'zendesk',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/pre_content_sources/zendesk',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/settings/connectors', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/settings/connectors',
+      });
+
+      registerOrgSourceOauthConfigurationsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      mockRouter.callRoute({});
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/settings/connectors/{service_type}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/settings/connectors/{service_type}',
+        payload: 'params',
+      });
+
+      registerOrgSourceOauthConfigurationRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          service_type: 'zendesk',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors/zendesk',
+      });
+    });
+  });
+
+  describe('POST /api/workplace_search/org/settings/connectors/{service_type}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/org/settings/connectors/{service_type}',
+        payload: 'body',
+      });
+
+      registerOrgSourceOauthConfigurationRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          service_type: 'zendesk',
+        },
+        body: mockConfig,
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors/zendesk',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('PUT /api/workplace_search/org/settings/connectors/{service_type}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/org/settings/connectors/{service_type}',
+        payload: 'body',
+      });
+
+      registerOrgSourceOauthConfigurationRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          service_type: 'zendesk',
+        },
+        body: mockConfig,
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors/zendesk',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('DELETE /api/workplace_search/org/settings/connectors/{service_type}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'delete',
+        path: '/api/workplace_search/org/settings/connectors/{service_type}',
+        payload: 'params',
+      });
+
+      registerOrgSourceOauthConfigurationRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        params: {
+          service_type: 'zendesk',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors/zendesk',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -1,0 +1,543 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import { RouteDependencies } from '../../plugin';
+
+const pageSchema = schema.object({
+  current: schema.number(),
+  size: schema.number(),
+  total_pages: schema.number(),
+  total_results: schema.number(),
+});
+
+const oAuthConfigSchema = schema.object({
+  base_url: schema.maybe(schema.string()),
+  client_id: schema.maybe(schema.string()),
+  client_secret: schema.maybe(schema.string()),
+  service_type: schema.string(),
+  private_key: schema.string(),
+  public_key: schema.string(),
+  consumer_key: schema.string(),
+});
+
+export function registerAccountSourceRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/account/sources/{id}',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/sources/${request.params.id}`,
+      })(context, request, response);
+    }
+  );
+
+  router.delete(
+    {
+      path: '/api/workplace_search/account/sources/{id}',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/sources/${request.params.id}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountCreateSourceRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.post(
+    {
+      path: '/api/workplace_search/account/create_source',
+      validate: {
+        body: schema.object({
+          service_type: schema.string(),
+          name: schema.maybe(schema.string()),
+          login: schema.maybe(schema.string()),
+          password: schema.maybe(schema.string()),
+          organizations: schema.maybe(schema.arrayOf(schema.string())),
+          indexPermissions: schema.boolean(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/ws/sources/form_create',
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountSourceDocumentsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.post(
+    {
+      path: '/api/workplace_search/account/sources/{id}/documents',
+      validate: {
+        body: schema.object({
+          query: schema.string(),
+          page: pageSchema,
+        }),
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/sources/${request.params.id}/documents`,
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountSourceFederatedSummaryRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/account/sources/{id}/federated_summary',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/sources/${request.params.id}/federated_summary`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountSourceReauthPrepareRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/account/sources/{id}/reauth_prepare',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/sources/${request.params.id}/reauth_prepare`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountSourceSettingsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.patch(
+    {
+      path: '/api/workplace_search/account/sources/{id}/settings',
+      validate: {
+        body: schema.object({
+          query: schema.object({
+            content_source: schema.object({
+              name: schema.string(),
+            }),
+          }),
+        }),
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/sources/${request.params.id}/settings`,
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountPreSourceRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/account/pre_sources/{id}',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/pre_content_sources/${request.params.id}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerAccountPrepareSourcesRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/account/sources/{service_type}/prepare',
+      validate: {
+        params: schema.object({
+          service_type: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/pre_content_sources/${request.params.service_type}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/sources/{id}',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/sources/${request.params.id}`,
+      })(context, request, response);
+    }
+  );
+
+  router.delete(
+    {
+      path: '/api/workplace_search/org/sources/{id}',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/sources/${request.params.id}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgCreateSourceRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.post(
+    {
+      path: '/api/workplace_search/org/create_source',
+      validate: {
+        body: schema.object({
+          service_type: schema.string(),
+          name: schema.maybe(schema.string()),
+          login: schema.maybe(schema.string()),
+          password: schema.maybe(schema.string()),
+          organizations: schema.maybe(schema.arrayOf(schema.string())),
+          indexPermissions: schema.boolean(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/ws/org/sources/form_create',
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceDocumentsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.post(
+    {
+      path: '/api/workplace_search/org/sources/{id}/documents',
+      validate: {
+        body: schema.object({
+          query: schema.string(),
+          page: pageSchema,
+        }),
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/sources/${request.params.id}/documents`,
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceFederatedSummaryRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/sources/{id}/federated_summary',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/sources/${request.params.id}/federated_summary`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceReauthPrepareRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/sources/{id}/reauth_prepare',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/sources/${request.params.id}/reauth_prepare`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceSettingsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.patch(
+    {
+      path: '/api/workplace_search/org/sources/{id}/settings',
+      validate: {
+        body: schema.object({
+          query: schema.object({
+            content_source: schema.object({
+              name: schema.string(),
+            }),
+          }),
+        }),
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/sources/${request.params.id}/settings`,
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgPreSourceRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/pre_sources/{id}',
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/pre_content_sources/${request.params.id}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgPrepareSourcesRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/sources/{service_type}/prepare',
+      validate: {
+        params: schema.object({
+          service_type: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/pre_content_sources/${request.params.service_type}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceOauthConfigurationsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/settings/connectors',
+      validate: false,
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/ws/org/settings/connectors',
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSourceOauthConfigurationRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      validate: {
+        params: schema.object({
+          service_type: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/settings/connectors/${request.params.service_type}`,
+      })(context, request, response);
+    }
+  );
+
+  router.post(
+    {
+      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      validate: {
+        params: schema.object({
+          service_type: schema.string(),
+        }),
+        body: oAuthConfigSchema,
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/settings/connectors/${request.params.service_type}`,
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+
+  router.put(
+    {
+      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      validate: {
+        params: schema.object({
+          service_type: schema.string(),
+        }),
+        body: oAuthConfigSchema,
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/settings/connectors/${request.params.service_type}`,
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+
+  router.delete(
+    {
+      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      validate: {
+        params: schema.object({
+          service_type: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: `/ws/org/settings/connectors/${request.params.service_type}`,
+      })(context, request, response);
+    }
+  );
+}
+
+export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
+  registerAccountSourceRoute(dependencies);
+  registerAccountCreateSourceRoute(dependencies);
+  registerAccountSourceDocumentsRoute(dependencies);
+  registerAccountSourceFederatedSummaryRoute(dependencies);
+  registerAccountSourceReauthPrepareRoute(dependencies);
+  registerAccountSourceSettingsRoute(dependencies);
+  registerAccountPreSourceRoute(dependencies);
+  registerAccountPrepareSourcesRoute(dependencies);
+  registerOrgSourceRoute(dependencies);
+  registerOrgCreateSourceRoute(dependencies);
+  registerOrgSourceDocumentsRoute(dependencies);
+  registerOrgSourceFederatedSummaryRoute(dependencies);
+  registerOrgSourceReauthPrepareRoute(dependencies);
+  registerOrgSourceSettingsRoute(dependencies);
+  registerOrgPreSourceRoute(dependencies);
+  registerOrgPrepareSourcesRoute(dependencies);
+  registerOrgSourceOauthConfigurationsRoute(dependencies);
+  registerOrgSourceOauthConfigurationRoute(dependencies);
+};


### PR DESCRIPTION
## Summary

This PR adds the server routes needed for the migration of `SourceLogic` from `ent-search`

NOTE: Not sure how those first 2 commits got in there but they basically cancel each other out 🤷 

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
