### PR TITLE
[Lens] fix transition date_histogram/last_value -> top values/last_value

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -90,7 +90,8 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
   buildColumn({ layer, field, indexPattern }) {
     const existingMetricColumn = Object.entries(layer.columns)
       .filter(
-        ([columnId, column]) => column && !column.isBucketed && !isReferenced(layer, columnId)
+        ([columnId, column]) =>
+          column && !isReferenced(layer, columnId) && isSortableByColumn(column)
       )
       .map(([id]) => id)[0];
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -341,11 +341,14 @@ describe('terms', () => {
         layer: {
           columns: {
             col1: {
-              label: 'Last value',
+              label: 'Last value of a',
               dataType: 'number',
               isBucketed: false,
-              sourceField: 'source',
+              sourceField: 'a',
               operationType: 'last_value',
+              params: {
+                sortField: 'datefield',
+              },
             },
           },
           columnOrder: [],

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -305,7 +305,7 @@ describe('terms', () => {
       expect(termsColumn.params.otherBucket).toEqual(false);
     });
 
-    it('should use existing metric column as order column', () => {
+    it('should use existing sortable metric column as order column', () => {
       const termsColumn = termsOperation.buildColumn({
         indexPattern: createMockedIndexPattern(),
         layer: {
@@ -333,6 +333,34 @@ describe('terms', () => {
         expect.objectContaining({
           orderBy: { type: 'column', columnId: 'col1' },
         })
+      );
+    });
+    it('should set alphabetical order type if metric column is of type last value', () => {
+      const termsColumn = termsOperation.buildColumn({
+        indexPattern: createMockedIndexPattern(),
+        layer: {
+          columns: {
+            col1: {
+              label: 'Last value',
+              dataType: 'number',
+              isBucketed: false,
+              sourceField: 'source',
+              operationType: 'last_value',
+            },
+          },
+          columnOrder: [],
+          indexPatternId: '',
+        },
+        field: {
+          aggregatable: true,
+          searchable: true,
+          type: 'boolean',
+          name: 'test',
+          displayName: 'test',
+        },
+      });
+      expect(termsColumn.params).toEqual(
+        expect.objectContaining({ orderBy: { type: 'alphabetical' } })
       );
     });
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/86424

The bug was caused because top values column wanted to order by last_value column which is not possible. While implementing it I checked this condition for changing other column (so eg. average to last value), but didn't check the switching field in the bucket operation (date_histogram->top_values). 
