### PR TITLE
[Monitoring] Safeguarding alerts in case they come back undefined

### DIFF
--- a/x-pack/plugins/monitoring/public/views/base_controller.js
+++ b/x-pack/plugins/monitoring/public/views/base_controller.js
@@ -168,7 +168,7 @@ export class MonitoringViewBaseController {
         $scope.$apply(() => {
           this._isDataInitialized = true; // render will replace loading screen with the react component
           $scope.pageData = this.data = pageData.value; // update the view's data with the fetch result
-          $scope.alerts = this.alerts = alerts.value || {};
+          $scope.alerts = this.alerts = alerts && alerts.value ? alerts.value : {};
         });
       });
     };


### PR DESCRIPTION
Small regression from: https://github.com/elastic/kibana/pull/84676 cases an error on the clusters' listing page (`.../app/monitoring#/home`):

![Screen Shot 2020-12-06 at 11 44 42 PM](https://user-images.githubusercontent.com/27822304/101311515-98956000-381f-11eb-8967-ac59892a9601.png)
