### PR TITLE
[App Search] Minor EngineLogic hardening

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -153,6 +153,18 @@ describe('EngineLogic', () => {
         });
       });
 
+      describe('engineName', () => {
+        it('should be reset to an empty string', () => {
+          mount({ engineName: 'hello-world' });
+          EngineLogic.actions.clearEngine();
+
+          expect(EngineLogic.values).toEqual({
+            ...DEFAULT_VALUES,
+            engineName: '',
+          });
+        });
+      });
+
       describe('dataLoading', () => {
         it('should be set to true', () => {
           mount({ dataLoading: false });
@@ -161,6 +173,18 @@ describe('EngineLogic', () => {
           expect(EngineLogic.values).toEqual({
             ...DEFAULT_VALUES,
             dataLoading: true,
+          });
+        });
+      });
+
+      describe('engineNotFound', () => {
+        it('should be set to false', () => {
+          mount({ engineNotFound: true });
+          EngineLogic.actions.clearEngine();
+
+          expect(EngineLogic.values).toEqual({
+            ...DEFAULT_VALUES,
+            engineNotFound: false,
           });
         });
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -64,12 +64,14 @@ export const EngineLogic = kea<MakeLogicType<EngineValues, EngineActions>>({
       '',
       {
         setEngineName: (_, { engineName }) => engineName,
+        clearEngine: () => '',
       },
     ],
     engineNotFound: [
       false,
       {
         setEngineNotFound: (_, { notFound }) => notFound,
+        clearEngine: () => false,
       },
     ],
   },


### PR DESCRIPTION
## Summary

Something I also realized while reading #86702/QAing #87258 - we reset `engine` but not `engineName` or `engineNotFound` on `clearEngine()`. This doesn't actually affect any production behavior/bugs, but it potentially _could_ in the future, especially if we continue to treat `engineName` as a source of truth. I decided to open up a separate PR for this minor hardening since it isn't naming related.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios