### PR TITLE
[Fleet] Add APM traces index names to Fleet enroll role

### DIFF
--- a/x-pack/plugins/fleet/server/services/api_keys/index.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/index.ts
@@ -24,16 +24,7 @@ export async function generateOutputApiKey(
       cluster: ['monitor'],
       index: [
         {
-          names: [
-            'logs-*',
-            'metrics-*',
-            'events-*',
-            'traces-*',
-            '.ds-logs-*',
-            '.ds-metrics-*',
-            '.ds-events-*',
-            '.ds-traces-*',
-          ],
+          names: ['logs-*', 'metrics-*', 'traces-*', '.ds-logs-*', '.ds-metrics-*', '.ds-traces-*'],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/plugins/fleet/server/services/api_keys/index.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/index.ts
@@ -24,7 +24,16 @@ export async function generateOutputApiKey(
       cluster: ['monitor'],
       index: [
         {
-          names: ['logs-*', 'metrics-*', 'events-*', '.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          names: [
+            'logs-*',
+            'metrics-*',
+            'events-*',
+            'traces-*',
+            '.ds-logs-*',
+            '.ds-metrics-*',
+            '.ds-events-*',
+            '.ds-traces-*',
+          ],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -139,7 +139,7 @@ export async function setupFleet(
       cluster: ['monitor', 'manage_api_key'],
       indices: [
         {
-          names: ['logs-*', 'metrics-*', 'traces-*', '.ds-logs-*', '.ds-metrics-*', '.ds-traces'],
+          names: ['logs-*', 'metrics-*', 'traces-*', '.ds-logs-*', '.ds-metrics-*', '.ds-traces-*'],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -139,7 +139,16 @@ export async function setupFleet(
       cluster: ['monitor', 'manage_api_key'],
       indices: [
         {
-          names: ['logs-*', 'metrics-*', 'events-*', '.ds-logs-*', '.ds-metrics-*', '.ds-events-*'],
+          names: [
+            'logs-*',
+            'metrics-*',
+            'events-*',
+            'traces-*',
+            '.ds-logs-*',
+            '.ds-metrics-*',
+            '.ds-events-*',
+            '.ds-traces',
+          ],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -139,16 +139,7 @@ export async function setupFleet(
       cluster: ['monitor', 'manage_api_key'],
       indices: [
         {
-          names: [
-            'logs-*',
-            'metrics-*',
-            'events-*',
-            'traces-*',
-            '.ds-logs-*',
-            '.ds-metrics-*',
-            '.ds-events-*',
-            '.ds-traces',
-          ],
+          names: ['logs-*', 'metrics-*', 'traces-*', '.ds-logs-*', '.ds-metrics-*', '.ds-traces'],
           privileges: ['write', 'create_index', 'indices:admin/auto_create'],
         },
       ],

--- a/x-pack/test/fleet_api_integration/apis/agents_setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents_setup.ts
@@ -62,10 +62,10 @@ export default function (providerContext: FtrProviderContext) {
             names: [
               'logs-*',
               'metrics-*',
-              'events-*',
+              'traces-*',
               '.ds-logs-*',
               '.ds-metrics-*',
-              '.ds-events-*',
+              '.ds-traces-*',
             ],
             privileges: ['write', 'create_index', 'indices:admin/auto_create'],
             allow_restricted_indices: false,


### PR DESCRIPTION
This PR adds the additional APM data stream and template names to the permissions for the `fleet_enroll` role.

fixes #85761

## How to test this
1. Start up Kibana
2. Enroll an Elastic Agent and add the APM integration
3. Ingest some data, e.g. by sending [example events](https://www.elastic.co/guide/en/apm/server/7.10/example-intake-events.html) via curl (`curl -i -k -H "Content-type: application/x-ndjson" --data-binary @testdata.ndjson http://localhost:8200/intake/v2/events`)

cc @ruflin 