### PR TITLE
[App Search] Minor var names follow-up

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -57,8 +57,7 @@ describe('EngineRouter', () => {
   });
 
   it('redirects to engines list and flashes an error if the engine param was not found', () => {
-    (useParams as jest.Mock).mockReturnValue({ engineName: '404-engine' });
-    setMockValues({ ...values, engineNotFound: true });
+    setMockValues({ ...values, engineNotFound: true, engineName: '404-engine' });
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(Redirect).prop('to')).toEqual('/engines');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -69,30 +69,30 @@ export const EngineRouter: React.FC = () => {
     },
   } = useValues(AppLogic);
 
+  const { engineName: engineNameFromUrl } = useParams() as { engineName: string };
   const { engineName, dataLoading, engineNotFound } = useValues(EngineLogic);
   const { setEngineName, initializeEngine, clearEngine } = useActions(EngineLogic);
 
-  const { engineName: engineNameParam } = useParams() as { engineName: string };
-  const engineBreadcrumb = [ENGINES_TITLE, engineNameParam];
-
   useEffect(() => {
-    setEngineName(engineNameParam);
+    setEngineName(engineNameFromUrl);
     initializeEngine();
     return clearEngine;
-  }, [engineNameParam]);
+  }, [engineNameFromUrl]);
 
   if (engineNotFound) {
     setQueuedErrorMessage(
       i18n.translate('xpack.enterpriseSearch.appSearch.engine.notFound', {
-        defaultMessage: "No engine with name '{engineNameParam}' could be found.",
-        values: { engineNameParam },
+        defaultMessage: "No engine with name '{engineName}' could be found.",
+        values: { engineName },
       })
     );
     return <Redirect to={ENGINES_PATH} />;
   }
 
-  const isLoadingNewEngine = engineName !== engineNameParam;
+  const isLoadingNewEngine = engineName !== engineNameFromUrl;
   if (isLoadingNewEngine || dataLoading) return <Loading />;
+
+  const engineBreadcrumb = [ENGINES_TITLE, engineName];
 
   return (
     <Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -75,8 +75,6 @@ export const EngineRouter: React.FC = () => {
   const { engineName: engineNameParam } = useParams() as { engineName: string };
   const engineBreadcrumb = [ENGINES_TITLE, engineNameParam];
 
-  const isEngineInStateStale = () => engineName !== engineNameParam;
-
   useEffect(() => {
     setEngineName(engineNameParam);
     initializeEngine();
@@ -93,7 +91,8 @@ export const EngineRouter: React.FC = () => {
     return <Redirect to={ENGINES_PATH} />;
   }
 
-  if (isEngineInStateStale() || dataLoading) return <Loading />;
+  const isLoadingNewEngine = engineName !== engineNameParam;
+  if (isLoadingNewEngine || dataLoading) return <Loading />;
 
   return (
     <Switch>


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/86702#discussion_r551425221: a var rename suggestion and then a little more because I can't leave well enough alone 

### Checklist

- [x] Going to a meta engine and then clicking into a source engine document still works
- [x] Hitting back to said meta engine still works
- [x] (Regression) hitting a 404 engine (e.g., http://localhost:5601/xyz/app/enterprise_search/app_search/engines/404/documents) still works as expected