### PR TITLE
[EPM] Install Lens assets from packages if present.

### DIFF
--- a/x-pack/plugins/fleet/common/services/package_to_package_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/package_to_package_policy.test.ts
@@ -26,6 +26,7 @@ describe('Fleet - packageToPackagePolicy', () => {
         search: [],
         index_pattern: [],
         map: [],
+        lens: [],
       },
       elasticsearch: {
         ingest_pipeline: [],

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -46,6 +46,7 @@ export enum KibanaAssetType {
   search = 'search',
   indexPattern = 'index_pattern',
   map = 'map',
+  lens = 'lens',
 }
 
 /*
@@ -57,6 +58,7 @@ export enum KibanaSavedObjectType {
   search = 'search',
   indexPattern = 'index-pattern',
   map = 'map',
+  lens = 'lens',
 }
 
 export enum ElasticsearchAssetType {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/epm/constants.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/epm/constants.tsx
@@ -28,6 +28,7 @@ export const AssetTitleMap: Record<AssetType, string> = {
   input: 'Agent input',
   map: 'Map',
   data_stream_ilm_policy: 'Data Stream ILM Policy',
+  lens: 'Lens',
 };
 
 export const ServiceTitleMap: Record<ServiceName, string> = {
@@ -41,6 +42,7 @@ export const AssetIcons: Record<KibanaAssetType, IconType> = {
   search: 'searchProfilerApp',
   visualization: 'visualizeApp',
   map: 'emsApp',
+  lens: 'lensApp',
 };
 
 export const ServiceIcons: Record<ServiceName, IconType> = {

--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -39,6 +39,7 @@ const KibanaSavedObjectTypeMapping: Record<KibanaAssetType, KibanaSavedObjectTyp
   [KibanaAssetType.map]: KibanaSavedObjectType.map,
   [KibanaAssetType.search]: KibanaSavedObjectType.search,
   [KibanaAssetType.visualization]: KibanaSavedObjectType.visualization,
+  [KibanaAssetType.lens]: KibanaSavedObjectType.lens,
 };
 
 // Define how each asset type will be installed
@@ -54,6 +55,7 @@ const AssetInstallers: Record<
   [KibanaAssetType.map]: installKibanaSavedObjects,
   [KibanaAssetType.search]: installKibanaSavedObjects,
   [KibanaAssetType.visualization]: installKibanaSavedObjects,
+  [KibanaAssetType.lens]: installKibanaSavedObjects,
 };
 
 export async function getKibanaAsset(key: string): Promise<ArchiveAsset> {

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -388,6 +388,11 @@ const expectAssetsInstalled = ({
       id: 'sample_search',
     });
     expect(resSearch.id).equal('sample_search');
+    const resLens = await kibanaServer.savedObjects.get({
+      type: 'lens',
+      id: 'sample_lens',
+    });
+    expect(resLens.id).equal('sample_lens');
     const resIndexPattern = await kibanaServer.savedObjects.get({
       type: 'index-pattern',
       id: 'test-*',
@@ -448,6 +453,10 @@ const expectAssetsInstalled = ({
         {
           id: 'test-*',
           type: 'index-pattern',
+        },
+        {
+          id: 'sample_lens',
+          type: 'lens',
         },
         {
           id: 'sample_search',
@@ -515,6 +524,7 @@ const expectAssetsInstalled = ({
         { id: '60d6d054-57e4-590f-a580-52bf3f5e7cca', type: 'epm-packages-assets' },
         { id: '47758dc2-979d-5fbe-a2bd-9eded68a5a43', type: 'epm-packages-assets' },
         { id: '318959c9-997b-5a14-b328-9fc7355b4b74', type: 'epm-packages-assets' },
+        { id: 'e21b59b5-eb76-5ab0-bef2-1c8e379e6197', type: 'epm-packages-assets' },
         { id: 'e786cbd9-0f3b-5a0b-82a6-db25145ebf58', type: 'epm-packages-assets' },
         { id: '53c94591-aa33-591d-8200-cd524c2a0561', type: 'epm-packages-assets' },
         { id: 'b658d2d4-752e-54b8-afc2-4c76155c1466', type: 'epm-packages-assets' },

--- a/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/update_assets.ts
@@ -291,6 +291,10 @@ export default function (providerContext: FtrProviderContext) {
             id: 'sample_search2',
             type: 'search',
           },
+          {
+            id: 'sample_lens',
+            type: 'lens',
+          },
         ],
         installed_es: [
           {
@@ -338,6 +342,7 @@ export default function (providerContext: FtrProviderContext) {
           { id: '5c3aa147-089c-5084-beca-53c00e72ac80', type: 'epm-packages-assets' },
           { id: '48e582df-b1d2-5f88-b6ea-ba1fafd3a569', type: 'epm-packages-assets' },
           { id: 'bf3b0b65-9fdc-53c6-a9ca-e76140e56490', type: 'epm-packages-assets' },
+          { id: '7f4c5aca-b4f5-5f0a-95af-051da37513fc', type: 'epm-packages-assets' },
           { id: '2e56f08b-1d06-55ed-abee-4708e1ccf0aa', type: 'epm-packages-assets' },
           { id: 'c7bf1a39-e057-58a0-afde-fb4b48751d8c', type: 'epm-packages-assets' },
           { id: '8c665f28-a439-5f43-b5fd-8fda7b576735', type: 'epm-packages-assets' },

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/kibana/lens/sample_lens.json
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/all_assets/0.1.0/kibana/lens/sample_lens.json
@@ -1,0 +1,114 @@
+{
+    "type": "lens",
+    "id": "sample_lens",
+    "attributes": {
+        "title": "sample-lens",
+        "description": "",
+        "visualizationType": "lnsXY",
+        "state": {
+            "datasourceStates": {
+                "indexpattern": {
+                    "layers": {
+                        "91b37ed1-ec9f-401d-8ba5-990c2fc65cd0": {
+                            "columns": {
+                                "2c9a6ea8-f3c1-4178-b6af-9e1a5811888a": {
+                                    "label": "Top values of HostDetails.agent.name",
+                                    "dataType": "string",
+                                    "operationType": "terms",
+                                    "scale": "ordinal",
+                                    "sourceField": "HostDetails.agent.name",
+                                    "isBucketed": true,
+                                    "params": {
+                                        "size": 5,
+                                        "orderBy": {
+                                            "type": "column",
+                                            "columnId": "64b26756-2616-4835-bf77-e0e3807cf827"
+                                        },
+                                        "orderDirection": "desc",
+                                        "otherBucket": true,
+                                        "missingBucket": false
+                                    }
+                                },
+                                "64b26756-2616-4835-bf77-e0e3807cf827": {
+                                    "label": "Count of records",
+                                    "dataType": "number",
+                                    "operationType": "count",
+                                    "isBucketed": false,
+                                    "scale": "ratio",
+                                    "sourceField": "Records"
+                                }
+                            },
+                            "columnOrder": [
+                                "2c9a6ea8-f3c1-4178-b6af-9e1a5811888a",
+                                "64b26756-2616-4835-bf77-e0e3807cf827"
+                            ],
+                            "incompleteColumns": {}
+                        }
+                    }
+                }
+            },
+            "visualization": {
+                "legend": {
+                    "isVisible": true,
+                    "position": "right"
+                },
+                "valueLabels": "hide",
+                "fittingFunction": "None",
+                "axisTitlesVisibilitySettings": {
+                    "x": true,
+                    "yLeft": true,
+                    "yRight": true
+                },
+                "tickLabelsVisibilitySettings": {
+                    "x": true,
+                    "yLeft": true,
+                    "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                    "x": true,
+                    "yLeft": true,
+                    "yRight": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "layers": [
+                    {
+                        "layerId": "91b37ed1-ec9f-401d-8ba5-990c2fc65cd0",
+                        "accessors": [
+                            "64b26756-2616-4835-bf77-e0e3807cf827"
+                        ],
+                        "position": "top",
+                        "seriesType": "bar_stacked",
+                        "showGridlines": false,
+                        "xAccessor": "2c9a6ea8-f3c1-4178-b6af-9e1a5811888a"
+                    }
+                ]
+            },
+            "query": {
+                "query": "",
+                "language": "kuery"
+            },
+            "filters": []
+        }
+    },
+    "references": [
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "indexpattern-datasource-current-indexpattern"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "indexpattern-datasource-layer-91b37ed1-ec9f-401d-8ba5-990c2fc65cd0"
+        }
+    ],
+    "migrationVersion": {
+        "lens": "7.11.0"
+    },
+    "updated_at": "2021-01-13T15:16:10.075Z",
+    "version": "WzI5NCwxXQ==",
+    "namespaces": [
+        "default"
+    ],
+    "score": 0
+}

--- a/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/kibana/lens/sample_lens.json
+++ b/x-pack/test/fleet_api_integration/apis/fixtures/test_packages/all_assets/0.2.0/kibana/lens/sample_lens.json
@@ -1,0 +1,114 @@
+{
+    "type": "lens",
+    "id": "sample_lens",
+    "attributes": {
+        "title": "sample-lens",
+        "description": "",
+        "visualizationType": "lnsXY",
+        "state": {
+            "datasourceStates": {
+                "indexpattern": {
+                    "layers": {
+                        "91b37ed1-ec9f-401d-8ba5-990c2fc65cd0": {
+                            "columns": {
+                                "2c9a6ea8-f3c1-4178-b6af-9e1a5811888a": {
+                                    "label": "Top values of HostDetails.agent.name",
+                                    "dataType": "string",
+                                    "operationType": "terms",
+                                    "scale": "ordinal",
+                                    "sourceField": "HostDetails.agent.name",
+                                    "isBucketed": true,
+                                    "params": {
+                                        "size": 5,
+                                        "orderBy": {
+                                            "type": "column",
+                                            "columnId": "64b26756-2616-4835-bf77-e0e3807cf827"
+                                        },
+                                        "orderDirection": "desc",
+                                        "otherBucket": true,
+                                        "missingBucket": false
+                                    }
+                                },
+                                "64b26756-2616-4835-bf77-e0e3807cf827": {
+                                    "label": "Count of records",
+                                    "dataType": "number",
+                                    "operationType": "count",
+                                    "isBucketed": false,
+                                    "scale": "ratio",
+                                    "sourceField": "Records"
+                                }
+                            },
+                            "columnOrder": [
+                                "2c9a6ea8-f3c1-4178-b6af-9e1a5811888a",
+                                "64b26756-2616-4835-bf77-e0e3807cf827"
+                            ],
+                            "incompleteColumns": {}
+                        }
+                    }
+                }
+            },
+            "visualization": {
+                "legend": {
+                    "isVisible": true,
+                    "position": "right"
+                },
+                "valueLabels": "hide",
+                "fittingFunction": "None",
+                "axisTitlesVisibilitySettings": {
+                    "x": true,
+                    "yLeft": true,
+                    "yRight": true
+                },
+                "tickLabelsVisibilitySettings": {
+                    "x": true,
+                    "yLeft": true,
+                    "yRight": true
+                },
+                "gridlinesVisibilitySettings": {
+                    "x": true,
+                    "yLeft": true,
+                    "yRight": true
+                },
+                "preferredSeriesType": "bar_stacked",
+                "layers": [
+                    {
+                        "layerId": "91b37ed1-ec9f-401d-8ba5-990c2fc65cd0",
+                        "accessors": [
+                            "64b26756-2616-4835-bf77-e0e3807cf827"
+                        ],
+                        "position": "top",
+                        "seriesType": "bar_stacked",
+                        "showGridlines": false,
+                        "xAccessor": "2c9a6ea8-f3c1-4178-b6af-9e1a5811888a"
+                    }
+                ]
+            },
+            "query": {
+                "query": "",
+                "language": "kuery"
+            },
+            "filters": []
+        }
+    },
+    "references": [
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "indexpattern-datasource-current-indexpattern"
+        },
+        {
+            "type": "index-pattern",
+            "id": "metrics-*",
+            "name": "indexpattern-datasource-layer-91b37ed1-ec9f-401d-8ba5-990c2fc65cd0"
+        }
+    ],
+    "migrationVersion": {
+        "lens": "7.11.0"
+    },
+    "updated_at": "2021-01-13T15:16:10.075Z",
+    "version": "WzI5NCwxXQ==",
+    "namespaces": [
+        "default"
+    ],
+    "score": 0
+}


### PR DESCRIPTION
## Summary

Implements https://github.com/elastic/kibana/issues/85428

This adds the kibana asset type 'lens' to the supported asset types.

### How to test this manually

You need a package that contains a Kibana asset of type `lens`. ~I have a modified version of the apache package that can be used with a local registry (ping me on slack), or wait for https://github.com/elastic/integrations/pull/530 to be available in the staging registry~ The package `apache-0.3.1` in the staging registry has one (thanks @mtojek for providing the package!).

Navigate to the package in Fleet->Integration. On the integration detail page, verify that the Lens asset is listed on the right side:

![image](https://user-images.githubusercontent.com/189073/104589267-df217a00-5669-11eb-8c94-4410607874d1.png)

Install the package with the "Install Apache assets" on the Settings tab (or any other way). The installation should go through without errors.

After installation, verify in "Visualize" that a Lens asset has been installed and appears in the list of visualizations (for me it's on the third page and called "Workers with Lens", this might be different with the new `apache-0.3.1` package from https://github.com/elastic/integrations/pull/530 ):

![image](https://user-images.githubusercontent.com/189073/104589541-51925a00-566a-11eb-84f1-7f5dced6470f.png)

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
