### PR TITLE
[Fleet] Make the encryptedSavedObject plugin optionnal

### DIFF
--- a/x-pack/plugins/fleet/kibana.json
+++ b/x-pack/plugins/fleet/kibana.json
@@ -4,8 +4,15 @@
   "server": true,
   "ui": true,
   "configPath": ["xpack", "fleet"],
-  "requiredPlugins": ["licensing", "data", "encryptedSavedObjects"],
-  "optionalPlugins": ["security", "features", "cloud", "usageCollection", "home"],
+  "requiredPlugins": ["licensing", "data"],
+  "optionalPlugins": [
+    "security",
+    "features",
+    "cloud",
+    "usageCollection",
+    "home",
+    "encryptedSavedObjects"
+  ],
   "extraPublicDirs": ["common"],
   "requiredBundles": ["kibanaReact", "esUiShared", "home", "infra", "kibanaUtils"]
 }

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -91,12 +91,12 @@ export interface FleetSetupDeps {
 }
 
 export interface FleetStartDeps {
-  encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
+  encryptedSavedObjects?: EncryptedSavedObjectsPluginStart;
   security?: SecurityPluginStart;
 }
 
 export interface FleetAppContext {
-  encryptedSavedObjectsStart: EncryptedSavedObjectsPluginStart;
+  encryptedSavedObjectsStart?: EncryptedSavedObjectsPluginStart;
   encryptedSavedObjectsSetup?: EncryptedSavedObjectsPluginSetup;
   security?: SecurityPluginStart;
   config$?: Observable<FleetConfigType>;
@@ -250,8 +250,7 @@ export class FleetPlugin
 
       // Conditional config routes
       if (config.agents.enabled) {
-        const isESOUsingEphemeralEncryptionKey =
-          deps.encryptedSavedObjects.usingEphemeralEncryptionKey;
+        const isESOUsingEphemeralEncryptionKey = !deps.encryptedSavedObjects;
         if (isESOUsingEphemeralEncryptionKey) {
           if (this.logger) {
             this.logger.warn(

--- a/x-pack/plugins/fleet/server/routes/setup/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/handlers.ts
@@ -22,8 +22,7 @@ export const getFleetStatusHandler: RequestHandler = async (context, request, re
     const isProductionMode = appContextService.getIsProductionMode();
     const isCloud = appContextService.getCloud()?.isCloudEnabled ?? false;
     const isTLSCheckDisabled = appContextService.getConfig()?.agents?.tlsCheckDisabled ?? false;
-    const isUsingEphemeralEncryptionKey = appContextService.getEncryptedSavedObjectsSetup()
-      .usingEphemeralEncryptionKey;
+    const isUsingEphemeralEncryptionKey = !appContextService.getEncryptedSavedObjectsSetup();
 
     const missingRequirements: GetFleetStatusResponse['missing_requirements'] = [];
     if (!isAdminUserSetup) {

--- a/x-pack/plugins/fleet/server/services/app_context.ts
+++ b/x-pack/plugins/fleet/server/services/app_context.ts
@@ -114,10 +114,6 @@ class AppContextService {
   }
 
   public getEncryptedSavedObjectsSetup() {
-    if (!this.encryptedSavedObjectsSetup) {
-      throw new Error('encryptedSavedObjectsSetup is not set');
-    }
-
     return this.encryptedSavedObjectsSetup;
   }
 


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/81619

The encryptedSavedObject plugin will no longer be enabled if there is no encryptionKey set, this PR make the requiring change in Fleet.

The plugin is now optionnal for Fleet and we will not enable Agents feature if the plugin is not here.