### PR TITLE
Fix Example code

### DIFF
--- a/docs/api/logstash-configuration-management/create-logstash.asciidoc
+++ b/docs/api/logstash-configuration-management/create-logstash.asciidoc
@@ -24,7 +24,7 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
   (Required, string) The pipeline ID.
 
 `description`::
-  (Optional, string) The pipeline description.
+  (Required, string) The pipeline description.
 
 `pipeline`::
   (Required, string) The pipeline definition.
@@ -46,6 +46,8 @@ experimental[] Create a centrally-managed Logstash pipeline, or update an existi
 --------------------------------------------------
 $ curl -X PUT api/logstash/pipeline/hello-world
 {
+  "id": "hello-world",
+  "description": "My Hello World pipeline",
   "pipeline": "input { stdin {} } output { stdout {} }",
   "settings": {
     "queue.type": "persisted"


### PR DESCRIPTION
The example as presented does not work on 7.8. 
The `"id"` and `"description"` are required fields in the body.

Also change the text to show that "description" is a  required field.

NOTE: Please do not merge/backport this to any other versions. These changes are *not* valid for 7.10.

