### PR TITLE
Fix broken documentation link in Visualize app

### DIFF
--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -198,3 +198,8 @@ This page has moved. Refer to <<url_templating-language>>.
 === Variables
 
 This page has moved. Refer to <<url-template-variables>>.
+
+[role="exclude",id="visualize"]
+== Visualize
+
+This page has been removed.

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -202,4 +202,4 @@ This page has moved. Refer to <<url-template-variables>>.
 [role="exclude",id="visualize"]
 == Visualize
 
-This page has been removed.
+This page has been removed. Refer to <<dashboard>>.

--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -155,7 +155,7 @@ export class DocLinksService {
           guide: `${ELASTICSEARCH_DOCS}transforms.html`,
         },
         visualize: {
-          guide: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/visualize.html`,
+          guide: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/dashboard.html`,
           timelionDeprecation: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/dashboard.html#timelion-deprecation`,
           lens: `${ELASTIC_WEBSITE_URL}what-is/kibana-lens`,
           maps: `${ELASTIC_WEBSITE_URL}maps`,

--- a/src/plugins/visualize/public/application/utils/utils.ts
+++ b/src/plugins/visualize/public/application/utils/utils.ts
@@ -31,7 +31,7 @@ export const addHelpMenuToAppChrome = (chrome: ChromeStart, docLinks: DocLinksSt
     links: [
       {
         linkType: 'documentation',
-        href: `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/visualize.html`,
+        href: `${docLinks.links.visualize.guide}`,
       },
     ],
   });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/85176

Relates https://github.com/elastic/kibana/pull/76194

Adds a redirect for https://www.elastic.co/guide/en/kibana/master/visualize.html

Updates the URL for visualize in the [documentation links service](https://github.com/elastic/kibana/blob/master/src/core/public/doc_links/doc_links_service.ts#L158).

Updates the help menu in the Visualize app to use the appropriate URL from the documentation links service.

