### PR TITLE
[Lens] (Accessibility) add aria-label to chart type icon

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.tsx
@@ -26,10 +26,21 @@ export function LayerSettings({
     return null;
   }
 
-  const a11yText = i18n.translate('xpack.lens.editLayerSettings', {
-    defaultMessage: 'Edit layer settings',
-  });
+  const a11yText = (chartType?: string) => {
+    if (chartType) {
+      return i18n.translate('xpack.lens.editLayerSettingsChartType', {
+        defaultMessage: 'Edit layer settings, {chartType}',
+        values: {
+          chartType,
+        },
+      });
+    }
+    return i18n.translate('xpack.lens.editLayerSettings', {
+      defaultMessage: 'Edit layer settings',
+    });
+  };
 
+  const contextMenuIcon = activeVisualization.getLayerContextMenuIcon?.(layerConfigProps);
   return (
     <EuiPopover
       id={`lnsLayerPopover_${layerId}`}
@@ -43,9 +54,9 @@ export function LayerSettings({
         >
           <ToolbarButton
             size="s"
-            iconType={activeVisualization.getLayerContextMenuIcon?.(layerConfigProps) || 'gear'}
-            aria-label={a11yText}
-            title={a11yText}
+            iconType={contextMenuIcon?.icon || 'gear'}
+            aria-label={a11yText(contextMenuIcon?.label || '')}
+            title={a11yText(contextMenuIcon?.label || '')}
             onClick={() => setIsOpen(!isOpen)}
             data-test-subj="lns_layer_settings"
           />

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -540,7 +540,10 @@ export interface Visualization<T = unknown> {
    * Visualizations can provide a custom icon which will open a layer-specific popover
    * If no icon is provided, gear icon is default
    */
-  getLayerContextMenuIcon?: (opts: { state: T; layerId: string }) => IconType | undefined;
+  getLayerContextMenuIcon?: (opts: {
+    state: T;
+    layerId: string;
+  }) => { icon: IconType | 'gear'; label: string } | undefined;
 
   /**
    * The frame is telling the visualization to update or set a dimension based on user interaction

--- a/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/visualization.tsx
@@ -300,7 +300,11 @@ export const getXyVisualization = ({
 
   getLayerContextMenuIcon({ state, layerId }) {
     const layer = state.layers.find((l) => l.layerId === layerId);
-    return visualizationTypes.find((t) => t.id === layer?.seriesType)?.icon;
+    const visualizationType = visualizationTypes.find((t) => t.id === layer?.seriesType);
+    return {
+      icon: visualizationType?.icon || 'gear',
+      label: visualizationType?.label || '',
+    };
   },
 
   renderLayerContextMenu(domElement, props) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/83599

Added label of the current chartType to `aria-label` of the element:

`<button class="{...}" type="button" data-test-subj="lns_layer_settings" aria-label="Edit layer settings, Bar" title="Edit layer settings, Bar">`

(proposed solution of @myasonik `extend the aria-label to read something like Edit layer settings; {chartType} (instead of the current Edit layer settings`)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
