### PR TITLE
[APM] Service overview: Makes service overview default landing page

### DIFF
--- a/x-pack/plugins/apm/e2e/cypress/integration/apm.feature
+++ b/x-pack/plugins/apm/e2e/cypress/integration/apm.feature
@@ -3,4 +3,4 @@ Feature: APM
   Scenario: Transaction duration charts
     Given a user browses the APM UI application
     When the user inspects the opbeans-node service
-    Then should redirect to correct path with correct params
+    Then should redirect to correct path

--- a/x-pack/plugins/apm/e2e/cypress/support/step_definitions/apm.ts
+++ b/x-pack/plugins/apm/e2e/cypress/support/step_definitions/apm.ts
@@ -25,6 +25,6 @@ When(`the user inspects the opbeans-node service`, () => {
     .click({ force: true });
 });
 
-Then(`should redirect to correct`, () => {
+Then(`should redirect to correct path`, () => {
   cy.url().should('contain', `/app/apm/services/opbeans-node/overview`);
 });

--- a/x-pack/plugins/apm/e2e/cypress/support/step_definitions/apm.ts
+++ b/x-pack/plugins/apm/e2e/cypress/support/step_definitions/apm.ts
@@ -25,7 +25,6 @@ When(`the user inspects the opbeans-node service`, () => {
     .click({ force: true });
 });
 
-Then(`should redirect to correct path with correct params`, () => {
-  cy.url().should('contain', `/app/apm/services/opbeans-node/transactions`);
-  cy.url().should('contain', `transactionType=request`);
+Then(`should redirect to correct`, () => {
+  cy.url().should('contain', `/app/apm/services/opbeans-node/overview`);
 });

--- a/x-pack/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -27,6 +27,8 @@ import {
   CreateAgentConfigurationRouteHandler,
   EditAgentConfigurationRouteHandler,
 } from './route_handlers/agent_configuration';
+import { enableServiceOverview } from '../../../../../common/ui_settings_keys';
+import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 
 /**
  * Given a path, redirect to that location, preserving the search and maintaining
@@ -143,6 +145,20 @@ function SettingsCustomizeUI(props: RouteComponentProps<{}>) {
   );
 }
 
+function DefaultServicePageRouteHandler(
+  props: RouteComponentProps<{ serviceName: string }>
+) {
+  const { uiSettings } = useApmPluginContext().core;
+  if (uiSettings.get(enableServiceOverview)) {
+    return renderAsRedirectTo(
+      `/services/${props.match.params.serviceName}/overview`
+    )(props);
+  }
+  return renderAsRedirectTo(
+    `/services/${props.match.params.serviceName}/transactions`
+  )(props);
+}
+
 /**
  * The array of route definitions to be used when the application
  * creates the routes.
@@ -217,10 +233,7 @@ export const routes: APMRouteDefinition[] = [
     exact: true,
     path: '/services/:serviceName',
     breadcrumb: ({ match }) => match.params.serviceName,
-    render: (props: RouteComponentProps<{ serviceName: string }>) =>
-      renderAsRedirectTo(
-        `/services/${props.match.params.serviceName}/transactions`
-      )(props),
+    component: DefaultServicePageRouteHandler,
   } as APMRouteDefinition<{ serviceName: string }>,
   {
     exact: true,

--- a/x-pack/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -149,13 +149,14 @@ function DefaultServicePageRouteHandler(
   props: RouteComponentProps<{ serviceName: string }>
 ) {
   const { uiSettings } = useApmPluginContext().core;
+  const { serviceName } = props.match.params;
   if (uiSettings.get(enableServiceOverview)) {
     return renderAsRedirectTo(
-      `/services/${props.match.params.serviceName}/overview`
+      `/services/${serviceName}/overview`
     )(props);
   }
   return renderAsRedirectTo(
-    `/services/${props.match.params.serviceName}/transactions`
+    `/services/${serviceName}/transactions`
   )(props);
 }
 

--- a/x-pack/plugins/apm/public/components/app/Main/route_config/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Main/route_config/index.tsx
@@ -151,13 +151,9 @@ function DefaultServicePageRouteHandler(
   const { uiSettings } = useApmPluginContext().core;
   const { serviceName } = props.match.params;
   if (uiSettings.get(enableServiceOverview)) {
-    return renderAsRedirectTo(
-      `/services/${serviceName}/overview`
-    )(props);
+    return renderAsRedirectTo(`/services/${serviceName}/overview`)(props);
   }
-  return renderAsRedirectTo(
-    `/services/${serviceName}/transactions`
-  )(props);
+  return renderAsRedirectTo(`/services/${serviceName}/transactions`)(props);
 }
 
 /**

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/Buttons.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/Buttons.tsx
@@ -29,7 +29,7 @@ export function Buttons({
 
   const detailsUrl = getAPMHref({
     basePath,
-    path: `/services/${selectedNodeServiceName}/transactions`,
+    path: `/services/${selectedNodeServiceName}`,
     query: urlParams,
   });
   const focusUrl = getAPMHref({

--- a/x-pack/plugins/apm/public/components/shared/Links/apm/TransactionOverviewLink.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/TransactionOverviewLink.tsx
@@ -30,7 +30,7 @@ export function TransactionOverviewLink({ serviceName, ...rest }: Props) {
 
   return (
     <APMLink
-      path={`/services/${serviceName}/transactions`}
+      path={`/services/${serviceName}`}
       query={pickKeys(urlParams as APMQueryParams, ...persistedFilters)}
       {...rest}
     />

--- a/x-pack/plugins/apm/server/ui_settings.ts
+++ b/x-pack/plugins/apm/server/ui_settings.ts
@@ -36,7 +36,7 @@ export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
     name: i18n.translate('xpack.apm.enableServiceOverviewExperimentName', {
       defaultMessage: 'APM Service overview',
     }),
-    value: false,
+    value: true,
     description: i18n.translate(
       'xpack.apm.enableServiceOverviewExperimentDescription',
       {


### PR DESCRIPTION
Closes #81948 by setting the default route for services to the service overview page. Also updates links to the general path which gets redirected according to user settings.