### PR TITLE
[Enterprise Search] Add a helper for clearFlashMessages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
@@ -12,4 +12,5 @@ export {
   setErrorMessage,
   setQueuedSuccessMessage,
   setQueuedErrorMessage,
+  clearFlashMessages,
 } from './set_message_helpers';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -16,6 +16,7 @@ import {
   setErrorMessage,
   setQueuedSuccessMessage,
   setQueuedErrorMessage,
+  clearFlashMessages,
 } from './';
 
 describe('Flash Message Helpers', () => {
@@ -67,5 +68,11 @@ describe('Flash Message Helpers', () => {
         type: 'error',
       },
     ]);
+  });
+
+  it('clearFlashMessages()', () => {
+    clearFlashMessages();
+
+    expect(FlashMessagesLogic.values.messages).toEqual([]);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.ts
@@ -33,3 +33,7 @@ export const setQueuedErrorMessage = (message: string) => {
     message,
   });
 };
+
+export const clearFlashMessages = () => {
+  FlashMessagesLogic.actions.clearFlashMessages();
+};


### PR DESCRIPTION
This PR adds a convenience function for clearing flash messages to align with others.

## Summary

In Workplace Search there were several places where we were only importing FlashMessagesLogic to call this method and it would be cleaner to have this helper along with the others.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios