### PR TITLE
[Lens] Fix duplicate suggestions on single-bucket charts

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -1876,7 +1876,7 @@ describe('IndexPattern Data Source suggestions', () => {
       expect(suggestions.length).toBe(6);
     });
 
-    it('returns an only metric version of a given table', () => {
+    it('returns an only metric version of a given table, but does not include current state as reduced', () => {
       const initialState = testInitialState();
       const state: IndexPatternPrivateState = {
         indexPatternRefs: [],
@@ -1953,6 +1953,21 @@ describe('IndexPattern Data Source suggestions', () => {
       };
 
       const suggestions = getSuggestionSubset(getDatasourceSuggestionsFromCurrentState(state));
+      expect(suggestions).not.toContainEqual(
+        expect.objectContaining({
+          table: expect.objectContaining({
+            changeType: 'reduced',
+            columns: [
+              expect.objectContaining({
+                operation: expect.objectContaining({ label: 'field2' }),
+              }),
+              expect.objectContaining({
+                operation: expect.objectContaining({ label: 'Average of field1' }),
+              }),
+            ],
+          }),
+        })
+      );
       expect(suggestions).toContainEqual(
         expect.objectContaining({
           table: expect.objectContaining({

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
@@ -583,8 +583,9 @@ function createSimplifiedTableSuggestions(state: IndexPatternPrivateState, layer
         columnOrder: [...bucketedColumns, ...availableMetricColumns],
       };
 
-      if (availableReferenceColumns.length) {
-        // Don't remove buckets when dealing with any refs. This can break refs.
+      if (availableBucketedColumns.length <= 1 || availableReferenceColumns.length) {
+        // Don't simplify when dealing with single-bucket table. Also don't break
+        // reference-based columns by removing buckets.
         return [];
       } else if (availableMetricColumns.length > 1) {
         return [{ ...layer, columnOrder: [...bucketedColumns, availableMetricColumns[0]] }];
@@ -597,7 +598,6 @@ function createSimplifiedTableSuggestions(state: IndexPatternPrivateState, layer
       availableReferenceColumns.length
         ? []
         : availableMetricColumns.map((columnId) => {
-            // build suggestions with only metrics
             return { ...layer, columnOrder: [columnId] };
           })
     )
@@ -606,8 +606,7 @@ function createSimplifiedTableSuggestions(state: IndexPatternPrivateState, layer
         state,
         layerId,
         updatedLayer,
-        changeType:
-          layer.columnOrder.length === updatedLayer.columnOrder.length ? 'unchanged' : 'reduced',
+        changeType: 'reduced',
         label:
           updatedLayer.columnOrder.length === 1
             ? getMetricSuggestionTitle(updatedLayer, availableMetricColumns.length === 1)


### PR DESCRIPTION
The duplicate suggestions were caused by the work on reference-based operations. The datasource was generating 2 identical suggestions of type `unchanged` because the logic that I thought was only generated `reduce` suggestions was capable of generating 2 types. I've fixed this by separating the code: we now have a path for `unchanged`, and a path that always does a `reduce` suggestion.

Steps to test:

1. Drag a string field into the Lens workspace
2. Notice that there are no more duplicate suggestions on the bottom suggestion bar

Fixes https://github.com/elastic/kibana/issues/86881

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
