### PR TITLE
[APM] Hide `recording` setting from from RUM agents

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -125,7 +125,7 @@ export const generalSettings: RawSettingDefinition[] = [
       defaultMessage:
         'When recording, the agent instruments incoming HTTP requests, tracks errors, and collects and sends metrics. When set to non-recording, the agent works as a noop, not collecting data and not communicating with the APM Server except for polling for updated configuration. As this is a reversible switch, agent threads are not being killed when set to non-recording, but they will be mostly idle in this state, so the overhead should be negligible. You can use this setting to dynamically control whether Elastic APM is enabled or disabled.',
     }),
-    excludeAgents: ['nodejs'],
+    excludeAgents: ['nodejs', 'rum-js', 'js-base'],
   },
 
   // SERVER_TIMEOUT

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -87,14 +87,12 @@ describe('filterByAgent', () => {
 
     it('js-base', () => {
       expect(getSettingKeysForAgent('js-base')).toEqual([
-        'recording',
         'transaction_sample_rate',
       ]);
     });
 
     it('rum-js', () => {
       expect(getSettingKeysForAgent('rum-js')).toEqual([
-        'recording',
         'transaction_sample_rate',
       ]);
     });


### PR DESCRIPTION
Closes #87631

## `recording` is no longer displayed for RUM services
![image](https://user-images.githubusercontent.com/209966/104438674-8b8f2d80-5590-11eb-8e52-7967746c7ed5.png)