### PR TITLE
[App Search] Result component - a11y enhancements

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.scss
@@ -1,17 +1,42 @@
 .appSearchResult {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto;
+  grid-template-areas:
+    'content actions'
+    'toggle actions';
 
   &__content {
+    grid-area: content;
     width: 100%;
     padding: $euiSize;
     overflow: hidden;
     color: $euiTextColor;
   }
 
-  &__hiddenFieldsIndicator {
+  &__hiddenFieldsToggle {
+    grid-area: toggle;
+    display: flex;
+    justify-content: center;
+    padding: $euiSizeS;
+    border-top: $euiBorderThin;
     font-size: $euiFontSizeXS;
-    color: $euiColorDarkShade;
-    margin-top: $euiSizeS;
+    color: $euiColorPrimary;
+
+    &:hover,
+    &:focus {
+      background-color: $euiPageBackgroundColor;
+    }
+
+    .euiIcon {
+      margin-left: $euiSizeXS;
+    }
+  }
+
+  &__actionButtons {
+    grid-area: actions;
+    display: flex;
+    flex-wrap: no-wrap;
   }
 
   &__actionButton {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.scss
@@ -5,6 +5,7 @@
   grid-template-areas:
     'content actions'
     'toggle actions';
+  overflow: hidden; // Prevents child background-colors from clipping outside of panel border-radius
 
   &__content {
     grid-area: content;
@@ -47,10 +48,27 @@
     border-left: $euiBorderThin;
 
     &:hover,
-    &:focus,
-    &:active {
+    &:focus {
       background-color: $euiPageBackgroundColor;
-      cursor: pointer;
     }
+  }
+}
+
+/**
+ * CSS for hover specific logic
+ * It's mildly horrific, so I pulled it out to its own section here
+ */
+
+.appSearchResult--link {
+  &:hover,
+  &:focus {
+    @include euiSlightShadowHover;
+  }
+}
+.appSearchResult__content--link:hover {
+  cursor: pointer;
+
+  & ~ .appSearchResult__actionButtons .appSearchResult__actionButton--link {
+    background-color: $euiPageBackgroundColor;
   }
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
@@ -76,16 +76,20 @@ describe('Result', () => {
   describe('document detail link', () => {
     it('will render a link if shouldLinkToDetailPage is true', () => {
       const wrapper = shallow(<Result {...props} shouldLinkToDetailPage={true} />);
-      expect(wrapper.find(ReactRouterHelper).prop('to')).toEqual('/engines/my-engine/documents/1');
-      expect(wrapper.find('article.appSearchResult__content').exists()).toBe(false);
-      expect(wrapper.find('a.appSearchResult__content').exists()).toBe(true);
+      wrapper.find(ReactRouterHelper).forEach((link) => {
+        expect(link.prop('to')).toEqual('/engines/my-engine/documents/1');
+      });
+      expect(wrapper.hasClass('appSearchResult--link')).toBe(true);
+      expect(wrapper.find('.appSearchResult__content--link').exists()).toBe(true);
+      expect(wrapper.find('.appSearchResult__actionButton--link').exists()).toBe(true);
     });
 
     it('will not render a link if shouldLinkToDetailPage is not set', () => {
       const wrapper = shallow(<Result {...props} />);
       expect(wrapper.find(ReactRouterHelper).exists()).toBe(false);
-      expect(wrapper.find('article.appSearchResult__content').exists()).toBe(true);
-      expect(wrapper.find('a.appSearchResult__content').exists()).toBe(false);
+      expect(wrapper.hasClass('appSearchResult--link')).toBe(false);
+      expect(wrapper.find('.appSearchResult__content--link').exists()).toBe(false);
+      expect(wrapper.find('.appSearchResult__actionButton--link').exists()).toBe(false);
     });
   });
 
@@ -140,18 +144,16 @@ describe('Result', () => {
         wrapper = shallow(<Result {...propsWithMoreFields} />);
       });
 
-      it('renders a collapse button', () => {
+      it('renders a hidden fields toggle button', () => {
+        expect(wrapper.find('.appSearchResult__hiddenFieldsToggle').exists()).toBe(true);
+      });
+
+      it('renders a collapse icon', () => {
         expect(wrapper.find('[data-test-subj="CollapseResult"]').exists()).toBe(false);
       });
 
-      it('does not render an expand button', () => {
+      it('does not render an expand icon', () => {
         expect(wrapper.find('[data-test-subj="ExpandResult"]').exists()).toBe(true);
-      });
-
-      it('renders a hidden fields indicator', () => {
-        expect(wrapper.find('.appSearchResult__hiddenFieldsIndicator').text()).toEqual(
-          '1 more fields'
-        );
       });
 
       it('shows no more than 5 fields', () => {
@@ -164,20 +166,22 @@ describe('Result', () => {
 
       beforeAll(() => {
         wrapper = shallow(<Result {...propsWithMoreFields} />);
-        expect(wrapper.find('.appSearchResult__actionButton').exists()).toBe(true);
-        wrapper.find('.appSearchResult__actionButton').simulate('click');
+        expect(wrapper.find('.appSearchResult__hiddenFieldsToggle').exists()).toBe(true);
+        wrapper.find('.appSearchResult__hiddenFieldsToggle').simulate('click');
       });
 
-      it('renders a collapse button', () => {
+      it('renders correct toggle text', () => {
+        expect(wrapper.find('.appSearchResult__hiddenFieldsToggle').text()).toEqual(
+          'Hide additional fields<EuiIcon />'
+        );
+      });
+
+      it('renders a collapse icon', () => {
         expect(wrapper.find('[data-test-subj="CollapseResult"]').exists()).toBe(true);
       });
 
-      it('does not render an expand button', () => {
+      it('does not render an expand icon', () => {
         expect(wrapper.find('[data-test-subj="ExpandResult"]').exists()).toBe(false);
-      });
-
-      it('does not render a hidden fields indicator', () => {
-        expect(wrapper.find('.appSearchResult__hiddenFieldsIndicator').exists()).toBe(false);
       });
 
       it('shows all fields', () => {
@@ -190,23 +194,23 @@ describe('Result', () => {
 
       beforeAll(() => {
         wrapper = shallow(<Result {...propsWithMoreFields} />);
-        expect(wrapper.find('.appSearchResult__actionButton').exists()).toBe(true);
-        wrapper.find('.appSearchResult__actionButton').simulate('click');
-        wrapper.find('.appSearchResult__actionButton').simulate('click');
+        expect(wrapper.find('.appSearchResult__hiddenFieldsToggle').exists()).toBe(true);
+        wrapper.find('.appSearchResult__hiddenFieldsToggle').simulate('click');
+        wrapper.find('.appSearchResult__hiddenFieldsToggle').simulate('click');
       });
 
-      it('renders a collapse button', () => {
+      it('renders correct toggle text', () => {
+        expect(wrapper.find('.appSearchResult__hiddenFieldsToggle').text()).toEqual(
+          'Show 1 additional field<EuiIcon />'
+        );
+      });
+
+      it('renders a collapse icon', () => {
         expect(wrapper.find('[data-test-subj="CollapseResult"]').exists()).toBe(false);
       });
 
-      it('does not render an expand button', () => {
+      it('does not render an expand icon', () => {
         expect(wrapper.find('[data-test-subj="ExpandResult"]').exists()).toBe(true);
-      });
-
-      it('renders a hidden fields indicator', () => {
-        expect(wrapper.find('.appSearchResult__hiddenFieldsIndicator').text()).toEqual(
-          '1 more fields'
-        );
       });
 
       it('shows no more than 5 fields', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
@@ -49,6 +49,7 @@ describe('Result', () => {
   it('renders', () => {
     const wrapper = shallow(<Result {...props} />);
     expect(wrapper.find(EuiPanel).exists()).toBe(true);
+    expect(wrapper.find(EuiPanel).prop('title')).toEqual('Document 1');
   });
 
   it('should render a ResultField for each field except id and _meta', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -109,7 +109,8 @@ export const Result: React.FC<Props> = ({
                 defaultMessage: 'Hide additional fields',
               })
             : i18n.translate('xpack.enterpriseSearch.appSearch.result.showAdditionalFields', {
-                defaultMessage: 'Show {numberOfAdditionalFields} additional fields',
+                defaultMessage:
+                  'Show {numberOfAdditionalFields, number} additional {numberOfAdditionalFields, plural, one {field} other {fields}}',
                 values: {
                   numberOfAdditionalFields: numResults - RESULT_CUTOFF,
                 },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -88,40 +88,28 @@ export const Result: React.FC<Props> = ({
                 />
               ))}
           </div>
-          {numResults > RESULT_CUTOFF && !isOpen && (
-            <footer className="appSearchResult__hiddenFieldsIndicator">
-              {i18n.translate('xpack.enterpriseSearch.appSearch.result.numberOfAdditionalFields', {
-                defaultMessage: '{numberOfAdditionalFields} more fields',
-                values: {
-                  numberOfAdditionalFields: numResults - RESULT_CUTOFF,
-                },
-              })}
-            </footer>
-          )}
         </>
       )}
       {numResults > RESULT_CUTOFF && (
         <button
           type="button"
-          className="appSearchResult__actionButton"
+          className="appSearchResult__hiddenFieldsToggle"
           onClick={() => setIsOpen(!isOpen)}
-          aria-label={
-            isOpen
-              ? i18n.translate('xpack.enterpriseSearch.appSearch.result.hideAdditionalFields', {
-                  defaultMessage: 'Hide additional fields',
-                })
-              : i18n.translate('xpack.enterpriseSearch.appSearch.result.showAdditionalFields', {
-                  defaultMessage: 'Show additional fields',
-                })
-          }
         >
-          {isOpen ? (
-            <EuiIcon data-test-subj="CollapseResult" type="arrowUp" />
-          ) : (
-            <EuiIcon data-test-subj="ExpandResult" type="arrowDown" />
-          )}
+          {isOpen
+            ? i18n.translate('xpack.enterpriseSearch.appSearch.result.hideAdditionalFields', {
+                defaultMessage: 'Hide additional fields',
+              })
+            : i18n.translate('xpack.enterpriseSearch.appSearch.result.showAdditionalFields', {
+                defaultMessage: 'Show {numberOfAdditionalFields} additional fields',
+                values: {
+                  numberOfAdditionalFields: numResults - RESULT_CUTOFF,
+                },
+              })}
+          <EuiIcon type={isOpen ? 'arrowUp' : 'arrowDown'} />
         </button>
       )}
+      <div className="appSearchResult__actionButtons">TODO</div>
     </EuiPanel>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -49,10 +49,11 @@ export const Result: React.FC<Props> = ({
     if (schemaForTypeHighlights) return schemaForTypeHighlights[fieldName];
   };
 
+  const documentLink = getDocumentDetailRoute(resultMeta.engine, resultMeta.id);
   const conditionallyLinkedArticle = (children: React.ReactNode) => {
     return shouldLinkToDetailPage ? (
-      <ReactRouterHelper to={getDocumentDetailRoute(resultMeta.engine, resultMeta.id)}>
-        <a className="appSearchResult__content">{children}</a>
+      <ReactRouterHelper to={documentLink}>
+        <article className="appSearchResult__content">{children}</article>
       </ReactRouterHelper>
     ) : (
       <article className="appSearchResult__content">{children}</article>
@@ -109,7 +110,21 @@ export const Result: React.FC<Props> = ({
           <EuiIcon type={isOpen ? 'arrowUp' : 'arrowDown'} />
         </button>
       )}
-      <div className="appSearchResult__actionButtons">TODO</div>
+      <div className="appSearchResult__actionButtons">
+        {shouldLinkToDetailPage && (
+          <ReactRouterHelper to={documentLink}>
+            <a
+              className="appSearchResult__actionButton"
+              aria-label={i18n.translate(
+                'xpack.enterpriseSearch.appSearch.result.documentDetailLink',
+                { defaultMessage: 'Visit document details' }
+              )}
+            >
+              <EuiIcon type="popout" />
+            </a>
+          </ReactRouterHelper>
+        )}
+      </div>
     </EuiPanel>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -5,6 +5,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
+import classNames from 'classnames';
 
 import './result.scss';
 
@@ -53,17 +54,23 @@ export const Result: React.FC<Props> = ({
   const conditionallyLinkedArticle = (children: React.ReactNode) => {
     return shouldLinkToDetailPage ? (
       <ReactRouterHelper to={documentLink}>
-        <article className="appSearchResult__content">{children}</article>
+        <article className="appSearchResult__content appSearchResult__content--link">
+          {children}
+        </article>
       </ReactRouterHelper>
     ) : (
       <article className="appSearchResult__content">{children}</article>
     );
   };
 
+  const classes = classNames('appSearchResult', {
+    'appSearchResult--link': shouldLinkToDetailPage,
+  });
+
   return (
     <EuiPanel
       paddingSize="none"
-      className="appSearchResult"
+      className={classes}
       data-test-subj="AppSearchResult"
       title={i18n.translate('xpack.enterpriseSearch.appSearch.result.title', {
         defaultMessage: 'View document details',
@@ -114,7 +121,7 @@ export const Result: React.FC<Props> = ({
         {shouldLinkToDetailPage && (
           <ReactRouterHelper to={documentLink}>
             <a
-              className="appSearchResult__actionButton"
+              className="appSearchResult__actionButton appSearchResult__actionButton--link"
               aria-label={i18n.translate(
                 'xpack.enterpriseSearch.appSearch.result.documentDetailLink',
                 { defaultMessage: 'Visit document details' }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -115,7 +115,10 @@ export const Result: React.FC<Props> = ({
                   numberOfAdditionalFields: numResults - RESULT_CUTOFF,
                 },
               })}
-          <EuiIcon type={isOpen ? 'arrowUp' : 'arrowDown'} />
+          <EuiIcon
+            type={isOpen ? 'arrowUp' : 'arrowDown'}
+            data-test-subj={isOpen ? 'CollapseResult' : 'ExpandResult'}
+          />
         </button>
       )}
       <div className="appSearchResult__actionButtons">

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -73,7 +73,8 @@ export const Result: React.FC<Props> = ({
       className={classes}
       data-test-subj="AppSearchResult"
       title={i18n.translate('xpack.enterpriseSearch.appSearch.result.title', {
-        defaultMessage: 'View document details',
+        defaultMessage: 'Document {id}',
+        values: { id: result[ID].raw },
       })}
     >
       {conditionallyLinkedArticle(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -83,19 +83,17 @@ export const Result: React.FC<Props> = ({
             showScore={!!showScore}
             isMetaEngine={isMetaEngine}
           />
-          <div className="appSearchResult__body">
-            {resultFields
-              .slice(0, isOpen ? resultFields.length : RESULT_CUTOFF)
-              .map(([field, value]: [string, FieldValue]) => (
-                <ResultField
-                  key={field}
-                  field={field}
-                  raw={value.raw}
-                  snippet={value.snippet}
-                  type={typeForField(field)}
-                />
-              ))}
-          </div>
+          {resultFields
+            .slice(0, isOpen ? resultFields.length : RESULT_CUTOFF)
+            .map(([field, value]: [string, FieldValue]) => (
+              <ResultField
+                key={field}
+                field={field}
+                raw={value.raw}
+                snippet={value.snippet}
+                type={typeForField(field)}
+              />
+            ))}
         </>
       )}
       {numResults > RESULT_CUTOFF && (


### PR DESCRIPTION
## Summary

This PR is a follow-up to [this conversation](https://github.com/elastic/kibana/pull/86181#discussion_r545448105) where we added links to document views. The issue with the wrapping `<a>` tag around the article content was that it caused screen readers to read out all the content at once, resulting in a lot of overwhelming verbiage:

![image](https://user-images.githubusercontent.com/549407/102933358-fac4a680-4456-11eb-896d-1397438155d2.png)

This approach of changing our Result card markup/layout as a compromise to get working behavior for all kinds of users  follows a pattern similar to EuiCard, where it balances the following trade-offs:

- [Keyboard & Screenreader users] A focus-able link with a large/predictable location
- [Screenreader users] Main internal article remains individually navigable
- [Mouse users] The entire component still remains clickable with a large/predictable main link button where the link URL is previewable (bottom left corner of browser)

## Screencaps

<img width="782" alt="" src="https://user-images.githubusercontent.com/549407/102933682-89392800-4457-11eb-8e87-53583cba3c77.png">

<img width="1396" alt="" src="https://user-images.githubusercontent.com/549407/102934021-36ac3b80-4458-11eb-8ad4-de52b0f1e034.png">

![immkaJAWMD](https://user-images.githubusercontent.com/549407/102933692-8f2f0900-4457-11eb-930e-d34b4637b75f.gif)

## QA

- Go to http://localhost:5601/xyz/app/enterprise_search/app_search/library
- [x] Confirm that cards without a link still look fine and function as normal
- [x] Confirm that collapse/expand behavior still behaves as before
- Go to http://localhost:5601/xyz/app/enterprise_search/app_search/engines/national-parks-demo/
- [x] Confirm that clicking on the new link button takes you to the correct document view
- [x] Confirm that clicking anywhere on the card content takes you to the correct document view
- [x] (Keyboard) Confirm that you can correctly tab to both the collapse button and the link button
- [x] (Screen reader) Confirm that when navigating (ctrl+option+left/right arrow) through the card contents, each key/value pair is individually read out instead of all at once

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)