### PR TITLE
[Visualize] Fix color picker close on blur

### DIFF
--- a/src/plugins/vis_type_xy/public/utils/use_color_picker.tsx
+++ b/src/plugins/vis_type_xy/public/utils/use_color_picker.tsx
@@ -17,10 +17,11 @@
  * under the License.
  */
 
-import React, { BaseSyntheticEvent, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { BaseSyntheticEvent, useCallback, useMemo, useRef } from 'react';
 
 import { LegendColorPicker, Position, XYChartSeriesIdentifier, SeriesName } from '@elastic/charts';
-import { PopoverAnchorPosition, EuiWrappingPopover } from '@elastic/eui';
+import { PopoverAnchorPosition, EuiWrappingPopover, EuiOutsideClickDetector } from '@elastic/eui';
+import { EuiEvent } from '@elastic/eui/src/components/outside_click_detector/outside_click_detector';
 
 import { ColorPicker } from '../../../charts/public';
 
@@ -65,7 +66,7 @@ export const useColorPicker = (
 
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const handleOutsideClick = useCallback(
-        (e: MouseEvent) => {
+        (e: EuiEvent) => {
           if (ref.current && !(ref.current! as any).contains(e.target)) {
             onClose?.();
           }
@@ -73,27 +74,21 @@ export const useColorPicker = (
         [onClose]
       );
 
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      useEffect(() => {
-        document.addEventListener('click', handleOutsideClick);
-        return () => {
-          document.removeEventListener('click', handleOutsideClick);
-        };
-      }, [handleOutsideClick]);
-
       return (
-        <EuiWrappingPopover
-          popoverRef={ref}
-          isOpen
-          ownFocus
-          display="block"
-          button={anchor}
-          anchorPosition={getAnchorPosition(legendPosition)}
-          closePopover={onClose}
-          panelPaddingSize="s"
-        >
-          <ColorPicker color={color} onChange={handlChange} label={seriesName} />
-        </EuiWrappingPopover>
+        <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
+          <EuiWrappingPopover
+            popoverRef={ref}
+            isOpen
+            ownFocus
+            display="block"
+            button={anchor}
+            anchorPosition={getAnchorPosition(legendPosition)}
+            closePopover={onClose}
+            panelPaddingSize="s"
+          >
+            <ColorPicker color={color} onChange={handlChange} label={seriesName} />
+          </EuiWrappingPopover>
+        </EuiOutsideClickDetector>
       );
     },
     [getSeriesName, legendPosition, setColor]

--- a/src/plugins/vis_type_xy/public/utils/use_color_picker.tsx
+++ b/src/plugins/vis_type_xy/public/utils/use_color_picker.tsx
@@ -61,6 +61,7 @@ export const useColorPicker = (
         onClose();
       };
 
+      // rule doesn't know this is inside a functional component
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const handleOutsideClick = useCallback(() => {
         onClose?.();

--- a/src/plugins/vis_type_xy/public/utils/use_color_picker.tsx
+++ b/src/plugins/vis_type_xy/public/utils/use_color_picker.tsx
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-import React, { BaseSyntheticEvent, useCallback, useMemo, useRef } from 'react';
+import React, { BaseSyntheticEvent, useCallback, useMemo } from 'react';
 
 import { LegendColorPicker, Position, XYChartSeriesIdentifier, SeriesName } from '@elastic/charts';
 import { PopoverAnchorPosition, EuiWrappingPopover, EuiOutsideClickDetector } from '@elastic/eui';
-import { EuiEvent } from '@elastic/eui/src/components/outside_click_detector/outside_click_detector';
 
 import { ColorPicker } from '../../../charts/public';
 
@@ -49,8 +48,6 @@ export const useColorPicker = (
 ): LegendColorPicker =>
   useMemo(
     () => ({ anchor, color, onClose, onChange, seriesIdentifier }) => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const ref = useRef<HTMLDivElement | null>(null);
       const seriesName = getSeriesName(seriesIdentifier as XYChartSeriesIdentifier);
       const handlChange = (newColor: string | null, event: BaseSyntheticEvent) => {
         if (!seriesName) {
@@ -65,19 +62,13 @@ export const useColorPicker = (
       };
 
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      const handleOutsideClick = useCallback(
-        (e: EuiEvent) => {
-          if (ref.current && !(ref.current! as any).contains(e.target)) {
-            onClose?.();
-          }
-        },
-        [onClose]
-      );
+      const handleOutsideClick = useCallback(() => {
+        onClose?.();
+      }, [onClose]);
 
       return (
         <EuiOutsideClickDetector onOutsideClick={handleOutsideClick}>
           <EuiWrappingPopover
-            popoverRef={ref}
             isOpen
             ownFocus
             display="block"


### PR DESCRIPTION
## Summary

fix #87341

Fixes duplicate active color picker popovers. Closed color picker when blurred away. Works to set and clear colors.

### Before
![Screen Recording 2021-01-12 at 11 39 AM](https://user-images.githubusercontent.com/19007109/104351337-e3636100-54ca-11eb-8925-1d2b362eeafd.gif)


### After
![Screen Recording 2021-01-12 at 11 31 AM](https://user-images.githubusercontent.com/19007109/104350987-6c2dcd00-54ca-11eb-972f-9085a03ce40f.gif)


### Checklist

- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))