### PR TITLE
[APM] Adds config option xpack.apm.maxServiceSelection

### DIFF
--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -44,6 +44,7 @@ export const config = {
     telemetryCollectionEnabled: schema.boolean({ defaultValue: true }),
     metricsInterval: schema.number({ defaultValue: 30 }),
     maxServiceEnvironments: schema.number({ defaultValue: 100 }),
+    maxServiceSelection: schema.number({ defaultValue: 50 }),
   }),
 };
 
@@ -76,6 +77,7 @@ export function mergeConfigs(
       apmConfig.serviceMapMaxTracesPerRequest,
     'xpack.apm.ui.enabled': apmConfig.ui.enabled,
     'xpack.apm.maxServiceEnvironments': apmConfig.maxServiceEnvironments,
+    'xpack.apm.maxServiceSelection': apmConfig.maxServiceSelection,
     'xpack.apm.ui.maxTraceItems': apmConfig.ui.maxTraceItems,
     'xpack.apm.ui.transactionGroupBucketSize':
       apmConfig.ui.transactionGroupBucketSize,

--- a/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
+++ b/x-pack/plugins/apm/server/lib/settings/agent_configuration/get_service_names.ts
@@ -21,7 +21,8 @@ export async function getServiceNames({
   setup: Setup;
   searchAggregatedTransactions: boolean;
 }) {
-  const { apmEventClient } = setup;
+  const { apmEventClient, config } = setup;
+  const maxServiceSelection = config['xpack.apm.maxServiceSelection'];
 
   const params = {
     apm: {
@@ -40,7 +41,7 @@ export async function getServiceNames({
         services: {
           terms: {
             field: SERVICE_NAME,
-            size: 50,
+            size: maxServiceSelection,
             min_doc_count: 0,
           },
         },

--- a/x-pack/plugins/apm/server/utils/test_helpers.tsx
+++ b/x-pack/plugins/apm/server/utils/test_helpers.tsx
@@ -79,6 +79,9 @@ export async function inspectSearchParams(
 
             case 'xpack.apm.maxServiceEnvironments':
               return 100;
+
+            case 'xpack.apm.maxServiceSelection':
+              return 50;
           }
         },
       }


### PR DESCRIPTION
Closes #84094 by adding configuration `xpack.apm.maxServiceSelection` to control max number of services visible when creating new agent configurations.