### PR TITLE
[Enterprise Search] Add EuiButtonEmptyTo component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
@@ -8,11 +8,11 @@ import '../../__mocks__/kea.mock';
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { EuiLink, EuiButton, EuiPanel } from '@elastic/eui';
+import { EuiLink, EuiButton, EuiButtonEmpty, EuiPanel } from '@elastic/eui';
 
 import { mockKibanaValues, mockHistory } from '../../__mocks__';
 
-import { EuiLinkTo, EuiButtonTo, EuiPanelTo } from './eui_components';
+import { EuiLinkTo, EuiButtonTo, EuiButtonEmptyTo, EuiPanelTo } from './eui_components';
 
 describe('EUI & React Router Component Helpers', () => {
   beforeEach(() => {
@@ -29,6 +29,12 @@ describe('EUI & React Router Component Helpers', () => {
     const wrapper = shallow(<EuiButtonTo to="/" />);
 
     expect(wrapper.find(EuiButton)).toHaveLength(1);
+  });
+
+  it('renders an EuiButtonEmpty', () => {
+    const wrapper = shallow(<EuiButtonEmptyTo to="/" />);
+
+    expect(wrapper.find(EuiButtonEmpty)).toHaveLength(1);
   });
 
   it('renders an EuiPanel', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
@@ -6,7 +6,15 @@
 
 import React from 'react';
 import { useValues } from 'kea';
-import { EuiLink, EuiButton, EuiButtonProps, EuiLinkAnchorProps, EuiPanel } from '@elastic/eui';
+import {
+  EuiLink,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonEmptyProps,
+  EuiButtonProps,
+  EuiLinkAnchorProps,
+  EuiPanel,
+} from '@elastic/eui';
 import { EuiPanelProps } from '@elastic/eui/src/components/panel/panel';
 
 import { KibanaLogic } from '../kibana';
@@ -80,6 +88,18 @@ export const EuiButtonTo: React.FC<ReactRouterEuiButtonProps> = ({
 }) => (
   <ReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
     <EuiButton {...rest} />
+  </ReactRouterHelper>
+);
+
+type ReactRouterEuiButtonEmptyProps = ReactRouterProps & EuiButtonEmptyProps;
+export const EuiButtonEmptyTo: React.FC<ReactRouterEuiButtonEmptyProps> = ({
+  to,
+  onClick,
+  shouldNotCreateHref,
+  ...rest
+}) => (
+  <ReactRouterHelper {...{ to, onClick, shouldNotCreateHref }}>
+    <EuiButtonEmpty {...rest} />
   </ReactRouterHelper>
 );
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/index.ts
@@ -6,4 +6,4 @@
 
 export { letBrowserHandleEvent } from './link_events';
 export { createHref, CreateHrefOptions } from './create_href';
-export { EuiLinkTo, EuiButtonTo, EuiPanelTo } from './eui_components';
+export { EuiLinkTo, EuiButtonTo, EuiButtonEmptyTo, EuiPanelTo } from './eui_components';


### PR DESCRIPTION
## Summary

This PR adds another wrapper component for internal routing, the `EuiButtonEmptyTo` component.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios