### PR TITLE
Remove src/plugins/visualizations -> src/plugins/visualize cyclic dependencies

### DIFF
--- a/src/dev/run_find_plugins_with_circular_deps.ts
+++ b/src/dev/run_find_plugins_with_circular_deps.ts
@@ -31,7 +31,6 @@ interface Options {
 type CircularDepList = Set<string>;
 
 const allowedList: CircularDepList = new Set([
-  'src/plugins/visualizations -> src/plugins/visualize',
   'x-pack/plugins/actions -> x-pack/plugins/case',
   'x-pack/plugins/case -> x-pack/plugins/security_solution',
   'x-pack/plugins/apm -> x-pack/plugins/infra',

--- a/src/plugins/vis_default_editor/public/default_editor.tsx
+++ b/src/plugins/vis_default_editor/public/default_editor.tsx
@@ -23,8 +23,11 @@ import 'brace/mode/json';
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { EventEmitter } from 'events';
 
-import { EditorRenderProps } from 'src/plugins/visualize/public';
-import { Vis, VisualizeEmbeddableContract } from 'src/plugins/visualizations/public';
+import {
+  Vis,
+  VisualizeEmbeddableContract,
+  EditorRenderProps,
+} from 'src/plugins/visualizations/public';
 import { KibanaContextProvider, PanelsContainer, Panel } from '../../kibana_react/public';
 import { Storage } from '../../kibana_utils/public';
 

--- a/src/plugins/vis_default_editor/public/default_editor_controller.tsx
+++ b/src/plugins/vis_default_editor/public/default_editor_controller.tsx
@@ -22,8 +22,12 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { EventEmitter } from 'events';
 import { EuiErrorBoundary, EuiLoadingChart } from '@elastic/eui';
 
-import { EditorRenderProps, IEditorController } from 'src/plugins/visualize/public';
-import { Vis, VisualizeEmbeddableContract } from 'src/plugins/visualizations/public';
+import {
+  Vis,
+  IEditorController,
+  EditorRenderProps,
+  VisualizeEmbeddableContract,
+} from 'src/plugins/visualizations/public';
 
 // @ts-ignore
 const DefaultEditor = lazy(() => import('./default_editor'));

--- a/src/plugins/visualizations/public/index.ts
+++ b/src/plugins/visualizations/public/index.ts
@@ -44,6 +44,9 @@ export type {
   ReactVisTypeOptions,
   Schema,
   ISchemas,
+  VisEditorConstructor,
+  IEditorController,
+  EditorRenderProps,
 } from './vis_types';
 export { VisParams, SerializedVis, SerializedVisData, VisData } from './vis';
 export type VisualizeEmbeddableFactoryContract = PublicContract<VisualizeEmbeddableFactory>;

--- a/src/plugins/visualizations/public/vis_types/index.ts
+++ b/src/plugins/visualizations/public/vis_types/index.ts
@@ -20,6 +20,13 @@
 export * from './types_service';
 export { Schemas } from './schemas';
 export { VisGroups } from './types';
-export type { VisType, ISchemas, Schema } from './types';
+export type {
+  VisType,
+  ISchemas,
+  Schema,
+  IEditorController,
+  VisEditorConstructor,
+  EditorRenderProps,
+} from './types';
 export type { BaseVisTypeOptions } from './base_vis_type';
 export type { ReactVisTypeOptions } from './react_vis_type';

--- a/src/plugins/visualizations/public/vis_types/types.ts
+++ b/src/plugins/visualizations/public/vis_types/types.ts
@@ -20,7 +20,8 @@ import { EventEmitter } from 'events';
 import { IconType } from '@elastic/eui';
 import React, { ReactNode } from 'react';
 import { Adapters } from 'src/plugins/inspector';
-import { CoreStart, SavedObject } from 'src/core/public';
+import { CoreStart } from 'src/core/public';
+import { SavedObject } from 'src/plugins/saved_objects/public';
 import {
   IndexPattern,
   AggGroupNames,

--- a/src/plugins/visualizations/public/vis_types/types.ts
+++ b/src/plugins/visualizations/public/vis_types/types.ts
@@ -16,13 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+import { EventEmitter } from 'events';
 import { IconType } from '@elastic/eui';
 import React, { ReactNode } from 'react';
 import { Adapters } from 'src/plugins/inspector';
-import { VisEditorConstructor } from 'src/plugins/visualize/public';
-import { IndexPattern, AggGroupNames, AggParam, AggGroupName } from '../../../data/public';
+import { CoreStart, SavedObject } from 'src/core/public';
+import {
+  IndexPattern,
+  AggGroupNames,
+  AggParam,
+  AggGroupName,
+  DataPublicPluginStart,
+  Filter,
+  TimeRange,
+  Query,
+} from '../../../data/public';
 import { Vis, VisParams, VisToExpressionAst, VisualizationControllerConstructor } from '../types';
+import { PersistedState, VisualizeEmbeddableContract } from '../index';
 
 export interface VisTypeOptions {
   showTimePicker: boolean;
@@ -151,4 +161,30 @@ export interface VisType<TVisParams = unknown> {
   // TODO: The following types still need to be refined properly.
   readonly editorConfig: Record<string, any>;
   readonly visConfig: Record<string, any>;
+}
+
+export type VisEditorConstructor = new (
+  element: HTMLElement,
+  vis: Vis,
+  eventEmitter: EventEmitter,
+  embeddableHandler: VisualizeEmbeddableContract
+) => IEditorController;
+
+export interface IEditorController {
+  render(props: EditorRenderProps): Promise<void> | void;
+  destroy(): void;
+}
+
+export interface EditorRenderProps {
+  core: CoreStart;
+  data: DataPublicPluginStart;
+  filters: Filter[];
+  timeRange: TimeRange;
+  query?: Query;
+  savedSearch?: SavedObject;
+  uiState: PersistedState;
+  /**
+   * Flag to determine if visualiztion is linked to the saved search
+   */
+  linked: boolean;
 }

--- a/src/plugins/visualize/public/application/types.ts
+++ b/src/plugins/visualize/public/application/types.ts
@@ -18,9 +18,8 @@
  */
 
 import { History } from 'history';
-import { TimeRange, Query, Filter, DataPublicPluginStart } from 'src/plugins/data/public';
+import { Query, Filter, DataPublicPluginStart } from 'src/plugins/data/public';
 import {
-  PersistedState,
   SavedVisState,
   VisualizationsStart,
   Vis,
@@ -45,7 +44,6 @@ import { SharePluginStart } from 'src/plugins/share/public';
 import { SavedObjectsStart, SavedObject } from 'src/plugins/saved_objects/public';
 import { EmbeddableStart, EmbeddableStateTransfer } from 'src/plugins/embeddable/public';
 import { UrlForwardingStart } from 'src/plugins/url_forwarding/public';
-import { EventEmitter } from 'events';
 import { DashboardStart } from '../../../dashboard/public';
 import type { SavedObjectsTaggingApi } from '../../../saved_objects_tagging_oss/public';
 
@@ -79,20 +77,6 @@ export type VisualizeAppStateContainer = ReduxLikeStateContainer<
   VisualizeAppState,
   VisualizeAppStateTransitions
 >;
-
-export interface EditorRenderProps {
-  core: CoreStart;
-  data: DataPublicPluginStart;
-  filters: Filter[];
-  timeRange: TimeRange;
-  query?: Query;
-  savedSearch?: SavedObject;
-  uiState: PersistedState;
-  /**
-   * Flag to determine if visualiztion is linked to the saved search
-   */
-  linked: boolean;
-}
 
 export interface VisualizeServices extends CoreStart {
   stateTransferService: EmbeddableStateTransfer;
@@ -135,15 +119,3 @@ export interface ByValueVisInstance {
 }
 
 export type VisualizeEditorVisInstance = SavedVisInstance | ByValueVisInstance;
-
-export type VisEditorConstructor = new (
-  element: HTMLElement,
-  vis: Vis,
-  eventEmitter: EventEmitter,
-  embeddableHandler: VisualizeEmbeddableContract
-) => IEditorController;
-
-export interface IEditorController {
-  render(props: EditorRenderProps): Promise<void> | void;
-  destroy(): void;
-}

--- a/src/plugins/visualize/public/application/utils/use/use_editor_updates.test.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_editor_updates.test.ts
@@ -21,12 +21,8 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { EventEmitter } from 'events';
 
 import { useEditorUpdates } from './use_editor_updates';
-import {
-  VisualizeServices,
-  VisualizeAppStateContainer,
-  SavedVisInstance,
-  IEditorController,
-} from '../../types';
+import { VisualizeServices, VisualizeAppStateContainer, SavedVisInstance } from '../../types';
+import type { IEditorController } from '../../../../../visualizations/public';
 import { visualizeAppStateStub } from '../stubs';
 import { createVisualizeServicesMock } from '../mocks';
 

--- a/src/plugins/visualize/public/application/utils/use/use_editor_updates.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_editor_updates.ts
@@ -25,9 +25,9 @@ import {
   VisualizeServices,
   VisualizeAppState,
   VisualizeAppStateContainer,
-  IEditorController,
   VisualizeEditorVisInstance,
 } from '../../types';
+import type { IEditorController } from '../../../../../visualizations/public';
 
 export const useEditorUpdates = (
   services: VisualizeServices,

--- a/src/plugins/visualize/public/application/utils/use/use_saved_vis_instance.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_saved_vis_instance.ts
@@ -26,9 +26,10 @@ import { redirectWhenMissing } from '../../../../../kibana_utils/public';
 
 import { getVisualizationInstance } from '../get_visualization_instance';
 import { getEditBreadcrumbs, getCreateBreadcrumbs } from '../breadcrumbs';
-import { SavedVisInstance, IEditorController, VisualizeServices } from '../../types';
+import { SavedVisInstance, VisualizeServices } from '../../types';
 import { VisualizeConstants } from '../../visualize_constants';
 import { getDefaultEditor } from '../../../services';
+import type { IEditorController } from '../../../../../visualizations/public';
 
 /**
  * This effect is responsible for instantiating a saved vis or creating a new one

--- a/src/plugins/visualize/public/application/utils/use/use_vis_byvalue.ts
+++ b/src/plugins/visualize/public/application/utils/use/use_vis_byvalue.ts
@@ -20,7 +20,8 @@
 import { EventEmitter } from 'events';
 import { useEffect, useRef, useState } from 'react';
 import { VisualizeInput } from 'src/plugins/visualizations/public';
-import { ByValueVisInstance, IEditorController, VisualizeServices } from '../../types';
+import { ByValueVisInstance, VisualizeServices } from '../../types';
+import type { IEditorController } from '../../../../../visualizations/public';
 import { getVisualizationInstanceFromInput } from '../get_visualization_instance';
 import { getEditBreadcrumbs } from '../breadcrumbs';
 import { getDefaultEditor } from '../../../services';

--- a/src/plugins/visualize/public/index.ts
+++ b/src/plugins/visualize/public/index.ts
@@ -20,11 +20,6 @@
 import { PluginInitializerContext } from 'kibana/public';
 import { VisualizePlugin, VisualizePluginSetup } from './plugin';
 
-export type {
-  EditorRenderProps,
-  IEditorController,
-  VisEditorConstructor,
-} from './application/types';
 export { VisualizeConstants } from './application/visualize_constants';
 
 export { VisualizePluginSetup };

--- a/src/plugins/visualize/public/plugin.ts
+++ b/src/plugins/visualize/public/plugin.ts
@@ -41,10 +41,10 @@ import { DataPublicPluginStart, DataPublicPluginSetup, esFilters } from '../../d
 import { NavigationPublicPluginStart as NavigationStart } from '../../navigation/public';
 import { SharePluginStart, SharePluginSetup } from '../../share/public';
 import { UrlForwardingSetup, UrlForwardingStart } from '../../url_forwarding/public';
-import { VisualizationsStart } from '../../visualizations/public';
+import { VisualizationsStart, VisEditorConstructor } from '../../visualizations/public';
 import { VisualizeConstants } from './application/visualize_constants';
 import { FeatureCatalogueCategory, HomePublicPluginSetup } from '../../home/public';
-import { VisEditorConstructor, VisualizeServices } from './application/types';
+import { VisualizeServices } from './application/types';
 import { DEFAULT_APP_CATEGORIES } from '../../../core/public';
 import { SavedObjectsStart } from '../../saved_objects/public';
 import { EmbeddableStart } from '../../embeddable/public';

--- a/src/plugins/visualize/public/services.ts
+++ b/src/plugins/visualize/public/services.ts
@@ -20,8 +20,8 @@
 import { ApplicationStart, IUiSettingsClient } from '../../../core/public';
 import { createGetterSetter } from '../../../plugins/kibana_utils/public';
 import { IndexPatternsContract, DataPublicPluginStart } from '../../../plugins/data/public';
+import { VisEditorConstructor } from '../../../plugins/visualizations/public';
 import { SharePluginStart } from '../../../plugins/share/public';
-import { VisEditorConstructor } from './application/types';
 
 export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClient>('UISettings');
 


### PR DESCRIPTION
Part of #84750

## Summary

Removes circular dependencies between `src/plugins/visualizations` and `src/plugins/visualize` plugins.

The dependencies that were removed based on the `node scripts/find_plugins_with_circular_deps --debug` script.

What was changed in that PR: 
1) `EditorRenderProps`, `IEditorController`, `VisEditorConstructor` types  were moved from `visualize` to  `visualizations` plugin.