### PR TITLE
[Workplace Search] Add routes for Org Settings

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -9,9 +9,11 @@ import { RouteDependencies } from '../../plugin';
 import { registerOverviewRoute } from './overview';
 import { registerGroupsRoutes } from './groups';
 import { registerSourcesRoutes } from './sources';
+import { registerSettingsRoutes } from './settings';
 
 export const registerWorkplaceSearchRoutes = (dependencies: RouteDependencies) => {
   registerOverviewRoute(dependencies);
   registerGroupsRoutes(dependencies);
   registerSourcesRoutes(dependencies);
+  registerSettingsRoutes(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
+
+import {
+  registerOrgSettingsRoute,
+  registerOrgSettingsCustomizeRoute,
+  registerOrgSettingsOauthApplicationRoute,
+} from './settings';
+
+describe('settings routes', () => {
+  describe('GET /api/workplace_search/org/settings', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/settings',
+        payload: 'params',
+      });
+
+      registerOrgSettingsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      mockRouter.callRoute({});
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings',
+      });
+    });
+  });
+
+  describe('PUT /api/workplace_search/org/settings/customize', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/org/settings/customize',
+        payload: 'body',
+      });
+
+      registerOrgSettingsCustomizeRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        body: {
+          name: 'foo',
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/customize',
+        body: mockRequest.body,
+      });
+    });
+  });
+
+  describe('PUT /api/workplace_search/org/settings/oauth_application', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('creates a request handler', () => {
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/org/settings/oauth_application',
+        payload: 'body',
+      });
+
+      registerOrgSettingsOauthApplicationRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+
+      const mockRequest = {
+        body: {
+          oauth_application: {
+            name: 'foo',
+            confidential: true,
+            redirect_uri: 'http://foo.bar',
+          },
+        },
+      };
+
+      mockRouter.callRoute(mockRequest);
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/oauth_application',
+        body: mockRequest.body,
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import { RouteDependencies } from '../../plugin';
+
+export function registerOrgSettingsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/settings',
+      validate: false,
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/ws/org/settings',
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSettingsCustomizeRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.put(
+    {
+      path: '/api/workplace_search/org/settings/customize',
+      validate: {
+        body: schema.object({
+          name: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/ws/org/settings/customize',
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export function registerOrgSettingsOauthApplicationRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.put(
+    {
+      path: '/api/workplace_search/org/settings/oauth_application',
+      validate: {
+        body: schema.object({
+          oauth_application: schema.object({
+            name: schema.string(),
+            confidential: schema.boolean(),
+            redirect_uri: schema.string(),
+          }),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      return enterpriseSearchRequestHandler.createRequest({
+        path: '/ws/org/settings/oauth_application',
+        body: request.body,
+      })(context, request, response);
+    }
+  );
+}
+
+export const registerSettingsRoutes = (dependencies: RouteDependencies) => {
+  registerOrgSettingsRoute(dependencies);
+  registerOrgSettingsCustomizeRoute(dependencies);
+  registerOrgSettingsOauthApplicationRoute(dependencies);
+};


### PR DESCRIPTION
## Summary

Add server routes for use in Workplace Search Settings

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
