### PR TITLE
Update index.tsx to note use can go to docs for DEB/RPM Agent deploy instructions

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/enrollment_instructions/manual/index.tsx
@@ -72,7 +72,7 @@ export const ManualInstructions: React.FunctionComponent<Props> = ({
       <EuiText>
         <FormattedMessage
           id="xpack.fleet.enrollmentInstructions.moreInstructionsText"
-          defaultMessage="See the {link} for more instructions and options."
+          defaultMessage="See the {link} for RPM / DEB deploy instructions."
           values={{
             link: (
               <EuiLink


### PR DESCRIPTION
## Summary

I'm proposing a modification to the text link to the on-line Elastic docs to help better call out the need to use different instructions for DEB or RPM usage.  It was brought up in https://github.com/elastic/kibana/issues/85954

screenshot
![Screen Shot 2020-12-16 at 10 49 15 AM](https://user-images.githubusercontent.com/12970373/102372714-7d4bf280-3f8d-11eb-9889-f220bd9a5683.png)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
