### PR TITLE
Show ML jobs on chart when only one environment

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/latency_chart/index.tsx
@@ -12,7 +12,7 @@ import { LatencyAggregationType } from '../../../../../common/latency_aggregatio
 import { getDurationFormatter } from '../../../../../common/utils/formatters';
 import { useLicenseContext } from '../../../../context/license/use_license_context';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
-import { useTransactionLatencyChartsFetcher } from '../../../../hooks/use_transaction_latency_chart_fetcher';
+import { useTransactionLatencyChartFetcher } from '../../../../hooks/use_transaction_latency_chart_fetcher';
 import { TimeseriesChart } from '../../../shared/charts/timeseries_chart';
 import {
   getMaxY,
@@ -40,7 +40,7 @@ export function LatencyChart({ height }: Props) {
   const {
     latencyChartsData,
     latencyChartsStatus,
-  } = useTransactionLatencyChartsFetcher();
+  } = useTransactionLatencyChartFetcher();
 
   const { latencyTimeseries, anomalyTimeseries, mlJobId } = latencyChartsData;
 


### PR DESCRIPTION
Make it so if you're looking at the latency chart for a service with only one environment, while the environment selector is set to "All", it uses the single environment so the ML will be shown.

It does this by overriding the uiFilters in this case.

Rename the exported function from use_transaction_latency_chart_fetcher to match the file name.

Fixes #86775.
