### PR TITLE
[Fleet] Only display log level in Filter that are present in the logs

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
@@ -32,4 +32,6 @@ export const AGENT_LOG_LEVELS = {
   DEBUG: 'debug',
 };
 
+export const ORDERED_FILTER_LOG_LEVELS = ['error', 'warning', 'warn', 'notice', 'info', 'debug'];
+
 export const DEFAULT_LOG_LEVEL = AGENT_LOG_LEVELS.INFO;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
@@ -6,10 +6,19 @@
 import React, { memo, useState, useEffect } from 'react';
 import { EuiPopover, EuiFilterButton, EuiFilterSelectItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { AGENT_LOG_LEVELS, AGENT_LOG_INDEX_PATTERN, LOG_LEVEL_FIELD } from './constants';
+import { ORDERED_FILTER_LOG_LEVELS, AGENT_LOG_INDEX_PATTERN, LOG_LEVEL_FIELD } from './constants';
 import { useStartServices } from '../../../../../hooks';
 
-const LEVEL_VALUES = Object.values(AGENT_LOG_LEVELS);
+function sortLogLevels(levels: string[]): string[] {
+  return [
+    ...new Set([
+      // order by severity for known level
+      ...ORDERED_FILTER_LOG_LEVELS.filter((level) => levels.includes(level)),
+      // Add unknown log level
+      ...levels.sort(),
+    ]),
+  ];
+}
 
 export const LogLevelFilter: React.FunctionComponent<{
   selectedLevels: string[];
@@ -18,7 +27,7 @@ export const LogLevelFilter: React.FunctionComponent<{
   const { data } = useStartServices();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [levelValues, setLevelValues] = useState<string[]>(LEVEL_VALUES);
+  const [levelValues, setLevelValues] = useState<string[]>([]);
 
   useEffect(() => {
     const fetchValues = async () => {
@@ -32,7 +41,7 @@ export const LogLevelFilter: React.FunctionComponent<{
           field: LOG_LEVEL_FIELD,
           query: '',
         });
-        setLevelValues([...new Set([...LEVEL_VALUES, ...values.sort()])]);
+        setLevelValues(sortLogLevels(values));
       } catch (e) {
         setLevelValues([]);
       }


### PR DESCRIPTION
## Summary

Prefilling the filter for log level, create some confusing scenario like this where you have `warn` and `warning`  (only `warn` is present in the logs)
![image](https://user-images.githubusercontent.com/1336873/100147756-c6ff5c80-2e69-11eb-87e9-e42cedf4cb63.png)

To avoid confusion we should probably only show level that are present in the logs.

I added a sort by log level severity instead of alphabetical.

cc @EricDavisX 
