### PR TITLE
Vega Maps Referencing from kibana.yml

### DIFF
--- a/src/plugins/maps_legacy/public/common/constants/index.ts
+++ b/src/plugins/maps_legacy/public/common/constants/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const TMS_IN_YML_ID = 'TMS in config/kibana.yml';
+
+export { ORIGIN } from './origin';

--- a/src/plugins/maps_legacy/public/index.ts
+++ b/src/plugins/maps_legacy/public/index.ts
@@ -53,7 +53,7 @@ export {
 
 export * from '../common';
 export * from './common/types';
-export { ORIGIN } from './common/constants/origin';
+export { ORIGIN, TMS_IN_YML_ID } from './common/constants';
 
 export { WmsOptions } from './components/wms_options';
 export { LegacyMapDeprecationMessage } from './components/legacy_map_deprecation_message';

--- a/src/plugins/maps_legacy/public/map/service_settings.js
+++ b/src/plugins/maps_legacy/public/map/service_settings.js
@@ -22,9 +22,7 @@ import MarkdownIt from 'markdown-it';
 import { EMSClient } from '@elastic/ems-client';
 import { i18n } from '@kbn/i18n';
 import { getKibanaVersion } from '../kibana_services';
-import { ORIGIN } from '../common/constants/origin';
-
-const TMS_IN_YML_ID = 'TMS in config/kibana.yml';
+import { ORIGIN, TMS_IN_YML_ID } from '../common/constants';
 
 export class ServiceSettings {
   constructor(mapConfig, tilemapsConfig) {

--- a/src/plugins/vis_type_vega/public/services.ts
+++ b/src/plugins/vis_type_vega/public/services.ts
@@ -45,4 +45,3 @@ export const [getMapsLegacyConfig, setMapsLegacyConfig] = createGetterSetter<Map
 );
 
 export const getEnableExternalUrls = () => getInjectedVars().enableExternalUrls;
-export const getEmsTileLayerId = () => getMapsLegacyConfig().emsTileLayerId;

--- a/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
+++ b/src/plugins/vis_type_vega/public/vega_view/vega_map_view.js
@@ -29,15 +29,17 @@ const isUserConfiguredTmsLayer = ({ tilemap }) => Boolean(tilemap.url);
 const getMapStyleOptions = async (serviceSettings, mapConfig, isDarkMode) => {
   const mapsLegacyConfig = getMapsLegacyConfig();
   const tmsServices = await serviceSettings.getTMSServices();
+
   let mapStyle;
 
-  if (isUserConfiguredTmsLayer(mapsLegacyConfig)) {
-    mapStyle = TMS_IN_YML_ID;
+  if (mapConfig.mapStyle !== 'default') {
+    mapStyle = mapConfig.mapStyle;
   } else {
-    mapStyle =
-      mapConfig.mapStyle === 'default'
-        ? mapsLegacyConfig.emsTileLayerId.bright
-        : mapConfig.mapStyle;
+    if (isUserConfiguredTmsLayer(mapsLegacyConfig)) {
+      mapStyle = TMS_IN_YML_ID;
+    } else {
+      mapStyle = mapsLegacyConfig.emsTileLayerId.bright;
+    }
   }
 
   const mapOptions = tmsServices.find((s) => s.id === mapStyle);

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4568,6 +4568,7 @@
     "visTypeVega.inspector.vegaAdapter.value": "値",
     "visTypeVega.inspector.vegaDebugLabel": "Vegaデバッグ",
     "visTypeVega.mapView.experimentalMapLayerInfo": "マップレイヤーはまだ実験段階であり、オフィシャルGA機能のサポートSLAが適用されません。フィードバックがある場合は、{githubLink}で問題を報告してください。",
+    "visTypeVega.mapView.mapStyleNotFoundWarningMessage": "{mapStyleParam} が見つかりませんでした",
     "visTypeVega.mapView.minZoomAndMaxZoomHaveBeenSwappedWarningMessage": "{minZoomPropertyName} と {maxZoomPropertyName} が交換されました",
     "visTypeVega.mapView.resettingPropertyToMaxValueWarningMessage": "{name} を {max} にリセットしています",
     "visTypeVega.mapView.resettingPropertyToMinValueWarningMessage": "{name} を {min} にリセットしています",

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -4568,7 +4568,6 @@
     "visTypeVega.inspector.vegaAdapter.value": "値",
     "visTypeVega.inspector.vegaDebugLabel": "Vegaデバッグ",
     "visTypeVega.mapView.experimentalMapLayerInfo": "マップレイヤーはまだ実験段階であり、オフィシャルGA機能のサポートSLAが適用されません。フィードバックがある場合は、{githubLink}で問題を報告してください。",
-    "visTypeVega.mapView.mapStyleNotFoundWarningMessage": "{mapStyleParam} が見つかりませんでした",
     "visTypeVega.mapView.minZoomAndMaxZoomHaveBeenSwappedWarningMessage": "{minZoomPropertyName} と {maxZoomPropertyName} が交換されました",
     "visTypeVega.mapView.resettingPropertyToMaxValueWarningMessage": "{name} を {max} にリセットしています",
     "visTypeVega.mapView.resettingPropertyToMinValueWarningMessage": "{name} を {min} にリセットしています",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4573,6 +4573,7 @@
     "visTypeVega.inspector.vegaAdapter.value": "值",
     "visTypeVega.inspector.vegaDebugLabel": "Vega 调试",
     "visTypeVega.mapView.experimentalMapLayerInfo": "地图图层处于试验状态，不受正式发行版功能的支持 SLA 的约束。如欲提供反馈，请在 {githubLink} 中创建问题。",
+    "visTypeVega.mapView.mapStyleNotFoundWarningMessage": "找不到 {mapStyleParam}",
     "visTypeVega.mapView.minZoomAndMaxZoomHaveBeenSwappedWarningMessage": "已互换 {minZoomPropertyName} 和 {maxZoomPropertyName}",
     "visTypeVega.mapView.resettingPropertyToMaxValueWarningMessage": "将 {name} 重置为 {max}",
     "visTypeVega.mapView.resettingPropertyToMinValueWarningMessage": "将 {name} 重置为 {min}",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4573,7 +4573,6 @@
     "visTypeVega.inspector.vegaAdapter.value": "值",
     "visTypeVega.inspector.vegaDebugLabel": "Vega 调试",
     "visTypeVega.mapView.experimentalMapLayerInfo": "地图图层处于试验状态，不受正式发行版功能的支持 SLA 的约束。如欲提供反馈，请在 {githubLink} 中创建问题。",
-    "visTypeVega.mapView.mapStyleNotFoundWarningMessage": "找不到 {mapStyleParam}",
     "visTypeVega.mapView.minZoomAndMaxZoomHaveBeenSwappedWarningMessage": "已互换 {minZoomPropertyName} 和 {maxZoomPropertyName}",
     "visTypeVega.mapView.resettingPropertyToMaxValueWarningMessage": "将 {name} 重置为 {max}",
     "visTypeVega.mapView.resettingPropertyToMinValueWarningMessage": "将 {name} 重置为 {min}",


### PR DESCRIPTION
Closes: #87853

## Summary

"Vega maps should use `map.tilemap.url` when provided instead of getting its base map layer from `Elastic` map service"

**Steps to reproduce:**
1. Change map.tilemap.url from default to point to another map tile service, like Openmaptiles.
    
2. Open Vega in kibana and attempt to layer a map using the help guide found at https://www.elastic.co/guide/en/kibana/6.8/vega-with-a-map.html 

**For testing:**
1. set the following `env` params for your Kibana instance (you can do it in `config/kibana.yml`)
`map.tilemap.url: http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg`
2. open `Kibana` instance and create/open Vega visualization with Map layer. You can use the following empty vega spec for testing
```
 {
  $schema: https://vega.github.io/schema/vega/v5.json
  config: {
    kibana: {
      type: map
    }
  }
}
```

3. After updating visualization your should see user configured map layer
 
![image](https://user-images.githubusercontent.com/20072247/104589445-edc45d00-567a-11eb-9278-0f257c268a05.png)

4. Also using` "mapStyle": false `user should be able to disable base layer.
```
{
  $schema: https://vega.github.io/schema/vega/v5.json
  config: {
    kibana: {
      type: map
      mapStyle: false
    }
  }
}

```

![image](https://user-images.githubusercontent.com/20072247/104590714-c3739f00-567c-11eb-8e76-7b259f23b7a2.png)
