### PR TITLE
[Fleet] Only display logs UI for agent >= 7.11

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -205,7 +205,7 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
         title={
           <FormattedMessage
             id="xpack.fleet.agentLogs.oldAgentWarningTitle"
-            defaultMessage="The logs viewer requires Elastic Agent 7.11 or higher. To upgrade an agent, go to the Agents page, or {downloadLink} a newer version."
+            defaultMessage="The Logs view requires Elastic Agent 7.11 or higher. To upgrade an agent, go to the Actions menu, or {downloadLink} a newer version."
             values={{
               downloadLink: (
                 <EuiLink href="https://ela.st/download-elastic-agent" external target="_blank">

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -205,13 +205,13 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
         title={
           <FormattedMessage
             id="xpack.fleet.agentLogs.oldAgentWarningTitle"
-            defaultMessage="The logs viewer is only compatible with Elastic Agents version 7.11 and higher. Please upgrade your Elastic Agent on the Agents details page, or by {downloadLink} a newer version."
+            defaultMessage="The logs viewer requires Elastic Agent 7.11 or higher. To upgrade an agent, go to the Agents page, or {downloadLink} a newer version."
             values={{
               downloadLink: (
                 <EuiLink href="https://ela.st/download-elastic-agent" external target="_blank">
                   <FormattedMessage
                     id="xpack.fleet.agentLogs.downloadLink"
-                    defaultMessage="downloading"
+                    defaultMessage="download"
                   />
                 </EuiLink>
               ),

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -15,9 +15,12 @@ import {
   EuiFilterGroup,
   EuiPanel,
   EuiButtonEmpty,
+  EuiCallOut,
+  EuiLink,
 } from '@elastic/eui';
 import useMeasure from 'react-use/lib/useMeasure';
 import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 import semverGte from 'semver/functions/gte';
 import semverCoerce from 'semver/functions/coerce';
 import { createStateContainerReactHelpers } from '../../../../../../../../../../../src/plugins/kibana_utils/public';
@@ -184,7 +187,7 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
   const [logsPanelRef, { height: logPanelHeight }] = useMeasure();
 
   const agentVersion = agent.local_metadata?.elastic?.agent?.version;
-  const isLogLevelSelectionAvailable = useMemo(() => {
+  const isLogFeatureAvailable = useMemo(() => {
     if (!agentVersion) {
       return false;
     }
@@ -194,6 +197,31 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
     }
     return semverGte(agentVersionWithPrerelease, '7.11.0');
   }, [agentVersion]);
+
+  if (!isLogFeatureAvailable) {
+    return (
+      <EuiCallOut
+        size="m"
+        color="warning"
+        title={
+          <FormattedMessage
+            id="xpack.fleet.agentLogs.oldAgentWarningTitle"
+            defaultMessage="The logs viewer is only compatible with Elastic Agents version 7.11 and higher. Please upgrade your Elastic Agent on the Agents details page, or by {downloadLink} a newer version."
+            values={{
+              downloadLink: (
+                <EuiLink href="https://ela.st/download-elastic-agent" external target="_blank">
+                  <FormattedMessage
+                    id="xpack.fleet.agentLogs.downloadLink"
+                    defaultMessage="downloading"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        }
+      />
+    );
+  }
 
   return (
     <WrapperFlexGroup direction="column" gutterSize="m">
@@ -271,11 +299,9 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(({ agen
           />
         </EuiPanel>
       </EuiFlexItem>
-      {isLogLevelSelectionAvailable && (
-        <EuiFlexItem grow={false}>
-          <SelectLogLevel agent={agent} />
-        </EuiFlexItem>
-      )}
+      <EuiFlexItem grow={false}>
+        <SelectLogLevel agent={agent} />
+      </EuiFlexItem>
     </WrapperFlexGroup>
   );
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -20,7 +20,6 @@ import {
 } from '@elastic/eui';
 import useMeasure from 'react-use/lib/useMeasure';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { i18n } from '@kbn/i18n';
 import semverGte from 'semver/functions/gte';
 import semverCoerce from 'semver/functions/coerce';
 import { createStateContainerReactHelpers } from '../../../../../../../../../../../src/plugins/kibana_utils/public';


### PR DESCRIPTION
## Summary

Resolve #87841

The new logs UI for agents is not working for agent before 7.11 as we discussed we are going to display a message saying the feature is not available for agent with previous version. cc @mostlyjason 


## UI Change

## With a 7.10 agent
<img width="1390" alt="Screen Shot 2021-01-11 at 5 03 12 PM" src="https://user-images.githubusercontent.com/1336873/104238640-bd3cb300-542f-11eb-83da-1e6cebd5473a.png">

## With a 8.0.0 agent
<img width="1321" alt="Screen Shot 2021-01-11 at 5 05 27 PM" src="https://user-images.githubusercontent.com/1336873/104238595-ba41c280-542f-11eb-8812-7bddd31b6dac.png">

