### PR TITLE
[Fleet] Rename Fleet Integration Detail "Custom" tab to "Advanced"

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/epm/screens/detail/index.tsx
@@ -63,7 +63,7 @@ const PanelDisplayNames: Record<DetailViewPanelName, string> = {
     defaultMessage: 'Settings',
   }),
   custom: i18n.translate('xpack.fleet.epm.packageDetailsNav.packageCustomLinkText', {
-    defaultMessage: 'Custom',
+    defaultMessage: 'Advanced',
   }),
 };
 


### PR DESCRIPTION
## Summary

Rename the "Custom" tab _(only shown when a custom UI extension is registered in fleet)_ under Integrations > integration detail to "Advanced"

![image](https://user-images.githubusercontent.com/56442535/102533859-f1f95c80-4073-11eb-9581-45df6ed2e797.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
