### PR TITLE
[Enterprise Search] Fix schema errors button

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.test.tsx
@@ -7,9 +7,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { EuiCallOut, EuiButton } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
 
-import { EuiLinkTo } from '../react_router_helpers';
+import { EuiButtonTo } from '../react_router_helpers';
 
 import { IndexingStatusErrors } from './indexing_status_errors';
 
@@ -17,9 +17,8 @@ describe('IndexingStatusErrors', () => {
   it('renders', () => {
     const wrapper = shallow(<IndexingStatusErrors viewLinkPath="/path" />);
 
-    expect(wrapper.find(EuiButton)).toHaveLength(1);
     expect(wrapper.find(EuiCallOut)).toHaveLength(1);
-    expect(wrapper.find(EuiLinkTo)).toHaveLength(1);
-    expect(wrapper.find(EuiLinkTo).prop('to')).toEqual('/path');
+    expect(wrapper.find(EuiButtonTo)).toHaveLength(1);
+    expect(wrapper.find(EuiButtonTo).prop('to')).toEqual('/path');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
@@ -6,9 +6,9 @@
 
 import React from 'react';
 
-import { EuiButton, EuiCallOut } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
 
-import { EuiLinkTo } from '../react_router_helpers';
+import { EuiButtonTo } from '../react_router_helpers';
 
 import { INDEXING_STATUS_HAS_ERRORS_TITLE, INDEXING_STATUS_HAS_ERRORS_BUTTON } from './constants';
 
@@ -25,10 +25,8 @@ export const IndexingStatusErrors: React.FC<IIndexingStatusErrorsProps> = ({ vie
   >
     <p>{INDEXING_STATUS_HAS_ERRORS_TITLE}</p>
 
-    <EuiLinkTo to={viewLinkPath}>
-      <EuiButton color="danger" fill size="s" data-test-subj="ViewErrorsButton">
-        {INDEXING_STATUS_HAS_ERRORS_BUTTON}
-      </EuiButton>
-    </EuiLinkTo>
+    <EuiButtonTo to={viewLinkPath} color="danger" fill size="s" data-test-subj="ViewErrorsButton">
+      {INDEXING_STATUS_HAS_ERRORS_BUTTON}
+    </EuiButtonTo>
   </EuiCallOut>
 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
@@ -26,7 +26,7 @@ export const IndexingStatusErrors: React.FC<IIndexingStatusErrorsProps> = ({ vie
     <p>{INDEXING_STATUS_HAS_ERRORS_TITLE}</p>
 
     <EuiLinkTo to={viewLinkPath}>
-      <EuiButton color="danger" fill={true} size="s" data-test-subj="ViewErrorsButton">
+      <EuiButton color="danger" fill size="s" data-test-subj="ViewErrorsButton">
         {INDEXING_STATUS_HAS_ERRORS_BUTTON}
       </EuiButton>
     </EuiLinkTo>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
@@ -24,8 +24,11 @@ export const IndexingStatusErrors: React.FC<IIndexingStatusErrorsProps> = ({ vie
     data-test-subj="IndexingStatusErrors"
   >
     <p>{INDEXING_STATUS_HAS_ERRORS_TITLE}</p>
-    <EuiButton color="danger" fill={true} size="s" data-test-subj="ViewErrorsButton">
-      <EuiLinkTo to={viewLinkPath}>{INDEXING_STATUS_HAS_ERRORS_BUTTON}</EuiLinkTo>
-    </EuiButton>
+
+    <EuiLinkTo to={viewLinkPath}>
+      <EuiButton color="danger" fill={true} size="s" data-test-subj="ViewErrorsButton">
+        {INDEXING_STATUS_HAS_ERRORS_BUTTON}
+      </EuiButton>
+    </EuiLinkTo>
   </EuiCallOut>
 );


### PR DESCRIPTION
## Summary

When migrated, the button was wrapping the link and it should be the other way around. This caused a blue link color.

**Before**
![before](https://user-images.githubusercontent.com/1869731/100938631-a6af4d80-34ba-11eb-9bc9-68254a01b396.png)

**After**
![after](https://user-images.githubusercontent.com/1869731/100938646-ad3dc500-34ba-11eb-8643-d74c760c9582.png)
