### PR TITLE
[Time to Visualize] Redirect To Visualize Listing Page on Failure to Load By Value

### DIFF
--- a/src/plugins/visualize/public/application/components/visualize_byvalue_editor.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_byvalue_editor.tsx
@@ -33,6 +33,7 @@ import {
 import { VisualizeServices } from '../types';
 import { VisualizeEditorCommon } from './visualize_editor_common';
 import { VisualizeAppProps } from '../app';
+import { VisualizeConstants } from '../..';
 
 export const VisualizeByValueEditor = ({ onAppLeave }: VisualizeAppProps) => {
   const [originatingApp, setOriginatingApp] = useState<string>();
@@ -52,7 +53,8 @@ export const VisualizeByValueEditor = ({ onAppLeave }: VisualizeAppProps) => {
     setValueInput(valueInputValue);
     setEmbeddableId(embeddableIdValue);
     if (!valueInputValue) {
-      history.back();
+      // if there is no value input to load, redirect to the visualize listing page.
+      services.history.replace(VisualizeConstants.LANDING_PAGE_PATH);
     }
   }, [services]);
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/84286

Quick one liner that makes the failure case for loading a by value visualization redirect to the visualize landing page instead of going back to the last page.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
