### PR TITLE
Fixes for service overview layout

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -4,8 +4,15 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiPage, EuiPanel } from '@elastic/eui';
-import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPage,
+  EuiPanel,
+  isWithinMaxBreakpoint,
+} from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import useWindowSize from 'react-use/lib/useWindowSize';
 import { useTrackPageview } from '../../../../../observability/public';
 import { isRumAgentName } from '../../../../common/agent_name';
 import { AnnotationsContextProvider } from '../../../context/annotations/annotations_context';
@@ -19,12 +26,13 @@ import { ServiceOverviewErrorsTable } from './service_overview_errors_table';
 import { ServiceOverviewInstancesTable } from './service_overview_instances_table';
 import { ServiceOverviewThroughputChart } from './service_overview_throughput_chart';
 import { ServiceOverviewTransactionsTable } from './service_overview_transactions_table';
+import { useShouldUseMobileLayout } from './use_should_use_mobile_layout';
 
 /**
  * The height a chart should be if it's next to a table with 5 rows and a title.
  * Add the height of the pagination row.
  */
-export const chartHeight = 322;
+export const chartHeight = 288;
 
 interface ServiceOverviewProps {
   agentName?: string;
@@ -38,6 +46,11 @@ export function ServiceOverview({
   useTrackPageview({ app: 'apm', path: 'service_overview' });
   useTrackPageview({ app: 'apm', path: 'service_overview', delay: 15000 });
 
+  // The default EuiFlexGroup breaks at 768, but we want to break at 992, so we
+  // observe the window width and set the flex directions of rows accordingly
+  const shouldUseMobileLayout = useShouldUseMobileLayout();
+  const rowDirection = shouldUseMobileLayout ? 'column' : 'row';
+
   return (
     <AnnotationsContextProvider>
       <ChartPointerEventContextProvider>
@@ -50,11 +63,15 @@ export function ServiceOverview({
               </EuiPanel>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFlexGroup gutterSize="s">
-                <EuiFlexItem grow={4}>
+              <EuiFlexGroup
+                direction={rowDirection}
+                gutterSize="s"
+                responsive={false}
+              >
+                <EuiFlexItem grow={3}>
                   <ServiceOverviewThroughputChart height={chartHeight} />
                 </EuiFlexItem>
-                <EuiFlexItem grow={6}>
+                <EuiFlexItem grow={7}>
                   <EuiPanel>
                     <ServiceOverviewTransactionsTable
                       serviceName={serviceName}
@@ -64,16 +81,20 @@ export function ServiceOverview({
               </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFlexGroup gutterSize="s">
+              <EuiFlexGroup
+                direction={rowDirection}
+                gutterSize="s"
+                responsive={false}
+              >
                 {!isRumAgentName(agentName) && (
-                  <EuiFlexItem grow={4}>
+                  <EuiFlexItem grow={3}>
                     <TransactionErrorRateChart
                       height={chartHeight}
                       showAnnotations={false}
                     />
                   </EuiFlexItem>
                 )}
-                <EuiFlexItem grow={6}>
+                <EuiFlexItem grow={7}>
                   <EuiPanel>
                     <ServiceOverviewErrorsTable serviceName={serviceName} />
                   </EuiPanel>
@@ -81,11 +102,15 @@ export function ServiceOverview({
               </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFlexGroup gutterSize="s">
-                <EuiFlexItem grow={4}>
+              <EuiFlexGroup
+                direction={rowDirection}
+                gutterSize="s"
+                responsive={false}
+              >
+                <EuiFlexItem grow={3}>
                   <TransactionBreakdownChart showAnnotations={false} />
                 </EuiFlexItem>
-                <EuiFlexItem grow={6}>
+                <EuiFlexItem grow={7}>
                   <EuiPanel>
                     <ServiceOverviewDependenciesTable
                       serviceName={serviceName}

--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -4,15 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPage,
-  EuiPanel,
-  isWithinMaxBreakpoint,
-} from '@elastic/eui';
-import React, { useEffect, useState } from 'react';
-import useWindowSize from 'react-use/lib/useWindowSize';
+import { EuiFlexGroup, EuiFlexItem, EuiPage, EuiPanel } from '@elastic/eui';
+import React from 'react';
 import { useTrackPageview } from '../../../../../observability/public';
 import { isRumAgentName } from '../../../../common/agent_name';
 import { AnnotationsContextProvider } from '../../../context/annotations/annotations_context';

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_dependencies_table/index.tsx
@@ -53,7 +53,7 @@ export function ServiceOverviewDependenciesTable({ serviceName }: Props) {
           <TruncateWithTooltip
             text={item.name}
             content={
-              <EuiFlexGroup gutterSize="s">
+              <EuiFlexGroup gutterSize="s" responsive={false}>
                 <EuiFlexItem grow={false}>
                   {item.type === 'service' ? (
                     <AgentIcon agentName={item.agentName} />
@@ -190,9 +190,9 @@ export function ServiceOverviewDependenciesTable({ serviceName }: Props) {
   }));
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
-        <EuiFlexGroup>
+        <EuiFlexGroup responsive={false}>
           <EuiFlexItem>
             <EuiTitle size="xs">
               <h2>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_errors_table/index.tsx
@@ -4,26 +4,25 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import {
+  EuiBasicTable,
   EuiBasicTableColumn,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
-  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
-import styled from 'styled-components';
-import { EuiBasicTable } from '@elastic/eui';
 import { asInteger } from '../../../../../common/utils/formatters';
-import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
 import { callApmApi } from '../../../../services/rest/createCallApmApi';
-import { px, truncate, unit } from '../../../../style/variables';
+import { px, unit } from '../../../../style/variables';
 import { SparkPlot } from '../../../shared/charts/spark_plot';
 import { ErrorDetailLink } from '../../../shared/Links/apm/ErrorDetailLink';
 import { ErrorOverviewLink } from '../../../shared/Links/apm/ErrorOverviewLink';
 import { TableFetchWrapper } from '../../../shared/table_fetch_wrapper';
 import { TimestampTooltip } from '../../../shared/TimestampTooltip';
+import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { ServiceOverviewTableContainer } from '../service_overview_table_container';
 import { TableLinkFlexItem } from '../table_link_flex_item';
 
@@ -50,18 +49,6 @@ const DEFAULT_SORT = {
   field: 'occurrences' as const,
 };
 
-const ErrorDetailLinkWrapper = styled.div`
-  width: 100%;
-  .euiToolTipAnchor {
-    width: 100% !important;
-  }
-`;
-
-const StyledErrorDetailLink = styled(ErrorDetailLink)`
-  display: block;
-  ${truncate('100%')}
-`;
-
 export function ServiceOverviewErrorsTable({ serviceName }: Props) {
   const {
     urlParams: { start, end },
@@ -87,16 +74,17 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
       }),
       render: (_, { name, group_id: errorGroupId }) => {
         return (
-          <ErrorDetailLinkWrapper>
-            <EuiToolTip delay="long" content={name}>
-              <StyledErrorDetailLink
+          <TruncateWithTooltip
+            text={name}
+            content={
+              <ErrorDetailLink
                 serviceName={serviceName}
                 errorGroupId={errorGroupId}
               >
                 {name}
-              </StyledErrorDetailLink>
-            </EuiToolTip>
-          </ErrorDetailLinkWrapper>
+              </ErrorDetailLink>
+            }
+          />
         );
       },
     },
@@ -202,9 +190,9 @@ export function ServiceOverviewErrorsTable({ serviceName }: Props) {
   } = data;
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
-        <EuiFlexGroup>
+        <EuiFlexGroup responsive={false}>
           <EuiFlexItem>
             <EuiTitle size="xs">
               <h2>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_instances_table/index.tsx
@@ -236,7 +236,7 @@ export function ServiceOverviewInstancesTable({ serviceName }: Props) {
     status === FETCH_STATUS.LOADING || status === FETCH_STATUS.PENDING;
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
         <EuiTitle size="xs">
           <h2>

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_table_container.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_table_container.tsx
@@ -4,24 +4,33 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
+import { useShouldUseMobileLayout } from './use_should_use_mobile_layout';
 
 /**
  * The height for a table on the overview page. Is the height of a 5-row basic
  * table.
  */
-const tableHeight = 298;
+const tableHeight = 282;
 
 /**
  * A container for the table. Sets height and flex properties on the EUI Basic
  * Table contained within and the first child div of that. This makes it so the
  * pagination controls always stay fixed at the bottom in the same position.
  *
+ * Only do this when we're at a non-mobile breakpoint.
+ *
  * Hide the empty message when we don't yet have any items and are still loading.
  */
-export const ServiceOverviewTableContainer = styled.div<{
+const ServiceOverviewTableContainerDiv = styled.div<{
   isEmptyAndLoading: boolean;
+  shouldUseMobileLayout: boolean;
 }>`
+  ${({ shouldUseMobileLayout }) =>
+    shouldUseMobileLayout
+      ? ''
+      : `
   height: ${tableHeight}px;
   display: flex;
   flex-direction: column;
@@ -34,10 +43,29 @@ export const ServiceOverviewTableContainer = styled.div<{
     > :first-child {
       flex-grow: 1;
     }
-  }
+  `}
 
   .euiTableRowCell {
     visibility: ${({ isEmptyAndLoading }) =>
       isEmptyAndLoading ? 'hidden' : 'visible'};
   }
 `;
+
+export function ServiceOverviewTableContainer({
+  children,
+  isEmptyAndLoading,
+}: {
+  children?: ReactNode;
+  isEmptyAndLoading: boolean;
+}) {
+  const shouldUseMobileLayout = useShouldUseMobileLayout();
+
+  return (
+    <ServiceOverviewTableContainerDiv
+      isEmptyAndLoading={isEmptyAndLoading}
+      shouldUseMobileLayout={shouldUseMobileLayout}
+    >
+      {children}
+    </ServiceOverviewTableContainerDiv>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_transactions_table/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import {
+  EuiBasicTable,
   EuiBasicTableColumn,
   EuiFlexGroup,
   EuiFlexItem,
@@ -12,31 +13,29 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
-import styled from 'styled-components';
-import { EuiToolTip } from '@elastic/eui';
 import { ValuesType } from 'utility-types';
-import { EuiBasicTable } from '@elastic/eui';
-import { useLatencyAggregationType } from '../../../../hooks/use_latency_Aggregation_type';
 import { LatencyAggregationType } from '../../../../../common/latency_aggregation_types';
 import {
   asDuration,
   asPercent,
   asTransactionRate,
 } from '../../../../../common/utils/formatters';
-import { px, truncate, unit } from '../../../../style/variables';
-import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
+import { useLatencyAggregationType } from '../../../../hooks/use_latency_Aggregation_type';
 import {
   APIReturnType,
   callApmApi,
 } from '../../../../services/rest/createCallApmApi';
+import { px, unit } from '../../../../style/variables';
+import { SparkPlot } from '../../../shared/charts/spark_plot';
+import { ImpactBar } from '../../../shared/ImpactBar';
 import { TransactionDetailLink } from '../../../shared/Links/apm/TransactionDetailLink';
 import { TransactionOverviewLink } from '../../../shared/Links/apm/TransactionOverviewLink';
 import { TableFetchWrapper } from '../../../shared/table_fetch_wrapper';
-import { TableLinkFlexItem } from '../table_link_flex_item';
-import { SparkPlot } from '../../../shared/charts/spark_plot';
-import { ImpactBar } from '../../../shared/ImpactBar';
+import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { ServiceOverviewTableContainer } from '../service_overview_table_container';
+import { TableLinkFlexItem } from '../table_link_flex_item';
 
 type ServiceTransactionGroupItem = ValuesType<
   APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups/overview'>['transactionGroups']
@@ -54,18 +53,6 @@ const DEFAULT_SORT = {
   direction: 'desc' as const,
   field: 'impact' as const,
 };
-
-const TransactionGroupLinkWrapper = styled.div`
-  width: 100%;
-  .euiToolTipAnchor {
-    width: 100% !important;
-  }
-`;
-
-const StyledTransactionDetailLink = styled(TransactionDetailLink)`
-  display: block;
-  ${truncate('100%')}
-`;
 
 function getLatencyAggregationTypeLabel(
   latencyAggregationType?: LatencyAggregationType
@@ -189,17 +176,18 @@ export function ServiceOverviewTransactionsTable({ serviceName }: Props) {
       ),
       render: (_, { name, transactionType }) => {
         return (
-          <TransactionGroupLinkWrapper>
-            <EuiToolTip delay="long" content={name}>
-              <StyledTransactionDetailLink
+          <TruncateWithTooltip
+            text={name}
+            content={
+              <TransactionDetailLink
                 serviceName={serviceName}
                 transactionName={name}
                 transactionType={transactionType}
               >
                 {name}
-              </StyledTransactionDetailLink>
-            </EuiToolTip>
-          </TransactionGroupLinkWrapper>
+              </TransactionDetailLink>
+            }
+          />
         );
       },
     },
@@ -274,9 +262,9 @@ export function ServiceOverviewTransactionsTable({ serviceName }: Props) {
   ];
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
-        <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>
           <EuiFlexItem>
             <EuiTitle size="xs">
               <h2>

--- a/x-pack/plugins/apm/public/components/app/service_overview/use_should_use_mobile_layout.ts
+++ b/x-pack/plugins/apm/public/components/app/service_overview/use_should_use_mobile_layout.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { isWithinMaxBreakpoint } from '@elastic/eui';
+import { useEffect, useState } from 'react';
+
+export function useShouldUseMobileLayout() {
+  const [shouldUseMobileLayout, setShouldUseMobileLayout] = useState(
+    isWithinMaxBreakpoint(window.innerWidth, 'm')
+  );
+
+  useEffect(() => {
+    const resizeHandler = () => {
+      setShouldUseMobileLayout(isWithinMaxBreakpoint(window.innerWidth, 'm'));
+    };
+    window.addEventListener('resize', resizeHandler);
+
+    return () => {
+      window.removeEventListener('resize', resizeHandler);
+    };
+  });
+
+  return shouldUseMobileLayout;
+}

--- a/x-pack/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
@@ -48,11 +48,11 @@ export function LatencyChart({ height }: Props) {
   const latencyFormatter = getDurationFormatter(latencyMaxY);
 
   return (
-    <EuiFlexGroup direction="column">
+    <EuiFlexGroup direction="column" gutterSize="s">
       <EuiFlexItem>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem>
-            <EuiFlexGroup alignItems="center">
+            <EuiFlexGroup alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiTitle size="xs">
                   <h2>

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -58,7 +58,7 @@ export function SparkPlot({
   const colorValue = theme.eui[color];
 
   return (
-    <EuiFlexGroup gutterSize="m">
+    <EuiFlexGroup gutterSize="m" responsive={false}>
       <EuiFlexItem grow={false}>
         {!series || series.every((point) => point.y === null) ? (
           <EuiIcon type="visLine" color="subdued" />


### PR DESCRIPTION
* Use 3/7 instead of 4/6 for `grow` between charts/tables
* Decrease chart height
* Use "s" gutterSize on tables
* Decrease table height
* Use `TruncateWithToolTip` on errors and transactions tables to remove tooltip inline-block style
* Use `responsive={false}` on dependency titles so icon/name pairs don't wrap
* Use `responsive={false}` on spark plots so plot/value pairs don't wrap
* Use `responsive={false}` on latency chart and table titles so controls and links don't wrap
* Make the fixed sizing overrides for the tables only be applied when we're using a wide, non-mobile (> 992) viewport
* Switch to "mobile" viewport (with one item per row) at 992 instead of 768

Since you cannot control the breakpoints at which EUI switches to "responsive" mode, we trigger these manually to change the number of columns. and whether or not the tables use a fixed height.

The overview now has three "modes":

# Large (> 992px)

* Two columns for chart/table rows
* Tables in non-responsive mode

![image](https://user-images.githubusercontent.com/9912/102416373-51e1fb80-3fbf-11eb-811c-91d6a19ce2f0.png)

# Medium (> 768px, < 992px)

* One column for charts/tables
* Tables in non-responsive mode

![image](https://user-images.githubusercontent.com/9912/102416389-5ad2cd00-3fbf-11eb-8710-94e8280a754a.png)

# Small (< 768px)

* One column for charts/tables
* Tables in responsive mode

![image](https://user-images.githubusercontent.com/9912/102416419-6625f880-3fbf-11eb-854d-7b1b67f1bf9a.png)

Fixes #85781.
