### PR TITLE
[Enterprise Search] Add parseQueryParams helper

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { parseQueryParams } from './query_params';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
@@ -7,7 +7,7 @@
 import { parseQueryParams } from './';
 
 describe('parseQueryParams', () => {
-  it('should call queryString parse method', () => {
+  it('parse query strings', () => {
     expect(parseQueryParams('?foo=bar')).toEqual({ foo: 'bar' });
     expect(parseQueryParams('?foo[]=bar&foo[]=baz')).toEqual({ foo: ['bar', 'baz'] });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
@@ -4,16 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import queryString from 'query-string';
-
 import { parseQueryParams } from './';
 
 describe('parseQueryParams', () => {
   it('should call queryString parse method', () => {
-    const parseMock = jest.fn();
-    jest.spyOn(queryString, 'parse').mockImplementation(parseMock);
-    parseQueryParams('?foo=bar');
-
-    expect(queryString.parse).toHaveBeenCalledWith('?foo=bar', { arrayFormat: 'bracket' });
+    expect(parseQueryParams('?foo=bar')).toEqual({ foo: 'bar' });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
@@ -4,11 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-jest.mock('queryString', () => ({
-  ...(jest.requireActual('queryString') as object),
-  parse: jest.fn(),
-}));
-
 import queryString from 'query-string';
 
 import { parseQueryParams } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
@@ -9,5 +9,6 @@ import { parseQueryParams } from './';
 describe('parseQueryParams', () => {
   it('should call queryString parse method', () => {
     expect(parseQueryParams('?foo=bar')).toEqual({ foo: 'bar' });
+    expect(parseQueryParams('?foo[]=bar&foo[]=baz')).toEqual({ foo: ['bar', 'baz'] });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+jest.mock('queryString', () => ({
+  ...(jest.requireActual('queryString') as object),
+  parse: jest.fn(),
+}));
+
+import queryString from 'query-string';
+
+import { parseQueryParams } from './';
+
+describe('parseQueryParams', () => {
+  it('should call queryString parse method', () => {
+    const parseMock = jest.fn();
+    jest.spyOn(queryString, 'parse').mockImplementation(parseMock);
+    parseQueryParams('?foo=bar');
+
+    expect(queryString.parse).toHaveBeenCalledWith('?foo=bar', { arrayFormat: 'bracket' });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/query_params/query_params.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import queryString from 'query-string';
+
+export const parseQueryParams = (search: string) =>
+  queryString.parse(search, { arrayFormat: 'bracket' });


### PR DESCRIPTION
## Summary

This PR migrates part of the ent-search [queryParams](https://github.com/elastic/ent-search/blob/master/app/javascript/app_search/utils/queryParams.ts) util, `parseQueryParams` for use in Workplace Search.

`setQueryParams` was no a part of this PR because it is only used in one [component](https://github.com/elastic/ent-search/blob/master/app/javascript/app_search/Analytics/AnalyticsHeaderActions.tsx) in App Search and a better alternative might be available for that use-case

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios