### PR TITLE
[7.11] add support for xpack registry environment variable in Docker (#87445)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker
@@ -169,6 +169,7 @@ kibana_vars=(
     xpack.fleet.agents.elasticsearch.host
     xpack.fleet.agents.kibana.host
     xpack.fleet.agents.tlsCheckDisabled
+    xpack.fleet.registryUrl
     xpack.graph.enabled
     xpack.graph.canEditDrillDownUrls
     xpack.graph.savePolicy


### PR DESCRIPTION
Backports the following commits to 7.11:
 - add support for xpack registry environment variable in Docker (#87445)