### PR TITLE
[Fleet][EPM] Pass through valid manifest values from upload

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -5,7 +5,7 @@
  */
 
 import yaml from 'js-yaml';
-import { uniq } from 'lodash';
+import { pick, uniq } from 'lodash';
 import {
   ArchivePackage,
   RegistryPolicyTemplate,
@@ -20,6 +20,40 @@ import { pkgToPkgKey } from '../registry';
 
 const MANIFESTS: Record<string, Buffer> = {};
 const MANIFEST_NAME = 'manifest.yml';
+
+// not sure these are 100% correct but they do the job here
+// keeping them local until others need them
+type OptionalPropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]> ? never : K;
+  }[keyof T],
+  undefined
+>;
+type RequiredPropertyOf<T extends object> = Exclude<keyof T, OptionalPropertyOf<T>>;
+
+// pro: guarantee only supplying known values. these keys must be in ArchivePackage. no typos or new values
+// pro: any values added to these lists will be passed through by default
+// pro & con: values do need to be shadowed / repeated from ArchivePackage, but perhaps we want to limit values
+const requiredArchivePackageProps: ReadonlyArray<RequiredPropertyOf<ArchivePackage>> = [
+  'name',
+  'version',
+  'description',
+  'type',
+  'categories',
+  'format_version',
+] as const;
+
+const optionalArchivePackageProps: ReadonlyArray<OptionalPropertyOf<ArchivePackage>> = [
+  'title',
+  'release',
+  'readme',
+  'screenshots',
+  'icons',
+  'assets',
+  'internal',
+  'data_streams',
+  'policy_templates',
+] as const;
 
 // TODO: everything below performs verification of manifest.yml files, and hence duplicates functionality already implemented in the
 // package registry. At some point this should probably be replaced (or enhanced) with verification based on
@@ -58,43 +92,43 @@ function parseAndVerifyArchive(paths: string[]): ArchivePackage {
   }
 
   // ... which must be valid YAML
-  let manifest;
+  let manifest: ArchivePackage;
   try {
     manifest = yaml.load(manifestBuffer.toString());
   } catch (error) {
     throw new PackageInvalidArchiveError(`Could not parse top-level package manifest: ${error}.`);
   }
 
+  // must have mandatory fields
+  const reqGiven = pick(manifest, requiredArchivePackageProps);
+  const requiredKeysMatch =
+    Object.keys(reqGiven).toString() === requiredArchivePackageProps.toString();
+  if (!requiredKeysMatch) {
+    const list = requiredArchivePackageProps.join(', ');
+    throw new PackageInvalidArchiveError(
+      `Invalid top-level package manifest: one or more fields missing of ${list}`
+    );
+  }
+
+  // at least have all required properties
+  // get optional values and combine into one object for the remaining operations
+  const optGiven = pick(manifest, optionalArchivePackageProps);
+  const parsed: ArchivePackage = { ...reqGiven, ...optGiven };
+
   // Package name and version from the manifest must match those from the toplevel directory
-  const pkgKey = pkgToPkgKey({ name: manifest.name, version: manifest.version });
+  const pkgKey = pkgToPkgKey({ name: parsed.name, version: parsed.version });
   if (toplevelDir !== pkgKey) {
     throw new PackageInvalidArchiveError(
-      `Name ${manifest.name} and version ${manifest.version} do not match top-level directory ${toplevelDir}`
+      `Name ${parsed.name} and version ${parsed.version} do not match top-level directory ${toplevelDir}`
     );
   }
 
-  const { name, version, description, type, categories, format_version: formatVersion } = manifest;
-  // check for mandatory fields
-  if (!(name && version && description && type && categories && formatVersion)) {
-    throw new PackageInvalidArchiveError(
-      'Invalid top-level package manifest: one or more fields missing of name, version, description, type, categories, format_version'
-    );
-  }
+  parsed.data_streams = parseAndVerifyDataStreams(paths, parsed.name, parsed.version);
+  parsed.policy_templates = parseAndVerifyPolicyTemplates(manifest);
 
-  const dataStreams = parseAndVerifyDataStreams(paths, name, version);
-  const policyTemplates = parseAndVerifyPolicyTemplates(manifest);
-
-  return {
-    name,
-    version,
-    description,
-    type,
-    categories,
-    format_version: formatVersion,
-    data_streams: dataStreams,
-    policy_templates: policyTemplates,
-  };
+  return parsed;
 }
+
 function parseAndVerifyDataStreams(
   paths: string[],
   pkgName: string,

--- a/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/validation.ts
@@ -31,10 +31,12 @@ type OptionalPropertyOf<T extends object> = Exclude<
 >;
 type RequiredPropertyOf<T extends object> = Exclude<keyof T, OptionalPropertyOf<T>>;
 
+type RequiredPackageProp = RequiredPropertyOf<ArchivePackage>;
+type OptionalPackageProp = OptionalPropertyOf<ArchivePackage>;
 // pro: guarantee only supplying known values. these keys must be in ArchivePackage. no typos or new values
 // pro: any values added to these lists will be passed through by default
 // pro & con: values do need to be shadowed / repeated from ArchivePackage, but perhaps we want to limit values
-const requiredArchivePackageProps: ReadonlyArray<RequiredPropertyOf<ArchivePackage>> = [
+const requiredArchivePackageProps: readonly RequiredPackageProp[] = [
   'name',
   'version',
   'description',
@@ -43,7 +45,7 @@ const requiredArchivePackageProps: ReadonlyArray<RequiredPropertyOf<ArchivePacka
   'format_version',
 ] as const;
 
-const optionalArchivePackageProps: ReadonlyArray<OptionalPropertyOf<ArchivePackage>> = [
+const optionalArchivePackageProps: readonly OptionalPackageProp[] = [
   'title',
   'release',
   'readme',


### PR DESCRIPTION
## Summary

  * Pass through as many valid properties as possible from the manifest (currently missing values like `icons` & `screenshots` even if they are present in the manifest
  * Improve type safety

refs #84583
doesn't close #84583 because it doesn't add `readme` for example


**Type additions**
Added `RequiredPropertyOf<T>` and  `OptionalPropertyOf<T>` utility types. They return a string union of the required or optional properties from a type/interface.

Compare these
<img width="999" alt="Screen Shot 2020-12-01 at 3 23 29 PM" src="https://user-images.githubusercontent.com/57655/100793016-8a8fab80-33e9-11eb-9c64-eed9276342be.png">

<img width="1220" alt="Screen Shot 2020-12-01 at 3 23 38 PM" src="https://user-images.githubusercontent.com/57655/100792969-79469f00-33e9-11eb-86bc-dcfddbc579ad.png">

with package definition: 
https://github.com/elastic/kibana/blob/497264e891a2009fc0ea3f331b8ae5259cd18da9/x-pack/plugins/fleet/common/types/models/epm.ts#L73-L89


Can't typo property names, put required props on optional list, or vice-versa
<img width="827" alt="Screen Shot 2020-12-01 at 3 06 31 PM" src="https://user-images.githubusercontent.com/57655/100793067-9d09e500-33e9-11eb-9267-25badfebf4ca.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
