### PR TITLE
[Fleet] Fix agent details logs on safari

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -16,6 +16,7 @@ import {
   EuiPanel,
   EuiButtonEmpty,
 } from '@elastic/eui';
+import useMeasure from 'react-use/lib/useMeasure';
 import { FormattedMessage } from '@kbn/i18n/react';
 import semverGte from 'semver/functions/gte';
 import semverCoerce from 'semver/functions/coerce';
@@ -180,6 +181,8 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
     [http.basePath, state.start, state.end, logStreamQuery]
   );
 
+  const [logsPanelRef, { height: logPanelHeight }] = useMeasure();
+
   const agentVersion = agent.local_metadata?.elastic?.agent?.version;
   const isLogLevelSelectionAvailable = useMemo(() => {
     if (!agentVersion) {
@@ -259,9 +262,9 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiPanel paddingSize="none">
+        <EuiPanel paddingSize="none" panelRef={logsPanelRef}>
           <LogStream
-            height="100%"
+            height={logPanelHeight}
             startTimestamp={dateRangeTimestamps.start}
             endTimestamp={dateRangeTimestamps.end}
             query={logStreamQuery}


### PR DESCRIPTION
## Summary

Resolve #85838 

The agent logs panel was not correctly displayed on safari, this PR fix it, by settings an absolute value as the height of the `LogStream` component.

## Before


<img width="1860" alt="Screen Shot 2020-12-14 at 2 55 10 PM" src="https://user-images.githubusercontent.com/1336873/102143239-a9526100-3e31-11eb-818c-05feaaca05c1.png">

## After 

<img width="2106" alt="Screen Shot 2020-12-14 at 5 21 10 PM" src="https://user-images.githubusercontent.com/1336873/102143263-b3745f80-3e31-11eb-953d-85a74d7706d0.png">


## How to reproduce

Enroll an agent, go the details page then go to the log page on safari

Tested on safari, chrome and firefox.