### PR TITLE
[Fleet] Support URL query state in agent logs UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -1,0 +1,257 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React, { memo, useMemo, useState, useCallback } from 'react';
+import styled from 'styled-components';
+import url from 'url';
+import { encode } from 'rison-node';
+import { stringify } from 'query-string';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSuperDatePicker,
+  EuiFilterGroup,
+  EuiPanel,
+  EuiButtonEmpty,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import semverGte from 'semver/functions/gte';
+import semverCoerce from 'semver/functions/coerce';
+import { createStateContainerReactHelpers } from '../../../../../../../../../../../src/plugins/kibana_utils/public';
+import { RedirectAppLinks } from '../../../../../../../../../../../src/plugins/kibana_react/public';
+import { TimeRange, esKuery } from '../../../../../../../../../../../src/plugins/data/public';
+import { LogStream } from '../../../../../../../../../infra/public';
+import { Agent } from '../../../../../types';
+import { useStartServices } from '../../../../../hooks';
+import { DatasetFilter } from './filter_dataset';
+import { LogLevelFilter } from './filter_log_level';
+import { LogQueryBar } from './query_bar';
+import { buildQuery } from './build_query';
+import { SelectLogLevel } from './select_log_level';
+
+const WrapperFlexGroup = styled(EuiFlexGroup)`
+  height: 100%;
+`;
+
+const DatePickerFlexItem = styled(EuiFlexItem)`
+  max-width: 312px;
+`;
+
+export interface AgentLogsProps {
+  agent: Agent;
+  state: AgentLogsState;
+}
+
+export interface AgentLogsState {
+  start: string;
+  end: string;
+  logLevels: string[];
+  datasets: string[];
+  query: string;
+}
+
+export const AgentLogsUrlStateHelper = createStateContainerReactHelpers();
+
+export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agent, state }) => {
+  const { data, application, http } = useStartServices();
+  const { update: updateState } = AgentLogsUrlStateHelper.useTransitions();
+
+  // Util to convert date expressions (returned by datepicker) to timestamps (used by LogStream)
+  const getDateRangeTimestamps = useCallback(
+    (timeRange: TimeRange) => {
+      const { min, max } = data.query.timefilter.timefilter.calculateBounds(timeRange);
+      return min && max
+        ? {
+            startTimestamp: min.valueOf(),
+            endTimestamp: max.valueOf(),
+          }
+        : undefined;
+    },
+    [data.query.timefilter.timefilter]
+  );
+
+  const tryUpdateDateRange = useCallback(
+    (timeRange: TimeRange) => {
+      const timestamps = getDateRangeTimestamps(timeRange);
+      if (timestamps) {
+        updateState({
+          start: timeRange.from,
+          end: timeRange.to,
+        });
+      }
+    },
+    [getDateRangeTimestamps, updateState]
+  );
+
+  const dateRangeTimestamps = useMemo(
+    () =>
+      getDateRangeTimestamps({
+        from: state.start,
+        to: state.end,
+      }),
+    [getDateRangeTimestamps, state.end, state.start]
+  );
+
+  // Query validation helper
+  const isQueryValid = useCallback((testQuery: string) => {
+    try {
+      esKuery.fromKueryExpression(testQuery);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }, []);
+
+  // User query state
+  const [draftQuery, setDraftQuery] = useState<string>(state.query);
+  const [isDraftQueryValid, setIsDraftQueryValid] = useState<boolean>(isQueryValid(state.query));
+  const onUpdateDraftQuery = useCallback(
+    (newDraftQuery: string, runQuery?: boolean) => {
+      setDraftQuery(newDraftQuery);
+      if (isQueryValid(newDraftQuery)) {
+        setIsDraftQueryValid(true);
+        if (runQuery) {
+          updateState({ query: newDraftQuery });
+        }
+      } else {
+        setIsDraftQueryValid(false);
+      }
+    },
+    [isQueryValid, updateState]
+  );
+
+  // Build final log stream query from agent id, datasets, log levels, and user input
+  const logStreamQuery = useMemo(
+    () =>
+      buildQuery({
+        agentId: agent.id,
+        datasets: state.datasets,
+        logLevels: state.logLevels,
+        userQuery: state.query,
+      }),
+    [agent.id, state.datasets, state.logLevels, state.query]
+  );
+
+  // Generate URL to pass page state to Logs UI
+  const viewInLogsUrl = useMemo(
+    () =>
+      http.basePath.prepend(
+        url.format({
+          pathname: '/app/logs/stream',
+          search: stringify(
+            {
+              logPosition: encode({
+                start: state.start,
+                end: state.end,
+                streamLive: false,
+              }),
+              logFilter: encode({
+                expression: logStreamQuery,
+                kind: 'kuery',
+              }),
+            },
+            { sort: false, encode: false }
+          ),
+        })
+      ),
+    [http.basePath, state.start, state.end, logStreamQuery]
+  );
+
+  const agentVersion = agent.local_metadata?.elastic?.agent?.version;
+  const isLogLevelSelectionAvailable = useMemo(() => {
+    if (!agentVersion) {
+      return false;
+    }
+    const agentVersionWithPrerelease = semverCoerce(agentVersion)?.version;
+    if (!agentVersionWithPrerelease) {
+      return false;
+    }
+    return semverGte(agentVersionWithPrerelease, '7.11.0');
+  }, [agentVersion]);
+
+  return (
+    <WrapperFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="m">
+          <EuiFlexItem>
+            <LogQueryBar
+              query={draftQuery}
+              onUpdateQuery={onUpdateDraftQuery}
+              isQueryValid={isDraftQueryValid}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFilterGroup>
+              <DatasetFilter
+                selectedDatasets={state.datasets}
+                onToggleDataset={(dataset: string) => {
+                  const currentDatasets = [...state.datasets];
+                  const datasetPosition = currentDatasets.indexOf(dataset);
+                  if (datasetPosition >= 0) {
+                    currentDatasets.splice(datasetPosition, 1);
+                    updateState({ datasets: currentDatasets });
+                  } else {
+                    updateState({ datasets: [...state.datasets, dataset] });
+                  }
+                }}
+              />
+              <LogLevelFilter
+                selectedLevels={state.logLevels}
+                onToggleLevel={(level: string) => {
+                  const currentLevels = [...state.logLevels];
+                  const levelPosition = currentLevels.indexOf(level);
+                  if (levelPosition >= 0) {
+                    currentLevels.splice(levelPosition, 1);
+                    updateState({ logLevels: currentLevels });
+                  } else {
+                    updateState({ logLevels: [...state.logLevels, level] });
+                  }
+                }}
+              />
+            </EuiFilterGroup>
+          </EuiFlexItem>
+          <DatePickerFlexItem grow={false}>
+            <EuiSuperDatePicker
+              showUpdateButton={false}
+              start={state.start}
+              end={state.end}
+              onTimeChange={({ start, end }) => {
+                tryUpdateDateRange({
+                  from: start,
+                  to: end,
+                });
+              }}
+            />
+          </DatePickerFlexItem>
+          <EuiFlexItem grow={false}>
+            <RedirectAppLinks application={application}>
+              <EuiButtonEmpty href={viewInLogsUrl} iconType="popout" flush="both">
+                <FormattedMessage
+                  id="xpack.fleet.agentLogs.openInLogsUiLinkText"
+                  defaultMessage="Open in Logs"
+                />
+              </EuiButtonEmpty>
+            </RedirectAppLinks>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiPanel paddingSize="none">
+          <LogStream
+            height="100%"
+            startTimestamp={dateRangeTimestamps!.startTimestamp}
+            endTimestamp={dateRangeTimestamps!.endTimestamp}
+            query={logStreamQuery}
+          />
+        </EuiPanel>
+      </EuiFlexItem>
+      {isLogLevelSelectionAvailable && (
+        <EuiFlexItem grow={false}>
+          <SelectLogLevel agent={agent} />
+        </EuiFlexItem>
+      )}
+    </WrapperFlexGroup>
+  );
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/constants.tsx
@@ -3,6 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+import { AgentLogsState } from './agent_logs';
+
 export const AGENT_LOG_INDEX_PATTERN = 'logs-elastic_agent-*,logs-elastic_agent.*-*';
 export const AGENT_DATASET = 'elastic_agent';
 export const AGENT_DATASET_PATTERN = 'elastic_agent.*';
@@ -23,6 +25,13 @@ export const LOG_LEVEL_FIELD = {
 export const DEFAULT_DATE_RANGE = {
   start: 'now-1d',
   end: 'now',
+};
+export const DEFAULT_LOGS_STATE: AgentLogsState = {
+  start: DEFAULT_DATE_RANGE.start,
+  end: DEFAULT_DATE_RANGE.end,
+  logLevels: [],
+  datasets: [AGENT_DATASET],
+  query: '',
 };
 
 export const AGENT_LOG_LEVELS = {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
@@ -3,71 +3,17 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import React, { memo, useMemo, useState, useCallback, useEffect } from 'react';
-import styled from 'styled-components';
-import url from 'url';
-import { encode } from 'rison-node';
-import { stringify } from 'query-string';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiSuperDatePicker,
-  EuiFilterGroup,
-  EuiPanel,
-  EuiButtonEmpty,
-} from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
-import semverGte from 'semver/functions/gte';
-import semverCoerce from 'semver/functions/coerce';
+import React, { memo, useEffect } from 'react';
 import {
   createStateContainer,
   syncState,
   createKbnUrlStateStorage,
   INullableBaseStateContainer,
-  createStateContainerReactHelpers,
   PureTransition,
   getStateFromKbnUrl,
 } from '../../../../../../../../../../../src/plugins/kibana_utils/public';
-import { RedirectAppLinks } from '../../../../../../../../../../../src/plugins/kibana_react/public';
-import { TimeRange, esKuery } from '../../../../../../../../../../../src/plugins/data/public';
-import { LogStream } from '../../../../../../../../../infra/public';
-import { Agent } from '../../../../../types';
-import { useStartServices } from '../../../../../hooks';
-import { DEFAULT_DATE_RANGE, AGENT_DATASET } from './constants';
-import { DatasetFilter } from './filter_dataset';
-import { LogLevelFilter } from './filter_log_level';
-import { LogQueryBar } from './query_bar';
-import { buildQuery } from './build_query';
-import { SelectLogLevel } from './select_log_level';
-
-const WrapperFlexGroup = styled(EuiFlexGroup)`
-  height: 100%;
-`;
-
-const DatePickerFlexItem = styled(EuiFlexItem)`
-  max-width: 312px;
-`;
-
-interface AgentLogsProps {
-  agent: Agent;
-  state: AgentLogsState;
-}
-
-export interface AgentLogsState {
-  start: string;
-  end: string;
-  logLevels: string[];
-  datasets: string[];
-  query: string;
-}
-
-const defaultState: AgentLogsState = {
-  start: DEFAULT_DATE_RANGE.start,
-  end: DEFAULT_DATE_RANGE.end,
-  logLevels: [],
-  datasets: [AGENT_DATASET],
-  query: '',
-};
+import { DEFAULT_LOGS_STATE } from './constants';
+import { AgentLogsUI, AgentLogsProps, AgentLogsState, AgentLogsUrlStateHelper } from './agent_logs';
 
 const stateStorageKey = '_q';
 
@@ -76,230 +22,23 @@ const stateContainer = createStateContainer<
   {
     update: PureTransition<AgentLogsState, [Partial<AgentLogsState>]>;
   }
->(defaultState, {
-  update: (state) => (updatedState) => ({ ...state, ...updatedState }),
-});
+>(
+  {
+    ...DEFAULT_LOGS_STATE,
+    ...getStateFromKbnUrl<AgentLogsState>(stateStorageKey, window.location.href),
+  },
+  {
+    update: (state) => (updatedState) => ({ ...state, ...updatedState }),
+  }
+);
 
-const AgentLogsUrlStateHelper = createStateContainerReactHelpers<typeof stateContainer>();
-
-const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agent, state }) => {
-  const { data, application, http } = useStartServices();
-  const { update: updateState } = AgentLogsUrlStateHelper.useTransitions();
-
-  // Util to convert date expressions (returned by datepicker) to timestamps (used by LogStream)
-  const getDateRangeTimestamps = useCallback(
-    (timeRange: TimeRange) => {
-      const { min, max } = data.query.timefilter.timefilter.calculateBounds(timeRange);
-      return min && max
-        ? {
-            startTimestamp: min.valueOf(),
-            endTimestamp: max.valueOf(),
-          }
-        : undefined;
-    },
-    [data.query.timefilter.timefilter]
-  );
-
-  const tryUpdateDateRange = useCallback(
-    (timeRange: TimeRange) => {
-      const timestamps = getDateRangeTimestamps(timeRange);
-      if (timestamps) {
-        updateState({
-          start: timeRange.from,
-          end: timeRange.to,
-        });
-      }
-    },
-    [getDateRangeTimestamps, updateState]
-  );
-
-  const dateRangeTimestamps = useMemo(
-    () =>
-      getDateRangeTimestamps({
-        from: state.start,
-        to: state.end,
-      }),
-    [getDateRangeTimestamps, state.end, state.start]
-  );
-
-  // Query validation helper
-  const isQueryValid = useCallback((testQuery: string) => {
-    try {
-      esKuery.fromKueryExpression(testQuery);
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }, []);
-
-  // User query state
-  const [draftQuery, setDraftQuery] = useState<string>(state.query);
-  const [isDraftQueryValid, setIsDraftQueryValid] = useState<boolean>(isQueryValid(state.query));
-  const onUpdateDraftQuery = useCallback(
-    (newDraftQuery: string, runQuery?: boolean) => {
-      setDraftQuery(newDraftQuery);
-      if (isQueryValid(newDraftQuery)) {
-        setIsDraftQueryValid(true);
-        if (runQuery) {
-          updateState({ query: newDraftQuery });
-        }
-      } else {
-        setIsDraftQueryValid(false);
-      }
-    },
-    [isQueryValid, updateState]
-  );
-
-  // Build final log stream query from agent id, datasets, log levels, and user input
-  const logStreamQuery = useMemo(
-    () =>
-      buildQuery({
-        agentId: agent.id,
-        datasets: state.datasets,
-        logLevels: state.logLevels,
-        userQuery: state.query,
-      }),
-    [agent.id, state.datasets, state.logLevels, state.query]
-  );
-
-  // Generate URL to pass page state to Logs UI
-  const viewInLogsUrl = useMemo(
-    () =>
-      http.basePath.prepend(
-        url.format({
-          pathname: '/app/logs/stream',
-          search: stringify(
-            {
-              logPosition: encode({
-                start: state.start,
-                end: state.end,
-                streamLive: false,
-              }),
-              logFilter: encode({
-                expression: logStreamQuery,
-                kind: 'kuery',
-              }),
-            },
-            { sort: false, encode: false }
-          ),
-        })
-      ),
-    [http.basePath, state.start, state.end, logStreamQuery]
-  );
-
-  const agentVersion = agent.local_metadata?.elastic?.agent?.version;
-  const isLogLevelSelectionAvailable = useMemo(() => {
-    if (!agentVersion) {
-      return false;
-    }
-    const agentVersionWithPrerelease = semverCoerce(agentVersion)?.version;
-    if (!agentVersionWithPrerelease) {
-      return false;
-    }
-    return semverGte(agentVersionWithPrerelease, '7.11.0');
-  }, [agentVersion]);
-
-  const logStream = useMemo(
-    () => (
-      <LogStream
-        height="100%"
-        startTimestamp={dateRangeTimestamps!.startTimestamp}
-        endTimestamp={dateRangeTimestamps!.endTimestamp}
-        query={logStreamQuery}
-      />
-    ),
-    [dateRangeTimestamps, logStreamQuery]
-  );
-
-  return (
-    <WrapperFlexGroup direction="column" gutterSize="m">
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup gutterSize="m">
-          <EuiFlexItem>
-            <LogQueryBar
-              query={draftQuery}
-              onUpdateQuery={onUpdateDraftQuery}
-              isQueryValid={isDraftQueryValid}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFilterGroup>
-              <DatasetFilter
-                selectedDatasets={state.datasets}
-                onToggleDataset={(dataset: string) => {
-                  const currentDatasets = [...state.datasets];
-                  const datasetPosition = currentDatasets.indexOf(dataset);
-                  if (datasetPosition >= 0) {
-                    currentDatasets.splice(datasetPosition, 1);
-                    updateState({ datasets: currentDatasets });
-                  } else {
-                    updateState({ datasets: [...state.datasets, dataset] });
-                  }
-                }}
-              />
-              <LogLevelFilter
-                selectedLevels={state.logLevels}
-                onToggleLevel={(level: string) => {
-                  const currentLevels = [...state.logLevels];
-                  const levelPosition = currentLevels.indexOf(level);
-                  if (levelPosition >= 0) {
-                    currentLevels.splice(levelPosition, 1);
-                    updateState({ logLevels: currentLevels });
-                  } else {
-                    updateState({ logLevels: [...state.logLevels, level] });
-                  }
-                }}
-              />
-            </EuiFilterGroup>
-          </EuiFlexItem>
-          <DatePickerFlexItem grow={false}>
-            <EuiSuperDatePicker
-              showUpdateButton={false}
-              start={state.start}
-              end={state.end}
-              onTimeChange={({ start, end }) => {
-                tryUpdateDateRange({
-                  from: start,
-                  to: end,
-                });
-              }}
-            />
-          </DatePickerFlexItem>
-          <EuiFlexItem grow={false}>
-            <RedirectAppLinks application={application}>
-              <EuiButtonEmpty href={viewInLogsUrl} iconType="popout" flush="both">
-                <FormattedMessage
-                  id="xpack.fleet.agentLogs.openInLogsUiLinkText"
-                  defaultMessage="Open in Logs"
-                />
-              </EuiButtonEmpty>
-            </RedirectAppLinks>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiPanel paddingSize="none">{logStream}</EuiPanel>
-      </EuiFlexItem>
-      {isLogLevelSelectionAvailable && (
-        <EuiFlexItem grow={false}>
-          <SelectLogLevel agent={agent} />
-        </EuiFlexItem>
-      )}
-    </WrapperFlexGroup>
-  );
-});
-
-const AgentLogsConnected = AgentLogsUrlStateHelper.connect<AgentLogsProps, never>((state) => ({
-  state: state || defaultState,
+const AgentLogsConnected = AgentLogsUrlStateHelper.connect<AgentLogsProps, 'state'>((state) => ({
+  state: state || DEFAULT_LOGS_STATE,
 }))(AgentLogsUI);
 
-export const AgentLogs: React.FunctionComponent<Exclude<AgentLogsProps, 'state'>> = memo(
-  ({ ...props }) => {
+export const AgentLogs: React.FunctionComponent<Pick<AgentLogsProps, 'agent'>> = memo(
+  ({ agent }) => {
     useEffect(() => {
-      stateContainer.set({
-        ...defaultState,
-        ...getStateFromKbnUrl<AgentLogsState>(stateStorageKey, window.location.href),
-      });
       const stateStorage = createKbnUrlStateStorage();
       const { start, stop } = syncState({
         storageKey: stateStorageKey,
@@ -310,13 +49,13 @@ export const AgentLogs: React.FunctionComponent<Exclude<AgentLogsProps, 'state'>
 
       return () => {
         stop();
-        stateContainer.set(defaultState);
+        stateContainer.set(DEFAULT_LOGS_STATE);
       };
     }, []);
 
     return (
       <AgentLogsUrlStateHelper.Provider value={stateContainer}>
-        <AgentLogsConnected {...props} />
+        <AgentLogsConnected agent={agent} />
       </AgentLogsUrlStateHelper.Provider>
     );
   }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/index.tsx
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import React, { memo, useEffect } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import {
   createStateContainer,
   syncState,
@@ -38,6 +38,8 @@ const AgentLogsConnected = AgentLogsUrlStateHelper.connect<AgentLogsProps, 'stat
 
 export const AgentLogs: React.FunctionComponent<Pick<AgentLogsProps, 'agent'>> = memo(
   ({ agent }) => {
+    const [isSyncReady, setIsSyncReady] = useState<boolean>(false);
+
     useEffect(() => {
       const stateStorage = createKbnUrlStateStorage();
       const { start, stop } = syncState({
@@ -46,6 +48,7 @@ export const AgentLogs: React.FunctionComponent<Pick<AgentLogsProps, 'agent'>> =
         stateStorage,
       });
       start();
+      setIsSyncReady(true);
 
       return () => {
         stop();
@@ -55,7 +58,7 @@ export const AgentLogs: React.FunctionComponent<Pick<AgentLogsProps, 'agent'>> =
 
     return (
       <AgentLogsUrlStateHelper.Provider value={stateContainer}>
-        <AgentLogsConnected agent={agent} />
+        {isSyncReady ? <AgentLogsConnected agent={agent} /> : null}
       </AgentLogsUrlStateHelper.Provider>
     );
   }


### PR DESCRIPTION
## Summary

Resolves #83736. This PR adds URL query state to agent logs UI using [Kibana's state syncing utilities](https://github.com/elastic/kibana/tree/master/src/plugins/kibana_utils/docs/state_sync). When user updates their query, filter, or date parameters in the logs table, the change will be reflected in the URL query string. On full page reload, the table state will be loaded from the same URL params.

This will be useful for other applications that want to link to this page with a predefined context.

Example URL that is generated for looking at agent and filebeat error logs, from within the past week, that includes `FLEET`:
```
{KBN_BASE_PATH}/app/fleet#/fleet/agents/{AGENT_ID}/logs?_q=(datasets:!(elastic_agent,elastic_agent.filebeat),end:now%2Fw,logLevels:!(error),query:FLEET,start:now%2Fw)
```

Note: most of this PR diff is moving the main agent logs component to its own file at `agent_logs.tsx`. You may want to focus more on reviewing the containers that were added to `index.tsx`.

## Screenshots

Gif showing URL query being populated:

![Nov-24-2020 16-52-31](https://user-images.githubusercontent.com/1965714/100168158-8d345300-2e75-11eb-85d4-6cf87506dfe3.gif)

And persistence of the table state on page reload:

![Nov-24-2020 16-53-12](https://user-images.githubusercontent.com/1965714/100168190-9a514200-2e75-11eb-9f01-a2e7c7754924.gif)
