### PR TITLE
[APM] Adding some e2e tests

### DIFF
--- a/x-pack/plugins/apm/e2e/cypress/integration/apm.feature
+++ b/x-pack/plugins/apm/e2e/cypress/integration/apm.feature
@@ -1,6 +1,7 @@
 Feature: APM
 
-  Scenario: Transaction duration charts
+  Scenario: User is redirected to Service Overview page
     Given a user browses the APM UI application
     When the user inspects the opbeans-node service
-    Then should redirect to correct path
+    Then should redirect to correct service overview page
+

--- a/x-pack/plugins/apm/e2e/cypress/integration/custom_links.feature
+++ b/x-pack/plugins/apm/e2e/cypress/integration/custom_links.feature
@@ -1,0 +1,15 @@
+Feature: Custom links
+
+  Scenario: User creates Custom links
+    Given a user browses the APM UI settings page
+    When the user creates a custom link
+    Then a new custom link is shown in the table
+    Then delete custom link
+
+  Scenario: User edits Custom links
+    Given a user browses the APM UI settings page
+    When the user edits a custom link
+    Then custom link was edited
+    Then delete custom link
+
+

--- a/x-pack/plugins/apm/e2e/cypress/integration/indices.feature
+++ b/x-pack/plugins/apm/e2e/cypress/integration/indices.feature
@@ -1,0 +1,7 @@
+Feature: Indices
+
+  Scenario: User updates APM default index pattern
+    Given a user browses the APM UI settings page
+    When the user updates APM indices
+    Then default indices were updated
+    Then reset indices

--- a/x-pack/plugins/apm/e2e/cypress/integration/snapshots.js
+++ b/x-pack/plugins/apm/e2e/cypress/integration/snapshots.js
@@ -1,3 +1,3 @@
 module.exports = {
-  "__version": "6.0.1"
+  "__version": "6.2.1"
 }

--- a/x-pack/plugins/apm/e2e/cypress/support/step_definitions/apm.ts
+++ b/x-pack/plugins/apm/e2e/cypress/support/step_definitions/apm.ts
@@ -18,6 +18,14 @@ Given(`a user browses the APM UI application`, () => {
   });
 });
 
+Given(`a user browses the APM UI settings page`, () => {
+  // Open service inventory page
+  loginAndWaitForPage(`/app/apm/settings`, {
+    from: '2020-06-01T14:59:32.686Z',
+    to: '2020-06-16T16:59:36.219Z',
+  });
+});
+
 When(`the user inspects the opbeans-node service`, () => {
   // click opbeans-node service
   cy.get(':contains(opbeans-node)', { timeout: DEFAULT_TIMEOUT })
@@ -25,6 +33,115 @@ When(`the user inspects the opbeans-node service`, () => {
     .click({ force: true });
 });
 
-Then(`should redirect to correct path`, () => {
+Then(`should redirect to correct service overview page`, () => {
   cy.url().should('contain', `/app/apm/services/opbeans-node/overview`);
+});
+
+const newIndexPattern = 'new-index-*';
+const indicesFieldTestName = [
+  'sourcemapIndice',
+  'errorIndices',
+  'onboardingIndices',
+  'spanIndices',
+  'transactionIndices',
+  'metricsIndices',
+];
+When(`the user updates APM indices`, () => {
+  cy.contains('Indices').click();
+  cy.url().should('include', 'apm-indices');
+  cy.contains('Apply changes').should('not.be.disabled');
+
+  indicesFieldTestName.map((fieldTestName) => {
+    cy.get(`[data-test-subj="${fieldTestName}"]`).type(newIndexPattern);
+  });
+  cy.contains('Apply changes').click();
+});
+
+Then(`default indices were updated`, () => {
+  cy.contains('Indices applied');
+  indicesFieldTestName.map((fieldTestName) => {
+    cy.get(`[data-test-subj="${fieldTestName}"]`).should(
+      'have.value',
+      newIndexPattern
+    );
+  });
+});
+
+Then(`reset indices`, () => {
+  indicesFieldTestName.map((fieldTestName) => {
+    cy.get(`[data-test-subj="${fieldTestName}"]`).clear();
+  });
+  cy.contains('Apply changes').click();
+  cy.contains('Indices applied');
+});
+
+When(`the user creates a custom link`, () => {
+  cy.get('.euiToast__closeButton').click();
+  cy.contains('Customize app').click();
+  cy.contains('Custom Links');
+  cy.contains('No links found');
+  cy.contains('Create custom link').click();
+  cy.contains('Create link');
+  cy.get('[data-test-subj="saveButton"]').should('be.disabled');
+
+  cy.get('[data-test-subj="label"]').type('Service overview');
+  cy.get('[data-test-subj="url"]').type(
+    'https://elastic/app/apm/services/{{service.name}}/overview',
+    {
+      parseSpecialCharSequences: false,
+    }
+  );
+
+  cy.get('[data-test-subj="filter-0"]').select('service.name');
+  cy.get('[data-test-subj="service.name.value"]').type('opbeans-node');
+
+  cy.contains('https://elastic/app/apm/services/opbeans-node/overview');
+
+  cy.get('[data-test-subj="saveButton"]').click();
+});
+
+Then('a new custom link is shown in the table', () => {
+  cy.contains('Link saved!');
+  cy.contains('Service overview');
+  cy.contains('https://elastic/app/apm/services/{{service.name}}/overview');
+});
+
+When('the user edits a custom link', () => {
+  cy.request({
+    method: 'POST',
+    url: 'http://localhost:5701/api/apm/settings/custom_links',
+    body: {
+      label: 'Service overview',
+      url: 'https://elastic/app/apm/services/{{service.name}}/overview',
+      filters: [{ key: 'service.name', value: 'opbeans-node' }],
+    },
+    auth: {
+      user: 'admin',
+      pass: 'changeme',
+    },
+    headers: {
+      'kbn-version': '8.0.0',
+    },
+  });
+
+  cy.get('.euiToast__closeButton').click();
+  cy.contains('Customize app').click();
+  cy.contains('Custom Links');
+  cy.contains('Service overview');
+  cy.get('.euiTableRowCell--hasActions .euiButtonIcon').click();
+  cy.get('[data-test-subj="label"]').clear().type('Edited Service overview');
+  cy.get('[data-test-subj="saveButton"]').click();
+});
+
+Then('custom link was edited', () => {
+  cy.contains('Link saved!');
+  cy.contains('Edited Service overview');
+  cy.contains('https://elastic/app/apm/services/{{service.name}}/overview');
+});
+
+Then('delete custom link', () => {
+  cy.get('.euiToast__closeButton').click();
+  cy.get('.euiTableRowCell--hasActions .euiButtonIcon').click();
+  cy.contains('Delete').click();
+  cy.contains('Deleted custom link.');
 });

--- a/x-pack/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
@@ -27,6 +27,7 @@ import { callApmApi } from '../../../../services/rest/createCallApmApi';
 
 const APM_INDEX_LABELS = [
   {
+    dataTestSubj: 'sourcemapIndice',
     configurationName: 'apm_oss.sourcemapIndices',
     label: i18n.translate(
       'xpack.apm.settings.apmIndices.sourcemapIndicesLabel',
@@ -34,12 +35,14 @@ const APM_INDEX_LABELS = [
     ),
   },
   {
+    dataTestSubj: 'errorIndices',
     configurationName: 'apm_oss.errorIndices',
     label: i18n.translate('xpack.apm.settings.apmIndices.errorIndicesLabel', {
       defaultMessage: 'Error Indices',
     }),
   },
   {
+    dataTestSubj: 'onboardingIndices',
     configurationName: 'apm_oss.onboardingIndices',
     label: i18n.translate(
       'xpack.apm.settings.apmIndices.onboardingIndicesLabel',
@@ -47,12 +50,14 @@ const APM_INDEX_LABELS = [
     ),
   },
   {
+    dataTestSubj: 'spanIndices',
     configurationName: 'apm_oss.spanIndices',
     label: i18n.translate('xpack.apm.settings.apmIndices.spanIndicesLabel', {
       defaultMessage: 'Span Indices',
     }),
   },
   {
+    dataTestSubj: 'transactionIndices',
     configurationName: 'apm_oss.transactionIndices',
     label: i18n.translate(
       'xpack.apm.settings.apmIndices.transactionIndicesLabel',
@@ -60,6 +65,7 @@ const APM_INDEX_LABELS = [
     ),
   },
   {
+    dataTestSubj: 'metricsIndices',
     configurationName: 'apm_oss.metricsIndices',
     label: i18n.translate('xpack.apm.settings.apmIndices.metricsIndicesLabel', {
       defaultMessage: 'Metrics Indices',
@@ -187,40 +193,43 @@ export function ApmIndices() {
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiForm>
-              {APM_INDEX_LABELS.map(({ configurationName, label }) => {
-                const matchedConfiguration = data.find(
-                  ({ configurationName: configName }) =>
-                    configName === configurationName
-                );
-                const defaultValue = matchedConfiguration
-                  ? matchedConfiguration.defaultValue
-                  : '';
-                const savedUiIndexValue = apmIndices[configurationName] || '';
-                return (
-                  <EuiFormRow
-                    key={configurationName}
-                    label={label}
-                    helpText={i18n.translate(
-                      'xpack.apm.settings.apmIndices.helpText',
-                      {
-                        defaultMessage:
-                          'Overrides {configurationName}: {defaultValue}',
-                        values: { configurationName, defaultValue },
-                      }
-                    )}
-                    fullWidth
-                  >
-                    <EuiFieldText
-                      disabled={!canSave}
+              {APM_INDEX_LABELS.map(
+                ({ configurationName, label, dataTestSubj }) => {
+                  const matchedConfiguration = data.find(
+                    ({ configurationName: configName }) =>
+                      configName === configurationName
+                  );
+                  const defaultValue = matchedConfiguration
+                    ? matchedConfiguration.defaultValue
+                    : '';
+                  const savedUiIndexValue = apmIndices[configurationName] || '';
+                  return (
+                    <EuiFormRow
+                      key={configurationName}
+                      label={label}
+                      helpText={i18n.translate(
+                        'xpack.apm.settings.apmIndices.helpText',
+                        {
+                          defaultMessage:
+                            'Overrides {configurationName}: {defaultValue}',
+                          values: { configurationName, defaultValue },
+                        }
+                      )}
                       fullWidth
-                      name={configurationName}
-                      placeholder={defaultValue}
-                      value={savedUiIndexValue}
-                      onChange={handleChangeIndexConfigurationEvent}
-                    />
-                  </EuiFormRow>
-                );
-              })}
+                    >
+                      <EuiFieldText
+                        data-test-subj={dataTestSubj}
+                        disabled={!canSave}
+                        fullWidth
+                        name={configurationName}
+                        placeholder={defaultValue}
+                        value={savedUiIndexValue}
+                        onChange={handleChangeIndexConfigurationEvent}
+                      />
+                    </EuiFormRow>
+                  );
+                }
+              )}
               <EuiSpacer />
               <EuiFlexGroup justifyContent="flexEnd">
                 <EuiFlexItem grow={false}>

--- a/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateEditCustomLinkFlyout/FlyoutFooter.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateEditCustomLinkFlyout/FlyoutFooter.tsx
@@ -45,6 +45,7 @@ export function FlyoutFooter({
             <DeleteButton customLinkId={customLinkId} onDelete={onDelete} />
           )}
           <EuiButton
+            data-test-subj="saveButton"
             fill
             type="submit"
             isLoading={isSaving}


### PR DESCRIPTION
Adding new e2e tests. 

I basically followed my instincts about name convention (😅) suggestions to improve are more than welcome.

Tests added:
`Settings -> Indices page`
 - Edit default index pattern
 - Resert to default value
 
 `Settings -> Custom links page`
 - Create new custom link
 - Edit a custom link
 - Delete a custom link 

A downside that I've seen is that we don't have a statefull test, where the data is reset before every test. Maybe it's possible and I don't know how it should be done.

<img width="753" alt="Screenshot 2021-01-11 at 14 53 25" src="https://user-images.githubusercontent.com/55978943/104191515-e3f1ee00-541d-11eb-9573-c77768842122.png">
