### PR TITLE
[Lens] Fix Treemap outer labels with transparent background

### DIFF
--- a/x-pack/plugins/lens/public/pie_visualization/render_function.tsx
+++ b/x-pack/plugins/lens/public/pie_visualization/render_function.tsx
@@ -65,6 +65,7 @@ export function PieComponent(
   } = props.args;
   const chartTheme = chartsThemeService.useChartsTheme();
   const chartBaseTheme = chartsThemeService.useChartsBaseTheme();
+  const isDarkMode = chartsThemeService.useDarkMode();
 
   if (!hideLabels) {
     firstTable.columns.forEach((column) => {
@@ -125,7 +126,9 @@ export function PieComponent(
           if (shape === 'treemap') {
             // Only highlight the innermost color of the treemap, as it accurately represents area
             if (layerIndex < bucketColumns.length - 1) {
-              return 'rgba(0,0,0,0)';
+              // Mind the difference here: the contrast computation for the text ignores the alpha/opacity
+              // therefore change it for dask mode
+              return isDarkMode ? 'rgba(0,0,0,0)' : 'rgba(255,255,255,0)';
             }
             // only use the top level series layer for coloring
             if (seriesLayers.length > 1) {
@@ -256,6 +259,7 @@ export function PieComponent(
           theme={{
             ...chartTheme,
             background: {
+              ...chartTheme.background,
               color: undefined, // removes background for embeddables
             },
           }}


### PR DESCRIPTION
## Summary

Fixes #83525 

The outer layer has a transparent background, precisely a `rgba(0,0,0,0)` (note `0` opacity), which makes the elastic charts library produce a `white` text color. The library ignores the alpha parameter when computing the contrast color, so it requires a hint about dark mode.
This PR makes the component aware of the dark mode theme state and hints the chart library about the Kibana background color.
Tested on Lens + Dashboard

<img width="1455" alt="Screenshot 2020-11-24 at 16 40 25" src="https://user-images.githubusercontent.com/924948/100118508-34b18580-2e76-11eb-8a35-85b9fc1a258f.png">
<img width="848" alt="Screenshot 2020-11-24 at 16 40 33" src="https://user-images.githubusercontent.com/924948/100118520-37ac7600-2e76-11eb-925d-c43fa87ff0b8.png">
<img width="1456" alt="Screenshot 2020-11-24 at 16 41 23" src="https://user-images.githubusercontent.com/924948/100118521-38450c80-2e76-11eb-8c64-2dd9c35c0fc2.png">

