### PR TITLE
[Fleet] Add input level condition to the agent config

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -43,6 +43,7 @@ export interface FullAgentPolicyInput {
   name: string;
   revision: number;
   type: string;
+  condition?: string;
   data_stream: { namespace: string };
   use_output: string;
   meta?: {

--- a/x-pack/plugins/fleet/server/services/package_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.test.ts
@@ -118,6 +118,75 @@ describe('Package policy service', () => {
       ]);
     });
 
+    it('should work with input condition', async () => {
+      const inputs = await packagePolicyService.compilePackagePolicyInputs(
+        ({
+          data_streams: [
+            {
+              type: 'logs',
+              dataset: 'package.dataset1',
+              streams: [{ input: 'log', template_path: 'some_template_path.yml' }],
+            },
+          ],
+          policy_templates: [
+            {
+              inputs: [
+                {
+                  type: 'log',
+                  condition: "${host.platform} != 'linux'",
+                },
+              ],
+            },
+          ],
+        } as unknown) as PackageInfo,
+        [
+          {
+            type: 'log',
+            enabled: true,
+            streams: [
+              {
+                id: 'datastream01',
+                data_stream: { dataset: 'package.dataset1', type: 'logs' },
+                enabled: true,
+                vars: {
+                  paths: {
+                    value: ['/var/log/set.log'],
+                  },
+                },
+              },
+            ],
+          },
+        ]
+      );
+
+      expect(inputs).toEqual([
+        {
+          type: 'log',
+          enabled: true,
+          compiled_input: {
+            condition: "${host.platform} != 'linux'",
+          },
+          streams: [
+            {
+              id: 'datastream01',
+              data_stream: { dataset: 'package.dataset1', type: 'logs' },
+              enabled: true,
+              vars: {
+                paths: {
+                  value: ['/var/log/set.log'],
+                },
+              },
+              compiled_stream: {
+                metricset: ['dataset1'],
+                paths: ['/var/log/set.log'],
+                type: 'log',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should work with config variables at the input level', async () => {
       const inputs = await packagePolicyService.compilePackagePolicyInputs(
         ({


### PR DESCRIPTION
## Summary

Unblock https://github.com/elastic/integrations/pull/411
Blocked on https://github.com/elastic/package-registry/pull/658

In an Agent policy It's now possible to specify a condition at the `input` level using the `condition` property. 

This PR add the support for input condition when adding a packagePolicy to a config.

The field is added server side and stored in the property `compiled_input` that contains the info for the input coming from the package registry.

## Example

<img width="800" alt="Screen Shot 2020-12-07 at 2 28 35 PM" src="https://user-images.githubusercontent.com/1336873/101398122-9b359b00-389b-11eb-9637-73d9add54081.png">

## How to test this

You can run a custom package registry with https://github.com/elastic/package-registry/pull/658 and add that integration https://github.com/elastic/integrations/pull/411 to see a policy with an input condition.
