### PR TITLE
[APM] Adjust time formats based on the difference between start and end

### DIFF
--- a/x-pack/plugins/apm/common/utils/formatters/datetime.test.ts
+++ b/x-pack/plugins/apm/common/utils/formatters/datetime.test.ts
@@ -73,19 +73,37 @@ describe('date time formatters', () => {
         const dateRange = asRelativeDateTimeRange(start, end);
         expect(dateRange).toEqual('Oct 29, 2019, 10:01 - 15:01 (UTC+1)');
       });
-    });
-    describe('MMM D, YYYY, HH:mm:ss - HH:mm:ss (UTC)', () => {
       it('range: 14 minutes', () => {
         const start = formatDateToTimezone('2019-10-29 10:01:01');
         const end = formatDateToTimezone('2019-10-29 10:15:01');
         const dateRange = asRelativeDateTimeRange(start, end);
-        expect(dateRange).toEqual('Oct 29, 2019, 10:01:01 - 10:15:01 (UTC+1)');
+        expect(dateRange).toEqual('Oct 29, 2019, 10:01 - 10:15 (UTC+1)');
       });
       it('range: 5 minutes', () => {
         const start = formatDateToTimezone('2019-10-29 10:01:01');
         const end = formatDateToTimezone('2019-10-29 10:06:01');
         const dateRange = asRelativeDateTimeRange(start, end);
-        expect(dateRange).toEqual('Oct 29, 2019, 10:01:01 - 10:06:01 (UTC+1)');
+        expect(dateRange).toEqual('Oct 29, 2019, 10:01 - 10:06 (UTC+1)');
+      });
+      it('range: 1 minute', () => {
+        const start = formatDateToTimezone('2019-10-29 10:01:01');
+        const end = formatDateToTimezone('2019-10-29 10:02:01');
+        const dateRange = asRelativeDateTimeRange(start, end);
+        expect(dateRange).toEqual('Oct 29, 2019, 10:01 - 10:02 (UTC+1)');
+      });
+    });
+    describe('MMM D, YYYY, HH:mm:ss - HH:mm:ss (UTC)', () => {
+      it('range: 50 seconds', () => {
+        const start = formatDateToTimezone('2019-10-29 10:01:01');
+        const end = formatDateToTimezone('2019-10-29 10:01:50');
+        const dateRange = asRelativeDateTimeRange(start, end);
+        expect(dateRange).toEqual('Oct 29, 2019, 10:01:01 - 10:01:50 (UTC+1)');
+      });
+      it('range: 10 seconds', () => {
+        const start = formatDateToTimezone('2019-10-29 10:01:01');
+        const end = formatDateToTimezone('2019-10-29 10:01:11');
+        const dateRange = asRelativeDateTimeRange(start, end);
+        expect(dateRange).toEqual('Oct 29, 2019, 10:01:01 - 10:01:11 (UTC+1)');
       });
     });
     describe('MMM D, YYYY, HH:mm:ss.SSS - HH:mm:ss.SSS (UTC)', () => {

--- a/x-pack/plugins/apm/common/utils/formatters/datetime.ts
+++ b/x-pack/plugins/apm/common/utils/formatters/datetime.ts
@@ -80,14 +80,14 @@ function getFormatsAccordingToDateDifference(
     return { dateFormat: dateFormatWithDays };
   }
 
-  if (getDateDifference(start, end, 'hours') >= 5) {
+  if (getDateDifference(start, end, 'minutes') >= 1) {
     return {
       dateFormat: dateFormatWithDays,
       timeFormat: getTimeFormat('minutes'),
     };
   }
 
-  if (getDateDifference(start, end, 'minutes') >= 5) {
+  if (getDateDifference(start, end, 'seconds') >= 10) {
     return {
       dateFormat: dateFormatWithDays,
       timeFormat: getTimeFormat('seconds'),
@@ -121,8 +121,8 @@ export function asAbsoluteDateTime(
  * | >= 5 years     | YYYY - YYYY                                    |
  * | >= 5 months    | MMM YYYY - MMM YYYY                            |
  * | > 1 day        | MMM D, YYYY - MMM D, YYYY                      |
- * | >= 5 hours     | MMM D, YYYY, HH:mm - HH:mm (UTC)               |
- * | >= 5 minutes   | MMM D, YYYY, HH:mm:ss - HH:mm:ss (UTC)         |
+ * | >= 1 minute    | MMM D, YYYY, HH:mm - HH:mm (UTC)               |
+ * | >= 10 seconds  | MMM D, YYYY, HH:mm:ss - HH:mm:ss (UTC)         |
  * | default        | MMM D, YYYY, HH:mm:ss.SSS - HH:mm:ss.SSS (UTC) |
  *
  * @param start timestamp


### PR DESCRIPTION
This is related to this issue: https://github.com/elastic/kibana/issues/84178

- Chart tooltips should be made more legible. Reduce the timestamp to only hh:mm:ss instead of showing the absolute (this is also the case in our existing charts, I would just prefer to change it)

<img width="522" alt="Screenshot 2020-11-30 at 10 39 08" src="https://user-images.githubusercontent.com/55978943/100593707-03fba100-32f9-11eb-9b3f-0722bc109c69.png">
<img width="441" alt="Screenshot 2020-11-30 at 10 39 23" src="https://user-images.githubusercontent.com/55978943/100593712-052cce00-32f9-11eb-939a-134adf3a4599.png">
<img width="492" alt="Screenshot 2020-11-30 at 10 40 09" src="https://user-images.githubusercontent.com/55978943/100593716-05c56480-32f9-11eb-8cd1-6865ad603017.png">
