### PR TITLE
[Lens] (Accessibility) Added focus state and accessible name to suggestions

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
@@ -1143,7 +1143,7 @@ describe('editor_frame', () => {
           .find(EuiPanel)
           .map((el) => el.parents(EuiToolTip).prop('content'))
       ).toEqual([
-        'Current Visualization',
+        'Current visualization',
         'Suggestion1',
         'Suggestion2',
         'Suggestion3',

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/editor_frame.test.tsx
@@ -1143,7 +1143,7 @@ describe('editor_frame', () => {
           .find(EuiPanel)
           .map((el) => el.parents(EuiToolTip).prop('content'))
       ).toEqual([
-        'Current',
+        'Current Visualization',
         'Suggestion1',
         'Suggestion2',
         'Suggestion3',

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.scss
@@ -16,6 +16,7 @@
   // Padding / negative margins to make room for overflow shadow
   padding-left: $euiSizeXS;
   margin-left: -$euiSizeXS;
+  padding-bottom: $euiSizeXS;
 }
 
 .lnsSuggestionPanel__button {
@@ -27,13 +28,26 @@
   margin-left: $euiSizeXS / 2;
   margin-bottom: $euiSizeXS / 2;
 
+  &:focus {
+    @include euiFocusRing;
+    transform: none !important; // sass-lint:disable-line no-important
+  }
+
   .lnsSuggestionPanel__expressionRenderer {
     position: static; // Let the progress indicator position itself against the button
   }
 }
 
 .lnsSuggestionPanel__button-isSelected {
-  @include euiFocusRing;
+  background-color: $euiColorLightestShade !important; // sass-lint:disable-line no-important
+
+  &:not(:focus) {
+    box-shadow: none !important; // sass-lint:disable-line no-important
+  }
+
+  &:focus {
+    @include euiFocusRing;
+  }
 }
 
 .lnsSuggestionPanel__suggestionIcon {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.scss
@@ -40,6 +40,7 @@
 
 .lnsSuggestionPanel__button-isSelected {
   background-color: $euiColorLightestShade !important; // sass-lint:disable-line no-important
+  border-color: $euiColorMediumShade;
 
   &:not(:focus) {
     box-shadow: none !important; // sass-lint:disable-line no-important
@@ -47,6 +48,10 @@
 
   &:focus {
     @include euiFocusRing;
+  }
+
+  &:hover {
+    transform: none !important; // sass-lint:disable-line no-important
   }
 }
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
@@ -98,7 +98,7 @@ describe('suggestion_panel', () => {
         .find('[data-test-subj="lnsSuggestion"]')
         .find(EuiPanel)
         .map((el) => el.parents(EuiToolTip).prop('content'))
-    ).toEqual(['Current', 'Suggestion1', 'Suggestion2']);
+    ).toEqual(['Current Visualization', 'Suggestion1', 'Suggestion2']);
   });
 
   describe('uncommitted suggestions', () => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
@@ -98,7 +98,7 @@ describe('suggestion_panel', () => {
         .find('[data-test-subj="lnsSuggestion"]')
         .find(EuiPanel)
         .map((el) => el.parents(EuiToolTip).prop('content'))
-    ).toEqual(['Current Visualization', 'Suggestion1', 'Suggestion2']);
+    ).toEqual(['Current visualization', 'Suggestion1', 'Suggestion2']);
   });
 
   describe('uncommitted suggestions', () => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -133,9 +133,10 @@ const SuggestionPreview = ({
             // eslint-disable-next-line @typescript-eslint/naming-convention
             'lnsSuggestionPanel__button-isSelected': selected,
           })}
-          paddingSize="none"
           data-test-subj="lnsSuggestion"
           onClick={onSelect}
+          aria-current={!!selected}
+          aria-label={preview.title}
         >
           {preview.expression || preview.error ? (
             <PreviewRenderer
@@ -356,7 +357,7 @@ export function SuggestionPanel({
                 visualizationMap[currentVisualizationId].getDescription(currentVisualizationState)
                   .icon || 'empty',
               title: i18n.translate('xpack.lens.suggestions.currentVisLabel', {
-                defaultMessage: 'Current',
+                defaultMessage: 'Current visualization',
               }),
             }}
             ExpressionRenderer={AutoRefreshExpressionRenderer}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -133,6 +133,7 @@ const SuggestionPreview = ({
             // eslint-disable-next-line @typescript-eslint/naming-convention
             'lnsSuggestionPanel__button-isSelected': selected,
           })}
+          paddingSize="none"
           data-test-subj="lnsSuggestion"
           onClick={onSelect}
           aria-current={!!selected}

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -10797,7 +10797,6 @@
     "xpack.lens.shared.nestedLegendLabel": "ネスト済み",
     "xpack.lens.sugegstion.refreshSuggestionLabel": "更新",
     "xpack.lens.suggestion.refreshSuggestionTooltip": "選択したビジュアライゼーションに基づいて、候補を更新します。",
-    "xpack.lens.suggestions.currentVisLabel": "現在",
     "xpack.lens.visTypeAlias.title": "レンズビジュアライゼーション",
     "xpack.lens.visTypeAlias.type": "レンズ",
     "xpack.lens.xyChart.addLayer": "レイヤーを追加",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -10810,7 +10810,6 @@
     "xpack.lens.shared.nestedLegendLabel": "嵌套",
     "xpack.lens.sugegstion.refreshSuggestionLabel": "刷新",
     "xpack.lens.suggestion.refreshSuggestionTooltip": "基于选定可视化刷新建议。",
-    "xpack.lens.suggestions.currentVisLabel": "当前",
     "xpack.lens.visTypeAlias.title": "Lens 可视化",
     "xpack.lens.visTypeAlias.type": "Lens",
     "xpack.lens.xyChart.addLayer": "添加图层",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/83602

- [x] Focus styles and hover styles demo:
![image](https://user-images.githubusercontent.com/4283304/100995321-e8da9c80-3557-11eb-9ced-f72e815940c0.png)


(gif didn't pick up the color difference between light background of selected vis but it's there)
![suggestions](https://user-images.githubusercontent.com/4283304/100991804-b4fd7800-3553-11eb-8b0d-d60bfa87ad8c.gif)



- [x] Changed name of current suggestion from 'current' to 'current visualization'
- [x] added `aria-current={true}` for current vis
- [x] added `aria-label` with suggestion name