### PR TITLE
[App Search] Convert DocumentCreationModal to DocumentCreationFlyout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/constants.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/constants.tsx
@@ -6,12 +6,14 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const MODAL_CANCEL_BUTTON = i18n.translate(
-  'xpack.enterpriseSearch.appSearch.documentCreation.modalCancel',
+export const FLYOUT_ARIA_LABEL_ID = 'documentCreationFlyoutHeadingId';
+
+export const FLYOUT_CANCEL_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.documentCreation.flyoutCancel',
   { defaultMessage: 'Cancel' }
 );
-export const MODAL_CONTINUE_BUTTON = i18n.translate(
-  'xpack.enterpriseSearch.appSearch.documentCreation.modalContinue',
+export const FLYOUT_CONTINUE_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.documentCreation.flyoutContinue',
   { defaultMessage: 'Continue' }
 );
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { EuiCode, EuiCodeBlock, EuiButtonEmpty } from '@elastic/eui';
 
-import { ApiCodeExample, ModalHeader, ModalBody, ModalFooter } from './api_code_example';
+import { ApiCodeExample, FlyoutHeader, FlyoutBody, FlyoutFooter } from './api_code_example';
 
 describe('ApiCodeExample', () => {
   const values = {
@@ -29,23 +29,23 @@ describe('ApiCodeExample', () => {
 
   it('renders', () => {
     const wrapper = shallow(<ApiCodeExample />);
-    expect(wrapper.find(ModalHeader)).toHaveLength(1);
-    expect(wrapper.find(ModalBody)).toHaveLength(1);
-    expect(wrapper.find(ModalFooter)).toHaveLength(1);
+    expect(wrapper.find(FlyoutHeader)).toHaveLength(1);
+    expect(wrapper.find(FlyoutBody)).toHaveLength(1);
+    expect(wrapper.find(FlyoutFooter)).toHaveLength(1);
   });
 
-  describe('ModalHeader', () => {
+  describe('FlyoutHeader', () => {
     it('renders', () => {
-      const wrapper = shallow(<ModalHeader />);
+      const wrapper = shallow(<FlyoutHeader />);
       expect(wrapper.find('h2').text()).toEqual('Indexing by API');
     });
   });
 
-  describe('ModalBody', () => {
+  describe('FlyoutBody', () => {
     let wrapper: ShallowWrapper;
 
     beforeAll(() => {
-      wrapper = shallow(<ModalBody />);
+      wrapper = shallow(<FlyoutBody />);
     });
 
     it('renders with the full remote Enterprise Search API URL', () => {
@@ -64,9 +64,9 @@ describe('ApiCodeExample', () => {
     });
   });
 
-  describe('ModalFooter', () => {
-    it('closes the modal', () => {
-      const wrapper = shallow(<ModalFooter />);
+  describe('FlyoutFooter', () => {
+    it('closes the flyout', () => {
+      const wrapper = shallow(<FlyoutFooter />);
 
       wrapper.find(EuiButtonEmpty).simulate('click');
       expect(actions.closeDocumentCreation).toHaveBeenCalled();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.tsx
@@ -11,10 +11,10 @@ import { useValues, useActions } from 'kea';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import {
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
   EuiButtonEmpty,
   EuiText,
   EuiLink,
@@ -30,39 +30,43 @@ import { EngineLogic } from '../../engine';
 import { EngineDetails } from '../../engine/types';
 
 import { DOCS_PREFIX } from '../../../routes';
-import { DOCUMENTS_API_JSON_EXAMPLE, MODAL_CANCEL_BUTTON } from '../constants';
+import {
+  DOCUMENTS_API_JSON_EXAMPLE,
+  FLYOUT_ARIA_LABEL_ID,
+  FLYOUT_CANCEL_BUTTON,
+} from '../constants';
 import { DocumentCreationLogic } from '../';
 
 export const ApiCodeExample: React.FC = () => (
   <>
-    <ModalHeader />
-    <ModalBody />
-    <ModalFooter />
+    <FlyoutHeader />
+    <FlyoutBody />
+    <FlyoutFooter />
   </>
 );
 
-export const ModalHeader: React.FC = () => {
+export const FlyoutHeader: React.FC = () => {
   return (
-    <EuiModalHeader>
-      <EuiModalHeaderTitle>
-        <h2>
+    <EuiFlyoutHeader hasBorder>
+      <EuiTitle size="m">
+        <h2 id={FLYOUT_ARIA_LABEL_ID}>
           {i18n.translate('xpack.enterpriseSearch.appSearch.documentCreation.api.title', {
             defaultMessage: 'Indexing by API',
           })}
         </h2>
-      </EuiModalHeaderTitle>
-    </EuiModalHeader>
+      </EuiTitle>
+    </EuiFlyoutHeader>
   );
 };
 
-export const ModalBody: React.FC = () => {
+export const FlyoutBody: React.FC = () => {
   const { engineName, engine } = useValues(EngineLogic);
   const { apiKey } = engine as EngineDetails;
 
   const documentsApiUrl = getEnterpriseSearchUrl(`/api/as/v1/engines/${engineName}/documents`);
 
   return (
-    <EuiModalBody>
+    <EuiFlyoutBody>
       <EuiText color="subdued">
         <p>
           <FormattedMessage
@@ -113,16 +117,16 @@ export const ModalBody: React.FC = () => {
         # ]
       `)}
       </EuiCodeBlock>
-    </EuiModalBody>
+    </EuiFlyoutBody>
   );
 };
 
-export const ModalFooter: React.FC = () => {
+export const FlyoutFooter: React.FC = () => {
   const { closeDocumentCreation } = useActions(DocumentCreationLogic);
 
   return (
-    <EuiModalFooter>
-      <EuiButtonEmpty onClick={closeDocumentCreation}>{MODAL_CANCEL_BUTTON}</EuiButtonEmpty>
-    </EuiModalFooter>
+    <EuiFlyoutFooter>
+      <EuiButtonEmpty onClick={closeDocumentCreation}>{FLYOUT_CANCEL_BUTTON}</EuiButtonEmpty>
+    </EuiFlyoutFooter>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { EuiTextArea, EuiButtonEmpty, EuiButton } from '@elastic/eui';
 
-import { PasteJsonText, ModalHeader, ModalBody, ModalFooter } from './paste_json_text';
+import { PasteJsonText, FlyoutHeader, FlyoutBody, FlyoutFooter } from './paste_json_text';
 
 describe('PasteJsonText', () => {
   const values = {
@@ -35,22 +35,22 @@ describe('PasteJsonText', () => {
 
   it('renders', () => {
     const wrapper = shallow(<PasteJsonText />);
-    expect(wrapper.find(ModalHeader)).toHaveLength(1);
-    expect(wrapper.find(ModalBody)).toHaveLength(1);
-    expect(wrapper.find(ModalFooter)).toHaveLength(1);
+    expect(wrapper.find(FlyoutHeader)).toHaveLength(1);
+    expect(wrapper.find(FlyoutBody)).toHaveLength(1);
+    expect(wrapper.find(FlyoutFooter)).toHaveLength(1);
   });
 
-  describe('ModalHeader', () => {
+  describe('FlyoutHeader', () => {
     it('renders', () => {
-      const wrapper = shallow(<ModalHeader />);
+      const wrapper = shallow(<FlyoutHeader />);
       expect(wrapper.find('h2').text()).toEqual('Create documents');
     });
   });
 
-  describe('ModalBody', () => {
+  describe('FlyoutBody', () => {
     it('renders and updates the textarea value', () => {
       setMockValues({ ...values, textInput: 'lorem ipsum' });
-      const wrapper = shallow(<ModalBody />);
+      const wrapper = shallow(<FlyoutBody />);
       const textarea = wrapper.find(EuiTextArea);
 
       expect(textarea.prop('value')).toEqual('lorem ipsum');
@@ -60,16 +60,16 @@ describe('PasteJsonText', () => {
     });
   });
 
-  describe('ModalFooter', () => {
+  describe('FlyoutFooter', () => {
     it('closes the modal', () => {
-      const wrapper = shallow(<ModalFooter />);
+      const wrapper = shallow(<FlyoutFooter />);
 
       wrapper.find(EuiButtonEmpty).simulate('click');
       expect(actions.closeDocumentCreation).toHaveBeenCalled();
     });
 
     it('disables/enables the Continue button based on whether text has been entered', () => {
-      const wrapper = shallow(<ModalFooter />);
+      const wrapper = shallow(<FlyoutFooter />);
       expect(wrapper.find(EuiButton).prop('isDisabled')).toBe(false);
 
       setMockValues({ ...values, textInput: '' });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.tsx
@@ -9,10 +9,12 @@ import { useValues, useActions } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 import {
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiButton,
   EuiButtonEmpty,
   EuiTextArea,
@@ -22,34 +24,34 @@ import {
 
 import { AppLogic } from '../../../app_logic';
 
-import { MODAL_CANCEL_BUTTON, MODAL_CONTINUE_BUTTON } from '../constants';
+import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CANCEL_BUTTON, FLYOUT_CONTINUE_BUTTON } from '../constants';
 import { DocumentCreationLogic } from '../';
 
 import './paste_json_text.scss';
 
 export const PasteJsonText: React.FC = () => (
   <>
-    <ModalHeader />
-    <ModalBody />
-    <ModalFooter />
+    <FlyoutHeader />
+    <FlyoutBody />
+    <FlyoutFooter />
   </>
 );
 
-export const ModalHeader: React.FC = () => {
+export const FlyoutHeader: React.FC = () => {
   return (
-    <EuiModalHeader>
-      <EuiModalHeaderTitle>
-        <h2>
+    <EuiFlyoutHeader hasBorder>
+      <EuiTitle size="m">
+        <h2 id={FLYOUT_ARIA_LABEL_ID}>
           {i18n.translate('xpack.enterpriseSearch.appSearch.documentCreation.pasteJsonText.title', {
             defaultMessage: 'Create documents',
           })}
         </h2>
-      </EuiModalHeaderTitle>
-    </EuiModalHeader>
+      </EuiTitle>
+    </EuiFlyoutHeader>
   );
 };
 
-export const ModalBody: React.FC = () => {
+export const FlyoutBody: React.FC = () => {
   const { configuredLimits } = useValues(AppLogic);
   const maxDocumentByteSize = configuredLimits?.engine?.maxDocumentByteSize;
 
@@ -57,7 +59,7 @@ export const ModalBody: React.FC = () => {
   const { setTextInput } = useActions(DocumentCreationLogic);
 
   return (
-    <EuiModalBody>
+    <EuiFlyoutBody>
       <EuiText color="subdued">
         <p>
           {i18n.translate(
@@ -82,20 +84,26 @@ export const ModalBody: React.FC = () => {
         fullWidth
         rows={12}
       />
-    </EuiModalBody>
+    </EuiFlyoutBody>
   );
 };
 
-export const ModalFooter: React.FC = () => {
+export const FlyoutFooter: React.FC = () => {
   const { textInput } = useValues(DocumentCreationLogic);
   const { closeDocumentCreation } = useActions(DocumentCreationLogic);
 
   return (
-    <EuiModalFooter>
-      <EuiButtonEmpty onClick={closeDocumentCreation}>{MODAL_CANCEL_BUTTON}</EuiButtonEmpty>
-      <EuiButton fill isDisabled={!textInput.length}>
-        {MODAL_CONTINUE_BUTTON}
-      </EuiButton>
-    </EuiModalFooter>
+    <EuiFlyoutFooter>
+      <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={closeDocumentCreation}>{FLYOUT_CANCEL_BUTTON}</EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton fill isDisabled={!textInput.length}>
+            {FLYOUT_CONTINUE_BUTTON}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlyoutFooter>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.test.tsx
@@ -30,7 +30,7 @@ describe('ShowCreationModes', () => {
     expect(wrapper.find(DocumentCreationButtons)).toHaveLength(1);
   });
 
-  it('closes the modal', () => {
+  it('closes the flyout', () => {
     wrapper.find(EuiButtonEmpty).simulate('click');
     expect(actions.closeDocumentCreation).toHaveBeenCalled();
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.tsx
@@ -9,14 +9,14 @@ import { useActions } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 import {
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
   EuiButtonEmpty,
 } from '@elastic/eui';
 
-import { MODAL_CANCEL_BUTTON } from '../constants';
+import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CANCEL_BUTTON } from '../constants';
 import { DocumentCreationLogic, DocumentCreationButtons } from '../';
 
 export const ShowCreationModes: React.FC = () => {
@@ -24,22 +24,22 @@ export const ShowCreationModes: React.FC = () => {
 
   return (
     <>
-      <EuiModalHeader>
-        <EuiModalHeaderTitle>
-          <h2>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id={FLYOUT_ARIA_LABEL_ID}>
             {i18n.translate(
               'xpack.enterpriseSearch.appSearch.documentCreation.showCreationModes.title',
               { defaultMessage: 'Add new documents' }
             )}
           </h2>
-        </EuiModalHeaderTitle>
-      </EuiModalHeader>
-      <EuiModalBody>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
         <DocumentCreationButtons />
-      </EuiModalBody>
-      <EuiModalFooter>
-        <EuiButtonEmpty onClick={closeDocumentCreation}>{MODAL_CANCEL_BUTTON}</EuiButtonEmpty>
-      </EuiModalFooter>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiButtonEmpty onClick={closeDocumentCreation}>{FLYOUT_CANCEL_BUTTON}</EuiButtonEmpty>
+      </EuiFlyoutFooter>
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.test.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { EuiFilePicker, EuiButtonEmpty, EuiButton } from '@elastic/eui';
 
-import { UploadJsonFile, ModalHeader, ModalBody, ModalFooter } from './upload_json_file';
+import { UploadJsonFile, FlyoutHeader, FlyoutBody, FlyoutFooter } from './upload_json_file';
 
 describe('UploadJsonFile', () => {
   const mockFile = new File(['mock'], 'mock.json', { type: 'application/json' });
@@ -41,21 +41,21 @@ describe('UploadJsonFile', () => {
 
   it('renders', () => {
     const wrapper = shallow(<UploadJsonFile />);
-    expect(wrapper.find(ModalHeader)).toHaveLength(1);
-    expect(wrapper.find(ModalBody)).toHaveLength(1);
-    expect(wrapper.find(ModalFooter)).toHaveLength(1);
+    expect(wrapper.find(FlyoutHeader)).toHaveLength(1);
+    expect(wrapper.find(FlyoutBody)).toHaveLength(1);
+    expect(wrapper.find(FlyoutFooter)).toHaveLength(1);
   });
 
-  describe('ModalHeader', () => {
+  describe('FlyoutHeader', () => {
     it('renders', () => {
-      const wrapper = shallow(<ModalHeader />);
+      const wrapper = shallow(<FlyoutHeader />);
       expect(wrapper.find('h2').text()).toEqual('Drag and drop .json');
     });
   });
 
-  describe('ModalBody', () => {
+  describe('FlyoutBody', () => {
     it('updates fileInput when files are added & removed', () => {
-      const wrapper = shallow(<ModalBody />);
+      const wrapper = shallow(<FlyoutBody />);
 
       wrapper.find(EuiFilePicker).simulate('change', [mockFile]);
       expect(actions.setFileInput).toHaveBeenCalledWith(mockFile);
@@ -65,16 +65,16 @@ describe('UploadJsonFile', () => {
     });
   });
 
-  describe('ModalFooter', () => {
-    it('closes the modal', () => {
-      const wrapper = shallow(<ModalFooter />);
+  describe('FlyoutFooter', () => {
+    it('closes the flyout', () => {
+      const wrapper = shallow(<FlyoutFooter />);
 
       wrapper.find(EuiButtonEmpty).simulate('click');
       expect(actions.closeDocumentCreation).toHaveBeenCalled();
     });
 
     it('disables/enables the Continue button based on whether files have been uploaded', () => {
-      const wrapper = shallow(<ModalFooter />);
+      const wrapper = shallow(<FlyoutFooter />);
       expect(wrapper.find(EuiButton).prop('isDisabled')).toBe(true);
 
       setMockValues({ ...values, fineInput: mockFile });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.tsx
@@ -14,10 +14,12 @@ import { useValues, useActions } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 import {
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiButton,
   EuiButtonEmpty,
   EuiFilePicker,
@@ -27,40 +29,40 @@ import {
 
 import { AppLogic } from '../../../app_logic';
 
-import { MODAL_CANCEL_BUTTON, MODAL_CONTINUE_BUTTON } from '../constants';
+import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CANCEL_BUTTON, FLYOUT_CONTINUE_BUTTON } from '../constants';
 import { DocumentCreationLogic } from '../';
 
 export const UploadJsonFile: React.FC = () => (
   <>
-    <ModalHeader />
-    <ModalBody />
-    <ModalFooter />
+    <FlyoutHeader />
+    <FlyoutBody />
+    <FlyoutFooter />
   </>
 );
 
-export const ModalHeader: React.FC = () => {
+export const FlyoutHeader: React.FC = () => {
   return (
-    <EuiModalHeader>
-      <EuiModalHeaderTitle>
-        <h2>
+    <EuiFlyoutHeader hasBorder>
+      <EuiTitle size="m">
+        <h2 id={FLYOUT_ARIA_LABEL_ID}>
           {i18n.translate(
             'xpack.enterpriseSearch.appSearch.documentCreation.uploadJsonFile.title',
             { defaultMessage: 'Drag and drop .json' }
           )}
         </h2>
-      </EuiModalHeaderTitle>
-    </EuiModalHeader>
+      </EuiTitle>
+    </EuiFlyoutHeader>
   );
 };
 
-export const ModalBody: React.FC = () => {
+export const FlyoutBody: React.FC = () => {
   const { configuredLimits } = useValues(AppLogic);
   const maxDocumentByteSize = configuredLimits?.engine?.maxDocumentByteSize;
 
   const { setFileInput } = useActions(DocumentCreationLogic);
 
   return (
-    <EuiModalBody>
+    <EuiFlyoutBody>
       <EuiText color="subdued">
         <p>
           {i18n.translate(
@@ -79,20 +81,26 @@ export const ModalBody: React.FC = () => {
         accept="application/json"
         fullWidth
       />
-    </EuiModalBody>
+    </EuiFlyoutBody>
   );
 };
 
-export const ModalFooter: React.FC = () => {
+export const FlyoutFooter: React.FC = () => {
   const { fileInput } = useValues(DocumentCreationLogic);
   const { closeDocumentCreation } = useActions(DocumentCreationLogic);
 
   return (
-    <EuiModalFooter>
-      <EuiButtonEmpty onClick={closeDocumentCreation}>{MODAL_CANCEL_BUTTON}</EuiButtonEmpty>
-      <EuiButton fill isDisabled={!fileInput}>
-        {MODAL_CONTINUE_BUTTON}
-      </EuiButton>
-    </EuiModalFooter>
+    <EuiFlyoutFooter>
+      <EuiFlexGroup justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={closeDocumentCreation}>{FLYOUT_CANCEL_BUTTON}</EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton fill isDisabled={!fileInput}>
+            {FLYOUT_CONTINUE_BUTTON}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlyoutFooter>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.test.tsx
@@ -43,7 +43,7 @@ describe('DocumentCreationButtons', () => {
     expect(wrapper.find(EuiCardTo).prop('isDisabled')).toEqual(true);
   });
 
-  it('opens the DocumentCreationModal on click', () => {
+  it('opens the DocumentCreationFlyout on click', () => {
     const wrapper = shallow(<DocumentCreationButtons />);
 
     wrapper.find(EuiCard).at(0).simulate('click');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.test.tsx
@@ -8,7 +8,7 @@ import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { EuiModal } from '@elastic/eui';
+import { EuiFlyout } from '@elastic/eui';
 
 import {
   ShowCreationModes,
@@ -18,9 +18,9 @@ import {
 } from './creation_mode_components';
 import { DocumentCreationStep } from './types';
 
-import { DocumentCreationModal, ModalContent } from './document_creation_modal';
+import { DocumentCreationFlyout, FlyoutContent } from './document_creation_flyout';
 
-describe('DocumentCreationModal', () => {
+describe('DocumentCreationFlyout', () => {
   const values = {
     isDocumentCreationOpen: true,
     creationMode: 'text',
@@ -36,25 +36,25 @@ describe('DocumentCreationModal', () => {
     setMockActions(actions);
   });
 
-  it('renders a closeable modal', () => {
-    const wrapper = shallow(<DocumentCreationModal />);
-    expect(wrapper.find(EuiModal)).toHaveLength(1);
+  it('renders a closeable flyout', () => {
+    const wrapper = shallow(<DocumentCreationFlyout />);
+    expect(wrapper.find(EuiFlyout)).toHaveLength(1);
 
-    wrapper.find(EuiModal).prop('onClose')();
+    wrapper.find(EuiFlyout).prop('onClose')();
     expect(actions.closeDocumentCreation).toHaveBeenCalled();
   });
 
   it('does not render if isDocumentCreationOpen is false', () => {
     setMockValues({ ...values, isDocumentCreationOpen: false });
-    const wrapper = shallow(<DocumentCreationModal />);
+    const wrapper = shallow(<DocumentCreationFlyout />);
 
     expect(wrapper.isEmptyRender()).toBe(true);
   });
 
-  describe('ModalContent', () => {
+  describe('FlyoutContent', () => {
     it('renders ShowCreationModes', () => {
       setMockValues({ ...values, creationStep: DocumentCreationStep.ShowCreationModes });
-      const wrapper = shallow(<ModalContent />);
+      const wrapper = shallow(<FlyoutContent />);
 
       expect(wrapper.find(ShowCreationModes)).toHaveLength(1);
     });
@@ -62,21 +62,21 @@ describe('DocumentCreationModal', () => {
     describe('creation modes', () => {
       it('renders ApiCodeExample', () => {
         setMockValues({ ...values, creationMode: 'api' });
-        const wrapper = shallow(<ModalContent />);
+        const wrapper = shallow(<FlyoutContent />);
 
         expect(wrapper.find(ApiCodeExample)).toHaveLength(1);
       });
 
       it('renders PasteJsonText', () => {
         setMockValues({ ...values, creationMode: 'text' });
-        const wrapper = shallow(<ModalContent />);
+        const wrapper = shallow(<FlyoutContent />);
 
         expect(wrapper.find(PasteJsonText)).toHaveLength(1);
       });
 
       it('renders UploadJsonFile', () => {
         setMockValues({ ...values, creationMode: 'file' });
-        const wrapper = shallow(<ModalContent />);
+        const wrapper = shallow(<FlyoutContent />);
 
         expect(wrapper.find(UploadJsonFile)).toHaveLength(1);
       });
@@ -85,21 +85,21 @@ describe('DocumentCreationModal', () => {
     describe('creation steps', () => {
       it('renders an error page', () => {
         setMockValues({ ...values, creationStep: DocumentCreationStep.ShowError });
-        const wrapper = shallow(<ModalContent />);
+        const wrapper = shallow(<FlyoutContent />);
 
         expect(wrapper.text()).toBe('DocumentCreationError'); // TODO: actual component
       });
 
       it('renders an error summary', () => {
         setMockValues({ ...values, creationStep: DocumentCreationStep.ShowErrorSummary });
-        const wrapper = shallow(<ModalContent />);
+        const wrapper = shallow(<FlyoutContent />);
 
         expect(wrapper.text()).toBe('DocumentCreationSummary'); // TODO: actual component
       });
 
       it('renders a success summary', () => {
         setMockValues({ ...values, creationStep: DocumentCreationStep.ShowSuccessSummary });
-        const wrapper = shallow(<ModalContent />);
+        const wrapper = shallow(<FlyoutContent />);
 
         // TODO: Figure out if the error and success summary should remain the same vs different components
         expect(wrapper.text()).toBe('DocumentCreationSummary'); // TODO: actual component

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.tsx
@@ -7,10 +7,11 @@
 import React from 'react';
 import { useValues, useActions } from 'kea';
 
-import { EuiOverlayMask, EuiModal } from '@elastic/eui';
+import { EuiPortal, EuiFlyout } from '@elastic/eui';
 
 import { DocumentCreationLogic } from './';
 import { DocumentCreationStep } from './types';
+import { FLYOUT_ARIA_LABEL_ID } from './constants';
 
 import {
   ShowCreationModes,
@@ -19,20 +20,20 @@ import {
   UploadJsonFile,
 } from './creation_mode_components';
 
-export const DocumentCreationModal: React.FC = () => {
+export const DocumentCreationFlyout: React.FC = () => {
   const { closeDocumentCreation } = useActions(DocumentCreationLogic);
   const { isDocumentCreationOpen } = useValues(DocumentCreationLogic);
 
   return isDocumentCreationOpen ? (
-    <EuiOverlayMask>
-      <EuiModal onClose={closeDocumentCreation}>
-        <ModalContent />
-      </EuiModal>
-    </EuiOverlayMask>
+    <EuiPortal>
+      <EuiFlyout ownFocus aria-labelledby={FLYOUT_ARIA_LABEL_ID} onClose={closeDocumentCreation}>
+        <FlyoutContent />
+      </EuiFlyout>
+    </EuiPortal>
   ) : null;
 };
 
-export const ModalContent: React.FC = () => {
+export const FlyoutContent: React.FC = () => {
   const { creationStep, creationMode } = useValues(DocumentCreationLogic);
 
   switch (creationStep) {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.ts
@@ -30,7 +30,7 @@ interface DocumentCreationActions {
 export const DocumentCreationLogic = kea<
   MakeLogicType<DocumentCreationValues, DocumentCreationActions>
 >({
-  path: ['enterprise_search', 'app_search', 'document_creation_modal_logic'],
+  path: ['enterprise_search', 'app_search', 'document_creation_logic'],
   actions: () => ({
     showCreationModes: () => null,
     openDocumentCreation: (creationMode) => ({ creationMode }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/index.ts
@@ -5,5 +5,5 @@
  */
 
 export { DocumentCreationButtons } from './document_creation_buttons';
-export { DocumentCreationModal } from './document_creation_modal';
+export { DocumentCreationFlyout } from './document_creation_flyout';
 export { DocumentCreationLogic } from './document_creation_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { EuiButton } from '@elastic/eui';
 
-import { DocumentCreationModal } from '../document_creation';
+import { DocumentCreationFlyout } from '../document_creation';
 import { DocumentCreationButton } from './document_creation_button';
 
 describe('DocumentCreationButton', () => {
@@ -24,7 +24,7 @@ describe('DocumentCreationButton', () => {
 
   it('renders', () => {
     expect(wrapper.find(EuiButton).length).toEqual(1);
-    expect(wrapper.find(DocumentCreationModal).length).toEqual(1);
+    expect(wrapper.find(DocumentCreationFlyout).length).toEqual(1);
   });
 
   it('opens the document creation modes modal on click', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.tsx
@@ -10,7 +10,7 @@ import { useActions } from 'kea';
 import { i18n } from '@kbn/i18n';
 import { EuiButton } from '@elastic/eui';
 
-import { DocumentCreationLogic, DocumentCreationModal } from '../document_creation';
+import { DocumentCreationLogic, DocumentCreationFlyout } from '../document_creation';
 
 export const DocumentCreationButton: React.FC = () => {
   const { showCreationModes } = useActions(DocumentCreationLogic);
@@ -27,7 +27,7 @@ export const DocumentCreationButton: React.FC = () => {
           defaultMessage: 'Index documents',
         })}
       </EuiButton>
-      <DocumentCreationModal />
+      <DocumentCreationFlyout />
     </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.test.tsx
@@ -10,7 +10,7 @@ import { EuiButton } from '@elastic/eui';
 
 import { CURRENT_MAJOR_VERSION } from '../../../../../common/version';
 
-import { DocumentCreationButtons, DocumentCreationModal } from '../document_creation';
+import { DocumentCreationButtons, DocumentCreationFlyout } from '../document_creation';
 import { EmptyEngineOverview } from './engine_overview_empty';
 
 describe('EmptyEngineOverview', () => {
@@ -32,6 +32,6 @@ describe('EmptyEngineOverview', () => {
 
   it('renders document creation components', () => {
     expect(wrapper.find(DocumentCreationButtons)).toHaveLength(1);
-    expect(wrapper.find(DocumentCreationModal)).toHaveLength(1);
+    expect(wrapper.find(DocumentCreationFlyout)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.tsx
@@ -16,7 +16,7 @@ import {
 } from '@elastic/eui';
 
 import { DOCS_PREFIX } from '../../routes';
-import { DocumentCreationButtons, DocumentCreationModal } from '../document_creation';
+import { DocumentCreationButtons, DocumentCreationFlyout } from '../document_creation';
 
 export const EmptyEngineOverview: React.FC = () => {
   return (
@@ -42,7 +42,7 @@ export const EmptyEngineOverview: React.FC = () => {
       </EuiPageHeader>
       <EuiPageContentBody>
         <DocumentCreationButtons />
-        <DocumentCreationModal />
+        <DocumentCreationFlyout />
       </EuiPageContentBody>
     </>
   );


### PR DESCRIPTION
## Summary

I was brainstorming with @daveyholler yesterday on how best to show form feedback errors on DocumentCreationModal. Here's the current problem with it:

<img src="https://user-images.githubusercontent.com/549407/102649972-fd559200-411e-11eb-92ad-c24c0aa0bbf5.gif" alt="" width="500" />

As you can see, on small/laptop screens, errors are hidden in the overflowing modal body and are super difficult to see. This is pretty awful UX and additionally [not what modals are suited for per EUI's guidelines](https://elastic.github.io/eui/#/layout/modal/guidelines):

>Avoid scrolling content
> Modal content should fit in a single view. If your modal has a lot of detail or a long list of items, consider a different solution, such as a form or a table. 

The advantages we get from switching to EuiFlyout instead are numerous:

- We get (almost) the full height / vertical real estate of the screen (sans Kibana's top headers)
- We get EuiFlyout's `banner` prop, which makes displaying form errors SUPER easy and awesome, and is never hidden by scrolling
  <img width="500" alt="" src="https://user-images.githubusercontent.com/549407/102650430-c7fd7400-411f-11eb-9e2f-8b54338391a0.png">
- EuiFlyout's can be dismissed by clicking outside the flyout by default unlike EuiModal (I personally love this feature so much I can't even say, I hate modals that can't be dismissed by clicking outside them :D)

## Screencaps

![f13se63bA4](https://user-images.githubusercontent.com/549407/102650689-26c2ed80-4120-11eb-81ea-8dffbdb929f8.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)