### PR TITLE
[Fleet] Fix broken maps icon key

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/epm/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/epm/constants.tsx
@@ -39,7 +39,7 @@ export const AssetIcons: Record<KibanaAssetType, IconType> = {
   index_pattern: 'indexPatternApp',
   search: 'searchProfilerApp',
   visualization: 'visualizeApp',
-  map: 'mapApp',
+  map: 'emsApp',
 };
 
 export const ServiceIcons: Record<ServiceName, IconType> = {


### PR DESCRIPTION
## PR Summary
Show [`emsApp` icon from EUI](https://eui.elastic.co/#/display/icons#apps) if integration includes map assets.

<img width="229" alt="Screen Shot 2021-01-12 at 3 14 14 PM" src="https://user-images.githubusercontent.com/57655/104367878-65628280-54e9-11eb-8d9c-fa838e2c15ae.png">

Looking at https://github.com/elastic/kibana/pull/62059#discussion_r401211966, I believe it landed with the incorrect key at a time when that part of the page wasn't visible. When we enabled that section, we likely didn't notice the missing key since most integrations don't have Maps assets

## Bug: `master` doesn't have an icon for Map assets
 1. Visit an integration with map assets, like AWS http://localhost:5601/app/fleet#/integrations/detail/aws-0.3.16
 2. Observe missing icon for Map in right column summary & HTTP request for `/app/mapApp`
    <img width="1013" alt="Screen Shot 2021-01-12 at 3 10 44 PM" src="https://user-images.githubusercontent.com/57655/104367875-64c9ec00-54e9-11eb-81d8-982bec862f5f.png">

## This PR adds one
 1. Visit an integration with map assets, like AWS http://localhost:5601/app/fleet#/integrations/detail/aws-0.3.16
 2. Observe EMS icon is present in right column summary
    <img width="1087" alt="Screen Shot 2021-01-12 at 3 11 39 PM" src="https://user-images.githubusercontent.com/57655/104367877-65628280-54e9-11eb-91da-578fec6ff769.png">

