### PR TITLE
Fix aggregation select external link in visualization editor

### DIFF
--- a/src/plugins/vis_default_editor/public/components/agg_select.tsx
+++ b/src/plugins/vis_default_editor/public/components/agg_select.tsx
@@ -77,15 +77,15 @@ function DefaultEditorAggSelect({
   }
 
   const helpLink = value && aggHelpLink && (
-    <EuiLink href={aggHelpLink} target="_blank" rel="noopener">
-      <EuiText size="xs">
+    <EuiText size="xs">
+      <EuiLink href={aggHelpLink} target="_blank" rel="noopener">
         <FormattedMessage
           id="visDefaultEditor.aggSelect.helpLinkLabel"
           defaultMessage="{aggTitle} help"
           values={{ aggTitle: value ? value.title : '' }}
         />
-      </EuiText>
-    </EuiLink>
+      </EuiLink>
+    </EuiText>
   );
 
   const errors = aggError ? [aggError] : [];


### PR DESCRIPTION
## Summary

Fix `Aggregation` select external link:

Before:

![image](https://user-images.githubusercontent.com/31325372/101610952-f2fa1080-3a19-11eb-97ef-52dd73f9717b.png)


After:

![image](https://user-images.githubusercontent.com/31325372/101610843-d231bb00-3a19-11eb-9abd-c5cab3a4ed24.png)


