### PR TITLE
[Monitoring] Make alert status fetching more resilient

### DIFF
--- a/x-pack/plugins/monitoring/public/views/base_controller.js
+++ b/x-pack/plugins/monitoring/public/views/base_controller.js
@@ -163,12 +163,12 @@ export class MonitoringViewBaseController {
       if (isSetupModeFeatureEnabled(SetupModeFeature.MetricbeatMigration)) {
         promises.push(updateSetupModeData());
       }
-      this.updateDataPromise = new PromiseWithCancel(Promise.all(promises));
+      this.updateDataPromise = new PromiseWithCancel(Promise.allSettled(promises));
       return this.updateDataPromise.promise().then(([pageData, alerts]) => {
         $scope.$apply(() => {
           this._isDataInitialized = true; // render will replace loading screen with the react component
-          $scope.pageData = this.data = pageData; // update the view's data with the fetch result
-          $scope.alerts = this.alerts = alerts;
+          $scope.pageData = this.data = pageData.value; // update the view's data with the fetch result
+          $scope.alerts = this.alerts = alerts.value || {};
         });
       });
     };

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.js
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.js
@@ -151,20 +151,32 @@ export async function getClustersFromRequest(
           'production'
         );
         if (prodLicenseInfo.clusterAlerts.enabled) {
-          cluster.alerts = {
-            list: await fetchStatus(
-              alertsClient,
-              req.server.plugins.monitoring.info,
-              undefined,
-              cluster.cluster_uuid,
-              start,
-              end,
-              []
-            ),
-            alertsMeta: {
-              enabled: true,
-            },
-          };
+          try {
+            cluster.alerts = {
+              list: await fetchStatus(
+                alertsClient,
+                req.server.plugins.monitoring.info,
+                undefined,
+                cluster.cluster_uuid,
+                start,
+                end,
+                []
+              ),
+              alertsMeta: {
+                enabled: true,
+              },
+            };
+          } catch (err) {
+            req.logger.warn(
+              `Unable to fetch alert status because '${err.message}'. Alerts may not properly show up in the UI.`
+            );
+            cluster.alerts = {
+              list: {},
+              alertsMeta: {
+                enabled: true,
+              },
+            };
+          }
           continue;
         }
 


### PR DESCRIPTION
Resolves #84451

See issue for more information. I don't have a great way to test this, but if you just add a custom `throw new Error('')` into `fetchStatus()`, it will trigger.