### PR TITLE
[7.x] update geckodriver to 0.28 (#84085)

### DIFF
--- a/package.json
+++ b/package.json
@@ -651,7 +651,7 @@
     "file-loader": "^4.2.0",
     "file-saver": "^1.3.8",
     "formsy-react": "^1.1.5",
-    "geckodriver": "^1.20.0",
+    "geckodriver": "^1.21.0",
     "glob-watcher": "5.0.3",
     "graphql-code-generator": "^0.18.2",
     "graphql-codegen-add": "^0.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14390,10 +14390,10 @@ gaze@^1.0.0, gaze@^1.1.0:
   dependencies:
     globule "^1.0.0"
 
-geckodriver@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.20.0.tgz#cd16edb177b88e31affcb54b18a238cae88950a7"
-  integrity sha512-5nVF4ixR+ZGhVsc4udnVihA9RmSlO6guPV1d2HqxYsgAOUNh0HfzxbzG7E49w4ilXq/CSu87x9yWvrsOstrADQ==
+geckodriver@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.21.0.tgz#1f04780ebfb451ffd08fa8fddc25cc26e37ac4a2"
+  integrity sha512-NamdJwGIWpPiafKQIvGman95BBi/SBqHddRXAnIEpFNFCFToTW0sEA0nUckMKCBNn1DVIcLfULfyFq/sTn9bkA==
   dependencies:
     adm-zip "0.4.16"
     bluebird "3.7.2"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - update geckodriver to 0.28 (#84085)