### PR TITLE
Fix advanced settings category sorting

### DIFF
--- a/src/plugins/advanced_settings/public/management_app/lib/get_category_name.ts
+++ b/src/plugins/advanced_settings/public/management_app/lib/get_category_name.ts
@@ -25,6 +25,12 @@ const names: Record<string, string> = {
   general: i18n.translate('advancedSettings.categoryNames.generalLabel', {
     defaultMessage: 'General',
   }),
+  machineLearning: i18n.translate('advancedSettings.categoryNames.machineLearningLabel', {
+    defaultMessage: 'Machine Learning',
+  }),
+  observability: i18n.translate('advancedSettings.categoryNames.observabilityLabel', {
+    defaultMessage: 'Observability',
+  }),
   timelion: i18n.translate('advancedSettings.categoryNames.timelionLabel', {
     defaultMessage: 'Timelion',
   }),

--- a/x-pack/plugins/apm/server/ui_settings.ts
+++ b/x-pack/plugins/apm/server/ui_settings.ts
@@ -17,7 +17,7 @@ import {
  */
 export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
   [enableCorrelations]: {
-    category: ['Observability'],
+    category: ['observability'],
     name: i18n.translate('xpack.apm.enableCorrelationsExperimentName', {
       defaultMessage: 'APM Correlations',
     }),
@@ -32,7 +32,7 @@ export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
     schema: schema.boolean(),
   },
   [enableServiceOverview]: {
-    category: ['Observability'],
+    category: ['observability'],
     name: i18n.translate('xpack.apm.enableServiceOverviewExperimentName', {
       defaultMessage: 'APM Service overview',
     }),

--- a/x-pack/plugins/ml/server/lib/register_settings.ts
+++ b/x-pack/plugins/ml/server/lib/register_settings.ts
@@ -27,7 +27,7 @@ export function registerKibanaSettings(coreSetup: CoreSetup) {
         defaultMessage:
           'Sets the file size limit when importing data in the File Data Visualizer. The highest supported value for this setting is 1GB.',
       }),
-      category: ['Machine Learning'],
+      category: ['machineLearning'],
       schema: schema.string(),
       validation: {
         regexString: '\\d+[mMgG][bB]',
@@ -49,7 +49,7 @@ export function registerKibanaSettings(coreSetup: CoreSetup) {
             'Use the default time filter in the Single Metric Viewer and Anomaly Explorer. If not enabled, the results for the full time range of the job are displayed.',
         }
       ),
-      category: ['Machine Learning'],
+      category: ['machineLearning'],
     },
     [ANOMALY_DETECTION_DEFAULT_TIME_RANGE]: {
       name: i18n.translate('xpack.ml.advancedSettings.anomalyDetectionDefaultTimeRangeName', {
@@ -69,7 +69,7 @@ export function registerKibanaSettings(coreSetup: CoreSetup) {
         to: schema.string(),
       }),
       requiresPageReload: true,
-      category: ['Machine Learning'],
+      category: ['machineLearning'],
     },
   });
 }


### PR DESCRIPTION
In the advanced settings categories, "Observability" and "Machine Learning" were using uppercase letters in their keys while everything else was using lowercase

This caused them both to show up before the rest of the options in the dropdown and in the sorting in the advanced settings UI.

Add keys for them to the get_category_name module in the advanced settings plugin and use those keys in the plugins that apply these categories.

This also makes it so i18n keys are available for these items.

Fixes #81974.
