### PR TITLE
[Enterprise Search] Rename React Router helpers

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
@@ -10,7 +10,7 @@ import { mockTelemetryActions, mountWithIntl } from '../../../__mocks__/';
 
 import React from 'react';
 import { EuiBasicTable, EuiPagination, EuiButtonEmpty } from '@elastic/eui';
-import { EuiLink } from '../../../shared/react_router_helpers';
+import { EuiLinkTo } from '../../../shared/react_router_helpers';
 
 import { EnginesTable } from './engines_table';
 
@@ -50,7 +50,7 @@ describe('EnginesTable', () => {
   });
 
   it('contains engine links which send telemetry', () => {
-    const engineLinks = wrapper.find(EuiLink);
+    const engineLinks = wrapper.find(EuiLinkTo);
 
     engineLinks.forEach((link) => {
       expect(link.prop('to')).toEqual('/engines/test-engine');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -11,7 +11,7 @@ import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/reac
 import { i18n } from '@kbn/i18n';
 
 import { TelemetryLogic } from '../../../shared/telemetry';
-import { EuiLink } from '../../../shared/react_router_helpers';
+import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { getEngineRoute } from '../../routes';
 
 import { ENGINES_PAGE_SIZE } from '../../../../../common/constants';
@@ -59,9 +59,9 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
         defaultMessage: 'Name',
       }),
       render: (name: string) => (
-        <EuiLink data-test-subj="engineNameLink" {...engineLinkProps(name)}>
+        <EuiLinkTo data-test-subj="engineNameLink" {...engineLinkProps(name)}>
           {name}
-        </EuiLink>
+        </EuiLinkTo>
       ),
       width: '30%',
       truncateText: true,
@@ -122,12 +122,12 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
       ),
       dataType: 'string',
       render: (name: string) => (
-        <EuiLink {...engineLinkProps(name)}>
+        <EuiLinkTo {...engineLinkProps(name)}>
           <FormattedMessage
             id="xpack.enterpriseSearch.appSearch.enginesOverview.table.action.manage"
             defaultMessage="Manage"
           />
-        </EuiLink>
+        </EuiLinkTo>
       ),
       align: 'right',
       width: '100px',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.test.tsx
@@ -12,7 +12,7 @@ import { useValues } from 'kea';
 import { shallow } from 'enzyme';
 
 import { EuiCard } from '@elastic/eui';
-import { EuiButton } from '../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
 
 import { ProductCard } from './';
@@ -29,7 +29,7 @@ describe('ProductCard', () => {
     expect(card.find('h2').text()).toEqual('Elastic App Search');
     expect(card.find('.productCard__image').prop('src')).toEqual('as.jpg');
 
-    const button = card.find(EuiButton);
+    const button = card.find(EuiButtonTo);
     expect(button.prop('to')).toEqual('/app/enterprise_search/app_search');
     expect(button.prop('children')).toEqual('Launch App Search');
 
@@ -47,7 +47,7 @@ describe('ProductCard', () => {
     expect(card.find('h2').text()).toEqual('Elastic Workplace Search');
     expect(card.find('.productCard__image').prop('src')).toEqual('ws.jpg');
 
-    const button = card.find(EuiButton);
+    const button = card.find(EuiButtonTo);
     expect(button.prop('to')).toEqual('/app/enterprise_search/workplace_search');
     expect(button.prop('children')).toEqual('Launch Workplace Search');
 
@@ -63,7 +63,7 @@ describe('ProductCard', () => {
 
     const wrapper = shallow(<ProductCard product={WORKPLACE_SEARCH_PLUGIN} image="ws.jpg" />);
     const card = wrapper.find(EuiCard).dive().shallow();
-    const button = card.find(EuiButton);
+    const button = card.find(EuiButtonTo);
 
     expect(button.prop('children')).toEqual('Setup Workplace Search');
   });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
@@ -10,7 +10,7 @@ import { snakeCase } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { EuiCard, EuiTextColor } from '@elastic/eui';
 
-import { EuiButton } from '../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
 import { KibanaLogic } from '../../../shared/kibana';
 
@@ -63,7 +63,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, image }) => {
       paddingSize="l"
       description={<EuiTextColor color="subdued">{product.CARD_DESCRIPTION}</EuiTextColor>}
       footer={
-        <EuiButton
+        <EuiButtonTo
           fill
           to={product.URL}
           shouldNotCreateHref={true}
@@ -75,7 +75,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, image }) => {
           }
         >
           {config.host ? LAUNCH_BUTTON_TEXT : SETUP_BUTTON_TEXT}
-        </EuiButton>
+        </EuiButtonTo>
       }
     />
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.tsx
@@ -7,13 +7,13 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiText } from '@elastic/eui';
-import { EuiPanel } from '../../../shared/react_router_helpers';
+import { EuiPanelTo } from '../../../shared/react_router_helpers';
 
 import CtaImage from './assets/getting_started.png';
 import './setup_guide_cta.scss';
 
 export const SetupGuideCta: React.FC = () => (
-  <EuiPanel to="/setup_guide" paddingSize="l" className="enterpriseSearchSetupCta">
+  <EuiPanelTo to="/setup_guide" paddingSize="l" className="enterpriseSearchSetupCta">
     <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
       <EuiFlexItem className="enterpriseSearchSetupCta__text">
         <EuiTitle size="s">
@@ -34,5 +34,5 @@ export const SetupGuideCta: React.FC = () => (
         <img src={CtaImage} alt="" className="enterpriseSearchSetupCta__image" />
       </EuiFlexItem>
     </EuiFlexGroup>
-  </EuiPanel>
+  </EuiPanelTo>
 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
@@ -9,7 +9,7 @@ import { useValues } from 'kea';
 import { EuiEmptyPrompt, EuiCode } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { EuiButton } from '../react_router_helpers';
+import { EuiButtonTo } from '../react_router_helpers';
 import { KibanaLogic } from '../../shared/kibana';
 
 import './error_state_prompt.scss';
@@ -90,12 +90,12 @@ export const ErrorStatePrompt: React.FC = () => {
         </>
       }
       actions={
-        <EuiButton iconType="help" fill to="/setup_guide">
+        <EuiButtonTo iconType="help" fill to="/setup_guide">
           <FormattedMessage
             id="xpack.enterpriseSearch.errorConnectingState.setupGuideCta"
             defaultMessage="Review setup guide"
           />
-        </EuiButton>
+        </EuiButtonTo>
       }
     />
   );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.test.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { shallow } from 'enzyme';
 
-import { EuiLink as EuiLinkExternal } from '@elastic/eui';
-import { EuiLink } from '../react_router_helpers';
+import { EuiLink } from '@elastic/eui';
+import { EuiLinkTo } from '../react_router_helpers';
 import { ENTERPRISE_SEARCH_PLUGIN, APP_SEARCH_PLUGIN } from '../../../../common/constants';
 
 import { SideNav, SideNavLink, SideNavItem } from './';
@@ -42,7 +42,7 @@ describe('SideNavLink', () => {
     const wrapper = shallow(<SideNavLink to="/">Link</SideNavLink>);
 
     expect(wrapper.type()).toEqual('li');
-    expect(wrapper.find(EuiLink)).toHaveLength(1);
+    expect(wrapper.find(EuiLinkTo)).toHaveLength(1);
     expect(wrapper.find('.enterpriseSearchNavLinks__item')).toHaveLength(1);
   });
 
@@ -52,7 +52,7 @@ describe('SideNavLink', () => {
         Link
       </SideNavLink>
     );
-    const externalLink = wrapper.find(EuiLinkExternal);
+    const externalLink = wrapper.find(EuiLink);
 
     expect(externalLink).toHaveLength(1);
     expect(externalLink.prop('href')).toEqual('http://website.com');

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.tsx
@@ -9,8 +9,8 @@ import { useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 
 import { i18n } from '@kbn/i18n';
-import { EuiIcon, EuiTitle, EuiText, EuiLink as EuiLinkExternal } from '@elastic/eui'; // TODO: Remove EuiLinkExternal after full Kibana transition
-import { EuiLink } from '../react_router_helpers';
+import { EuiIcon, EuiTitle, EuiText, EuiLink } from '@elastic/eui'; // TODO: Remove EuiLink after full Kibana transition
+import { EuiLinkTo } from '../react_router_helpers';
 
 import { ENTERPRISE_SEARCH_PLUGIN } from '../../../../common/constants';
 import { stripTrailingSlash } from '../../../../common/strip_slashes';
@@ -96,19 +96,14 @@ export const SideNavLink: React.FC<SideNavLinkProps> = ({
   return (
     <li>
       {isExternal ? (
-        <EuiLinkExternal
-          {...rest}
-          className={classes}
-          href={to}
-          target="_blank"
-          onClick={closeNavigation}
-        >
-          {children}
-        </EuiLinkExternal>
-      ) : (
-        <EuiLink {...rest} className={classes} to={to} onClick={closeNavigation}>
+        // eslint-disable-next-line @elastic/eui/href-or-on-click
+        <EuiLink {...rest} className={classes} href={to} target="_blank" onClick={closeNavigation}>
           {children}
         </EuiLink>
+      ) : (
+        <EuiLinkTo {...rest} className={classes} to={to} onClick={closeNavigation}>
+          {children}
+        </EuiLinkTo>
       )}
       {subNav && <ul className="enterpriseSearchNavLinks__subNav">{subNav}</ul>}
     </li>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/not_found/not_found.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/not_found/not_found.tsx
@@ -13,7 +13,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton as EuiButtonExternal,
+  EuiButton,
 } from '@elastic/eui';
 
 import {
@@ -22,7 +22,7 @@ import {
   LICENSED_SUPPORT_URL,
 } from '../../../../common/constants';
 
-import { EuiButton } from '../react_router_helpers';
+import { EuiButtonTo } from '../react_router_helpers';
 import { SetAppSearchChrome, SetWorkplaceSearchChrome } from '../kibana_chrome';
 import { SendAppSearchTelemetry, SendWorkplaceSearchTelemetry } from '../telemetry';
 import { LicensingLogic } from '../licensing';
@@ -89,18 +89,18 @@ export const NotFound: React.FC<NotFoundProps> = ({ product = {} }) => {
           actions={
             <EuiFlexGroup>
               <EuiFlexItem>
-                <EuiButton to="/" color="primary" fill>
+                <EuiButtonTo to="/" color="primary" fill>
                   {i18n.translate('xpack.enterpriseSearch.notFound.action1', {
                     defaultMessage: 'Back to your dashboard',
                   })}
-                </EuiButton>
+                </EuiButtonTo>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiButtonExternal href={supportUrl} target="_blank">
+                <EuiButton href={supportUrl} target="_blank">
                   {i18n.translate('xpack.enterpriseSearch.notFound.action2', {
                     defaultMessage: 'Contact support',
                   })}
-                </EuiButtonExternal>
+                </EuiButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
@@ -12,7 +12,7 @@ import { EuiLink, EuiButton, EuiPanel } from '@elastic/eui';
 
 import { mockKibanaValues, mockHistory } from '../../__mocks__';
 
-import { EuiReactRouterLink, EuiReactRouterButton, EuiReactRouterPanel } from './eui_link';
+import { EuiLinkTo, EuiButtonTo, EuiPanelTo } from './eui_components';
 
 describe('EUI & React Router Component Helpers', () => {
   beforeEach(() => {
@@ -20,26 +20,26 @@ describe('EUI & React Router Component Helpers', () => {
   });
 
   it('renders an EuiLink', () => {
-    const wrapper = shallow(<EuiReactRouterLink to="/" />);
+    const wrapper = shallow(<EuiLinkTo to="/" />);
 
     expect(wrapper.find(EuiLink)).toHaveLength(1);
   });
 
   it('renders an EuiButton', () => {
-    const wrapper = shallow(<EuiReactRouterButton to="/" />);
+    const wrapper = shallow(<EuiButtonTo to="/" />);
 
     expect(wrapper.find(EuiButton)).toHaveLength(1);
   });
 
   it('renders an EuiPanel', () => {
-    const wrapper = shallow(<EuiReactRouterPanel to="/" paddingSize="l" />);
+    const wrapper = shallow(<EuiPanelTo to="/" paddingSize="l" />);
 
     expect(wrapper.find(EuiPanel)).toHaveLength(1);
     expect(wrapper.find(EuiPanel).prop('paddingSize')).toEqual('l');
   });
 
   it('passes down all ...rest props', () => {
-    const wrapper = shallow(<EuiReactRouterLink to="/" data-test-subj="foo" external={true} />);
+    const wrapper = shallow(<EuiLinkTo to="/" data-test-subj="foo" external={true} />);
     const link = wrapper.find(EuiLink);
 
     expect(link.prop('external')).toEqual(true);
@@ -47,7 +47,7 @@ describe('EUI & React Router Component Helpers', () => {
   });
 
   it('renders with the correct href and onClick props', () => {
-    const wrapper = mount(<EuiReactRouterLink to="/foo/bar" />);
+    const wrapper = mount(<EuiLinkTo to="/foo/bar" />);
     const link = wrapper.find(EuiLink);
 
     expect(link.prop('onClick')).toBeInstanceOf(Function);
@@ -56,7 +56,7 @@ describe('EUI & React Router Component Helpers', () => {
   });
 
   it('renders with the correct non-basenamed href when shouldNotCreateHref is passed', () => {
-    const wrapper = mount(<EuiReactRouterLink to="/foo/bar" shouldNotCreateHref />);
+    const wrapper = mount(<EuiLinkTo to="/foo/bar" shouldNotCreateHref />);
     const link = wrapper.find(EuiLink);
 
     expect(link.prop('href')).toEqual('/foo/bar');
@@ -65,7 +65,7 @@ describe('EUI & React Router Component Helpers', () => {
 
   describe('onClick', () => {
     it('prevents default navigation and uses React Router history', () => {
-      const wrapper = mount(<EuiReactRouterLink to="/bar/baz" />);
+      const wrapper = mount(<EuiLinkTo to="/bar/baz" />);
 
       const simulatedEvent = {
         button: 0,
@@ -79,7 +79,7 @@ describe('EUI & React Router Component Helpers', () => {
     });
 
     it('does not prevent default browser behavior on new tab/window clicks', () => {
-      const wrapper = mount(<EuiReactRouterLink to="/bar/baz" />);
+      const wrapper = mount(<EuiLinkTo to="/bar/baz" />);
 
       const simulatedEvent = {
         shiftKey: true,
@@ -92,7 +92,7 @@ describe('EUI & React Router Component Helpers', () => {
 
     it('calls inherited onClick actions in addition to default navigation', () => {
       const customOnClick = jest.fn(); // Can be anything from telemetry to a state reset
-      const wrapper = mount(<EuiReactRouterLink to="/narnia" onClick={customOnClick} />);
+      const wrapper = mount(<EuiLinkTo to="/narnia" onClick={customOnClick} />);
 
       wrapper.find(EuiLink).simulate('click', { shiftKey: true });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
@@ -20,7 +20,7 @@ import { letBrowserHandleEvent, createHref } from './';
  * https://github.com/elastic/eui/blob/master/wiki/react-router.md#react-router-51
  */
 
-interface EuiReactRouterProps {
+interface ReactRouterProps {
   to: string;
   onClick?(): void;
   // Used to navigate outside of the React Router plugin basename but still within Kibana,
@@ -28,7 +28,7 @@ interface EuiReactRouterProps {
   shouldNotCreateHref?: boolean;
 }
 
-export const EuiReactRouterHelper: React.FC<EuiReactRouterProps> = ({
+export const ReactRouterHelper: React.FC<ReactRouterProps> = ({
   to,
   onClick,
   shouldNotCreateHref,
@@ -59,38 +59,38 @@ export const EuiReactRouterHelper: React.FC<EuiReactRouterProps> = ({
  * Component helpers
  */
 
-type EuiReactRouterLinkProps = EuiLinkAnchorProps & EuiReactRouterProps;
-export const EuiReactRouterLink: React.FC<EuiReactRouterLinkProps> = ({
+type ReactRouterEuiLinkProps = ReactRouterProps & EuiLinkAnchorProps;
+export const EuiLinkTo: React.FC<ReactRouterEuiLinkProps> = ({
   to,
   onClick,
   shouldNotCreateHref,
   ...rest
 }) => (
-  <EuiReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
+  <ReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
     <EuiLink {...rest} />
-  </EuiReactRouterHelper>
+  </ReactRouterHelper>
 );
 
-type EuiReactRouterButtonProps = EuiButtonProps & EuiReactRouterProps;
-export const EuiReactRouterButton: React.FC<EuiReactRouterButtonProps> = ({
+type ReactRouterEuiButtonProps = ReactRouterProps & EuiButtonProps;
+export const EuiButtonTo: React.FC<ReactRouterEuiButtonProps> = ({
   to,
   onClick,
   shouldNotCreateHref,
   ...rest
 }) => (
-  <EuiReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
+  <ReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
     <EuiButton {...rest} />
-  </EuiReactRouterHelper>
+  </ReactRouterHelper>
 );
 
-type EuiReactRouterPanelProps = EuiPanelProps & EuiReactRouterProps;
-export const EuiReactRouterPanel: React.FC<EuiReactRouterPanelProps> = ({
+type ReactRouterEuiPanelProps = ReactRouterProps & EuiPanelProps;
+export const EuiPanelTo: React.FC<ReactRouterEuiPanelProps> = ({
   to,
   onClick,
   shouldNotCreateHref,
   ...rest
 }) => (
-  <EuiReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
+  <ReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
     <EuiPanel {...rest} />
-  </EuiReactRouterHelper>
+  </ReactRouterHelper>
 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/index.ts
@@ -6,8 +6,4 @@
 
 export { letBrowserHandleEvent } from './link_events';
 export { createHref, CreateHrefOptions } from './create_href';
-export {
-  EuiReactRouterLink as EuiLink,
-  EuiReactRouterButton as EuiButton,
-  EuiReactRouterPanel as EuiPanel,
-} from './eui_link';
+export { EuiLinkTo, EuiButtonTo, EuiPanelTo } from './eui_components';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -23,7 +23,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 
-import { EuiLink } from '../../../../shared/react_router_helpers';
+import { EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { SOURCE_STATUSES as statuses } from '../../../constants';
 import { ContentSourceDetails } from '../../../types';
 import { ADD_SOURCE_PATH, SOURCE_DETAILS_PATH, getContentSourcePath } from '../../../routes';
@@ -77,9 +77,9 @@ export const SourceRow: React.FC<SourceRowProps> = ({
   const imageClass = classNames('source-row__icon', { 'source-row__icon--loading': isIndexing });
 
   const fixLink = (
-    <EuiLink to={`${ADD_SOURCE_PATH}/${_kebabCase(serviceType)}/re-authenticate?sourceId=${id}`}>
+    <EuiLinkTo to={`${ADD_SOURCE_PATH}/${_kebabCase(serviceType)}/re-authenticate?sourceId=${id}`}>
       Fix
-    </EuiLink>
+    </EuiLinkTo>
   );
 
   const remoteTooltip = (
@@ -159,13 +159,13 @@ export const SourceRow: React.FC<SourceRowProps> = ({
           {showFix && <EuiFlexItem grow={false}>{fixLink}</EuiFlexItem>}
           <EuiFlexItem grow={false}>
             {showDetails && (
-              <EuiLink
+              <EuiLinkTo
                 className="eui-textNoWrap"
                 data-test-subj="SourceDetailsLink"
                 to={getContentSourcePath(SOURCE_DETAILS_PATH, id, !!isOrganization)}
               >
                 Details
-              </EuiLink>
+              </EuiLinkTo>
             )}
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.tsx
@@ -26,7 +26,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { EuiButton as EuiLinkButton } from '../../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 
 import { Group } from '../../../types';
 import { ORG_SOURCES_PATH } from '../../../routes';
@@ -96,9 +96,9 @@ export const GroupManagerModal: React.FC<GroupManagerModalProps> = ({
   const handleSelectAll = () => selectAll(allSelected ? [] : allItems);
 
   const sourcesButton = (
-    <EuiLinkButton to={ORG_SOURCES_PATH} fill color="primary">
+    <EuiButtonTo to={ORG_SOURCES_PATH} fill color="primary">
       {ADD_SOURCE_BUTTON_TEXT}
-    </EuiLinkButton>
+    </EuiButtonTo>
   );
 
   const emptyState = (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
@@ -13,7 +13,7 @@ import { i18n } from '@kbn/i18n';
 import { EuiTableRow, EuiTableRowCell, EuiIcon } from '@elastic/eui';
 
 import { TruncatedContent } from '../../../../shared/truncate';
-import { EuiLink } from '../../../../shared/react_router_helpers';
+import { EuiLinkTo } from '../../../../shared/react_router_helpers';
 
 import { Group } from '../../../types';
 
@@ -64,9 +64,9 @@ export const GroupRow: React.FC<Group> = ({
     <EuiTableRow data-test-subj="GroupsRow">
       <EuiTableRowCell>
         <strong>
-          <EuiLink to={getGroupPath(id)}>
+          <EuiLinkTo to={getGroupPath(id)}>
             <TruncatedContent tooltipType="title" content={name} length={MAX_NAME_LENGTH} />
-          </EuiLink>
+          </EuiLinkTo>
         </strong>
         <br />
         <small>{GROUP_UPDATED_TEXT}</small>
@@ -93,9 +93,9 @@ export const GroupRow: React.FC<Group> = ({
       )}
       <EuiTableRowCell>
         <strong>
-          <EuiLink to={getGroupPath(id)}>
+          <EuiLinkTo to={getGroupPath(id)}>
             <EuiIcon type="pencil" />
-          </EuiLink>
+          </EuiLinkTo>
         </strong>
       </EuiTableRowCell>
     </EuiTableRow>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.test.tsx
@@ -27,7 +27,7 @@ import { TableFilters } from './components/table_filters';
 import { DEFAULT_META } from '../../../shared/constants';
 
 import { EuiFieldSearch, EuiLoadingSpinner } from '@elastic/eui';
-import { EuiButton as EuiLinkButton } from '../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 
 const getSearchResults = jest.fn();
 const openNewGroupModal = jest.fn();
@@ -138,7 +138,7 @@ describe('GroupOverview', () => {
     const action = shallow(<Action />);
 
     expect(action.find('[data-test-subj="InviteUsersButton"]')).toHaveLength(1);
-    expect(action.find(EuiLinkButton)).toHaveLength(1);
+    expect(action.find(EuiButtonTo)).toHaveLength(1);
   });
 
   it('does not render inviteUsersButton when federated auth', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -10,7 +10,7 @@ import { useActions, useValues } from 'kea';
 import { i18n } from '@kbn/i18n';
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
-import { EuiButton as EuiLinkButton } from '../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 
 import { AppLogic } from '../../app_logic';
 
@@ -61,7 +61,7 @@ export const Groups: React.FC = () => {
 
   if (newGroup && hasMessages) {
     messages[0].description = (
-      <EuiLinkButton
+      <EuiButtonTo
         to={getGroupPath(newGroup.id)}
         color="primary"
         data-test-subj="NewGroupManageButton"
@@ -69,17 +69,17 @@ export const Groups: React.FC = () => {
         {i18n.translate('xpack.enterpriseSearch.workplaceSearch.groups.newGroup.action', {
           defaultMessage: 'Manage Group',
         })}
-      </EuiLinkButton>
+      </EuiButtonTo>
     );
   }
 
   const clearFilters = hasFiltersSet && <ClearFiltersLink />;
   const inviteUsersButton = !isFederatedAuth ? (
-    <EuiLinkButton to={USERS_PATH} data-test-subj="InviteUsersButton">
+    <EuiButtonTo to={USERS_PATH} data-test-subj="InviteUsersButton">
       {i18n.translate('xpack.enterpriseSearch.workplaceSearch.groups.inviteUsers.action', {
         defaultMessage: 'Invite users',
       })}
-    </EuiLinkButton>
+    </EuiButtonTo>
   ) : null;
 
   const headerAction = (


### PR DESCRIPTION
## Summary

Jason pointed out in https://github.com/elastic/kibana/pull/83504#discussion_r526138822 that bogarting EUI's `EuiLink`/`EuiButton` components is confusing and also leads to naming conflicts when we have both our EuiLink and EUI's EuiLink on the same page.

After some naming brainstorming and voting w/ the team, I've opened this PR to distinguish our component apart from EUI's. Hopefully less confusion all around for everyone! (see https://github.com/elastic/kibana/commit/41ce45b5863012092a0154f545a1155967a0a7c9, which I think benefits the most from the renaming).

### Checklist

- [x] All nav links still working as expected in QA (e.g., 404 page)
- [x] All tests pass
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios