### PR TITLE
[Workplace Search] Refactor AddSource component state and add tests

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../../../__mocks__/kea.mock';
+import '../../../../../__mocks__/shallow_useeffect.mock';
+
+import { setMockActions, setMockValues } from '../../../../../__mocks__';
+import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
+
+jest.mock('../../../../../shared/kibana', () => ({
+  KibanaLogic: { values: { navigateToUrl: jest.fn() } },
+}));
+import { KibanaLogic } from '../../../../../shared/kibana';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Loading } from '../../../../../shared/loading';
+
+import { AddSource } from './add_source';
+import { AddSourceSteps } from './add_source_logic';
+import { ConfigCompleted } from './config_completed';
+import { ConfigurationIntro } from './configuration_intro';
+import { ConfigureCustom } from './configure_custom';
+import { ConfigureOauth } from './configure_oauth';
+import { ConnectInstance } from './connect_instance';
+import { ReAuthenticate } from './re_authenticate';
+import { SaveConfig } from './save_config';
+import { SaveCustom } from './save_custom';
+
+describe('AddSourceList', () => {
+  const initializeAddSource = jest.fn();
+  const setAddSourceStep = jest.fn();
+  const saveSourceConfig = jest.fn((_, setConfigCompletedStep) => {
+    setConfigCompletedStep();
+  });
+  const createContentSource = jest.fn((_, formSubmitSuccess) => {
+    formSubmitSuccess();
+  });
+  const resetSourcesState = jest.fn();
+
+  const mockValues = {
+    addSourceCurrentStep: AddSourceSteps.ConfigIntroStep,
+    sourceConfigData,
+    dataLoading: false,
+    newCustomSource: {},
+    isOrganization: true,
+  };
+
+  beforeEach(() => {
+    setMockActions({
+      initializeAddSource,
+      setAddSourceStep,
+      saveSourceConfig,
+      createContentSource,
+      resetSourcesState,
+    });
+    setMockValues(mockValues);
+  });
+
+  it('renders default state', () => {
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+    wrapper.find(ConfigurationIntro).prop('advanceStep')();
+
+    expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.SaveConfigStep);
+  });
+
+  it('handles loading state', () => {
+    setMockValues({ ...mockValues, dataLoading: true });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+
+    expect(wrapper.find(Loading)).toHaveLength(1);
+  });
+
+  it('renders Config Completed step', () => {
+    setMockValues({
+      ...mockValues,
+      addSourceCurrentStep: AddSourceSteps.ConfigCompletedStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+    wrapper.find(ConfigCompleted).prop('advanceStep')();
+
+    expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(
+      '/sources/add/confluence_cloud/connect'
+    );
+    expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.ConnectInstanceStep);
+  });
+
+  it('renders Save Config step', () => {
+    setMockValues({
+      ...mockValues,
+      addSourceCurrentStep: AddSourceSteps.SaveConfigStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+    const saveConfig = wrapper.find(SaveConfig);
+    saveConfig.prop('advanceStep')();
+    saveConfig.prop('goBackStep')!();
+
+    expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.ConfigIntroStep);
+    expect(saveSourceConfig).toHaveBeenCalled();
+  });
+
+  it('renders Connect Instance step', () => {
+    setMockValues({
+      ...mockValues,
+      sourceConfigData,
+      addSourceCurrentStep: AddSourceSteps.ConnectInstanceStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} connect />);
+    wrapper.find(ConnectInstance).prop('onFormCreated')('foo');
+
+    expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(
+      '/sources/add/confluence_cloud/connect'
+    );
+  });
+
+  it('renders Configure Custom step', () => {
+    setMockValues({
+      ...mockValues,
+      addSourceCurrentStep: AddSourceSteps.ConfigureCustomStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+    wrapper.find(ConfigureCustom).prop('advanceStep')();
+
+    expect(createContentSource).toHaveBeenCalled();
+  });
+
+  it('renders Configure Oauth step', () => {
+    setMockValues({
+      ...mockValues,
+      addSourceCurrentStep: AddSourceSteps.ConfigureOauthStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+
+    wrapper.find(ConfigureOauth).prop('onFormCreated')('foo');
+
+    expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(
+      '/sources/add/confluence_cloud/connect'
+    );
+  });
+
+  it('renders Save Custom step', () => {
+    setMockValues({
+      ...mockValues,
+      addSourceCurrentStep: AddSourceSteps.SaveCustomStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+
+    expect(wrapper.find(SaveCustom)).toHaveLength(1);
+  });
+
+  it('renders ReAuthenticate step', () => {
+    setMockValues({
+      ...mockValues,
+      addSourceCurrentStep: AddSourceSteps.ReAuthenticateStep,
+    });
+    const wrapper = shallow(<AddSource sourceIndex={1} />);
+
+    expect(wrapper.find(ReAuthenticate)).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -28,7 +28,7 @@ import { ReAuthenticate } from './re_authenticate';
 import { SaveConfig } from './save_config';
 import { SaveCustom } from './save_custom';
 
-enum Steps {
+enum AddSourceSteps {
   ConfigIntroStep = 'Config Intro',
   SaveConfigStep = 'Save Config',
   ConfigCompletedStep = 'Config Completed',
@@ -91,28 +91,28 @@ export const AddSource: React.FC<AddSourceProps> = ({
   const isCustom = serviceType === CUSTOM_SERVICE_TYPE;
 
   const getFirstStep = () => {
-    if (isCustom) return Steps.ConfigureCustomStep;
-    if (connect) return Steps.ConnectInstanceStep;
-    if (configure) return Steps.ConfigureOauthStep;
-    if (reAuthenticate) return Steps.ReAuthenticateStep;
-    return Steps.ConfigIntroStep;
+    if (isCustom) return AddSourceSteps.ConfigureCustomStep;
+    if (connect) return AddSourceSteps.ConnectInstanceStep;
+    if (configure) return AddSourceSteps.ConfigureOauthStep;
+    if (reAuthenticate) return AddSourceSteps.ReAuthenticateStep;
+    return AddSourceSteps.ConfigIntroStep;
   };
 
-  const [currentStep, setStep] = useState(getFirstStep());
+  const [addSourceCurrentStep, setAddSourceStep] = useState(getFirstStep());
 
   if (dataLoading) return <Loading />;
 
-  const goToConfigurationIntro = () => setStep(Steps.ConfigIntroStep);
-  const goToSaveConfig = () => setStep(Steps.SaveConfigStep);
-  const setConfigCompletedStep = () => setStep(Steps.ConfigCompletedStep);
+  const goToConfigurationIntro = () => setAddSourceStep(AddSourceSteps.ConfigIntroStep);
+  const goToSaveConfig = () => setAddSourceStep(AddSourceSteps.SaveConfigStep);
+  const setConfigCompletedStep = () => setAddSourceStep(AddSourceSteps.ConfigCompletedStep);
   const goToConfigCompleted = () => saveSourceConfig(false, setConfigCompletedStep);
 
   const goToConnectInstance = () => {
-    setStep(Steps.ConnectInstanceStep);
+    setAddSourceStep(AddSourceSteps.ConnectInstanceStep);
     history.push(`${getSourcesPath(addPath, isOrganization)}/connect`);
   };
 
-  const saveCustomSuccess = () => setStep(Steps.SaveCustomStep);
+  const saveCustomSuccess = () => setAddSourceStep(AddSourceSteps.SaveCustomStep);
   const goToSaveCustom = () => createContentSource(CUSTOM_SERVICE_TYPE, saveCustomSuccess);
 
   const goToFormSourceCreated = (sourceName: string) => {
@@ -123,10 +123,10 @@ export const AddSource: React.FC<AddSourceProps> = ({
 
   return (
     <>
-      {currentStep === Steps.ConfigIntroStep && (
+      {addSourceCurrentStep === AddSourceSteps.ConfigIntroStep && (
         <ConfigurationIntro name={name} advanceStep={goToSaveConfig} header={header} />
       )}
-      {currentStep === Steps.SaveConfigStep && (
+      {addSourceCurrentStep === AddSourceSteps.SaveConfigStep && (
         <SaveConfig
           name={name}
           configuration={configuration}
@@ -135,7 +135,7 @@ export const AddSource: React.FC<AddSourceProps> = ({
           header={header}
         />
       )}
-      {currentStep === Steps.ConfigCompletedStep && (
+      {addSourceCurrentStep === AddSourceSteps.ConfigCompletedStep && (
         <ConfigCompleted
           name={name}
           accountContextOnly={accountContextOnly}
@@ -144,7 +144,7 @@ export const AddSource: React.FC<AddSourceProps> = ({
           header={header}
         />
       )}
-      {currentStep === Steps.ConnectInstanceStep && (
+      {addSourceCurrentStep === AddSourceSteps.ConnectInstanceStep && (
         <ConnectInstance
           name={name}
           serviceType={serviceType}
@@ -158,17 +158,17 @@ export const AddSource: React.FC<AddSourceProps> = ({
           header={header}
         />
       )}
-      {currentStep === Steps.ConfigureCustomStep && (
+      {addSourceCurrentStep === AddSourceSteps.ConfigureCustomStep && (
         <ConfigureCustom
           helpText={configuration.helpText}
           advanceStep={goToSaveCustom}
           header={header}
         />
       )}
-      {currentStep === Steps.ConfigureOauthStep && (
+      {addSourceCurrentStep === AddSourceSteps.ConfigureOauthStep && (
         <ConfigureOauth name={name} onFormCreated={goToFormSourceCreated} header={header} />
       )}
-      {currentStep === Steps.SaveCustomStep && (
+      {addSourceCurrentStep === AddSourceSteps.SaveCustomStep && (
         <SaveCustom
           documentationUrl={configuration.documentationUrl}
           newCustomSource={newCustomSource}
@@ -176,7 +176,9 @@ export const AddSource: React.FC<AddSourceProps> = ({
           header={header}
         />
       )}
-      {currentStep === Steps.ReAuthenticateStep && <ReAuthenticate name={name} header={header} />}
+      {addSourceCurrentStep === AddSourceSteps.ReAuthenticateStep && (
+        <ReAuthenticate name={name} header={header} />
+      )}
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -6,12 +6,11 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { History } from 'history';
 import { useActions, useValues } from 'kea';
-import { useHistory } from 'react-router-dom';
 
 import { AppLogic } from '../../../../app_logic';
-import { Loading } from '../../../../../../applications/shared/loading';
+import { KibanaLogic } from '../../../../../shared/kibana';
+import { Loading } from '../../../../../shared/loading';
 import { CUSTOM_SERVICE_TYPE } from '../../../../constants';
 import { staticSourceData } from '../../source_data';
 import { AddSourceLogic } from './add_source_logic';
@@ -109,14 +108,16 @@ export const AddSource: React.FC<AddSourceProps> = ({
 
   const goToConnectInstance = () => {
     setAddSourceStep(AddSourceSteps.ConnectInstanceStep);
-    history.push(`${getSourcesPath(addPath, isOrganization)}/connect`);
+    KibanaLogic.values.navigateToUrl(`${getSourcesPath(addPath, isOrganization)}/connect`);
   };
 
   const saveCustomSuccess = () => setAddSourceStep(AddSourceSteps.SaveCustomStep);
   const goToSaveCustom = () => createContentSource(CUSTOM_SERVICE_TYPE, saveCustomSuccess);
 
   const goToFormSourceCreated = (sourceName: string) => {
-    history.push(`${getSourcesPath(SOURCE_ADDED_PATH, isOrganization)}/?name=${sourceName}`);
+    KibanaLogic.values.navigateToUrl(
+      `${getSourcesPath(SOURCE_ADDED_PATH, isOrganization)}/?name=${sourceName}`
+    );
   };
 
   const header = <AddSourceHeader name={name} serviceType={serviceType} categories={categories} />;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -13,7 +13,7 @@ import { KibanaLogic } from '../../../../../shared/kibana';
 import { Loading } from '../../../../../shared/loading';
 import { CUSTOM_SERVICE_TYPE } from '../../../../constants';
 import { staticSourceData } from '../../source_data';
-import { AddSourceLogic } from './add_source_logic';
+import { AddSourceLogic, AddSourceProps, AddSourceSteps } from './add_source_logic';
 import { SourceDataItem } from '../../../../types';
 import { SOURCE_ADDED_PATH, getSourcesPath } from '../../../../routes';
 
@@ -27,38 +27,16 @@ import { ReAuthenticate } from './re_authenticate';
 import { SaveConfig } from './save_config';
 import { SaveCustom } from './save_custom';
 
-enum AddSourceSteps {
-  ConfigIntroStep = 'Config Intro',
-  SaveConfigStep = 'Save Config',
-  ConfigCompletedStep = 'Config Completed',
-  ConnectInstanceStep = 'Connect Instance',
-  ConfigureCustomStep = 'Configure Custom',
-  ConfigureOauthStep = 'Configure Oauth',
-  SaveCustomStep = 'Save Custom',
-  ReAuthenticateStep = 'ReAuthenticate',
-}
-
-interface AddSourceProps {
-  sourceIndex: number;
-  connect?: boolean;
-  configure?: boolean;
-  reAuthenticate?: boolean;
-}
-
-export const AddSource: React.FC<AddSourceProps> = ({
-  sourceIndex,
-  connect,
-  configure,
-  reAuthenticate,
-}) => {
-  const history = useHistory() as History;
+export const AddSource: React.FC<AddSourceProps> = (props) => {
   const {
-    getSourceConfigData,
+    initializeAddSource,
+    setAddSourceStep,
     saveSourceConfig,
     createContentSource,
     resetSourceState,
   } = useActions(AddSourceLogic);
   const {
+    addSourceCurrentStep,
     sourceConfigData: {
       name,
       categories,
@@ -78,26 +56,14 @@ export const AddSource: React.FC<AddSourceProps> = ({
     sourceDescription,
     connectStepDescription,
     addPath,
-  } = staticSourceData[sourceIndex] as SourceDataItem;
+  } = staticSourceData[props.sourceIndex] as SourceDataItem;
 
   const { isOrganization } = useValues(AppLogic);
 
   useEffect(() => {
-    getSourceConfigData(serviceType);
+    initializeAddSource(props);
     return resetSourceState;
   }, []);
-
-  const isCustom = serviceType === CUSTOM_SERVICE_TYPE;
-
-  const getFirstStep = () => {
-    if (isCustom) return AddSourceSteps.ConfigureCustomStep;
-    if (connect) return AddSourceSteps.ConnectInstanceStep;
-    if (configure) return AddSourceSteps.ConfigureOauthStep;
-    if (reAuthenticate) return AddSourceSteps.ReAuthenticateStep;
-    return AddSourceSteps.ConfigIntroStep;
-  };
-
-  const [addSourceCurrentStep, setAddSourceStep] = useState(getFirstStep());
 
   if (dataLoading) return <Loading />;
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -32,6 +32,7 @@ import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 
 import {
   AddSourceLogic,
+  AddSourceSteps,
   SourceConfigData,
   SourceConnectData,
   OrganizationsMap,
@@ -39,6 +40,8 @@ import {
 
 describe('AddSourceLogic', () => {
   const defaultValues = {
+    addSourceCurrentStep: AddSourceSteps.ConfigIntroStep,
+    addSourceProps: {},
     dataLoading: true,
     sectionLoading: true,
     buttonLoading: false,
@@ -69,6 +72,8 @@ describe('AddSourceLogic', () => {
     serviceType: 'github',
     githubOrganizations: ['foo', 'bar'],
   };
+
+  const CUSTOM_SERVICE_TYPE_INDEX = 17;
 
   const clearFlashMessagesSpy = jest.spyOn(FlashMessagesLogic.actions, 'clearFlashMessages');
 
@@ -224,6 +229,53 @@ describe('AddSourceLogic', () => {
   });
 
   describe('listeners', () => {
+    it('initializeAddSource', () => {
+      const addSourceProps = { sourceIndex: 1 };
+      const getSourceConfigDataSpy = jest.spyOn(AddSourceLogic.actions, 'getSourceConfigData');
+      const setAddSourcePropsSpy = jest.spyOn(AddSourceLogic.actions, 'setAddSourceProps');
+      const setAddSourceStepSpy = jest.spyOn(AddSourceLogic.actions, 'setAddSourceStep');
+
+      AddSourceLogic.actions.initializeAddSource(addSourceProps);
+
+      expect(setAddSourcePropsSpy).toHaveBeenCalledWith({ addSourceProps });
+      expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ConfigIntroStep);
+      expect(getSourceConfigDataSpy).toHaveBeenCalledWith('confluence_cloud');
+    });
+
+    describe('getFirstStep', () => {
+      it('sets custom as first step', () => {
+        const setAddSourceStepSpy = jest.spyOn(AddSourceLogic.actions, 'setAddSourceStep');
+        const addSourceProps = { sourceIndex: CUSTOM_SERVICE_TYPE_INDEX };
+        AddSourceLogic.actions.initializeAddSource(addSourceProps);
+
+        expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ConfigureCustomStep);
+      });
+
+      it('sets connect as first step', () => {
+        const setAddSourceStepSpy = jest.spyOn(AddSourceLogic.actions, 'setAddSourceStep');
+        const addSourceProps = { sourceIndex: 1, connect: true };
+        AddSourceLogic.actions.initializeAddSource(addSourceProps);
+
+        expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ConnectInstanceStep);
+      });
+
+      it('sets configure as first step', () => {
+        const setAddSourceStepSpy = jest.spyOn(AddSourceLogic.actions, 'setAddSourceStep');
+        const addSourceProps = { sourceIndex: 1, configure: true };
+        AddSourceLogic.actions.initializeAddSource(addSourceProps);
+
+        expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ConfigureOauthStep);
+      });
+
+      it('sets reAuthenticate as first step', () => {
+        const setAddSourceStepSpy = jest.spyOn(AddSourceLogic.actions, 'setAddSourceStep');
+        const addSourceProps = { sourceIndex: 1, reAuthenticate: true };
+        AddSourceLogic.actions.initializeAddSource(addSourceProps);
+
+        expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ReAuthenticateStep);
+      });
+    });
+
     describe('organization context', () => {
       describe('getSourceConfigData', () => {
         it('calls API and sets values', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -18,10 +18,40 @@ import {
   FlashMessagesLogic,
 } from '../../../../../shared/flash_messages';
 
+import { staticSourceData } from '../../source_data';
+import { CUSTOM_SERVICE_TYPE } from '../../../../constants';
+
 import { AppLogic } from '../../../../app_logic';
 import { CustomSource } from '../../../../types';
 
+export interface AddSourceProps {
+  sourceIndex: number;
+  connect?: boolean;
+  configure?: boolean;
+  reAuthenticate?: boolean;
+}
+
+export enum AddSourceSteps {
+  ConfigIntroStep = 'Config Intro',
+  SaveConfigStep = 'Save Config',
+  ConfigCompletedStep = 'Config Completed',
+  ConnectInstanceStep = 'Connect Instance',
+  ConfigureCustomStep = 'Configure Custom',
+  ConfigureOauthStep = 'Configure Oauth',
+  SaveCustomStep = 'Save Custom',
+  ReAuthenticateStep = 'ReAuthenticate',
+}
+
 export interface AddSourceActions {
+  initializeAddSource: (addSourceProps: AddSourceProps) => { addSourceProps: AddSourceProps };
+  setAddSourceProps: ({
+    addSourceProps,
+  }: {
+    addSourceProps: AddSourceProps;
+  }) => {
+    addSourceProps: AddSourceProps;
+  };
+  setAddSourceStep(addSourceCurrentStep: AddSourceSteps): AddSourceSteps;
   setSourceConfigData(sourceConfigData: SourceConfigData): SourceConfigData;
   setSourceConnectData(sourceConnectData: SourceConnectData): SourceConnectData;
   setClientIdValue(clientIdValue: string): string;
@@ -83,6 +113,8 @@ export interface OrganizationsMap {
 }
 
 interface AddSourceValues {
+  addSourceProps: AddSourceProps;
+  addSourceCurrentStep: AddSourceSteps;
   dataLoading: boolean;
   sectionLoading: boolean;
   buttonLoading: boolean;
@@ -112,6 +144,11 @@ interface PreContentSourceResponse {
 export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceActions>>({
   path: ['enterprise_search', 'workplace_search', 'add_source_logic'],
   actions: {
+    initializeAddSource: (addSourceProps: AddSourceProps) => ({ addSourceProps }),
+    setAddSourceProps: ({ addSourceProps }: { addSourceProps: AddSourceProps }) => ({
+      addSourceProps,
+    }),
+    setAddSourceStep: (addSourceCurrentStep: AddSourceSteps) => addSourceCurrentStep,
     setSourceConfigData: (sourceConfigData: SourceConfigData) => sourceConfigData,
     setSourceConnectData: (sourceConnectData: SourceConnectData) => sourceConnectData,
     setClientIdValue: (clientIdValue: string) => clientIdValue,
@@ -145,6 +182,18 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
     setButtonNotLoading: () => false,
   },
   reducers: {
+    addSourceProps: [
+      {} as AddSourceProps,
+      {
+        setAddSourceProps: (_, { addSourceProps }) => addSourceProps,
+      },
+    ],
+    addSourceCurrentStep: [
+      AddSourceSteps.ConfigIntroStep,
+      {
+        setAddSourceStep: (_, addSourceCurrentStep) => addSourceCurrentStep,
+      },
+    ],
     sourceConfigData: [
       {} as SourceConfigData,
       {
@@ -282,6 +331,12 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
     ],
   }),
   listeners: ({ actions, values }) => ({
+    initializeAddSource: ({ addSourceProps }) => {
+      const { serviceType } = staticSourceData[addSourceProps.sourceIndex];
+      actions.setAddSourceProps({ addSourceProps });
+      actions.setAddSourceStep(getFirstStep(addSourceProps));
+      actions.getSourceConfigData(serviceType);
+    },
     getSourceConfigData: async ({ serviceType }) => {
       const route = `/api/workplace_search/org/settings/connectors/${serviceType}`;
 
@@ -435,3 +490,15 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
     },
   }),
 });
+
+const getFirstStep = (props: AddSourceProps): AddSourceSteps => {
+  const { sourceIndex, connect, configure, reAuthenticate } = props;
+  const { serviceType } = staticSourceData[sourceIndex];
+  const isCustom = serviceType === CUSTOM_SERVICE_TYPE;
+
+  if (isCustom) return AddSourceSteps.ConfigureCustomStep;
+  if (connect) return AddSourceSteps.ConnectInstanceStep;
+  if (configure) return AddSourceSteps.ConfigureOauthStep;
+  if (reAuthenticate) return AddSourceSteps.ReAuthenticateStep;
+  return AddSourceSteps.ConfigIntroStep;
+};


### PR DESCRIPTION
## Summary

This is the last PR of the Add Source component tree migration to Kibana. It takes the state logic for determining the step the user is on when adding a source and moves it to the logic file. It also adds the last of the unit tests:

![coverage](https://user-images.githubusercontent.com/1869731/102638286-e2821e00-411c-11eb-846a-6cd916756216.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
