### PR TITLE
[App Search] Sample Engines should have access to the Crawler

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.test.tsx
@@ -16,8 +16,6 @@ import { DocumentCreationButtons } from './';
 describe('DocumentCreationButtons', () => {
   const values = {
     engineName: 'test-engine',
-    isSampleEngine: false,
-    myRole: { canViewEngineCrawler: true },
   };
   const actions = {
     openDocumentCreation: jest.fn(),
@@ -56,25 +54,9 @@ describe('DocumentCreationButtons', () => {
     expect(actions.openDocumentCreation).toHaveBeenCalledWith('api');
   });
 
-  describe('crawler card', () => {
-    it('renders the crawler button with a link to the crawler page', () => {
-      const wrapper = shallow(<DocumentCreationButtons />);
+  it('renders the crawler button with a link to the crawler page', () => {
+    const wrapper = shallow(<DocumentCreationButtons />);
 
-      expect(wrapper.find(EuiCardTo).prop('to')).toEqual('/engines/test-engine/crawler');
-    });
-
-    it('does not render the crawler button if the user does not have access', () => {
-      setMockValues({ ...values, myRole: { canViewEngineCrawler: false } });
-      const wrapper = shallow(<DocumentCreationButtons />);
-
-      expect(wrapper.find(EuiCardTo)).toHaveLength(0);
-    });
-
-    it('does not render the crawler button for the sample engine', () => {
-      setMockValues({ ...values, isSampleEngine: true });
-      const wrapper = shallow(<DocumentCreationButtons />);
-
-      expect(wrapper.find(EuiCardTo)).toHaveLength(0);
-    });
+    expect(wrapper.find(EuiCardTo).prop('to')).toEqual('/engines/test-engine/crawler');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.tsx
@@ -22,7 +22,6 @@ import {
 
 import { EuiCardTo } from '../../../shared/react_router_helpers';
 import { DOCS_PREFIX, getEngineRoute, ENGINE_CRAWLER_PATH } from '../../routes';
-import { AppLogic } from '../../app_logic';
 import { EngineLogic } from '../engine';
 
 import { DocumentCreationLogic } from './';
@@ -34,11 +33,7 @@ interface Props {
 export const DocumentCreationButtons: React.FC<Props> = ({ disabled = false }) => {
   const { openDocumentCreation } = useActions(DocumentCreationLogic);
 
-  const { engineName, isSampleEngine } = useValues(EngineLogic);
-  const {
-    myRole: { canViewEngineCrawler },
-  } = useValues(AppLogic);
-  const showCrawlerLink = canViewEngineCrawler && !isSampleEngine;
+  const { engineName } = useValues(EngineLogic);
   const crawlerLink = getEngineRoute(engineName) + ENGINE_CRAWLER_PATH;
 
   return (
@@ -61,7 +56,7 @@ export const DocumentCreationButtons: React.FC<Props> = ({ disabled = false }) =
         </p>
       </EuiText>
       <EuiSpacer />
-      <EuiFlexGrid columns={showCrawlerLink ? 2 : 3}>
+      <EuiFlexGrid columns={2}>
         <EuiFlexItem>
           <EuiCard
             title={i18n.translate(
@@ -98,31 +93,29 @@ export const DocumentCreationButtons: React.FC<Props> = ({ disabled = false }) =
             isDisabled={disabled}
           />
         </EuiFlexItem>
-        {showCrawlerLink && (
-          <EuiFlexItem>
-            <EuiCardTo
-              title={i18n.translate(
-                'xpack.enterpriseSearch.appSearch.documentCreation.buttons.crawl',
-                { defaultMessage: 'Use the Crawler' }
-              )}
-              description=""
-              icon={<EuiIcon type="globe" size="xxl" color="primary" />}
-              betaBadgeLabel={i18n.translate(
-                'xpack.enterpriseSearch.appSearch.documentCreation.buttons.betaTitle',
-                { defaultMessage: 'Beta' }
-              )}
-              betaBadgeTooltipContent={i18n.translate(
-                'xpack.enterpriseSearch.appSearch.documentCreation.buttons.betaTooltip',
-                {
-                  defaultMessage:
-                    'The Elastic Crawler is not GA. Please help us by reporting any bugs.',
-                }
-              )}
-              to={crawlerLink}
-              isDisabled={disabled}
-            />
-          </EuiFlexItem>
-        )}
+        <EuiFlexItem>
+          <EuiCardTo
+            title={i18n.translate(
+              'xpack.enterpriseSearch.appSearch.documentCreation.buttons.crawl',
+              { defaultMessage: 'Use the Crawler' }
+            )}
+            description=""
+            icon={<EuiIcon type="globe" size="xxl" color="primary" />}
+            betaBadgeLabel={i18n.translate(
+              'xpack.enterpriseSearch.appSearch.documentCreation.buttons.betaTitle',
+              { defaultMessage: 'Beta' }
+            )}
+            betaBadgeTooltipContent={i18n.translate(
+              'xpack.enterpriseSearch.appSearch.documentCreation.buttons.betaTooltip',
+              {
+                defaultMessage:
+                  'The Elastic Crawler is not GA. Please help us by reporting any bugs.',
+              }
+            )}
+            to={crawlerLink}
+            isDisabled={disabled}
+          />
+        </EuiFlexItem>
       </EuiFlexGrid>
     </>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -102,12 +102,6 @@ describe('EngineNav', () => {
       const wrapper = shallow(<EngineNav />);
       expect(wrapper.find('[data-test-subj="EngineCrawlerLink"]')).toHaveLength(0);
     });
-
-    it('does not render for sample engine', () => {
-      setMockValues({ ...values, myRole, isSampleEngine: true });
-      const wrapper = shallow(<EngineNav />);
-      expect(wrapper.find('[data-test-subj="EngineCrawlerLink"]')).toHaveLength(0);
-    });
   });
 
   describe('meta engine source engines link', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -153,7 +153,7 @@ export const EngineNav: React.FC = () => {
           </EuiFlexGroup>
         </SideNavLink>
       )}
-      {canViewEngineCrawler && !isMetaEngine && !isSampleEngine && (
+      {canViewEngineCrawler && !isMetaEngine && (
         <SideNavLink
           isExternal
           to={getAppSearchUrl(engineRoute + ENGINE_CRAWLER_PATH)}


### PR DESCRIPTION
## Summary

I was going over the new DocumentCreation modal with @zumwalt the other day, and he confirmed that if sample engines can index new documents, there's no reason why they shouldn't have access to the Crawler. I've removed checks around `isSampleEngine` for crawler links, and the DocumentCreationButtons should now always show 4 buttons.

## QA

- Checkout branch
- Create a Sample engine in the standalone UI, then navigate to it in Kibana
- [x] Confirm the Crawler link shows up in the sidebar for the sample engine
- [x] Go to Documents > Index Documents, confirm the "Use the Crawler" button shows up and there are 4 cards total

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios