### PR TITLE
[Enterprise Search] Add Cloud-specific setup guide instructions

### DIFF
--- a/x-pack/plugins/enterprise_search/kibana.json
+++ b/x-pack/plugins/enterprise_search/kibana.json
@@ -4,7 +4,7 @@
   "kibanaVersion": "kibana",
   "requiredPlugins": ["features", "licensing"],
   "configPath": ["enterpriseSearch"],
-  "optionalPlugins": ["usageCollection", "security", "home", "spaces"],
+  "optionalPlugins": ["usageCollection", "security", "home", "spaces", "cloud"],
   "server": true,
   "ui": true,
   "requiredBundles": ["home"]

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_logic.mock.ts
@@ -9,6 +9,10 @@ import { mockHistory } from './';
 export const mockKibanaValues = {
   config: { host: 'http://localhost:3002' },
   history: mockHistory,
+  cloud: {
+    isCloudEnabled: false,
+    cloudDeploymentUrl: 'https://cloud.elastic.co/deployments/some-id',
+  },
   navigateToUrl: jest.fn(),
   setBreadcrumbs: jest.fn(),
   setDocTitle: jest.fn(),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
+import { SetupGuideLayout } from '../../../shared/setup_guide';
 import { SetupGuide } from './';
 
 describe('SetupGuide', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuide as SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
+import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { DOCS_PREFIX } from '../../routes';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
+import { SetupGuide as SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { DOCS_PREFIX } from '../../routes';
@@ -23,13 +23,7 @@ export const SetupGuide: React.FC = () => (
     standardAuthLink={`${DOCS_PREFIX}/security-and-users.html#app-search-self-managed-security-and-user-management-standard`}
     elasticsearchNativeAuthLink={`${DOCS_PREFIX}/security-and-users.html#app-search-self-managed-security-and-user-management-elasticsearch-native-realm`}
   >
-    <SetPageChrome
-      trail={[
-        i18n.translate('xpack.enterpriseSearch.setupGuide.title', {
-          defaultMessage: 'Setup Guide',
-        }),
-      ]}
-    />
+    <SetPageChrome trail={[SETUP_GUIDE_TITLE]} />
     <SendTelemetry action="viewed" metric="setup_guide" />
 
     <a

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
+import { SetupGuideLayout } from '../../../shared/setup_guide';
 import { SetupGuide } from './';
 
 describe('SetupGuide', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { ENTERPRISE_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuide as SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
+import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import GettingStarted from './assets/getting_started.png';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { ENTERPRISE_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
+import { SetupGuide as SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import GettingStarted from './assets/getting_started.png';
@@ -22,13 +22,7 @@ export const SetupGuide: React.FC = () => (
     standardAuthLink="https://www.elastic.co/guide/en/app-search/current/security-and-users.html#app-search-self-managed-security-and-user-management-standard"
     elasticsearchNativeAuthLink="https://www.elastic.co/guide/en/app-search/current/security-and-users.html#app-search-self-managed-security-and-user-management-elasticsearch-native-realm"
   >
-    <SetPageChrome
-      trail={[
-        i18n.translate('xpack.enterpriseSearch.setupGuide.title', {
-          defaultMessage: 'Setup Guide',
-        }),
-      ]}
-    />
+    <SetPageChrome trail={[SETUP_GUIDE_TITLE]} />
     <SendTelemetry action="viewed" metric="setup_guide" />
 
     <a href="https://www.elastic.co/enterprise-search" target="_blank" rel="noopener noreferrer">

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -41,6 +41,7 @@ export const renderApp = (
 
   const unmountKibanaLogic = mountKibanaLogic({
     config,
+    cloud: plugins.cloud || {},
     history: params.history,
     navigateToUrl: core.application.navigateToUrl,
     setBreadcrumbs: core.chrome.setBreadcrumbs,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/constants/documentation_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/constants/documentation_links.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { CURRENT_MAJOR_VERSION } from '../../../../common/version';
+
+export const ENT_SEARCH_DOCS_PREFIX = `https://www.elastic.co/guide/en/enterprise-search/${CURRENT_MAJOR_VERSION}`;
+
+export const CLOUD_DOCS_PREFIX = `https://www.elastic.co/guide/en/cloud/current`; // Cloud does not have version-prefixed documentation

--- a/x-pack/plugins/enterprise_search/public/applications/shared/constants/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/constants/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { DEFAULT_META } from './default_meta';
+export * from './documentation_links';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
@@ -34,6 +34,12 @@ describe('KibanaLogic', () => {
 
       expect(KibanaLogic.values.config).toEqual({});
     });
+
+    it('gracefully handles non-cloud installs', () => {
+      mountKibanaLogic({ ...mockKibanaValues, cloud: undefined } as any);
+
+      expect(KibanaLogic.values.cloud).toEqual({});
+    });
   });
 
   describe('navigateToUrl()', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -9,6 +9,7 @@ import { kea, MakeLogicType } from 'kea';
 import { FC } from 'react';
 import { History } from 'history';
 import { ApplicationStart, ChromeBreadcrumb } from 'src/core/public';
+import { CloudSetup } from '../../../../../cloud/public';
 
 import { HttpLogic } from '../http';
 import { createHref, CreateHrefOptions } from '../react_router_helpers';
@@ -16,6 +17,7 @@ import { createHref, CreateHrefOptions } from '../react_router_helpers';
 interface KibanaLogicProps {
   config: { host?: string };
   history: History;
+  cloud: Partial<CloudSetup>;
   navigateToUrl: ApplicationStart['navigateToUrl'];
   setBreadcrumbs(crumbs: ChromeBreadcrumb[]): void;
   setDocTitle(title: string): void;
@@ -30,6 +32,7 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
   reducers: ({ props }) => ({
     config: [props.config || {}, {}],
     history: [props.history, {}],
+    cloud: [props.cloud || {}, {}],
     navigateToUrl: [
       (url: string, options?: CreateHrefOptions) => {
         const deps = { history: props.history, http: HttpLogic.values.http };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EuiSteps, EuiLink } from '@elastic/eui';
+
+import { mountWithIntl } from '../../../__mocks__';
+
+import { CloudSetupInstructions } from './instructions';
+
+describe('CloudSetupInstructions', () => {
+  it('renders', () => {
+    const wrapper = shallow(<CloudSetupInstructions productName="App Search" />);
+    expect(wrapper.find(EuiSteps)).toHaveLength(1);
+  });
+
+  it('renders with a link to the Elastic Cloud deployment', () => {
+    const wrapper = mountWithIntl(
+      <CloudSetupInstructions
+        productName="App Search"
+        cloudDeploymentLink="https://cloud.elastic.co/deployments/some-id"
+      />
+    );
+    const cloudDeploymentLink = wrapper.find(EuiLink).first();
+    expect(cloudDeploymentLink.prop('href')).toEqual(
+      'https://cloud.elastic.co/deployments/some-id'
+    );
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
+import { EuiPageContent, EuiSteps, EuiText, EuiLink, EuiCallOut } from '@elastic/eui';
+
+import { CLOUD_DOCS_PREFIX, ENT_SEARCH_DOCS_PREFIX } from '../../constants';
+
+interface Props {
+  productName: string;
+  cloudDeploymentLink?: string;
+}
+
+export const CloudSetupInstructions: React.FC<Props> = ({ productName, cloudDeploymentLink }) => (
+  <EuiPageContent>
+    <EuiSteps
+      headingElement="h2"
+      steps={[
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.cloud.step1.title', {
+            defaultMessage: 'Edit your Elastic Cloud deployment’s configuration',
+          }),
+          children: (
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.cloud.step1.instruction1"
+                  defaultMessage="{visitCloudLink} and select your deployment. Within your deployment, select “Edit” from the sidebar to manage your deployment’s configuration."
+                  values={{
+                    visitCloudLink: cloudDeploymentLink ? (
+                      <EuiLink href={cloudDeploymentLink} target="_blank">
+                        Visit the Elastic Cloud console
+                      </EuiLink>
+                    ) : (
+                      'Visit the Elastic Cloud console'
+                    ),
+                  }}
+                />
+              </p>
+            </EuiText>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.cloud.step2.title', {
+            defaultMessage: 'Enable Enterprise Search for your deployment',
+          }),
+          children: (
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.cloud.step2.instruction1"
+                  defaultMessage="Once you're within your deployment's “Edit deployment” screen, scroll to the Enterprise Search configuration and select “Enable”."
+                />
+              </p>
+            </EuiText>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.cloud.step3.title', {
+            defaultMessage: 'Configure your Enterprise Search instance',
+          }),
+          children: (
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.cloud.step3.instruction1"
+                  defaultMessage="After enabling Enterprise Search for your instance you can customize the instance, including fault tolerance, RAM, and other {optionsLink}."
+                  values={{
+                    optionsLink: (
+                      <EuiLink
+                        href={`${ENT_SEARCH_DOCS_PREFIX}/configuration.html`}
+                        target="_blank"
+                      >
+                        configurable options
+                      </EuiLink>
+                    ),
+                  }}
+                />
+              </p>
+            </EuiText>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.cloud.step4.title', {
+            defaultMessage: 'Save your deployment configuration',
+          }),
+          children: (
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.cloud.step4.instruction1"
+                  defaultMessage="Once you click “Save”, you'll see a confirmation dialog summarizing the changes being made to your deployment. Once you confirm, your deployment will process the configuration change, which should only take a few moments."
+                />
+              </p>
+            </EuiText>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.cloud.step5.title', {
+            defaultMessage: '{productName} is now available to use',
+            values: { productName },
+          }),
+          children: (
+            <EuiCallOut>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.cloud.step5.instruction1"
+                  defaultMessage="For {productName} indices that contain time-series statistical data, you may want to {configurePolicyLink}, so as to ensure optimal performance and cost-effective storage in the long run."
+                  values={{
+                    productName,
+                    configurePolicyLink: (
+                      <EuiLink
+                        href={`${CLOUD_DOCS_PREFIX}/ec-configure-index-management.html`}
+                        target="_blank"
+                      >
+                        configure an index lifecycle policy
+                      </EuiLink>
+                    ),
+                  }}
+                />
+              </p>
+            </EuiCallOut>
+          ),
+        },
+      ]}
+    />
+  </EuiPageContent>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/constants.ts
@@ -4,5 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export { SetupGuide } from './setup_guide';
-export { SETUP_GUIDE_TITLE } from './constants';
+import { i18n } from '@kbn/i18n';
+
+export const SETUP_GUIDE_TITLE = i18n.translate('xpack.enterpriseSearch.setupGuide.title', {
+  defaultMessage: 'Setup Guide',
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/index.ts
@@ -4,5 +4,5 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export { SetupGuide } from './setup_guide';
+export { SetupGuideLayout } from './setup_guide';
 export { SETUP_GUIDE_TITLE } from './constants';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EuiSteps, EuiLink } from '@elastic/eui';
+
+import { mountWithIntl } from '../../__mocks__';
+
+import { SetupInstructions } from './instructions';
+
+describe('SetupInstructions', () => {
+  it('renders', () => {
+    const wrapper = shallow(<SetupInstructions productName="Workplace Search" />);
+    expect(wrapper.find(EuiSteps)).toHaveLength(1);
+  });
+
+  it('renders with auth links', () => {
+    const wrapper = mountWithIntl(
+      <SetupInstructions
+        productName="Enterprise Search"
+        standardAuthLink="http://foo.com"
+        elasticsearchNativeAuthLink="http://bar.com"
+      />
+    );
+
+    expect(wrapper.find(EuiLink).first().prop('href')).toEqual('http://bar.com');
+    expect(wrapper.find(EuiLink).last().prop('href')).toEqual('http://foo.com');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiPageContent,
+  EuiSpacer,
+  EuiText,
+  EuiSteps,
+  EuiCode,
+  EuiCodeBlock,
+  EuiAccordion,
+  EuiLink,
+} from '@elastic/eui';
+
+interface Props {
+  productName: string;
+  standardAuthLink?: string;
+  elasticsearchNativeAuthLink?: string;
+}
+
+export const SetupInstructions: React.FC<Props> = ({
+  productName,
+  standardAuthLink,
+  elasticsearchNativeAuthLink,
+}) => (
+  <EuiPageContent>
+    <EuiSteps
+      headingElement="h2"
+      steps={[
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.step1.title', {
+            defaultMessage: 'Add your {productName} host URL to your Kibana configuration',
+            values: { productName },
+          }),
+          children: (
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.step1.instruction1"
+                  defaultMessage="In your {configFile} file, set {configSetting} to the URL of your {productName} instance. For example:"
+                  values={{
+                    productName,
+                    configFile: <EuiCode>config/kibana.yml</EuiCode>,
+                    configSetting: <EuiCode>enterpriseSearch.host</EuiCode>,
+                  }}
+                />
+              </p>
+              <EuiCodeBlock language="yml">
+                enterpriseSearch.host: &apos;http://localhost:3002&apos;
+              </EuiCodeBlock>
+            </EuiText>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.step2.title', {
+            defaultMessage: 'Reload your Kibana instance',
+          }),
+          children: (
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.step2.instruction1"
+                  defaultMessage="Restart Kibana to pick up the configuration changes from the previous step."
+                />
+              </p>
+              <p>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.setupGuide.step2.instruction2"
+                  defaultMessage="If you’re using {elasticsearchNativeAuthLink} in {productName}, you’re all set. Your users can now access {productName} in Kibana with their current {productName} access and permissions."
+                  values={{
+                    productName,
+                    elasticsearchNativeAuthLink: elasticsearchNativeAuthLink ? (
+                      <EuiLink href={elasticsearchNativeAuthLink} target="_blank">
+                        Elasticsearch Native Auth
+                      </EuiLink>
+                    ) : (
+                      'Elasticsearch Native Auth'
+                    ),
+                  }}
+                />
+              </p>
+            </EuiText>
+          ),
+        },
+        {
+          title: i18n.translate('xpack.enterpriseSearch.setupGuide.step3.title', {
+            defaultMessage: 'Troubleshooting issues',
+          }),
+          children: (
+            <>
+              <EuiAccordion
+                buttonContent={i18n.translate(
+                  'xpack.enterpriseSearch.troubleshooting.differentEsClusters.title',
+                  {
+                    defaultMessage:
+                      '{productName} and Kibana are on different Elasticsearch clusters',
+                    values: { productName },
+                  }
+                )}
+                id="differentEsClusters"
+                paddingSize="s"
+              >
+                <EuiText>
+                  <p>
+                    <FormattedMessage
+                      id="xpack.enterpriseSearch.troubleshooting.differentEsClusters.description"
+                      defaultMessage="This plugin does not currently support {productName} and Kibana running on different clusters."
+                      values={{ productName }}
+                    />
+                  </p>
+                </EuiText>
+              </EuiAccordion>
+              <EuiSpacer />
+              <EuiAccordion
+                buttonContent={i18n.translate(
+                  'xpack.enterpriseSearch.troubleshooting.differentAuth.title',
+                  {
+                    defaultMessage:
+                      '{productName} and Kibana are on different authentication methods',
+                    values: { productName },
+                  }
+                )}
+                id="differentAuth"
+                paddingSize="s"
+              >
+                <EuiText>
+                  <p>
+                    <FormattedMessage
+                      id="xpack.enterpriseSearch.troubleshooting.differentAuth.description"
+                      defaultMessage="This plugin does not currently support {productName} and Kibana operating on different authentication methods, for example, {productName} using a different SAML provider than Kibana."
+                      values={{ productName }}
+                    />
+                  </p>
+                </EuiText>
+              </EuiAccordion>
+              <EuiSpacer />
+              <EuiAccordion
+                buttonContent={i18n.translate(
+                  'xpack.enterpriseSearch.troubleshooting.standardAuth.title',
+                  {
+                    defaultMessage: '{productName} on Standard authentication is not supported',
+                    values: { productName },
+                  }
+                )}
+                id="standardAuth"
+                paddingSize="s"
+              >
+                <EuiText>
+                  <p>
+                    <FormattedMessage
+                      id="xpack.enterpriseSearch.troubleshooting.standardAuth.description"
+                      defaultMessage="This plugin does not fully support {productName} on {standardAuthLink}. Users created in {productName} must have Kibana access. Users created in Kibana will not see {productName} in the navigation menu."
+                      values={{
+                        productName,
+                        standardAuthLink: standardAuthLink ? (
+                          <EuiLink href={standardAuthLink} target="_blank">
+                            Standard Auth
+                          </EuiLink>
+                        ) : (
+                          'Standard Auth'
+                        ),
+                      }}
+                    />
+                  </p>
+                </EuiText>
+              </EuiAccordion>
+            </>
+          ),
+        },
+      ]}
+    />
+  </EuiPageContent>
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.test.tsx
@@ -10,9 +10,9 @@ import { EuiSteps, EuiIcon, EuiLink } from '@elastic/eui';
 
 import { mountWithIntl } from '../../__mocks__';
 
-import { SetupGuide } from './';
+import { SetupGuideLayout } from './';
 
-describe('SetupGuide', () => {
+describe('SetupGuideLayout', () => {
   it('renders', () => {
     const wrapper = shallow(
       <SetupGuide productName="Enterprise Search" productEuiIcon="logoEnterpriseSearch">

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.test.tsx
@@ -4,41 +4,46 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
-import { shallow } from 'enzyme';
-import { EuiSteps, EuiIcon, EuiLink } from '@elastic/eui';
+import { setMockValues } from '../../__mocks__/kea.mock';
+import { rerender } from '../../__mocks__';
 
-import { mountWithIntl } from '../../__mocks__';
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { EuiIcon } from '@elastic/eui';
+
+import { SetupInstructions } from './instructions';
+import { CloudSetupInstructions } from './cloud/instructions';
 
 import { SetupGuideLayout } from './';
 
 describe('SetupGuideLayout', () => {
-  it('renders', () => {
-    const wrapper = shallow(
-      <SetupGuide productName="Enterprise Search" productEuiIcon="logoEnterpriseSearch">
-        <p data-test-subj="test">Wow!</p>
-      </SetupGuide>
-    );
+  let wrapper: ShallowWrapper;
 
+  beforeAll(() => {
+    setMockValues({ isCloudEnabled: false });
+    wrapper = shallow(
+      <SetupGuideLayout productName="Enterprise Search" productEuiIcon="logoEnterpriseSearch">
+        <p data-test-subj="test">Wow!</p>
+      </SetupGuideLayout>
+    );
+  });
+
+  it('renders', () => {
     expect(wrapper.find('h1').text()).toEqual('Enterprise Search');
     expect(wrapper.find(EuiIcon).prop('type')).toEqual('logoEnterpriseSearch');
     expect(wrapper.find('[data-test-subj="test"]').text()).toEqual('Wow!');
-    expect(wrapper.find(EuiSteps)).toHaveLength(1);
   });
 
-  it('renders with optional auth links', () => {
-    const wrapper = mountWithIntl(
-      <SetupGuide
-        productName="Foo"
-        productEuiIcon="logoAppSearch"
-        standardAuthLink="http://foo.com"
-        elasticsearchNativeAuthLink="http://bar.com"
-      >
-        Baz
-      </SetupGuide>
-    );
+  it('renders with default self-managed instructions', () => {
+    expect(wrapper.find(SetupInstructions)).toHaveLength(1);
+    expect(wrapper.find(CloudSetupInstructions)).toHaveLength(0);
+  });
 
-    expect(wrapper.find(EuiLink).first().prop('href')).toEqual('http://bar.com');
-    expect(wrapper.find(EuiLink).last().prop('href')).toEqual('http://foo.com');
+  it('renders with cloud instructions', () => {
+    setMockValues({ cloud: { isCloudEnabled: true } });
+    rerender(wrapper);
+
+    expect(wrapper.find(SetupInstructions)).toHaveLength(0);
+    expect(wrapper.find(CloudSetupInstructions)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.tsx
@@ -32,7 +32,7 @@ import './setup_guide.scss';
  * customizable, but the basic layout and instruction steps are DRYed out
  */
 
-interface SetupGuideProps {
+interface Props {
   children: React.ReactNode;
   productName: string;
   productEuiIcon: 'logoAppSearch' | 'logoWorkplaceSearch' | 'logoEnterpriseSearch';
@@ -40,7 +40,7 @@ interface SetupGuideProps {
   elasticsearchNativeAuthLink?: string;
 }
 
-export const SetupGuide: React.FC<SetupGuideProps> = ({
+export const SetupGuideLayout: React.FC<Props> = ({
   children,
   productName,
   productEuiIcon,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.tsx
@@ -5,26 +5,25 @@
  */
 
 import React from 'react';
+import { useValues } from 'kea';
+
 import {
   EuiPage,
   EuiPageSideBar,
   EuiPageBody,
-  EuiPageContent,
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
   EuiText,
   EuiIcon,
-  EuiSteps,
-  EuiCode,
-  EuiCodeBlock,
-  EuiAccordion,
-  EuiLink,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
-import { i18n } from '@kbn/i18n';
 
+import { KibanaLogic } from '../kibana';
+
+import { SetupInstructions } from './instructions';
+import { CloudSetupInstructions } from './cloud/instructions';
+import { SETUP_GUIDE_TITLE } from './constants';
 import './setup_guide.scss';
 
 /**
@@ -46,181 +45,47 @@ export const SetupGuideLayout: React.FC<Props> = ({
   productEuiIcon,
   standardAuthLink,
   elasticsearchNativeAuthLink,
-}) => (
-  <EuiPage className="setupGuide">
-    <EuiPageSideBar className="setupGuide__sidebar">
-      <EuiText color="subdued" size="s">
-        <strong>
-          <FormattedMessage
-            id="xpack.enterpriseSearch.setupGuide.title"
-            defaultMessage="Setup Guide"
+}) => {
+  const { cloud } = useValues(KibanaLogic);
+  const isCloudEnabled = Boolean(cloud.isCloudEnabled);
+  const cloudDeploymentLink = cloud.cloudDeploymentUrl || '';
+
+  return (
+    <EuiPage className="setupGuide">
+      <EuiPageSideBar className="setupGuide__sidebar">
+        <EuiText color="subdued" size="s">
+          <strong>{SETUP_GUIDE_TITLE}</strong>
+        </EuiText>
+        <EuiSpacer size="s" />
+
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type={productEuiIcon} size="l" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiTitle size="m">
+              <h1>{productName}</h1>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        {children}
+      </EuiPageSideBar>
+
+      <EuiPageBody className="setupGuide__body">
+        {isCloudEnabled ? (
+          <CloudSetupInstructions
+            productName={productName}
+            cloudDeploymentLink={cloudDeploymentLink}
           />
-        </strong>
-      </EuiText>
-      <EuiSpacer size="s" />
-
-      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-        <EuiFlexItem grow={false}>
-          <EuiIcon type={productEuiIcon} size="l" />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiTitle size="m">
-            <h1>{productName}</h1>
-          </EuiTitle>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-
-      {children}
-    </EuiPageSideBar>
-
-    <EuiPageBody className="setupGuide__body">
-      <EuiPageContent>
-        <EuiSteps
-          headingElement="h2"
-          steps={[
-            {
-              title: i18n.translate('xpack.enterpriseSearch.setupGuide.step1.title', {
-                defaultMessage: 'Add your {productName} host URL to your Kibana configuration',
-                values: { productName },
-              }),
-              children: (
-                <EuiText>
-                  <p>
-                    <FormattedMessage
-                      id="xpack.enterpriseSearch.setupGuide.step1.instruction1"
-                      defaultMessage="In your {configFile} file, set {configSetting} to the URL of your {productName} instance. For example:"
-                      values={{
-                        productName,
-                        configFile: <EuiCode>config/kibana.yml</EuiCode>,
-                        configSetting: <EuiCode>enterpriseSearch.host</EuiCode>,
-                      }}
-                    />
-                  </p>
-                  <EuiCodeBlock language="yml">
-                    enterpriseSearch.host: &apos;http://localhost:3002&apos;
-                  </EuiCodeBlock>
-                </EuiText>
-              ),
-            },
-            {
-              title: i18n.translate('xpack.enterpriseSearch.setupGuide.step2.title', {
-                defaultMessage: 'Reload your Kibana instance',
-              }),
-              children: (
-                <EuiText>
-                  <p>
-                    <FormattedMessage
-                      id="xpack.enterpriseSearch.setupGuide.step2.instruction1"
-                      defaultMessage="Restart Kibana to pick up the configuration changes from the previous step."
-                    />
-                  </p>
-                  <p>
-                    <FormattedMessage
-                      id="xpack.enterpriseSearch.setupGuide.step2.instruction2"
-                      defaultMessage="If you’re using {elasticsearchNativeAuthLink} in {productName}, you’re all set. Your users can now access {productName} in Kibana with their current {productName} access and permissions."
-                      values={{
-                        productName,
-                        elasticsearchNativeAuthLink: elasticsearchNativeAuthLink ? (
-                          <EuiLink href={elasticsearchNativeAuthLink} target="_blank">
-                            Elasticsearch Native Auth
-                          </EuiLink>
-                        ) : (
-                          'Elasticsearch Native Auth'
-                        ),
-                      }}
-                    />
-                  </p>
-                </EuiText>
-              ),
-            },
-            {
-              title: i18n.translate('xpack.enterpriseSearch.setupGuide.step3.title', {
-                defaultMessage: 'Troubleshooting issues',
-              }),
-              children: (
-                <>
-                  <EuiAccordion
-                    buttonContent={i18n.translate(
-                      'xpack.enterpriseSearch.troubleshooting.differentEsClusters.title',
-                      {
-                        defaultMessage:
-                          '{productName} and Kibana are on different Elasticsearch clusters',
-                        values: { productName },
-                      }
-                    )}
-                    id="differentEsClusters"
-                    paddingSize="s"
-                  >
-                    <EuiText>
-                      <p>
-                        <FormattedMessage
-                          id="xpack.enterpriseSearch.troubleshooting.differentEsClusters.description"
-                          defaultMessage="This plugin does not currently support {productName} and Kibana running on different clusters."
-                          values={{ productName }}
-                        />
-                      </p>
-                    </EuiText>
-                  </EuiAccordion>
-                  <EuiSpacer />
-                  <EuiAccordion
-                    buttonContent={i18n.translate(
-                      'xpack.enterpriseSearch.troubleshooting.differentAuth.title',
-                      {
-                        defaultMessage:
-                          '{productName} and Kibana are on different authentication methods',
-                        values: { productName },
-                      }
-                    )}
-                    id="differentAuth"
-                    paddingSize="s"
-                  >
-                    <EuiText>
-                      <p>
-                        <FormattedMessage
-                          id="xpack.enterpriseSearch.troubleshooting.differentAuth.description"
-                          defaultMessage="This plugin does not currently support {productName} and Kibana operating on different authentication methods, for example, {productName} using a different SAML provider than Kibana."
-                          values={{ productName }}
-                        />
-                      </p>
-                    </EuiText>
-                  </EuiAccordion>
-                  <EuiSpacer />
-                  <EuiAccordion
-                    buttonContent={i18n.translate(
-                      'xpack.enterpriseSearch.troubleshooting.standardAuth.title',
-                      {
-                        defaultMessage: '{productName} on Standard authentication is not supported',
-                        values: { productName },
-                      }
-                    )}
-                    id="standardAuth"
-                    paddingSize="s"
-                  >
-                    <EuiText>
-                      <p>
-                        <FormattedMessage
-                          id="xpack.enterpriseSearch.troubleshooting.standardAuth.description"
-                          defaultMessage="This plugin does not fully support {productName} on {standardAuthLink}. Users created in {productName} must have Kibana access. Users created in Kibana will not see {productName} in the navigation menu."
-                          values={{
-                            productName,
-                            standardAuthLink: standardAuthLink ? (
-                              <EuiLink href={standardAuthLink} target="_blank">
-                                Standard Auth
-                              </EuiLink>
-                            ) : (
-                              'Standard Auth'
-                            ),
-                          }}
-                        />
-                      </p>
-                    </EuiText>
-                  </EuiAccordion>
-                </>
-              ),
-            },
-          ]}
-        />
-      </EuiPageContent>
-    </EuiPageBody>
-  </EuiPage>
-);
+        ) : (
+          <SetupInstructions
+            productName={productName}
+            standardAuthLink={standardAuthLink}
+            elasticsearchNativeAuthLink={elasticsearchNativeAuthLink}
+          />
+        )}
+      </EuiPageBody>
+    </EuiPage>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -7,6 +7,7 @@
 import { generatePath } from 'react-router-dom';
 
 import { CURRENT_MAJOR_VERSION } from '../../../common/version';
+import { ENT_SEARCH_DOCS_PREFIX } from '../shared/constants';
 
 export const SETUP_GUIDE_PATH = '/setup_guide';
 
@@ -16,7 +17,6 @@ export const LEAVE_FEEDBACK_EMAIL = 'support@elastic.co';
 export const LEAVE_FEEDBACK_URL = `mailto:${LEAVE_FEEDBACK_EMAIL}?Subject=Elastic%20Workplace%20Search%20Feedback`;
 
 export const DOCS_PREFIX = `https://www.elastic.co/guide/en/workplace-search/${CURRENT_MAJOR_VERSION}`;
-export const ENT_SEARCH_DOCS_PREFIX = `https://www.elastic.co/guide/en/enterprise-search/${CURRENT_MAJOR_VERSION}`;
 export const DOCUMENT_PERMISSIONS_DOCS_URL = `${DOCS_PREFIX}/workplace-search-sources-document-permissions.html`;
 export const DOCUMENT_PERMISSIONS_SYNC_DOCS_URL = `${DOCUMENT_PERMISSIONS_DOCS_URL}#sources-permissions-synchronizing`;
 export const PRIVATE_SOURCES_DOCS_URL = `${DOCUMENT_PERMISSIONS_DOCS_URL}#sources-permissions-org-private`;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
+import { SetupGuideLayout } from '../../../shared/setup_guide';
 import { SetupGuide } from './';
 
 describe('SetupGuide', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
@@ -13,10 +13,11 @@ import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+
 import GettingStarted from './assets/getting_started.png';
 
-const GETTING_STARTED_LINK_URL =
-  'https://www.elastic.co/guide/en/workplace-search/current/workplace-search-getting-started.html';
+import { DOCS_PREFIX } from '../../routes';
+const GETTING_STARTED_LINK_URL = `${DOCS_PREFIX}/workplace-search-getting-started.html`;
 
 export const SetupGuide: React.FC = () => {
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuide as SetupGuideLayout } from '../../../shared/setup_guide';
+import { SetupGuide as SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import GettingStarted from './assets/getting_started.png';
@@ -26,13 +26,7 @@ export const SetupGuide: React.FC = () => {
       standardAuthLink="https://www.elastic.co/guide/en/workplace-search/current/workplace-search-security.html#standard"
       elasticsearchNativeAuthLink="https://www.elastic.co/guide/en/workplace-search/current/workplace-search-security.html#elasticsearch-native-realm"
     >
-      <SetPageChrome
-        trail={[
-          i18n.translate('xpack.enterpriseSearch.setupGuide.title', {
-            defaultMessage: 'Setup Guide',
-          }),
-        ]}
-      />
+      <SetPageChrome trail={[SETUP_GUIDE_TITLE]} />
       <SendTelemetry action="viewed" metric="setup_guide" />
 
       <a href={GETTING_STARTED_LINK_URL} target="_blank" rel="noopener noreferrer">

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuide as SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
+import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import GettingStarted from './assets/getting_started.png';

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -16,6 +16,7 @@ import {
   FeatureCatalogueCategory,
   HomePublicPluginSetup,
 } from '../../../../src/plugins/home/public';
+import { CloudSetup } from '../../cloud/public';
 import { LicensingPluginStart } from '../../licensing/public';
 
 import {
@@ -34,9 +35,11 @@ export interface ClientData extends InitialAppData {
 }
 
 interface PluginsSetup {
+  cloud?: CloudSetup;
   home?: HomePublicPluginSetup;
 }
 export interface PluginsStart {
+  cloud?: CloudSetup;
   licensing: LicensingPluginStart;
 }
 
@@ -50,6 +53,8 @@ export class EnterpriseSearchPlugin implements Plugin {
   }
 
   public setup(core: CoreSetup, plugins: PluginsSetup) {
+    const { cloud } = plugins;
+
     core.application.register({
       id: ENTERPRISE_SEARCH_PLUGIN.ID,
       title: ENTERPRISE_SEARCH_PLUGIN.NAV_TITLE,
@@ -57,7 +62,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       appRoute: ENTERPRISE_SEARCH_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
-        const kibanaDeps = await this.getKibanaDeps(core, params);
+        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(ENTERPRISE_SEARCH_PLUGIN.NAME);
 
@@ -78,7 +83,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       appRoute: APP_SEARCH_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
-        const kibanaDeps = await this.getKibanaDeps(core, params);
+        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(APP_SEARCH_PLUGIN.NAME);
 
@@ -99,7 +104,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       appRoute: WORKPLACE_SEARCH_PLUGIN.URL,
       category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
       mount: async (params: AppMountParameters) => {
-        const kibanaDeps = await this.getKibanaDeps(core, params);
+        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(WORKPLACE_SEARCH_PLUGIN.NAME);
 
@@ -150,11 +155,13 @@ export class EnterpriseSearchPlugin implements Plugin {
 
   public stop() {}
 
-  private async getKibanaDeps(core: CoreSetup, params: AppMountParameters) {
+  private async getKibanaDeps(core: CoreSetup, params: AppMountParameters, cloud?: CloudSetup) {
     // Helper for using start dependencies on mount (instead of setup dependencies)
     // and for grouping Kibana-related args together (vs. plugin-specific args)
     const [coreStart, pluginsStart] = await core.getStartServices();
-    return { params, core: coreStart, plugins: pluginsStart as PluginsStart };
+    const plugins = { ...pluginsStart, cloud } as PluginsStart;
+
+    return { params, core: coreStart, plugins };
   }
 
   private getPluginData() {


### PR DESCRIPTION
## Summary

![Enterprise Search](https://user-images.githubusercontent.com/549407/99866763-bd73ad00-2b68-11eb-8402-0801616f3b10.png)

![App Search](https://user-images.githubusercontent.com/549407/99866648-a3859a80-2b67-11eb-85a1-3a5de165778f.png)

![Workplace Search](https://user-images.githubusercontent.com/549407/99866785-ded49900-2b68-11eb-9832-c1ae5396c215.png)

### Review recommendations

- I strongly recommend following along by-commit, as there's a few cleanup commits I added in (tagged with `[]`s) in the middle of my work
- I also strongly recommend turning off whitespace changes (add `?w=1` to the URL of whatever diff you're viewing) for the last commit.

## QA

### Testing with your local dev environment flagged as Cloud

Setup:
- Check out this branch/PR
- Open your `kibana.dev.yml` and add the following properties:
```yml
xpack.cloud.id: 'fake-cloud-id'
xpack.cloud.deploymentUrl: 'https://cloud.elastic.co/deployments/fake-deployment-id'
```
- Restart/start Kibana locally
- Navigate to http://localhost:5601/xyz/app/enterprise_search/overview/setup_guide
- [x] Confirm that the Cloud instructions show up 
- [x] Confirm that clicking the Visit the Elastic Cloud link takes you to the fake deployment URL
- [x] Confirm that the AS & WS setup guides also show Cloud instructions

### Regression testing

- Remove the properties added to `kibana.dev.yml` from the previous section and allow Kibana to restart.
- [x] Revisit http://localhost:5601/xyz/app/enterprise_search/overview/setup_guide and confirm that the old instructions appear (with `localhost:3002` setup)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)