### PR TITLE
[Fleet] Do not display inactive enrollment token in the agent enrollment flyout

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_enrollment_flyout/agent_policy_selection.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_enrollment_flyout/agent_policy_selection.tsx
@@ -110,7 +110,9 @@ export const EnrollmentStepAgentPolicy: React.FC<Props> = (props) => {
           }
 
           setEnrollmentAPIKeys(
-            res.data.list.filter((key) => key.policy_id === selectedState.agentPolicyId)
+            res.data.list.filter(
+              (key) => key.policy_id === selectedState.agentPolicyId && key.active === true
+            )
           );
         } catch (error) {
           notifications.toasts.addError(error, {


### PR DESCRIPTION
# Description 

Resolve #87287

We should not display inactive Enrollment token to the user in the add agent flyout. This PR fix that bug

With the following tokens

<img width="1318" alt="Screen Shot 2021-01-05 at 9 19 36 AM" src="https://user-images.githubusercontent.com/1336873/103652353-60299480-4f39-11eb-87b0-8fbe409d0480.png">

Before

<img width="1569" alt="Screen Shot 2021-01-05 at 9 20 18 AM" src="https://user-images.githubusercontent.com/1336873/103652345-5c960d80-4f39-11eb-8e0a-106512c78721.png">

After

<img width="1023" alt="Screen Shot 2021-01-05 at 9 19 43 AM" src="https://user-images.githubusercontent.com/1336873/103652349-5f90fe00-4f39-11eb-94c4-6f045aee0d4c.png">



## How to test 

* Create a new enrollment token
*  Delete it (desactivate it) 
* then try to add an agent, you should not see the token
