### PR TITLE
[APM] Add log_level/sanitize_field_names config options to Python Agent

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -110,7 +110,7 @@ export const generalSettings: RawSettingDefinition[] = [
       { text: 'critical', value: 'critical' },
       { text: 'off', value: 'off' },
     ],
-    includeAgents: ['dotnet', 'ruby', 'java'],
+    includeAgents: ['dotnet', 'ruby', 'java', 'python'],
   },
 
   // Recording

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -235,7 +235,7 @@ export const generalSettings: RawSettingDefinition[] = [
           'Sometimes it is necessary to sanitize, i.e., remove, sensitive data sent to Elastic APM. This config accepts a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields). The query string and the captured request body (such as `application/json` data) will not get sanitized.',
       }
     ),
-    includeAgents: ['java'],
+    includeAgents: ['java', 'python'],
   },
 
   // Ignore transactions based on URLs

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -111,6 +111,7 @@ describe('filterByAgent', () => {
         'api_request_time',
         'capture_body',
         'capture_headers',
+        'log_level',
         'recording',
         'span_frames_min_duration',
         'transaction_max_spans',

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -113,6 +113,7 @@ describe('filterByAgent', () => {
         'capture_headers',
         'log_level',
         'recording',
+        'sanitize_field_names',
         'span_frames_min_duration',
         'transaction_max_spans',
         'transaction_sample_rate',


### PR DESCRIPTION
## Summary

Adds the existing `log_level` and `sanitize_field_names` configs to the python agent config options.

Closes https://github.com/elastic/apm-agent-python/issues/969
Ref https://github.com/elastic/apm-agent-python/issues/904

### Checklist

Delete any items that are not applicable to this PR.

(None of the items were applicable to this change)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
