### PR TITLE
[Lens] Close popover on repeated button click

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -259,7 +259,7 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
                   iconType="arrowDown"
                   iconSide="right"
                   onClick={() => {
-                    setPopoverOpen(true);
+                    setPopoverOpen(!popoverOpen);
                   }}
                 >
                   {i18n.translate('xpack.lens.indexPattern.terms.advancedSettings', {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/87521

The advanced settings button of the top values function always set the open state flag to true instead of inverting the current state, making it impossible to close the popover by clicking the button again. This PR fixes this.