### PR TITLE
[APM] Truncate long service names in Trace overview

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -46,7 +46,6 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
     ) => (
       <EuiToolTip content={transactionName} anchorClassName="eui-textTruncate">
         <StyledTransactionLink
-          className="eui-textTruncate"
           serviceName={serviceName}
           transactionName={transactionName}
           transactionType={transactionType}

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -44,8 +44,9 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
       _: string,
       { serviceName, transactionName, transactionType }: TraceGroup
     ) => (
-      <EuiToolTip content={transactionName}>
+      <EuiToolTip content={transactionName} anchorClassName="eui-textTruncate">
         <StyledTransactionLink
+          className="eui-textTruncate"
           serviceName={serviceName}
           transactionName={transactionName}
           transactionType={transactionType}


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/86676

<img width="857" alt="Screenshot 2020-12-22 at 13 21 44" src="https://user-images.githubusercontent.com/55978943/102888587-63ad1e00-4459-11eb-8e03-46d3b44c0716.png">
