### PR TITLE
[Enterprise Search] Kea mount test helper

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
@@ -10,7 +10,13 @@ export { mockLicensingValues } from './licensing_logic.mock';
 export { mockHttpValues } from './http_logic.mock';
 export { mockTelemetryActions } from './telemetry_logic.mock';
 export { mockFlashMessagesValues, mockFlashMessagesActions } from './flash_messages_logic.mock';
-export { mockAllValues, mockAllActions, setMockValues, setMockActions } from './kea.mock';
+export {
+  mockAllValues,
+  mockAllActions,
+  setMockValues,
+  setMockActions,
+  LogicMounter,
+} from './kea.mock';
 
 export { mountAsync } from './mount_async.mock';
 export { mountWithIntl } from './mount_with_i18n.mock';

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
@@ -40,14 +40,18 @@ jest.mock('kea', () => ({
 }));
 
 /**
- * Call this function to override a specific set of Kea values while retaining all other defaults
- * Example usage within a component test:
+ * React component helpers
  *
- * import '../../../__mocks__/kea';
- * import { setMockValues } from ''../../../__mocks__';
+ * Call this function to override a specific set of Kea values while retaining all other defaults
+ *
+ * Example usage:
+ *
+ * import { setMockValues } from '../../../__mocks__/kea.mock';
+ * import { SomeComponent } from './';
  *
  * it('some test', () => {
  *   setMockValues({ someValue: 'hello' });
+ *   shallow(<SomeComponent />);
  * });
  */
 import { useValues, useActions } from 'kea';
@@ -58,3 +62,53 @@ export const setMockValues = (values: object) => {
 export const setMockActions = (actions: object) => {
   (useActions as jest.Mock).mockImplementation(() => ({ ...mockAllActions, ...actions }));
 };
+
+/**
+ * Kea logic helpers
+ *
+ * Call this function to mount a logic file and optionally override default values.
+ * Automatically DRYs out a lot of cruft for us, such as resetting context, creating the
+ * nested defaults path obj (see https://kea.js.org/docs/api/context#resetcontext), and
+ * returning an unmount function
+ *
+ * Example usage:
+ *
+ * import { LogicMounter } from '../../../__mocks__/kea.mock';
+ * import { SomeLogic } from './';
+ *
+ * const { mount } = new LogicMounter(SomeLogic);
+ *
+ * it('some test', () => {
+ *   mount({ someValue: 'hello' });
+ * });
+ */
+import { resetContext, Logic, LogicInput } from 'kea';
+
+interface LogicFile {
+  inputs: Array<LogicInput<Logic>>;
+  mount(): Function;
+}
+export class LogicMounter {
+  private logicFile: LogicFile;
+
+  constructor(logicFile: LogicFile) {
+    this.logicFile = logicFile;
+  }
+
+  // Reset context with optional default value overrides
+  public resetContext = (values?: object) => {
+    if (!values) {
+      resetContext({});
+    } else {
+      const path = this.logicFile.inputs[0].path as string[]; // example: ['x', 'y', 'z']
+      const defaults = path.reduceRight((value: object, key: string) => ({ [key]: value }), values); // example: { x: { y: { z: values } } }
+      resetContext({ defaults });
+    }
+  };
+
+  // Automatically reset context & mount the logic file
+  public mount = (values?: object) => {
+    this.resetContext(values);
+    this.logicFile.mount();
+  };
+}

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
@@ -76,10 +76,11 @@ export const setMockActions = (actions: object) => {
  * import { LogicMounter } from '../../../__mocks__/kea.mock';
  * import { SomeLogic } from './';
  *
- * const { mount } = new LogicMounter(SomeLogic);
+ * const { mount, unmount } = new LogicMounter(SomeLogic);
  *
  * it('some test', () => {
  *   mount({ someValue: 'hello' });
+ *   unmount();
  * });
  */
 import { resetContext, Logic, LogicInput } from 'kea';
@@ -90,6 +91,7 @@ interface LogicFile {
 }
 export class LogicMounter {
   private logicFile: LogicFile;
+  private unmountFn!: Function;
 
   constructor(logicFile: LogicFile) {
     this.logicFile = logicFile;
@@ -109,6 +111,13 @@ export class LogicMounter {
   // Automatically reset context & mount the logic file
   public mount = (values?: object) => {
     this.resetContext(values);
-    this.logicFile.mount();
+    const unmount = this.logicFile.mount();
+    this.unmountFn = unmount;
+    return unmount; // Keep Kea behavior of returning an unmount fn from mount
+  };
+
+  // Also add unmount as a class method that can be destructured on init without becoming stale later
+  public unmount = () => {
+    this.unmountFn();
   };
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
 
 import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
@@ -57,24 +57,7 @@ describe('CredentialsLogic', () => {
     fullEngineAccessChecked: false,
   };
 
-  const mount = (defaults?: object) => {
-    if (!defaults) {
-      resetContext({});
-    } else {
-      resetContext({
-        defaults: {
-          enterprise_search: {
-            app_search: {
-              credentials_logic: {
-                ...defaults,
-              },
-            },
-          },
-        },
-      });
-    }
-    CredentialsLogic.mount();
-  };
+  const { mount } = new LogicMounter(CredentialsLogic);
 
   const newToken = {
     id: 1,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.test.ts
@@ -4,7 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
+
 import dedent from 'dedent';
 
 jest.mock('./utils', () => ({
@@ -39,24 +40,7 @@ describe('DocumentCreationLogic', () => {
   };
   const mockFile = new File(['mockFile'], 'mockFile.json');
 
-  const mount = (defaults?: object) => {
-    if (!defaults) {
-      resetContext({});
-    } else {
-      resetContext({
-        defaults: {
-          enterprise_search: {
-            app_search: {
-              document_creation_logic: {
-                ...defaults,
-              },
-            },
-          },
-        },
-      });
-    }
-    DocumentCreationLogic.mount();
-  };
+  const { mount } = new LogicMounter(DocumentCreationLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
 
 import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
@@ -36,24 +36,7 @@ describe('DocumentDetailLogic', () => {
     fields: [],
   };
 
-  const mount = (defaults?: object) => {
-    if (!defaults) {
-      resetContext({});
-    } else {
-      resetContext({
-        defaults: {
-          enterprise_search: {
-            app_search: {
-              document_detail_logic: {
-                ...defaults,
-              },
-            },
-          },
-        },
-      });
-    }
-    DocumentDetailLogic.mount();
-  };
+  const { mount } = new LogicMounter(DocumentDetailLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
 
 import { DocumentsLogic } from './documents_logic';
 
@@ -13,24 +13,7 @@ describe('DocumentsLogic', () => {
     isDocumentCreationOpen: false,
   };
 
-  const mount = (defaults?: object) => {
-    if (!defaults) {
-      resetContext({});
-    } else {
-      resetContext({
-        defaults: {
-          enterprise_search: {
-            app_search: {
-              documents_logic: {
-                ...defaults,
-              },
-            },
-          },
-        },
-      });
-    }
-    DocumentsLogic.mount();
-  };
+  const { mount } = new LogicMounter(DocumentsLogic);
 
   describe('actions', () => {
     describe('openDocumentCreation', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
 
 import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
@@ -46,24 +46,7 @@ describe('EngineLogic', () => {
     engineNotFound: false,
   };
 
-  const mount = (values?: object) => {
-    if (!values) {
-      resetContext({});
-    } else {
-      resetContext({
-        defaults: {
-          enterprise_search: {
-            app_search: {
-              engine_logic: {
-                ...values,
-              },
-            },
-          },
-        },
-      });
-    }
-    EngineLogic.mount();
-  };
+  const { mount } = new LogicMounter(EngineLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
 
 import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
@@ -48,10 +48,7 @@ describe('EngineOverviewLogic', () => {
     timeoutId: null,
   };
 
-  const mount = () => {
-    resetContext({});
-    EngineOverviewLogic.mount();
-  };
+  const { mount, unmount } = new LogicMounter(EngineOverviewLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -141,12 +138,9 @@ describe('EngineOverviewLogic', () => {
   });
 
   describe('unmount', () => {
-    let unmount: Function;
-
     beforeEach(() => {
       jest.useFakeTimers();
-      resetContext({});
-      unmount = EngineOverviewLogic.mount();
+      mount();
     });
 
     it('clears existing polling timeouts on unmount', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../../__mocks__/kea.mock';
 
 import { mockHttpValues } from '../../../../__mocks__';
 jest.mock('../../../../shared/http', () => ({
@@ -53,24 +53,7 @@ describe('LogRetentionLogic', () => {
     isLogRetentionUpdating: false,
   };
 
-  const mount = (defaults?: object) => {
-    if (!defaults) {
-      resetContext({});
-    } else {
-      resetContext({
-        defaults: {
-          enterprise_search: {
-            app_search: {
-              log_retention_logic: {
-                ...defaults,
-              },
-            },
-          },
-        },
-      });
-    }
-    LogRetentionLogic.mount();
-  };
+  const { mount } = new LogicMounter(LogRetentionLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
## Summary

After discussing this in a previous PR (https://github.com/elastic/kibana/pull/86822#pullrequestreview-557383108), I went ahead and created a test helper that DRY's out our repeated `mount` helpers across several tests. Super huge thanks to Jason for giving an example API!

Usage:
```js
import { LogicMounter } from '../../../__mocks__/kea.mock';

const { mount, unmount } = new LogicMounter(SomeLogic);

it('mounts with context automatically reset between tests', () => {
  mount();
});

it('mounts and overrides default values', () => {
  mount({ foo: 'bar' });
  expect(SomeLogic.values.foo).toEqual('bar');
});

it('unmounts', () => {
  mount();
  unmount();
});
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios