### PR TITLE
[Fleet] Fix initialization of history instance provided to react-router

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/app.tsx
@@ -186,16 +186,9 @@ export const FleetAppContext: React.FC<{
   /** For testing purposes only */
   routerHistory?: History<any>;
 }> = memo(
-  ({
-    children,
-    startServices,
-    config,
-    history,
-    kibanaVersion,
-    extensions,
-    routerHistory = createHashHistory(),
-  }) => {
+  ({ children, startServices, config, history, kibanaVersion, extensions, routerHistory }) => {
     const isDarkMode = useObservable<boolean>(startServices.uiSettings.get$('theme:darkMode'));
+    const [routerHistoryInstance] = useState(routerHistory || createHashHistory());
 
     return (
       <startServices.i18n.Context>
@@ -207,7 +200,7 @@ export const FleetAppContext: React.FC<{
                   <UIExtensionsContext.Provider value={extensions}>
                     <FleetStatusProvider>
                       <IntraAppStateProvider kibanaScopedHistory={history}>
-                        <Router history={routerHistory}>
+                        <Router history={routerHistoryInstance}>
                           <PackageInstallProvider notifications={startServices.notifications}>
                             {children}
                           </PackageInstallProvider>


### PR DESCRIPTION
## Summary

Fixes a react-router browser console warning indicating that `history` can not be changed (`You cannot change <Router history>`). Ensures that the History instance is only created once for the lifecycle of the `<Router>` component.

