### PR TITLE
[Fleet] Fix Page title on Integrations Edit Package Policy

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -51,8 +51,8 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiText>
-                <h1>
-                  {from === 'edit' ? (
+                <h1 data-test-subj={`${dataTestSubj}_pageTitle`}>
+                  {from === 'edit' || from === 'package-edit' ? (
                     <FormattedMessage
                       id="xpack.fleet.editPackagePolicy.pageTitleWithPackageName"
                       defaultMessage="Edit {packageName} integration"
@@ -78,7 +78,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
 
       return from === 'edit' || from === 'package-edit' ? (
         <EuiText>
-          <h1>
+          <h1 data-test-subj={`${dataTestSubj}_pageTitle`}>
             <FormattedMessage
               id="xpack.fleet.editPackagePolicy.pageTitle"
               defaultMessage="Edit integration"
@@ -95,7 +95,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
           </h1>
         </EuiText>
       );
-    }, [from, packageInfo]);
+    }, [dataTestSubj, from, packageInfo]);
 
     const pageDescription = useMemo(() => {
       return from === 'edit' || from === 'package-edit' ? (


### PR DESCRIPTION
## Summary

When navigating to the Integration Policy Edit page (from  "Integrations > {package} > Polices > {click policy title}"), the page title should be `Edit {package name} integration`

Fixes #86763 

![image](https://user-images.githubusercontent.com/56442535/103310796-76d66580-49e6-11eb-8524-a3c04e660c6a.png)



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
