### PR TITLE
[DoNotMerge] Id-less log columns

### DIFF
--- a/x-pack/plugins/infra/common/http_api/log_entries/entries.ts
+++ b/x-pack/plugins/infra/common/http_api/log_entries/entries.ts
@@ -61,15 +61,13 @@ export const logMessageFieldPartRT = rt.type({
 
 export const logMessagePartRT = rt.union([logMessageConstantPartRT, logMessageFieldPartRT]);
 
-export const logTimestampColumnRT = rt.type({ columnId: rt.string, timestamp: rt.number });
+export const logTimestampColumnRT = rt.type({ timestamp: rt.number });
 export const logFieldColumnRT = rt.type({
-  columnId: rt.string,
   field: rt.string,
   value: jsonArrayRT,
   highlights: rt.array(rt.string),
 });
 export const logMessageColumnRT = rt.type({
-  columnId: rt.string,
   message: rt.array(logMessagePartRT),
 });
 

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/column_headers.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/column_headers.tsx
@@ -31,12 +31,12 @@ export const LogColumnHeaders: React.FunctionComponent<{
   const { firstVisiblePosition } = useContext(LogPositionState.Context);
   return (
     <LogColumnHeadersWrapper>
-      {columnConfigurations.map((columnConfiguration) => {
+      {columnConfigurations.map((columnConfiguration, columnPosition) => {
         if (isTimestampLogColumnConfiguration(columnConfiguration)) {
           return (
             <LogColumnHeader
-              key={columnConfiguration.timestampColumn.id}
-              columnWidth={columnWidths[columnConfiguration.timestampColumn.id]}
+              key={columnPosition}
+              columnWidth={columnWidths[columnPosition]}
               data-test-subj="logColumnHeader timestampLogColumnHeader"
             >
               {firstVisiblePosition ? localizedDate(firstVisiblePosition.time) : 'Timestamp'}
@@ -45,9 +45,9 @@ export const LogColumnHeaders: React.FunctionComponent<{
         } else if (isMessageLogColumnConfiguration(columnConfiguration)) {
           return (
             <LogColumnHeader
-              columnWidth={columnWidths[columnConfiguration.messageColumn.id]}
+              columnWidth={columnWidths[columnPosition]}
               data-test-subj="logColumnHeader messageLogColumnHeader"
-              key={columnConfiguration.messageColumn.id}
+              key={columnPosition}
             >
               Message
             </LogColumnHeader>
@@ -55,9 +55,9 @@ export const LogColumnHeaders: React.FunctionComponent<{
         } else if (isFieldLogColumnConfiguration(columnConfiguration)) {
           return (
             <LogColumnHeader
-              columnWidth={columnWidths[columnConfiguration.fieldColumn.id]}
+              columnWidth={columnWidths[columnPosition]}
               data-test-subj="logColumnHeader fieldLogColumnHeader"
-              key={columnConfiguration.fieldColumn.id}
+              key={columnPosition}
             >
               {columnConfiguration.fieldColumn.field}
             </LogColumnHeader>

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/index.ts
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/index.ts
@@ -6,9 +6,9 @@
 
 export {
   LogEntryColumn,
+  LogEntryColumnWidth,
   LogEntryColumnWidths,
   useColumnWidths,
-  iconColumnId,
 } from './log_entry_column';
 export { LogEntryFieldColumn } from './log_entry_field_column';
 export { LogEntryMessageColumn } from './log_entry_message_column';

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_column.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_column.tsx
@@ -51,14 +51,7 @@ export type LogEntryColumnWidth = Pick<
   'baseWidth' | 'growWeight' | 'shrinkWeight'
 >;
 
-export const iconColumnId = Symbol('iconColumnId');
-
 export type LogEntryColumnWidths = LogEntryColumnWidth[];
-
-// export interface LogEntryColumnWidths {
-//   [columnId: string]: LogEntryColumnWidth;
-//   [iconColumnId]: LogEntryColumnWidth;
-// }
 
 export const getColumnWidths = (
   columns: LogColumnConfiguration[],

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_column.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_column.tsx
@@ -53,61 +53,54 @@ export type LogEntryColumnWidth = Pick<
 
 export const iconColumnId = Symbol('iconColumnId');
 
-export interface LogEntryColumnWidths {
-  [columnId: string]: LogEntryColumnWidth;
-  [iconColumnId]: LogEntryColumnWidth;
-}
+export type LogEntryColumnWidths = LogEntryColumnWidth[];
+
+// export interface LogEntryColumnWidths {
+//   [columnId: string]: LogEntryColumnWidth;
+//   [iconColumnId]: LogEntryColumnWidth;
+// }
 
 export const getColumnWidths = (
   columns: LogColumnConfiguration[],
   characterWidth: number,
   formattedDateWidth: number
-): LogEntryColumnWidths =>
-  columns.reduce<LogEntryColumnWidths>(
-    (columnWidths, column) => {
-      if (isTimestampLogColumnConfiguration(column)) {
-        return {
-          ...columnWidths,
-          [column.timestampColumn.id]: {
-            growWeight: 0,
-            shrinkWeight: 0,
-            baseWidth: `${
-              Math.ceil(characterWidth * formattedDateWidth * DATE_COLUMN_SLACK_FACTOR) +
-              2 * COLUMN_PADDING
-            }px`,
-          },
-        };
-      } else if (isMessageLogColumnConfiguration(column)) {
-        return {
-          ...columnWidths,
-          [column.messageColumn.id]: {
-            growWeight: 5,
-            shrinkWeight: 0,
-            baseWidth: '0%',
-          },
-        };
-      } else {
-        return {
-          ...columnWidths,
-          [column.fieldColumn.id]: {
-            growWeight: 1,
-            shrinkWeight: 0,
-            baseWidth: `${
-              Math.ceil(characterWidth * FIELD_COLUMN_MIN_WIDTH_CHARACTERS) + 2 * COLUMN_PADDING
-            }px`,
-          },
-        };
-      }
-    },
-    {
-      // the detail flyout icon column
-      [iconColumnId]: {
+): LogEntryColumnWidths => {
+  const columnWidths: LogEntryColumnWidths = columns.map((column) => {
+    if (isTimestampLogColumnConfiguration(column)) {
+      return {
         growWeight: 0,
         shrinkWeight: 0,
-        baseWidth: `${DETAIL_FLYOUT_ICON_MIN_WIDTH + 2 * COLUMN_PADDING}px`,
-      },
+        baseWidth: `${
+          Math.ceil(characterWidth * formattedDateWidth * DATE_COLUMN_SLACK_FACTOR) +
+          2 * COLUMN_PADDING
+        }px`,
+      };
+    } else if (isMessageLogColumnConfiguration(column)) {
+      return {
+        growWeight: 5,
+        shrinkWeight: 0,
+        baseWidth: '0%',
+      };
+    } else {
+      return {
+        growWeight: 1,
+        shrinkWeight: 0,
+        baseWidth: `${
+          Math.ceil(characterWidth * FIELD_COLUMN_MIN_WIDTH_CHARACTERS) + 2 * COLUMN_PADDING
+        }px`,
+      };
     }
-  );
+  });
+
+  // Actions menu column
+  columnWidths.push({
+    growWeight: 0,
+    shrinkWeight: 0,
+    baseWidth: `${DETAIL_FLYOUT_ICON_MIN_WIDTH + 2 * COLUMN_PADDING}px`,
+  });
+
+  return columnWidths;
+};
 
 /**
  * This hook calculates the column widths based on the given configuration. It

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_field_column.test.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_field_column.test.tsx
@@ -13,7 +13,6 @@ import { LogEntryFieldColumn } from './log_entry_field_column';
 describe('LogEntryFieldColumn', () => {
   it('renders a single value without a wrapping list', () => {
     const column: LogFieldColumn = {
-      columnId: 'TEST_COLUMN',
       field: 'TEST_FIELD',
       value: ['a'],
       highlights: [],
@@ -35,7 +34,6 @@ describe('LogEntryFieldColumn', () => {
 
   it('renders an array of values as a list', () => {
     const column: LogFieldColumn = {
-      columnId: 'TEST_COLUMN',
       field: 'TEST_FIELD',
       value: ['a', 'b', 'c'],
       highlights: [],
@@ -59,7 +57,6 @@ describe('LogEntryFieldColumn', () => {
 
   it('renders a text representation of a single complex object', () => {
     const column: LogFieldColumn = {
-      columnId: 'TEST_COLUMN',
       field: 'TEST_FIELD',
       value: [
         {
@@ -87,7 +84,6 @@ describe('LogEntryFieldColumn', () => {
 
   it('renders text representations of a multiple complex objects', () => {
     const column: LogFieldColumn = {
-      columnId: 'TEST_COLUMN',
       field: 'TEST_FIELD',
       value: [
         {

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_message_column.test.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_message_column.test.tsx
@@ -13,7 +13,6 @@ import { LogEntryMessageColumn } from './log_entry_message_column';
 describe('LogEntryMessageColumn', () => {
   it('renders a single scalar field value without a wrapping list', () => {
     const column: LogMessageColumn = {
-      columnId: 'TEST_COLUMN',
       message: [{ field: 'TEST_FIELD', value: ['VALUE'], highlights: [] }],
     };
 
@@ -33,7 +32,6 @@ describe('LogEntryMessageColumn', () => {
 
   it('renders a single array of scalar field values as a list', () => {
     const column: LogMessageColumn = {
-      columnId: 'TEST_COLUMN',
       message: [{ field: 'TEST_FIELD', value: ['VALUE_1', 'VALUE_2'], highlights: [] }],
     };
 
@@ -54,7 +52,6 @@ describe('LogEntryMessageColumn', () => {
 
   it('renders a complex message with an array of complex field values', () => {
     const column: LogMessageColumn = {
-      columnId: 'TEST_COLUMN',
       message: [
         { constant: 'CONSTANT_1' },
         { field: 'TEST_FIELD', value: [{ lat: 1, lon: 2 }, 'VALUE_2'], highlights: [] },

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_row.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_row.tsx
@@ -131,11 +131,10 @@ export const LogEntryRow = memo(
       >
         {columnConfigurations.map((columnConfiguration, columnPosition) => {
           const column = logEntry.columns[columnPosition];
+          const columnWidth = columnWidths[columnPosition];
           const columnHighlights = highlights.flatMap((h) => h.columns[columnPosition]);
 
           if (isTimestampLogColumnConfiguration(columnConfiguration)) {
-            const columnWidth = columnWidths[columnConfiguration.timestampColumn.id];
-
             return (
               <LogEntryColumn
                 data-test-subj="logColumn timestampLogColumn"
@@ -148,8 +147,6 @@ export const LogEntryRow = memo(
               </LogEntryColumn>
             );
           } else if (isMessageLogColumnConfiguration(columnConfiguration)) {
-            const columnWidth = columnWidths[columnConfiguration.messageColumn.id];
-
             return (
               <LogEntryColumn
                 data-test-subj="logColumn messageLogColumn"
@@ -167,8 +164,6 @@ export const LogEntryRow = memo(
               </LogEntryColumn>
             );
           } else if (isFieldLogColumnConfiguration(columnConfiguration)) {
-            const columnWidth = columnWidths[columnConfiguration.fieldColumn.id];
-
             return (
               <LogEntryColumn
                 data-test-subj={`logColumn fieldLogColumn fieldLogColumn:${columnConfiguration.fieldColumn.field}`}
@@ -190,7 +185,7 @@ export const LogEntryRow = memo(
         {hasActionsMenu ? (
           <LogEntryColumn
             key="logColumn iconLogColumn iconLogColumn:details"
-            {...columnWidths[iconColumnId]}
+            {...columnWidths[columnWidths.length - 1]}
           >
             {isHovered || isMenuOpen ? (
               <LogEntryContextMenu

--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_row.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/log_entry_row.tsx
@@ -17,7 +17,7 @@ import {
   isFieldLogColumnConfiguration,
 } from '../../../utils/source_configuration';
 import { TextScale } from '../../../../common/log_text_scale';
-import { LogEntryColumn, LogEntryColumnWidths, iconColumnId } from './log_entry_column';
+import { LogEntryColumn, LogEntryColumnWidths } from './log_entry_column';
 import { LogEntryFieldColumn } from './log_entry_field_column';
 import { LogEntryMessageColumn } from './log_entry_message_column';
 import { LogEntryTimestampColumn } from './log_entry_timestamp_column';

--- a/x-pack/plugins/infra/public/pages/logs/log_entry_categories/sections/top_categories/category_example_message.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/log_entry_categories/sections/top_categories/category_example_message.tsx
@@ -85,7 +85,6 @@ export const CategoryExampleMessage: React.FunctionComponent<{
       <LogEntryColumn {...columnWidths[messageColumnId]}>
         <LogEntryMessageColumn
           columnValue={{
-            columnId: messageColumnId,
             message: [{ field: 'message', value: [message], highlights: [] }],
           }}
           highlights={noHighlights}
@@ -96,7 +95,6 @@ export const CategoryExampleMessage: React.FunctionComponent<{
       <LogEntryColumn {...columnWidths[datasetColumnId]}>
         <LogEntryFieldColumn
           columnValue={{
-            columnId: datasetColumnId,
             field: 'event.dataset',
             value: [humanFriendlyDataset],
             highlights: [],

--- a/x-pack/plugins/infra/public/pages/logs/log_entry_rate/sections/anomalies/log_entry_example.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/log_entry_rate/sections/anomalies/log_entry_example.tsx
@@ -17,8 +17,7 @@ import {
   LogEntryRowWrapper,
   LogEntryTimestampColumn,
   LogEntryContextMenu,
-  LogEntryColumnWidths,
-  iconColumnId,
+  LogEntryColumnWidth,
 } from '../../../../../components/logging/log_text_stream';
 import {
   LogColumnHeadersWrapper,
@@ -207,11 +206,12 @@ const noHighlights: never[] = [];
 const timestampColumnId = 'log-entry-example-timestamp-column' as const;
 const messageColumnId = 'log-entry-examples-message-column' as const;
 const datasetColumnId = 'log-entry-examples-dataset-column' as const;
+const iconColumnId = 'log-entry-examples-icon-column' as const;
 
 const DETAIL_FLYOUT_ICON_MIN_WIDTH = 32;
 const COLUMN_PADDING = 8;
 
-export const columnWidths: LogEntryColumnWidths = {
+export const columnWidths: { [id: string]: LogEntryColumnWidth } = {
   [timestampColumnId]: {
     growWeight: 0,
     shrinkWeight: 0,

--- a/x-pack/plugins/infra/public/pages/logs/log_entry_rate/sections/anomalies/log_entry_example.tsx
+++ b/x-pack/plugins/infra/public/pages/logs/log_entry_rate/sections/anomalies/log_entry_example.tsx
@@ -163,7 +163,6 @@ export const LogEntryExampleMessage: React.FunctionComponent<Props> = ({
       <LogEntryColumn {...columnWidths[messageColumnId]}>
         <LogEntryMessageColumn
           columnValue={{
-            columnId: messageColumnId,
             message: [{ field: 'message', value: [message], highlights: [] }],
           }}
           highlights={noHighlights}
@@ -174,7 +173,6 @@ export const LogEntryExampleMessage: React.FunctionComponent<Props> = ({
       <LogEntryColumn {...columnWidths[datasetColumnId]}>
         <LogEntryFieldColumn
           columnValue={{
-            columnId: datasetColumnId,
             field: 'event.dataset',
             value: [humanFriendlyDataset],
             highlights: [],

--- a/x-pack/plugins/infra/server/lib/domains/log_entries_domain/log_entries_domain.ts
+++ b/x-pack/plugins/infra/server/lib/domains/log_entries_domain/log_entries_domain.ts
@@ -159,17 +159,14 @@ export class InfraLogEntriesDomain {
           (column): LogColumn => {
             if ('timestampColumn' in column) {
               return {
-                columnId: column.timestampColumn.id,
                 timestamp: doc.cursor.time,
               };
             } else if ('messageColumn' in column) {
               return {
-                columnId: column.messageColumn.id,
                 message: messageFormattingRules.format(doc.fields, doc.highlights),
               };
             } else {
               return {
-                columnId: column.fieldColumn.id,
                 field: column.fieldColumn.field,
                 value: doc.fields[column.fieldColumn.field] ?? [],
                 highlights: doc.highlights[column.fieldColumn.field] ?? [],


### PR DESCRIPTION
## Summary

This proof of concept tries to eliminate the reliance on the `id` property for the log source configuration columns.

The goal is to simplify how the columns are defined at the source configuration level to simplify the implementation of https://github.com/elastic/kibana/issues/82748 and https://github.com/elastic/kibana/issues/82746.

---

The approach I tried to follow goes as follows: The columns are defined in an array and the order is stable. If columns are defined as `['@timestamp', 'event.dataset', 'message']`, they will always be represented by an array of three elements, and always in that order.

With that column configuration, the values for each entry in the log stream will also always be in an array of three elements, and always in the order of the column definition (i.e. `[Date.now(), 'nginx.access', 'Some IP logged visited some URL']`)

Following this correspondence of column definitions and log entry values an ID is no longer necessary to find the correct value for each column.

Look-ups for each column value happen at constant time, since we keep track of what column we are rendering via `columnPosition`.

---

Since the IDs are no longer used they can be removed from the `log_entries/entries` API response, reducing the payload.

Before:
<img width="868" alt="Screenshot 2020-11-19 at 21 24 29" src="https://user-images.githubusercontent.com/57448/99721237-2c8ccb00-2aaf-11eb-98dd-318f620ecd69.png">

After (the request params are the same)
<img width="1275" alt="Screenshot 2020-11-19 at 21 26 56" src="https://user-images.githubusercontent.com/57448/99721252-34e50600-2aaf-11eb-93d1-c859a9cbd33a.png">

