### PR TITLE
[Security Solution] Give notice when endpoint policy is out of date

### DIFF
--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -69,7 +69,6 @@ export const config: PluginConfigDescriptor = {
 export type FleetConfigType = TypeOf<typeof config.schema>;
 
 export { PackagePolicyServiceInterface } from './services/package_policy';
-export { AgentPolicyServiceInterface } from './services/agent_policy';
 
 export const plugin = (initializerContext: PluginInitializerContext) => {
   return new FleetPlugin(initializerContext);

--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -6,7 +6,6 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginConfigDescriptor, PluginInitializerContext } from 'src/core/server';
 import { FleetPlugin } from './plugin';
-import { agentPolicyService } from './services';
 import {
   AGENT_POLICY_ROLLOUT_RATE_LIMIT_INTERVAL_MS,
   AGENT_POLICY_ROLLOUT_RATE_LIMIT_REQUEST_PER_INTERVAL,
@@ -14,9 +13,14 @@ import {
 } from '../common';
 
 export { default as apm } from 'elastic-apm-node';
-export { AgentService, ESIndexPatternService, getRegistryUrl, PackageService } from './services';
+export {
+  AgentService,
+  ESIndexPatternService,
+  getRegistryUrl,
+  PackageService,
+  AgentPolicyService,
+} from './services';
 export { FleetSetupContract, FleetSetupDeps, FleetStartContract, ExternalCallback } from './plugin';
-export type AgentPolicyService = typeof agentPolicyService;
 
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {
@@ -65,6 +69,7 @@ export const config: PluginConfigDescriptor = {
 export type FleetConfigType = TypeOf<typeof config.schema>;
 
 export { PackagePolicyServiceInterface } from './services/package_policy';
+export { AgentPolicyServiceInterface } from './services/agent_policy';
 
 export const plugin = (initializerContext: PluginInitializerContext) => {
   return new FleetPlugin(initializerContext);

--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -6,6 +6,7 @@
 import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginConfigDescriptor, PluginInitializerContext } from 'src/core/server';
 import { FleetPlugin } from './plugin';
+import { agentPolicyService } from './services';
 import {
   AGENT_POLICY_ROLLOUT_RATE_LIMIT_INTERVAL_MS,
   AGENT_POLICY_ROLLOUT_RATE_LIMIT_REQUEST_PER_INTERVAL,
@@ -15,6 +16,7 @@ import {
 export { default as apm } from 'elastic-apm-node';
 export { AgentService, ESIndexPatternService, getRegistryUrl, PackageService } from './services';
 export { FleetSetupContract, FleetSetupDeps, FleetStartContract, ExternalCallback } from './plugin';
+export type AgentPolicyService = typeof agentPolicyService;
 
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {

--- a/x-pack/plugins/fleet/server/index.ts
+++ b/x-pack/plugins/fleet/server/index.ts
@@ -18,7 +18,7 @@ export {
   ESIndexPatternService,
   getRegistryUrl,
   PackageService,
-  AgentPolicyService,
+  AgentPolicyServiceInterface,
 } from './services';
 export { FleetSetupContract, FleetSetupDeps, FleetStartContract, ExternalCallback } from './plugin';
 

--- a/x-pack/plugins/fleet/server/mocks.ts
+++ b/x-pack/plugins/fleet/server/mocks.ts
@@ -9,7 +9,7 @@ import { FleetAppContext } from './plugin';
 import { encryptedSavedObjectsMock } from '../../encrypted_saved_objects/server/mocks';
 import { securityMock } from '../../security/server/mocks';
 import { PackagePolicyServiceInterface } from './services/package_policy';
-import { AgentPolicyService, AgentService } from './services';
+import { AgentPolicyServiceInterface, AgentService } from './services';
 
 export const createAppContextStartContractMock = (): FleetAppContext => {
   return {
@@ -41,7 +41,7 @@ export const createPackagePolicyServiceMock = () => {
  * Create mock AgentPolicyService
  */
 
-export const createMockAgentPolicyService = (): jest.Mocked<AgentPolicyService> => {
+export const createMockAgentPolicyService = (): jest.Mocked<AgentPolicyServiceInterface> => {
   return {
     get: jest.fn(),
     list: jest.fn(),

--- a/x-pack/plugins/fleet/server/mocks.ts
+++ b/x-pack/plugins/fleet/server/mocks.ts
@@ -9,6 +9,7 @@ import { FleetAppContext } from './plugin';
 import { encryptedSavedObjectsMock } from '../../encrypted_saved_objects/server/mocks';
 import { securityMock } from '../../security/server/mocks';
 import { PackagePolicyServiceInterface } from './services/package_policy';
+import { AgentPolicyService, AgentService } from './services';
 
 export const createAppContextStartContractMock = (): FleetAppContext => {
   return {
@@ -34,4 +35,29 @@ export const createPackagePolicyServiceMock = () => {
     list: jest.fn(),
     update: jest.fn(),
   } as jest.Mocked<PackagePolicyServiceInterface>;
+};
+
+/**
+ * Create mock AgentPolicyService
+ */
+
+export const createMockAgentPolicyService = (): jest.Mocked<AgentPolicyService> => {
+  return {
+    get: jest.fn(),
+    list: jest.fn(),
+    getDefaultAgentPolicyId: jest.fn(),
+    getFullAgentPolicy: jest.fn(),
+  };
+};
+
+/**
+ * Creates a mock AgentService
+ */
+export const createMockAgentService = (): jest.Mocked<AgentService> => {
+  return {
+    getAgentStatusById: jest.fn(),
+    authenticateAgentWithAccessToken: jest.fn(),
+    getAgent: jest.fn(),
+    listAgents: jest.fn(),
+  };
 };

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -58,7 +58,7 @@ import {
   ESIndexPatternSavedObjectService,
   ESIndexPatternService,
   AgentService,
-  AgentPolicyService,
+  AgentPolicyServiceInterface,
   agentPolicyService,
   packagePolicyService,
   PackageService,
@@ -136,7 +136,7 @@ export interface FleetStartContract {
    * Services for Fleet's package policies
    */
   packagePolicyService: typeof packagePolicyService;
-  agentPolicyService: AgentPolicyService;
+  agentPolicyService: AgentPolicyServiceInterface;
   /**
    * Register callbacks for inclusion in fleet API processing
    * @param args
@@ -295,7 +295,12 @@ export class FleetPlugin
         getAgentStatusById,
         authenticateAgentWithAccessToken,
       },
-      agentPolicyService,
+      agentPolicyService: {
+        get: agentPolicyService.get,
+        list: agentPolicyService.list,
+        getDefaultAgentPolicyId: agentPolicyService.getDefaultAgentPolicyId,
+        getFullAgentPolicy: agentPolicyService.getFullAgentPolicy,
+      },
       packagePolicyService,
       registerExternalCallback: (...args: ExternalCallback) => {
         return appContextService.addExternalCallback(...args);

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -58,6 +58,7 @@ import {
   ESIndexPatternSavedObjectService,
   ESIndexPatternService,
   AgentService,
+  agentPolicyService,
   packagePolicyService,
   PackageService,
 } from './services';
@@ -134,6 +135,7 @@ export interface FleetStartContract {
    * Services for Fleet's package policies
    */
   packagePolicyService: typeof packagePolicyService;
+  agentPolicyService: typeof agentPolicyService;
   /**
    * Register callbacks for inclusion in fleet API processing
    * @param args
@@ -292,6 +294,7 @@ export class FleetPlugin
         getAgentStatusById,
         authenticateAgentWithAccessToken,
       },
+      agentPolicyService,
       packagePolicyService,
       registerExternalCallback: (...args: ExternalCallback) => {
         return appContextService.addExternalCallback(...args);

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -58,6 +58,7 @@ import {
   ESIndexPatternSavedObjectService,
   ESIndexPatternService,
   AgentService,
+  AgentPolicyService,
   agentPolicyService,
   packagePolicyService,
   PackageService,
@@ -135,7 +136,7 @@ export interface FleetStartContract {
    * Services for Fleet's package policies
    */
   packagePolicyService: typeof packagePolicyService;
-  agentPolicyService: typeof agentPolicyService;
+  agentPolicyService: AgentPolicyService;
   /**
    * Register callbacks for inclusion in fleet API processing
    * @param args

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -571,4 +571,3 @@ class AgentPolicyService {
 }
 
 export const agentPolicyService = new AgentPolicyService();
-export type AgentPolicyServiceInterface = AgentPolicyService;

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -571,3 +571,4 @@ class AgentPolicyService {
 }
 
 export const agentPolicyService = new AgentPolicyService();
+export type AgentPolicyServiceInterface = AgentPolicyService;

--- a/x-pack/plugins/fleet/server/services/index.ts
+++ b/x-pack/plugins/fleet/server/services/index.ts
@@ -5,9 +5,10 @@
  */
 
 import { SavedObjectsClientContract, KibanaRequest } from 'kibana/server';
-import { AgentStatus, Agent, EsAssetReference } from '../types';
+import { AgentStatus, Agent, EsAssetReference, AgentPolicy, ListWithKuery } from '../types';
 import * as settingsService from './settings';
 import { getAgent, listAgents } from './agents';
+import { FullAgentPolicy } from '../../common';
 export { ESIndexPatternSavedObjectService } from './es_index_pattern';
 
 export { getRegistryUrl } from './epm/registry/registry_url';
@@ -57,6 +58,26 @@ export interface AgentService {
    * List agents
    */
   listAgents: typeof listAgents;
+}
+
+export interface AgentPolicyService {
+  get(
+    soClient: SavedObjectsClientContract,
+    id: string,
+    withPackagePolicies?: boolean
+  ): Promise<AgentPolicy | null>;
+  list(
+    soClient: SavedObjectsClientContract,
+    options: ListWithKuery & {
+      withPackagePolicies?: boolean;
+    }
+  ): Promise<{ items: AgentPolicy[]; total: number; page: number; perPage: number }>;
+  getDefaultAgentPolicyId(soClient: SavedObjectsClientContract): Promise<string>;
+  getFullAgentPolicy(
+    soClient: SavedObjectsClientContract,
+    id: string,
+    options?: { standalone: boolean }
+  ): Promise<FullAgentPolicy | null>;
 }
 
 // Saved object services

--- a/x-pack/plugins/fleet/server/services/index.ts
+++ b/x-pack/plugins/fleet/server/services/index.ts
@@ -5,11 +5,11 @@
  */
 
 import { SavedObjectsClientContract, KibanaRequest } from 'kibana/server';
-import { AgentStatus, Agent, EsAssetReference, AgentPolicy, ListWithKuery } from '../types';
+import { AgentStatus, Agent, EsAssetReference } from '../types';
 import * as settingsService from './settings';
 import { getAgent, listAgents } from './agents';
-import { FullAgentPolicy } from '../../common';
 export { ESIndexPatternSavedObjectService } from './es_index_pattern';
+import { agentPolicyService } from './agent_policy';
 
 export { getRegistryUrl } from './epm/registry/registry_url';
 
@@ -60,24 +60,11 @@ export interface AgentService {
   listAgents: typeof listAgents;
 }
 
-export interface AgentPolicyService {
-  get(
-    soClient: SavedObjectsClientContract,
-    id: string,
-    withPackagePolicies?: boolean
-  ): Promise<AgentPolicy | null>;
-  list(
-    soClient: SavedObjectsClientContract,
-    options: ListWithKuery & {
-      withPackagePolicies?: boolean;
-    }
-  ): Promise<{ items: AgentPolicy[]; total: number; page: number; perPage: number }>;
-  getDefaultAgentPolicyId(soClient: SavedObjectsClientContract): Promise<string>;
-  getFullAgentPolicy(
-    soClient: SavedObjectsClientContract,
-    id: string,
-    options?: { standalone: boolean }
-  ): Promise<FullAgentPolicy | null>;
+export interface AgentPolicyServiceInterface {
+  get: typeof agentPolicyService['get'];
+  list: typeof agentPolicyService['list'];
+  getDefaultAgentPolicyId: typeof agentPolicyService['getDefaultAgentPolicyId'];
+  getFullAgentPolicy: typeof agentPolicyService['getFullAgentPolicy'];
 }
 
 // Saved object services

--- a/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/generate_data.ts
@@ -118,21 +118,29 @@ const APPLIED_POLICIES: Array<{
   name: string;
   id: string;
   status: HostPolicyResponseActionStatus;
+  endpoint_policy_version: number;
+  version: number;
 }> = [
   {
     name: 'Default',
     id: '00000000-0000-0000-0000-000000000000',
     status: HostPolicyResponseActionStatus.success,
+    endpoint_policy_version: 1,
+    version: 3,
   },
   {
     name: 'With Eventing',
     id: 'C2A9093E-E289-4C0A-AA44-8C32A414FA7A',
     status: HostPolicyResponseActionStatus.success,
+    endpoint_policy_version: 3,
+    version: 5,
   },
   {
     name: 'Detect Malware Only',
     id: '47d7965d-6869-478b-bd9c-fb0d2bb3959f',
     status: HostPolicyResponseActionStatus.success,
+    endpoint_policy_version: 4,
+    version: 9,
   },
 ];
 
@@ -251,6 +259,8 @@ interface HostInfo {
         id: string;
         status: HostPolicyResponseActionStatus;
         name: string;
+        endpoint_policy_version: number;
+        version: number;
       };
     };
   };
@@ -1332,7 +1342,7 @@ export class EndpointDocGenerator {
     allStatus?: HostPolicyResponseActionStatus;
     policyDataStream?: DataStream;
   } = {}): HostPolicyResponse {
-    const policyVersion = this.seededUUIDv4();
+    const policyVersion = this.randomN(10);
     const status = () => {
       return allStatus || this.randomHostPolicyResponseActionStatus();
     };
@@ -1501,6 +1511,8 @@ export class EndpointDocGenerator {
             status: this.commonInfo.Endpoint.policy.applied.status,
             version: policyVersion,
             name: this.commonInfo.Endpoint.policy.applied.name,
+            endpoint_policy_version: this.commonInfo.Endpoint.policy.applied
+              .endpoint_policy_version,
           },
         },
       },

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -523,6 +523,13 @@ export enum MetadataQueryStrategyVersions {
 export type HostInfo = Immutable<{
   metadata: HostMetadata;
   host_status: HostStatus;
+  policy_versions: {
+    agent: {
+      configured: number; // current agentPolicy version
+      applied: number; // policy that the agent is currently reporting
+    };
+    endpoint: number; // current intended 'endpoint' package policy
+  };
   /* the version of the query strategy */
   query_strategy_version: MetadataQueryStrategyVersions;
 }>;
@@ -558,6 +565,7 @@ export type HostMetadata = Immutable<{
         id: string;
         status: HostPolicyResponseActionStatus;
         name: string;
+        version: number;
       };
     };
   };

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -532,10 +532,19 @@ export type HostInfo = Immutable<{
   host_status: HostStatus;
   policy_info?: {
     agent: {
-      configured: PolicyInfo; // as set in kibana
-      applied: PolicyInfo; // last reported running in agent (may lag behind configured)
+      /**
+       * As set in Kibana
+       */
+      configured: PolicyInfo;
+      /**
+       * Last reported running in agent (may lag behind configured)
+       */
+      applied: PolicyInfo;
     };
-    endpoint: PolicyInfo; // current intended 'endpoint' package policy
+    /**
+     * Current intended 'endpoint' package policy
+     */
+    endpoint: PolicyInfo;
   };
   /* the version of the query strategy */
   query_strategy_version: MetadataQueryStrategyVersions;

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -299,6 +299,8 @@ export interface HostResultList {
   request_page_index: number;
   /* the version of the query strategy */
   query_strategy_version: MetadataQueryStrategyVersions;
+  /* policy IDs and versions */
+  policy_info?: HostInfo['policy_info'];
 }
 
 /**

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -520,15 +520,20 @@ export enum MetadataQueryStrategyVersions {
   VERSION_2 = 'v2',
 }
 
+export type PolicyInfo = Immutable<{
+  revision: number;
+  id: string;
+}>;
+
 export type HostInfo = Immutable<{
   metadata: HostMetadata;
   host_status: HostStatus;
-  policy_versions?: {
+  policy_info?: {
     agent: {
-      configured: number; // current agentPolicy version
-      applied: number; // policy that the agent is currently reporting
+      configured: PolicyInfo; // as set in kibana
+      applied: PolicyInfo; // last reported running in agent (may lag behind configured)
     };
-    endpoint: number; // current intended 'endpoint' package policy
+    endpoint: PolicyInfo; // current intended 'endpoint' package policy
   };
   /* the version of the query strategy */
   query_strategy_version: MetadataQueryStrategyVersions;

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -565,6 +565,7 @@ export type HostMetadata = Immutable<{
         id: string;
         status: HostPolicyResponseActionStatus;
         name: string;
+        endpoint_policy_version: number;
         version: number;
       };
     };

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -523,7 +523,7 @@ export enum MetadataQueryStrategyVersions {
 export type HostInfo = Immutable<{
   metadata: HostMetadata;
   host_status: HostStatus;
-  policy_versions: {
+  policy_versions?: {
     agent: {
       configured: number; // current agentPolicy version
       applied: number; // policy that the agent is currently reporting
@@ -1077,7 +1077,8 @@ export interface HostPolicyResponse {
   Endpoint: {
     policy: {
       applied: {
-        version: string;
+        version: number;
+        endpoint_policy_version: number;
         id: string;
         name: string;
         status: HostPolicyResponseActionStatus;

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/index.test.ts
@@ -63,6 +63,7 @@ describe('EndpointList store concerns', () => {
         agentsWithEndpointsTotalError: undefined,
         endpointsTotalError: undefined,
         queryStrategyVersion: undefined,
+        policyVersionInfo: undefined,
       });
     });
 

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/reducer.ts
@@ -41,6 +41,7 @@ export const initialEndpointListState: Immutable<EndpointState> = {
   endpointsTotal: 0,
   endpointsTotalError: undefined,
   queryStrategyVersion: undefined,
+  policyVersionInfo: undefined,
 };
 
 /* eslint-disable-next-line complexity */
@@ -55,6 +56,7 @@ export const endpointListReducer: ImmutableReducer<EndpointState, AppAction> = (
       request_page_size: pageSize,
       request_page_index: pageIndex,
       query_strategy_version: queryStrategyVersion,
+      policy_info: policyVersionInfo,
     } = action.payload;
     return {
       ...state,
@@ -63,6 +65,7 @@ export const endpointListReducer: ImmutableReducer<EndpointState, AppAction> = (
       pageSize,
       pageIndex,
       queryStrategyVersion,
+      policyVersionInfo,
       loading: false,
       error: undefined,
     };
@@ -104,6 +107,7 @@ export const endpointListReducer: ImmutableReducer<EndpointState, AppAction> = (
     return {
       ...state,
       details: action.payload.metadata,
+      policyVersionInfo: action.payload.policy_info,
       detailsLoading: false,
       detailsError: undefined,
     };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/selectors.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/store/selectors.ts
@@ -55,6 +55,8 @@ export const isAutoRefreshEnabled = (state: Immutable<EndpointState>) => state.i
 
 export const autoRefreshInterval = (state: Immutable<EndpointState>) => state.autoRefreshInterval;
 
+export const policyVersionInfo = (state: Immutable<EndpointState>) => state.policyVersionInfo;
+
 export const areEndpointsEnrolling = (state: Immutable<EndpointState>) => {
   return state.agentsWithEndpointsTotal > state.endpointsTotal;
 };

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/types.ts
@@ -76,6 +76,8 @@ export interface EndpointState {
   endpointsTotalError?: ServerApiError;
   /** The query strategy version that informs whether the transform for KQL is enabled or not */
   queryStrategyVersion?: MetadataQueryStrategyVersions;
+  /** The policy IDs and revision number of the corresponding agent, and endpoint. May be more recent than what's running */
+  policyVersionInfo?: HostInfo['policy_info'];
 }
 
 /**

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/utils.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/utils.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { HostInfo, HostMetadata } from '../../../../common/endpoint/types';
+
+export const isPolicyOutOfDate = (
+  reported: HostMetadata['Endpoint']['policy']['applied'],
+  current: HostInfo['policy_info']
+): boolean => {
+  if (current === undefined || current === null) {
+    return false; // we don't know, can't declare it out-of-date
+  }
+  return !(
+    reported.id === current.endpoint.id && // endpoint package policy not reassigned
+    current.agent.configured.id === current.agent.applied.id && // agent policy wasn't reassigned and not-yet-applied
+    // all revisions match up
+    reported.version >= current.agent.applied.revision &&
+    reported.version >= current.agent.configured.revision &&
+    reported.endpoint_policy_version >= current.endpoint.revision
+  );
+};

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/out_of_date.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/out_of_date.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { EuiText, EuiIcon } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+export const OutOfDate = React.memo<{ style?: React.CSSProperties }>(({ style, ...otherProps }) => {
+  return (
+    <EuiText color="subdued" size="xs" className="eui-textNoWrap" style={style} {...otherProps}>
+      <EuiIcon size="m" type="alert" color="warning" />
+      <FormattedMessage id="xpack.securitySolution.outOfDateLabel" defaultMessage="Out-of-date" />
+    </EuiText>
+  );
+});
+
+OutOfDate.displayName = 'OutOfDate';

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_details.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/endpoint_details.tsx
@@ -18,6 +18,7 @@ import {
 import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
+import { isPolicyOutOfDate } from '../../utils';
 import { HostInfo, HostMetadata } from '../../../../../../common/endpoint/types';
 import { useEndpointSelector, useAgentDetailsIngestUrl } from '../hooks';
 import { useNavigateToAppEventHandler } from '../../../../../common/hooks/endpoint/use_navigate_to_app_event_handler';
@@ -31,6 +32,7 @@ import { SecurityPageName } from '../../../../../app/types';
 import { useFormatUrl } from '../../../../../common/components/link_to';
 import { AgentDetailsReassignPolicyAction } from '../../../../../../../fleet/public';
 import { EndpointPolicyLink } from '../components/endpoint_policy_link';
+import { OutOfDate } from '../components/out_of_date';
 
 const HostIds = styled(EuiListGroupItem)`
   margin-top: 0;
@@ -136,6 +138,7 @@ export const EndpointDetails = memo(
               >
                 {details.Endpoint.policy.applied.name}
               </EndpointPolicyLink>
+              {isPolicyOutOfDate(details.Endpoint.policy.applied, policyInfo) && <OutOfDate />}
             </>
           ),
         },
@@ -144,43 +147,25 @@ export const EndpointDetails = memo(
             defaultMessage: 'Policy Response',
           }),
           description: (
-            <>
-              <EuiHealth
-                color={POLICY_STATUS_TO_HEALTH_COLOR[policyStatus] || 'subdued'}
-                data-test-subj="policyStatusHealth"
+            <EuiHealth
+              color={POLICY_STATUS_TO_HEALTH_COLOR[policyStatus] || 'subdued'}
+              data-test-subj="policyStatusHealth"
+            >
+              {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
+              <EuiLink
+                data-test-subj="policyStatusValue"
+                href={policyResponseUri}
+                onClick={policyStatusClickHandler}
               >
-                {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
-                <EuiLink
-                  data-test-subj="policyStatusValue"
-                  href={policyResponseUri}
-                  onClick={policyStatusClickHandler}
-                >
-                  <EuiText size="m">
-                    <FormattedMessage
-                      id="xpack.securitySolution.endpoint.details.policyStatusValue"
-                      defaultMessage="{policyStatus, select, success {Success} warning {Warning} failure {Failed} other {Unknown}}"
-                      values={{ policyStatus }}
-                    />
-                  </EuiText>
-                </EuiLink>
-              </EuiHealth>
-              {policyInfo &&
-                ((details.Endpoint.policy.applied.id === policyInfo.endpoint.id && // package policy wasn't changed
-                  policyInfo.agent.configured.id === policyInfo.agent.applied.id && // agent policy wasn't changed
-                  // all revisions match up
-                  details.Endpoint.policy.applied.version >= policyInfo.agent.applied.revision &&
-                  details.Endpoint.policy.applied.version >= policyInfo.agent.configured.revision &&
-                  details.Endpoint.policy.applied.endpoint_policy_version >=
-                    policyInfo.endpoint.revision) || (
-                  <EuiText color="subdued" size="xs" className="eui-textNoWrap">
-                    <EuiIcon size="m" type="alert" color="warning" />
-                    <FormattedMessage
-                      id="xpack.securitySolution.endpoint.details.outOfDateLabel"
-                      defaultMessage="Out-of-date"
-                    />
-                  </EuiText>
-                ))}
-            </>
+                <EuiText size="m">
+                  <FormattedMessage
+                    id="xpack.securitySolution.endpoint.details.policyStatusValue"
+                    defaultMessage="{policyStatus, select, success {Success} warning {Warning} failure {Failed} other {Unknown}}"
+                    values={{ policyStatus }}
+                  />
+                </EuiText>
+              </EuiLink>
+            </EuiHealth>
           ),
         },
       ];

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/index.tsx
@@ -33,6 +33,7 @@ import {
   policyResponseError,
   policyResponseLoading,
   policyResponseTimestamp,
+  policyVersionInfo,
 } from '../../store/selectors';
 import { EndpointDetails } from './endpoint_details';
 import { PolicyResponse } from './policy_response';
@@ -53,6 +54,7 @@ export const EndpointDetailsFlyout = memo(() => {
     ...queryParamsWithoutSelectedEndpoint
   } = queryParams;
   const details = useEndpointSelector(detailsData);
+  const policyInfo = useEndpointSelector(policyVersionInfo);
   const loading = useEndpointSelector(detailsLoading);
   const error = useEndpointSelector(detailsError);
   const show = useEndpointSelector(showView);
@@ -101,7 +103,7 @@ export const EndpointDetailsFlyout = memo(() => {
           {show === 'details' && (
             <>
               <EuiFlyoutBody data-test-subj="endpointDetailsFlyoutBody">
-                <EndpointDetails details={details} />
+                <EndpointDetails details={details} policyInfo={policyInfo} />
               </EuiFlyoutBody>
             </>
           )}

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -372,7 +372,12 @@ export const EndpointList = () => {
                   policy.version >= item.policy_info.agent.configured.revision &&
                   policy.endpoint_policy_version >= item.policy_info.endpoint.revision) || (
                   <EuiFlexItem grow={false}>
-                    <EuiText color="subdued" size="xs" className="eui-textNoWrap">
+                    <EuiText
+                      color="subdued"
+                      size="xs"
+                      className="eui-textNoWrap"
+                      data-test-subj="rowPolicyOutOfDate"
+                    >
                       <EuiIcon size="m" type="alert" color="warning" />
                       <FormattedMessage
                         id="xpack.securitySolution.endpoint.list.outOfDateLabel"

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -364,19 +364,20 @@ export const EndpointList = () => {
                   dataTestSubj="policyStatusCellLink"
                 />
               </EuiHealth>
-              {(policy.version < item.policy_versions.agent.applied ||
-                policy.version < item.policy_versions.agent.configured ||
-                policy.endpoint_policy_version < item.policy_versions.endpoint) && (
-                <EuiFlexItem grow={false}>
-                  <EuiText color="subdued" size="xs" className="eui-textNoWrap">
-                    <EuiIcon size="m" type="alert" color="warning" />
-                    <FormattedMessage
-                      id="xpack.securitySolution.endpoint.list.outOfDateLabel"
-                      defaultMessage="Out-of-date"
-                    />
-                  </EuiText>
-                </EuiFlexItem>
-              )}
+              {item.policy_versions &&
+                (policy.version < item.policy_versions.agent.applied ||
+                  policy.version < item.policy_versions.agent.configured ||
+                  policy.endpoint_policy_version < item.policy_versions.endpoint) && (
+                  <EuiFlexItem grow={false}>
+                    <EuiText color="subdued" size="xs" className="eui-textNoWrap">
+                      <EuiIcon size="m" type="alert" color="warning" />
+                      <FormattedMessage
+                        id="xpack.securitySolution.endpoint.list.outOfDateLabel"
+                        defaultMessage="Out-of-date"
+                      />
+                    </EuiText>
+                  </EuiFlexItem>
+                )}
             </>
           );
         },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -364,10 +364,13 @@ export const EndpointList = () => {
                   dataTestSubj="policyStatusCellLink"
                 />
               </EuiHealth>
-              {item.policy_versions &&
-                (policy.version < item.policy_versions.agent.applied ||
-                  policy.version < item.policy_versions.agent.configured ||
-                  policy.endpoint_policy_version < item.policy_versions.endpoint) && (
+              {item.policy_info &&
+                ((policy.id === item.policy_info.endpoint.id && // package policy wasn't changed
+                  item.policy_info.agent.configured.id === item.policy_info.agent.applied.id && // agent policy wasn't changed
+                  // all revisions match up
+                  policy.version >= item.policy_info.agent.applied.revision &&
+                  policy.version >= item.policy_info.agent.configured.revision &&
+                  policy.endpoint_policy_version >= item.policy_info.endpoint.revision) || (
                   <EuiFlexItem grow={false}>
                     <EuiText color="subdued" size="xs" className="eui-textNoWrap">
                       <EuiIcon size="m" type="alert" color="warning" />
@@ -377,7 +380,7 @@ export const EndpointList = () => {
                       />
                     </EuiText>
                   </EuiFlexItem>
-                )}
+                ))}
             </>
           );
         },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -364,16 +364,14 @@ export const EndpointList = () => {
                   dataTestSubj="policyStatusCellLink"
                 />
               </EuiHealth>
-              {(item.metadata.Endpoint.policy.applied.version <
-                item.policy_versions.agent.applied ||
-                item.metadata.Endpoint.policy.applied.version <
-                  item.policy_versions.agent.configured ||
-                item.metadata.Endpoint.policy.applied.version < item.policy_versions.endpoint) && (
+              {(policy.version < item.policy_versions.agent.applied ||
+                policy.version < item.policy_versions.agent.configured ||
+                policy.endpoint_policy_version < item.policy_versions.endpoint) && (
                 <EuiFlexItem grow={false}>
                   <EuiText color="subdued" size="xs" className="eui-textNoWrap">
                     <EuiIcon size="m" type="alert" color="warning" />
                     <FormattedMessage
-                      id="xpack.fleet.securitySolution.endpoint.list.outOfDateLabel"
+                      id="xpack.securitySolution.endpoint.list.outOfDateLabel"
                       defaultMessage="Out-of-date"
                     />
                   </EuiText>

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -16,6 +16,7 @@ import {
   EuiSelectableProps,
   EuiSuperDatePicker,
   EuiSpacer,
+  EuiIcon,
   EuiPopover,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -350,18 +351,35 @@ export const EndpointList = () => {
           });
           const toRouteUrl = formatUrl(toRoutePath);
           return (
-            <EuiHealth
-              color={POLICY_STATUS_TO_HEALTH_COLOR[policy.status]}
-              className="eui-textTruncate"
-              data-test-subj="rowPolicyStatus"
-            >
-              <EndpointListNavLink
-                name={POLICY_STATUS_TO_TEXT[policy.status]}
-                href={toRouteUrl}
-                route={toRoutePath}
-                dataTestSubj="policyStatusCellLink"
-              />
-            </EuiHealth>
+            <>
+              <EuiHealth
+                color={POLICY_STATUS_TO_HEALTH_COLOR[policy.status]}
+                className="eui-textTruncate"
+                data-test-subj="rowPolicyStatus"
+              >
+                <EndpointListNavLink
+                  name={POLICY_STATUS_TO_TEXT[policy.status]}
+                  href={toRouteUrl}
+                  route={toRoutePath}
+                  dataTestSubj="policyStatusCellLink"
+                />
+              </EuiHealth>
+              {(item.metadata.Endpoint.policy.applied.version <
+                item.policy_versions.agent.applied ||
+                item.metadata.Endpoint.policy.applied.version <
+                  item.policy_versions.agent.configured ||
+                item.metadata.Endpoint.policy.applied.version < item.policy_versions.endpoint) && (
+                <EuiFlexItem grow={false}>
+                  <EuiText color="subdued" size="xs" className="eui-textNoWrap">
+                    <EuiIcon size="m" type="alert" color="warning" />
+                    <FormattedMessage
+                      id="xpack.fleet.securitySolution.endpoint.list.outOfDateLabel"
+                      defaultMessage="Out-of-date"
+                    />
+                  </EuiText>
+                </EuiFlexItem>
+              )}
+            </>
           );
         },
       },

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.tsx
@@ -371,20 +371,18 @@ export const EndpointList = () => {
                   policy.version >= item.policy_info.agent.applied.revision &&
                   policy.version >= item.policy_info.agent.configured.revision &&
                   policy.endpoint_policy_version >= item.policy_info.endpoint.revision) || (
-                  <EuiFlexItem grow={false}>
-                    <EuiText
-                      color="subdued"
-                      size="xs"
-                      className="eui-textNoWrap"
-                      data-test-subj="rowPolicyOutOfDate"
-                    >
-                      <EuiIcon size="m" type="alert" color="warning" />
-                      <FormattedMessage
-                        id="xpack.securitySolution.endpoint.list.outOfDateLabel"
-                        defaultMessage="Out-of-date"
-                      />
-                    </EuiText>
-                  </EuiFlexItem>
+                  <EuiText
+                    color="subdued"
+                    size="xs"
+                    className="eui-textNoWrap"
+                    data-test-subj="rowPolicyOutOfDate"
+                  >
+                    <EuiIcon size="m" type="alert" color="warning" />
+                    <FormattedMessage
+                      id="xpack.securitySolution.endpoint.list.outOfDateLabel"
+                      defaultMessage="Out-of-date"
+                    />
+                  </EuiText>
                 ))}
             </>
           );

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -14,6 +14,7 @@ import {
   AgentService,
   FleetStartContract,
   PackageService,
+  AgentPolicyService,
   PackagePolicyServiceInterface,
 } from '../../../fleet/server';
 import { PluginStartContract as AlertsPluginStartContract } from '../../../alerts/server';
@@ -71,7 +72,10 @@ export const createMetadataService = (packageService: PackageService): MetadataS
 };
 
 export type EndpointAppContextServiceStartContract = Partial<
-  Pick<FleetStartContract, 'agentService' | 'packageService' | 'packagePolicyService'>
+  Pick<
+  FleetStartContract,
+    'agentService' | 'packageService' | 'packagePolicyService' | 'agentPolicyService'
+  >
 > & {
   logger: Logger;
   manifestManager?: ManifestManager;
@@ -91,12 +95,14 @@ export class EndpointAppContextService {
   private agentService: AgentService | undefined;
   private manifestManager: ManifestManager | undefined;
   private packagePolicyService: PackagePolicyServiceInterface | undefined;
+  private agentPolicyService: AgentPolicyService | undefined;
   private savedObjectsStart: SavedObjectsServiceStart | undefined;
   private metadataService: MetadataService | undefined;
 
   public start(dependencies: EndpointAppContextServiceStartContract) {
     this.agentService = dependencies.agentService;
     this.packagePolicyService = dependencies.packagePolicyService;
+    this.agentPolicyService = dependencies.agentPolicyService;
     this.manifestManager = dependencies.manifestManager;
     this.savedObjectsStart = dependencies.savedObjectsStart;
     this.metadataService = createMetadataService(dependencies.packageService!);
@@ -124,6 +130,10 @@ export class EndpointAppContextService {
 
   public getPackagePolicyService(): PackagePolicyServiceInterface | undefined {
     return this.packagePolicyService;
+  }
+
+  public getAgentPolicyService(): AgentPolicyService | undefined {
+    return this.agentPolicyService;
   }
 
   public getMetadataService(): MetadataService | undefined {

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -14,7 +14,7 @@ import {
   AgentService,
   FleetStartContract,
   PackageService,
-  AgentPolicyService,
+  AgentPolicyServiceInterface,
   PackagePolicyServiceInterface,
 } from '../../../fleet/server';
 import { PluginStartContract as AlertsPluginStartContract } from '../../../alerts/server';
@@ -95,7 +95,7 @@ export class EndpointAppContextService {
   private agentService: AgentService | undefined;
   private manifestManager: ManifestManager | undefined;
   private packagePolicyService: PackagePolicyServiceInterface | undefined;
-  private agentPolicyService: AgentPolicyService | undefined;
+  private agentPolicyService: AgentPolicyServiceInterface | undefined;
   private savedObjectsStart: SavedObjectsServiceStart | undefined;
   private metadataService: MetadataService | undefined;
 
@@ -132,7 +132,7 @@ export class EndpointAppContextService {
     return this.packagePolicyService;
   }
 
-  public getAgentPolicyService(): AgentPolicyService | undefined {
+  public getAgentPolicyService(): AgentPolicyServiceInterface | undefined {
     return this.agentPolicyService;
   }
 

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -73,7 +73,7 @@ export const createMetadataService = (packageService: PackageService): MetadataS
 
 export type EndpointAppContextServiceStartContract = Partial<
   Pick<
-  FleetStartContract,
+    FleetStartContract,
     'agentService' | 'packageService' | 'packagePolicyService' | 'agentPolicyService'
   >
 > & {

--- a/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -10,7 +10,12 @@ import {
   SavedObjectsClientContract,
 } from 'src/core/server';
 import { SecurityPluginSetup } from '../../../security/server';
-import { AgentService, FleetStartContract, PackageService } from '../../../fleet/server';
+import {
+  AgentService,
+  FleetStartContract,
+  PackageService,
+  PackagePolicyServiceInterface,
+} from '../../../fleet/server';
 import { PluginStartContract as AlertsPluginStartContract } from '../../../alerts/server';
 import { getPackagePolicyCreateCallback } from './ingest_integration';
 import { ManifestManager } from './services/artifacts';
@@ -66,7 +71,7 @@ export const createMetadataService = (packageService: PackageService): MetadataS
 };
 
 export type EndpointAppContextServiceStartContract = Partial<
-  Pick<FleetStartContract, 'agentService' | 'packageService'>
+  Pick<FleetStartContract, 'agentService' | 'packageService' | 'packagePolicyService'>
 > & {
   logger: Logger;
   manifestManager?: ManifestManager;
@@ -85,11 +90,13 @@ export type EndpointAppContextServiceStartContract = Partial<
 export class EndpointAppContextService {
   private agentService: AgentService | undefined;
   private manifestManager: ManifestManager | undefined;
+  private packagePolicyService: PackagePolicyServiceInterface | undefined;
   private savedObjectsStart: SavedObjectsServiceStart | undefined;
   private metadataService: MetadataService | undefined;
 
   public start(dependencies: EndpointAppContextServiceStartContract) {
     this.agentService = dependencies.agentService;
+    this.packagePolicyService = dependencies.packagePolicyService;
     this.manifestManager = dependencies.manifestManager;
     this.savedObjectsStart = dependencies.savedObjectsStart;
     this.metadataService = createMetadataService(dependencies.packageService!);
@@ -113,6 +120,10 @@ export class EndpointAppContextService {
 
   public getAgentService(): AgentService | undefined {
     return this.agentService;
+  }
+
+  public getPackagePolicyService(): PackagePolicyServiceInterface | undefined {
+    return this.packagePolicyService;
   }
 
   public getMetadataService(): MetadataService | undefined {

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -14,6 +14,7 @@ import {
   FleetStartContract,
   ExternalCallback,
   PackageService,
+  AgentPolicyService,
 } from '../../../fleet/server';
 import { createPackagePolicyServiceMock } from '../../../fleet/server/mocks';
 import { AppClientFactory } from '../client';
@@ -91,6 +92,19 @@ export const createMockPackageService = (): jest.Mocked<PackageService> => {
 };
 
 /**
+ * Create mock AgentPolicyService
+ */
+
+export const createMockAgentPolicyService = (): jest.Mocked<AgentPolicyService> => {
+  return {
+    get: jest.fn(),
+    list: jest.fn(),
+    getDefaultAgentPolicyId: jest.fn(),
+    getFullAgentPolicy: jest.fn(),
+  };
+};
+
+/**
  * Creates a mock AgentService
  */
 export const createMockAgentService = (): jest.Mocked<AgentService> => {
@@ -116,6 +130,7 @@ export const createMockFleetStartContract = (indexPattern: string): FleetStartCo
     },
     agentService: createMockAgentService(),
     packageService: createMockPackageService(),
+    agentPolicyService: createMockAgentPolicyService(),
     registerExternalCallback: jest.fn((...args: ExternalCallback) => {}),
     packagePolicyService: createPackagePolicyServiceMock(),
   };

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -26,6 +26,7 @@ import {
 import { ManifestManager } from './services/artifacts/manifest_manager/manifest_manager';
 import { getManifestManagerMock } from './services/artifacts/manifest_manager/manifest_manager.mock';
 import { EndpointAppContext } from './types';
+import { MetadataRequestContext } from './routes/metadata/handlers';
 
 /**
  * Creates a mocked EndpointAppContext.
@@ -50,6 +51,7 @@ export const createMockEndpointAppContextService = (
     start: jest.fn(),
     stop: jest.fn(),
     getAgentService: jest.fn(),
+    getAgentPolicyService: jest.fn(),
     getManifestManager: jest.fn().mockReturnValue(mockManifestManager ?? jest.fn()),
     getScopedSavedObjectsClient: jest.fn(),
   } as unknown) as jest.Mocked<EndpointAppContextService>;
@@ -133,6 +135,14 @@ export const createMockFleetStartContract = (indexPattern: string): FleetStartCo
     agentPolicyService: createMockAgentPolicyService(),
     registerExternalCallback: jest.fn((...args: ExternalCallback) => {}),
     packagePolicyService: createPackagePolicyServiceMock(),
+  };
+};
+
+export const createMockMetadataRequestContext = (): jest.Mocked<MetadataRequestContext> => {
+  return {
+    endpointAppContextService: createMockEndpointAppContextService(),
+    logger: loggingSystemMock.create().get('mock_endpoint_app_context'),
+    requestHandlerContext: xpackMocks.createRequestHandlerContext(),
   };
 };
 

--- a/x-pack/plugins/security_solution/server/endpoint/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/mocks.ts
@@ -9,14 +9,12 @@ import { loggingSystemMock, savedObjectsServiceMock } from 'src/core/server/mock
 import { securityMock } from '../../../security/server/mocks';
 import { alertsMock } from '../../../alerts/server/mocks';
 import { xpackMocks } from '../../../../mocks';
+import { FleetStartContract, ExternalCallback, PackageService } from '../../../fleet/server';
 import {
-  AgentService,
-  FleetStartContract,
-  ExternalCallback,
-  PackageService,
-  AgentPolicyService,
-} from '../../../fleet/server';
-import { createPackagePolicyServiceMock } from '../../../fleet/server/mocks';
+  createPackagePolicyServiceMock,
+  createMockAgentPolicyService,
+  createMockAgentService,
+} from '../../../fleet/server/mocks';
 import { AppClientFactory } from '../client';
 import { createMockConfig } from '../lib/detection_engine/routes/__mocks__';
 import {
@@ -90,31 +88,6 @@ export const createMockEndpointAppContextServiceStartContract = (): jest.Mocked<
 export const createMockPackageService = (): jest.Mocked<PackageService> => {
   return {
     getInstalledEsAssetReferences: jest.fn(),
-  };
-};
-
-/**
- * Create mock AgentPolicyService
- */
-
-export const createMockAgentPolicyService = (): jest.Mocked<AgentPolicyService> => {
-  return {
-    get: jest.fn(),
-    list: jest.fn(),
-    getDefaultAgentPolicyId: jest.fn(),
-    getFullAgentPolicy: jest.fn(),
-  };
-};
-
-/**
- * Creates a mock AgentService
- */
-export const createMockAgentService = (): jest.Mocked<AgentService> => {
-  return {
-    getAgentStatusById: jest.fn(),
-    authenticateAgentWithAccessToken: jest.fn(),
-    getAgent: jest.fn(),
-    listAgents: jest.fn(),
   };
 };
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/enrichment.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/enrichment.test.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { HostStatus, MetadataQueryStrategyVersions } from '../../../../common/endpoint/types';
+import { createMockMetadataRequestContext } from '../../mocks';
+import { EndpointDocGenerator } from '../../../../common/endpoint/generate_data';
+import { enrichHostMetadata, MetadataRequestContext } from './handlers';
+
+describe('test document enrichment', () => {
+  let metaReqCtx: jest.Mocked<MetadataRequestContext>;
+  const docGen = new EndpointDocGenerator();
+
+  beforeEach(() => {
+    metaReqCtx = createMockMetadataRequestContext();
+  });
+
+  // verify query version passed through
+  describe('metadata query strategy enrichment', () => {
+    it('should match v1 strategy when directed', async () => {
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_1
+      );
+      expect(enrichedHostList.query_strategy_version).toEqual(
+        MetadataQueryStrategyVersions.VERSION_1
+      );
+    });
+    it('should match v2 strategy when directed', async () => {
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.query_strategy_version).toEqual(
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+    });
+  });
+
+  describe('host status enrichment', () => {
+    let statusFn: jest.Mock;
+
+    beforeEach(() => {
+      statusFn = jest.fn();
+      (metaReqCtx.endpointAppContextService.getAgentService as jest.Mock).mockImplementation(() => {
+        return {
+          getAgentStatusById: statusFn,
+        };
+      });
+    });
+
+    it('should return host online for online agent', async () => {
+      statusFn.mockImplementation(() => 'online');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.ONLINE);
+    });
+
+    it('should return host offline for offline agent', async () => {
+      statusFn.mockImplementation(() => 'offline');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.OFFLINE);
+    });
+
+    it('should return host unenrolling for unenrolling agent', async () => {
+      statusFn.mockImplementation(() => 'unenrolling');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.UNENROLLING);
+    });
+
+    it('should return host error for degraded agent', async () => {
+      statusFn.mockImplementation(() => 'degraded');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.ERROR);
+    });
+
+    it('should return host error for erroring agent', async () => {
+      statusFn.mockImplementation(() => 'error');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.ERROR);
+    });
+
+    it('should return host error for warning agent', async () => {
+      statusFn.mockImplementation(() => 'warning');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.ERROR);
+    });
+
+    it('should return host error for invalid agent', async () => {
+      statusFn.mockImplementation(() => 'asliduasofb');
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.host_status).toEqual(HostStatus.ERROR);
+    });
+  });
+
+  describe('policy info enrichment', () => {
+    let agentMock: jest.Mock;
+    let agentPolicyMock: jest.Mock;
+
+    beforeEach(() => {
+      agentMock = jest.fn();
+      agentPolicyMock = jest.fn();
+      (metaReqCtx.endpointAppContextService.getAgentService as jest.Mock).mockImplementation(() => {
+        return {
+          getAgent: agentMock,
+          getAgentStatusById: jest.fn(),
+        };
+      });
+      (metaReqCtx.endpointAppContextService.getAgentPolicyService as jest.Mock).mockImplementation(
+        () => {
+          return {
+            get: agentPolicyMock,
+          };
+        }
+      );
+    });
+
+    it('reflects current applied agent info', async () => {
+      const policyID = 'abc123';
+      const policyRev = 9;
+      agentMock.mockImplementation(() => {
+        return {
+          policy_id: policyID,
+          policy_revision: policyRev,
+        };
+      });
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.policy_info).toBeDefined();
+      expect(enrichedHostList.policy_info!.agent.applied.id).toEqual(policyID);
+      expect(enrichedHostList.policy_info!.agent.applied.revision).toEqual(policyRev);
+    });
+
+    it('reflects current fleet agent info', async () => {
+      const policyID = 'xyz456';
+      const policyRev = 15;
+      agentPolicyMock.mockImplementation(() => {
+        return {
+          id: policyID,
+          revision: policyRev,
+        };
+      });
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.policy_info).toBeDefined();
+      expect(enrichedHostList.policy_info!.agent.configured.id).toEqual(policyID);
+      expect(enrichedHostList.policy_info!.agent.configured.revision).toEqual(policyRev);
+    });
+
+    it('reflects current endpoint policy info', async () => {
+      const policyID = 'endpoint-b33f';
+      const policyRev = 2;
+      agentPolicyMock.mockImplementation(() => {
+        return {
+          package_policies: [
+            {
+              package: { name: 'endpoint' },
+              id: policyID,
+              revision: policyRev,
+            },
+          ],
+        };
+      });
+
+      const enrichedHostList = await enrichHostMetadata(
+        docGen.generateHostMetadata(),
+        metaReqCtx,
+        MetadataQueryStrategyVersions.VERSION_2
+      );
+      expect(enrichedHostList.policy_info).toBeDefined();
+      expect(enrichedHostList.policy_info!.endpoint.id).toEqual(policyID);
+      expect(enrichedHostList.policy_info!.endpoint.revision).toEqual(policyRev);
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -282,9 +282,31 @@ async function enrichHostMetadata(
       throw e;
     }
   }
+
+  let policyVersions: HostInfo['policy_versions'];
+  try {
+    const agent = await metadataRequestContext.endpointAppContextService
+      ?.getAgentService()
+      ?.getAgent(
+        metadataRequestContext.requestHandlerContext.core.savedObjects.client,
+        elasticAgentId
+      );
+    policyVersions = {
+      agent: {
+        applied: agent?.policy_revision!,
+        configured: 0,
+      },
+      endpoint: 0,
+    };
+  } catch (e) {
+    log.error(e);
+    throw e;
+  }
+
   return {
     metadata: hostMetadata,
     host_status: hostStatus,
+    policy_versions: policyVersions,
     query_strategy_version: metadataQueryStrategyVersion,
   };
 }

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -291,12 +291,18 @@ async function enrichHostMetadata(
         metadataRequestContext.requestHandlerContext.core.savedObjects.client,
         elasticAgentId
       );
+    const endpointPolicy = await metadataRequestContext.endpointAppContextService
+      .getPackagePolicyService()
+      ?.get(
+        metadataRequestContext.requestHandlerContext.core.savedObjects.client,
+        hostMetadata.Endpoint.policy.applied.id
+      );
     policyVersions = {
       agent: {
-        applied: agent?.policy_revision!,
+        applied: agent?.policy_revision || 0,
         configured: 0,
       },
-      endpoint: 0,
+      endpoint: endpointPolicy?.revision || 0,
     };
   } catch (e) {
     log.error(e);

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -245,7 +245,7 @@ export async function mapToHostResultList(
   }
 }
 
-async function enrichHostMetadata(
+export async function enrichHostMetadata(
   hostMetadata: HostMetadata,
   metadataRequestContext: MetadataRequestContext,
   metadataQueryStrategyVersion: MetadataQueryStrategyVersions
@@ -298,7 +298,7 @@ async function enrichHostMetadata(
         agent?.policy_id!,
         true
       );
-    const endpointPolicy = (agentPolicy?.package_policies as PackagePolicy[]).find(
+    const endpointPolicy = ((agentPolicy?.package_policies || []) as PackagePolicy[]).find(
       (x: PackagePolicy) => x.package?.name === 'endpoint'
     );
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -299,7 +299,7 @@ export async function enrichHostMetadata(
         true
       );
     const endpointPolicy = ((agentPolicy?.package_policies || []) as PackagePolicy[]).find(
-      (x: PackagePolicy) => x.package?.name === 'endpoint'
+      (policy: PackagePolicy) => policy.package?.name === 'endpoint'
     );
 
     policyInfo = {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -283,13 +283,7 @@ async function enrichHostMetadata(
     }
   }
 
-  let policyVersions: HostInfo['policy_versions'] = {
-    agent: {
-      applied: 0,
-      configured: 0,
-    },
-    endpoint: 0,
-  };
+  let policyVersions: HostInfo['policy_versions'];
   try {
     const [agent, endpointPolicy] = await Promise.all([
       metadataRequestContext.endpointAppContextService

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/agent_status.test.ts
@@ -8,7 +8,7 @@ import { SavedObjectsClientContract } from 'kibana/server';
 import { findAgentIDsByStatus } from './agent_status';
 import { savedObjectsClientMock } from '../../../../../../../../src/core/server/mocks';
 import { AgentService } from '../../../../../../fleet/server/services';
-import { createMockAgentService } from '../../../mocks';
+import { createMockAgentService } from '../../../../../../fleet/server/mocks';
 import { Agent } from '../../../../../../fleet/common/types/models';
 import { AgentStatusKueryHelper } from '../../../../../../fleet/common/services';
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/unenroll.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/support/unenroll.test.ts
@@ -8,7 +8,7 @@ import { SavedObjectsClientContract } from 'kibana/server';
 import { findAllUnenrolledAgentIds } from './unenroll';
 import { savedObjectsClientMock } from '../../../../../../../../src/core/server/mocks';
 import { AgentService } from '../../../../../../fleet/server/services';
-import { createMockAgentService } from '../../../mocks';
+import { createMockAgentService } from '../../../../../../fleet/server/mocks';
 import { Agent } from '../../../../../../fleet/common/types/models';
 
 describe('test find all unenrolled Agent id', () => {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/policy/handlers.test.ts
@@ -5,10 +5,10 @@
  */
 import { EndpointAppContextService } from '../../endpoint_app_context_services';
 import {
-  createMockAgentService,
   createMockEndpointAppContextServiceStartContract,
   createRouteHandlerContext,
 } from '../../mocks';
+import { createMockAgentService } from '../../../../../fleet/server/mocks';
 import { getHostPolicyResponseHandler, getAgentPolicySummaryHandler } from './handlers';
 import {
   ILegacyScopedClusterClient,

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -348,6 +348,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       agentService: plugins.fleet?.agentService,
       packageService: plugins.fleet?.packageService,
       packagePolicyService: plugins.fleet?.packagePolicyService,
+      agentPolicyService: plugins.fleet?.agentPolicyService,
       appClientFactory: this.appClientFactory,
       security: this.setupPlugins!.security!,
       alerts: plugins.alerts,

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -347,6 +347,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     this.endpointAppContextService.start({
       agentService: plugins.fleet?.agentService,
       packageService: plugins.fleet?.packageService,
+      packagePolicyService: plugins.fleet?.packagePolicyService,
       appClientFactory: this.appClientFactory,
       security: this.setupPlugins!.security!,
       alerts: plugins.alerts,


### PR DESCRIPTION
## Summary

Give a visual indicator that an endpoint's current policy is out-of-date, and expecting to be updated.

![2020-11-19-142011_scrot](https://user-images.githubusercontent.com/315796/99713482-5c69ad80-2a72-11eb-8248-6b4497b8e20e.png)
![2020-11-19-142022_scrot](https://user-images.githubusercontent.com/315796/99713487-5f649e00-2a72-11eb-81f1-23c34ca455a8.png)


changes to API response:

```json
{
    "hosts": [
        {
            "host_status": "offline",
            "metadata": {
                 ... 
            },
            "policy_info": {
                "agent": {
                    "applied": {
                        "id": "632f4680-25d0-11eb-95f2-4d677aabe46b",
                        "revision": 5
                    },
                    "configured": {
                        "id": "632f4680-25d0-11eb-95f2-4d677aabe46b",
                        "revision": 5
                    }
                },
                "endpoint": {
                    "id": "77fcc567-fe1b-4e20-8add-045a41ab0e5d",
                    "revision": 1
                }
            },
            "query_strategy_version": "v2"
        }
    ],
    "query_strategy_version": "v2",
    "request_page_index": 0,
    "request_page_size": 10,
    "total": 1
}
```

the `policy_info` key, being enriched for each endpoint record


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
