### PR TITLE
[APM] add sanitize_field_names & transaction_ignore_urls vars to Node.js agent remote config

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -232,7 +232,7 @@ export const generalSettings: RawSettingDefinition[] = [
       'xpack.apm.agentConfig.sanitizeFiledNames.description',
       {
         defaultMessage:
-          'Sometimes it is <b>necessary</b> to sanitize, i.e., remove, sensitive data sent to Elastic APM. This config accepts a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields). The query string and the captured request body (such as `application/json` data) will not get sanitized.',
+          'Sometimes it is necessary to sanitize, i.e., remove, sensitive data sent to Elastic APM. This config accepts a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields). The query string and the captured request body (such as `application/json` data) will not get sanitized.',
       }
     ),
     includeAgents: ['java', 'python', 'go', 'dotnet', 'nodejs'],

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -232,10 +232,10 @@ export const generalSettings: RawSettingDefinition[] = [
       'xpack.apm.agentConfig.sanitizeFiledNames.description',
       {
         defaultMessage:
-          'Sometimes it is necessary to sanitize, i.e., remove, sensitive data sent to Elastic APM. This config accepts a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields). The query string and the captured request body (such as `application/json` data) will not get sanitized.',
+          'Sometimes it is <b>necessary</b> to sanitize, i.e., remove, sensitive data sent to Elastic APM. This config accepts a list of wildcard patterns of field names which should be sanitized. These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields). The query string and the captured request body (such as `application/json` data) will not get sanitized.',
       }
     ),
-    includeAgents: ['java', 'python', 'go', 'dotnet'],
+    includeAgents: ['java', 'python', 'go', 'dotnet', 'nodejs'],
   },
 
   // Ignore transactions based on URLs
@@ -254,6 +254,6 @@ export const generalSettings: RawSettingDefinition[] = [
           'Used to restrict requests to certain URLs from being instrumented. This config accepts a comma-separated list of wildcard patterns of URL paths that should be ignored. When an incoming HTTP request is detected, its request path will be tested against each element in this list. For example, adding `/home/index` to this list would match and remove instrumentation from `http://localhost/home/index` as well as `http://whatever.com/home/index?value1=123`',
       }
     ),
-    includeAgents: ['java'],
+    includeAgents: ['java', 'nodejs'],
   },
 ];

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -102,6 +102,8 @@ describe('filterByAgent', () => {
       expect(getSettingKeysForAgent('nodejs')).toEqual([
         'capture_body',
         'log_level',
+        'sanitize_field_names',
+        'transaction_ignore_urls',
         'transaction_max_spans',
         'transaction_sample_rate',
       ]);


### PR DESCRIPTION
## Summary

This adds the Node.js agent to the include list for two APM agent central config vars:
- sanitize_field_names: see https://github.com/elastic/apm-agent-nodejs/issues/1811
- transaction_ignore_urls: see https://github.com/elastic/apm-agent-nodejs/issues/1689


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


## Kibana unit tests

Running the relevant test file passed:

```
[x-pack]% node scripts/jest.js plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
Running Jest with --config /Users/trentm/tm/kibana/x-pack/jest.config.js
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/x-pack/plugins/enterprise_search/server/__mocks__/index.ts
    * <rootDir>/x-pack/plugins/enterprise_search/common/__mocks__/index.ts
...
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/x-pack/plugins/security_solution/public/common/lib/kibana/__mocks__/index.ts
    * <rootDir>/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/__mocks__/index.tsx

  PASS  plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
  filterByAgent
    when `excludeAgents` is dotnet and nodejs
      ✓ should not include dotnet (1 ms)
      ✓ should include go
    when `includeAgents` is dotnet and nodejs
      ✓ should not include go (1 ms)
      ✓ should include dotnet (1 ms)
    options per agent
      ✓ go (1 ms)
      ✓ java (1 ms)
      ✓ js-base
      ✓ rum-js
      ✓ nodejs
      ✓ python
      ✓ dotnet (1 ms)
      ✓ ruby (1 ms)
      ✓ "All" services (no agent name) (1 ms)
  settingDefinitions
    ✓ should have correct default values (5 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   1 passed, 1 total
Time:        2.239 s, estimated 3 s
Ran all test suites matching /plugins\/apm\/common\/agent_configuration\/setting_definitions\/index.test.ts/i.
```

## End to end test

Creating an Agent settings configuration now includes those two vars as expected:

![Screen Shot 2020-12-10 at 1 30 01 PM](https://user-images.githubusercontent.com/46866/101835331-76863100-3af0-11eb-8ee3-0f612e117f1e.png)



I was able to observe my running play "esapp" updating its log level to "trace" (required to see the following log output):

```
% node esapp.js
...
Remote config failure. Unsupported config names: sanitize_field_names
Remote config success. Updated captureBody: off
Remote config success. Updated logLevel: trace
Remote config success. Updated transactionIgnoreUrls: /ping,/metrics,/ol*
Remote config success. Updated transactionSampleRate: 1
Remote config success. Updated transactionIgnoreUrlRegExp: /^\/ping$/i,/^\/metrics$/i,/^\/ol.*$/i
...
```

The "Unsupported config names: sanitize_field_names" is because that is coming in https://github.com/elastic/apm-agent-nodejs/pull/1898 (currently in code review).
/cc @astorm

