### PR TITLE
[APM] Make route `tags` required

### DIFF
--- a/x-pack/plugins/apm/server/routes/correlations.ts
+++ b/x-pack/plugins/apm/server/routes/correlations.ts
@@ -30,6 +30,7 @@ export const correlationsForSlowTransactionsRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const {
@@ -71,6 +72,7 @@ export const correlationsForRangesRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 

--- a/x-pack/plugins/apm/server/routes/create_api/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/create_api/index.test.ts
@@ -53,6 +53,7 @@ describe('createApi', () => {
     createApi()
       .add(() => ({
         endpoint: 'GET /foo',
+        options: { tags: ['access:apm'] },
         handler: async () => null,
       }))
       .add(() => ({
@@ -60,6 +61,7 @@ describe('createApi', () => {
         params: t.type({
           body: t.string,
         }),
+        options: { tags: ['access:apm'] },
         handler: async () => null,
       }))
       .add(() => ({
@@ -125,6 +127,7 @@ describe('createApi', () => {
         .add(() => ({
           endpoint: 'GET /foo',
           params,
+          options: { tags: ['access:apm'] },
           handler: handlerMock,
         }))
         .init(mock, context);

--- a/x-pack/plugins/apm/server/routes/create_api/index.ts
+++ b/x-pack/plugins/apm/server/routes/create_api/index.ts
@@ -50,12 +50,7 @@ export function createApi() {
             ? routeOrFactoryFn(core)
             : routeOrFactoryFn;
 
-        const {
-          params,
-          endpoint,
-          options = { tags: ['access:apm'] },
-          handler,
-        } = route;
+        const { params, endpoint, options, handler } = route;
 
         const [method, path] = endpoint.split(' ');
 

--- a/x-pack/plugins/apm/server/routes/errors.ts
+++ b/x-pack/plugins/apm/server/routes/errors.ts
@@ -27,6 +27,7 @@ export const errorsRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { params } = context;
@@ -51,6 +52,7 @@ export const errorGroupsRoute = createRoute({
     }),
     query: t.intersection([uiFiltersRt, rangeRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName, groupId } = context.params.path;
@@ -72,6 +74,7 @@ export const errorDistributionRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { params } = context;

--- a/x-pack/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/index_pattern.ts
@@ -15,6 +15,7 @@ import { UIProcessorEvent } from '../../common/processor_event';
 
 export const staticIndexPatternRoute = createRoute((core) => ({
   endpoint: 'POST /api/apm/index_pattern/static',
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const savedObjectsClient = await getInternalSavedObjectsClient(core);
@@ -37,6 +38,7 @@ export const dynamicIndexPatternRoute = createRoute({
       ]),
     }),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context }) => {
     const indices = await getApmIndices({
       config: context.config,
@@ -59,6 +61,7 @@ export const dynamicIndexPatternRoute = createRoute({
 
 export const apmIndexPatternTitleRoute = createRoute({
   endpoint: 'GET /api/apm/index_pattern/title',
+  options: { tags: ['access:apm'] },
   handler: async ({ context }) => {
     return getApmIndexPatternTitle(context);
   },

--- a/x-pack/plugins/apm/server/routes/metrics.ts
+++ b/x-pack/plugins/apm/server/routes/metrics.ts
@@ -27,6 +27,7 @@ export const metricsChartsRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { params } = context;

--- a/x-pack/plugins/apm/server/routes/observability_overview.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview.ts
@@ -14,6 +14,7 @@ import { getSearchAggregatedTransactions } from '../lib/helpers/aggregated_trans
 
 export const observabilityOverviewHasDataRoute = createRoute({
   endpoint: 'GET /api/apm/observability_overview/has_data',
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     return await hasData({ setup });
@@ -25,6 +26,7 @@ export const observabilityOverviewRoute = createRoute({
   params: t.type({
     query: t.intersection([rangeRt, t.type({ bucketSize: t.string })]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { bucketSize } = context.params.query;

--- a/x-pack/plugins/apm/server/routes/rum_client.ts
+++ b/x-pack/plugins/apm/server/routes/rum_client.ts
@@ -36,6 +36,7 @@ export const rumClientMetricsRoute = createRoute({
   params: t.type({
     query: uxQueryRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -56,6 +57,7 @@ export const rumPageLoadDistributionRoute = createRoute({
   params: t.type({
     query: t.intersection([uxQueryRt, percentileRangeRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -81,6 +83,7 @@ export const rumPageLoadDistBreakdownRoute = createRoute({
       t.type({ breakdown: t.string }),
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -103,6 +106,7 @@ export const rumPageViewsTrendRoute = createRoute({
   params: t.type({
     query: t.intersection([uxQueryRt, t.partial({ breakdowns: t.string })]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -123,6 +127,7 @@ export const rumServicesRoute = createRoute({
   params: t.type({
     query: t.intersection([uiFiltersRt, rangeRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -135,6 +140,7 @@ export const rumVisitorsBreakdownRoute = createRoute({
   params: t.type({
     query: uxQueryRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -154,6 +160,7 @@ export const rumWebCoreVitals = createRoute({
   params: t.type({
     query: uxQueryRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -174,6 +181,7 @@ export const rumLongTaskMetrics = createRoute({
   params: t.type({
     query: uxQueryRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -194,6 +202,7 @@ export const rumUrlSearch = createRoute({
   params: t.type({
     query: uxQueryRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -215,6 +224,7 @@ export const rumJSErrors = createRoute({
       t.partial({ urlQuery: t.string }),
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -236,6 +246,7 @@ export const rumHasDataRoute = createRoute({
   params: t.type({
     query: t.intersection([uiFiltersRt, rangeRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     return await hasRumData({ setup });

--- a/x-pack/plugins/apm/server/routes/service_map.ts
+++ b/x-pack/plugins/apm/server/routes/service_map.ts
@@ -29,6 +29,7 @@ export const serviceMapRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     if (!context.config['xpack.apm.serviceMapEnabled']) {
       throw Boom.notFound();
@@ -69,6 +70,7 @@ export const serviceMapServiceNodeRoute = createRoute({
     }),
     query: t.intersection([rangeRt, uiFiltersRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     if (!context.config['xpack.apm.serviceMapEnabled']) {
       throw Boom.notFound();

--- a/x-pack/plugins/apm/server/routes/service_nodes.ts
+++ b/x-pack/plugins/apm/server/routes/service_nodes.ts
@@ -17,6 +17,7 @@ export const serviceNodesRoute = createRoute({
     }),
     query: t.intersection([rangeRt, uiFiltersRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { params } = context;

--- a/x-pack/plugins/apm/server/routes/services.ts
+++ b/x-pack/plugins/apm/server/routes/services.ts
@@ -25,6 +25,7 @@ export const servicesRoute = createRoute({
   params: t.type({
     query: t.intersection([uiFiltersRt, rangeRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -50,6 +51,7 @@ export const serviceAgentNameRoute = createRoute({
     }),
     query: rangeRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.path;
@@ -73,6 +75,7 @@ export const serviceTransactionTypesRoute = createRoute({
     }),
     query: rangeRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.path;
@@ -96,6 +99,7 @@ export const serviceNodeMetadataRoute = createRoute({
     }),
     query: t.intersection([uiFiltersRt, rangeRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName, serviceNodeName } = context.params.path;
@@ -116,6 +120,7 @@ export const serviceAnnotationsRoute = createRoute({
       }),
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.path;
@@ -220,6 +225,7 @@ export const serviceErrorGroupsRoute = createRoute({
       }),
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration.ts
@@ -27,6 +27,7 @@ import { getSearchAggregatedTransactions } from '../../lib/helpers/aggregated_tr
 // get list of configurations
 export const agentConfigurationRoute = createRoute({
   endpoint: 'GET /api/apm/settings/agent-configuration',
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     return await listConfigurations({ setup });
@@ -39,6 +40,7 @@ export const getSingleAgentConfigurationRoute = createRoute({
   params: t.partial({
     query: serviceRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { name, environment } = context.params.query;
@@ -148,6 +150,7 @@ export const agentConfigurationSearchRoute = createRoute({
   params: t.type({
     body: searchParamsRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const {
       service,
@@ -194,6 +197,7 @@ export const agentConfigurationSearchRoute = createRoute({
 // get list of services
 export const listAgentConfigurationServicesRoute = createRoute({
   endpoint: 'GET /api/apm/settings/agent-configuration/services',
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const searchAggregatedTransactions = await getSearchAggregatedTransactions(
@@ -212,6 +216,7 @@ export const listAgentConfigurationEnvironmentsRoute = createRoute({
   params: t.partial({
     query: t.partial({ serviceName: t.string }),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.query;
@@ -233,6 +238,7 @@ export const agentConfigurationAgentNameRoute = createRoute({
   params: t.type({
     query: t.type({ serviceName: t.string }),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.query;

--- a/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
+++ b/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
@@ -71,6 +71,7 @@ export const createAnomalyDetectionJobsRoute = createRoute({
 // get all available environments to create anomaly detection jobs for
 export const anomalyDetectionEnvironmentsRoute = createRoute({
   endpoint: 'GET /api/apm/settings/anomaly-detection/environments',
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices.ts
@@ -15,6 +15,7 @@ import { saveApmIndices } from '../../lib/settings/apm_indices/save_apm_indices'
 // get list of apm indices and values
 export const apmIndexSettingsRoute = createRoute({
   endpoint: 'GET /api/apm/settings/apm-index-settings',
+  options: { tags: ['access:apm'] },
   handler: async ({ context }) => {
     return await getApmIndexSettings({ context });
   },
@@ -23,6 +24,7 @@ export const apmIndexSettingsRoute = createRoute({
 // get apm indices configuration object
 export const apmIndicesRoute = createRoute({
   endpoint: 'GET /api/apm/settings/apm-indices',
+  options: { tags: ['access:apm'] },
   handler: async ({ context }) => {
     return await getApmIndices({
       savedObjectsClient: context.core.savedObjects.client,

--- a/x-pack/plugins/apm/server/routes/settings/custom_link.ts
+++ b/x-pack/plugins/apm/server/routes/settings/custom_link.ts
@@ -28,6 +28,7 @@ function isActiveGoldLicense(license: ILicense) {
 
 export const customLinkTransactionRoute = createRoute({
   endpoint: 'GET /api/apm/settings/custom_links/transaction',
+  options: { tags: ['access:apm'] },
   params: t.partial({
     query: filterOptionsRt,
   }),
@@ -42,6 +43,7 @@ export const customLinkTransactionRoute = createRoute({
 
 export const listCustomLinksRoute = createRoute({
   endpoint: 'GET /api/apm/settings/custom_links',
+  options: { tags: ['access:apm'] },
   params: t.partial({
     query: filterOptionsRt,
   }),
@@ -62,9 +64,7 @@ export const createCustomLinkRoute = createRoute({
   params: t.type({
     body: payloadRt,
   }),
-  options: {
-    tags: ['access:apm', 'access:apm_write'],
-  },
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     if (!isActiveGoldLicense(context.licensing.license)) {
       throw Boom.forbidden(INVALID_LICENSE);

--- a/x-pack/plugins/apm/server/routes/traces.ts
+++ b/x-pack/plugins/apm/server/routes/traces.ts
@@ -17,6 +17,7 @@ export const tracesRoute = createRoute({
   params: t.type({
     query: t.intersection([rangeRt, uiFiltersRt]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const searchAggregatedTransactions = await getSearchAggregatedTransactions(
@@ -37,6 +38,7 @@ export const tracesByIdRoute = createRoute({
     }),
     query: rangeRt,
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     return getTrace(context.params.path.traceId, setup);

--- a/x-pack/plugins/apm/server/routes/transaction.ts
+++ b/x-pack/plugins/apm/server/routes/transaction.ts
@@ -16,6 +16,7 @@ export const transactionByTraceIdRoute = createRoute({
       traceId: t.string,
     }),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const { traceId } = context.params.path;
     const setup = await setupRequest(context, request);

--- a/x-pack/plugins/apm/server/routes/transaction_groups.ts
+++ b/x-pack/plugins/apm/server/routes/transaction_groups.ts
@@ -31,6 +31,7 @@ export const transactionGroupsRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.path;
@@ -67,6 +68,7 @@ export const transactionGroupsChartsRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const logger = context.logger;
@@ -116,6 +118,7 @@ export const transactionGroupsDistributionRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.path;
@@ -159,6 +162,7 @@ export const transactionGroupsBreakdownRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.path;
@@ -182,6 +186,7 @@ export const transactionSampleForGroupRoute = createRoute({
       t.type({ serviceName: t.string, transactionName: t.string }),
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
 
@@ -212,6 +217,7 @@ export const transactionGroupsErrorRateRoute = createRoute({
       }),
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { params } = context;

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -59,7 +59,7 @@ export interface Route<
   TReturn
 > {
   endpoint: TEndpoint;
-  options?: RouteOptions;
+  options: RouteOptions;
   params?: TRouteParamsRT;
   handler: RouteHandler<TRouteParamsRT, TReturn>;
 }

--- a/x-pack/plugins/apm/server/routes/ui_filters.ts
+++ b/x-pack/plugins/apm/server/routes/ui_filters.ts
@@ -40,6 +40,7 @@ export const uiFiltersEnvironmentsRoute = createRoute({
       rangeRt,
     ]),
   }),
+  options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
     const { serviceName } = context.params.query;
@@ -94,6 +95,7 @@ function createLocalFiltersRoute<
     params: t.type({
       query: t.intersection([localUiBaseQueryRt, queryRt]),
     }),
+    options: { tags: ['access:apm'] },
     handler: async ({ context, request }) => {
       const setup = await setupRequest(context, request);
       const { uiFilters } = setup;


### PR DESCRIPTION
This PR makes `tags` on routes required to make sure they are explicitly added. This makes it easier when inspecting endpoints and knowing what permissions is required when calling it