### PR TITLE
[Fleet] Rename usage collection object to 'fleet'.

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/config_collectors.ts
+++ b/x-pack/plugins/fleet/server/collectors/config_collectors.ts
@@ -6,6 +6,6 @@
 
 import { FleetConfigType } from '..';
 
-export const getIsFleetEnabled = (config: FleetConfigType) => {
+export const getIsAgentsEnabled = (config: FleetConfigType) => {
   return config.agents.enabled;
 };

--- a/x-pack/plugins/fleet/server/collectors/register.ts
+++ b/x-pack/plugins/fleet/server/collectors/register.ts
@@ -13,7 +13,7 @@ import { PackageUsage, getPackageUsage } from './package_collectors';
 import { FleetConfigType } from '..';
 
 interface Usage {
-  fleet_enabled: boolean;
+  agents_enabled: boolean;
   agents: AgentUsage;
   packages: PackageUsage[];
 }
@@ -36,13 +36,13 @@ export function registerIngestManagerUsageCollector(
     fetch: async () => {
       const soClient = await getInternalSavedObjectsClient(core);
       return {
-        fleet_enabled: getIsFleetEnabled(config),
+        agents_enabled: getIsFleetEnabled(config),
         agents: await getAgentUsage(soClient),
         packages: await getPackageUsage(soClient),
       };
     },
     schema: {
-      fleet_enabled: { type: 'boolean' },
+      agents_enabled: { type: 'boolean' },
       agents: {
         total: { type: 'long' },
         online: { type: 'long' },

--- a/x-pack/plugins/fleet/server/collectors/register.ts
+++ b/x-pack/plugins/fleet/server/collectors/register.ts
@@ -31,7 +31,7 @@ export function registerIngestManagerUsageCollector(
 
   // create usage collector
   const ingestManagerCollector = usageCollection.makeUsageCollector<Usage>({
-    type: 'ingest_manager',
+    type: 'fleet',
     isReady: () => true,
     fetch: async () => {
       const soClient = await getInternalSavedObjectsClient(core);

--- a/x-pack/plugins/fleet/server/collectors/register.ts
+++ b/x-pack/plugins/fleet/server/collectors/register.ts
@@ -6,7 +6,7 @@
 
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 import { CoreSetup } from 'kibana/server';
-import { getIsFleetEnabled } from './config_collectors';
+import { getIsAgentsEnabled } from './config_collectors';
 import { AgentUsage, getAgentUsage } from './agent_collectors';
 import { getInternalSavedObjectsClient } from './helpers';
 import { PackageUsage, getPackageUsage } from './package_collectors';
@@ -18,7 +18,7 @@ interface Usage {
   packages: PackageUsage[];
 }
 
-export function registerIngestManagerUsageCollector(
+export function registerFleetUsageCollector(
   core: CoreSetup,
   config: FleetConfigType,
   usageCollection: UsageCollectionSetup | undefined
@@ -30,13 +30,13 @@ export function registerIngestManagerUsageCollector(
   }
 
   // create usage collector
-  const ingestManagerCollector = usageCollection.makeUsageCollector<Usage>({
+  const fleetCollector = usageCollection.makeUsageCollector<Usage>({
     type: 'fleet',
     isReady: () => true,
     fetch: async () => {
       const soClient = await getInternalSavedObjectsClient(core);
       return {
-        agents_enabled: getIsFleetEnabled(config),
+        agents_enabled: getIsAgentsEnabled(config),
         agents: await getAgentUsage(soClient),
         packages: await getPackageUsage(soClient),
       };
@@ -61,5 +61,5 @@ export function registerIngestManagerUsageCollector(
   });
 
   // register usage collector
-  usageCollection.registerCollector(ingestManagerCollector);
+  usageCollection.registerCollector(fleetCollector);
 }

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -71,7 +71,7 @@ import {
 } from './services/agents';
 import { CloudSetup } from '../../cloud/server';
 import { agentCheckinState } from './services/agents/checkin/state';
-import { registerIngestManagerUsageCollector } from './collectors/register';
+import { registerFleetUsageCollector } from './collectors/register';
 import { getInstallation } from './services/epm/packages';
 
 export interface FleetSetupDeps {
@@ -216,7 +216,7 @@ export class FleetPlugin
     const config = await this.config$.pipe(first()).toPromise();
 
     // Register usage collection
-    registerIngestManagerUsageCollector(core, config, deps.usageCollection);
+    registerFleetUsageCollector(core, config, deps.usageCollection);
 
     // Always register app routes for permissions checking
     registerAppRoutes(router);

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -1780,7 +1780,7 @@
     },
     "fleet": {
       "properties": {
-        "fleet_enabled": {
+        "agents_enabled": {
           "type": "boolean"
         },
         "agents": {

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -1778,7 +1778,7 @@
         }
       }
     },
-    "ingest_manager": {
+    "fleet": {
       "properties": {
         "fleet_enabled": {
           "type": "boolean"


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/80118.

This changes the telemetry object to follow the recent renamings in the fleet plugin.
