### PR TITLE
[App Search] Version documentation links

### DIFF
--- a/x-pack/plugins/enterprise_search/common/version.ts
+++ b/x-pack/plugins/enterprise_search/common/version.ts
@@ -8,4 +8,4 @@ import { SemVer } from 'semver';
 import pkg from '../../../../package.json';
 
 export const CURRENT_VERSION = new SemVer(pkg.version as string);
-export const CURRENT_MAJOR_VERSION = CURRENT_VERSION.major;
+export const CURRENT_MAJOR_VERSION = `${CURRENT_VERSION.major}.${CURRENT_VERSION.minor}`;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/constants.ts
@@ -5,6 +5,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { DOCS_PREFIX } from '../../routes';
 
 export const CREDENTIALS_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.credentials.title',
@@ -100,4 +101,4 @@ export const TOKEN_TYPE_INFO = [
 
 export const FLYOUT_ARIA_LABEL_ID = 'credentialsFlyoutTitle';
 
-export const DOCS_HREF = 'https://www.elastic.co/guide/en/app-search/current/authentication.html';
+export const DOCS_HREF = `${DOCS_PREFIX}/authentication.html`;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
@@ -10,6 +10,8 @@ import { i18n } from '@kbn/i18n';
 import { EuiLink, EuiSpacer, EuiSwitch, EuiText, EuiTextColor, EuiTitle } from '@elastic/eui';
 import { useActions, useValues } from 'kea';
 
+import { DOCS_PREFIX } from '../../../routes';
+
 import { LogRetentionLogic } from './log_retention_logic';
 import { AnalyticsLogRetentionMessage, ApiLogRetentionMessage } from './messaging';
 import { LogRetentionOptions } from './types';
@@ -41,10 +43,7 @@ export const LogRetentionPanel: React.FC = () => {
           {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.description', {
             defaultMessage: 'Manage the default write settings for API Logs and Analytics.',
           })}{' '}
-          <EuiLink
-            href="https://www.elastic.co/guide/en/app-search/current/logs.html"
-            target="_blank"
-          >
+          <EuiLink href={`${DOCS_PREFIX}/logs.html`} target="_blank">
             {i18n.translate('xpack.enterpriseSearch.appSearch.settings.logRetention.learnMore', {
               defaultMessage: 'Learn more about retention settings.',
             })}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
@@ -13,14 +13,15 @@ import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { DOCS_PREFIX } from '../../routes';
 import GettingStarted from './assets/getting_started.png';
 
 export const SetupGuide: React.FC = () => (
   <SetupGuideLayout
     productName={APP_SEARCH_PLUGIN.NAME}
     productEuiIcon="logoAppSearch"
-    standardAuthLink="https://www.elastic.co/guide/en/app-search/current/security-and-users.html#app-search-self-managed-security-and-user-management-standard"
-    elasticsearchNativeAuthLink="https://www.elastic.co/guide/en/app-search/current/security-and-users.html#app-search-self-managed-security-and-user-management-elasticsearch-native-realm"
+    standardAuthLink={`${DOCS_PREFIX}/security-and-users.html#app-search-self-managed-security-and-user-management-standard`}
+    elasticsearchNativeAuthLink={`${DOCS_PREFIX}/security-and-users.html#app-search-self-managed-security-and-user-management-elasticsearch-native-realm`}
   >
     <SetPageChrome
       trail={[

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -6,6 +6,10 @@
 
 import { generatePath } from 'react-router-dom';
 
+import { CURRENT_MAJOR_VERSION } from '../../../common/version';
+
+export const DOCS_PREFIX = `https://www.elastic.co/guide/en/app-search/${CURRENT_MAJOR_VERSION}`;
+
 export const ROOT_PATH = '/';
 export const SETUP_GUIDE_PATH = '/setup_guide';
 export const SETTINGS_PATH = '/settings/account';


### PR DESCRIPTION
## Summary

Adds a DRY version prefix to our outgoing App Search documentation URLs. I believe @chriscressman noted that we should be versioning our doc URLs going forward (instead of using `current`) so that older users land up on the correct docs and don't get dead links.

Workplace Search is [currently already doing this](https://github.com/elastic/kibana/blob/cf13fe2b7cfd2e967e1763a20f9a5f8cff7bd2d1/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts#L16), so we're just catching up/copying them 🐒 

## QA

- Go to http://localhost:5601/xyz/app/enterprise_search/app_search/settings/account
- [x] Confirm that the doc links now takes you to https://www.elastic.co/guide/en/app-search/8.0/logs.html
- [x] You should be able to swap out `8.0` in the URL for `7.9` or `7.10` and get a working doc page.