### PR TITLE
Rename chartLibrary setting to legacyChartsLibrary

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -453,8 +453,8 @@ of buckets to try to represent.
 ==== Visualization
 
 [horizontal]
-[[visualization-visualize-chartslibrary]]`visualization:visualize:chartsLibrary`::
-Enables the new charts library for area, line, and bar charts in visualization panels. Does *not* support the split chart aggregation.
+[[visualization-visualize-chartslibrary]]`visualization:visualize:legacyChartsLibrary`::
+Enables legacy charts library for area, line and bar charts in visualize. Currently, only legacy charts library supports split chart aggregation.
 
 [[visualization-colormapping]]`visualization:colorMapping`::
 **This setting is deprecated and will not be supported as of 8.0.**

--- a/src/plugins/vis_type_vislib/public/plugin.ts
+++ b/src/plugins/vis_type_vislib/public/plugin.ts
@@ -61,7 +61,7 @@ export class VisTypeVislibPlugin
     core: VisTypeVislibCoreSetup,
     { expressions, visualizations, charts }: VisTypeVislibPluginSetupDependencies
   ) {
-    if (core.uiSettings.get(LEGACY_CHARTS_LIBRARY, true)) {
+    if (!core.uiSettings.get(LEGACY_CHARTS_LIBRARY, true)) {
       // Register only non-replaced vis types
       convertedTypeDefinitions.forEach(visualizations.createBaseVisualization);
       visualizations.createBaseVisualization(pieVisTypeDefinition);

--- a/src/plugins/vis_type_vislib/public/plugin.ts
+++ b/src/plugins/vis_type_vislib/public/plugin.ts
@@ -24,7 +24,7 @@ import { VisualizationsSetup } from '../../visualizations/public';
 import { ChartsPluginSetup } from '../../charts/public';
 import { DataPublicPluginStart } from '../../data/public';
 import { KibanaLegacyStart } from '../../kibana_legacy/public';
-import { CHARTS_LIBRARY } from '../../vis_type_xy/public';
+import { LEGACY_CHARTS_LIBRARY } from '../../vis_type_xy/public';
 
 import { createVisTypeVislibVisFn } from './vis_type_vislib_vis_fn';
 import { createPieVisFn } from './pie_fn';
@@ -61,7 +61,7 @@ export class VisTypeVislibPlugin
     core: VisTypeVislibCoreSetup,
     { expressions, visualizations, charts }: VisTypeVislibPluginSetupDependencies
   ) {
-    if (core.uiSettings.get(CHARTS_LIBRARY)) {
+    if (core.uiSettings.get(LEGACY_CHARTS_LIBRARY, true)) {
       // Register only non-replaced vis types
       convertedTypeDefinitions.forEach(visualizations.createBaseVisualization);
       visualizations.createBaseVisualization(pieVisTypeDefinition);

--- a/src/plugins/vis_type_xy/common/index.ts
+++ b/src/plugins/vis_type_xy/common/index.ts
@@ -34,4 +34,4 @@ export type ChartType = $Values<typeof ChartType>;
  */
 export type XyVisType = ChartType | 'horizontal_bar';
 
-export const CHARTS_LIBRARY = 'visualization:visualize:chartsLibrary';
+export const LEGACY_CHARTS_LIBRARY = 'visualization:visualize:legacyChartsLibrary';

--- a/src/plugins/vis_type_xy/public/components/split_chart_warning.tsx
+++ b/src/plugins/vis_type_xy/public/components/split_chart_warning.tsx
@@ -38,13 +38,13 @@ export const SplitChartWarning: FC = () => {
     >
       <FormattedMessage
         id="visTypeXy.splitChartWarning.content"
-        defaultMessage="The new charts library does not support split chart aggregation. Please disable the {link} advanced setting to use split chart aggregation."
+        defaultMessage="The new charts library does not support split chart aggregation. Please enable the {link} advanced setting to use split chart aggregation."
         values={{
           link: (
             <EuiLink href={advancedSettingsLink} target="_blank" external>
               <FormattedMessage
                 id="visTypeXy.splitChartWarning.link"
-                defaultMessage="Charts library"
+                defaultMessage="Legacy charts library"
               />
             </EuiLink>
           ),

--- a/src/plugins/vis_type_xy/public/plugin.ts
+++ b/src/plugins/vis_type_xy/public/plugin.ts
@@ -34,7 +34,7 @@ import {
   setDocLinks,
 } from './services';
 import { visTypesDefinitions } from './vis_types';
-import { CHARTS_LIBRARY } from '../common';
+import { LEGACY_CHARTS_LIBRARY } from '../common';
 import { xyVisRenderer } from './vis_renderer';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -71,7 +71,7 @@ export class VisTypeXyPlugin
     core: VisTypeXyCoreSetup,
     { expressions, visualizations, charts }: VisTypeXyPluginSetupDependencies
   ) {
-    if (core.uiSettings.get(CHARTS_LIBRARY, false)) {
+    if (core.uiSettings.get(LEGACY_CHARTS_LIBRARY, true)) {
       setUISettings(core.uiSettings);
       setThemeService(charts.theme);
       setColorsService(charts.legacyColors);

--- a/src/plugins/vis_type_xy/public/plugin.ts
+++ b/src/plugins/vis_type_xy/public/plugin.ts
@@ -71,7 +71,7 @@ export class VisTypeXyPlugin
     core: VisTypeXyCoreSetup,
     { expressions, visualizations, charts }: VisTypeXyPluginSetupDependencies
   ) {
-    if (core.uiSettings.get(LEGACY_CHARTS_LIBRARY, true)) {
+    if (!core.uiSettings.get(LEGACY_CHARTS_LIBRARY, true)) {
       setUISettings(core.uiSettings);
       setThemeService(charts.theme);
       setColorsService(charts.legacyColors);

--- a/src/plugins/vis_type_xy/public/vis_types/split_tooltip.tsx
+++ b/src/plugins/vis_type_xy/public/vis_types/split_tooltip.tsx
@@ -25,10 +25,7 @@ export function SplitTooltip() {
   return (
     <FormattedMessage
       id="visTypeXy.splitTitle.tooltip"
-      defaultMessage="Split chart aggregation is not supported with the new {setting}. Please disable the {setting} advanced setting to enable split chart aggregation"
-      values={{
-        setting: <strong>charts library</strong>,
-      }}
+      defaultMessage="Split chart aggregation is not supported with the new charts library. Please enable the legacy charts library advanced setting to use split chart aggregation."
     />
   );
 }

--- a/src/plugins/vis_type_xy/server/plugin.ts
+++ b/src/plugins/vis_type_xy/server/plugin.ts
@@ -29,7 +29,7 @@ export const uiSettingsConfig: Record<string, UiSettingsParams<boolean>> = {
   // https://github.com/elastic/kibana/issues/56143
   [LEGACY_CHARTS_LIBRARY]: {
     name: i18n.translate('visTypeXy.advancedSettings.visualization.legacyChartsLibrary.name', {
-      defaultMessage: 'Legact charts library',
+      defaultMessage: 'Legacy charts library',
     }),
     value: true,
     description: i18n.translate(

--- a/src/plugins/vis_type_xy/server/plugin.ts
+++ b/src/plugins/vis_type_xy/server/plugin.ts
@@ -22,21 +22,21 @@ import { schema } from '@kbn/config-schema';
 
 import { CoreSetup, Plugin, UiSettingsParams } from 'kibana/server';
 
-import { CHARTS_LIBRARY } from '../common';
+import { LEGACY_CHARTS_LIBRARY } from '../common';
 
 export const uiSettingsConfig: Record<string, UiSettingsParams<boolean>> = {
   // TODO: Remove this when vis_type_vislib is removed
   // https://github.com/elastic/kibana/issues/56143
-  [CHARTS_LIBRARY]: {
-    name: i18n.translate('visTypeXy.advancedSettings.visualization.chartsLibrary', {
-      defaultMessage: 'Charts library',
+  [LEGACY_CHARTS_LIBRARY]: {
+    name: i18n.translate('visTypeXy.advancedSettings.visualization.legacyChartsLibrary.name', {
+      defaultMessage: 'Legact charts library',
     }),
-    value: false,
+    value: true,
     description: i18n.translate(
-      'visTypeXy.advancedSettings.visualization.chartsLibrary.description',
+      'visTypeXy.advancedSettings.visualization.legacyChartsLibrary.description',
       {
         defaultMessage:
-          'Enables new charts library for areas, lines and bars in visualize. Currently, does <strong>not</strong> support split chart aggregation.',
+          'Enables legacy charts library for area, line and bar charts in visualize. Currently, only legacy charts library supports split chart aggregation.',
       }
     ),
     category: ['visualization'],

--- a/test/functional/apps/dashboard/dashboard_state.ts
+++ b/test/functional/apps/dashboard/dashboard_state.ts
@@ -46,16 +46,16 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('dashboard state', function describeIndexTests() {
     // Used to track flag before and after reset
-    let isNewChartUiEnabled = false;
+    let isNewChartsLibraryEnabled = false;
 
     before(async function () {
-      isNewChartUiEnabled = await PageObjects.visChart.isNewChartUiEnabled();
+      isNewChartsLibraryEnabled = await PageObjects.visChart.isNewChartsLibraryEnabled();
       await PageObjects.dashboard.initTests();
       await PageObjects.dashboard.preserveCrossAppState();
 
-      if (isNewChartUiEnabled) {
+      if (isNewChartsLibraryEnabled) {
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': true,
+          'visualization:visualize:legacyChartsLibrary': false,
         });
         await browser.refresh();
       }
@@ -73,12 +73,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       const visName = await PageObjects.visChart.getExpectedValue(
         AREA_CHART_VIS_NAME,
-        `${AREA_CHART_VIS_NAME} - chartsLibrary`
+        `${AREA_CHART_VIS_NAME} - new charts library`
       );
       await dashboardAddPanel.addVisualization(visName);
       const dashboarName = await PageObjects.visChart.getExpectedValue(
         'Overridden colors',
-        'Overridden colors - chartsLibrary'
+        'Overridden colors - new charts library'
       );
       await PageObjects.dashboard.saveDashboard(dashboarName);
 
@@ -93,7 +93,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.dashboard.gotoDashboardLandingPage();
       await PageObjects.dashboard.loadSavedDashboard(dashboarName);
 
-      if (await PageObjects.visChart.isNewChartUiEnabled()) {
+      if (await PageObjects.visChart.isNewChartsLibraryEnabled()) {
         await elasticChart.setNewChartUiDebugFlag();
         await queryBar.submitQuery();
       }

--- a/test/functional/apps/dashboard/index.ts
+++ b/test/functional/apps/dashboard/index.ts
@@ -126,7 +126,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       before(async () => {
         await loadLogstash();
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': true,
+          'visualization:visualize:legacyChartsLibrary': false,
         });
         await browser.refresh();
       });
@@ -134,7 +134,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       after(async () => {
         await unloadLogstash();
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': false,
+          'visualization:visualize:legacyChartsLibrary': true,
         });
         await browser.refresh();
       });

--- a/test/functional/apps/getting_started/_shakespeare.ts
+++ b/test/functional/apps/getting_started/_shakespeare.ts
@@ -49,22 +49,22 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     // order they are added.
     let aggIndex = 1;
     // Used to track flag before and after reset
-    let isNewChartUiEnabled = false;
+    let isNewChartsLibraryEnabled = false;
 
     before(async function () {
       log.debug(
         'Load empty_kibana and Shakespeare Getting Started data\n' +
           'https://www.elastic.co/guide/en/kibana/current/tutorial-load-dataset.html'
       );
-      isNewChartUiEnabled = await PageObjects.visChart.isNewChartUiEnabled();
+      isNewChartsLibraryEnabled = await PageObjects.visChart.isNewChartsLibraryEnabled();
       await security.testUser.setRoles(['kibana_admin', 'test_shakespeare_reader']);
       await esArchiver.load('empty_kibana', { skipExisting: true });
       log.debug('Load shakespeare data');
       await esArchiver.loadIfNeeded('getting_started/shakespeare');
 
-      if (isNewChartUiEnabled) {
+      if (isNewChartsLibraryEnabled) {
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': true,
+          'visualization:visualize:legacyChartsLibrary': false,
         });
         await browser.refresh();
       }

--- a/test/functional/apps/getting_started/index.ts
+++ b/test/functional/apps/getting_started/index.ts
@@ -31,17 +31,17 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     });
 
     // TODO: Remove when vislib is removed
-    describe('chartsLibrary', function () {
+    describe('new charts library', function () {
       before(async () => {
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': true,
+          'visualization:visualize:legacyChartsLibrary': false,
         });
         await browser.refresh();
       });
 
       after(async () => {
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': false,
+          'visualization:visualize:legacyChartsLibrary': true,
         });
         await browser.refresh();
       });

--- a/test/functional/apps/visualize/index.ts
+++ b/test/functional/apps/visualize/index.ts
@@ -43,19 +43,19 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     });
 
     // TODO: Remove when vislib is removed
-    describe('chartsLibrary', function () {
+    describe('new charts library', function () {
       this.tags('ciGroup7');
 
       before(async () => {
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': true,
+          'visualization:visualize:legacyChartsLibrary': false,
         });
         await browser.refresh();
       });
 
       after(async () => {
         await kibanaServer.uiSettings.update({
-          'visualization:visualize:chartsLibrary': false,
+          'visualization:visualize:legacyChartsLibrary': true,
         });
         await browser.refresh();
       });

--- a/test/functional/page_objects/visualize_chart_page.ts
+++ b/test/functional/page_objects/visualize_chart_page.ts
@@ -41,22 +41,23 @@ export function VisualizeChartPageProvider({ getService, getPageObjects }: FtrPr
     }
 
     /**
-     * Is chartsLibrary advanced setting enabled
+     * Is new charts library advanced setting enabled
      */
-    public async isNewChartUiEnabled(): Promise<boolean> {
-      const enabled =
-        Boolean(await kibanaServer.uiSettings.get('visualization:visualize:chartsLibrary')) ??
-        false;
-      log.debug(`-- isNewChartUiEnabled = ${enabled}`);
+    public async isNewChartsLibraryEnabled(): Promise<boolean> {
+      const legacyChartsLibrary =
+        Boolean(await kibanaServer.uiSettings.get('visualization:visualize:legacyChartsLibrary')) ??
+        true;
+      const enabled = !legacyChartsLibrary;
+      log.debug(`-- isNewChartsLibraryEnabled = ${enabled}`);
 
       return enabled;
     }
 
     /**
-     * Is chartsLibrary enabled and an area, line or histogram chart is available
+     * Is new charts library enabled and an area, line or histogram chart exists
      */
     private async isVisTypeXYChart(): Promise<boolean> {
-      const enabled = await this.isNewChartUiEnabled();
+      const enabled = await this.isNewChartsLibraryEnabled();
 
       if (!enabled) {
         log.debug(`-- isVisTypeXYChart = false`);

--- a/test/functional/page_objects/visualize_editor_page.ts
+++ b/test/functional/page_objects/visualize_editor_page.ts
@@ -74,7 +74,7 @@ export function VisualizeEditorPageProvider({ getService, getPageObjects }: FtrP
     }
 
     public async clickGo() {
-      if (await visChart.isNewChartUiEnabled()) {
+      if (await visChart.isNewChartsLibraryEnabled()) {
         await elasticChart.setNewChartUiDebugFlag();
       }
 

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -99,7 +99,7 @@ export function VisualizePageProvider({ getService, getPageObjects }: FtrProvide
     }
 
     public async clickRefresh() {
-      if (await visChart.isNewChartUiEnabled()) {
+      if (await visChart.isNewChartsLibraryEnabled()) {
         await elasticChart.setNewChartUiDebugFlag();
       }
       await queryBar.clickQuerySubmitButton();


### PR DESCRIPTION
## Summary

This PR renames the current advance setting `visualization:visualize:chartsLibrary` to `visualization:visualize:legacyChartsLibrary`. This change reversed the previous behavior and is now _enabled_ by default.

Additional cleanup of copy material and testing comments to reflect change.

A follow-up PR will disable this setting in `master`

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
