### PR TITLE
[Enterprise Search] Small test helper for expected async errors

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/expected_async_error.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/expected_async_error.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const expectedAsyncError = async (promise: Promise<unknown>) => {
+  let expectedError: unknown;
+
+  try {
+    await promise;
+  } catch (e) {
+    // Silence expected errors from being reported by tests
+
+    // Pass back expected error to optionally assert on
+    expectedError = e;
+  }
+
+  return expectedError;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
@@ -23,3 +23,5 @@ export { mountWithIntl } from './mount_with_i18n.mock';
 export { shallowWithIntl } from './shallow_with_i18n.mock';
 export { rerender } from './enzyme_rerender.mock';
 // Note: shallow_useeffect must be imported directly as a file
+
+export { expectedAsyncError } from './expected_async_error';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_logic.test.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { LogicMounter, expectedAsyncError } from '../../../__mocks__';
 
 jest.mock('../../../shared/kibana', () => ({
   KibanaLogic: { values: { history: { location: { search: '' } } } },
@@ -215,12 +215,8 @@ describe('AnalyticsLogic', () => {
         mount();
         jest.spyOn(AnalyticsLogic.actions, 'onAnalyticsUnavailable');
 
-        try {
-          AnalyticsLogic.actions.loadAnalyticsData();
-          await promise;
-        } catch {
-          // Do nothing
-        }
+        AnalyticsLogic.actions.loadAnalyticsData();
+        await expectedAsyncError(promise);
 
         expect(flashAPIErrors).toHaveBeenCalledWith('error');
         expect(AnalyticsLogic.actions.onAnalyticsUnavailable).toHaveBeenCalled();
@@ -293,12 +289,8 @@ describe('AnalyticsLogic', () => {
         mount();
         jest.spyOn(AnalyticsLogic.actions, 'onAnalyticsUnavailable');
 
-        try {
-          AnalyticsLogic.actions.loadQueryData('some-query');
-          await promise;
-        } catch {
-          // Do nothing
-        }
+        AnalyticsLogic.actions.loadQueryData('some-query');
+        await expectedAsyncError(promise);
 
         expect(flashAPIErrors).toHaveBeenCalledWith('error');
         expect(AnalyticsLogic.actions.onAnalyticsUnavailable).toHaveBeenCalled();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -4,9 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 
-import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
   HttpLogic: { values: mockHttpValues },
 }));
@@ -1093,11 +1092,9 @@ describe('CredentialsLogic', () => {
         http.get.mockReturnValue(promise);
 
         CredentialsLogic.actions.fetchCredentials();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
       });
     });
 
@@ -1124,11 +1121,9 @@ describe('CredentialsLogic', () => {
         http.get.mockReturnValue(promise);
 
         CredentialsLogic.actions.fetchDetails();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
       });
     });
 
@@ -1154,11 +1149,9 @@ describe('CredentialsLogic', () => {
         http.delete.mockReturnValue(promise);
 
         CredentialsLogic.actions.deleteApiKey(tokenName);
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
       });
     });
 
@@ -1218,11 +1211,9 @@ describe('CredentialsLogic', () => {
         http.post.mockReturnValue(promise);
 
         CredentialsLogic.actions.onApiTokenChange();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
       });
 
       describe('token type data', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
@@ -4,9 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 
-import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
   HttpLogic: { values: mockHttpValues },
 }));
@@ -81,12 +80,9 @@ describe('DocumentDetailLogic', () => {
         const promise = Promise.reject('An error occurred');
         http.get.mockReturnValue(promise);
 
-        try {
-          DocumentDetailLogic.actions.getDocumentDetails('1');
-          await promise;
-        } catch {
-          // Do nothing
-        }
+        DocumentDetailLogic.actions.getDocumentDetails('1');
+        await expectedAsyncError(promise);
+
         expect(flashAPIErrors).toHaveBeenCalledWith('An error occurred', { isQueued: true });
         expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith('/engines/engine1/documents');
       });
@@ -134,12 +130,9 @@ describe('DocumentDetailLogic', () => {
         promise = Promise.reject('An error occured');
         http.delete.mockReturnValue(promise);
 
-        try {
-          DocumentDetailLogic.actions.deleteDocument('1');
-          await promise;
-        } catch {
-          // Do nothing
-        }
+        DocumentDetailLogic.actions.deleteDocument('1');
+        await expectedAsyncError(promise);
+
         expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -4,9 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 
-import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
   HttpLogic: { values: mockHttpValues },
 }));
@@ -193,12 +192,9 @@ describe('EngineLogic', () => {
         const promise = Promise.reject('An error occured');
         http.get.mockReturnValue(promise);
 
-        try {
-          EngineLogic.actions.initializeEngine();
-          await promise;
-        } catch {
-          // Do nothing
-        }
+        EngineLogic.actions.initializeEngine();
+        await expectedAsyncError(promise);
+
         expect(EngineLogic.actions.setEngineNotFound).toHaveBeenCalledWith(true);
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
@@ -4,9 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 
-import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
   HttpLogic: { values: mockHttpValues },
 }));
@@ -106,12 +105,9 @@ describe('EngineOverviewLogic', () => {
         const promise = Promise.reject('An error occurred');
         http.get.mockReturnValue(promise);
 
-        try {
-          EngineOverviewLogic.actions.pollForOverviewMetrics();
-          await promise;
-        } catch {
-          // Do nothing
-        }
+        EngineOverviewLogic.actions.pollForOverviewMetrics();
+        await expectedAsyncError(promise);
+
         expect(flashAPIErrors).toHaveBeenCalledWith('An error occurred');
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
@@ -4,9 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 
-import { mockHttpValues } from '../../../__mocks__';
 jest.mock('../../../shared/http', () => ({
   HttpLogic: { values: mockHttpValues },
 }));
@@ -232,12 +231,8 @@ describe('LogRetentionLogic', () => {
         http.put.mockReturnValue(promise);
 
         LogRetentionLogic.actions.saveLogRetention(LogRetentionOptions.Analytics, true);
+        await expectedAsyncError(promise);
 
-        try {
-          await promise;
-        } catch {
-          // Do nothing
-        }
         expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
         expect(LogRetentionLogic.actions.clearLogRetentionUpdating).toHaveBeenCalled();
       });
@@ -305,12 +300,8 @@ describe('LogRetentionLogic', () => {
         http.get.mockReturnValue(promise);
 
         LogRetentionLogic.actions.fetchLogRetention();
+        await expectedAsyncError(promise);
 
-        try {
-          await promise;
-        } catch {
-          // Do nothing
-        }
         expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
         expect(LogRetentionLogic.actions.clearLogRetentionUpdating).toHaveBeenCalled();
       });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
@@ -6,6 +6,8 @@
 
 import { resetContext } from 'kea';
 
+import { expectedAsyncError } from '../../__mocks__';
+
 jest.mock('../http', () => ({
   HttpLogic: {
     values: { http: { get: jest.fn() } },
@@ -82,11 +84,8 @@ describe('IndexingStatusLogic', () => {
       IndexingStatusLogic.actions.fetchIndexingStatus({ statusPath, onComplete });
       jest.advanceTimersByTime(TIMEOUT);
 
-      try {
-        await promise;
-      } catch {
-        // Do nothing
-      }
+      await expectedAsyncError(promise);
+
       expect(flashAPIErrors).toHaveBeenCalledWith('An error occured');
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -5,7 +5,9 @@
  */
 
 import { resetContext } from 'kea';
-import { mockHttpValues } from '../../../../../__mocks__';
+
+import { mockHttpValues, expectedAsyncError } from '../../../../../__mocks__';
+
 jest.mock('../../../../../shared/http', () => ({
   HttpLogic: {
     values: { http: mockHttpValues.http },
@@ -296,11 +298,8 @@ describe('AddSourceLogic', () => {
           (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceConfigData('github');
-          try {
-            await promise;
-          } catch {
-            // Do nothing
-          }
+          await expectedAsyncError(promise);
+
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         });
       });
@@ -345,11 +344,8 @@ describe('AddSourceLogic', () => {
           (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceConnectData('github', successCallback);
-          try {
-            await promise;
-          } catch {
-            // Do nothing
-          }
+          await expectedAsyncError(promise);
+
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         });
       });
@@ -377,11 +373,8 @@ describe('AddSourceLogic', () => {
           (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceReConnectData('github');
-          try {
-            await promise;
-          } catch {
-            // Do nothing
-          }
+          await expectedAsyncError(promise);
+
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         });
       });
@@ -409,11 +402,8 @@ describe('AddSourceLogic', () => {
           (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
           AddSourceLogic.actions.getPreContentSourceConfigData('123');
-          try {
-            await promise;
-          } catch {
-            // Do nothing
-          }
+          await expectedAsyncError(promise);
+
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         });
       });
@@ -485,11 +475,8 @@ describe('AddSourceLogic', () => {
           (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
 
           AddSourceLogic.actions.saveSourceConfig(true);
-          try {
-            await promise;
-          } catch {
-            // Do nothing
-          }
+          await expectedAsyncError(promise);
+
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         });
       });
@@ -550,11 +537,8 @@ describe('AddSourceLogic', () => {
           (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
 
           AddSourceLogic.actions.createContentSource(serviceType, successCallback, errorCallback);
-          try {
-            await promise;
-          } catch {
-            // Do nothing
-          }
+          await expectedAsyncError(promise);
+
           expect(errorCallback).toHaveBeenCalled();
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -6,6 +6,8 @@
 
 import { resetContext } from 'kea';
 
+import { expectedAsyncError } from '../../../__mocks__';
+
 jest.mock('../../../shared/http', () => ({
   HttpLogic: {
     values: { http: { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() } },
@@ -253,16 +255,13 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.initializeGroup(sourceIds[0]);
+        await expectedAsyncError(promise);
 
-        try {
-          await promise;
-        } catch {
-          expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
-          expect(FlashMessagesLogic.actions.setQueuedMessages).toHaveBeenCalledWith({
-            type: 'error',
-            message: 'Unable to find group with ID: "123".',
-          });
-        }
+        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
+        expect(FlashMessagesLogic.actions.setQueuedMessages).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'Unable to find group with ID: "123".',
+        });
       });
 
       it('handles non-404 error', async () => {
@@ -270,16 +269,13 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.initializeGroup(sourceIds[0]);
+        await expectedAsyncError(promise);
 
-        try {
-          await promise;
-        } catch {
-          expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
-          expect(FlashMessagesLogic.actions.setQueuedMessages).toHaveBeenCalledWith({
-            type: 'error',
-            message: 'this is an error',
-          });
-        }
+        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
+        expect(FlashMessagesLogic.actions.setQueuedMessages).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'this is an error',
+        });
       });
     });
 
@@ -308,11 +304,9 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.delete as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.deleteGroup();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -343,11 +337,9 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.updateGroupName();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -381,11 +373,9 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupSources();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -418,11 +408,9 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupUsers();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -463,11 +451,9 @@ describe('GroupLogic', () => {
         (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupSourcePrioritization();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
@@ -6,6 +6,8 @@
 
 import { resetContext } from 'kea';
 
+import { expectedAsyncError } from '../../../__mocks__';
+
 jest.mock('../../../shared/http', () => ({
   HttpLogic: {
     values: { http: { get: jest.fn(), post: jest.fn() } },
@@ -240,11 +242,9 @@ describe('GroupsLogic', () => {
         (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
         GroupsLogic.actions.initializeGroups();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -304,13 +304,10 @@ describe('GroupsLogic', () => {
         (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
 
         GroupsLogic.actions.getSearchResults();
-        try {
-          await promise;
-        } catch {
-          // Account for `breakpoint` that debounces filter value.
-          await delay();
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+        await delay();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -333,11 +330,9 @@ describe('GroupsLogic', () => {
         (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
 
         GroupsLogic.actions.fetchGroupUsers('123');
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -363,11 +358,9 @@ describe('GroupsLogic', () => {
         (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
 
         GroupsLogic.actions.saveNewGroup();
-        try {
-          await promise;
-        } catch {
-          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
-        }
+        await expectedAsyncError(promise);
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
       });
     });
 


### PR DESCRIPTION
## Summary

Follow up to this conversation we had here: https://github.com/elastic/kibana/pull/88250#discussion_r557634525

Byron made an excellent point that the try/catch boilerplate around expected errors isn't super intuitive and is confusing at first glance (especially the comment, probably). I thought it would help us to DRY out a very small helper which serves a few purposes:

- Handles silencing expected errors so we don't see them in test results
- Prevents us from writing `expect()`s within `catch`, which as we've already discussed previously can lead to false positive test results
- Optionally returns the thrown error to assert on (we're not doing so currently in any tests, but I think it'll potentially be helpful in the future!)

Let me know what y'all think! Just IMO, 50+ deleted lines is worth 💪 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios