### PR TITLE
[Dashboard] Fix Duplicated Duplicate Title Message

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable_factory.tsx
@@ -197,6 +197,7 @@ export class VisualizeEmbeddableFactory
       const saveOptions = {
         confirmOverwrite: false,
         returnToOrigin: true,
+        isTitleDuplicateConfirmed: true,
       };
       savedVis.title = title;
       savedVis.copyOnSave = false;


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/87758

One liner fix for the duplicated duplicate title message that pops up on saving a visualize embeddable to the library from a dashboard.