### PR TITLE
[APM] WIP: Send inspected queries to client

### DIFF
--- a/x-pack/plugins/apm/server/routes/create_route.ts
+++ b/x-pack/plugins/apm/server/routes/create_route.ts
@@ -5,20 +5,20 @@
  */
 
 import { CoreSetup } from 'src/core/server';
-import { Route, RouteParamsRT } from './typings';
+import { HandlerReturn, Route, RouteParamsRT } from './typings';
 
 export function createRoute<
   TEndpoint extends string,
-  TRouteParamsRT extends RouteParamsRT | undefined = undefined,
-  TReturn = unknown
+  TReturn extends HandlerReturn,
+  TRouteParamsRT extends RouteParamsRT | undefined = undefined
 >(
   route: Route<TEndpoint, TRouteParamsRT, TReturn>
 ): Route<TEndpoint, TRouteParamsRT, TReturn>;
 
 export function createRoute<
   TEndpoint extends string,
-  TRouteParamsRT extends RouteParamsRT | undefined = undefined,
-  TReturn = unknown
+  TReturn extends HandlerReturn,
+  TRouteParamsRT extends RouteParamsRT | undefined = undefined
 >(
   route: (core: CoreSetup) => Route<TEndpoint, TRouteParamsRT, TReturn>
 ): (core: CoreSetup) => Route<TEndpoint, TRouteParamsRT, TReturn>;

--- a/x-pack/plugins/apm/server/routes/index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/index_pattern.ts
@@ -63,6 +63,8 @@ export const apmIndexPatternTitleRoute = createRoute({
   endpoint: 'GET /api/apm/index_pattern/title',
   options: { tags: ['access:apm'] },
   handler: async ({ context }) => {
-    return getApmIndexPatternTitle(context);
+    return {
+      indexPatternTitle: getApmIndexPatternTitle(context),
+    };
   },
 });

--- a/x-pack/plugins/apm/server/routes/observability_overview.ts
+++ b/x-pack/plugins/apm/server/routes/observability_overview.ts
@@ -17,7 +17,9 @@ export const observabilityOverviewHasDataRoute = createRoute({
   options: { tags: ['access:apm'] },
   handler: async ({ context, request }) => {
     const setup = await setupRequest(context, request);
-    return await hasData({ setup });
+    return {
+      hasData: await hasData({ setup }),
+    };
   },
 });
 

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -25,6 +25,8 @@ export interface RouteParams {
   body?: any;
 }
 
+export type HandlerReturn = Record<string, any> | void;
+
 type WithoutIncompatibleMethods<T extends t.Any> = Omit<
   T,
   'encode' | 'asEncoder'
@@ -34,7 +36,7 @@ export type RouteParamsRT = WithoutIncompatibleMethods<t.Type<RouteParams>>;
 
 export type RouteHandler<
   TParamsRT extends RouteParamsRT | undefined,
-  TReturn
+  TReturn extends HandlerReturn
 > = (kibanaContext: {
   context: APMRequestHandlerContext<
     (TParamsRT extends RouteParamsRT ? t.TypeOf<TParamsRT> : {}) & {
@@ -56,7 +58,7 @@ interface RouteOptions {
 export interface Route<
   TEndpoint extends string,
   TRouteParamsRT extends RouteParamsRT | undefined,
-  TReturn
+  TReturn extends HandlerReturn
 > {
   endpoint: TEndpoint;
   options: RouteOptions;
@@ -88,8 +90,8 @@ export interface ServerAPI<TRouteState extends RouteState> {
   _S: TRouteState;
   add<
     TEndpoint extends string,
-    TRouteParamsRT extends RouteParamsRT | undefined = undefined,
-    TReturn = unknown
+    TReturn extends HandlerReturn,
+    TRouteParamsRT extends RouteParamsRT | undefined = undefined
   >(
     route:
       | Route<TEndpoint, TRouteParamsRT, TReturn>


### PR DESCRIPTION
Currently it's possible to output ES queries to the log output on the server side. This is fine for local development but on a remote Kibana instance it's difficult to access. 
This PR appends the inspected queries to the response to allow the browser to see them.


![image](https://user-images.githubusercontent.com/209966/101202539-b0c37e80-3669-11eb-80d0-adbe684e4e17.png)
