### PR TITLE
Fix broken documentation link in Lens app

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -166,6 +166,7 @@ export class DocLinksService {
           guide: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/dashboard.html`,
           timelionDeprecation: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/dashboard.html#timelion-deprecation`,
           lens: `${ELASTIC_WEBSITE_URL}what-is/kibana-lens`,
+          lensPanels: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/dashboard.html#create-panels-with-lens`,
           maps: `${ELASTIC_WEBSITE_URL}maps`,
         },
         observability: {

--- a/x-pack/plugins/lens/public/help_menu_util.tsx
+++ b/x-pack/plugins/lens/public/help_menu_util.tsx
@@ -12,7 +12,7 @@ export function addHelpMenuToAppChrome(chrome: ChromeStart, docLinks: DocLinksSt
     links: [
       {
         linkType: 'documentation',
-        href: `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/lens.html`,
+        href: docLinks.links.visualize.lensPanels,
       },
       {
         linkType: 'github',


### PR DESCRIPTION
## Summary

The drop-down help menu for the Lens app contains a link to https://www.elastic.co/guide/en/kibana/master/lens.html, which is a deleted page.

This PR adds a new keyword in the documentation link service for the Lens documentation and uses that keyword in the help menu.

## Screenshot

![image](https://user-images.githubusercontent.com/26471269/103707414-6cc2e280-4f63-11eb-91f5-edd2a8bf556e.png)

