### PR TITLE
[Fleet] Handle errors happenning during Fleet setup in the UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/hooks/use_fleet_status.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/hooks/use_fleet_status.tsx
@@ -13,6 +13,7 @@ interface FleetStatusState {
   enabled: boolean;
   isLoading: boolean;
   isReady: boolean;
+  error?: Error;
   missingRequirements?: GetFleetStatusResponse['missing_requirements'];
 }
 
@@ -44,7 +45,7 @@ export const FleetStatusProvider: React.FC = ({ children }) => {
         missingRequirements: res.data?.missing_requirements,
       }));
     } catch (error) {
-      setState((s) => ({ ...s, isLoading: true }));
+      setState((s) => ({ ...s, isLoading: false, error }));
     }
   }
   useEffect(() => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.tsx
@@ -4,9 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 import React from 'react';
+import { FormattedMessage } from '@kbn/i18n/react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import { PAGE_ROUTING_PATHS } from '../../constants';
-import { Loading } from '../../components';
+import { Loading, Error } from '../../components';
 import { useConfig, useFleetStatus, useBreadcrumbs, useCapabilities } from '../../hooks';
 import { AgentListPage } from './agent_list_page';
 import { SetupPage } from './setup_page';
@@ -14,6 +15,7 @@ import { AgentDetailsPage } from './agent_details_page';
 import { NoAccessPage } from './error_pages/no_access';
 import { EnrollmentTokenListPage } from './enrollment_token_list_page';
 import { ListLayout } from './components/list_layout';
+import { WithoutHeaderLayout } from '../../layouts';
 
 export const FleetApp: React.FunctionComponent = () => {
   useBreadcrumbs('fleet');
@@ -25,6 +27,22 @@ export const FleetApp: React.FunctionComponent = () => {
   if (!agents.enabled) return null;
   if (fleetStatus.isLoading) {
     return <Loading />;
+  }
+
+  if (fleetStatus.error) {
+    return (
+      <WithoutHeaderLayout>
+        <Error
+          title={
+            <FormattedMessage
+              id="xpack.fleet.agentsInitializationErrorMessageTitle"
+              defaultMessage="Unable to initialize Fleet Agents"
+            />
+          }
+          error={fleetStatus.error}
+        />
+      </WithoutHeaderLayout>
+    );
   }
 
   if (fleetStatus.isReady === false) {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/index.tsx
@@ -36,7 +36,7 @@ export const FleetApp: React.FunctionComponent = () => {
           title={
             <FormattedMessage
               id="xpack.fleet.agentsInitializationErrorMessageTitle"
-              defaultMessage="Unable to initialize Fleet Agents"
+              defaultMessage="Unable to initialize central management for Elastic Agents"
             />
           }
           error={fleetStatus.error}


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/86864

Currently when an error happens during fleet agents setup the UI is stuck loading

![](https://user-images.githubusercontent.com/59917825/102968571-18a70f80-451a-11eb-93f5-f9cb419b5fd4.png)

This PR handle the error and display it as we do for the plugin setup

<img width="962" alt="Screen Shot 2021-01-04 at 1 31 52 PM" src="https://user-images.githubusercontent.com/1336873/103562660-ceb31780-4e91-11eb-97e8-c5a82dcfdc3b.png">
