### PR TITLE
Add opentelemetry icon for agents elastic doesn't officially support.

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/AgentIcon/get_agent_icon.test.ts
+++ b/x-pack/plugins/apm/public/components/shared/AgentIcon/get_agent_icon.test.ts
@@ -28,7 +28,7 @@ const examples = {
   python: 'python',
   ruby: 'ruby',
   'rum-js': 'rum',
-  'something else': undefined,
+  'something else': 'opentelemetry',
 };
 
 describe('getAgentIconKey', () => {

--- a/x-pack/plugins/apm/public/components/shared/AgentIcon/get_agent_icon.ts
+++ b/x-pack/plugins/apm/public/components/shared/AgentIcon/get_agent_icon.ts
@@ -57,6 +57,9 @@ export function getAgentIconKey(agentName: string) {
   if (OPEN_TELEMETRY_AGENT_NAMES.includes(lowercasedAgentName as AgentName)) {
     return 'opentelemetry';
   }
+
+  // Undetermined, likely unsupported official language agent
+  return 'opentelemetry';
 }
 
 export function getAgentIcon(agentName?: string) {


### PR DESCRIPTION
## Summary

An [APM agent was created for the OCaml programming language](https://github.com/elastic/apm-agent-ocaml) by an internal team. This agent isn't going to be publically supported AFAIK, but an interesting issue I seen in the UI was that the language Icon was missing:

<img width="1738" alt="Screenshot 2021-01-13 at 13 14 44" src="https://user-images.githubusercontent.com/8960296/104457143-8be3f480-55a1-11eb-8685-25cdb9859f22.png">

This PR defaults into the OpenTelemtry icon if a language icon isn't there.
However, given that there are other APM agents being created by the community we could add additional logo icons such as PHP, Rust, etc. I considered defaulting into the APM logo icon, but that doesn't make a lot of sense if the agent isn't supported by Elastic. Let me know your thoughts on this, please.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~~
- [ ] ~~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~~
- [ ] ~~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~~
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
