### PR TITLE
[Fleet]Fix updating package policy without input

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.test.ts
@@ -295,6 +295,36 @@ describe('Package policy service', () => {
         },
       ]);
     });
+
+    it('should work with a package without input', async () => {
+      const inputs = await packagePolicyService.compilePackagePolicyInputs(
+        ({
+          policy_templates: [
+            {
+              inputs: undefined,
+            },
+          ],
+        } as unknown) as PackageInfo,
+        []
+      );
+
+      expect(inputs).toEqual([]);
+    });
+
+    it('should work with a package with a empty inputs array', async () => {
+      const inputs = await packagePolicyService.compilePackagePolicyInputs(
+        ({
+          policy_templates: [
+            {
+              inputs: [],
+            },
+          ],
+        } as unknown) as PackageInfo,
+        []
+      );
+
+      expect(inputs).toEqual([]);
+    });
   });
 
   describe('update', () => {

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -437,7 +437,7 @@ async function _compilePackagePolicyInput(
   pkgInfo: PackageInfo,
   input: PackagePolicyInput
 ) {
-  if (!input.enabled || !pkgInfo.policy_templates?.[0].inputs) {
+  if ((!input.enabled || !pkgInfo.policy_templates?.[0]?.inputs?.length) ?? 0 > 0) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Resolve #88282
If the package do not define inputs we should not try to compile the inputs for that package. 

## How to reproduce 

Try to add endpoint and edit endpoint you should see the error, after this PR you should not see the error anymore and should be able to add and edit endpoint.

```
server    log   [14:10:56.966] [error][fleet][plugins] Error: Input template not found, unable to find input type endpoint
    at _compilePackagePolicyInput (/kibana/x-pack/plugins/fleet/server/services/package_policy.ts:447:11)
    at map (/kibana/x-pack/plugins/fleet/server/services/package_policy.ts:387:35)
    at Array.map (<anonymous>)
```