### PR TITLE
[Fleet] Fix agent status updating count, and mitigate performance issue

### DIFF
--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -49,7 +49,7 @@ export function buildKueryForUnenrollingAgents() {
 }
 
 export function buildKueryForOnlineAgents() {
-  return `not (${buildKueryForOfflineAgents()}) AND not (${buildKueryForErrorAgents()}) AND not (${buildKueryForEnrollingAgents()}) AND not (${buildKueryForUnenrollingAgents()})`;
+  return `not (${buildKueryForOfflineAgents()}) AND not (${buildKueryForErrorAgents()}) AND not (${buildKueryForUpdatingAgents()})`;
 }
 
 export function buildKueryForErrorAgents() {
@@ -59,11 +59,11 @@ export function buildKueryForErrorAgents() {
 export function buildKueryForOfflineAgents() {
   return `${AGENT_SAVED_OBJECT_TYPE}.last_checkin < now-${
     (4 * AGENT_POLLING_THRESHOLD_MS) / 1000
-  }s AND not (${buildKueryForErrorAgents()})`;
+  }s AND not (${buildKueryForErrorAgents()}) AND not ( ${buildKueryForUpdatingAgents()} )`;
 }
 
 export function buildKueryForUpgradingAgents() {
-  return `${AGENT_SAVED_OBJECT_TYPE}.upgrade_started_at:*`;
+  return `(${AGENT_SAVED_OBJECT_TYPE}.upgrade_started_at:*) and not (${AGENT_SAVED_OBJECT_TYPE}.upgraded_at:*)`;
 }
 
 export function buildKueryForUpdatingAgents() {

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -219,5 +219,6 @@ export interface GetAgentStatusResponse {
     error: number;
     offline: number;
     other: number;
+    updating: number;
   };
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -47,7 +47,7 @@ import { AgentTableHeader } from './components/table_header';
 import { SelectionMode } from './components/bulk_actions';
 import { SearchAndFilterBar } from './components/search_and_filter_bar';
 
-const REFRESH_INTERVAL_MS = 10000;
+const REFRESH_INTERVAL_MS = 30000;
 
 const RowActions = React.memo<{
   agent: Agent;
@@ -282,7 +282,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           healthy: agentsStatusRequest.data.results.online,
           unhealthy: agentsStatusRequest.data.results.error,
           offline: agentsStatusRequest.data.results.offline,
-          updating: agentsStatusRequest.data.results.other,
+          updating: agentsStatusRequest.data.results.updating,
           inactive: agentsRequest.data.totalInactive,
         });
 

--- a/x-pack/plugins/fleet/server/services/agents/status.ts
+++ b/x-pack/plugins/fleet/server/services/agents/status.ts
@@ -5,6 +5,7 @@
  */
 
 import { SavedObjectsClientContract } from 'src/core/server';
+import pMap from 'p-map';
 import { getAgent, listAgents } from './crud';
 import { AGENT_EVENT_SAVED_OBJECT_TYPE, AGENT_SAVED_OBJECT_TYPE } from '../../constants';
 import { AgentStatus } from '../../types';
@@ -21,18 +22,32 @@ export async function getAgentStatusById(
 
 export const getAgentStatus = AgentStatusKueryHelper.getAgentStatus;
 
+function joinKuerys(...kuerys: Array<string | undefined>) {
+  return kuerys
+    .filter((kuery) => kuery !== undefined)
+    .reduce((acc, kuery) => {
+      if (acc === '') {
+        return `(${kuery})`;
+      }
+
+      return `${acc} and (${kuery})`;
+    }, '');
+}
+
 export async function getAgentStatusForAgentPolicy(
   soClient: SavedObjectsClientContract,
   agentPolicyId?: string,
   filterKuery?: string
 ) {
-  const [all, online, error, offline] = await Promise.all(
+  const [all, online, error, offline, updating] = await pMap(
     [
       undefined,
       AgentStatusKueryHelper.buildKueryForOnlineAgents(),
       AgentStatusKueryHelper.buildKueryForErrorAgents(),
       AgentStatusKueryHelper.buildKueryForOfflineAgents(),
-    ].map((kuery) =>
+      AgentStatusKueryHelper.buildKueryForUpdatingAgents(),
+    ],
+    (kuery) =>
       listAgents(soClient, {
         showInactive: false,
         perPage: 0,
@@ -44,21 +59,11 @@ export async function getAgentStatusForAgentPolicy(
             agentPolicyId ? `${AGENT_SAVED_OBJECT_TYPE}.policy_id:"${agentPolicyId}"` : undefined,
           ]
         ),
-      })
-    )
+      }),
+    {
+      concurrency: 1,
+    }
   );
-
-  function joinKuerys(...kuerys: Array<string | undefined>) {
-    return kuerys
-      .filter((kuery) => kuery !== undefined)
-      .reduce((acc, kuery) => {
-        if (acc === '') {
-          return `(${kuery})`;
-        }
-
-        return `${acc} and (${kuery})`;
-      }, '');
-  }
 
   return {
     events: await getEventsCount(soClient, agentPolicyId),
@@ -66,6 +71,7 @@ export async function getAgentStatusForAgentPolicy(
     online: online.total,
     error: error.total,
     offline: offline.total,
+    updating: updating.total,
     other: all.total - online.total - error.total - offline.total,
   };
 }

--- a/x-pack/plugins/security_solution/public/management/pages/policy/types.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/types.ts
@@ -61,7 +61,7 @@ export interface PolicyDetailsState {
   /** current location of the application */
   location?: Immutable<AppLocation>;
   /** A summary of stats for the agents associated with a given Fleet Agent Policy */
-  agentStatusSummary?: GetAgentStatusResponse['results'];
+  agentStatusSummary?: Omit<GetAgentStatusResponse['results'], 'updating'>;
   /** Status of an update to the policy  */
   updateStatus?: {
     success: boolean;


### PR DESCRIPTION
## Summary

Fix #86882  and potentially mitigate https://github.com/elastic/kibana/issues/86742 

Fix the count of updating agent by modifying the agent status handler and agent status service 

## UI example

<img width="1349" alt="Screen Shot 2021-01-12 at 8 52 07 AM" src="https://user-images.githubusercontent.com/1336873/104365032-db68e880-54ed-11eb-96e4-6dae4e1d7419.png">


## How to test?

Try to upgrade an agent, you should see the `updating` status count updated

## Mitigate socket hang up error

After some investigation looks like we can have 503 errors in cloud and these errors are related to the `/agent-status` endpoint this endpoint is  blocking a lot the event loop because it's using a lot of KQL queries.

I tried to mitigate the problem by refreshin the agent list less often, and by doing the kql queries in series instead of concurently (this problem should be solved by moving away from saved object soon)
