### PR TITLE
[Lens] (Accessibility) Focus mistakenly stops on righthand form

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -88,7 +88,7 @@ function LayerPanels(
   const layerIds = activeVisualization.getLayerIds(visualizationState);
 
   return (
-    <EuiForm className="lnsConfigPanel">
+    <EuiForm className="lnsConfigPanel" tabIndex={-1}>
       {layerIds.map((layerId, index) => (
         <LayerPanel
           {...props}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/83591 (description in the issue)
