### PR TITLE
[APM] Prefer `APIReturnType` over `PromiseReturnType`

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
@@ -20,6 +20,7 @@ import { first } from 'lodash';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { px, unit, units } from '../../../../style/variables';

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/DetailView/index.tsx
@@ -20,8 +20,6 @@ import { first } from 'lodash';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { ErrorGroupAPIResponse } from '../../../../../server/lib/errors/get_error_group';
 import { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { px, unit, units } from '../../../../style/variables';
@@ -56,7 +54,9 @@ const TransactionLinkName = styled.div`
 `;
 
 interface Props {
-  errorGroup: ErrorGroupAPIResponse;
+  errorGroup: APIReturnType<
+    'GET /api/apm/services/{serviceName}/errors/{groupId}'
+  >;
   urlParams: IUrlParams;
   location: Location;
 }

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/Distribution/index.tsx
@@ -18,10 +18,13 @@ import {
 import { EuiTitle } from '@elastic/eui';
 import d3 from 'd3';
 import React from 'react';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { asRelativeDateTimeRange } from '../../../../../common/utils/formatters';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import type { ErrorDistributionAPIResponse } from '../../../../../server/lib/errors/distribution/get_distribution';
 import { useTheme } from '../../../../hooks/useTheme';
+
+type ErrorDistributionAPIResponse = APIReturnType<
+  'GET /api/apm/services/{serviceName}/errors/distribution'
+>;
 
 interface FormattedBucket {
   x0: number;

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { EuiIconTip } from '@elastic/eui';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
 import {
   fontFamilyCode,
@@ -24,7 +25,6 @@ import { ErrorDetailLink } from '../../../shared/Links/apm/ErrorDetailLink';
 import { TimestampTooltip } from '../../../shared/TimestampTooltip';
 import { ErrorOverviewLink } from '../../../shared/Links/apm/ErrorOverviewLink';
 import { APMQueryParams } from '../../../shared/Links/url_helpers';
-import { APIReturnType } from '../../../services/rest/createCallApmApi';
 
 const GroupIdLink = styled(ErrorDetailLink)`
   font-family: ${fontFamilyCode};
@@ -48,8 +48,12 @@ const Culprit = styled.div`
   font-family: ${fontFamilyCode};
 `;
 
+type ErrorGroupListAPIResponse = APIReturnType<
+  'GET /api/apm/services/{serviceName}/errors'
+>;
+
 interface Props {
-  items: APIReturnType<'GET /api/apm/services/{serviceName}/errors'>;
+  items: ErrorGroupListAPIResponse;
   serviceName: string;
 }
 

--- a/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupOverview/List/index.tsx
@@ -11,8 +11,6 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { EuiIconTip } from '@elastic/eui';
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { ErrorGroupListAPIResponse } from '../../../../../server/lib/errors/get_error_groups';
 import {
   fontFamilyCode,
   fontSizes,
@@ -26,6 +24,7 @@ import { ErrorDetailLink } from '../../../shared/Links/apm/ErrorDetailLink';
 import { TimestampTooltip } from '../../../shared/TimestampTooltip';
 import { ErrorOverviewLink } from '../../../shared/Links/apm/ErrorOverviewLink';
 import { APMQueryParams } from '../../../shared/Links/url_helpers';
+import { APIReturnType } from '../../../services/rest/createCallApmApi';
 
 const GroupIdLink = styled(ErrorDetailLink)`
   font-family: ${fontFamilyCode};
@@ -50,7 +49,7 @@ const Culprit = styled.div`
 `;
 
 interface Props {
-  items: ErrorGroupListAPIResponse;
+  items: APIReturnType<'GET /api/apm/services/{serviceName}/errors'>;
   serviceName: string;
 }
 

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/ConfirmDeleteModal.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/ConfirmDeleteModal.tsx
@@ -8,13 +8,14 @@ import React, { useState } from 'react';
 import { EuiConfirmModal, EuiOverlayMask } from '@elastic/eui';
 import { NotificationsStart } from 'kibana/public';
 import { i18n } from '@kbn/i18n';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { AgentConfigurationListAPIResponse } from '../../../../../../server/lib/settings/agent_configuration/list_configurations';
 import { getOptionLabel } from '../../../../../../common/agent_configuration/all_option';
-import { callApmApi } from '../../../../../services/rest/createCallApmApi';
+import {
+  APIReturnType,
+  callApmApi,
+} from '../../../../../services/rest/createCallApmApi';
 import { useApmPluginContext } from '../../../../../hooks/useApmPluginContext';
 
-type Config = AgentConfigurationListAPIResponse[0];
+type Config = APIReturnType<'GET /api/apm/settings/agent-configuration'>[0];
 
 interface Props {
   config: Config;

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
@@ -16,9 +16,8 @@ import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { APIReturnType } from '../../../../../services/rest/createCallApmApi';
 import { getOptionLabel } from '../../../../../../common/agent_configuration/all_option';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { AgentConfigurationListAPIResponse } from '../../../../../../server/lib/settings/agent_configuration/list_configurations';
 import { useApmPluginContext } from '../../../../../hooks/useApmPluginContext';
 import { FETCH_STATUS } from '../../../../../hooks/useFetcher';
 import { useTheme } from '../../../../../hooks/useTheme';
@@ -32,7 +31,7 @@ import { ITableColumn, ManagedTable } from '../../../../shared/ManagedTable';
 import { TimestampTooltip } from '../../../../shared/TimestampTooltip';
 import { ConfirmDeleteModal } from './ConfirmDeleteModal';
 
-type Config = AgentConfigurationListAPIResponse[0];
+type Config = APIReturnType<'GET /api/apm/settings/agent-configuration'>[0];
 
 interface Props {
   status: FETCH_STATUS;

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -8,8 +8,6 @@ import { EuiIcon, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import styled from 'styled-components';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { TransactionGroup } from '../../../../server/lib/transaction_groups/fetcher';
 import { asMillisecondDuration } from '../../../../common/utils/formatters';
 import { fontSizes, truncate } from '../../../style/variables';
 import { EmptyMessage } from '../../shared/EmptyMessage';
@@ -17,6 +15,9 @@ import { ImpactBar } from '../../shared/ImpactBar';
 import { ITableColumn, ManagedTable } from '../../shared/ManagedTable';
 import { LoadingStatePrompt } from '../../shared/LoadingStatePrompt';
 import { TransactionDetailLink } from '../../shared/Links/apm/TransactionDetailLink';
+import { APIReturnType } from '../../../services/rest/createCallApmApi';
+
+type TraceGroup = APIReturnType<'GET /api/apm/traces'>['items'][0];
 
 const StyledTransactionLink = styled(TransactionDetailLink)`
   font-size: ${fontSizes.large};
@@ -24,11 +25,11 @@ const StyledTransactionLink = styled(TransactionDetailLink)`
 `;
 
 interface Props {
-  items: TransactionGroup[];
+  items: TraceGroup[];
   isLoading: boolean;
 }
 
-const traceListColumns: Array<ITableColumn<TransactionGroup>> = [
+const traceListColumns: Array<ITableColumn<TraceGroup>> = [
   {
     field: 'name',
     name: i18n.translate('xpack.apm.tracesTable.nameColumnLabel', {
@@ -38,7 +39,7 @@ const traceListColumns: Array<ITableColumn<TransactionGroup>> = [
     sortable: true,
     render: (
       _: string,
-      { serviceName, transactionName, transactionType }: TransactionGroup
+      { serviceName, transactionName, transactionType }: TraceGroup
     ) => (
       <EuiToolTip content={transactionName}>
         <StyledTransactionLink

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -24,17 +24,24 @@ import d3 from 'd3';
 import { isEmpty } from 'lodash';
 import React, { useCallback } from 'react';
 import { ValuesType } from 'utility-types';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { useTheme } from '../../../../../../observability/public';
 import { getDurationFormatter } from '../../../../../common/utils/formatters';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import type { TransactionDistributionAPIResponse } from '../../../../../server/lib/transactions/distribution';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import type { DistributionBucket } from '../../../../../server/lib/transactions/distribution/get_buckets';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { FETCH_STATUS } from '../../../../hooks/useFetcher';
 import { unit } from '../../../../style/variables';
 import { ChartContainer } from '../../../shared/charts/chart_container';
 import { EmptyMessage } from '../../../shared/EmptyMessage';
+
+type TransactionDistributionAPIResponse = APIReturnType<
+  'GET /api/apm/services/{serviceName}/transaction_groups/distribution'
+>;
+
+type DistributionApiResponse = APIReturnType<
+  'GET /api/apm/services/{serviceName}/transaction_groups/distribution'
+>;
+
+type DistributionBucket = DistributionApiResponse['buckets'][0];
 
 interface IChartPoint {
   x0: number;

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/index.tsx
@@ -17,8 +17,7 @@ import { i18n } from '@kbn/i18n';
 import { Location } from 'history';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { DistributionBucket } from '../../../../../server/lib/transactions/distribution/get_buckets';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { IUrlParams } from '../../../../context/UrlParamsContext/types';
 import { fromQuery, toQuery } from '../../../shared/Links/url_helpers';
 import { LoadingStatePrompt } from '../../../shared/LoadingStatePrompt';
@@ -27,6 +26,12 @@ import { TransactionActionMenu } from '../../../shared/TransactionActionMenu/Tra
 import { MaybeViewTraceLink } from './MaybeViewTraceLink';
 import { TransactionTabs } from './TransactionTabs';
 import { IWaterfall } from './WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers';
+
+type DistributionApiResponse = APIReturnType<
+  'GET /api/apm/services/{serviceName}/transaction_groups/distribution'
+>;
+
+type DistributionBucket = DistributionApiResponse['buckets'][0];
 
 interface Props {
   urlParams: IUrlParams;

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/TransactionList/TransactionList.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/TransactionList/TransactionList.stories.tsx
@@ -6,10 +6,13 @@
 
 import React, { ComponentType } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { TransactionGroup } from '../../../../../server/lib/transaction_groups/fetcher';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { MockApmPluginContextWrapper } from '../../../../context/ApmPluginContext/MockApmPluginContext';
 import { TransactionList } from './';
+
+type TransactionGroup = APIReturnType<
+  'GET /api/apm/services/{serviceName}/transaction_groups'
+>['items'][0];
 
 export default {
   title: 'app/TransactionOverview/TransactionList',

--- a/x-pack/plugins/apm/public/components/app/TransactionOverview/TransactionList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionOverview/TransactionList/index.tsx
@@ -8,8 +8,7 @@ import { EuiToolTip, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { TransactionGroup } from '../../../../../server/lib/transaction_groups/fetcher';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import {
   asDecimal,
   asMillisecondDuration,
@@ -20,6 +19,10 @@ import { ITableColumn, ManagedTable } from '../../../shared/ManagedTable';
 import { LoadingStatePrompt } from '../../../shared/LoadingStatePrompt';
 import { EmptyMessage } from '../../../shared/EmptyMessage';
 import { TransactionDetailLink } from '../../../shared/Links/apm/TransactionDetailLink';
+
+type TransactionGroup = APIReturnType<
+  'GET /api/apm/services/{serviceName}/transaction_groups'
+>['items'][0];
 
 // Truncate both the link and the child span (the tooltip anchor.) The link so
 // it doesn't overflow, and the anchor so we get the ellipsis.

--- a/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
@@ -26,13 +26,13 @@ import { AgentIcon } from '../../../shared/AgentIcon';
 import { HealthBadge } from './HealthBadge';
 import { ServiceListMetric } from './ServiceListMetric';
 
-type Items = APIReturnType<'GET /api/apm/services'>['items'];
+type ServiceListAPIResponse = APIReturnType<'GET /api/apm/services'>;
+type Items = ServiceListAPIResponse['items'];
 
 interface Props {
   items: Items;
   noItemsMessage?: React.ReactNode;
 }
-
 type ServiceListItem = ValuesType<Items>;
 
 function formatNumber(value: number) {

--- a/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
@@ -10,14 +10,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { ValuesType } from 'utility-types';
 import { orderBy } from 'lodash';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { ServiceHealthStatus } from '../../../../../common/service_health_status';
 import {
   asPercent,
   asDecimal,
   asMillisecondDuration,
 } from '../../../../../common/utils/formatters';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { ServiceListAPIResponse } from '../../../../../server/lib/services/get_services';
 import { NOT_AVAILABLE_LABEL } from '../../../../../common/i18n';
 import { fontSizes, px, truncate, unit } from '../../../../style/variables';
 import { ManagedTable, ITableColumn } from '../../../shared/ManagedTable';
@@ -27,12 +26,14 @@ import { AgentIcon } from '../../../shared/AgentIcon';
 import { HealthBadge } from './HealthBadge';
 import { ServiceListMetric } from './ServiceListMetric';
 
+type Items = APIReturnType<'GET /api/apm/services'>['items'];
+
 interface Props {
-  items: ServiceListAPIResponse['items'];
+  items: Items;
   noItemsMessage?: React.ReactNode;
 }
 
-type ServiceListItem = ValuesType<Props['items']>;
+type ServiceListItem = ValuesType<Items>;
 
 function formatNumber(value: number) {
   if (value === 0) {

--- a/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/service_list.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/service_list.test.tsx
@@ -7,12 +7,13 @@
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ServiceHealthStatus } from '../../../../../common/service_health_status';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { ServiceListAPIResponse } from '../../../../../server/lib/services/get_services';
 import { MockApmPluginContextWrapper } from '../../../../context/ApmPluginContext/MockApmPluginContext';
 import { mockMoment, renderWithTheme } from '../../../../utils/testHelpers';
+import { APIReturnType } from '../../../../services/rest/createCallApmApi';
 import { ServiceList, SERVICE_COLUMNS } from './';
 import props from './__fixtures__/props.json';
+
+type ServiceListAPIResponse = APIReturnType<'GET /api/apm/services'>;
 
 function Wrapper({ children }: { children?: ReactNode }) {
   return (

--- a/x-pack/plugins/apm/public/hooks/useTransactionDistribution.ts
+++ b/x-pack/plugins/apm/public/hooks/useTransactionDistribution.ts
@@ -9,13 +9,16 @@ import { useHistory, useParams } from 'react-router-dom';
 import { IUrlParams } from '../context/UrlParamsContext/types';
 import { useFetcher } from './useFetcher';
 import { useUiFilters } from '../context/UrlParamsContext';
-// eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import type { TransactionDistributionAPIResponse } from '../../server/lib/transactions/distribution';
 import { toQuery, fromQuery } from '../components/shared/Links/url_helpers';
 import { maybe } from '../../common/utils/maybe';
+import { APIReturnType } from '../services/rest/createCallApmApi';
+
+type APIResponse = APIReturnType<
+  'GET /api/apm/services/{serviceName}/transaction_groups/distribution'
+>;
 
 const INITIAL_DATA = {
-  buckets: [] as TransactionDistributionAPIResponse['buckets'],
+  buckets: [] as APIResponse['buckets'],
   noHits: true,
   bucketSize: 0,
 };

--- a/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
+++ b/x-pack/plugins/apm/server/lib/errors/distribution/get_distribution.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { PromiseReturnType } from '../../../../../observability/typings/common';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import { BUCKET_TARGET_COUNT } from '../../transactions/constants';
 import { getBuckets } from './get_buckets';
@@ -12,10 +11,6 @@ import { getBuckets } from './get_buckets';
 function getBucketSize({ start, end }: SetupTimeRange) {
   return Math.floor((end - start) / BUCKET_TARGET_COUNT);
 }
-
-export type ErrorDistributionAPIResponse = PromiseReturnType<
-  typeof getErrorDistribution
->;
 
 export async function getErrorDistribution({
   serviceName,

--- a/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_group.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { PromiseReturnType } from '../../../../observability/typings/common';
 import {
   ERROR_GROUP_ID,
   SERVICE_NAME,
@@ -14,8 +13,6 @@ import { ProcessorEvent } from '../../../common/processor_event';
 import { rangeFilter } from '../../../common/utils/range_filter';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
 import { getTransaction } from '../transactions/get_transaction';
-
-export type ErrorGroupAPIResponse = PromiseReturnType<typeof getErrorGroup>;
 
 // TODO: rename from "getErrorGroup"  to "getErrorGroupSample" (since a single error is returned, not an errorGroup)
 export async function getErrorGroup({

--- a/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
+++ b/x-pack/plugins/apm/server/lib/errors/get_error_groups.ts
@@ -5,7 +5,6 @@
  */
 
 import { SortOptions } from '../../../../../typings/elasticsearch/aggregations';
-import { PromiseReturnType } from '../../../../observability/typings/common';
 import {
   ERROR_CULPRIT,
   ERROR_EXC_HANDLED,
@@ -18,10 +17,6 @@ import { getErrorGroupsProjection } from '../../projections/errors';
 import { mergeProjection } from '../../projections/util/merge_projection';
 import { getErrorName } from '../helpers/get_error_name';
 import { Setup, SetupTimeRange } from '../helpers/setup_request';
-
-export type ErrorGroupListAPIResponse = PromiseReturnType<
-  typeof getErrorGroups
->;
 
 export async function getErrorGroups({
   serviceName,

--- a/x-pack/plugins/apm/server/lib/services/get_services/get_services_items.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/get_services_items.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import { Logger } from '@kbn/logging';
-import { PromiseReturnType } from '../../../../../observability/typings/common';
 import { joinByKey } from '../../../../common/utils/join_by_key';
 import { getServicesProjection } from '../../../projections/services';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
@@ -17,7 +16,6 @@ import {
   getTransactionRates,
 } from './get_services_items_stats';
 
-export type ServiceListAPIResponse = PromiseReturnType<typeof getServicesItems>;
 export type ServicesItemsSetup = Setup & SetupTimeRange;
 export type ServicesItemsProjection = ReturnType<typeof getServicesProjection>;
 

--- a/x-pack/plugins/apm/server/lib/services/get_services/index.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_services/index.ts
@@ -6,13 +6,10 @@
 
 import { Logger } from '@kbn/logging';
 import { isEmpty } from 'lodash';
-import { PromiseReturnType } from '../../../../../observability/typings/common';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import { getLegacyDataStatus } from './get_legacy_data_status';
 import { getServicesItems } from './get_services_items';
 import { hasHistoricalAgentData } from './has_historical_agent_data';
-
-export type ServiceListAPIResponse = PromiseReturnType<typeof getServices>;
 
 export async function getServices({
   setup,

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/list_configurations.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/list_configurations.ts
@@ -4,14 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { PromiseReturnType } from '../../../../../observability/typings/common';
 import { Setup } from '../../helpers/setup_request';
 import { AgentConfiguration } from '../../../../common/agent_configuration/configuration_types';
 import { convertConfigSettingsToString } from './convert_settings_to_string';
 
-export type AgentConfigurationListAPIResponse = PromiseReturnType<
-  typeof listConfigurations
->;
 export async function listConfigurations({ setup }: { setup: Setup }) {
   const { internalClient, indices } = setup;
 

--- a/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
+++ b/x-pack/plugins/apm/server/lib/transaction_groups/fetcher.ts
@@ -204,7 +204,7 @@ export async function transactionGroupsFetcher(
   };
 }
 
-export interface TransactionGroup {
+interface TransactionGroup {
   key: string | Record<'service.name' | 'transaction.name', string>;
   serviceName: string;
   transactionName: string;

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/index.ts
@@ -3,8 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { ValuesType } from 'utility-types';
-import { PromiseReturnType } from '../../../../../../observability/typings/common';
+
 import {
   SERVICE_NAME,
   TRACE_ID,
@@ -196,7 +195,3 @@ export async function getBuckets({
     buckets,
   };
 }
-
-export type DistributionBucket = ValuesType<
-  PromiseReturnType<typeof getBuckets>['buckets']
->;

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/index.ts
@@ -4,7 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { PromiseReturnType } from '../../../../../observability/typings/common';
 import { Setup, SetupTimeRange } from '../../helpers/setup_request';
 import { getBuckets } from './get_buckets';
 import { getDistributionMax } from './get_distribution_max';
@@ -18,9 +17,6 @@ function getBucketSize(max: number) {
   );
 }
 
-export type TransactionDistributionAPIResponse = PromiseReturnType<
-  typeof getTransactionDistribution
->;
 export async function getTransactionDistribution({
   serviceName,
   transactionName,


### PR DESCRIPTION
Instead of using `PromiseReturnType` I suggest we use `APIReturnType` since it will return a type that is closer to the actual API response.

Additionally this will help us get rid of the pesky eslint-ignore flags.