### PR TITLE
[Lens] Fix error when selecting the current field again

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -1229,6 +1229,24 @@ describe('IndexPatternDimensionEditorPanel', () => {
     );
   });
 
+  it('should not update when selecting the current field again', () => {
+    wrapper = mount(<IndexPatternDimensionEditorComponent {...defaultProps} />);
+
+    const comboBox = wrapper
+      .find(EuiComboBox)
+      .filter('[data-test-subj="indexPattern-dimension-field"]');
+
+    const option = comboBox
+      .prop('options')![1]
+      .options!.find(({ label }) => label === 'timestampLabel')!;
+
+    act(() => {
+      comboBox.prop('onChange')!([option]);
+    });
+
+    expect(setState).not.toHaveBeenCalled();
+  });
+
   it('should show all operations that are not filtered out', () => {
     wrapper = mount(
       <IndexPatternDimensionEditorComponent

--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/field_select.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/field_select.tsx
@@ -195,9 +195,12 @@ export function FieldSelect({
           return;
         }
 
-        trackUiEvent('indexpattern_dimension_field_changed');
+        const choice = (choices[0].value as unknown) as FieldChoice;
 
-        onChoose((choices[0].value as unknown) as FieldChoice);
+        if (choice.field !== selectedField) {
+          trackUiEvent('indexpattern_dimension_field_changed');
+          onChoose(choice);
+        }
       }}
       renderOption={(option, searchValue) => {
         return (


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/84790

Steps to reproduce:

1. Create a field-based operation in Lens
2. Select the same field that is already selected
3. Nothing should happen

This behavior works in all released versions, but I broke it in the unreleased versions due to some refactoring.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
