### PR TITLE
[APM] Tooltip values for "Average duration by span type" should be rounded

### DIFF
--- a/x-pack/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/lib/transactions/__snapshots__/queries.test.ts.snap
@@ -160,6 +160,13 @@ Object {
             },
           },
           Object {
+            "range": Object {
+              "span.self_time.sum.us": Object {
+                "gte": 0,
+              },
+            },
+          },
+          Object {
             "term": Object {
               "service.environment": "test",
             },
@@ -290,6 +297,13 @@ Object {
                 "format": "epoch_millis",
                 "gte": 1528113600000,
                 "lte": 1528977600000,
+              },
+            },
+          },
+          Object {
+            "range": Object {
+              "span.self_time.sum.us": Object {
+                "gte": 0,
               },
             },
           },

--- a/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -80,6 +80,7 @@ export async function getTransactionBreakdown({
     { term: { [SERVICE_NAME]: serviceName } },
     { term: { [TRANSACTION_TYPE]: transactionType } },
     { range: rangeFilter(start, end) },
+    { range: { [SPAN_SELF_TIME_SUM]: { gte: 0 } } },
     ...esFilter,
   ];
 
@@ -126,17 +127,11 @@ export async function getTransactionBreakdown({
         const type = bucket.key as string;
 
         return bucket.subtypes.buckets.map((subBucket) => {
-          const totalSelfTimePerSubtype =
-            subBucket.total_self_time_per_subtype.value || 0;
-
-          const percentage =
-            sumAllSelfTimes < 0 || totalSelfTimePerSubtype < 0
-              ? 0
-              : totalSelfTimePerSubtype / sumAllSelfTimes;
-
           return {
             name: (subBucket.key as string) || type,
-            percentage,
+            percentage:
+              (subBucket.total_self_time_per_subtype.value || 0) /
+              sumAllSelfTimes,
           };
         });
       })

--- a/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/breakdown/index.ts
@@ -126,11 +126,17 @@ export async function getTransactionBreakdown({
         const type = bucket.key as string;
 
         return bucket.subtypes.buckets.map((subBucket) => {
+          const totalSelfTimePerSubtype =
+            subBucket.total_self_time_per_subtype.value || 0;
+
+          const percentage =
+            sumAllSelfTimes < 0 || totalSelfTimePerSubtype < 0
+              ? 0
+              : totalSelfTimePerSubtype / sumAllSelfTimes;
+
           return {
             name: (subBucket.key as string) || type,
-            percentage:
-              (subBucket.total_self_time_per_subtype.value || 0) /
-              sumAllSelfTimes,
+            percentage,
           };
         });
       })


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/84766

Before:
<img width="636" alt="Screenshot 2020-12-16 at 12 25 17" src="https://user-images.githubusercontent.com/55978943/102342626-d15cd400-3f99-11eb-8a9d-2241e16b5390.png">

After:
<img width="631" alt="Screenshot 2020-12-16 at 12 25 27" src="https://user-images.githubusercontent.com/55978943/102342648-d588f180-3f99-11eb-899c-61aa30b6454c.png">

I talked to @jahtalab and he said it might be a bug in the Browser or Agent, he suggested that I should remove documents that contain the field `span.self_time.sum.us` lower than `0`. A new bug was created https://github.com/elastic/apm-agent-rum-js/issues/947