### PR TITLE
[Fleet] Use new `QueryStringInput` props

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/query_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/query_bar.tsx
@@ -47,6 +47,8 @@ export const LogQueryBar: React.FunctionComponent<{
 
   return (
     <QueryStringInput
+      iconType="search"
+      disableLanguageSwitcher={true}
       indexPatterns={
         indexPatternFields
           ? [


### PR DESCRIPTION
## Summary

Resolves #83735. Follow up to #83356, new props for the `QueryStringInput` component is available now, this PR adds them to the agent logs UI query bar to match with design spec. A search icon now appears and the language selector is disabled (we only use KQL here):

![image](https://user-images.githubusercontent.com/1965714/99983587-e3fc3880-2d60-11eb-9e9a-05c382d99a00.png)
