### PR TITLE
Fix: tagcloud explicitly pass params

### DIFF
--- a/src/plugins/vis_type_tagcloud/public/to_ast.ts
+++ b/src/plugins/vis_type_tagcloud/public/to_ast.ts
@@ -44,9 +44,14 @@ export const toExpressionAst = (vis: Vis<TagCloudVisParams>, params: BuildPipeli
   });
 
   const schemas = getVisSchemas(vis, params);
+  const { scale, orientation, minFontSize, maxFontSize, showLabel } = vis.params;
 
   const tagcloud = buildExpressionFunction<TagcloudExpressionFunctionDefinition>('tagcloud', {
-    ...vis.params,
+    scale,
+    orientation,
+    minFontSize,
+    maxFontSize,
+    showLabel,
     metric: prepareDimension(schemas.metric[0]),
   });
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/83876

The regression was caused by https://github.com/elastic/kibana/pull/77910,
more detailed explanation of the regression described [here](https://github.com/elastic/kibana/issues/83876#issuecomment-731244941)

Explicitly pass each tagcloud expression param to avoid passing extra one from `params` of saved object.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
