### PR TITLE
[Lens] Make sure filter object is persistable

### DIFF
--- a/x-pack/plugins/lens/public/persistence/filter_references.test.ts
+++ b/x-pack/plugins/lens/public/persistence/filter_references.test.ts
@@ -56,6 +56,18 @@ describe('filter saved object references', () => {
     `);
   });
 
+  it('should remove index and value from persistable filter', () => {
+    const { persistableFilters } = extractFilterReferences([
+      { ...filters[0], meta: { ...filters[0].meta, value: 'CN' } },
+      { ...filters[1], meta: { ...filters[1].meta, value: 'US' } },
+    ]);
+    expect(persistableFilters.length).toBe(2);
+    persistableFilters.forEach((filter) => {
+      expect(filter.meta.hasOwnProperty('index')).toBe(false);
+      expect(filter.meta.hasOwnProperty('value')).toBe(false);
+    });
+  });
+
   it('should restore the same filter after extracting and injecting', () => {
     const { persistableFilters, references } = extractFilterReferences(filters);
     expect(injectFilterReferences(persistableFilters, references)).toEqual(filters);

--- a/x-pack/plugins/lens/public/persistence/filter_references.ts
+++ b/x-pack/plugins/lens/public/persistence/filter_references.ts
@@ -22,14 +22,18 @@ export function extractFilterReferences(
       type: 'index-pattern',
       id: filterRow.meta.index,
     });
-    return {
+    const newFilter = {
       ...filterRow,
       meta: {
         ...filterRow.meta,
         indexRefName: refName,
-        index: undefined,
       },
     };
+    // remove index because it's specified by indexRefName
+    delete newFilter.meta.index;
+    // remove value because it can't be persisted
+    delete newFilter.meta.value;
+    return newFilter;
   });
 
   return { persistableFilters, references };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/87268

This PR removes `value` and `index` keys from filter objects before persisting to make sure the check whether the saved object got modified works as intended.

This is save to do because:
* `index` is always undefined anyway, this PR just makes sure there's no `index` property at all
* `value` is sometimes a function (the types here are missleading) and thus can't be persisted. It will be recreated by the filter manager once the filter is added