### PR TITLE
[Timelion] Vertical cursor is not displayed across visualizations of a dashboard

### DIFF
--- a/src/plugins/vis_type_timelion/public/components/timelion_vis_component.tsx
+++ b/src/plugins/vis_type_timelion/public/components/timelion_vis_component.tsx
@@ -33,6 +33,8 @@ import {
   SERIES_ID_ATTR,
   colors,
   Axis,
+  ACTIVE_CURSOR,
+  eventBus,
 } from '../helpers/panel_utils';
 
 import { Series, Sheet } from '../helpers/timelion_request_handler';
@@ -338,16 +340,40 @@ function TimelionVisComponent({
     });
   }, [legendCaption, legendValueNumbers]);
 
-  const plotHoverHandler = useCallback(
-    (event: JQuery.TriggeredEvent, pos: Position) => {
-      if (!plot) {
-        return;
-      }
+  const plotHover = useCallback(
+    (pos: Position) => {
       (plot as CrosshairPlot).setCrosshair(pos);
       debouncedSetLegendNumbers(pos);
     },
     [plot, debouncedSetLegendNumbers]
   );
+
+  const plotHoverHandler = useCallback(
+    (event: JQuery.TriggeredEvent, pos: Position) => {
+      if (!plot) {
+        return;
+      }
+      plotHover(pos);
+      eventBus.trigger(ACTIVE_CURSOR, [event, pos]);
+    },
+    [plot, plotHover]
+  );
+
+  useEffect(() => {
+    const updateCursor = (_: any, event: JQuery.TriggeredEvent, pos: Position) => {
+      if (!plot) {
+        return;
+      }
+      plotHover(pos);
+    };
+
+    eventBus.on(ACTIVE_CURSOR, updateCursor);
+
+    return () => {
+      eventBus.off(ACTIVE_CURSOR, updateCursor);
+    };
+  }, [plot, plotHover]);
+
   const mouseLeaveHandler = useCallback(() => {
     if (!plot) {
       return;

--- a/src/plugins/vis_type_timelion/public/helpers/panel_utils.ts
+++ b/src/plugins/vis_type_timelion/public/helpers/panel_utils.ts
@@ -18,6 +18,7 @@
  */
 
 import { cloneDeep, defaults, mergeWith, compact } from 'lodash';
+import $ from 'jquery';
 import moment, { Moment } from 'moment-timezone';
 
 import { TimefilterContract } from 'src/plugins/data/public';
@@ -49,6 +50,9 @@ interface TimeRangeBounds {
   min: Moment | undefined;
   max: Moment | undefined;
 }
+
+export const ACTIVE_CURSOR = 'ACTIVE_CURSOR_TIMELION';
+export const eventBus = $({});
 
 const colors = [
   '#01A4A4',


### PR DESCRIPTION
Closes: #82250

## Summary

Added eventBus to trigger and listen plotHandler event so that we can set crosshair line in several instances of timelion.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
