### PR TITLE
[APM] Bug: Service overview - change the Traffic and Error rate chart legend labels to the current metric

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
@@ -66,9 +66,9 @@ export function ServiceOverviewThroughputChart({
             type: 'linemark',
             color: theme.eui.euiColorVis0,
             title: i18n.translate(
-              'xpack.apm.serviceOverview.throughputChart.currentPeriodLabel',
+              'xpack.apm.serviceOverview.throughputChart.traffic',
               {
-                defaultMessage: 'Current period',
+                defaultMessage: 'Traffic',
               }
             ),
           },

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -84,8 +84,8 @@ export function TransactionErrorRateChart({
             type: 'linemark',
             color: theme.eui.euiColorVis7,
             hideLegend: true,
-            title: i18n.translate('xpack.apm.errorRate.currentPeriodLabel', {
-              defaultMessage: 'Current period',
+            title: i18n.translate('xpack.apm.errorRate.chart.errorRate', {
+              defaultMessage: 'Error rate',
             }),
           },
         ]}

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -19,13 +19,6 @@ function yLabelFormat(y?: number | null) {
   return asPercent(y || 0, 1);
 }
 
-function yTickFormat(y?: number | null) {
-  return i18n.translate('xpack.apm.chart.averagePercentLabel', {
-    defaultMessage: '{y} (avg.)',
-    values: { y: yLabelFormat(y) },
-  });
-}
-
 interface Props {
   height?: number;
   showAnnotations?: boolean;
@@ -85,12 +78,11 @@ export function TransactionErrorRateChart({
             color: theme.eui.euiColorVis7,
             hideLegend: true,
             title: i18n.translate('xpack.apm.errorRate.chart.errorRate', {
-              defaultMessage: 'Error rate',
+              defaultMessage: 'Error rate (avg.)',
             }),
           },
         ]}
         yLabelFormat={yLabelFormat}
-        yTickFormat={yTickFormat}
         yDomain={{ min: 0, max: 1 }}
       />
     </EuiPanel>


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/85918

<img width="680" alt="Screenshot 2020-12-15 at 11 25 12" src="https://user-images.githubusercontent.com/55978943/102203351-c423e480-3ec8-11eb-8f1a-dc80378a1348.png">
