### PR TITLE
[APM] Fix incorrect table column header (95th instead of avg)

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_transactions_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_transactions_table/index.tsx
@@ -55,30 +55,29 @@ const DEFAULT_SORT = {
 
 function getLatencyAggregationTypeLabel(latencyAggregationType?: string) {
   switch (latencyAggregationType) {
-    case 'avg': {
-      i18n.translate(
+    case 'avg':
+      return i18n.translate(
         'xpack.apm.serviceOverview.transactionsTableColumnLatency.avg',
         {
           defaultMessage: 'Latency (avg.)',
         }
       );
-    }
-    case 'p95': {
+
+    case 'p95':
       return i18n.translate(
         'xpack.apm.serviceOverview.transactionsTableColumnLatency.p95',
         {
           defaultMessage: 'Latency (95th)',
         }
       );
-    }
-    case 'p99': {
+
+    case 'p99':
       return i18n.translate(
         'xpack.apm.serviceOverview.transactionsTableColumnLatency.p99',
         {
           defaultMessage: 'Latency (99th)',
         }
       );
-    }
   }
 }
 


### PR DESCRIPTION
Fixes issue raised by @formgeist in https://github.com/elastic/kibana/pull/88101