### PR TITLE
[Monitoring] Fix issues with show_license_expiration

### DIFF
--- a/x-pack/plugins/monitoring/public/components/cluster/overview/elasticsearch_panel.js
+++ b/x-pack/plugins/monitoring/public/components/cluster/overview/elasticsearch_panel.js
@@ -230,6 +230,46 @@ export function ElasticsearchPanel(props) {
     return null;
   };
 
+  const showLicense = () => {
+    if (!props.showLicenseExpiration) {
+      return null;
+    }
+    return (
+      <Fragment>
+        <EuiDescriptionListTitle className="eui-textBreakWord">
+          <FormattedMessage
+            id="xpack.monitoring.cluster.overview.esPanel.licenseLabel"
+            defaultMessage="License"
+          />
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription data-test-subj="esLicenseType">
+          <EuiFlexGroup direction="column" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiLink href={getSafeForExternalLink('#/license')}>
+                {capitalize(props.license.type)}
+              </EuiLink>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                {props.license.expiry_date_in_millis === undefined ? (
+                  ''
+                ) : (
+                  <FormattedMessage
+                    id="xpack.monitoring.cluster.overview.esPanel.expireDateText"
+                    defaultMessage="expires on {expiryDate}"
+                    values={{
+                      expiryDate: formatDateLocal(props.license.expiry_date_in_millis),
+                    }}
+                  />
+                )}
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiDescriptionListDescription>
+      </Fragment>
+    );
+  };
+
   const statusColorMap = {
     green: 'success',
     yellow: 'warning',
@@ -325,36 +365,7 @@ export function ElasticsearchPanel(props) {
                 {formatNumber(get(nodes, 'jvm.max_uptime_in_millis'), 'time_since')}
               </EuiDescriptionListDescription>
               {showMlJobs()}
-              <EuiDescriptionListTitle className="eui-textBreakWord">
-                <FormattedMessage
-                  id="xpack.monitoring.cluster.overview.esPanel.licenseLabel"
-                  defaultMessage="License"
-                />
-              </EuiDescriptionListTitle>
-              <EuiDescriptionListDescription data-test-subj="esLicenseType">
-                <EuiFlexGroup direction="column" gutterSize="xs">
-                  <EuiFlexItem grow={false}>
-                    <EuiLink href={getSafeForExternalLink('#/license')}>
-                      {capitalize(props.license.type)}
-                    </EuiLink>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="s">
-                      {props.license.expiry_date_in_millis === undefined ? (
-                        ''
-                      ) : (
-                        <FormattedMessage
-                          id="xpack.monitoring.cluster.overview.esPanel.expireDateText"
-                          defaultMessage="expires on {expiryDate}"
-                          values={{
-                            expiryDate: formatDateLocal(props.license.expiry_date_in_millis),
-                          }}
-                        />
-                      )}
-                    </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiDescriptionListDescription>
+              {showLicense()}
             </EuiDescriptionList>
           </EuiPanel>
         </EuiFlexItem>

--- a/x-pack/plugins/monitoring/server/alerts/license_expiration_alert.test.ts
+++ b/x-pack/plugins/monitoring/server/alerts/license_expiration_alert.test.ts
@@ -76,6 +76,7 @@ describe('LicenseExpirationAlert', () => {
     const monitoringCluster = null;
     const config = {
       ui: {
+        show_license_expiration: true,
         ccs: { enabled: true },
         container: { elasticsearch: { enabled: false } },
         metricbeat: { index: 'metricbeat-*' },
@@ -281,6 +282,33 @@ describe('LicenseExpirationAlert', () => {
         expiredDate: 'THE_DATE',
         state: 'resolved',
       });
+    });
+
+    it('should not fire actions if we are not showing license expiration', async () => {
+      const alert = new LicenseExpirationAlert();
+      const customConfig = {
+        ...config,
+        ui: {
+          ...config.ui,
+          show_license_expiration: false,
+        },
+      };
+      alert.initializeAlertType(
+        getUiSettingsService as any,
+        monitoringCluster as any,
+        getLogger as any,
+        customConfig as any,
+        kibanaUrl,
+        false
+      );
+      const type = alert.getAlertType();
+      await type.executor({
+        ...executorOptions,
+        // @ts-ignore
+        params: alert.defaultParams,
+      } as any);
+      expect(replaceState).not.toHaveBeenCalledWith({});
+      expect(scheduleActions).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/plugins/monitoring/server/alerts/license_expiration_alert.ts
+++ b/x-pack/plugins/monitoring/server/alerts/license_expiration_alert.ts
@@ -18,7 +18,7 @@ import {
   LegacyAlert,
   CommonAlertParams,
 } from '../../common/types/alerts';
-import { AlertInstance } from '../../../alerts/server';
+import { AlertExecutorOptions, AlertInstance } from '../../../alerts/server';
 import {
   INDEX_ALERTS,
   ALERT_LICENSE_EXPIRATION,
@@ -63,6 +63,13 @@ export class LicenseExpirationAlert extends BaseAlert {
     AlertingDefaults.ALERT_TYPE.context.action,
     AlertingDefaults.ALERT_TYPE.context.actionPlain,
   ];
+
+  protected async execute(options: AlertExecutorOptions): Promise<any> {
+    if (!this.config.ui.show_license_expiration) {
+      return;
+    }
+    return await super.execute(options);
+  }
 
   protected async fetchData(
     params: CommonAlertParams,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/84347

To test, set `monitoring.ui.show_license_expiration: false` in your `kibana.dev.yml` file and ensure the license expiration part of the Elasticsearch overview panel doesn't show up. I also decided to use this same toggle to disable the license expiration alert, as if they do not want to see it in the UI, chances are they don't want to receive an alert. I can be convinced to add an additional config to leave the alert active, when the `monitoring.ui.show_license_expiration` is `false`.