### PR TITLE
[APM] Only display relevant sections for rum agent in service overview

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -62,7 +62,7 @@ export function ServiceOverview({
           <EuiFlexGroup direction="column" gutterSize="s">
             {isRumAgent && (
               <EuiFlexItem>
-                <UserExperienceCallout />
+                <UserExperienceCallout serviceName={serviceName} />
               </EuiFlexItem>
             )}
             <EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -16,6 +16,7 @@ import { LatencyChart } from '../../shared/charts/latency_chart';
 import { TransactionBreakdownChart } from '../../shared/charts/transaction_breakdown_chart';
 import { TransactionErrorRateChart } from '../../shared/charts/transaction_error_rate_chart';
 import { SearchBar } from '../../shared/search_bar';
+import { UserExperienceCallout } from '../transaction_overview/user_experience_callout';
 import { ServiceOverviewDependenciesTable } from './service_overview_dependencies_table';
 import { ServiceOverviewErrorsTable } from './service_overview_errors_table';
 import { ServiceOverviewInstancesTable } from './service_overview_instances_table';
@@ -58,6 +59,11 @@ export function ServiceOverview({
         <SearchBar prepend={transactionTypeLabel} />
         <EuiPage>
           <EuiFlexGroup direction="column" gutterSize="s">
+            {isRumAgentName(agentName) && (
+              <EuiFlexItem>
+                <UserExperienceCallout />
+              </EuiFlexItem>
+            )}
             <EuiFlexItem>
               <EuiPanel>
                 <LatencyChart height={200} />
@@ -111,20 +117,24 @@ export function ServiceOverview({
                 <EuiFlexItem grow={3}>
                   <TransactionBreakdownChart showAnnotations={false} />
                 </EuiFlexItem>
-                <EuiFlexItem grow={7}>
-                  <EuiPanel>
-                    <ServiceOverviewDependenciesTable
-                      serviceName={serviceName}
-                    />
-                  </EuiPanel>
-                </EuiFlexItem>
+                {!isRumAgentName(agentName) && (
+                  <EuiFlexItem grow={7}>
+                    <EuiPanel>
+                      <ServiceOverviewDependenciesTable
+                        serviceName={serviceName}
+                      />
+                    </EuiPanel>
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
             </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiPanel>
-                <ServiceOverviewInstancesTable serviceName={serviceName} />
-              </EuiPanel>
-            </EuiFlexItem>
+            {!isRumAgentName(agentName) && (
+              <EuiFlexItem>
+                <EuiPanel>
+                  <ServiceOverviewInstancesTable serviceName={serviceName} />
+                </EuiPanel>
+              </EuiFlexItem>
+            )}
           </EuiFlexGroup>
         </EuiPage>
       </ChartPointerEventContextProvider>

--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -52,6 +52,7 @@ export function ServiceOverview({
     'xpack.apm.serviceOverview.searchBar.transactionTypeLabel',
     { defaultMessage: 'Type: {transactionType}', values: { transactionType } }
   );
+  const isRumAgent = isRumAgentName(agentName);
 
   return (
     <AnnotationsContextProvider>
@@ -59,7 +60,7 @@ export function ServiceOverview({
         <SearchBar prepend={transactionTypeLabel} />
         <EuiPage>
           <EuiFlexGroup direction="column" gutterSize="s">
-            {isRumAgentName(agentName) && (
+            {isRumAgent && (
               <EuiFlexItem>
                 <UserExperienceCallout />
               </EuiFlexItem>
@@ -93,7 +94,7 @@ export function ServiceOverview({
                 gutterSize="s"
                 responsive={false}
               >
-                {!isRumAgentName(agentName) && (
+                {!isRumAgent && (
                   <EuiFlexItem grow={3}>
                     <TransactionErrorRateChart
                       height={chartHeight}
@@ -117,7 +118,7 @@ export function ServiceOverview({
                 <EuiFlexItem grow={3}>
                   <TransactionBreakdownChart showAnnotations={false} />
                 </EuiFlexItem>
-                {!isRumAgentName(agentName) && (
+                {!isRumAgent && (
                   <EuiFlexItem grow={7}>
                     <EuiPanel>
                       <ServiceOverviewDependenciesTable
@@ -128,7 +129,7 @@ export function ServiceOverview({
                 )}
               </EuiFlexGroup>
             </EuiFlexItem>
-            {!isRumAgentName(agentName) && (
+            {!isRumAgent && (
               <EuiFlexItem>
                 <EuiPanel>
                   <ServiceOverviewInstancesTable serviceName={serviceName} />

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/index.tsx
@@ -123,7 +123,7 @@ export function TransactionOverview({ serviceName }: TransactionOverviewProps) {
           <EuiFlexItem grow={7}>
             {transactionType === TRANSACTION_PAGE_LOAD && (
               <>
-                <UserExperienceCallout />
+                <UserExperienceCallout serviceName={serviceName} />
                 <EuiSpacer size="s" />
               </>
             )}

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/user_experience_callout.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/user_experience_callout.tsx
@@ -9,9 +9,14 @@ import { EuiButton, EuiCallOut, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 
-export function UserExperienceCallout() {
+interface Props {
+  serviceName: string;
+}
+export function UserExperienceCallout({ serviceName }: Props) {
   const { core } = useApmPluginContext();
-  const userExperienceHref = core.http.basePath.prepend(`/app/ux`);
+  const userExperienceHref = core.http.basePath.prepend(
+    `/app/ux?serviceName=${serviceName}`
+  );
 
   return (
     <EuiCallOut


### PR DESCRIPTION
Closes #85546. Hides instances and dependencies tables form service overview. Also displays the callout which links to the User Experience app.

![Screen Shot 2021-01-14 at 4 30 18 PM](https://user-images.githubusercontent.com/1967266/104652137-848a1d00-566d-11eb-9d2c-5ba048ee59fd.png)
![Screen Shot 2021-01-14 at 4 30 35 PM](https://user-images.githubusercontent.com/1967266/104652145-87850d80-566d-11eb-9677-13c683c988fa.png)
