### PR TITLE
[Fleet] Remove misleading information from enrollment token revoke modal

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_delete_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_delete_modal.tsx
@@ -36,7 +36,8 @@ export const ConfirmEnrollmentTokenDelete = (props: Props) => {
       >
         <EuiCallOut
           title={i18n.translate('xpack.fleet.enrollmentTokenDeleteModal.description', {
-            defaultMessage: 'Are your sure you want to revoke {keyName}? New agents will no longer be able to be enrolled using this token.',
+            defaultMessage:
+              'Are your sure you want to revoke {keyName}? New agents will no longer be able to be enrolled using this token.',
             values: {
               keyName: enrollmentKey.name,
             },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_delete_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_delete_modal.tsx
@@ -36,8 +36,7 @@ export const ConfirmEnrollmentTokenDelete = (props: Props) => {
       >
         <EuiCallOut
           title={i18n.translate('xpack.fleet.enrollmentTokenDeleteModal.description', {
-            defaultMessage:
-              'Are your sure you want to revoke {keyName}? Agents that use this token will no longer be able to access policies or send data. ',
+            defaultMessage: 'Are your sure you want to revoke {keyName}?',
             values: {
               keyName: enrollmentKey.name,
             },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_delete_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/enrollment_token_list_page/components/confirm_delete_modal.tsx
@@ -36,7 +36,7 @@ export const ConfirmEnrollmentTokenDelete = (props: Props) => {
       >
         <EuiCallOut
           title={i18n.translate('xpack.fleet.enrollmentTokenDeleteModal.description', {
-            defaultMessage: 'Are your sure you want to revoke {keyName}?',
+            defaultMessage: 'Are your sure you want to revoke {keyName}? New agents will no longer be able to be enrolled using this token.',
             values: {
               keyName: enrollmentKey.name,
             },


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/87979
Do not display misleading information while revoking an enrollmnent token. Revoking an unrollment token will prevent to enroll new agent with that token, but will do nothing to already enrolled agent.

cc @jen-huang 

## UI Change

### Before
<img width="831" alt="Screen Shot 2021-01-12 at 4 28 13 PM" src="https://user-images.githubusercontent.com/1336873/104368989-36e9a500-54f3-11eb-86d3-708b0d6f7fca.png">


### After

<img width="1016" alt="Screen Shot 2021-01-12 at 4 24 38 PM" src="https://user-images.githubusercontent.com/1336873/104368885-128dc880-54f3-11eb-86b1-dbee04e117ab.png">



