### PR TITLE
[Fleet] Add definition for existing route to OpenAPI file

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1274,6 +1274,15 @@
       "put": {
         "summary": "PackagePolicies - Update",
         "operationId": "put-packagePolicies-packagePolicyId",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/update_package_policy"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2076,6 +2085,22 @@
           "format_version",
           "download",
           "path"
+        ]
+      },
+      "update_package_policy": {
+        "title": "UpdatePackagePolicy",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/new_package_policy"
+          }
         ]
       }
     }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -789,6 +789,11 @@ paths:
     put:
       summary: PackagePolicies - Update
       operationId: put-packagePolicies-packagePolicyId
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/update_package_policy'
       responses:
         '200':
           description: OK
@@ -1323,5 +1328,13 @@ components:
         - format_version
         - download
         - path
+    update_package_policy:
+      title: UpdatePackagePolicy
+      allOf:
+        - type: object
+          properties:
+            version:
+              type: string
+        - $ref: '#/components/schemas/new_package_policy'
 security:
   - basicAuth: []

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/update_package_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/update_package_policy.yaml
@@ -1,0 +1,7 @@
+title: UpdatePackagePolicy
+allOf:
+  - type: object
+    properties:
+      version:
+        type: string
+  - $ref: ./new_package_policy.yaml

--- a/x-pack/plugins/fleet/common/openapi/paths/package_policies@{package_policy_id}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/package_policies@{package_policy_id}.yaml
@@ -23,6 +23,11 @@ parameters:
 put:
   summary: PackagePolicies - Update
   operationId: put-packagePolicies-packagePolicyId
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/update_package_policy.yaml
   responses:
     '200':
       description: OK


### PR DESCRIPTION
## Summary

The operation for updating a package policy is missing from the OpenAPI file. We have a `GET` operation but nothing for `PUT`. This fixes that.

**Existing type:**
https://github.com/elastic/kibana/blob/284b1046df6981f0da1e743680bf99247523627e/x-pack/plugins/fleet/common/types/models/package_policy.ts#L59-L61

**Corresponding JSON Schema added in this PR:**
https://github.com/elastic/kibana/blob/6a26f11fb5de7d2458539278d721b80a3f28fb86/x-pack/plugins/fleet/common/openapi/components/schemas/update_package_policy.yaml#L1-L7

**Existing route definiton for `PUT` request:**
https://github.com/elastic/kibana/blob/441a0d4ec9f713c864f742846084ce598222afa4/x-pack/plugins/fleet/server/routes/package_policy/index.ts#L54-L62

**Where `UpdatePackagePolicyRequestSchema` is**

https://github.com/elastic/kibana/blob/441a0d4ec9f713c864f742846084ce598222afa4/x-pack/plugins/fleet/server/types/rest_spec/package_policy.ts#L24-L27

and expands to 
<img width="599" alt="Screen Shot 2021-01-04 at 1 03 20 PM" src="https://user-images.githubusercontent.com/57655/103564913-5ba7a200-4e8d-11eb-940d-59994c2cc0a9.png">

**Corresponding OpenAPI definition**
https://github.com/elastic/kibana/blob/6a26f11fb5de7d2458539278d721b80a3f28fb86/x-pack/plugins/fleet/common/openapi/paths/package_policies%40%7Bpackage_policy_id%7D.yaml#L23-L30

<details><summary>Screenshot showing docs for endpoint request & response values</summary>

This is using `npx @redocly/openapi-cli preview-docs bundled.json`, but can put `bundled.json` in any OpenAPI viewer to get similar results
<img width="2145" alt="Screen Shot 2021-01-04 at 12 42 53 PM" src="https://user-images.githubusercontent.com/57655/103565115-bfca6600-4e8d-11eb-9899-17fdfed5d23e.png">

</details>
