### PR TITLE
[APM] Hide “Create configuration” for users without write access

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
@@ -61,31 +61,38 @@ export function AgentConfigurationList({ status, data, refetch }: Props) {
         </h2>
       }
       body={
-        canSave ? (
-          <p>
-            {i18n.translate(
-              'xpack.apm.agentConfig.configTable.emptyPromptText',
-              {
-                defaultMessage:
-                  "Let's change that! You can fine-tune agent configuration directly from Kibana without having to redeploy. Get started by creating your first configuration.",
-              }
-            )}
-          </p>
-        ) : null
+        <p>
+          {i18n.translate('xpack.apm.agentConfig.configTable.emptyPromptText', {
+            defaultMessage:
+              "Let's change that! You can fine-tune agent configuration directly from Kibana without having to redeploy. Get started by creating your first configuration.",
+          })}
+        </p>
       }
       actions={
-        canSave ? (
+        <EuiToolTip
+          content={
+            !canSave &&
+            i18n.translate(
+              'xpack.apm.settings.agentConfig.createConfigButton.tooltip',
+              {
+                defaultMessage:
+                  "You don't have permissions to create agent configurations",
+              }
+            )
+          }
+        >
           <EuiButton
             color="primary"
             fill
             href={createAgentConfigurationHref(search, basePath)}
+            disabled={!canSave}
           >
             {i18n.translate(
               'xpack.apm.agentConfig.configTable.createConfigButtonLabel',
               { defaultMessage: 'Create configuration' }
             )}
           </EuiButton>
-        ) : null
+        </EuiToolTip>
       }
     />
   );

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
@@ -61,7 +61,7 @@ export function AgentConfigurationList({ status, data, refetch }: Props) {
         </h2>
       }
       body={
-        <>
+        canSave ? (
           <p>
             {i18n.translate(
               'xpack.apm.agentConfig.configTable.emptyPromptText',
@@ -71,7 +71,7 @@ export function AgentConfigurationList({ status, data, refetch }: Props) {
               }
             )}
           </p>
-        </>
+        ) : null
       }
       actions={
         canSave ? (

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
@@ -85,7 +85,7 @@ export function AgentConfigurationList({ status, data, refetch }: Props) {
             color="primary"
             fill
             href={createAgentConfigurationHref(search, basePath)}
-            disabled={!canSave}
+            isDisabled={!canSave}
           >
             {i18n.translate(
               'xpack.apm.agentConfig.configTable.createConfigButtonLabel',

--- a/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/AgentConfigurations/List/index.tsx
@@ -74,16 +74,18 @@ export function AgentConfigurationList({ status, data, refetch }: Props) {
         </>
       }
       actions={
-        <EuiButton
-          color="primary"
-          fill
-          href={createAgentConfigurationHref(search, basePath)}
-        >
-          {i18n.translate(
-            'xpack.apm.agentConfig.configTable.createConfigButtonLabel',
-            { defaultMessage: 'Create configuration' }
-          )}
-        </EuiButton>
+        canSave ? (
+          <EuiButton
+            color="primary"
+            fill
+            href={createAgentConfigurationHref(search, basePath)}
+          >
+            {i18n.translate(
+              'xpack.apm.agentConfig.configTable.createConfigButtonLabel',
+              { defaultMessage: 'Create configuration' }
+            )}
+          </EuiButton>
+        ) : null
       }
     />
   );

--- a/x-pack/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/ApmIndices/index.tsx
@@ -248,7 +248,7 @@ export function ApmIndices() {
                       fill
                       onClick={handleApplyChangesEvent}
                       isLoading={isSaving}
-                      disabled={!canSave}
+                      isDisabled={!canSave}
                     >
                       {i18n.translate(
                         'xpack.apm.settings.apmIndices.applyButton',


### PR DESCRIPTION
Closes #87644 

Tip: Easier to review [without whitespace changes](https://github.com/elastic/kibana/pull/88149/files?diff=unified&w=1)

## `elastic` (superuser)
![image](https://user-images.githubusercontent.com/209966/104435471-baa3a000-558c-11eb-9c2e-7c813ac791fc.png)

## `apm_read_user` 
![image](https://user-images.githubusercontent.com/209966/104447460-204b5880-559c-11eb-9a2f-13a4b9e26eda.png)

