### PR TITLE
[Fleet] Don't retry if icon isn't in initial response

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_package.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_package.tsx
@@ -141,15 +141,7 @@ export const StepSelectPackage: React.FunctionComponent<{
             return {
               label: title || name,
               key: pkgkey,
-              prepend: (
-                <PackageIcon
-                  packageName={name}
-                  version={version}
-                  icons={icons}
-                  size="m"
-                  tryApi={true}
-                />
-              ),
+              prepend: <PackageIcon packageName={name} version={version} icons={icons} size="m" />,
               checked: selectedPkgKey === pkgkey ? 'on' : undefined,
             };
           })}


### PR DESCRIPTION
## Summary

closes #66226

Remove `tryApi` param from `PackageIcon`, since response is *from* the Registry already

https://github.com/elastic/kibana/blob/5e351dbac226be505eb127461c6da6bd4cd4007d/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/step_select_package.tsx#L49

Setting `tryApi={true}` is just flooding the Registry with requests for items we know aren't there.

Compare `master` (note XHR requests for `bluecoat`, etc)

https://user-images.githubusercontent.com/57655/104645966-d175ef80-567d-11eb-8330-5596993165cf.mp4

vs PR only SVG's requested

https://user-images.githubusercontent.com/57655/104645972-d20e8600-567d-11eb-879f-0c11ee0068dc.mp4


