### PR TITLE
[coverage] Improve stability and report stats

### DIFF
--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -111,7 +111,7 @@ module.exports = {
   // An array of regexp pattern strings that are matched against all source file paths, matched files to include/exclude for code coverage
   collectCoverageFrom: [
     '**/*.{js,mjs,jsx,ts,tsx}',
-    '!**/{__test__,__snapshots__,__examples__,mocks,tests,test_helpers,integration_tests,types}/**/*',
+    '!**/{__test__,__snapshots__,__examples__,*mock*,tests,test_helpers,integration_tests,types}/**/*',
     '!**/*mock*.ts',
     '!**/*.test.ts',
     '!**/*.d.ts',

--- a/src/dev/code_coverage/nyc_config/nyc.functional.config.js
+++ b/src/dev/code_coverage/nyc_config/nyc.functional.config.js
@@ -18,7 +18,7 @@
  */
 
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
-const extraExclude = ['data/optimize/**', 'src/core/server/**', '**/test/**'];
+const extraExclude = ['data/optimize/**', 'src/core/server/**', '**/{test, types}/**/*'];
 const path = require('path');
 
 module.exports = {

--- a/test/scripts/jenkins_unit.sh
+++ b/test/scripts/jenkins_unit.sh
@@ -35,7 +35,7 @@ if [[ -z "$CODE_COVERAGE" ]] ; then
   ./test/scripts/checks/test_hardening.sh
 else
   echo " -> Running jest tests with coverage"
-  node scripts/jest --ci --verbose --coverage --config jest.config.oss.js
+  node scripts/jest --ci --verbose --coverage --config jest.config.oss.js || true;
   rename_coverage_file "oss"
   echo ""
   echo ""

--- a/test/scripts/jenkins_xpack.sh
+++ b/test/scripts/jenkins_xpack.sh
@@ -13,7 +13,7 @@ else
   node ./x-pack/plugins/canvas/scripts/shareable_runtime
   echo " -> Running jest tests with coverage"
   cd x-pack
-  node --max-old-space-size=6144 scripts/jest --ci --verbose --maxWorkers=5 --coverage --config jest.config.js
+  node --max-old-space-size=6144 scripts/jest --ci --verbose --maxWorkers=5 --coverage --config jest.config.js || true;
   # rename file in order to be unique one
   test -f ../target/kibana-coverage/jest/coverage-final.json \
     && mv ../target/kibana-coverage/jest/coverage-final.json \


### PR DESCRIPTION
## Summary

This PR fixes 2 minor issues with code coverage:

1. When any test fails,[ jest process exits with error code](https://kibana-ci.elastic.co/job/elastic+kibana+code-coverage/1416/testReport/junit/Jest%20Tests/x-pack_plugins_security_solution_public_management_pages_endpoint_hosts_view/Kibana_Pipeline___x_pack_intake_agent___when_on_the_list_page_when_there_is_no_selected_host_in_the_url_when_list_data_loads_should_display_correct_status/) and pipeline step is marked red,  in the end we do not ingest coverage for run at all.
Fix: It is really difficult to control stability of thousands jest tests that we have. By adding `|| true` jest process will always exit with 0 code, but coverage will be ingested since jest report is generated even when tests fail. As for flaky tests, we still see them in Jenkins report.
2. Coverage report contains path like `mock`, `mock_responses`, etc that used by tests only and reasonably have 0% coverage.
Fix: Adjust patterns in jest config, `collectCoverageFrom` property.

Tested: https://kibana-ci.elastic.co/job/elastic+kibana+qa-research/161/

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
