### PR TITLE
[TSVB] [Cleanup] Remove extra dateFormat props

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/markdown_editor.js
@@ -49,12 +49,12 @@ export class MarkdownEditor extends Component {
   }
 
   render() {
-    const { visData, model, dateFormat } = this.props;
+    const { visData, model, getConfig } = this.props;
 
     if (!visData) {
       return null;
     }
-
+    const dateFormat = getConfig('dateFormat');
     const series = _.get(visData, `${model.id}.series`, []);
     const variables = convertSeriesToVars(series, model, dateFormat, this.props.getConfig);
     const rows = [];
@@ -214,6 +214,6 @@ export class MarkdownEditor extends Component {
 MarkdownEditor.propTypes = {
   onChange: PropTypes.func,
   model: PropTypes.object,
-  dateFormat: PropTypes.string,
+  getConfig: PropTypes.func,
   visData: PropTypes.object,
 };

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config.js
@@ -90,6 +90,6 @@ PanelConfig.propTypes = {
   fields: PropTypes.object,
   model: PropTypes.object,
   onChange: PropTypes.func,
-  dateFormat: PropTypes.string,
   visData$: PropTypes.object,
+  getConfig: PropTypes.func,
 };

--- a/src/plugins/vis_type_timeseries/public/application/components/panel_config/markdown.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/panel_config/markdown.js
@@ -334,7 +334,6 @@ MarkdownPanelConfigUi.propTypes = {
   fields: PropTypes.object,
   model: PropTypes.object,
   onChange: PropTypes.func,
-  dateFormat: PropTypes.string,
 };
 
 export const MarkdownPanelConfig = injectI18n(MarkdownPanelConfigUi);

--- a/src/plugins/vis_type_timeseries/public/application/components/timeseries_visualization.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/timeseries_visualization.tsx
@@ -96,7 +96,6 @@ function TimeseriesVisualization({
   if (VisComponent) {
     return (
       <VisComponent
-        dateFormat={getConfig('dateFormat')}
         getConfig={getConfig}
         model={model}
         visData={visData}

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_editor.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_editor.js
@@ -181,7 +181,6 @@ export class VisEditor extends Component {
                   fields={this.state.visFields}
                   model={model}
                   visData$={this.visData$}
-                  dateFormat={this.props.config.get('dateFormat')}
                   onChange={this.handleChange}
                   getConfig={this.getConfig}
                 />

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/index.ts
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/index.ts
@@ -64,6 +64,5 @@ export interface TimeseriesVisProps {
   ) => void;
   uiState: PersistedState;
   visData: TimeseriesVisData;
-  dateFormat: string;
   getConfig: IUiSettingsClient['get'];
 }

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/markdown/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/markdown/vis.js
@@ -31,9 +31,9 @@ import { isBackgroundInverted } from '../../../lib/set_is_reversed';
 const getMarkdownId = (id) => `markdown-${id}`;
 
 function MarkdownVisualization(props) {
-  const { backgroundColor, model, visData, dateFormat } = props;
+  const { backgroundColor, model, visData, getConfig } = props;
   const series = get(visData, `${model.id}.series`, []);
-  const variables = convertSeriesToVars(series, model, dateFormat, props.getConfig);
+  const variables = convertSeriesToVars(series, model, getConfig('dateFormat'), props.getConfig);
   const markdownElementId = getMarkdownId(uuid.v1());
 
   const panelBackgroundColor = model.background_color || backgroundColor;
@@ -103,7 +103,6 @@ MarkdownVisualization.propTypes = {
   onBrush: PropTypes.func,
   onChange: PropTypes.func,
   visData: PropTypes.object,
-  dateFormat: PropTypes.string,
   getConfig: PropTypes.func,
 };
 

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/vis.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/vis.js
@@ -39,20 +39,18 @@ class TimeseriesVisualization extends Component {
     model: PropTypes.object,
     onBrush: PropTypes.func,
     visData: PropTypes.object,
-    dateFormat: PropTypes.string,
     getConfig: PropTypes.func,
   };
 
-  xAxisFormatter = (interval) => (val) => {
-    const scaledDataFormat = this.props.getConfig('dateFormat:scaled');
-    const { dateFormat } = this.props;
+  scaledDataFormat = this.props.getConfig('dateFormat:scaled');
+  dateFormat = this.props.getConfig('dateFormat');
 
-    if (!scaledDataFormat || !dateFormat) {
+  xAxisFormatter = (interval) => (val) => {
+    if (!this.scaledDataFormat || !this.dateFormat) {
       return val;
     }
 
-    const formatter = createXaxisFormatter(interval, scaledDataFormat, dateFormat);
-
+    const formatter = createXaxisFormatter(interval, this.scaledDataFormat, this.dateFormat);
     return formatter(val);
   };
 


### PR DESCRIPTION
## Summary

This PR fix the following comment https://github.com/elastic/kibana/pull/83554#discussion_r526704344.
We shouldn't pass extra props to a component if they can be obtained from another property.

In this case, `dateFormat` can be easily obtained from `getConfig`
