### PR TITLE
Revert "[Lens] (Accessibility) Focus mistakenly stops on righthand form"

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -88,7 +88,7 @@ function LayerPanels(
   const layerIds = activeVisualization.getLayerIds(visualizationState);
 
   return (
-    <EuiForm className="lnsConfigPanel" tabIndex={-1}>
+    <EuiForm className="lnsConfigPanel">
       {layerIds.map((layerId, index) => (
         <LayerPanel
           {...props}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/84827

Caused this bug: https://github.com/elastic/kibana/issues/84827

Reverts elastic/kibana#84519

