### PR TITLE
chore(NA): move missing apm plugin tests out of __tests__ folder

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/ErrorCount.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/ErrorCount.test.tsx
@@ -6,8 +6,8 @@
 
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { expectTextsInDocument } from '../../../../../utils/testHelpers';
-import { ErrorCount } from '../ErrorCount';
+import { expectTextsInDocument } from '../../../../utils/testHelpers';
+import { ErrorCount } from './ErrorCount';
 
 describe('ErrorCount', () => {
   it('shows singular error message', () => {


### PR DESCRIPTION
On https://github.com/elastic/kibana/pull/87601 I've missed that file so that PR intends to finish the last one. 