### PR TITLE
[Enterprise Search] Jest config & handy Jest script

### DIFF
--- a/x-pack/plugins/enterprise_search/README.md
+++ b/x-pack/plugins/enterprise_search/README.md
@@ -38,6 +38,16 @@ yarn test:jest
 yarn test:jest --watch
 ```
 
+Unfortunately coverage collection does not work as automatically, and requires using our handy jest.sh script if you want to run tests on a specific folder and only get coverage numbers for that folder:
+
+```bash
+# Running the jest.sh script from the `x-pack/plugins/enterprise_search` folder (vs. kibana root)
+# will save you time and allow you to Tab to complete folder dir names
+sh jest.sh {YOUR_COMPONENT_DIR}
+sh jest.sh public/applications/shared/kibana
+sh jest.sh server/routes/app_search
+```
+
 ### E2E tests
 
 See [our functional test runner README](../../test/functional_enterprise_search).

--- a/x-pack/plugins/enterprise_search/README.md
+++ b/x-pack/plugins/enterprise_search/README.md
@@ -31,8 +31,11 @@ To debug Kea state in-browser, Kea recommends [Redux Devtools](https://kea.js.or
 
 Documentation: https://www.elastic.co/guide/en/kibana/current/development-tests.html#_unit_testing
 
-```
-yarn test:jest x-pack/plugins/enterprise_search --watch
+Jest tests can be run directly from the `x-pack/plugins/enterprise_search` folder. This also works for any subfolders or subcomponents.
+
+```bash
+yarn test:jest
+yarn test:jest --watch
 ```
 
 ### E2E tests

--- a/x-pack/plugins/enterprise_search/jest.config.js
+++ b/x-pack/plugins/enterprise_search/jest.config.js
@@ -8,4 +8,11 @@ module.exports = {
   preset: '@kbn/test',
   rootDir: '../../..',
   roots: ['<rootDir>/x-pack/plugins/enterprise_search'],
+  collectCoverage: true,
+  coverageReporters: ['text'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/plugins/enterprise_search/**/*.{ts,tsx}',
+    '!<rootDir>/x-pack/plugins/enterprise_search/public/*.ts',
+    '!<rootDir>/x-pack/plugins/enterprise_search/server/*.ts',
+  ],
 };

--- a/x-pack/plugins/enterprise_search/jest.sh
+++ b/x-pack/plugins/enterprise_search/jest.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+# Whether to run Jest on the entire enterprise_search plugin or a specific component/folder
+FOLDER="${1:-all}"
+if [[ $FOLDER && $FOLDER != "all" ]]
+then
+  FOLDER=${FOLDER%/} # Strip any trailing slash
+  FOLDER="${FOLDER}/ --collectCoverageFrom='<rootDir>/x-pack/plugins/enterprise_search/${FOLDER}/**/*.{ts,tsx}'"
+else
+  FOLDER=''
+fi
+
+# Pass all remaining arguments (e.g., ...rest) from the 2nd arg onwards
+# as an open-ended string. Appends onto to the end the Jest CLI command
+# @see https://jestjs.io/docs/en/cli#options
+ARGS="${*:2}"
+
+yarn test:jest $FOLDER $ARGS


### PR DESCRIPTION
## Summary

- Updates our new Jest config file to automatically report coverage (no more copying and pasting super long CLI commands!)
- Because I'm very extra, I also added a shell script that makes the dev experience of running tests (& getting coverage) on a specific component folder easier. Example API:

```bash
# Run commands from the `enterprise_search` plugin folder root

# run and get coverage on all tests
sh jest.sh

# run and get coverage on specific folder
sh jest.sh public/applications/shared/http
```

Let me know what you think y'all!! 🙇‍♀️

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials