### PR TITLE
[Fleet] Allow to send SETTINGS action

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent.ts
@@ -26,6 +26,7 @@ export type AgentActionType =
   | 'POLICY_CHANGE'
   | 'UNENROLL'
   | 'UPGRADE'
+  | 'SETTINGS'
   // INTERNAL* actions are mean to interupt long polling calls these actions will not be distributed to the agent
   | 'INTERNAL_POLICY_REASSIGN';
 

--- a/x-pack/plugins/fleet/server/routes/agent/actions_handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/actions_handlers.test.ts
@@ -53,7 +53,6 @@ describe('test actions handlers', () => {
         action: {
           type: 'POLICY_CHANGE',
           data: 'data',
-          sent_at: '2020-03-14T19:45:02.620Z',
         },
       },
       params: {

--- a/x-pack/plugins/fleet/server/routes/agent/actions_handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/actions_handlers.test.ts
@@ -25,7 +25,6 @@ describe('test actions handlers schema', () => {
       NewAgentActionSchema.validate({
         type: 'POLICY_CHANGE',
         data: 'data',
-        sent_at: '2020-03-14T19:45:02.620Z',
       })
     ).toBeTruthy();
   });
@@ -34,7 +33,6 @@ describe('test actions handlers schema', () => {
     expect(() => {
       NewAgentActionSchema.validate({
         data: 'data',
-        sent_at: '2020-03-14T19:45:02.620Z',
       });
     }).toThrowError();
   });

--- a/x-pack/plugins/fleet/server/types/models/agent.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent.ts
@@ -62,14 +62,25 @@ export const AgentEventSchema = schema.object({
   id: schema.string(),
 });
 
-export const NewAgentActionSchema = schema.object({
-  type: schema.oneOf([
-    schema.literal('POLICY_CHANGE'),
-    schema.literal('UNENROLL'),
-    schema.literal('UPGRADE'),
-    schema.literal('INTERNAL_POLICY_REASSIGN'),
-  ]),
-  data: schema.maybe(schema.any()),
-  ack_data: schema.maybe(schema.any()),
-  sent_at: schema.maybe(schema.string()),
-});
+export const NewAgentActionSchema = schema.oneOf([
+  schema.object({
+    type: schema.oneOf([
+      schema.literal('POLICY_CHANGE'),
+      schema.literal('UNENROLL'),
+      schema.literal('UPGRADE'),
+      schema.literal('INTERNAL_POLICY_REASSIGN'),
+    ]),
+    data: schema.any(),
+  }),
+  schema.object({
+    type: schema.oneOf([schema.literal('SETTINGS')]),
+    data: schema.object({
+      log_level: schema.oneOf([
+        schema.literal('debug'),
+        schema.literal('info'),
+        schema.literal('warning'),
+        schema.literal('error'),
+      ]),
+    }),
+  }),
+]);

--- a/x-pack/plugins/fleet/server/types/models/agent.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent.ts
@@ -71,6 +71,7 @@ export const NewAgentActionSchema = schema.oneOf([
       schema.literal('INTERNAL_POLICY_REASSIGN'),
     ]),
     data: schema.any(),
+    ack_data: schema.any(),
   }),
   schema.object({
     type: schema.oneOf([schema.literal('SETTINGS')]),

--- a/x-pack/plugins/fleet/server/types/models/agent.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent.ts
@@ -70,8 +70,8 @@ export const NewAgentActionSchema = schema.oneOf([
       schema.literal('UPGRADE'),
       schema.literal('INTERNAL_POLICY_REASSIGN'),
     ]),
-    data: schema.any(),
-    ack_data: schema.any(),
+    data: schema.maybe(schema.any()),
+    ack_data: schema.maybe(schema.any()),
   }),
   schema.object({
     type: schema.oneOf([schema.literal('SETTINGS')]),


### PR DESCRIPTION
## Summary

Partially resolve https://github.com/elastic/kibana/issues/83330

To be able to dynamically set the log level of an agent, we need to send a new action to the agent with that `log_level`

This pull request update the actions endpoint to be able to send that new `SETTINGS` action.

Note action will exists in Fleet Server so there is no issue of adding a new one.


## Tests

I added an API integration test to ensure we can create that action.

If you want to test it manually you can enroll an agent, checkin, create a SETTINGS action, then checkin again you will have the action.

```shell
curl --request POST \
  --url http://localhost:5601/api/ingest_manager/fleet/agents/{AGENT_ID}/actions \
  --header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'Content-Type: application/json' \
  --header 'kbn-xsrf: as' \
  --data '{
	"action": {
			"type": "SETTINGS",
		"data": {
			"log_level": "debug"
		}
	}
}'
```


cc @michalpristas 
