### PR TITLE
[APM] Fix stale custom links list after creating new link

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/index.tsx
@@ -56,7 +56,7 @@ export function CustomLinkMenuSection({
   const { data: customLinks = [], status, refetch } = useFetcher(
     (callApmApi) =>
       callApmApi({
-        isCachable: true,
+        isCachable: false,
         endpoint: 'GET /api/apm/settings/custom_links',
         params: { query: convertFiltersToQuery(filters) },
       }),


### PR DESCRIPTION
Closes #86989. Disable caching for fetched custom links

![custom-link-disable-cache-fix](https://user-images.githubusercontent.com/1967266/104242495-1860ac80-5414-11eb-8cb3-e8f165c80ba9.gif)
