### PR TITLE
[APM] docs: update agent instructions

### DIFF
--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
@@ -388,7 +388,7 @@ secret_token: '${secretToken}'
 server_url: '${apmServerUrl || 'http://localhost:8200'}',
 
 # ${i18n.translate('apmOss.tutorial.rackClient.createConfig.commands.setServiceEnvironment', {
-      defaultMessage: 'Set the service environment (default: production)'
+      defaultMessage: 'Set the service environment (default: production)',
     })}
 environment: 'production'`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.rackClient.createConfig.textPost', {

--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
@@ -78,7 +78,7 @@ var apm = require('elastic-apm-node').start({curlyOpen}
   // ${i18n.translate(
     'apmOss.tutorial.nodeClient.configure.commands.setCustomServiceEnvironmentComment',
     {
-      defaultMessage: 'Set the service environment (default: production)',
+      defaultMessage: 'Set the service environment',
     }
   )}
   environment: 'production'
@@ -158,7 +158,7 @@ ELASTIC_APM = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.djangoClient.configure.commands.setServiceEnvironmentComment',
     {
-      defaultMessage: 'Set the service environment (default: production)',
+      defaultMessage: 'Set the service environment',
     }
   )}
   'ENVIRONMENT': 'production',
@@ -246,7 +246,7 @@ app.config['ELASTIC_APM'] = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.flaskClient.configure.commands.setServiceEnvironmentComment',
     {
-      defaultMessage: 'Set the service environment (default: production)',
+      defaultMessage: 'Set the service environment',
     }
   )}
   'ENVIRONMENT': 'production',
@@ -294,7 +294,7 @@ secret_token: '${secretToken}'
 # Set the custom APM Server URL (default: http://localhost:8200)
 server_url: '${apmServerUrl || 'http://localhost:8200'}'
 
-# Set the service environment (default: production)
+# Set the service environment
 environment: 'production'`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.railsClient.configure.textPost', {
       defaultMessage:
@@ -388,7 +388,7 @@ secret_token: '${secretToken}'
 server_url: '${apmServerUrl || 'http://localhost:8200'}',
 
 # ${i18n.translate('apmOss.tutorial.rackClient.createConfig.commands.setServiceEnvironment', {
-      defaultMessage: 'Set the service environment (default: production)',
+      defaultMessage: 'Set the service environment',
     })}
 environment: 'production'`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.rackClient.createConfig.textPost', {
@@ -458,7 +458,7 @@ var apm = initApm({curlyOpen}
   // ${i18n.translate(
     'apmOss.tutorial.jsClient.installDependency.commands.setServiceEnvironmentComment',
     {
-      defaultMessage: 'Set the service environment (default: production)',
+      defaultMessage: 'Set the service environment',
     }
   )}
   environment: 'production'
@@ -548,7 +548,7 @@ export ELASTIC_APM_SERVER_URL=${apmServerUrl}
 export ELASTIC_APM_SECRET_TOKEN=${secretToken}
 
 # ${i18n.translate('apmOss.tutorial.goClient.configure.commands.setServiceEnvironment', {
-      defaultMessage: 'Set the service environment (default: production)',
+      defaultMessage: 'Set the service environment',
     })}
 export ELASTIC_APM_ENVIRONMENT=
 `.split('\n'),
@@ -617,7 +617,7 @@ Do **not** add the agent as a dependency to your application.',
 * Set the required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)\n \
 * Set the custom APM Server URL (default: {customApmServerUrl})\n \
 * Set the APM Server secret token\n \
-* Set the service environment (default: production)\n \
+* Set the service environment\n \
 * Set the base package of your application',
       values: { customApmServerUrl: 'http://localhost:8200' },
     }),
@@ -697,7 +697,7 @@ export const createDotNetAgentInstructions = (apmServerUrl = '', secretToken = '
       apmServerUrl || 'http://localhost:8200'
     }", //Set custom APM Server URL (default: http://localhost:8200)
     "ServiceName": "MyApp", //allowed characters: a-z, A-Z, 0-9, -, _, and space. Default is the entry assembly of the application
-    "Environment": "production", // Set the service environment (default: production)
+    "Environment": "production", // Set the service environment
   {curlyClose}
 {curlyClose}`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.dotNetClient.configureAgent.textPost', {

--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
@@ -388,8 +388,8 @@ secret_token: '${secretToken}'
 server_url: '${apmServerUrl || 'http://localhost:8200'}',
 
 # ${i18n.translate('apmOss.tutorial.rackClient.createConfig.commands.setServiceEnvironment', {
-  defaultMessage: 'Set the service environment (default: production)'
-})}
+      defaultMessage: 'Set the service environment (default: production)'
+    })}
 environment: 'production'`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.rackClient.createConfig.textPost', {
       defaultMessage:
@@ -548,8 +548,8 @@ export ELASTIC_APM_SERVER_URL=${apmServerUrl}
 export ELASTIC_APM_SECRET_TOKEN=${secretToken}
 
 # ${i18n.translate('apmOss.tutorial.goClient.configure.commands.setServiceEnvironment', {
-  defaultMessage: 'Set the service environment (default: production)',
-})}
+      defaultMessage: 'Set the service environment (default: production)',
+    })}
 export ELASTIC_APM_ENVIRONMENT=
 `.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.goClient.configure.textPost', {
@@ -593,7 +593,7 @@ guide to instrumenting Go source code.',
   },
 ];
 
-export const createJavaAgentInstructions = (apmServerUrl = '', secretToken = '' ) => [
+export const createJavaAgentInstructions = (apmServerUrl = '', secretToken = '') => [
   {
     title: i18n.translate('apmOss.tutorial.javaClient.download.title', {
       defaultMessage: 'Download the APM agent',

--- a/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
+++ b/src/plugins/apm_oss/server/tutorial/instructions/apm_agent_instructions.ts
@@ -46,10 +46,11 @@ This agent supports a variety of frameworks but can also be used with your custo
       }
     )}
 var apm = require('elastic-apm-node').start({curlyOpen}
+
   // ${i18n.translate(
     'apmOss.tutorial.nodeClient.configure.commands.setRequiredServiceNameComment',
     {
-      defaultMessage: 'Override service name from package.json',
+      defaultMessage: 'Override the service name from package.json',
     }
   )}
   // ${i18n.translate('apmOss.tutorial.nodeClient.configure.commands.allowedCharactersComment', {
@@ -60,7 +61,7 @@ var apm = require('elastic-apm-node').start({curlyOpen}
   // ${i18n.translate(
     'apmOss.tutorial.nodeClient.configure.commands.useIfApmRequiresTokenComment',
     {
-      defaultMessage: 'Use if APM Server requires a token',
+      defaultMessage: 'Use if APM Server requires a secret token',
     }
   )}
   secretToken: '${secretToken}',
@@ -68,11 +69,19 @@ var apm = require('elastic-apm-node').start({curlyOpen}
   // ${i18n.translate(
     'apmOss.tutorial.nodeClient.configure.commands.setCustomApmServerUrlComment',
     {
-      defaultMessage: 'Set custom APM Server URL (default: {defaultApmServerUrl})',
+      defaultMessage: 'Set the custom APM Server URL (default: {defaultApmServerUrl})',
       values: { defaultApmServerUrl: 'http://localhost:8200' },
     }
   )}
-  serverUrl: '${apmServerUrl}'
+  serverUrl: '${apmServerUrl}',
+
+  // ${i18n.translate(
+    'apmOss.tutorial.nodeClient.configure.commands.setCustomServiceEnvironmentComment',
+    {
+      defaultMessage: 'Set the service environment (default: production)',
+    }
+  )}
+  environment: 'production'
 {curlyClose})`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.nodeClient.configure.textPost', {
       defaultMessage:
@@ -121,7 +130,7 @@ ELASTIC_APM = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.djangoClient.configure.commands.setRequiredServiceNameComment',
     {
-      defaultMessage: 'Set required service name. Allowed characters:',
+      defaultMessage: 'Set the required service name. Allowed characters:',
     }
   )}
   # ${i18n.translate('apmOss.tutorial.djangoClient.configure.commands.allowedCharactersComment', {
@@ -132,7 +141,7 @@ ELASTIC_APM = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.djangoClient.configure.commands.useIfApmServerRequiresTokenComment',
     {
-      defaultMessage: 'Use if APM Server requires a token',
+      defaultMessage: 'Use if APM Server requires a secret token',
     }
   )}
   'SECRET_TOKEN': '${secretToken}',
@@ -140,11 +149,19 @@ ELASTIC_APM = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.djangoClient.configure.commands.setCustomApmServerUrlComment',
     {
-      defaultMessage: 'Set custom APM Server URL (default: {defaultApmServerUrl})',
+      defaultMessage: 'Set the custom APM Server URL (default: {defaultApmServerUrl})',
       values: { defaultApmServerUrl: 'http://localhost:8200' },
     }
   )}
   'SERVER_URL': '${apmServerUrl}',
+
+  # ${i18n.translate(
+    'apmOss.tutorial.djangoClient.configure.commands.setServiceEnvironmentComment',
+    {
+      defaultMessage: 'Set the service environment (default: production)',
+    }
+  )}
+  'ENVIRONMENT': 'production',
 {curlyClose}
 
 # ${i18n.translate('apmOss.tutorial.djangoClient.configure.commands.addTracingMiddlewareComment', {
@@ -201,7 +218,7 @@ app.config['ELASTIC_APM'] = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.flaskClient.configure.commands.setRequiredServiceNameComment',
     {
-      defaultMessage: 'Set required service name. Allowed characters:',
+      defaultMessage: 'Set the required service name. Allowed characters:',
     }
   )}
   # ${i18n.translate('apmOss.tutorial.flaskClient.configure.commands.allowedCharactersComment', {
@@ -212,7 +229,7 @@ app.config['ELASTIC_APM'] = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.flaskClient.configure.commands.useIfApmServerRequiresTokenComment',
     {
-      defaultMessage: 'Use if APM Server requires a token',
+      defaultMessage: 'Use if APM Server requires a secret token',
     }
   )}
   'SECRET_TOKEN': '${secretToken}',
@@ -220,11 +237,19 @@ app.config['ELASTIC_APM'] = {curlyOpen}
   # ${i18n.translate(
     'apmOss.tutorial.flaskClient.configure.commands.setCustomApmServerUrlComment',
     {
-      defaultMessage: 'Set custom APM Server URL (default: {defaultApmServerUrl})',
+      defaultMessage: 'Set the custom APM Server URL (default: {defaultApmServerUrl})',
       values: { defaultApmServerUrl: 'http://localhost:8200' },
     }
   )}
   'SERVER_URL': '${apmServerUrl}',
+
+  # ${i18n.translate(
+    'apmOss.tutorial.flaskClient.configure.commands.setServiceEnvironmentComment',
+    {
+      defaultMessage: 'Set the service environment (default: production)',
+    }
+  )}
+  'ENVIRONMENT': 'production',
 {curlyClose}
 
 apm = ElasticAPM(app)`.split('\n'),
@@ -259,15 +284,18 @@ export const createRailsAgentInstructions = (apmServerUrl = '', secretToken = ''
     }),
     commands: `# config/elastic_apm.yml:
 
-# Set service name - allowed characters: a-z, A-Z, 0-9, -, _ and space
+# Set the service name - allowed characters: a-z, A-Z, 0-9, -, _ and space
 # Defaults to the name of your Rails app
-# service_name: 'my-service'
+service_name: 'my-service'
 
-# Use if APM Server requires a token
-# secret_token: '${secretToken}'
+# Use if APM Server requires a secret token
+secret_token: '${secretToken}'
 
-# Set custom APM Server URL (default: http://localhost:8200)
-# server_url: '${apmServerUrl || 'http://localhost:8200'}'`.split('\n'),
+# Set the custom APM Server URL (default: http://localhost:8200)
+server_url: '${apmServerUrl || 'http://localhost:8200'}'
+
+# Set the service environment (default: production)
+environment: 'production'`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.railsClient.configure.textPost', {
       defaultMessage:
         'See the [documentation]({documentationLink}) for configuration options and advanced usage.\n\n',
@@ -335,7 +363,7 @@ export const createRackAgentInstructions = (apmServerUrl = '', secretToken = '')
     commands: `# config/elastic_apm.yml:
 
 # ${i18n.translate('apmOss.tutorial.rackClient.createConfig.commands.setServiceNameComment', {
-      defaultMessage: 'Set service name - allowed characters: a-z, A-Z, 0-9, -, _ and space',
+      defaultMessage: 'Set the service name - allowed characters: a-z, A-Z, 0-9, -, _ and space',
     })}
 # ${i18n.translate(
       'apmOss.tutorial.rackClient.createConfig.commands.defaultsToTheNameOfRackAppClassComment',
@@ -343,7 +371,7 @@ export const createRackAgentInstructions = (apmServerUrl = '', secretToken = '')
         defaultMessage: "Defaults to the name of your Rack app's class.",
       }
     )}
-# service_name: 'my-service'
+service_name: 'my-service'
 
 # ${i18n.translate(
       'apmOss.tutorial.rackClient.createConfig.commands.useIfApmServerRequiresTokenComment',
@@ -351,13 +379,18 @@ export const createRackAgentInstructions = (apmServerUrl = '', secretToken = '')
         defaultMessage: 'Use if APM Server requires a token',
       }
     )}
-# secret_token: '${secretToken}'
+secret_token: '${secretToken}'
 
 # ${i18n.translate('apmOss.tutorial.rackClient.createConfig.commands.setCustomApmServerComment', {
       defaultMessage: 'Set custom APM Server URL (default: {defaultServerUrl})',
       values: { defaultServerUrl: 'http://localhost:8200' },
     })}
-# server_url: '${apmServerUrl || 'http://localhost:8200'}'`.split('\n'),
+server_url: '${apmServerUrl || 'http://localhost:8200'}',
+
+# ${i18n.translate('apmOss.tutorial.rackClient.createConfig.commands.setServiceEnvironment', {
+  defaultMessage: 'Set the service environment (default: production)'
+})}
+environment: 'production'`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.rackClient.createConfig.textPost', {
       defaultMessage:
         'See the [documentation]({documentationLink}) for configuration options and advanced usage.\n\n',
@@ -417,10 +450,18 @@ var apm = initApm({curlyOpen}
   // ${i18n.translate(
     'apmOss.tutorial.jsClient.installDependency.commands.setServiceVersionComment',
     {
-      defaultMessage: 'Set service version (required for source map feature)',
+      defaultMessage: 'Set the service version (required for source map feature)',
     }
   )}
-  serviceVersion: ''
+  serviceVersion: '',
+
+  // ${i18n.translate(
+    'apmOss.tutorial.jsClient.installDependency.commands.setServiceEnvironmentComment',
+    {
+      defaultMessage: 'Set the service environment (default: production)',
+    }
+  )}
+  environment: 'production'
 {curlyClose})`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.jsClient.installDependency.textPost', {
       defaultMessage:
@@ -502,9 +543,14 @@ export ELASTIC_APM_SERVICE_NAME=
 export ELASTIC_APM_SERVER_URL=${apmServerUrl}
 
 # ${i18n.translate('apmOss.tutorial.goClient.configure.commands.useIfApmRequiresTokenComment', {
-      defaultMessage: 'Use if APM Server requires a token',
+      defaultMessage: 'Use if APM Server requires a secret token',
     })}
 export ELASTIC_APM_SECRET_TOKEN=${secretToken}
+
+# ${i18n.translate('apmOss.tutorial.goClient.configure.commands.setServiceEnvironment', {
+  defaultMessage: 'Set the service environment (default: production)',
+})}
+export ELASTIC_APM_ENVIRONMENT=
 `.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.goClient.configure.textPost', {
       defaultMessage: 'See the [documentation]({documentationLink}) for advanced configuration.',
@@ -547,7 +593,7 @@ guide to instrumenting Go source code.',
   },
 ];
 
-export const createJavaAgentInstructions = (apmServerUrl = '', secretToken = '') => [
+export const createJavaAgentInstructions = (apmServerUrl = '', secretToken = '' ) => [
   {
     title: i18n.translate('apmOss.tutorial.javaClient.download.title', {
       defaultMessage: 'Download the APM agent',
@@ -568,8 +614,10 @@ Do **not** add the agent as a dependency to your application.',
     textPre: i18n.translate('apmOss.tutorial.javaClient.startApplication.textPre', {
       defaultMessage:
         'Add the `-javaagent` flag and configure the agent with system properties.\n\n \
-* Set required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)\n \
-* Set custom APM Server URL (default: {customApmServerUrl})\n \
+* Set the required service name (allowed characters: a-z, A-Z, 0-9, -, _, and space)\n \
+* Set the custom APM Server URL (default: {customApmServerUrl})\n \
+* Set the APM Server secret token\n \
+* Set the service environment (default: production)\n \
 * Set the base package of your application',
       values: { customApmServerUrl: 'http://localhost:8200' },
     }),
@@ -577,6 +625,7 @@ Do **not** add the agent as a dependency to your application.',
      -Delastic.apm.service_name=my-application \\
      -Delastic.apm.server_urls=${apmServerUrl || 'http://localhost:8200'} \\
      -Delastic.apm.secret_token=${secretToken} \\
+     -Delastic.apm.environment=production \\
      -Delastic.apm.application_packages=org.example \\
      -jar my-application.jar`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.javaClient.startApplication.textPost', {
@@ -647,7 +696,8 @@ export const createDotNetAgentInstructions = (apmServerUrl = '', secretToken = '
     "ServerUrls": "${
       apmServerUrl || 'http://localhost:8200'
     }", //Set custom APM Server URL (default: http://localhost:8200)
-    "ServiceName" : "MyApp", //allowed characters: a-z, A-Z, 0-9, -, _, and space. Default is the entry assembly of the application
+    "ServiceName": "MyApp", //allowed characters: a-z, A-Z, 0-9, -, _, and space. Default is the entry assembly of the application
+    "Environment": "production", // Set the service environment (default: production)
   {curlyClose}
 {curlyClose}`.split('\n'),
     textPost: i18n.translate('apmOss.tutorial.dotNetClient.configureAgent.textPost', {


### PR DESCRIPTION
## Summary

This PR updates the APM getting started tutorial snippets for each agent to include the service environment.

I also changed some words here and there to improve consistency between agent instructions.

<img width="1264" alt="Screen Shot 2020-12-14 at 12 09 26 PM" src="https://user-images.githubusercontent.com/5618806/102132951-2fa67d00-3e09-11eb-8b2e-5099150a8286.png">


## Related issues

Closes https://github.com/elastic/kibana/issues/77739.
