### PR TITLE
[App Search] ApiCodeExample - minor responsive tweaks

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.tsx
@@ -23,6 +23,8 @@ import {
   EuiBadge,
   EuiCode,
   EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 
 import { getEnterpriseSearchUrl } from '../../../../shared/enterprise_search_url';
@@ -95,8 +97,14 @@ export const FlyoutBody: React.FC = () => {
       </EuiText>
       <EuiSpacer />
       <EuiPanel hasShadow={false} paddingSize="s" className="eui-textBreakAll">
-        <EuiBadge color="primary">POST</EuiBadge>
-        <EuiCode transparentBackground>{documentsApiUrl}</EuiCode>
+        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="none">
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="primary">POST</EuiBadge>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiCode transparentBackground>{documentsApiUrl}</EuiCode>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiPanel>
       <EuiCodeBlock language="bash" fontSize="m" isCopyable>
         {dedent(`


### PR DESCRIPTION
## Summary

Super tiny tweaks to the [POST] {url} panel on top of the API example code block.

### Before
<img width="701" alt="" src="https://user-images.githubusercontent.com/549407/102936794-ad980300-445d-11eb-8b55-db706f16f0df.png">

### After

<img width="698" alt="" src="https://user-images.githubusercontent.com/549407/102936812-b4bf1100-445d-11eb-9766-752356362d3a.png">
<img width="455" alt="" src="https://user-images.githubusercontent.com/549407/102936813-b5f03e00-445d-11eb-995f-bdce839a634a.png">

(center alignment isn't my favorite but top alignment makes the one-line alignment looked weird so I think it's the best for now)

### Regression/one-line

<img width="692" alt="Screen Shot 2020-12-22 at 1 55 44 PM" src="https://user-images.githubusercontent.com/549407/102936822-bd174c00-445d-11eb-9bd4-fcccba0ef731.png">

### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)