### PR TITLE
[Lens] add typeToAgg for median

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
@@ -28,6 +28,7 @@ const typeToFn: Record<string, string> = {
   max: 'aggMax',
   avg: 'aggAvg',
   sum: 'aggSum',
+  median: 'aggMedian',
 };
 
 function buildMetricOperation<T extends MetricColumn<string>>({

--- a/x-pack/test/functional/apps/lens/smokescreen.ts
+++ b/x-pack/test/functional/apps/lens/smokescreen.ts
@@ -130,7 +130,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.lens.configureDimension(
         {
           dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
-          operation: 'avg',
+          operation: 'median',
           field: 'bytes',
         },
         1


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/85972 – bug was caused by an oversight from https://github.com/elastic/kibana/pull/84973

I modified one of the functional tests to configure median operation instead of configuring average,  so we can know the lens editor was configured without errors  – we test average in many places so I think it's a safe change.

