### PR TITLE
Added transaction_ignore_urls as central config 

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -254,6 +254,6 @@ export const generalSettings: RawSettingDefinition[] = [
           'Used to restrict requests to certain URLs from being instrumented. This config accepts a comma-separated list of wildcard patterns of URL paths that should be ignored. When an incoming HTTP request is detected, its request path will be tested against each element in this list. For example, adding `/home/index` to this list would match and remove instrumentation from `http://localhost/home/index` as well as `http://whatever.com/home/index?value1=123`',
       }
     ),
-    includeAgents: ['java', 'nodejs'],
+    includeAgents: ['java', 'nodejs', 'python', 'dotnet', 'ruby'],
   },
 ];

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -120,6 +120,7 @@ describe('filterByAgent', () => {
         'recording',
         'sanitize_field_names',
         'span_frames_min_duration',
+        'transaction_ignore_urls',
         'transaction_max_spans',
         'transaction_sample_rate',
       ]);
@@ -134,6 +135,7 @@ describe('filterByAgent', () => {
         'sanitize_field_names',
         'span_frames_min_duration',
         'stack_trace_limit',
+        'transaction_ignore_urls',
         'transaction_max_spans',
         'transaction_sample_rate',
       ]);
@@ -148,6 +150,7 @@ describe('filterByAgent', () => {
         'log_level',
         'recording',
         'span_frames_min_duration',
+        'transaction_ignore_urls',
         'transaction_max_spans',
         'transaction_sample_rate',
       ]);


### PR DESCRIPTION
Added transaction_ignore_urls (https://github.com/elastic/apm/issues/144) as central config for the Python, .NET and Ruby APM agents

