### PR TITLE
Skip jest coverage on CI

### DIFF
--- a/src/dev/code_coverage/shell_scripts/extract_archives.sh
+++ b/src/dev/code_coverage/shell_scripts/extract_archives.sh
@@ -6,7 +6,7 @@ EXTRACT_DIR=/tmp/extracted_coverage
 mkdir -p $EXTRACT_DIR
 
 echo "### Extracting downloaded artifacts"
-for x in kibana-intake x-pack-intake kibana-oss-tests kibana-xpack-tests; do
+for x in kibana-intake kibana-oss-tests kibana-xpack-tests; do #x-pack-intake skipping due to failures
   tar -xzf $DOWNLOAD_DIR/coverage/${x}/kibana-coverage.tar.gz -C $EXTRACT_DIR || echo "### Error 'tarring': ${x}"
 done
 

--- a/src/dev/code_coverage/shell_scripts/generate_team_assignments_and_ingest_coverage.sh
+++ b/src/dev/code_coverage/shell_scripts/generate_team_assignments_and_ingest_coverage.sh
@@ -32,7 +32,7 @@ TEAM_ASSIGN_PATH=$5
 # Build team assignments dat file
 node scripts/generate_team_assignments.js --verbose --src .github/CODEOWNERS --dest $TEAM_ASSIGN_PATH
 
-for x in jest functional; do
+for x in functional; do #jest skip due to failures
   echo "### Ingesting coverage for ${x}"
 
   COVERAGE_SUMMARY_FILE=target/kibana-coverage/${x}-combined/coverage-summary.json

--- a/src/dev/code_coverage/shell_scripts/merge_jest_and_functional.sh
+++ b/src/dev/code_coverage/shell_scripts/merge_jest_and_functional.sh
@@ -4,6 +4,6 @@ COVERAGE_TEMP_DIR=/tmp/extracted_coverage/target/kibana-coverage/
 export COVERAGE_TEMP_DIR
 
 echo "### Merge coverage reports"
-for x in jest functional; do
+for x in functional; do # jest skip due to failures
   yarn nyc report --nycrc-path src/dev/code_coverage/nyc_config/nyc.${x}.config.js
 done

--- a/test/scripts/jenkins_unit.sh
+++ b/test/scripts/jenkins_unit.sh
@@ -11,16 +11,16 @@ rename_coverage_file() {
 if [[ -z "$CODE_COVERAGE" ]] ; then
   "$(FORCE_COLOR=0 yarn bin)/grunt" jenkins:unit --dev;
 else
-  echo " -> Running jest tests with coverage"
-  node scripts/jest --ci --verbose --coverage
-  rename_coverage_file "oss"
-  echo ""
-  echo ""
-  echo " -> Running jest integration tests with coverage"
-  node --max-old-space-size=8192 scripts/jest_integration --ci --verbose --coverage || true;
-  rename_coverage_file "oss-integration"
-  echo ""
-  echo ""
+  # echo " -> Running jest tests with coverage"
+  # node scripts/jest --ci --verbose --coverage
+  # rename_coverage_file "oss"
+  # echo ""
+  # echo ""
+  # echo " -> Running jest integration tests with coverage"
+  # node --max-old-space-size=8192 scripts/jest_integration --ci --verbose --coverage || true;
+  # rename_coverage_file "oss-integration"
+  # echo ""
+  # echo ""
   echo " -> Running mocha tests with coverage"
   yarn run grunt "test:mochaCoverage";
   echo ""

--- a/vars/kibanaCoverage.groovy
+++ b/vars/kibanaCoverage.groovy
@@ -200,13 +200,14 @@ def ingest(jobName, buildNumber, buildUrl, timestamp, previousSha, teamAssignmen
 def runTests() {
   parallel([
     'kibana-intake-agent': workers.intake('kibana-intake', './test/scripts/jenkins_unit.sh'),
-    'x-pack-intake-agent': {
-      withEnv([
-        'NODE_ENV=test' // Needed for jest tests only
-      ]) {
-        workers.intake('x-pack-intake', './test/scripts/jenkins_xpack.sh')()
-      }
-    },
+    // skipping due to failures
+    // 'x-pack-intake-agent': {
+    //   withEnv([
+    //     'NODE_ENV=test' // Needed for jest tests only
+    //   ]) {
+    //     workers.intake('x-pack-intake', './test/scripts/jenkins_xpack.sh')()
+    //   }
+    // },
     'kibana-oss-agent'   : workers.functional(
       'kibana-oss-tests',
       { kibanaPipeline.buildOss() },

--- a/vars/kibanaCoverage.groovy
+++ b/vars/kibanaCoverage.groovy
@@ -59,7 +59,7 @@ def uploadBaseWebsiteFiles(prefix) {
 def uploadCoverageHtmls(prefix) {
   [
     'target/kibana-coverage/functional-combined',
-    'target/kibana-coverage/jest-combined',
+    // 'target/kibana-coverage/jest-combined', skipped due to failures
     'target/kibana-coverage/mocha-combined',
   ].each { uploadWithVault(prefix, it) }
 }


### PR DESCRIPTION
## Summary

While we are trying to find a fix for #85392 this PR skips collecting coverage for Jest tests, in order to get functional and mocha

Coverage job passed: https://kibana-ci.elastic.co/job/elastic+kibana+qa-research/153/