### PR TITLE
[APM] Change services panel guttersize to “xs”

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/ServiceList/index.tsx
@@ -234,7 +234,12 @@ export function ServiceList({ items, noItemsMessage }: Props) {
     : 'transactionsPerMinute';
 
   return (
-    <EuiFlexGroup direction="column" responsive={false} alignItems="flexEnd">
+    <EuiFlexGroup
+      gutterSize="xs"
+      direction="column"
+      responsive={false}
+      alignItems="flexEnd"
+    >
       <EuiFlexItem>
         <EuiFlexGroup responsive={false} alignItems="center" gutterSize="xs">
           <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

Just decreasing the gutter size in the panel flex group to condense the contents a bit more.

**Before**

<img width="1670" alt="Screenshot 2021-01-04 at 13 34 10" src="https://user-images.githubusercontent.com/4104278/103535728-898ee580-4e91-11eb-9940-5b31df1ec10a.png">

**After**

<img width="1672" alt="Screenshot 2021-01-04 at 13 28 41" src="https://user-images.githubusercontent.com/4104278/103535456-05d4f900-4e91-11eb-9f7b-1b771d2903f4.png">


