### PR TITLE
[Lens] Fix label input debouncing

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -6,7 +6,7 @@
 
 import './dimension_editor.scss';
 import _ from 'lodash';
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiListGroup,
@@ -45,10 +45,6 @@ export interface DimensionEditorProps extends IndexPatternDimensionEditorProps {
 
 const LabelInput = ({ value, onChange }: { value: string; onChange: (value: string) => void }) => {
   const [inputValue, setInputValue] = useState(value);
-
-  useEffect(() => {
-    setInputValue(value);
-  }, [value, setInputValue]);
 
   const onChangeDebounced = useMemo(() => _.debounce(onChange, 256), [onChange]);
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/filters/filter_popover.tsx
@@ -110,10 +110,6 @@ export const QueryInput = ({
 }) => {
   const [inputValue, setInputValue] = useState(value);
 
-  React.useEffect(() => {
-    setInputValue(value);
-  }, [value, setInputValue]);
-
   useDebounce(() => onChange(inputValue), 256, [inputValue]);
 
   const handleInputChange = (input: Query) => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/shared_components/label_input.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/shared_components/label_input.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
 import { EuiFieldText, keys } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/shared_components/label_input.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/shared_components/label_input.tsx
@@ -28,10 +28,6 @@ export const LabelInput = ({
 }) => {
   const [inputValue, setInputValue] = useState(value);
 
-  useEffect(() => {
-    setInputValue(value);
-  }, [value, setInputValue]);
-
   useDebounce(() => onChange(inputValue), 256, [inputValue]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/83818

In some places where debounced inputs where used, we were listening for changes coming from upstream as well using an effect hook. This helps if the same state is changed somewhere else and the input needs to be updated, but it can cause the weird typing issue seen in the original issue, because of this process:
Scenario: User types "abc", waits for 280ms before typing "de", then waits for 280ms again to type "fg"
What they see: "abcde" appearing, flipping back to "abc", "abcfg" appearing, switching to "abcde", then switching back to "abcfg"

* After 256ms the debounce kicks in and pushes the changes to the root
* It takes a while for react to update the whole tree (and it happens async), so the root change reaches the input again after ~300ms
* The user already typed "de", but the root change gets applied, setting the input to "abc"
* The "de" disappears, but it still stored in the debounced callback, and after 256ms "abcde" gets pushed to the root
* In the meantime, the user typed "fg", so the input is set to "abcfg", which is also stored in the debounced callback
* Now, "abcde" arrives from the root update, and the input is set to "abcde" (basically removing "fg")
* After further 256ms, "abcfg" is pushed to the root, and the input changes once again to "abcfg"

Removing the `useEffect` updating on root state changes fixes this behavior, but introduces a theoretical bug of not reflecting a change somewhere else. However I reviewed the places these inputs are used and we don't have such a case yet. So this is fine for now to fix the bug at hand and we can come back to solve it better once we refactor the state mangement.