### PR TITLE
[Workplace Search] Enable check for org context based on URL

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -19,6 +19,7 @@ describe('AppLogic', () => {
     account: {},
     hasInitialized: false,
     isFederatedAuth: true,
+    isOrganization: false,
     organization: {},
   };
 
@@ -34,6 +35,7 @@ describe('AppLogic', () => {
     },
     hasInitialized: true,
     isFederatedAuth: false,
+    isOrganization: false,
     organization: {
       defaultOrgName: 'My Organization',
       name: 'ACME Donuts',
@@ -59,6 +61,14 @@ describe('AppLogic', () => {
         hasInitialized: true,
         isFederatedAuth: false,
       });
+    });
+  });
+
+  describe('setContext()', () => {
+    it('sets context', () => {
+      AppLogic.actions.setContext(true);
+
+      expect(AppLogic.values.isOrganization).toEqual(true);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -16,9 +16,11 @@ import {
 interface AppValues extends WorkplaceSearchInitialData {
   hasInitialized: boolean;
   isFederatedAuth: boolean;
+  isOrganization: boolean;
 }
 interface AppActions {
   initializeAppData(props: InitialAppData): InitialAppData;
+  setContext(isOrganization: boolean): boolean;
 }
 
 const emptyOrg = {} as Organization;
@@ -31,6 +33,7 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       workplaceSearch,
       isFederatedAuth,
     }),
+    setContext: (isOrganization) => isOrganization,
   },
   reducers: {
     hasInitialized: [
@@ -43,6 +46,12 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       true,
       {
         initializeAppData: (_, { isFederatedAuth }) => !!isFederatedAuth,
+      },
+    ],
+    isOrganization: [
+      false,
+      {
+        setContext: (_, isOrganization) => isOrganization,
       },
     ],
     organization: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -46,9 +46,12 @@ describe('WorkplaceSearchUnconfigured', () => {
 });
 
 describe('WorkplaceSearchConfigured', () => {
+  const initializeAppData = jest.fn();
+  const setContext = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
-    setMockActions({ initializeAppData: () => {} });
+    setMockActions({ initializeAppData, setContext });
   });
 
   it('renders layout and header actions', () => {
@@ -60,17 +63,12 @@ describe('WorkplaceSearchConfigured', () => {
   });
 
   it('initializes app data with passed props', () => {
-    const initializeAppData = jest.fn();
-    setMockActions({ initializeAppData });
-
     shallow(<WorkplaceSearchConfigured isFederatedAuth={true} />);
 
     expect(initializeAppData).toHaveBeenCalledWith({ isFederatedAuth: true });
   });
 
   it('does not re-initialize app data or re-render header actions', () => {
-    const initializeAppData = jest.fn();
-    setMockActions({ initializeAppData });
     setMockValues({ hasInitialized: true });
 
     shallow(<WorkplaceSearchConfigured />);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -31,7 +31,7 @@ export const WorkplaceSearch: React.FC<InitialAppData> = (props) => {
 
 export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
   const { hasInitialized } = useValues(AppLogic);
-  const { initializeAppData } = useActions(AppLogic);
+  const { initializeAppData, setContext } = useActions(AppLogic);
   const { renderHeaderActions } = useValues(KibanaLogic);
   const { errorConnecting, readOnlyMode } = useValues(HttpLogic);
 
@@ -52,6 +52,10 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
       renderHeaderActions(WorkplaceSearchHeaderActions);
     }
   }, [hasInitialized]);
+
+  useEffect(() => {
+    setContext(isOrganization);
+  }, [isOrganization]);
 
   return (
     <Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { Route, Redirect, Switch } from 'react-router-dom';
+import { Route, Redirect, Switch, useLocation } from 'react-router-dom';
 import { useActions, useValues } from 'kea';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../common/constants';
@@ -34,6 +34,17 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
   const { initializeAppData } = useActions(AppLogic);
   const { renderHeaderActions } = useValues(KibanaLogic);
   const { errorConnecting, readOnlyMode } = useValues(HttpLogic);
+
+  const { pathname } = useLocation();
+
+  /**
+   * Personal dashboard urls begin with /p/
+   * EX: http://localhost:5601/app/enterprise_search/workplace_search/p/sources
+   */
+  const personalSourceUrlRegex = /^\/p\//g; // matches '/p/*'
+
+  // TODO: Once auth is figured out, we need to have a check for the equivilent of `isAdmin`.
+  const isOrganization = !pathname.match(personalSourceUrlRegex);
 
   useEffect(() => {
     if (!hasInitialized) {


### PR DESCRIPTION
## Summary

As a part of the Workplace Search migration to Kibana, we have to know in the Sources logic files whether the user is in an org context or in the personal dashboard. In the legacy ent-search app, we prefixed all organization routes with `/org`. It was decided that in Kibana, we'd switch the URL structure to have the prefix on non-org routes and use the `/p` prefix.

**Before**
Organization: http://localhost:3002/ws#/org/sources
Personal: http://localhost:3002/ws#/sources

**After**
Organization: http://localhost:5601/app/enterprise_search/workplace_search/sources
Personal: http://localhost:5601/app/enterprise_search/workplace_search/p/sources

[Equivalent logic in ent-search](https://github.com/elastic/ent-search/blob/master/app/javascript/workplace_search/App/App.tsx#L41-L56)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
