### PR TITLE
[Workplace Search] Migrate Sources Schema tree

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/constants/operations.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/constants/operations.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const ADD = 'add';
+export const UPDATE = 'update';
+export const REMOVE = 'remove';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -4,6 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { ADD, UPDATE } from './constants/operations';
+
 export type SchemaTypes = 'text' | 'number' | 'geolocation' | 'date';
 
 export interface Schema {
@@ -27,8 +29,16 @@ export interface SchemaConflicts {
   [key: string]: SchemaConflictFieldTypes;
 }
 
+
 export interface IIndexingStatus {
   percentageComplete: number;
   numDocumentsWithErrors: number;
   activeReindexJobId: number;
 }
+
+export interface IndexJob extends IIndexingStatus {
+  isActive?: boolean;
+  hasErrors?: boolean;
+}
+
+export type TOperation = typeof ADD | typeof UPDATE;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -29,7 +29,6 @@ export interface SchemaConflicts {
   [key: string]: SchemaConflictFieldTypes;
 }
 
-
 export interface IIndexingStatus {
   percentageComplete: number;
   numDocumentsWithErrors: number;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -126,3 +126,9 @@ export const getGroupSourcePrioritizationPath = (groupId: string): string =>
   `${GROUPS_PATH}/${groupId}/source_prioritization`;
 export const getSourcesPath = (path: string, isOrganization: boolean): string =>
   isOrganization ? path : `${PERSONAL_PATH}${path}`;
+export const getReindexJobRoute = (
+  sourceId: string,
+  activeReindexJobId: string,
+  isOrganization: boolean
+) =>
+  getSourcesPath(generatePath(REINDEX_JOB_PATH, { sourceId, activeReindexJobId }), isOrganization);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/constants.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import { i18n } from '@kbn/i18n';
+
+export const SCHEMA_ERRORS_HEADING = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.errors.heading',
+  {
+    defaultMessage: 'Schema Change Errors',
+  }
+);
+
+export const SCHEMA_ERRORS_TABLE_FIELD_NAME_HEADER = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.errors.header.fieldName',
+  {
+    defaultMessage: 'Field Name',
+  }
+);
+
+export const SCHEMA_ERRORS_TABLE_DATA_TYPE_HEADER = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.errors.header.dataType',
+  {
+    defaultMessage: 'Data Type',
+  }
+);
+
+export const SCHEMA_FIELD_ERRORS_ERROR_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.errors.message',
+  {
+    defaultMessage: 'Oops, we were not able to find any errors for this Schema.',
+  }
+);
+
+export const SCHEMA_FIELD_ADDED_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.fieldAdded.message',
+  {
+    defaultMessage: 'New field added.',
+  }
+);
+
+export const SCHEMA_UPDATED_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.updated.message',
+  {
+    defaultMessage: 'Schema updated.',
+  }
+);
+
+export const SCHEMA_ADD_FIELD_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.addField.button',
+  {
+    defaultMessage: 'Add field',
+  }
+);
+
+export const SCHEMA_MANAGE_SCHEMA_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.manage.title',
+  {
+    defaultMessage: 'Manage source schema',
+  }
+);
+
+export const SCHEMA_MANAGE_SCHEMA_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.manage.description',
+  {
+    defaultMessage: 'Add new fields or change the types of existing ones',
+  }
+);
+
+export const SCHEMA_FILTER_PLACEHOLDER = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.filter.placeholder',
+  {
+    defaultMessage: 'Filter schema fields...',
+  }
+);
+
+export const SCHEMA_UPDATING = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.updating',
+  {
+    defaultMessage: 'Updating schema...',
+  }
+);
+
+export const SCHEMA_SAVE_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.save.button',
+  {
+    defaultMessage: 'Save schema',
+  }
+);
+
+export const SCHEMA_EMPTY_SCHEMA_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.empty.title',
+  {
+    defaultMessage: 'Content source does not have a schema',
+  }
+);
+
+export const SCHEMA_EMPTY_SCHEMA_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.empty.description',
+  {
+    defaultMessage:
+      'A schema is created for you once you index some documents. Click below to create schema fields in advance.',
+  }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -4,6 +4,158 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
-export const Schema: React.FC = () => <>Schema Placeholder</>;
+import { useActions, useValues } from 'kea';
+
+import routes from 'workplace_search/routes';
+import { getReindexJobRoute } from 'workplace_search/utils/routePaths';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiEmptyPrompt,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiPanel,
+} from '@elastic/eui';
+
+import { AppLogic } from 'workplace_search/App/AppLogic';
+import { Loading, ViewContentHeader } from 'workplace_search/components';
+
+import FlashMessages from 'shared/components/FlashMessages';
+import IndexingStatus from 'shared/components/IndexingStatus';
+import { SchemaAddFieldModal } from 'shared/components/Schema';
+
+import { SchemaFieldsTable } from './SchemaFieldsTable';
+import { SchemaLogic } from './SchemaLogic';
+
+export const Schema: React.FC = () => {
+  const {
+    initializeSchema,
+    onIndexingComplete,
+    addNewField,
+    updateFields,
+    openAddFieldModal,
+    closeAddFieldModal,
+    setFilterValue,
+  } = useActions(SchemaLogic);
+
+  const {
+    sourceId,
+    activeSchema,
+    filterValue,
+    showAddFieldModal,
+    addFieldFormErrors,
+    mostRecentIndexJob,
+    formUnchanged,
+    flashMessages,
+    dataLoading,
+  } = useValues(SchemaLogic);
+
+  const { isOrganization } = useValues(AppLogic);
+
+  useEffect(() => {
+    initializeSchema();
+  }, []);
+
+  if (dataLoading) return <Loading />;
+
+  const hasSchemaFields = Object.keys(activeSchema).length > 0;
+  const { isActive, hasErrors, percentageComplete } = mostRecentIndexJob;
+
+  const addFieldButton = (
+    <EuiButtonEmpty color="primary" data-test-subj="AddFieldButton" onClick={openAddFieldModal}>
+      Add Field
+    </EuiButtonEmpty>
+  );
+  const getStatusPath = isOrganization
+    ? routes.statusFritoPieOrganizationContentSourceReindexJobPath
+    : routes.statusFritoPieAccountContentSourceReindexJobPath;
+
+  return (
+    <>
+      <ViewContentHeader
+        title="Manage source schema"
+        description="Add new fields or change the types of existing ones"
+      />
+      <div>
+        {!!flashMessages && <FlashMessages {...flashMessages} />}
+        {(isActive || hasErrors) && (
+          <IndexingStatus
+            itemId={sourceId}
+            viewLinkPath={getReindexJobRoute(
+              sourceId,
+              mostRecentIndexJob.activeReindexJobId,
+              isOrganization
+            )}
+            getStatusPath={getStatusPath}
+            onComplete={onIndexingComplete}
+            {...mostRecentIndexJob}
+          />
+        )}
+        {hasSchemaFields ? (
+          <>
+            <EuiSpacer />
+            <EuiFlexGroup justifyContent="spaceBetween">
+              <EuiFlexItem>
+                <EuiFieldSearch
+                  value={filterValue}
+                  data-test-subj="FilterSchemaInput"
+                  placeholder="Filter schema fields..."
+                  onChange={(e) => setFilterValue(e.target.value)}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup gutterSize="s">
+                  <EuiFlexItem>{addFieldButton}</EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    {percentageComplete < 100 ? (
+                      <EuiButton isLoading={true} fill={true}>
+                        Updating schema...
+                      </EuiButton>
+                    ) : (
+                      <EuiButton
+                        disabled={formUnchanged}
+                        data-test-subj="UpdateTypesButton"
+                        onClick={updateFields}
+                        fill={true}
+                      >
+                        Save Schema
+                      </EuiButton>
+                    )}
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer />
+            <SchemaFieldsTable />
+          </>
+        ) : (
+          <EuiPanel className="euiPanel--inset">
+            <EuiEmptyPrompt
+              iconType="managementApp"
+              title={<h2>Content source does not have a schema</h2>}
+              body={
+                <p>
+                  A schema is created for you once you index some documents. Click below to create
+                  schema fields in advance.
+                </p>
+              }
+              actions={addFieldButton}
+            />
+          </EuiPanel>
+        )}
+      </div>
+      {showAddFieldModal && (
+        <SchemaAddFieldModal
+          addFieldFormErrors={addFieldFormErrors}
+          addNewField={addNewField}
+          closeAddFieldModal={closeAddFieldModal}
+        />
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -8,9 +8,6 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import routes from 'workplace_search/routes';
-import { getReindexJobRoute } from 'workplace_search/utils/routePaths';
-
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -24,6 +21,7 @@ import {
 
 import { AppLogic } from 'workplace_search/App/AppLogic';
 import { Loading, ViewContentHeader } from 'workplace_search/components';
+import { getReindexJobRoute } from '../../../../routes';
 
 import IndexingStatus from 'shared/components/IndexingStatus';
 import { SchemaAddFieldModal } from 'shared/components/Schema';
@@ -62,16 +60,16 @@ export const Schema: React.FC = () => {
   if (dataLoading) return <Loading />;
 
   const hasSchemaFields = Object.keys(activeSchema).length > 0;
-  const { isActive, hasErrors, percentageComplete } = mostRecentIndexJob;
+  const { isActive, hasErrors, percentageComplete, activeReindexJobId } = mostRecentIndexJob;
 
   const addFieldButton = (
     <EuiButtonEmpty color="primary" data-test-subj="AddFieldButton" onClick={openAddFieldModal}>
       Add Field
     </EuiButtonEmpty>
   );
-  const getStatusPath = isOrganization
-    ? routes.statusFritoPieOrganizationContentSourceReindexJobPath
-    : routes.statusFritoPieAccountContentSourceReindexJobPath;
+  const statusPath = isOrganization
+    ? `/api/workplace_search/org/sources/${sourceId}/reindex_job/${activeReindexJobId}`
+    : `/api/workplace_search/account/sources/${sourceId}/reindex_job/${activeReindexJobId}`;
 
   return (
     <>
@@ -85,10 +83,10 @@ export const Schema: React.FC = () => {
             itemId={sourceId}
             viewLinkPath={getReindexJobRoute(
               sourceId,
-              mostRecentIndexJob.activeReindexJobId,
+              mostRecentIndexJob.activeReindexJobId.toString(),
               isOrganization
             )}
-            getStatusPath={getStatusPath}
+            statusPath={statusPath}
             onComplete={onIndexingComplete}
             {...mostRecentIndexJob}
           />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -25,7 +25,6 @@ import {
 import { AppLogic } from 'workplace_search/App/AppLogic';
 import { Loading, ViewContentHeader } from 'workplace_search/components';
 
-import FlashMessages from 'shared/components/FlashMessages';
 import IndexingStatus from 'shared/components/IndexingStatus';
 import { SchemaAddFieldModal } from 'shared/components/Schema';
 
@@ -51,7 +50,6 @@ export const Schema: React.FC = () => {
     addFieldFormErrors,
     mostRecentIndexJob,
     formUnchanged,
-    flashMessages,
     dataLoading,
   } = useValues(SchemaLogic);
 
@@ -82,7 +80,6 @@ export const Schema: React.FC = () => {
         description="Add new fields or change the types of existing ones"
       />
       <div>
-        {!!flashMessages && <FlashMessages {...flashMessages} />}
         {(isActive || hasErrors) && (
           <IndexingStatus
             itemId={sourceId}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -70,8 +70,8 @@ export const Schema: React.FC = () => {
     </EuiButtonEmpty>
   );
   const statusPath = isOrganization
-    ? `/api/workplace_search/org/sources/${sourceId}/reindex_job/${activeReindexJobId}`
-    : `/api/workplace_search/account/sources/${sourceId}/reindex_job/${activeReindexJobId}`;
+    ? `/api/workplace_search/org/sources/${sourceId}/reindex_job/${activeReindexJobId}/status`
+    : `/api/workplace_search/account/sources/${sourceId}/reindex_job/${activeReindexJobId}/status`;
 
   return (
     <>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -19,15 +19,17 @@ import {
   EuiPanel,
 } from '@elastic/eui';
 
-import { AppLogic } from 'workplace_search/App/AppLogic';
-import { Loading, ViewContentHeader } from 'workplace_search/components';
 import { getReindexJobRoute } from '../../../../routes';
+import { AppLogic } from '../../../../app_logic';
 
-import IndexingStatus from 'shared/components/IndexingStatus';
-import { SchemaAddFieldModal } from 'shared/components/Schema';
+import { Loading } from '../../../../../shared/loading';
+import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 
-import { SchemaFieldsTable } from './SchemaFieldsTable';
-import { SchemaLogic } from './SchemaLogic';
+import { SchemaAddFieldModal } from '../../../../../shared/schema/schema_add_field_modal';
+import { IndexingStatus } from '../../../../../shared/indexing_status';
+
+import { SchemaFieldsTable } from './schema_fields_table';
+import { SchemaLogic } from './schema_logic';
 
 export const Schema: React.FC = () => {
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -31,6 +31,17 @@ import { IndexingStatus } from '../../../../../shared/indexing_status';
 import { SchemaFieldsTable } from './schema_fields_table';
 import { SchemaLogic } from './schema_logic';
 
+import {
+  SCHEMA_ADD_FIELD_BUTTON,
+  SCHEMA_MANAGE_SCHEMA_TITLE,
+  SCHEMA_MANAGE_SCHEMA_DESCRIPTION,
+  SCHEMA_FILTER_PLACEHOLDER,
+  SCHEMA_UPDATING,
+  SCHEMA_SAVE_BUTTON,
+  SCHEMA_EMPTY_SCHEMA_TITLE,
+  SCHEMA_EMPTY_SCHEMA_DESCRIPTION,
+} from './constants';
+
 export const Schema: React.FC = () => {
   const {
     initializeSchema,
@@ -66,7 +77,7 @@ export const Schema: React.FC = () => {
 
   const addFieldButton = (
     <EuiButtonEmpty color="primary" data-test-subj="AddFieldButton" onClick={openAddFieldModal}>
-      Add Field
+      {SCHEMA_ADD_FIELD_BUTTON}
     </EuiButtonEmpty>
   );
   const statusPath = isOrganization
@@ -76,8 +87,8 @@ export const Schema: React.FC = () => {
   return (
     <>
       <ViewContentHeader
-        title="Manage source schema"
-        description="Add new fields or change the types of existing ones"
+        title={SCHEMA_MANAGE_SCHEMA_TITLE}
+        description={SCHEMA_MANAGE_SCHEMA_DESCRIPTION}
       />
       <div>
         {(isActive || hasErrors) && (
@@ -101,7 +112,7 @@ export const Schema: React.FC = () => {
                 <EuiFieldSearch
                   value={filterValue}
                   data-test-subj="FilterSchemaInput"
-                  placeholder="Filter schema fields..."
+                  placeholder={SCHEMA_FILTER_PLACEHOLDER}
                   onChange={(e) => setFilterValue(e.target.value)}
                 />
               </EuiFlexItem>
@@ -111,7 +122,7 @@ export const Schema: React.FC = () => {
                   <EuiFlexItem grow={false}>
                     {percentageComplete < 100 ? (
                       <EuiButton isLoading={true} fill={true}>
-                        Updating schema...
+                        {SCHEMA_UPDATING}
                       </EuiButton>
                     ) : (
                       <EuiButton
@@ -120,7 +131,7 @@ export const Schema: React.FC = () => {
                         onClick={updateFields}
                         fill={true}
                       >
-                        Save Schema
+                        {SCHEMA_SAVE_BUTTON}
                       </EuiButton>
                     )}
                   </EuiFlexItem>
@@ -134,13 +145,8 @@ export const Schema: React.FC = () => {
           <EuiPanel className="euiPanel--inset">
             <EuiEmptyPrompt
               iconType="managementApp"
-              title={<h2>Content source does not have a schema</h2>}
-              body={
-                <p>
-                  A schema is created for you once you index some documents. Click below to create
-                  schema fields in advance.
-                </p>
-              }
+              title={<h2>{SCHEMA_EMPTY_SCHEMA_TITLE}</h2>}
+              body={<p>{SCHEMA_EMPTY_SCHEMA_DESCRIPTION}</p>}
               actions={addFieldButton}
             />
           </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
@@ -14,6 +14,7 @@ import { EuiSpacer } from '@elastic/eui';
 import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 import { SchemaLogic } from './schema_logic';
+import { SCHEMA_ERRORS_HEADING } from './constants';
 
 export const SchemaChangeErrors: React.FC = () => {
   const { activeReindexJobId, sourceId } = useParams() as {
@@ -30,7 +31,7 @@ export const SchemaChangeErrors: React.FC = () => {
 
   return (
     <div>
-      <ViewContentHeader title="Schema Change Errors" />
+      <ViewContentHeader title={SCHEMA_ERRORS_HEADING} />
       <EuiSpacer size="xl" />
       <main>
         <SchemaErrorsAccordion

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
@@ -4,6 +4,41 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 
-export const SchemaChangeErrors: React.FC = () => <>Schema Errors Placeholder</>;
+import { useActions, useValues } from 'kea';
+
+import { EuiSpacer } from '@elastic/eui';
+
+import SchemaErrorsAccordion from 'shared/components/Schema/SchemaErrorsAccordion';
+import { ViewContentHeader } from 'workplace_search/components';
+import { SchemaLogic } from './SchemaLogic';
+
+export const SchemaChangeErrors: React.FC = () => {
+  const { activeReindexJobId, sourceId } = useParams() as {
+    activeReindexJobId: string;
+    sourceId: string;
+  };
+  const { initializeSchemaFieldErrors } = useActions(SchemaLogic);
+
+  const { fieldCoercionErrors, serverSchema } = useValues(SchemaLogic);
+
+  useEffect(() => {
+    initializeSchemaFieldErrors(activeReindexJobId, sourceId);
+  }, []);
+
+  return (
+    <div>
+      <ViewContentHeader title="Schema Change Errors" />
+      <EuiSpacer size="xl" />
+      <main>
+        <SchemaErrorsAccordion
+          fieldCoercionErrors={fieldCoercionErrors}
+          schema={serverSchema}
+          itemId={sourceId}
+        />
+      </main>
+    </div>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
@@ -11,9 +11,9 @@ import { useActions, useValues } from 'kea';
 
 import { EuiSpacer } from '@elastic/eui';
 
-import SchemaErrorsAccordion from 'shared/components/Schema/SchemaErrorsAccordion';
-import { ViewContentHeader } from 'workplace_search/components';
-import { SchemaLogic } from './SchemaLogic';
+import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
+import { ViewContentHeader } from '../../../../components/shared/view_content_header';
+import { SchemaLogic } from './schema_logic';
 
 export const SchemaChangeErrors: React.FC = () => {
   const { activeReindexJobId, sourceId } = useParams() as {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
@@ -66,7 +66,7 @@ export const SchemaFieldsTable: React.FC = () => {
   ) : (
     <p>
       {i18n.translate(
-        'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.errors.header.dataType',
+        'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.filter.noResults.message',
         {
           defaultMessage: 'No results found for "{filterValue}".',
           values: { filterValue },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTable,
+  EuiTableBody,
+  EuiTableHeader,
+  EuiTableHeaderCell,
+  EuiTableRow,
+  EuiTableRowCell,
+} from '@elastic/eui';
+
+import { SchemaExistingField } from 'shared/components/Schema';
+import { SchemaLogic } from './SchemaLogic';
+
+export const SchemaFieldsTable: React.FC = () => {
+  const { updateExistingFieldType } = useActions(SchemaLogic);
+
+  const { filteredSchemaFields, filterValue } = useValues(SchemaLogic);
+
+  return Object.keys(filteredSchemaFields).length > 0 ? (
+    <EuiTable>
+      <EuiTableHeader>
+        <EuiTableHeaderCell>Field Name</EuiTableHeaderCell>
+        <EuiTableHeaderCell>Data Type</EuiTableHeaderCell>
+      </EuiTableHeader>
+      <EuiTableBody>
+        {Object.keys(filteredSchemaFields).map((fieldName) => (
+          <EuiTableRow key={fieldName} data-test-subj="SchemaFieldRow">
+            <EuiTableRowCell>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem>
+                  <strong>{fieldName}</strong>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiTableRowCell>
+            <EuiTableRowCell>
+              <SchemaExistingField
+                disabled={fieldName === 'id'}
+                key={fieldName}
+                fieldName={fieldName}
+                hideName={true}
+                fieldType={filteredSchemaFields[fieldName]}
+                updateExistingFieldType={updateExistingFieldType}
+              />
+            </EuiTableRowCell>
+          </EuiTableRow>
+        ))}
+      </EuiTableBody>
+    </EuiTable>
+  ) : (
+    <p>No results found for &apos;{filterValue}&apos;.</p>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
@@ -19,8 +19,8 @@ import {
   EuiTableRowCell,
 } from '@elastic/eui';
 
-import { SchemaExistingField } from 'shared/components/Schema';
-import { SchemaLogic } from './SchemaLogic';
+import { SchemaExistingField } from '../../../../../shared/schema/schema_existing_field';
+import { SchemaLogic } from './schema_logic';
 
 export const SchemaFieldsTable: React.FC = () => {
   const { updateExistingFieldType } = useActions(SchemaLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
+import { i18n } from '@kbn/i18n';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -21,6 +23,10 @@ import {
 
 import { SchemaExistingField } from '../../../../../shared/schema/schema_existing_field';
 import { SchemaLogic } from './schema_logic';
+import {
+  SCHEMA_ERRORS_TABLE_FIELD_NAME_HEADER,
+  SCHEMA_ERRORS_TABLE_DATA_TYPE_HEADER,
+} from './constants';
 
 export const SchemaFieldsTable: React.FC = () => {
   const { updateExistingFieldType } = useActions(SchemaLogic);
@@ -30,8 +36,8 @@ export const SchemaFieldsTable: React.FC = () => {
   return Object.keys(filteredSchemaFields).length > 0 ? (
     <EuiTable>
       <EuiTableHeader>
-        <EuiTableHeaderCell>Field Name</EuiTableHeaderCell>
-        <EuiTableHeaderCell>Data Type</EuiTableHeaderCell>
+        <EuiTableHeaderCell>{SCHEMA_ERRORS_TABLE_FIELD_NAME_HEADER}</EuiTableHeaderCell>
+        <EuiTableHeaderCell>{SCHEMA_ERRORS_TABLE_DATA_TYPE_HEADER}</EuiTableHeaderCell>
       </EuiTableHeader>
       <EuiTableBody>
         {Object.keys(filteredSchemaFields).map((fieldName) => (
@@ -58,6 +64,14 @@ export const SchemaFieldsTable: React.FC = () => {
       </EuiTableBody>
     </EuiTable>
   ) : (
-    <p>No results found for &apos;{filterValue}&apos;.</p>
+    <p>
+      {i18n.translate(
+        'xpack.enterpriseSearch.workplaceSearch.contentSource.schema.errors.header.dataType',
+        {
+          defaultMessage: 'No results found for "{filterValue}".',
+          values: { filterValue },
+        }
+      )}
+    </p>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -186,6 +186,10 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
           hasErrors: numDocumentsWithErrors > 0,
           isActive: false,
         }),
+        updateFields: (state) => ({
+          ...state,
+          percentageComplete: 0,
+        }),
       },
     ],
     newFieldType: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -8,7 +8,6 @@ import { cloneDeep, isEqual } from 'lodash';
 import { kea, MakeLogicType } from 'kea';
 
 import http from 'shared/http';
-import routes from 'workplace_search/routes';
 
 import { TEXT } from '../../../../../shared/constants/field_types';
 import { ADD, UPDATE } from '../../../../../shared/constants/operations';
@@ -265,9 +264,10 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       const {
         contentSource: { id: sourceId },
       } = SourceLogic.values;
+
       const route = isOrganization
-        ? routes.fritoPieOrganizationContentSourceSchemasPath(sourceId)
-        : routes.fritoPieAccountContentSourceSchemasPath(sourceId);
+        ? `/api/workplace_search/org/sources/${sourceId}/schemas`
+        : `/api/workplace_search/account/sources/${sourceId}/schemas`;
 
       return http(route).then(({ data }) => actions.onInitializeSchema({ sourceId, ...data }));
     },
@@ -275,8 +275,8 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       const { isOrganization } = AppLogic.values;
 
       const route = isOrganization
-        ? routes.fritoPieOrganizationContentSourceReindexJobPath(sourceId, activeReindexJobId)
-        : routes.fritoPieAccountContentSourceReindexJobPath(sourceId, activeReindexJobId);
+        ? `/api/workplace_search/org/sources/${sourceId}/reindex_job/${activeReindexJobId}`
+        : `/api/workplace_search/account/sources/${sourceId}/reindex_job/${activeReindexJobId}`;
 
       try {
         await actions.initializeSchema();
@@ -304,8 +304,8 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       const { sourceId } = values;
       const successMessage = isAdding ? 'New field added.' : 'Schema updated.';
       const route = isOrganization
-        ? routes.fritoPieOrganizationContentSourceSchemasPath(sourceId)
-        : routes.fritoPieAccountContentSourceSchemasPath(sourceId);
+        ? `/api/workplace_search/org/sources/${sourceId}/schemas`
+        : `/api/workplace_search/account/sources/${sourceId}/schemas`;
 
       const emptyReindexJob = {
         percentageComplete: 100,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -23,6 +23,12 @@ import {
 import { AppLogic } from '../../../../app_logic';
 import { SourceLogic } from '../../source_logic';
 
+import {
+  SCHEMA_FIELD_ERRORS_ERROR_MESSAGE,
+  SCHEMA_FIELD_ADDED_MESSAGE,
+  SCHEMA_UPDATED_MESSAGE,
+} from './constants';
+
 interface SchemaActions {
   onInitializeSchema(schemaProps: SchemaInitialData): SchemaInitialData;
   onInitializeSchemaFieldErrors(
@@ -111,8 +117,6 @@ const dataTypeOptions = [
   { value: 'number', text: 'Number' },
   { value: 'geolocation', text: 'Geo Location' },
 ];
-
-const FIELD_ERRORS_ERROR = 'Oops, we were not able to find any errors for this Schema';
 
 export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
   actions: {
@@ -295,7 +299,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
           fieldCoercionErrors: response.fieldCoercionErrors,
         });
       } catch (e) {
-        flashAPIErrors({ ...e, message: FIELD_ERRORS_ERROR });
+        flashAPIErrors({ ...e, message: SCHEMA_FIELD_ERRORS_ERROR_MESSAGE });
       }
     },
     addNewField: ({ fieldName, newFieldType }) => {
@@ -314,7 +318,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       const { http } = HttpLogic.values;
       const isAdding = operation === ADD;
       const { sourceId } = values;
-      const successMessage = isAdding ? 'New field added.' : 'Schema updated.';
+      const successMessage = isAdding ? SCHEMA_FIELD_ADDED_MESSAGE : SCHEMA_UPDATED_MESSAGE;
       const route = isOrganization
         ? `/api/workplace_search/org/sources/${sourceId}/schemas`
         : `/api/workplace_search/account/sources/${sourceId}/schemas`;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -12,7 +12,7 @@ import routes from 'workplace_search/routes';
 
 import { TEXT } from '../../../../../shared/constants/field_types';
 import { ADD, UPDATE } from '../../../../../shared/constants/operations';
-import { IndexJob, TOperation } from '../../../../../shared/types';
+import { IndexJob, TOperation, Schema, SchemaTypes } from '../../../../../shared/types';
 import { OptionValue } from '../../../../types';
 
 import {
@@ -31,20 +31,23 @@ interface SchemaActions {
   ): SchemaChangeErrorsProps;
   onSchemaSetSuccess(schemaProps: SchemaResponseProps): SchemaResponseProps;
   onSchemaSetFormErrors(errors: string[]): string[];
-  updateNewFieldType(newFieldType: string): string;
+  updateNewFieldType(newFieldType: SchemaTypes): SchemaTypes;
   onFieldUpdate({
     schema,
     formUnchanged,
   }: {
-    schema: object;
+    schema: Schema;
     formUnchanged: boolean;
-  }): { schema: object; formUnchanged: boolean };
+  }): { schema: Schema; formUnchanged: boolean };
   onIndexingComplete(numDocumentsWithErrors: number): number;
   resetMostRecentIndexJob(emptyReindexJob: IndexJob): IndexJob;
   showFieldSuccess(successMessage: string): string;
   setFieldName(rawFieldName: string): string;
   setFilterValue(filterValue: string): string;
-  addNewField(fieldName: string, newFieldType: string): { fieldName: string; newFieldType: string };
+  addNewField(
+    fieldName: string,
+    newFieldType: SchemaTypes
+  ): { fieldName: string; newFieldType: SchemaTypes };
   updateFields(): void;
   openAddFieldModal(): void;
   closeAddFieldModal(): void;
@@ -56,20 +59,20 @@ interface SchemaActions {
   ): { activeReindexJobId: string; sourceId: string };
   updateExistingFieldType(
     fieldName: string,
-    newFieldType: string
-  ): { fieldName: string; newFieldType: string };
+    newFieldType: SchemaTypes
+  ): { fieldName: string; newFieldType: SchemaTypes };
   setServerField(
-    updatedSchema: object,
+    updatedSchema: Schema,
     operation: TOperation
-  ): { updatedSchema: object; operation: TOperation };
+  ): { updatedSchema: Schema; operation: TOperation };
 }
 
 interface SchemaValues {
   sourceId: string;
-  activeSchema: object;
-  serverSchema: object;
+  activeSchema: Schema;
+  serverSchema: Schema;
   filterValue: string;
-  filteredSchemaFields: object;
+  filteredSchemaFields: Schema;
   dataTypeOptions: OptionValue[];
   showAddFieldModal: boolean;
   addFieldFormErrors: string[] | null;
@@ -82,7 +85,7 @@ interface SchemaValues {
 }
 
 interface SchemaResponseProps {
-  schema: object;
+  schema: Schema;
   mostRecentIndexJob: IndexJob;
 }
 
@@ -120,7 +123,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
     onSchemaSetSuccess: (schemaProps: SchemaResponseProps) => schemaProps,
     onSchemaSetFormErrors: (errors: string[]) => errors,
     updateNewFieldType: (newFieldType: string) => newFieldType,
-    onFieldUpdate: ({ schema, formUnchanged }: { schema: object; formUnchanged: boolean }) => ({
+    onFieldUpdate: ({ schema, formUnchanged }: { schema: Schema; formUnchanged: boolean }) => ({
       schema,
       formUnchanged,
     }),
@@ -137,13 +140,13 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       activeReindexJobId,
       sourceId,
     }),
-    addNewField: (fieldName: string, newFieldType: string) => ({ fieldName, newFieldType }),
+    addNewField: (fieldName: string, newFieldType: SchemaTypes) => ({ fieldName, newFieldType }),
     updateExistingFieldType: (fieldName: string, newFieldType: string) => ({
       fieldName,
       newFieldType,
     }),
     updateFields: () => true,
-    setServerField: (updatedSchema: object, operation: TOperation) => ({
+    setServerField: (updatedSchema: Schema, operation: TOperation) => ({
       updatedSchema,
       operation,
     }),
@@ -248,7 +251,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
     filteredSchemaFields: [
       () => [selectors.activeSchema, selectors.filterValue],
       (activeSchema, filterValue) => {
-        const filteredSchema = {};
+        const filteredSchema = {} as Schema;
         Object.keys(activeSchema)
           .filter((x) => x.includes(filterValue))
           .forEach((k) => (filteredSchema[k] = activeSchema[k]));

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -10,13 +10,13 @@ import { kea, MakeLogicType } from 'kea';
 import http from 'shared/http';
 import routes from 'workplace_search/routes';
 
-import { TEXT } from 'shared/constants/fieldTypes';
-import { ADD, UPDATE } from 'shared/constants/operations';
-import { IIndexJob, IFlashMessagesProps, TOperation } from 'shared/types';
+import { TEXT } from '../../../../../shared/constants/field_types';
+import { ADD, UPDATE } from '../../../../../shared/constants/operations';
+import { IndexJob, IFlashMessagesProps, TOperation } from '../../../../../shared/types';
+import { OptionValue } from '../../../../types';
 
-import { AppLogic } from 'workplace_search/App/AppLogic';
-import { SourceLogic } from 'workplace_search/ContentSources/SourceLogic';
-import { IObject, OptionValue } from 'workplace_search/types';
+import { AppLogic } from '../../../../app_logic';
+import { SourceLogic } from '../../source_logic';
 
 interface SchemaActions {
   setFlashMessages(flashMessages: IFlashMessagesProps): { flashMessages: IFlashMessagesProps };
@@ -34,11 +34,11 @@ interface SchemaActions {
     schema,
     formUnchanged,
   }: {
-    schema: IObject;
+    schema: object;
     formUnchanged: boolean;
-  }): { schema: IObject; formUnchanged: boolean };
+  }): { schema: object; formUnchanged: boolean };
   onIndexingComplete(numDocumentsWithErrors: number): number;
-  resetMostRecentIndexJob(emptyReindexJob: IIndexJob): IIndexJob;
+  resetMostRecentIndexJob(emptyReindexJob: IndexJob): IndexJob;
   showFieldSuccess(successMessage: string): string;
   setFieldName(rawFieldName: string): string;
   setFilterValue(filterValue: string): string;
@@ -57,21 +57,21 @@ interface SchemaActions {
     newFieldType: string
   ): { fieldName: string; newFieldType: string };
   setServerField(
-    updatedSchema: IObject,
+    updatedSchema: object,
     operation: TOperation
-  ): { updatedSchema: IObject; operation: TOperation };
+  ): { updatedSchema: object; operation: TOperation };
 }
 
 interface SchemaValues {
   sourceId: string;
-  activeSchema: IObject;
-  serverSchema: IObject;
+  activeSchema: object;
+  serverSchema: object;
   filterValue: string;
-  filteredSchemaFields: IObject;
+  filteredSchemaFields: object;
   dataTypeOptions: OptionValue[];
   showAddFieldModal: boolean;
   addFieldFormErrors: string[] | null;
-  mostRecentIndexJob: IIndexJob;
+  mostRecentIndexJob: IndexJob;
   fieldCoercionErrors: FieldCoercionErrors;
   flashMessages: IFlashMessagesProps;
   newFieldType: string;
@@ -81,8 +81,8 @@ interface SchemaValues {
 }
 
 interface SchemaResponseProps {
-  schema: IObject;
-  mostRecentIndexJob: IIndexJob;
+  schema: object;
+  mostRecentIndexJob: IndexJob;
 }
 
 export interface SchemaInitialData extends SchemaResponseProps {
@@ -125,12 +125,12 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
     onSchemaSetError: (errorProps: SchemaSetProps) => errorProps,
     onSchemaSetFormErrors: (errors: string[]) => errors,
     updateNewFieldType: (newFieldType: string) => newFieldType,
-    onFieldUpdate: ({ schema, formUnchanged }: { schema: IObject; formUnchanged: boolean }) => ({
+    onFieldUpdate: ({ schema, formUnchanged }: { schema: object; formUnchanged: boolean }) => ({
       schema,
       formUnchanged,
     }),
     onIndexingComplete: (numDocumentsWithErrors: number) => numDocumentsWithErrors,
-    resetMostRecentIndexJob: (emptyReindexJob: IIndexJob) => emptyReindexJob,
+    resetMostRecentIndexJob: (emptyReindexJob: IndexJob) => emptyReindexJob,
     showFieldSuccess: (successMessage: string) => successMessage,
     setFieldName: (rawFieldName: string) => rawFieldName,
     setFilterValue: (filterValue: string) => filterValue,
@@ -148,7 +148,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       newFieldType,
     }),
     updateFields: () => true,
-    setServerField: (updatedSchema: IObject, operation: TOperation) => ({
+    setServerField: (updatedSchema: object, operation: TOperation) => ({
       updatedSchema,
       operation,
     }),
@@ -177,7 +177,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
       },
     ],
     mostRecentIndexJob: [
-      {} as IIndexJob,
+      {} as IndexJob,
       {
         onInitializeSchema: (_, { mostRecentIndexJob }) => mostRecentIndexJob,
         resetMostRecentIndexJob: (_, emptyReindexJob) => emptyReindexJob,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -1,0 +1,358 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { cloneDeep, isEqual } from 'lodash';
+import { kea, MakeLogicType } from 'kea';
+
+import http from 'shared/http';
+import routes from 'workplace_search/routes';
+
+import { TEXT } from 'shared/constants/fieldTypes';
+import { ADD, UPDATE } from 'shared/constants/operations';
+import { IIndexJob, IFlashMessagesProps, TOperation } from 'shared/types';
+
+import { AppLogic } from 'workplace_search/App/AppLogic';
+import { SourceLogic } from 'workplace_search/ContentSources/SourceLogic';
+import { IObject, OptionValue } from 'workplace_search/types';
+
+interface SchemaActions {
+  setFlashMessages(flashMessages: IFlashMessagesProps): { flashMessages: IFlashMessagesProps };
+  onInitializeSchema(schemaProps: SchemaInitialData): SchemaInitialData;
+  onInitializeSchemaFieldErrors(
+    fieldCoercionErrorsProps: SchemaChangeErrorsProps
+  ): SchemaChangeErrorsProps;
+  onSchemaSetSuccess(
+    schemaProps: SchemaSetProps & SchemaResponseProps
+  ): SchemaSetProps & SchemaResponseProps;
+  onSchemaSetError(errorProps: SchemaSetProps): SchemaSetProps;
+  onSchemaSetFormErrors(errors: string[]): string[];
+  updateNewFieldType(newFieldType: string): string;
+  onFieldUpdate({
+    schema,
+    formUnchanged,
+  }: {
+    schema: IObject;
+    formUnchanged: boolean;
+  }): { schema: IObject; formUnchanged: boolean };
+  onIndexingComplete(numDocumentsWithErrors: number): number;
+  resetMostRecentIndexJob(emptyReindexJob: IIndexJob): IIndexJob;
+  showFieldSuccess(successMessage: string): string;
+  setFieldName(rawFieldName: string): string;
+  setFilterValue(filterValue: string): string;
+  addNewField(fieldName: string, newFieldType: string): { fieldName: string; newFieldType: string };
+  updateFields(): void;
+  openAddFieldModal(): void;
+  closeAddFieldModal(): void;
+  resetSchemaState(): void;
+  initializeSchema(): void;
+  initializeSchemaFieldErrors(
+    activeReindexJobId: string,
+    sourceId: string
+  ): { activeReindexJobId: string; sourceId: string };
+  updateExistingFieldType(
+    fieldName: string,
+    newFieldType: string
+  ): { fieldName: string; newFieldType: string };
+  setServerField(
+    updatedSchema: IObject,
+    operation: TOperation
+  ): { updatedSchema: IObject; operation: TOperation };
+}
+
+interface SchemaValues {
+  sourceId: string;
+  activeSchema: IObject;
+  serverSchema: IObject;
+  filterValue: string;
+  filteredSchemaFields: IObject;
+  dataTypeOptions: OptionValue[];
+  showAddFieldModal: boolean;
+  addFieldFormErrors: string[] | null;
+  mostRecentIndexJob: IIndexJob;
+  fieldCoercionErrors: FieldCoercionErrors;
+  flashMessages: IFlashMessagesProps;
+  newFieldType: string;
+  rawFieldName: string;
+  formUnchanged: boolean;
+  dataLoading: boolean;
+}
+
+interface SchemaResponseProps {
+  schema: IObject;
+  mostRecentIndexJob: IIndexJob;
+}
+
+export interface SchemaInitialData extends SchemaResponseProps {
+  sourceId: string;
+}
+
+interface SchemaSetProps {
+  flashMessages: IFlashMessagesProps;
+}
+
+interface FieldCoercionError {
+  external_id: string;
+  error: string;
+}
+
+export interface FieldCoercionErrors {
+  [key: string]: FieldCoercionError[];
+}
+
+interface SchemaChangeErrorsProps {
+  fieldCoercionErrors: FieldCoercionErrors;
+}
+
+const dataTypeOptions = [
+  { value: 'text', text: 'Text' },
+  { value: 'date', text: 'Date' },
+  { value: 'number', text: 'Number' },
+  { value: 'geolocation', text: 'Geo Location' },
+];
+
+const FIELD_ERRORS_ERROR = 'Oops, we were not able to find any errors for this Schema';
+
+export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
+  actions: {
+    setFlashMessages: (flashMessages: IFlashMessagesProps) => ({ flashMessages }),
+    onInitializeSchema: (schemaProps: SchemaInitialData) => schemaProps,
+    onInitializeSchemaFieldErrors: (fieldCoercionErrorsProps: SchemaChangeErrorsProps) =>
+      fieldCoercionErrorsProps,
+    onSchemaSetSuccess: (schemaProps: SchemaSetProps & SchemaResponseProps) => schemaProps,
+    onSchemaSetError: (errorProps: SchemaSetProps) => errorProps,
+    onSchemaSetFormErrors: (errors: string[]) => errors,
+    updateNewFieldType: (newFieldType: string) => newFieldType,
+    onFieldUpdate: ({ schema, formUnchanged }: { schema: IObject; formUnchanged: boolean }) => ({
+      schema,
+      formUnchanged,
+    }),
+    onIndexingComplete: (numDocumentsWithErrors: number) => numDocumentsWithErrors,
+    resetMostRecentIndexJob: (emptyReindexJob: IIndexJob) => emptyReindexJob,
+    showFieldSuccess: (successMessage: string) => successMessage,
+    setFieldName: (rawFieldName: string) => rawFieldName,
+    setFilterValue: (filterValue: string) => filterValue,
+    openAddFieldModal: () => true,
+    closeAddFieldModal: () => true,
+    resetSchemaState: () => true,
+    initializeSchema: () => true,
+    initializeSchemaFieldErrors: (activeReindexJobId: string, sourceId: string) => ({
+      activeReindexJobId,
+      sourceId,
+    }),
+    addNewField: (fieldName: string, newFieldType: string) => ({ fieldName, newFieldType }),
+    updateExistingFieldType: (fieldName: string, newFieldType: string) => ({
+      fieldName,
+      newFieldType,
+    }),
+    updateFields: () => true,
+    setServerField: (updatedSchema: IObject, operation: TOperation) => ({
+      updatedSchema,
+      operation,
+    }),
+  },
+  reducers: {
+    dataTypeOptions: [dataTypeOptions],
+    sourceId: [
+      '',
+      {
+        onInitializeSchema: (_, { sourceId }) => sourceId,
+      },
+    ],
+    activeSchema: [
+      {},
+      {
+        onInitializeSchema: (_, { schema }) => schema,
+        onSchemaSetSuccess: (_, { schema }) => schema,
+        onFieldUpdate: (_, { schema }) => schema,
+      },
+    ],
+    serverSchema: [
+      {},
+      {
+        onInitializeSchema: (_, { schema }) => schema,
+        onSchemaSetSuccess: (_, { schema }) => schema,
+      },
+    ],
+    mostRecentIndexJob: [
+      {} as IIndexJob,
+      {
+        onInitializeSchema: (_, { mostRecentIndexJob }) => mostRecentIndexJob,
+        resetMostRecentIndexJob: (_, emptyReindexJob) => emptyReindexJob,
+        onSchemaSetSuccess: (_, { mostRecentIndexJob }) => mostRecentIndexJob,
+        onIndexingComplete: (state, numDocumentsWithErrors) => ({
+          ...state,
+          numDocumentsWithErrors,
+          percentageComplete: 100,
+          hasErrors: numDocumentsWithErrors > 0,
+          isActive: false,
+        }),
+      },
+    ],
+    flashMessages: [
+      {},
+      {
+        setFlashMessages: (_, { flashMessages }) => flashMessages,
+        resetMostRecentIndexJob: () => ({}),
+        resetSchemaState: () => ({}),
+        onSchemaSetSuccess: (_, { flashMessages }) => flashMessages,
+        onSchemaSetError: (_, { flashMessages }) => flashMessages,
+      },
+    ],
+    newFieldType: [
+      TEXT,
+      {
+        updateNewFieldType: (_, newFieldType) => newFieldType,
+        onSchemaSetSuccess: () => TEXT,
+      },
+    ],
+    addFieldFormErrors: [
+      null,
+      {
+        onSchemaSetSuccess: () => null,
+        closeAddFieldModal: () => null,
+        onSchemaSetFormErrors: (_, addFieldFormErrors) => addFieldFormErrors,
+      },
+    ],
+    filterValue: [
+      '',
+      {
+        setFilterValue: (_, filterValue) => filterValue,
+      },
+    ],
+    formUnchanged: [
+      true,
+      {
+        onSchemaSetSuccess: () => true,
+        onFieldUpdate: (_, { formUnchanged }) => formUnchanged,
+      },
+    ],
+    showAddFieldModal: [
+      false,
+      {
+        onSchemaSetSuccess: () => false,
+        onSchemaSetError: () => false,
+        openAddFieldModal: () => true,
+        closeAddFieldModal: () => false,
+      },
+    ],
+    dataLoading: [
+      true,
+      {
+        onSchemaSetSuccess: () => false,
+        onInitializeSchema: () => false,
+        resetSchemaState: () => true,
+      },
+    ],
+    rawFieldName: [
+      '',
+      {
+        setFieldName: (_, rawFieldName) => rawFieldName,
+        onSchemaSetSuccess: () => '',
+      },
+    ],
+    fieldCoercionErrors: [
+      {},
+      {
+        onInitializeSchemaFieldErrors: (_, { fieldCoercionErrors }) => fieldCoercionErrors,
+      },
+    ],
+  },
+  selectors: ({ selectors }) => ({
+    filteredSchemaFields: [
+      () => [selectors.activeSchema, selectors.filterValue],
+      (activeSchema, filterValue) => {
+        const filteredSchema = {};
+        Object.keys(activeSchema)
+          .filter((x) => x.includes(filterValue))
+          .forEach((k) => (filteredSchema[k] = activeSchema[k]));
+        return filteredSchema;
+      },
+    ],
+  }),
+  listeners: ({ actions, values }) => ({
+    initializeSchema: () => {
+      const { isOrganization } = AppLogic.values;
+      const {
+        contentSource: { id: sourceId },
+      } = SourceLogic.values;
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourceSchemasPath(sourceId)
+        : routes.fritoPieAccountContentSourceSchemasPath(sourceId);
+
+      return http(route).then(({ data }) => actions.onInitializeSchema({ sourceId, ...data }));
+    },
+    initializeSchemaFieldErrors: async ({ activeReindexJobId, sourceId }) => {
+      const { isOrganization } = AppLogic.values;
+
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourceReindexJobPath(sourceId, activeReindexJobId)
+        : routes.fritoPieAccountContentSourceReindexJobPath(sourceId, activeReindexJobId);
+
+      try {
+        await actions.initializeSchema();
+        http(route).then(({ data: { fieldCoercionErrors } }) =>
+          actions.onInitializeSchemaFieldErrors({ fieldCoercionErrors })
+        );
+      } catch (error) {
+        actions.setFlashMessages({ error: [FIELD_ERRORS_ERROR] });
+      }
+    },
+    addNewField: ({ fieldName, newFieldType }) => {
+      const schema = cloneDeep(values.activeSchema);
+      schema[fieldName] = newFieldType;
+      actions.setServerField(schema, ADD);
+    },
+    updateExistingFieldType: ({ fieldName, newFieldType }) => {
+      const schema = cloneDeep(values.activeSchema);
+      schema[fieldName] = newFieldType;
+      actions.onFieldUpdate({ schema, formUnchanged: isEqual(values.serverSchema, schema) });
+    },
+    updateFields: () => actions.setServerField(values.activeSchema, UPDATE),
+    setServerField: ({ updatedSchema, operation }) => {
+      const { isOrganization } = AppLogic.values;
+      const isAdding = operation === ADD;
+      const { sourceId } = values;
+      const successMessage = isAdding ? 'New field added.' : 'Schema updated.';
+      const route = isOrganization
+        ? routes.fritoPieOrganizationContentSourceSchemasPath(sourceId)
+        : routes.fritoPieAccountContentSourceSchemasPath(sourceId);
+
+      const emptyReindexJob = {
+        percentageComplete: 100,
+        numDocumentsWithErrors: 0,
+        activeReindexJobId: 0,
+        isActive: false,
+      };
+
+      actions.resetMostRecentIndexJob(emptyReindexJob);
+
+      http
+        .post(route, updatedSchema)
+        .then(({ data }) => {
+          window.scrollTo(0, 0);
+
+          actions.onSchemaSetSuccess({
+            ...data,
+            flashMessages: { success: [successMessage] },
+          });
+        })
+        .catch(
+          ({
+            response: {
+              data: { errors },
+            },
+          }) => {
+            window.scrollTo(0, 0);
+            if (isAdding) {
+              actions.onSchemaSetFormErrors(errors);
+            } else {
+              actions.onSchemaSetError({ flashMessages: { error: errors } });
+            }
+          }
+        );
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -8,6 +8,16 @@ import { schema } from '@kbn/config-schema';
 
 import { RouteDependencies } from '../../plugin';
 
+const schemaValuesSchema = schema.recordOf(
+  schema.string(),
+  schema.oneOf([
+    schema.literal('text'),
+    schema.literal('number'),
+    schema.literal('geolocation'),
+    schema.literal('date'),
+  ])
+);
+
 const pageSchema = schema.object({
   current: schema.number(),
   size: schema.number(),
@@ -363,7 +373,7 @@ export function registerAccountSourceSchemasRoute({
     {
       path: '/api/workplace_search/account/sources/{id}/schemas',
       validate: {
-        body: schema.object({}),
+        body: schemaValuesSchema,
         params: schema.object({
           id: schema.string(),
         }),
@@ -745,7 +755,7 @@ export function registerOrgSourceSchemasRoute({
     {
       path: '/api/workplace_search/org/sources/{id}/schemas',
       validate: {
-        body: schema.object({}),
+        body: schemaValuesSchema,
         params: schema.object({
           id: schema.string(),
         }),


### PR DESCRIPTION
## Summary

This PR migrates the ContentSources [Schema](https://github.com/elastic/ent-search/tree/master/app/javascript/workplace_search/ContentSources/components/Schema) tree from `ent-search`.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
