### PR TITLE
[APM] Add sanitize_field_names and transaction_ignore_urls config options to Ruby agent

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -235,7 +235,7 @@ export const generalSettings: RawSettingDefinition[] = [
           'Sometimes it is necessary to sanitize, i.e., remove, sensitive data sent to Elastic APM. This config accepts a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields). The query string and the captured request body (such as `application/json` data) will not get sanitized.',
       }
     ),
-    includeAgents: ['java', 'python', 'go', 'dotnet', 'nodejs'],
+    includeAgents: ['java', 'python', 'go', 'dotnet', 'nodejs', 'ruby'],
   },
 
   // Ignore transactions based on URLs

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -149,6 +149,7 @@ describe('filterByAgent', () => {
         'capture_headers',
         'log_level',
         'recording',
+        'sanitize_field_names',
         'span_frames_min_duration',
         'transaction_ignore_urls',
         'transaction_max_spans',


### PR DESCRIPTION
See https://github.com/elastic/apm/issues/319
Closes https://github.com/elastic/apm-agent-ruby/issues/903
Closes https://github.com/elastic/apm-agent-ruby/issues/914