### PR TITLE
[Lens] Create metric before bucket agg

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -188,7 +188,7 @@ describe('IndexPattern Data Source suggestions', () => {
         };
       }
 
-      it('should apply a bucketed aggregation for a string field', () => {
+      it('should apply a bucketed aggregation for a string field, using metric for sorting', () => {
         const suggestions = getDatasourceSuggestionsForField(stateWithoutLayer(), '1', {
           name: 'source',
           displayName: 'source',
@@ -202,14 +202,17 @@ describe('IndexPattern Data Source suggestions', () => {
             state: expect.objectContaining({
               layers: {
                 id1: expect.objectContaining({
-                  columnOrder: ['id2', 'id3'],
+                  columnOrder: ['id3', 'id2'],
                   columns: {
-                    id2: expect.objectContaining({
+                    id3: expect.objectContaining({
                       operationType: 'terms',
                       sourceField: 'source',
-                      params: expect.objectContaining({ size: 5 }),
+                      params: expect.objectContaining({
+                        size: 5,
+                        orderBy: { columnId: 'id2', type: 'column' },
+                      }),
                     }),
-                    id3: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -222,10 +225,10 @@ describe('IndexPattern Data Source suggestions', () => {
               isMultiRow: true,
               columns: [
                 expect.objectContaining({
-                  columnId: 'id2',
+                  columnId: 'id3',
                 }),
                 expect.objectContaining({
-                  columnId: 'id3',
+                  columnId: 'id2',
                 }),
               ],
               layerId: 'id1',
@@ -248,13 +251,13 @@ describe('IndexPattern Data Source suggestions', () => {
             state: expect.objectContaining({
               layers: {
                 id1: expect.objectContaining({
-                  columnOrder: ['id2', 'id3'],
+                  columnOrder: ['id3', 'id2'],
                   columns: {
-                    id2: expect.objectContaining({
+                    id3: expect.objectContaining({
                       operationType: 'date_histogram',
                       sourceField: 'timestamp',
                     }),
-                    id3: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -267,10 +270,10 @@ describe('IndexPattern Data Source suggestions', () => {
               isMultiRow: true,
               columns: [
                 expect.objectContaining({
-                  columnId: 'id2',
+                  columnId: 'id3',
                 }),
                 expect.objectContaining({
-                  columnId: 'id3',
+                  columnId: 'id2',
                 }),
               ],
               layerId: 'id1',
@@ -408,7 +411,7 @@ describe('IndexPattern Data Source suggestions', () => {
         };
       }
 
-      it('should apply a bucketed aggregation for a string field', () => {
+      it('should apply a bucketed aggregation for a string field, using metric for sorting', () => {
         const suggestions = getDatasourceSuggestionsForField(stateWithEmptyLayer(), '1', {
           name: 'source',
           displayName: 'source',
@@ -422,14 +425,17 @@ describe('IndexPattern Data Source suggestions', () => {
             state: expect.objectContaining({
               layers: {
                 previousLayer: expect.objectContaining({
-                  columnOrder: ['id1', 'id2'],
+                  columnOrder: ['id2', 'id1'],
                   columns: {
-                    id1: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'terms',
                       sourceField: 'source',
-                      params: expect.objectContaining({ size: 5 }),
+                      params: expect.objectContaining({
+                        size: 5,
+                        orderBy: { columnId: 'id1', type: 'column' },
+                      }),
                     }),
-                    id2: expect.objectContaining({
+                    id1: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -442,10 +448,10 @@ describe('IndexPattern Data Source suggestions', () => {
               isMultiRow: true,
               columns: [
                 expect.objectContaining({
-                  columnId: 'id1',
+                  columnId: 'id2',
                 }),
                 expect.objectContaining({
-                  columnId: 'id2',
+                  columnId: 'id1',
                 }),
               ],
               layerId: 'previousLayer',
@@ -468,13 +474,13 @@ describe('IndexPattern Data Source suggestions', () => {
             state: expect.objectContaining({
               layers: {
                 previousLayer: expect.objectContaining({
-                  columnOrder: ['id1', 'id2'],
+                  columnOrder: ['id2', 'id1'],
                   columns: {
-                    id1: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'date_histogram',
                       sourceField: 'timestamp',
                     }),
-                    id2: expect.objectContaining({
+                    id1: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -487,10 +493,10 @@ describe('IndexPattern Data Source suggestions', () => {
               isMultiRow: true,
               columns: [
                 expect.objectContaining({
-                  columnId: 'id1',
+                  columnId: 'id2',
                 }),
                 expect.objectContaining({
-                  columnId: 'id2',
+                  columnId: 'id1',
                 }),
               ],
               layerId: 'previousLayer',
@@ -1050,13 +1056,13 @@ describe('IndexPattern Data Source suggestions', () => {
               layers: {
                 previousLayer: initialState.layers.previousLayer,
                 currentLayer: expect.objectContaining({
-                  columnOrder: ['id1', 'id2'],
+                  columnOrder: ['id2', 'id1'],
                   columns: {
-                    id1: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'date_histogram',
                       sourceField: 'timestamp',
                     }),
-                    id2: expect.objectContaining({
+                    id1: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -1069,10 +1075,10 @@ describe('IndexPattern Data Source suggestions', () => {
               isMultiRow: true,
               columns: [
                 expect.objectContaining({
-                  columnId: 'id1',
+                  columnId: 'id2',
                 }),
                 expect.objectContaining({
-                  columnId: 'id2',
+                  columnId: 'id1',
                 }),
               ],
               layerId: 'currentLayer',
@@ -1097,13 +1103,13 @@ describe('IndexPattern Data Source suggestions', () => {
               layers: {
                 currentLayer: initialState.layers.currentLayer,
                 previousLayer: expect.objectContaining({
-                  columnOrder: ['id1', 'id2'],
+                  columnOrder: ['id2', 'id1'],
                   columns: {
-                    id1: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'date_histogram',
                       sourceField: 'timestamp',
                     }),
-                    id2: expect.objectContaining({
+                    id1: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -1146,14 +1152,14 @@ describe('IndexPattern Data Source suggestions', () => {
             state: expect.objectContaining({
               layers: {
                 id1: expect.objectContaining({
-                  columnOrder: ['id2', 'id3'],
+                  columnOrder: ['id3', 'id2'],
                   columns: {
-                    id2: expect.objectContaining({
+                    id3: expect.objectContaining({
                       operationType: 'terms',
                       sourceField: 'source',
                       params: expect.objectContaining({ size: 5 }),
                     }),
-                    id3: expect.objectContaining({
+                    id2: expect.objectContaining({
                       operationType: 'count',
                     }),
                   },
@@ -1166,10 +1172,10 @@ describe('IndexPattern Data Source suggestions', () => {
               isMultiRow: true,
               columns: [
                 expect.objectContaining({
-                  columnId: 'id2',
+                  columnId: 'id3',
                 }),
                 expect.objectContaining({
-                  columnId: 'id3',
+                  columnId: 'id2',
                 }),
               ],
               layerId: 'id1',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
@@ -289,16 +289,16 @@ function createNewLayerWithBucketAggregation(
   operation: OperationType
 ): IndexPatternLayer {
   return insertNewColumn({
-    op: 'count',
+    op: operation,
     layer: insertNewColumn({
-      op: operation,
+      op: 'count',
       layer: { indexPatternId: indexPattern.id, columns: {}, columnOrder: [] },
       columnId: generateId(),
-      field,
+      field: documentField,
       indexPattern,
     }),
     columnId: generateId(),
-    field: documentField,
+    field,
     indexPattern,
   });
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/83165

This PR flips around the order in which columns are created for the (bucket for field + count) suggestion. This gives the bucket operation the ability to use the metric for sorting (like the terms operation is doing)