### PR TITLE
[Alerting] Replaced single invalidateApiKey request with the bulk.

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/unenroll.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.ts
@@ -76,10 +76,10 @@ export async function forceUnenrollAgent(soClient: SavedObjectsClientContract, a
 
   await Promise.all([
     agent.access_api_key_id
-      ? APIKeyService.invalidateAPIKey(soClient, agent.access_api_key_id)
+      ? APIKeyService.invalidateAPIKey(soClient, [agent.access_api_key_id])
       : undefined,
     agent.default_api_key_id
-      ? APIKeyService.invalidateAPIKey(soClient, agent.default_api_key_id)
+      ? APIKeyService.invalidateAPIKey(soClient, [agent.default_api_key_id])
       : undefined,
   ]);
 
@@ -124,16 +124,8 @@ export async function forceUnenrollAgents(
   });
 
   // Invalidate all API keys
-  // ES doesn't provide a bulk invalidate API, so this could take a long time depending on
-  // number of keys to invalidate. We run these in batches to avoid overloading ES.
   if (apiKeys.length) {
-    const BATCH_SIZE = 500;
-    const batches = chunk(apiKeys, BATCH_SIZE);
-    for (const apiKeysBatch of batches) {
-      await Promise.all(
-        apiKeysBatch.map((apiKey) => APIKeyService.invalidateAPIKey(soClient, apiKey))
-      );
-    }
+    APIKeyService.invalidateAPIKey(soClient, apiKeys);
   }
 
   // Update the necessary agents

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.ts
@@ -3,7 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import { chunk } from 'lodash';
 import { SavedObjectsClientContract } from 'src/core/server';
 import { AgentSOAttributes } from '../../types';
 import { AGENT_SAVED_OBJECT_TYPE } from '../../constants';
@@ -76,10 +75,10 @@ export async function forceUnenrollAgent(soClient: SavedObjectsClientContract, a
 
   await Promise.all([
     agent.access_api_key_id
-      ? APIKeyService.invalidateAPIKey(soClient, [agent.access_api_key_id])
+      ? APIKeyService.invalidateAPIKeys(soClient, [agent.access_api_key_id])
       : undefined,
     agent.default_api_key_id
-      ? APIKeyService.invalidateAPIKey(soClient, [agent.default_api_key_id])
+      ? APIKeyService.invalidateAPIKeys(soClient, [agent.default_api_key_id])
       : undefined,
   ]);
 
@@ -125,7 +124,7 @@ export async function forceUnenrollAgents(
 
   // Invalidate all API keys
   if (apiKeys.length) {
-    APIKeyService.invalidateAPIKey(soClient, apiKeys);
+    APIKeyService.invalidateAPIKeys(soClient, apiKeys);
   }
 
   // Update the necessary agents

--- a/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.ts
@@ -66,7 +66,7 @@ export async function getEnrollmentAPIKey(soClient: SavedObjectsClientContract, 
 export async function deleteEnrollmentApiKey(soClient: SavedObjectsClientContract, id: string) {
   const enrollmentApiKey = await getEnrollmentAPIKey(soClient, id);
 
-  await invalidateAPIKey(soClient, enrollmentApiKey.api_key_id);
+  await invalidateAPIKey(soClient, [enrollmentApiKey.api_key_id]);
 
   await soClient.update(ENROLLMENT_API_KEYS_SAVED_OBJECT_TYPE, id, {
     active: false,

--- a/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/enrollment_api_key.ts
@@ -9,7 +9,7 @@ import Boom from '@hapi/boom';
 import { SavedObjectsClientContract, SavedObject } from 'src/core/server';
 import { EnrollmentAPIKey, EnrollmentAPIKeySOAttributes } from '../../types';
 import { ENROLLMENT_API_KEYS_SAVED_OBJECT_TYPE } from '../../constants';
-import { createAPIKey, invalidateAPIKey } from './security';
+import { createAPIKey, invalidateAPIKeys } from './security';
 import { agentPolicyService } from '../agent_policy';
 import { appContextService } from '../app_context';
 import { normalizeKuery } from '../saved_object';
@@ -66,7 +66,7 @@ export async function getEnrollmentAPIKey(soClient: SavedObjectsClientContract, 
 export async function deleteEnrollmentApiKey(soClient: SavedObjectsClientContract, id: string) {
   const enrollmentApiKey = await getEnrollmentAPIKey(soClient, id);
 
-  await invalidateAPIKey(soClient, [enrollmentApiKey.api_key_id]);
+  await invalidateAPIKeys(soClient, [enrollmentApiKey.api_key_id]);
 
   await soClient.update(ENROLLMENT_API_KEYS_SAVED_OBJECT_TYPE, id, {
     active: false,

--- a/x-pack/plugins/fleet/server/services/api_keys/index.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/index.ts
@@ -10,7 +10,7 @@ import { EnrollmentAPIKeySOAttributes, EnrollmentAPIKey } from '../../types';
 import { createAPIKey } from './security';
 import { escapeSearchQueryPhrase } from '../saved_object';
 
-export { invalidateAPIKey } from './security';
+export { invalidateAPIKeys } from './security';
 export * from './enrollment_api_key';
 
 export async function generateOutputApiKey(

--- a/x-pack/plugins/fleet/server/services/api_keys/security.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/security.ts
@@ -64,7 +64,7 @@ export async function authenticate(callCluster: CallESAsCurrentUser) {
   }
 }
 
-export async function invalidateAPIKey(soClient: SavedObjectsClientContract, ids: string[]) {
+export async function invalidateAPIKeys(soClient: SavedObjectsClientContract, ids: string[]) {
   const adminUser = await outputService.getAdminUser(soClient);
   if (!adminUser) {
     throw new Error('No admin user configured');

--- a/x-pack/plugins/fleet/server/services/api_keys/security.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/security.ts
@@ -64,7 +64,7 @@ export async function authenticate(callCluster: CallESAsCurrentUser) {
   }
 }
 
-export async function invalidateAPIKey(soClient: SavedObjectsClientContract, id: string) {
+export async function invalidateAPIKey(soClient: SavedObjectsClientContract, ids: string[]) {
   const adminUser = await outputService.getAdminUser(soClient);
   if (!adminUser) {
     throw new Error('No admin user configured');
@@ -88,7 +88,7 @@ export async function invalidateAPIKey(soClient: SavedObjectsClientContract, id:
 
   try {
     const res = await security.authc.apiKeys.invalidate(request, {
-      id,
+      ids,
     });
 
     return res;

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
@@ -323,7 +323,7 @@ describe('API Keys', () => {
       });
     });
 
-    it(`Only passes id as a parameter`, async () => {
+    it(`Only passes ids as a parameter`, async () => {
       mockLicense.isEnabled.mockReturnValue(true);
       mockScopedClusterClient.asCurrentUser.security.invalidateApiKey.mockResolvedValueOnce(
         securityMock.createApiResponse({
@@ -335,7 +335,7 @@ describe('API Keys', () => {
         })
       );
       const result = await apiKeys.invalidate(httpServerMock.createKibanaRequest(), {
-        id: '123',
+        ids: ['123'],
         name: 'abc',
       } as any);
       expect(result).toEqual({

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
@@ -289,7 +289,7 @@ describe('API Keys', () => {
     it('returns null when security feature is disabled', async () => {
       mockLicense.isEnabled.mockReturnValue(false);
       const result = await apiKeys.invalidate(httpServerMock.createKibanaRequest(), {
-        id: '123',
+        ids: ['123'],
       });
       expect(result).toBeNull();
       expect(
@@ -309,7 +309,7 @@ describe('API Keys', () => {
         })
       );
       const result = await apiKeys.invalidate(httpServerMock.createKibanaRequest(), {
-        id: '123',
+        ids: ['123'],
       });
       expect(result).toEqual({
         invalidated_api_keys: ['api-key-id-1'],

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
@@ -354,7 +354,7 @@ describe('API Keys', () => {
   describe('invalidateAsInternalUser()', () => {
     it('returns null when security feature is disabled', async () => {
       mockLicense.isEnabled.mockReturnValue(false);
-      const result = await apiKeys.invalidateAsInternalUser({ id: '123' });
+      const result = await apiKeys.invalidateAsInternalUser({ ids: ['123'] });
       expect(result).toBeNull();
       expect(mockClusterClient.asInternalUser.security.invalidateApiKey).not.toHaveBeenCalled();
     });
@@ -370,7 +370,7 @@ describe('API Keys', () => {
           },
         })
       );
-      const result = await apiKeys.invalidateAsInternalUser({ id: '123' });
+      const result = await apiKeys.invalidateAsInternalUser({ ids: ['123'] });
       expect(result).toEqual({
         invalidated_api_keys: ['api-key-id-1'],
         previously_invalidated_api_keys: [],

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
@@ -383,7 +383,7 @@ describe('API Keys', () => {
       });
     });
 
-    it('Only passes id as a parameter', async () => {
+    it('Only passes ids as a parameter', async () => {
       mockLicense.isEnabled.mockReturnValue(true);
       mockClusterClient.asInternalUser.security.invalidateApiKey.mockResolvedValueOnce(
         securityMock.createApiResponse({
@@ -395,7 +395,7 @@ describe('API Keys', () => {
         })
       );
       const result = await apiKeys.invalidateAsInternalUser({
-        id: '123',
+        ids: ['123'],
         name: 'abc',
       } as any);
       expect(result).toEqual({

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
@@ -46,6 +46,13 @@ export interface InvalidateAPIKeyParams {
 }
 
 /**
+ * Represents the params for invalidating multiple API keys
+ */
+export interface InvalidateAPIKeysParams {
+  ids: string[];
+}
+
+/**
  * The return value when creating an API key in Elasticsearch. The API key returned by this API
  * can then be used by sending a request with a Authorization header with a value having the
  * prefix ApiKey `{token}` where token is id and api_key joined by a colon `{id}:{api_key}` and
@@ -256,7 +263,7 @@ export class APIKeys {
    * Tries to invalidate an API key by using the internal user.
    * @param params The params to invalidate an API key.
    */
-  async invalidateAsInternalUser(params: InvalidateAPIKeyParams) {
+  async invalidateAsInternalUser(params: InvalidateAPIKeysParams) {
     if (!this.license.isEnabled()) {
       return null;
     }
@@ -268,7 +275,7 @@ export class APIKeys {
       // Internal user needs `cluster:admin/xpack/security/api_key/invalidate` privilege to use this API
       result = (
         await this.clusterClient.asInternalUser.security.invalidateApiKey<InvalidateAPIKeyResult>({
-          body: { ids: [params.id] },
+          body: { ids: params.ids },
         })
       ).body;
       this.logger.debug('API key was invalidated successfully');

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
@@ -260,8 +260,8 @@ export class APIKeys {
   }
 
   /**
-   * Tries to invalidate an API key by using the internal user.
-   * @param params The params to invalidate an API key.
+   * Tries to invalidate an API keys by using the internal user.
+   * @param params The params to invalidate an API keys.
    */
   async invalidateAsInternalUser(params: InvalidateAPIKeysParams) {
     if (!this.license.isEnabled()) {

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
@@ -39,13 +39,6 @@ interface GrantAPIKeyParams {
 }
 
 /**
- * Represents the params for invalidating an API key
- */
-export interface InvalidateAPIKeyParams {
-  id: string;
-}
-
-/**
  * Represents the params for invalidating multiple API keys
  */
 export interface InvalidateAPIKeysParams {
@@ -229,16 +222,16 @@ export class APIKeys {
   }
 
   /**
-   * Tries to invalidate an API key.
+   * Tries to invalidate an API keys.
    * @param request Request instance.
-   * @param params The params to invalidate an API key.
+   * @param params The params to invalidate an API keys.
    */
-  async invalidate(request: KibanaRequest, params: InvalidateAPIKeyParams) {
+  async invalidate(request: KibanaRequest, params: InvalidateAPIKeysParams) {
     if (!this.license.isEnabled()) {
       return null;
     }
 
-    this.logger.debug('Trying to invalidate an API key as current user');
+    this.logger.debug(`Trying to invalidate ${params.ids.length} an API key as current user`);
 
     let result;
     try {
@@ -247,12 +240,18 @@ export class APIKeys {
         await this.clusterClient
           .asScoped(request)
           .asCurrentUser.security.invalidateApiKey<InvalidateAPIKeyResult>({
-            body: { ids: [params.id] },
+            body: { ids: params.ids },
           })
       ).body;
-      this.logger.debug('API key was invalidated successfully as current user');
+      this.logger.debug(
+        `API keys by ids=[${params.ids.join(', ')}] was invalidated successfully as current user`
+      );
     } catch (e) {
-      this.logger.error(`Failed to invalidate API key as current user: ${e.message}`);
+      this.logger.error(
+        `Failed to invalidate API keys by ids=[${params.ids.join(', ')}] as current user: ${
+          e.message
+        }`
+      );
       throw e;
     }
 
@@ -260,15 +259,15 @@ export class APIKeys {
   }
 
   /**
-   * Tries to invalidate an API keys by using the internal user.
-   * @param params The params to invalidate an API keys.
+   * Tries to invalidate the API keys by using the internal user.
+   * @param params The params to invalidate the API keys.
    */
   async invalidateAsInternalUser(params: InvalidateAPIKeysParams) {
     if (!this.license.isEnabled()) {
       return null;
     }
 
-    this.logger.debug('Trying to invalidate an API key');
+    this.logger.debug(`Trying to invalidate ${params.ids.length} API keys`);
 
     let result;
     try {
@@ -278,9 +277,11 @@ export class APIKeys {
           body: { ids: params.ids },
         })
       ).body;
-      this.logger.debug('API key was invalidated successfully');
+      this.logger.debug(`API keys by ids=[${params.ids.join(', ')}] was invalidated successfully`);
     } catch (e) {
-      this.logger.error(`Failed to invalidate API key: ${e.message}`);
+      this.logger.error(
+        `Failed to invalidate API keys by ids=[${params.ids.join(', ')}]: ${e.message}`
+      );
       throw e;
     }
 

--- a/x-pack/plugins/security/server/authentication/api_keys/index.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/index.ts
@@ -10,5 +10,6 @@ export {
   InvalidateAPIKeyResult,
   CreateAPIKeyParams,
   InvalidateAPIKeyParams,
+  InvalidateAPIKeysParams,
   GrantAPIKeyResult,
 } from './api_keys';

--- a/x-pack/plugins/security/server/authentication/api_keys/index.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/index.ts
@@ -9,7 +9,6 @@ export {
   CreateAPIKeyResult,
   InvalidateAPIKeyResult,
   CreateAPIKeyParams,
-  InvalidateAPIKeyParams,
   InvalidateAPIKeysParams,
   GrantAPIKeyResult,
 } from './api_keys';

--- a/x-pack/plugins/security/server/authentication/index.ts
+++ b/x-pack/plugins/security/server/authentication/index.ts
@@ -29,5 +29,6 @@ export type {
   InvalidateAPIKeyResult,
   CreateAPIKeyParams,
   InvalidateAPIKeyParams,
+  InvalidateAPIKeysParams,
   GrantAPIKeyResult,
 } from './api_keys';

--- a/x-pack/plugins/security/server/authentication/index.ts
+++ b/x-pack/plugins/security/server/authentication/index.ts
@@ -28,7 +28,6 @@ export type {
   CreateAPIKeyResult,
   InvalidateAPIKeyResult,
   CreateAPIKeyParams,
-  InvalidateAPIKeyParams,
   InvalidateAPIKeysParams,
   GrantAPIKeyResult,
 } from './api_keys';

--- a/x-pack/plugins/security/server/index.ts
+++ b/x-pack/plugins/security/server/index.ts
@@ -24,7 +24,6 @@ import {
 // functions or removal of exports should be considered as a breaking change.
 export type {
   CreateAPIKeyResult,
-  InvalidateAPIKeyParams,
   InvalidateAPIKeysParams,
   InvalidateAPIKeyResult,
   GrantAPIKeyResult,

--- a/x-pack/plugins/security/server/index.ts
+++ b/x-pack/plugins/security/server/index.ts
@@ -25,6 +25,7 @@ import {
 export type {
   CreateAPIKeyResult,
   InvalidateAPIKeyParams,
+  InvalidateAPIKeysParams,
   InvalidateAPIKeyResult,
   GrantAPIKeyResult,
 } from './authentication';


### PR DESCRIPTION
Changes introduced based on the adding support to invalidate API keys in a bulk operation.
```
invalidateApiKey<InvalidateAPIKeyResult>({
          body: { ids: params.ids },
        })
```
Extended methods **invalidate**:
```
/**
   * Tries to invalidate an API keys.
   * @param request Request instance.
   * @param params The params to invalidate an API keys.
   */
  async invalidate(request: KibanaRequest, params: InvalidateAPIKeysParams) {
```
and **invalidateAsInternalUser**:
```
/**
   * Tries to invalidate the API keys by using the internal user.
   * @param params The params to invalidate the API keys.
   */
  async invalidateAsInternalUser(params: InvalidateAPIKeysParams) {
    if (!this.license.isEnabled()) {
      return null;
    }
```

of `x-pack/plugins/security/server/authentication/api_keys/api_keys.ts` to support invalidation by multiple ids parameters.
Introduced proper changes in the plugins which are using this API. 
Resolves #83224