### PR TITLE
[Security Solution][Exceptions][Tech Debt] - Refactor exceptions api file to follow value lists pattern

### DIFF
--- a/x-pack/plugins/lists/public/exceptions/api.test.ts
+++ b/x-pack/plugins/lists/public/exceptions/api.test.ts
@@ -11,12 +11,6 @@ import { getCreateExceptionListItemSchemaMock } from '../../common/schemas/reque
 import { getFoundExceptionListItemSchemaMock } from '../../common/schemas/response/found_exception_list_item_schema.mock';
 import { getUpdateExceptionListItemSchemaMock } from '../../common/schemas/request/update_exception_list_item_schema.mock';
 import { getUpdateExceptionListSchemaMock } from '../../common/schemas/request/update_exception_list_schema.mock';
-import {
-  CreateExceptionListItemSchema,
-  CreateExceptionListSchema,
-  ExceptionListItemSchema,
-  ExceptionListSchema,
-} from '../../common/schemas';
 import { getFoundExceptionListSchemaMock } from '../../common/schemas/response/found_exception_list_schema.mock';
 
 import {
@@ -33,7 +27,6 @@ import {
   updateExceptionList,
   updateExceptionListItem,
 } from './api';
-import { ApiCallByIdProps, ApiCallByListIdProps, ApiCallFetchExceptionListsProps } from './types';
 
 const abortCtrl = new AbortController();
 
@@ -73,20 +66,6 @@ describe('Exceptions Lists API', () => {
         signal: abortCtrl.signal,
       });
       expect(exceptionResponse).toEqual(getExceptionListSchemaMock());
-    });
-
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload: Omit<CreateExceptionListSchema, 'description'> & {
-        description?: string[];
-      } = { ...getCreateExceptionListSchemaMock(), description: ['123'] };
-
-      await expect(
-        addExceptionList({
-          http: httpMock,
-          list: (payload as unknown) as ExceptionListSchema,
-          signal: abortCtrl.signal,
-        })
-      ).rejects.toEqual('Invalid value "["123"]" supplied to "description"');
     });
 
     test('it returns error if response payload fails decode', async () => {
@@ -137,20 +116,6 @@ describe('Exceptions Lists API', () => {
       expect(exceptionResponse).toEqual(getExceptionListItemSchemaMock());
     });
 
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload: Omit<CreateExceptionListItemSchema, 'description'> & {
-        description?: string[];
-      } = { ...getCreateExceptionListItemSchemaMock(), description: ['123'] };
-
-      await expect(
-        addExceptionListItem({
-          http: httpMock,
-          listItem: (payload as unknown) as ExceptionListItemSchema,
-          signal: abortCtrl.signal,
-        })
-      ).rejects.toEqual('Invalid value "["123"]" supplied to "description"');
-    });
-
     test('it returns error if response payload fails decode', async () => {
       const payload = getCreateExceptionListItemSchemaMock();
       const badPayload = getExceptionListItemSchemaMock();
@@ -199,20 +164,6 @@ describe('Exceptions Lists API', () => {
       expect(exceptionResponse).toEqual(getExceptionListSchemaMock());
     });
 
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = getUpdateExceptionListSchemaMock();
-      // @ts-expect-error
-      delete payload.description;
-
-      await expect(
-        updateExceptionList({
-          http: httpMock,
-          list: payload,
-          signal: abortCtrl.signal,
-        })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "description"');
-    });
-
     test('it returns error if response payload fails decode', async () => {
       const payload = getUpdateExceptionListSchemaMock();
       const badPayload = getExceptionListSchemaMock();
@@ -259,20 +210,6 @@ describe('Exceptions Lists API', () => {
         signal: abortCtrl.signal,
       });
       expect(exceptionResponse).toEqual(getExceptionListItemSchemaMock());
-    });
-
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = getUpdateExceptionListItemSchemaMock();
-      // @ts-expect-error
-      delete payload.description;
-
-      await expect(
-        updateExceptionListItem({
-          http: httpMock,
-          listItem: payload,
-          signal: abortCtrl.signal,
-        })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "description"');
     });
 
     test('it returns error if response payload fails decode', async () => {
@@ -336,22 +273,6 @@ describe('Exceptions Lists API', () => {
       expect(exceptionResponse.data).toEqual([getExceptionListSchemaMock()]);
     });
 
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = ({
-        filters: 'exception-list.attributes.name: Sample Endpoint',
-        http: httpMock,
-        namespaceTypes: 'notANamespaceType',
-        pagination: {
-          page: 1,
-          perPage: 20,
-        },
-        signal: abortCtrl.signal,
-      } as unknown) as ApiCallFetchExceptionListsProps & { namespaceTypes: string[] };
-      await expect(fetchExceptionLists(payload)).rejects.toEqual(
-        'Invalid value "notANamespaceType" supplied to "namespace_type"'
-      );
-    });
-
     test('it returns error if response payload fails decode', async () => {
       const badPayload = getExceptionListSchemaMock();
       // @ts-expect-error
@@ -403,18 +324,6 @@ describe('Exceptions Lists API', () => {
         signal: abortCtrl.signal,
       });
       expect(exceptionResponse).toEqual(getExceptionListSchemaMock());
-    });
-
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = ({
-        http: httpMock,
-        id: 1,
-        namespaceType: 'single',
-        signal: abortCtrl.signal,
-      } as unknown) as ApiCallByIdProps & { id: number };
-      await expect(fetchExceptionListById(payload)).rejects.toEqual(
-        'Invalid value "1" supplied to "id"'
-      );
     });
 
     test('it returns error if response payload fails decode', async () => {
@@ -614,23 +523,6 @@ describe('Exceptions Lists API', () => {
       expect(exceptionResponse).toEqual(getFoundExceptionListItemSchemaMock());
     });
 
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = ({
-        filterOptions: [],
-        http: httpMock,
-        listIds: ['myList'],
-        namespaceTypes: ['not a namespace type'],
-        pagination: {
-          page: 1,
-          perPage: 20,
-        },
-        signal: abortCtrl.signal,
-      } as unknown) as ApiCallByListIdProps & { listId: number };
-      await expect(fetchExceptionListsItemsByListIds(payload)).rejects.toEqual(
-        'Invalid value "not a namespace type" supplied to "namespace_type"'
-      );
-    });
-
     test('it returns error if response payload fails decode', async () => {
       const badPayload = getExceptionListItemSchemaMock();
       // @ts-expect-error
@@ -687,18 +579,6 @@ describe('Exceptions Lists API', () => {
       expect(exceptionResponse).toEqual(getExceptionListItemSchemaMock());
     });
 
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = ({
-        http: httpMock,
-        id: '1',
-        namespaceType: 'not a namespace type',
-        signal: abortCtrl.signal,
-      } as unknown) as ApiCallByIdProps & { namespaceType: string };
-      await expect(fetchExceptionListItemById(payload)).rejects.toEqual(
-        'Invalid value "not a namespace type" supplied to "namespace_type"'
-      );
-    });
-
     test('it returns error if response payload fails decode', async () => {
       const badPayload = getExceptionListItemSchemaMock();
       // @ts-expect-error
@@ -748,18 +628,6 @@ describe('Exceptions Lists API', () => {
       expect(exceptionResponse).toEqual(getExceptionListSchemaMock());
     });
 
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = ({
-        http: httpMock,
-        id: 1,
-        namespaceType: 'single',
-        signal: abortCtrl.signal,
-      } as unknown) as ApiCallByIdProps & { id: number };
-      await expect(deleteExceptionListById(payload)).rejects.toEqual(
-        'Invalid value "1" supplied to "id"'
-      );
-    });
-
     test('it returns error if response payload fails decode', async () => {
       const badPayload = getExceptionListSchemaMock();
       // @ts-expect-error
@@ -807,18 +675,6 @@ describe('Exceptions Lists API', () => {
         signal: abortCtrl.signal,
       });
       expect(exceptionResponse).toEqual(getExceptionListItemSchemaMock());
-    });
-
-    test('it returns error and does not make request if request payload fails decode', async () => {
-      const payload = ({
-        http: httpMock,
-        id: 1,
-        namespaceType: 'single',
-        signal: abortCtrl.signal,
-      } as unknown) as ApiCallByIdProps & { id: number };
-      await expect(deleteExceptionListItemById(payload)).rejects.toEqual(
-        'Invalid value "1" supplied to "id"'
-      );
     });
 
     test('it returns error if response payload fails decode', async () => {

--- a/x-pack/plugins/lists/public/exceptions/api.test.ts
+++ b/x-pack/plugins/lists/public/exceptions/api.test.ts
@@ -81,7 +81,7 @@ describe('Exceptions Lists API', () => {
           list: payload,
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -129,7 +129,7 @@ describe('Exceptions Lists API', () => {
           listItem: payload,
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -177,7 +177,7 @@ describe('Exceptions Lists API', () => {
           list: payload,
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -225,7 +225,7 @@ describe('Exceptions Lists API', () => {
           listItem: payload,
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -290,7 +290,7 @@ describe('Exceptions Lists API', () => {
           },
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "data,id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "data,id"'));
     });
   });
 
@@ -339,7 +339,7 @@ describe('Exceptions Lists API', () => {
           namespaceType: 'single',
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -542,7 +542,9 @@ describe('Exceptions Lists API', () => {
           signal: abortCtrl.signal,
         })
       ).rejects.toEqual(
-        'Invalid value "undefined" supplied to "data",Invalid value "undefined" supplied to "page",Invalid value "undefined" supplied to "per_page",Invalid value "undefined" supplied to "total"'
+        new Error(
+          'Invalid value "undefined" supplied to "data",Invalid value "undefined" supplied to "page",Invalid value "undefined" supplied to "per_page",Invalid value "undefined" supplied to "total"'
+        )
       );
     });
   });
@@ -592,7 +594,7 @@ describe('Exceptions Lists API', () => {
           namespaceType: 'single',
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -641,7 +643,7 @@ describe('Exceptions Lists API', () => {
           namespaceType: 'single',
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 
@@ -690,7 +692,7 @@ describe('Exceptions Lists API', () => {
           namespaceType: 'single',
           signal: abortCtrl.signal,
         })
-      ).rejects.toEqual('Invalid value "undefined" supplied to "id"');
+      ).rejects.toEqual(new Error('Invalid value "undefined" supplied to "id"'));
     });
   });
 

--- a/x-pack/plugins/lists/public/exceptions/api.ts
+++ b/x-pack/plugins/lists/public/exceptions/api.ts
@@ -3,6 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+import { chain, fromEither, tryCatch } from 'fp-ts/lib/TaskEither';
+import { flow } from 'fp-ts/lib/function';
+
+import { validateEither } from '../../common/shared_imports';
+import { toError, toPromise } from '../common/fp_utils';
 import {
   ENDPOINT_LIST_URL,
   EXCEPTION_LIST_ITEM_URL,
@@ -17,22 +22,11 @@ import {
   FoundExceptionListItemSchema,
   FoundExceptionListSchema,
   createEndpointListSchema,
-  createExceptionListItemSchema,
-  createExceptionListSchema,
-  deleteExceptionListItemSchema,
-  deleteExceptionListSchema,
   exceptionListItemSchema,
   exceptionListSchema,
-  findExceptionListItemSchema,
-  findExceptionListSchema,
   foundExceptionListItemSchema,
   foundExceptionListSchema,
-  readExceptionListItemSchema,
-  readExceptionListSchema,
-  updateExceptionListItemSchema,
-  updateExceptionListSchema,
 } from '../../common/schemas';
-import { validate } from '../../common/shared_imports';
 
 import {
   AddEndpointExceptionListProps,
@@ -56,35 +50,38 @@ import {
  * @throws An error if response is not OK
  *
  */
-export const addExceptionList = async ({
+const addExceptionList = async ({
   http,
   list,
   signal,
-}: AddExceptionListProps): Promise<ExceptionListSchema> => {
-  const [validatedRequest, errorsRequest] = validate(list, createExceptionListSchema);
+}: AddExceptionListProps): Promise<ExceptionListSchema> =>
+  http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
+    body: JSON.stringify(list),
+    method: 'POST',
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_URL, {
-        body: JSON.stringify(list),
-        method: 'POST',
-        signal,
-      });
+const addExceptionListWithValidation = async ({
+  http,
+  list,
+  signal,
+}: AddExceptionListProps): Promise<ExceptionListSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          addExceptionList({
+            http,
+            list,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(exceptionListSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { addExceptionListWithValidation as addExceptionList };
 
 /**
  * Add new ExceptionListItem
@@ -96,35 +93,38 @@ export const addExceptionList = async ({
  * @throws An error if response is not OK
  *
  */
-export const addExceptionListItem = async ({
+const addExceptionListItem = async ({
   http,
   listItem,
   signal,
-}: AddExceptionListItemProps): Promise<ExceptionListItemSchema> => {
-  const [validatedRequest, errorsRequest] = validate(listItem, createExceptionListItemSchema);
+}: AddExceptionListItemProps): Promise<ExceptionListItemSchema> =>
+  http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
+    body: JSON.stringify(listItem),
+    method: 'POST',
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
-        body: JSON.stringify(listItem),
-        method: 'POST',
-        signal,
-      });
+const addExceptionListItemWithValidation = async ({
+  http,
+  listItem,
+  signal,
+}: AddExceptionListItemProps): Promise<ExceptionListItemSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          addExceptionListItem({
+            http,
+            listItem,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(exceptionListItemSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListItemSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { addExceptionListItemWithValidation as addExceptionListItem };
 
 /**
  * Update existing ExceptionList
@@ -136,35 +136,38 @@ export const addExceptionListItem = async ({
  * @throws An error if response is not OK
  *
  */
-export const updateExceptionList = async ({
+const updateExceptionList = async ({
   http,
   list,
   signal,
-}: UpdateExceptionListProps): Promise<ExceptionListSchema> => {
-  const [validatedRequest, errorsRequest] = validate(list, updateExceptionListSchema);
+}: UpdateExceptionListProps): Promise<ExceptionListSchema> =>
+  http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
+    body: JSON.stringify(list),
+    method: 'PUT',
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
-        body: JSON.stringify(list),
-        method: 'PUT',
-        signal,
-      });
+const updateExceptionListWithValidation = async ({
+  http,
+  list,
+  signal,
+}: UpdateExceptionListProps): Promise<ExceptionListSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          updateExceptionList({
+            http,
+            list,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(exceptionListSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { updateExceptionListWithValidation as updateExceptionList };
 
 /**
  * Update existing ExceptionListItem
@@ -176,35 +179,38 @@ export const updateExceptionList = async ({
  * @throws An error if response is not OK
  *
  */
-export const updateExceptionListItem = async ({
+const updateExceptionListItem = async ({
   http,
   listItem,
   signal,
-}: UpdateExceptionListItemProps): Promise<ExceptionListItemSchema> => {
-  const [validatedRequest, errorsRequest] = validate(listItem, updateExceptionListItemSchema);
+}: UpdateExceptionListItemProps): Promise<ExceptionListItemSchema> =>
+  http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
+    body: JSON.stringify(listItem),
+    method: 'PUT',
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
-        body: JSON.stringify(listItem),
-        method: 'PUT',
-        signal,
-      });
+const updateExceptionListItemWithValidation = async ({
+  http,
+  listItem,
+  signal,
+}: UpdateExceptionListItemProps): Promise<ExceptionListItemSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          updateExceptionListItem({
+            http,
+            listItem,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(exceptionListItemSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListItemSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { updateExceptionListItemWithValidation as updateExceptionListItem };
 
 /**
  * Fetch all ExceptionLists (optionally by namespaceType)
@@ -217,7 +223,7 @@ export const updateExceptionListItem = async ({
  *
  * @throws An error if request params or response is not OK
  */
-export const fetchExceptionLists = async ({
+const fetchExceptionLists = async ({
   http,
   filters,
   namespaceTypes,
@@ -233,30 +239,38 @@ export const fetchExceptionLists = async ({
     sort_order: 'desc',
   };
 
-  const [validatedRequest, errorsRequest] = validate(query, findExceptionListSchema);
-
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListSchema>(`${EXCEPTION_LIST_URL}/_find`, {
-        method: 'GET',
-        query,
-        signal,
-      });
-
-      const [validatedResponse, errorsResponse] = validate(response, foundExceptionListSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
+  return http.fetch<FoundExceptionListSchema>(`${EXCEPTION_LIST_URL}/_find`, {
+    method: 'GET',
+    query,
+    signal,
+  });
 };
+
+const fetchExceptionListsWithValidation = async ({
+  filters,
+  http,
+  namespaceTypes,
+  pagination,
+  signal,
+}: ApiCallFetchExceptionListsProps): Promise<FoundExceptionListSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          fetchExceptionLists({
+            filters,
+            http,
+            namespaceTypes,
+            pagination,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(foundExceptionListSchema, response))),
+    flow(toPromise)
+  )();
+
+export { fetchExceptionListsWithValidation as fetchExceptionLists };
 
 /**
  * Fetch an ExceptionList by providing a ExceptionList ID
@@ -268,39 +282,41 @@ export const fetchExceptionLists = async ({
  *
  * @throws An error if response is not OK
  */
-export const fetchExceptionListById = async ({
+const fetchExceptionListById = async ({
   http,
   id,
   namespaceType,
   signal,
-}: ApiCallByIdProps): Promise<ExceptionListSchema> => {
-  const [validatedRequest, errorsRequest] = validate(
-    { id, namespace_type: namespaceType },
-    readExceptionListSchema
-  );
+}: ApiCallByIdProps): Promise<ExceptionListSchema> =>
+  http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
+    method: 'GET',
+    query: { id, namespace_type: namespaceType },
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
-        method: 'GET',
-        query: { id, namespace_type: namespaceType },
-        signal,
-      });
+const fetchExceptionListByIdWithValidation = async ({
+  http,
+  id,
+  namespaceType,
+  signal,
+}: ApiCallByIdProps): Promise<ExceptionListSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          fetchExceptionListById({
+            http,
+            id,
+            namespaceType,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(exceptionListSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { fetchExceptionListByIdWithValidation as fetchExceptionListById };
 
 /**
  * Fetch an ExceptionList's ExceptionItems by providing a ExceptionList list_id
@@ -314,7 +330,7 @@ export const fetchExceptionListById = async ({
  *
  * @throws An error if response is not OK
  */
-export const fetchExceptionListsItemsByListIds = async ({
+const fetchExceptionListsItemsByListIds = async ({
   http,
   listIds,
   namespaceTypes,
@@ -349,33 +365,41 @@ export const fetchExceptionListsItemsByListIds = async ({
     sort_order: 'desc',
     ...(filters.trim() !== '' ? { filter: filters } : {}),
   };
-  const [validatedRequest, errorsRequest] = validate(query, findExceptionListItemSchema);
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<FoundExceptionListItemSchema>(
-        `${EXCEPTION_LIST_ITEM_URL}/_find`,
-        {
-          method: 'GET',
-          query,
-          signal,
-        }
-      );
-
-      const [validatedResponse, errorsResponse] = validate(response, foundExceptionListItemSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
+  return http.fetch<FoundExceptionListItemSchema>(`${EXCEPTION_LIST_ITEM_URL}/_find`, {
+    method: 'GET',
+    query,
+    signal,
+  });
 };
+
+const fetchExceptionListsItemsByListIdsWithValidation = async ({
+  filterOptions,
+  http,
+  listIds,
+  namespaceTypes,
+  pagination,
+  signal,
+}: ApiCallByListIdProps): Promise<FoundExceptionListItemSchema> =>
+  flow(
+    () =>
+      tryCatch(
+        () =>
+          fetchExceptionListsItemsByListIds({
+            filterOptions,
+            http,
+            listIds,
+            namespaceTypes,
+            pagination,
+            signal,
+          }),
+        toError
+      ),
+    chain((response) => fromEither(validateEither(foundExceptionListItemSchema, response))),
+    flow(toPromise)
+  )();
+
+export { fetchExceptionListsItemsByListIdsWithValidation as fetchExceptionListsItemsByListIds };
 
 /**
  * Fetch an ExceptionListItem by providing a ExceptionListItem ID
@@ -387,38 +411,31 @@ export const fetchExceptionListsItemsByListIds = async ({
  *
  * @throws An error if response is not OK
  */
-export const fetchExceptionListItemById = async ({
+const fetchExceptionListItemById = async ({
   http,
   id,
   namespaceType,
   signal,
-}: ApiCallByIdProps): Promise<ExceptionListItemSchema> => {
-  const [validatedRequest, errorsRequest] = validate(
-    { id, namespace_type: namespaceType },
-    readExceptionListItemSchema
-  );
+}: ApiCallByIdProps): Promise<ExceptionListItemSchema> =>
+  http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
+    method: 'GET',
+    query: { id, namespace_type: namespaceType },
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
-        method: 'GET',
-        query: { id, namespace_type: namespaceType },
-        signal,
-      });
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListItemSchema);
+const fetchExceptionListItemByIdWithValidation = async ({
+  http,
+  id,
+  namespaceType,
+  signal,
+}: ApiCallByIdProps): Promise<ExceptionListItemSchema> =>
+  flow(
+    () => tryCatch(() => fetchExceptionListItemById({ http, id, namespaceType, signal }), toError),
+    chain((response) => fromEither(validateEither(exceptionListItemSchema, response))),
+    flow(toPromise)
+  )();
 
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { fetchExceptionListItemByIdWithValidation as fetchExceptionListItemById };
 
 /**
  * Delete an ExceptionList by providing a ExceptionList ID
@@ -430,39 +447,31 @@ export const fetchExceptionListItemById = async ({
  *
  * @throws An error if response is not OK
  */
-export const deleteExceptionListById = async ({
+const deleteExceptionListById = async ({
   http,
   id,
   namespaceType,
   signal,
-}: ApiCallByIdProps): Promise<ExceptionListSchema> => {
-  const [validatedRequest, errorsRequest] = validate(
-    { id, namespace_type: namespaceType },
-    deleteExceptionListSchema
-  );
+}: ApiCallByIdProps): Promise<ExceptionListSchema> =>
+  http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
+    method: 'DELETE',
+    query: { id, namespace_type: namespaceType },
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListSchema>(EXCEPTION_LIST_URL, {
-        method: 'DELETE',
-        query: { id, namespace_type: namespaceType },
-        signal,
-      });
+const deleteExceptionListByIdWithValidation = async ({
+  http,
+  id,
+  namespaceType,
+  signal,
+}: ApiCallByIdProps): Promise<ExceptionListSchema> =>
+  flow(
+    () => tryCatch(() => deleteExceptionListById({ http, id, namespaceType, signal }), toError),
+    chain((response) => fromEither(validateEither(exceptionListSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { deleteExceptionListByIdWithValidation as deleteExceptionListById };
 
 /**
  * Delete an ExceptionListItem by providing a ExceptionListItem ID
@@ -474,39 +483,31 @@ export const deleteExceptionListById = async ({
  *
  * @throws An error if response is not OK
  */
-export const deleteExceptionListItemById = async ({
+const deleteExceptionListItemById = async ({
   http,
   id,
   namespaceType,
   signal,
-}: ApiCallByIdProps): Promise<ExceptionListItemSchema> => {
-  const [validatedRequest, errorsRequest] = validate(
-    { id, namespace_type: namespaceType },
-    deleteExceptionListItemSchema
-  );
+}: ApiCallByIdProps): Promise<ExceptionListItemSchema> =>
+  http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
+    method: 'DELETE',
+    query: { id, namespace_type: namespaceType },
+    signal,
+  });
 
-  if (validatedRequest != null) {
-    try {
-      const response = await http.fetch<ExceptionListItemSchema>(EXCEPTION_LIST_ITEM_URL, {
-        method: 'DELETE',
-        query: { id, namespace_type: namespaceType },
-        signal,
-      });
+const deleteExceptionListItemByIdWithValidation = async ({
+  http,
+  id,
+  namespaceType,
+  signal,
+}: ApiCallByIdProps): Promise<ExceptionListItemSchema> =>
+  flow(
+    () => tryCatch(() => deleteExceptionListItemById({ http, id, namespaceType, signal }), toError),
+    chain((response) => fromEither(validateEither(exceptionListItemSchema, response))),
+    flow(toPromise)
+  )();
 
-      const [validatedResponse, errorsResponse] = validate(response, exceptionListItemSchema);
-
-      if (errorsResponse != null || validatedResponse == null) {
-        return Promise.reject(errorsResponse);
-      } else {
-        return Promise.resolve(validatedResponse);
-      }
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  } else {
-    return Promise.reject(errorsRequest);
-  }
-};
+export { deleteExceptionListItemByIdWithValidation as deleteExceptionListItemById };
 
 /**
  * Add new Endpoint ExceptionList
@@ -517,27 +518,26 @@ export const deleteExceptionListItemById = async ({
  * @throws An error if response is not OK
  *
  */
-export const addEndpointExceptionList = async ({
+const addEndpointExceptionList = async ({
   http,
   signal,
-}: AddEndpointExceptionListProps): Promise<CreateEndpointListSchema> => {
-  try {
-    const response = await http.fetch<ExceptionListItemSchema>(ENDPOINT_LIST_URL, {
-      method: 'POST',
-      signal,
-    });
+}: AddEndpointExceptionListProps): Promise<CreateEndpointListSchema> =>
+  http.fetch<ExceptionListItemSchema>(ENDPOINT_LIST_URL, {
+    method: 'POST',
+    signal,
+  });
 
-    const [validatedResponse, errorsResponse] = validate(response, createEndpointListSchema);
+const addEndpointExceptionListWithValidation = async ({
+  http,
+  signal,
+}: AddEndpointExceptionListProps): Promise<CreateEndpointListSchema> =>
+  flow(
+    () => tryCatch(() => addEndpointExceptionList({ http, signal }), toError),
+    chain((response) => fromEither(validateEither(createEndpointListSchema, response))),
+    flow(toPromise)
+  )();
 
-    if (errorsResponse != null || validatedResponse == null) {
-      return Promise.reject(errorsResponse);
-    } else {
-      return Promise.resolve(validatedResponse);
-    }
-  } catch (error) {
-    return Promise.reject(error);
-  }
-};
+export { addEndpointExceptionListWithValidation as addEndpointExceptionList };
 
 /**
  * Fetch an ExceptionList by providing a ExceptionList ID


### PR DESCRIPTION
## Summary

Currently working on issues related to exceptions and it was noted on a separate PR that the request payload validation being done in the client side API calls was unnecessary. It was helpful in development, but not of any added value in production. Not only that, but the extra validations also add to the performance hit. 

Removed the payload validation and formatted the code to follow the same pattern as that in the value lists api file.

Tested that exceptions flows not affected by testing out exceptions CRUD flows.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
