### PR TITLE
[Workplace Search] Migrate SourceLogic from ent-search

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -10,6 +10,8 @@ import { CURRENT_MAJOR_VERSION } from '../../../common/version';
 
 export const SETUP_GUIDE_PATH = '/setup_guide';
 
+export const NOT_FOUND_PATH = '/404';
+
 export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -8,6 +8,17 @@ export * from '../../../common/types/workplace_search';
 
 export type SpacerSizeTypes = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 
+export interface MetaPage {
+  current: number;
+  size: number;
+  total_pages: number;
+  total_results: number;
+}
+
+export interface Meta {
+  page: MetaPage;
+}
+
 export interface Group {
   id: string;
   name: string;
@@ -89,6 +100,30 @@ export interface ContentSourceDetails extends ContentSource {
   boost: number;
 }
 
+interface DescriptionList {
+  title: string;
+  description: string;
+}
+
+export interface ContentSourceFullData extends ContentSourceDetails {
+  activities: object[];
+  details: DescriptionList[];
+  summary: object[];
+  groups: object[];
+  custom: boolean;
+  accessToken: string;
+  key: string;
+  urlField: string;
+  titleField: string;
+  licenseSupportsPermissions: boolean;
+  serviceTypeSupportsPermissions: boolean;
+  indexPermissions: boolean;
+  hasPermissions: boolean;
+  urlFieldIsLinkable: boolean;
+  createdAt: string;
+  serviceName: string;
+}
+
 export interface ContentSourceStatus {
   id: string;
   name: string;
@@ -120,4 +155,11 @@ export enum FeatureIds {
   Private = 'Private',
   GlobalAccessPermissions = 'GlobalAccessPermissions',
   DocumentLevelPermissions = 'DocumentLevelPermissions',
+}
+
+export interface CustomSource {
+  accessToken: string;
+  key: string;
+  name: string;
+  id: string;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -163,3 +163,9 @@ export interface CustomSource {
   name: string;
   id: string;
 }
+
+export type AnyType = string | number | boolean | object | undefined | null;
+
+export interface GenericObject {
+  [key: string]: AnyType | AnyType[];
+}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -163,9 +163,3 @@ export interface CustomSource {
   name: string;
   id: string;
 }
-
-export type AnyType = string | number | boolean | object | undefined | null;
-
-export interface GenericObject {
-  [key: string]: AnyType | AnyType[];
-}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -21,7 +21,7 @@ import {
 import { DEFAULT_META } from '../../../shared/constants';
 import { AppLogic } from '../../app_logic';
 import { NOT_FOUND_PATH } from '../../routes';
-import { ContentSourceFullData, CustomSource, Meta, GenericObject } from '../../types';
+import { ContentSourceFullData, CustomSource, Meta } from '../../types';
 
 export interface SourceActions {
   onInitializeSource(contentSource: ContentSourceFullData): ContentSourceFullData;
@@ -97,6 +97,10 @@ interface SourceConnectData {
   serviceType: string;
 }
 
+interface OrganizationsMap {
+  [key: string]: string | boolean;
+}
+
 interface SourceValues {
   contentSource: ContentSourceFullData;
   dataLoading: boolean;
@@ -118,7 +122,7 @@ interface SourceValues {
   newCustomSource: CustomSource;
   currentServiceType: string;
   githubOrganizations: string[];
-  selectedGithubOrganizationsMap: GenericObject;
+  selectedGithubOrganizationsMap: OrganizationsMap;
   selectedGithubOrganizations: string[];
 }
 
@@ -344,9 +348,9 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
       },
     ],
     selectedGithubOrganizationsMap: [
-      {} as GenericObject,
+      {} as OrganizationsMap,
       {
-        setSelectedGithubOrganizations: (state: GenericObject, option) => ({
+        setSelectedGithubOrganizations: (state, option) => ({
           ...state,
           ...{ [option]: !state[option] },
         }),
@@ -561,7 +565,9 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         password: passwordValue || undefined,
         organizations: githubOrganizations.length > 0 ? githubOrganizations : undefined,
         indexPermissions: indexPermissionsValue || undefined,
-      } as GenericObject;
+      } as {
+        [key: string]: string | string[] | undefined;
+      };
 
       // Remove undefined values from params
       Object.keys(params).forEach((key) => params[key] === undefined && delete params[key]);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -12,13 +12,13 @@ import http from 'shared/http';
 import routes from 'workplace_search/routes';
 
 import { handleAPIError } from 'app_search/utils/handleAPIError';
-import { DEFAULT_META } from 'shared/constants/defaultMeta';
-import { IMeta, IFlashMessagesProps } from 'shared/types';
-import { AppLogic } from 'workplace_search/App/AppLogic';
-import { NOT_FOUND_PATH } from 'workplace_search/utils/routePaths';
-import { IObject, ContentSourceFullData, CustomSource } from 'workplace_search/types';
+import { IFlashMessagesProps } from 'shared/types';
+import { DEFAULT_META } from '../../../shared/constants';
+import { AppLogic } from '../../app_logic';
+import { NOT_FOUND_PATH } from '../../routes';
+import { ContentSourceFullData, CustomSource, Meta } from '../../types';
 
-import { SourcesLogic } from './SourcesLogic';
+import { SourcesLogic } from './sources_logic';
 
 export interface SourceActions {
   onInitializeSource(contentSource: ContentSourceFullData): ContentSourceFullData;
@@ -28,7 +28,7 @@ export interface SourceActions {
   setFlashMessages(flashMessages: IFlashMessagesProps): { flashMessages: IFlashMessagesProps };
   setSearchResults(searchResultsResponse: SearchResultsResponse): SearchResultsResponse;
   initializeFederatedSummary(sourceId: string): { sourceId: string };
-  onUpdateSummary(summary: IObject[]): IObject[];
+  onUpdateSummary(summary: object[]): object[];
   setContentFilterValue(contentFilterValue: string): string;
   setActivePage(activePage: number): number;
   setClientIdValue(clientIdValue: string): string;
@@ -61,7 +61,7 @@ export interface SourceActions {
     isUpdating: boolean,
     successCallback?: () => void
   ): { isUpdating: boolean; successCallback?() };
-  initializeSource(sourceId: string, history: IObject): { sourceId: string; history: IObject };
+  initializeSource(sourceId: string, history: object): { sourceId: string; history: object };
   getSourceConfigData(serviceType: string): { serviceType: string };
   getSourceConnectData(
     serviceType: string,
@@ -100,8 +100,8 @@ interface SourceValues {
   dataLoading: boolean;
   sectionLoading: boolean;
   buttonLoading: boolean;
-  contentItems: IObject[];
-  contentMeta: IMeta;
+  contentItems: object[];
+  contentMeta: Meta;
   contentFilterValue: string;
   customSourceNameValue: string;
   clientIdValue: string;
@@ -116,13 +116,13 @@ interface SourceValues {
   newCustomSource: CustomSource;
   currentServiceType: string;
   githubOrganizations: string[];
-  selectedGithubOrganizationsMap: IObject;
-  selectedGithubOrganizations: IObject;
+  selectedGithubOrganizationsMap: object;
+  selectedGithubOrganizations: object;
 }
 
 interface SearchResultsResponse {
-  results: IObject[];
-  meta: IMeta;
+  results: object[];
+  meta: Meta;
 }
 
 interface PreContentSourceResponse {
@@ -137,7 +137,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
     onUpdateSourceName: (name: string) => name,
     setSourceConfigData: (sourceConfigData: SourceConfigData) => sourceConfigData,
     setSourceConnectData: (sourceConnectData: SourceConnectData) => sourceConnectData,
-    onUpdateSummary: (summary: IObject[]) => summary,
+    onUpdateSummary: (summary: object[]) => summary,
     setFlashMessages: (flashMessages: IFlashMessagesProps) => ({ flashMessages }),
     setSearchResults: (searchResultsResponse: SearchResultsResponse) => searchResultsResponse,
     setContentFilterValue: (contentFilterValue: string) => contentFilterValue,
@@ -153,7 +153,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
     setCustomSourceData: (data: CustomSource) => data,
     setPreContentSourceConfigData: (data: PreContentSourceResponse) => data,
     setSelectedGithubOrganizations: (option: string) => option,
-    initializeSource: (sourceId: string, history: IObject) => ({ sourceId, history }),
+    initializeSource: (sourceId: string, history: object) => ({ sourceId, history }),
     initializeFederatedSummary: (sourceId: string) => ({ sourceId }),
     searchContentSourceDocuments: (sourceId: string) => ({ sourceId }),
     updateContentSource: (sourceId: string, source: { name: string }) => ({ sourceId, source }),
@@ -571,7 +571,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
   }),
 });
 
-const setPage = (state: IMeta, page: number) => ({
+const setPage = (state: Meta, page: number) => ({
   ...state,
   page: {
     ...state.page,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -455,6 +455,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         successCallback();
       } catch (e) {
         flashAPIErrors(e);
+      } finally {
         actions.setButtonNotLoading();
       }
     },
@@ -487,6 +488,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         successCallback(response.oauthUrl);
       } catch (e) {
         flashAPIErrors(e);
+      } finally {
         actions.setButtonNotLoading();
       }
     },
@@ -560,8 +562,9 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         if (successCallback) successCallback();
       } catch (e) {
         flashAPIErrors(e);
-        actions.setButtonNotLoading();
         if (!isUpdating) throw new Error(e);
+      } finally {
+        actions.setButtonNotLoading();
       }
     },
     createContentSource: async ({ serviceType, successCallback, errorCallback }) => {
@@ -599,9 +602,10 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         successCallback();
       } catch (e) {
         flashAPIErrors(e);
-        actions.setButtonNotLoading();
         if (errorCallback) errorCallback();
         throw new Error('Auth Error');
+      } finally {
+        actions.setButtonNotLoading();
       }
     },
     onUpdateSourceName: (name: string) => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -21,7 +21,7 @@ import {
 import { DEFAULT_META } from '../../../shared/constants';
 import { AppLogic } from '../../app_logic';
 import { NOT_FOUND_PATH } from '../../routes';
-import { ContentSourceFullData, CustomSource, Meta } from '../../types';
+import { ContentSourceFullData, CustomSource, Meta, GenericObject } from '../../types';
 
 export interface SourceActions {
   onInitializeSource(contentSource: ContentSourceFullData): ContentSourceFullData;
@@ -118,8 +118,7 @@ interface SourceValues {
   newCustomSource: CustomSource;
   currentServiceType: string;
   githubOrganizations: string[];
-  selectedGithubOrganizationsMap: object;
-  selectedGithubOrganizations: object;
+  selectedGithubOrganizationsMap: GenericObject;
   selectedGithubOrganizations: string[];
 }
 
@@ -345,13 +344,13 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
       },
     ],
     selectedGithubOrganizationsMap: [
-      {},
+      {} as GenericObject,
       {
-        setSelectedGithubOrganizations: (state, option) => ({
+        setSelectedGithubOrganizations: (state: GenericObject, option) => ({
           ...state,
           ...{ [option]: !state[option] },
         }),
-        resetSourceState: () => [],
+        resetSourceState: () => ({}),
       },
     ],
   },
@@ -562,7 +561,7 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         password: passwordValue || undefined,
         organizations: githubOrganizations.length > 0 ? githubOrganizations : undefined,
         indexPermissions: indexPermissionsValue || undefined,
-      };
+      } as GenericObject;
 
       // Remove undefined values from params
       Object.keys(params).forEach((key) => params[key] === undefined && delete params[key]);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -139,9 +139,6 @@ interface PreContentSourceResponse {
   githubOrganizations: string[];
 }
 
-const ACCOUNT_CREATE_SOURCE_ROUTE = '/api/workplace_search/account/create_source';
-const ORG_CREATE_SOURCE_ROUTE = '/api/workplace_search/org/create_source';
-
 export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
   actions: {
     onInitializeSource: (contentSource: ContentSourceFullData) => contentSource,
@@ -570,7 +567,9 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
     createContentSource: async ({ serviceType, successCallback, errorCallback }) => {
       FlashMessagesLogic.actions.clearFlashMessages();
       const { isOrganization } = AppLogic.values;
-      const route = isOrganization ? ORG_CREATE_SOURCE_ROUTE : ACCOUNT_CREATE_SOURCE_ROUTE;
+      const route = isOrganization
+        ? '/api/workplace_search/org/create_source'
+        : '/api/workplace_search/account/create_source';
 
       const {
         selectedGithubOrganizations: githubOrganizations,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -8,6 +8,8 @@ import { keys, pickBy } from 'lodash';
 
 import { kea, MakeLogicType } from 'kea';
 
+import { i18n } from '@kbn/i18n';
+
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
 
@@ -441,7 +443,15 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
 
       try {
         const response = await HttpLogic.values.http.delete(route);
-        setQueuedSuccessMessage(`Successfully deleted ${response.name}`);
+        setQueuedSuccessMessage(
+          i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceRemoved',
+            {
+              defaultMessage: 'Successfully deleted {sourceName}.',
+              values: { sourceName: response.name },
+            }
+          )
+        );
         successCallback();
       } catch (e) {
         flashAPIErrors(e);
@@ -536,7 +546,16 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
         const response = await http(route, {
           body: JSON.stringify({ params }),
         });
-        if (isUpdating) setSuccessMessage('Successfully updated configuration.');
+        if (isUpdating) {
+          setSuccessMessage(
+            i18n.translate(
+              'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceConfigUpdated',
+              {
+                defaultMessage: 'Successfully updated configuration.',
+              }
+            )
+          );
+        }
         actions.setSourceConfigData(response);
         if (successCallback) successCallback();
       } catch (e) {
@@ -586,7 +605,15 @@ export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
       }
     },
     onUpdateSourceName: (name: string) => {
-      setSuccessMessage(`Successfully changed name to ${name}`);
+      setSuccessMessage(
+        i18n.translate(
+          'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceNameChanged',
+          {
+            defaultMessage: 'Successfully changed name to {sourceName}.',
+            values: { sourceName: name },
+          }
+        )
+      );
     },
     resetSourceState: () => {
       FlashMessagesLogic.actions.clearFlashMessages();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -1,0 +1,580 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { keys, pickBy } from 'lodash';
+
+import { kea, MakeLogicType } from 'kea';
+
+import http from 'shared/http';
+import routes from 'workplace_search/routes';
+
+import { handleAPIError } from 'app_search/utils/handleAPIError';
+import { DEFAULT_META } from 'shared/constants/defaultMeta';
+import { IMeta, IFlashMessagesProps } from 'shared/types';
+import { AppLogic } from 'workplace_search/App/AppLogic';
+import { NOT_FOUND_PATH } from 'workplace_search/utils/routePaths';
+import { IObject, ContentSourceFullData, CustomSource } from 'workplace_search/types';
+
+import { SourcesLogic } from './SourcesLogic';
+
+export interface SourceActions {
+  onInitializeSource(contentSource: ContentSourceFullData): ContentSourceFullData;
+  onUpdateSourceName(name: string): string;
+  setSourceConfigData(sourceConfigData: SourceConfigData): SourceConfigData;
+  setSourceConnectData(sourceConnectData: SourceConnectData): SourceConnectData;
+  setFlashMessages(flashMessages: IFlashMessagesProps): { flashMessages: IFlashMessagesProps };
+  setSearchResults(searchResultsResponse: SearchResultsResponse): SearchResultsResponse;
+  initializeFederatedSummary(sourceId: string): { sourceId: string };
+  onUpdateSummary(summary: IObject[]): IObject[];
+  setContentFilterValue(contentFilterValue: string): string;
+  setActivePage(activePage: number): number;
+  setClientIdValue(clientIdValue: string): string;
+  setClientSecretValue(clientSecretValue: string): string;
+  setBaseUrlValue(baseUrlValue: string): string;
+  setCustomSourceNameValue(customSourceNameValue: string): string;
+  setSourceLoginValue(loginValue: string): string;
+  setSourcePasswordValue(passwordValue: string): string;
+  setSourceSubdomainValue(subdomainValue: string): string;
+  setSourceIndexPermissionsValue(indexPermissionsValue: boolean): boolean;
+  setCustomSourceData(data: CustomSource): CustomSource;
+  setPreContentSourceConfigData(data: PreContentSourceResponse): PreContentSourceResponse;
+  setSelectedGithubOrganizations(option: string): string;
+  searchContentSourceDocuments(sourceId: string): { sourceId: string };
+  updateContentSource(
+    sourceId: string,
+    source: { name: string }
+  ): { sourceId: string; source: { name: string } };
+  resetSourceState(): void;
+  removeContentSource(
+    sourceId: string,
+    successCallback: () => void
+  ): { sourceId: string; successCallback() };
+  createContentSource(
+    serviceType: string,
+    successCallback: () => void,
+    errorCallback?: () => void
+  ): { serviceType: string; successCallback(); errorCallback?() };
+  saveSourceConfig(
+    isUpdating: boolean,
+    successCallback?: () => void
+  ): { isUpdating: boolean; successCallback?() };
+  initializeSource(sourceId: string, history: IObject): { sourceId: string; history: IObject };
+  getSourceConfigData(serviceType: string): { serviceType: string };
+  getSourceConnectData(
+    serviceType: string,
+    successCallback: (oauthUrl: string) => string
+  ): { serviceType: string; successCallback(oauthUrl: string) };
+  getSourceReConnectData(serviceType: string): { serviceType: string };
+  getPreContentSourceConfigData(preContentSourceId: string): { preContentSourceId: string };
+}
+
+interface SourceConfigData {
+  serviceType: string;
+  name: string;
+  configured: boolean;
+  categories: string[];
+  needsPermissions?: boolean;
+  privateSourcesEnabled: boolean;
+  configuredFields: {
+    publicKey: string;
+    privateKey: string;
+    consumerKey: string;
+    baseUrl?: string;
+    clientId?: string;
+    clientSecret?: string;
+  };
+  accountContextOnly?: boolean;
+}
+
+interface SourceConnectData {
+  oauthUrl: string;
+  serviceType: string;
+}
+
+interface SourceValues {
+  contentSource: ContentSourceFullData;
+  flashMessages: IFlashMessagesProps;
+  dataLoading: boolean;
+  sectionLoading: boolean;
+  buttonLoading: boolean;
+  contentItems: IObject[];
+  contentMeta: IMeta;
+  contentFilterValue: string;
+  customSourceNameValue: string;
+  clientIdValue: string;
+  clientSecretValue: string;
+  baseUrlValue: string;
+  loginValue: string;
+  passwordValue: string;
+  subdomainValue: string;
+  indexPermissionsValue: boolean;
+  sourceConfigData: SourceConfigData;
+  sourceConnectData: SourceConnectData;
+  newCustomSource: CustomSource;
+  currentServiceType: string;
+  githubOrganizations: string[];
+  selectedGithubOrganizationsMap: IObject;
+  selectedGithubOrganizations: IObject;
+}
+
+interface SearchResultsResponse {
+  results: IObject[];
+  meta: IMeta;
+}
+
+interface PreContentSourceResponse {
+  id: string;
+  serviceType: string;
+  githubOrganizations: string[];
+}
+
+export const SourceLogic = kea<MakeLogicType<SourceValues, SourceActions>>({
+  actions: {
+    onInitializeSource: (contentSource: ContentSourceFullData) => contentSource,
+    onUpdateSourceName: (name: string) => name,
+    setSourceConfigData: (sourceConfigData: SourceConfigData) => sourceConfigData,
+    setSourceConnectData: (sourceConnectData: SourceConnectData) => sourceConnectData,
+    onUpdateSummary: (summary: IObject[]) => summary,
+    setFlashMessages: (flashMessages: IFlashMessagesProps) => ({ flashMessages }),
+    setSearchResults: (searchResultsResponse: SearchResultsResponse) => searchResultsResponse,
+    setContentFilterValue: (contentFilterValue: string) => contentFilterValue,
+    setActivePage: (activePage: number) => activePage,
+    setClientIdValue: (clientIdValue: string) => clientIdValue,
+    setClientSecretValue: (clientSecretValue: string) => clientSecretValue,
+    setBaseUrlValue: (baseUrlValue: string) => baseUrlValue,
+    setCustomSourceNameValue: (customSourceNameValue: string) => customSourceNameValue,
+    setSourceLoginValue: (loginValue: string) => loginValue,
+    setSourcePasswordValue: (passwordValue: string) => passwordValue,
+    setSourceSubdomainValue: (subdomainValue: string) => subdomainValue,
+    setSourceIndexPermissionsValue: (indexPermissionsValue: boolean) => indexPermissionsValue,
+    setCustomSourceData: (data: CustomSource) => data,
+    setPreContentSourceConfigData: (data: PreContentSourceResponse) => data,
+    setSelectedGithubOrganizations: (option: string) => option,
+    initializeSource: (sourceId: string, history: IObject) => ({ sourceId, history }),
+    initializeFederatedSummary: (sourceId: string) => ({ sourceId }),
+    searchContentSourceDocuments: (sourceId: string) => ({ sourceId }),
+    updateContentSource: (sourceId: string, source: { name: string }) => ({ sourceId, source }),
+    removeContentSource: (sourceId: string, successCallback: () => void) => ({
+      sourceId,
+      successCallback,
+    }),
+    getSourceConfigData: (serviceType: string) => ({ serviceType }),
+    getSourceConnectData: (serviceType: string, successCallback: (oauthUrl: string) => string) => ({
+      serviceType,
+      successCallback,
+    }),
+    getSourceReConnectData: (serviceType: string) => ({ serviceType }),
+    getPreContentSourceConfigData: (preContentSourceId: string) => ({ preContentSourceId }),
+    saveSourceConfig: (isUpdating: boolean, successCallback?: () => void) => ({
+      isUpdating,
+      successCallback,
+    }),
+    createContentSource: (
+      serviceType: string,
+      successCallback: () => void,
+      errorCallback?: () => void
+    ) => ({ serviceType, successCallback, errorCallback }),
+    resetSourceState: () => true,
+  },
+  reducers: {
+    contentSource: [
+      {} as ContentSourceFullData,
+      {
+        onInitializeSource: (_, contentSource) => contentSource,
+        onUpdateSourceName: (contentSource, name) => ({
+          ...contentSource,
+          name,
+        }),
+        onUpdateSummary: (contentSource, summary) => ({
+          ...contentSource,
+          summary,
+        }),
+      },
+    ],
+    sourceConfigData: [
+      {} as SourceConfigData,
+      {
+        setSourceConfigData: (_, sourceConfigData) => sourceConfigData,
+      },
+    ],
+    sourceConnectData: [
+      {} as SourceConnectData,
+      {
+        setSourceConnectData: (_, sourceConnectData) => sourceConnectData,
+      },
+    ],
+    flashMessages: [
+      {},
+      {
+        setFlashMessages: (_, { flashMessages }) => flashMessages,
+        onUpdateSourceName: (_, name) => ({ success: [`Successfully changed name to ${name}`] }),
+        resetSourceState: () => ({}),
+        removeContentSource: () => ({}),
+        saveSourceConfig: () => ({}),
+        getSourceConnectData: () => ({}),
+        createContentSource: () => ({}),
+      },
+    ],
+    dataLoading: [
+      true,
+      {
+        onInitializeSource: () => false,
+        setSourceConfigData: () => false,
+        resetSourceState: () => false,
+        setPreContentSourceConfigData: () => false,
+      },
+    ],
+    buttonLoading: [
+      false,
+      {
+        setFlashMessages: () => false,
+        setSourceConnectData: () => false,
+        setSourceConfigData: () => false,
+        resetSourceState: () => false,
+        removeContentSource: () => true,
+        saveSourceConfig: () => true,
+        getSourceConnectData: () => true,
+        createContentSource: () => true,
+      },
+    ],
+    sectionLoading: [
+      true,
+      {
+        searchContentSourceDocuments: () => true,
+        getPreContentSourceConfigData: () => true,
+        setSearchResults: () => false,
+        setPreContentSourceConfigData: () => false,
+      },
+    ],
+    contentItems: [
+      [],
+      {
+        setSearchResults: (_, { results }) => results,
+      },
+    ],
+    contentMeta: [
+      DEFAULT_META,
+      {
+        setActivePage: (state, activePage) => setPage(state, activePage),
+        setContentFilterValue: (state) => setPage(state, DEFAULT_META.page.current),
+        setSearchResults: (_, { meta }) => meta,
+      },
+    ],
+    contentFilterValue: [
+      '',
+      {
+        setContentFilterValue: (_, contentFilterValue) => contentFilterValue,
+        resetSourceState: () => '',
+      },
+    ],
+    clientIdValue: [
+      '',
+      {
+        setClientIdValue: (_, clientIdValue) => clientIdValue,
+        setSourceConfigData: (_, { configuredFields: { clientId } }) => clientId || '',
+        resetSourceState: () => '',
+      },
+    ],
+    clientSecretValue: [
+      '',
+      {
+        setClientSecretValue: (_, clientSecretValue) => clientSecretValue,
+        setSourceConfigData: (_, { configuredFields: { clientSecret } }) => clientSecret || '',
+        resetSourceState: () => '',
+      },
+    ],
+    baseUrlValue: [
+      '',
+      {
+        setBaseUrlValue: (_, baseUrlValue) => baseUrlValue,
+        setSourceConfigData: (_, { configuredFields: { baseUrl } }) => baseUrl || '',
+        resetSourceState: () => '',
+      },
+    ],
+    loginValue: [
+      '',
+      {
+        setSourceLoginValue: (_, loginValue) => loginValue,
+        resetSourceState: () => '',
+      },
+    ],
+    passwordValue: [
+      '',
+      {
+        setSourcePasswordValue: (_, passwordValue) => passwordValue,
+        resetSourceState: () => '',
+      },
+    ],
+    subdomainValue: [
+      '',
+      {
+        setSourceSubdomainValue: (_, subdomainValue) => subdomainValue,
+        resetSourceState: () => '',
+      },
+    ],
+    indexPermissionsValue: [
+      false,
+      {
+        setSourceIndexPermissionsValue: (_, indexPermissionsValue) => indexPermissionsValue,
+        resetSourceState: () => false,
+      },
+    ],
+    customSourceNameValue: [
+      '',
+      {
+        setCustomSourceNameValue: (_, customSourceNameValue) => customSourceNameValue,
+        resetSourceState: () => '',
+      },
+    ],
+    newCustomSource: [
+      {} as CustomSource,
+      {
+        setCustomSourceData: (_, newCustomSource) => newCustomSource,
+        resetSourceState: () => ({} as CustomSource),
+      },
+    ],
+    currentServiceType: [
+      '',
+      {
+        setPreContentSourceConfigData: (_, { serviceType }) => serviceType,
+        resetSourceState: () => '',
+      },
+    ],
+    githubOrganizations: [
+      [],
+      {
+        setPreContentSourceConfigData: (_, { githubOrganizations }) => githubOrganizations,
+        resetSourceState: () => [],
+      },
+    ],
+    selectedGithubOrganizationsMap: [
+      {},
+      {
+        setSelectedGithubOrganizations: (state, option) => ({
+          ...state,
+          ...{ [option]: !state[option] },
+        }),
+        resetSourceState: () => [],
+      },
+    ],
+  },
+  selectors: ({ selectors }) => ({
+    selectedGithubOrganizations: [
+      () => [selectors.selectedGithubOrganizationsMap],
+      (orgsMap) => keys(pickBy(orgsMap)),
+    ],
+  }),
+  listeners: ({ actions, values }) => ({
+    initializeSource: ({ sourceId, history }) => {
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourcePath(sourceId)
+        : routes.fritoPieAccountContentSourcePath(sourceId);
+
+      http(route)
+        .then(({ data }) => {
+          actions.onInitializeSource(data);
+          if (data.isFederatedSource) {
+            actions.initializeFederatedSummary(sourceId);
+          }
+        })
+        .catch((error) => {
+          if (error.response.status === 404) {
+            history.push(NOT_FOUND_PATH);
+          } else {
+            handleAPIError((messages) => actions.setFlashMessages({ error: messages }));
+          }
+        });
+    },
+    initializeFederatedSummary: ({ sourceId }) => {
+      const route = routes.fritoPieAccountContentSourceFederatedSummaryPath(sourceId);
+
+      http(route)
+        .then(({ data }) => actions.onUpdateSummary(data.summary))
+        .catch(() => {
+          handleAPIError((messages) => actions.setFlashMessages({ error: messages }));
+        });
+    },
+    searchContentSourceDocuments: async ({ sourceId }, breakpoint) => {
+      await breakpoint(300);
+
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourceDocumentsPath(sourceId)
+        : routes.fritoPieAccountContentSourceDocumentsPath(sourceId);
+
+      const {
+        contentFilterValue: query,
+        contentMeta: { page },
+      } = values;
+
+      http
+        .post(route, { query, page })
+        .then(({ data }) => actions.setSearchResults(data))
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    updateContentSource: ({ sourceId, source }) => {
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourceSettingsPath(sourceId)
+        : routes.fritoPieAccountContentSourceSettingsPath(sourceId);
+
+      http
+        .patch(route, { content_source: source })
+        .then(({ data }) => actions.onUpdateSourceName(data.name))
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    removeContentSource: ({ sourceId, successCallback }) => {
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourcePath(sourceId)
+        : routes.fritoPieAccountContentSourcePath(sourceId);
+
+      return http
+        .delete(route)
+        .then(({ data: { name } }) => {
+          SourcesLogic.actions.setFlashMessages({ success: [`Successfully deleted ${name}`] });
+          successCallback();
+        })
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    getSourceConfigData: ({ serviceType }) => {
+      const route = routes.fritoPieOrganizationSettingsContentSourceOauthConfigurationPath(
+        serviceType
+      );
+
+      http(route)
+        .then(({ data }) => actions.setSourceConfigData(data))
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    getSourceConnectData: ({ serviceType, successCallback }) => {
+      const { isOrganization } = AppLogic.values;
+      const { subdomainValue: subdomain, indexPermissionsValue: indexPermissions } = values;
+
+      const route = isOrganization
+        ? routes.prepareFritoPieOrganizationContentSourcesPath(serviceType)
+        : routes.prepareFritoPieAccountContentSourcesPath(serviceType);
+
+      const params = new URLSearchParams();
+      if (subdomain) params.append('subdomain', subdomain);
+      if (indexPermissions) params.append('index_permissions', indexPermissions.toString());
+
+      return http(`${route}?${params}`)
+        .then(({ data }) => {
+          actions.setSourceConnectData(data);
+          successCallback(data.oauthUrl);
+        })
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    getSourceReConnectData: ({ serviceType }) => {
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourceReauthPreparePath(serviceType)
+        : routes.fritoPieAccountContentSourceReauthPreparePath(serviceType);
+
+      return http(route)
+        .then(({ data }) => actions.setSourceConnectData(data))
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    getPreContentSourceConfigData: ({ preContentSourceId }) => {
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationPreContentSourcePath(preContentSourceId)
+        : routes.fritoPieAccountPreContentSourcePath(preContentSourceId);
+
+      http(route)
+        .then(({ data }) => actions.setPreContentSourceConfigData(data))
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    saveSourceConfig: ({ isUpdating, successCallback }) => {
+      const {
+        sourceConfigData: { serviceType },
+        baseUrlValue,
+        clientIdValue,
+        clientSecretValue,
+        sourceConfigData,
+      } = values;
+
+      const route = isUpdating
+        ? routes.fritoPieOrganizationSettingsContentSourceOauthConfigurationPath(serviceType)
+        : routes.fritoPieOrganizationSettingsContentSourceOauthConfigurationsPath();
+
+      const method = isUpdating ? 'put' : 'post';
+
+      const params = {
+        base_url: baseUrlValue || undefined,
+        client_id: clientIdValue || undefined,
+        client_secret: clientSecretValue || undefined,
+        service_type: serviceType,
+        private_key: sourceConfigData.configuredFields?.privateKey,
+        public_key: sourceConfigData.configuredFields?.publicKey,
+        consumer_key: sourceConfigData.configuredFields?.consumerKey,
+      };
+
+      return http({ url: route, method, data: params })
+        .then(({ data }) => {
+          if (isUpdating)
+            actions.setFlashMessages({ success: ['Successfully updated configuration.'] });
+          actions.setSourceConfigData(data);
+          if (successCallback) successCallback();
+        })
+        .catch(
+          handleAPIError((messages) => {
+            actions.setFlashMessages({ error: messages });
+            if (!isUpdating) throw new Error(messages[0]);
+          })
+        );
+    },
+    createContentSource: ({ serviceType, successCallback, errorCallback }) => {
+      const { isOrganization } = AppLogic.values;
+      const route = isOrganization
+        ? routes.formCreateFritoPieOrganizationContentSourcesPath()
+        : routes.formCreateFritoPieAccountContentSourcesPath();
+
+      const {
+        selectedGithubOrganizations: githubOrganizations,
+        customSourceNameValue,
+        loginValue,
+        passwordValue,
+        indexPermissionsValue,
+      } = values;
+
+      const params = {
+        service_type: serviceType,
+        name: customSourceNameValue || undefined,
+        login: loginValue || undefined,
+        password: passwordValue || undefined,
+        organizations: githubOrganizations.length > 0 ? githubOrganizations : undefined,
+        indexPermissions: indexPermissionsValue || undefined,
+      };
+
+      // Remove undefined values from params
+      Object.keys(params).forEach((key) => params[key] === undefined && delete params[key]);
+
+      return http
+        .post(route, params)
+        .then(({ data }) => {
+          actions.setCustomSourceData(data);
+          successCallback();
+        })
+        .catch(
+          handleAPIError((messages) => {
+            actions.setFlashMessages({ error: messages });
+            if (errorCallback) errorCallback();
+            throw new Error('Auth Error');
+          })
+        );
+    },
+  }),
+});
+
+const setPage = (state: IMeta, page: number) => ({
+  ...state,
+  page: {
+    ...state.page,
+    current: page,
+  },
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -53,22 +53,22 @@ export interface SourceActions {
   removeContentSource(
     sourceId: string,
     successCallback: () => void
-  ): { sourceId: string; successCallback() };
+  ): { sourceId: string; successCallback(): void };
   createContentSource(
     serviceType: string,
     successCallback: () => void,
     errorCallback?: () => void
-  ): { serviceType: string; successCallback(); errorCallback?() };
+  ): { serviceType: string; successCallback(): void; errorCallback?(): void };
   saveSourceConfig(
     isUpdating: boolean,
     successCallback?: () => void
-  ): { isUpdating: boolean; successCallback?() };
+  ): { isUpdating: boolean; successCallback?(): void };
   initializeSource(sourceId: string, history: object): { sourceId: string; history: object };
   getSourceConfigData(serviceType: string): { serviceType: string };
   getSourceConnectData(
     serviceType: string,
     successCallback: (oauthUrl: string) => string
-  ): { serviceType: string; successCallback(oauthUrl: string) };
+  ): { serviceType: string; successCallback(oauthUrl: string): void };
   getSourceReConnectData(serviceType: string): { serviceType: string };
   getPreContentSourceConfigData(preContentSourceId: string): { preContentSourceId: string };
   setButtonNotLoading(): void;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -120,6 +120,7 @@ interface SourceValues {
   githubOrganizations: string[];
   selectedGithubOrganizationsMap: object;
   selectedGithubOrganizations: object;
+  selectedGithubOrganizations: string[];
 }
 
 interface SearchResultsResponse {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.ts
@@ -8,6 +8,8 @@ import { cloneDeep, findIndex } from 'lodash';
 
 import { kea, MakeLogicType } from 'kea';
 
+import { i18n } from '@kbn/i18n';
+
 import { HttpLogic } from '../../../shared/http';
 
 import {
@@ -208,10 +210,25 @@ export const SourcesLogic = kea<MakeLogicType<ISourcesValues, ISourcesActions>>(
       }
     },
     setAddedSource: ({ addedSourceName, additionalConfiguration }) => {
+      const successfullyConnectedMessage = i18n.translate(
+        'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.contentSourceConnected',
+        {
+          defaultMessage: 'Successfully connected {sourceName}.',
+          values: { sourceName: addedSourceName },
+        }
+      );
+
+      const additionalConfigurationMessage = i18n.translate(
+        'xpack.enterpriseSearch.workplaceSearch.sources.flashMessages.additionalConfigurationNeeded',
+        {
+          defaultMessage: 'This source requires additional configuration.',
+        }
+      );
+
       setSuccessMessage(
         [
-          `Successfully connected ${addedSourceName}.`,
-          additionalConfiguration ? 'This source requires additional configuration.' : '',
+          successfullyConnectedMessage,
+          additionalConfiguration ? additionalConfigurationMessage : '',
         ].join(' ')
       );
     },


### PR DESCRIPTION
## Summary

This PR migrates [SourceLogic](https://github.com/elastic/ent-search/blob/master/app/javascript/workplace_search/ContentSources/SourceLogic.ts) to Kibana. The first commit is merely a copy/paste of the existing file followed by the following:

- Remove routes/http in favor of HttpLogic
- Remove local flash messages in favor of global messages
- Update paths to imports
- Remove "I"s from interface names
- Varions type fixes
- Adds i18n support