### PR TITLE
[7.10] Fix delete phase serialization bug (#84870)

### DIFF
--- a/x-pack/plugins/index_lifecycle_management/common/types/policies.ts
+++ b/x-pack/plugins/index_lifecycle_management/common/types/policies.ts
@@ -88,7 +88,7 @@ export interface SerializedDeletePhase extends SerializedPhase {
       policy: string;
     };
     delete?: {
-      delete_searchable_snapshot: boolean;
+      delete_searchable_snapshot?: boolean;
     };
   };
 }

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/policies/delete_phase.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/policies/delete_phase.ts
@@ -57,7 +57,7 @@ export const deletePhaseToES = (
     esPhase.min_age = `${phase.selectedMinimumAge}${phase.selectedMinimumAgeUnits}`;
   }
 
-  esPhase.actions = esPhase.actions ? { ...esPhase.actions, delete: {} } : { delete: {} };
+  esPhase.actions = esPhase.actions ? {  delete: {}, ...esPhase.actions } : { delete: {} };
 
   if (phase.waitForSnapshotPolicy) {
     esPhase.actions.wait_for_snapshot = {

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/policies/delete_phase.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/policies/delete_phase.ts
@@ -57,7 +57,7 @@ export const deletePhaseToES = (
     esPhase.min_age = `${phase.selectedMinimumAge}${phase.selectedMinimumAgeUnits}`;
   }
 
-  esPhase.actions = esPhase.actions ? { ...esPhase.actions } : {};
+  esPhase.actions = esPhase.actions ? { ...esPhase.actions, delete: {} } : { delete: {} };
 
   if (phase.waitForSnapshotPolicy) {
     esPhase.actions.wait_for_snapshot = {

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/policies/delete_phase.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/policies/delete_phase.ts
@@ -57,7 +57,7 @@ export const deletePhaseToES = (
     esPhase.min_age = `${phase.selectedMinimumAge}${phase.selectedMinimumAgeUnits}`;
   }
 
-  esPhase.actions = esPhase.actions ? {  delete: {}, ...esPhase.actions } : { delete: {} };
+  esPhase.actions = esPhase.actions ? { delete: {}, ...esPhase.actions } : { delete: {} };
 
   if (phase.waitForSnapshotPolicy) {
     esPhase.actions.wait_for_snapshot = {

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/policies/policy_serialization.test.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/policies/policy_serialization.test.ts
@@ -371,7 +371,7 @@ describe('Policy serialization', () => {
     expect(originalPolicy).toEqual(originalClone);
   });
 
-  test('serialize a policy using "best_compression" codec for forcemerge', () => {
+  test('serialization adds an empty delete action to delete phase', () => {
     expect(
       serializePolicy(
         {
@@ -430,6 +430,48 @@ describe('Policy serialization', () => {
             set_priority: {
               priority: 50,
             },
+          },
+        },
+      },
+    });
+  });
+
+  test('serialize a policy using "best_compression" codec for forcemerge', () => {
+    expect(
+      serializePolicy({
+        name: 'test',
+        phases: {
+          hot: {
+            ...defaultNewHotPhase,
+          },
+          warm: {
+            ...defaultNewWarmPhase,
+          },
+          cold: {
+            ...defaultNewColdPhase,
+          },
+          delete: { ...defaultNewDeletePhase, phaseEnabled: true },
+        },
+      })
+    ).toEqual({
+      name: 'test',
+      phases: {
+        hot: {
+          actions: {
+            rollover: {
+              max_age: '30d',
+              max_size: '50gb',
+            },
+            set_priority: {
+              priority: 100,
+            },
+          },
+          min_age: '0ms',
+        },
+        delete: {
+          min_age: '0d',
+          actions: {
+            delete: {},
           },
         },
       },

--- a/x-pack/plugins/index_lifecycle_management/public/application/services/policies/policy_serialization.test.ts
+++ b/x-pack/plugins/index_lifecycle_management/public/application/services/policies/policy_serialization.test.ts
@@ -371,7 +371,7 @@ describe('Policy serialization', () => {
     expect(originalPolicy).toEqual(originalClone);
   });
 
-  test('serialization adds an empty delete action to delete phase', () => {
+  test('serialize a policy using "best_compression" codec for forcemerge', () => {
     expect(
       serializePolicy(
         {
@@ -436,7 +436,7 @@ describe('Policy serialization', () => {
     });
   });
 
-  test('serialize a policy using "best_compression" codec for forcemerge', () => {
+  test('serialization adds an empty delete action to delete phase', () => {
     expect(
       serializePolicy({
         name: 'test',
@@ -472,6 +472,77 @@ describe('Policy serialization', () => {
           min_age: '0d',
           actions: {
             delete: {},
+          },
+        },
+      },
+    });
+  });
+
+  test("serialization doesn't overwrite existing delete action in delete phase", () => {
+    expect(
+      serializePolicy(
+        {
+          name: 'test',
+          phases: {
+            hot: {
+              ...defaultNewHotPhase,
+            },
+            warm: {
+              ...defaultNewWarmPhase,
+            },
+            cold: {
+              ...defaultNewColdPhase,
+            },
+            delete: { ...defaultNewDeletePhase, phaseEnabled: true },
+          },
+        },
+        {
+          name: 'test',
+          phases: {
+            hot: {
+              actions: {
+                rollover: {
+                  max_age: '30d',
+                  max_size: '50gb',
+                },
+                set_priority: {
+                  priority: 100,
+                },
+              },
+              min_age: '0ms',
+            },
+            delete: {
+              min_age: '0d',
+              actions: {
+                delete: {
+                  delete_searchable_snapshot: true,
+                },
+              },
+            },
+          },
+        }
+      )
+    ).toEqual({
+      name: 'test',
+      phases: {
+        hot: {
+          actions: {
+            rollover: {
+              max_age: '30d',
+              max_size: '50gb',
+            },
+            set_priority: {
+              priority: 100,
+            },
+          },
+          min_age: '0ms',
+        },
+        delete: {
+          min_age: '0d',
+          actions: {
+            delete: {
+              delete_searchable_snapshot: true,
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary
Fixes [#84442](https://github.com/elastic/kibana/issues/84442). 
This PR makes sure that `delete`  actions is created when saving a policy with enabled Delete phase. 

This is a manual backport of [#84870](https://github.com/elastic/kibana/pull/84870) that was needed because of a recent change to use form lib in ILM edit policy component, specifically a different function for (de)serialization of form data. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

## Release Note
When creating an Index Lifecycle policy with a Delete phase, it will now correctly save it with a `delete` action. 
