### PR TITLE
[7.11] Prevent kibana crashing when multiple processes start APM telemetry task in parallel (#87645)

### DIFF
--- a/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/index.ts
@@ -159,7 +159,7 @@ export async function createApmTelemetry({
         logger.debug(
           `Stored telemetry is out of date. Task will run immediately. Stored: ${currentData.kibanaVersion}, expected: ${kibanaVersion}`
         );
-        taskManagerStart.runNow(APM_TELEMETRY_TASK_NAME);
+        await taskManagerStart.runNow(APM_TELEMETRY_TASK_NAME);
       }
     } catch (err) {
       if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Prevent kibana crashing when multiple processes start APM telemetry task in parallel (#87645)