### PR TITLE
[Fleet] Allow to edit package policy with input level template

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -108,7 +108,8 @@ export const EditPackagePolicyPage: React.FunctionComponent = () => {
           const newPackagePolicy = {
             ...restOfPackagePolicy,
             inputs: inputs.map((input) => {
-              const { streams, ...restOfInput } = input;
+              // Remove `compiled_input` from all input info, we assign this after saving
+              const { streams, compiled_input: compiledInput, ...restOfInput } = input;
               return {
                 ...restOfInput,
                 streams: streams.map((stream) => {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/85188
Introduced here https://github.com/elastic/kibana/pull/83878 

It's currently not possible to edit and save an integration with a input level template

<img width="1438" alt="Screen Shot 2020-12-08 at 9 04 14 AM" src="https://user-images.githubusercontent.com/1336873/101494445-58c09c80-3935-11eb-9383-5adbbaedae0b.png">


This PR fix that by omitting the property `compiled_input` while sending an input, like we do for `compiled_stream`

## How to test

* add the "Input level templates integration" to a policy
* try to edit that package policy
