### PR TITLE
[APM] Ensure APM jest script can run

### DIFF
--- a/x-pack/plugins/apm/jest.config.js
+++ b/x-pack/plugins/apm/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
   roots: [`${rootDir}/common`, `${rootDir}/public`, `${rootDir}/server`],
   collectCoverage: true,
   collectCoverageFrom: [
-    ...jestConfig.collectCoverageFrom,
+    ...(jestConfig.collectCoverageFrom ?? []),
     '**/*.{js,mjs,jsx,ts,tsx}',
     '!**/*.stories.{js,mjs,ts,tsx}',
     '!**/dev_docs/**',


### PR DESCRIPTION
APM Jest script was failing because a config property was seemingly removed. 