### PR TITLE
[APM] Consistent terminology for latency and throughput

### DIFF
--- a/x-pack/plugins/apm/common/alert_types.ts
+++ b/x-pack/plugins/apm/common/alert_types.ts
@@ -46,7 +46,7 @@ export const ALERT_TYPES_CONFIG: Record<
   },
   [AlertType.TransactionDuration]: {
     name: i18n.translate('xpack.apm.transactionDurationAlert.name', {
-      defaultMessage: 'Transaction duration threshold',
+      defaultMessage: 'Latency threshold',
     }),
     actionGroups: [THRESHOLD_MET_GROUP],
     defaultActionGroupId: THRESHOLD_MET_GROUP_ID,
@@ -55,7 +55,7 @@ export const ALERT_TYPES_CONFIG: Record<
   },
   [AlertType.TransactionDurationAnomaly]: {
     name: i18n.translate('xpack.apm.transactionDurationAnomalyAlert.name', {
-      defaultMessage: 'Transaction duration anomaly',
+      defaultMessage: 'Latency anomaly',
     }),
     actionGroups: [THRESHOLD_MET_GROUP],
     defaultActionGroupId: THRESHOLD_MET_GROUP_ID,

--- a/x-pack/plugins/apm/e2e/cypress/integration/apm.feature
+++ b/x-pack/plugins/apm/e2e/cypress/integration/apm.feature
@@ -1,6 +1,6 @@
 Feature: APM
 
-  Scenario: Transaction duration charts
+  Scenario: Transaction latency charts
     Given a user browses the APM UI application
     When the user inspects the opbeans-node service
     Then should redirect to correct path

--- a/x-pack/plugins/apm/public/application/action_menu/alerting_popover_flyout.tsx
+++ b/x-pack/plugins/apm/public/application/action_menu/alerting_popover_flyout.tsx
@@ -21,7 +21,7 @@ const alertLabel = i18n.translate('xpack.apm.home.alertsMenu.alerts', {
 });
 const transactionDurationLabel = i18n.translate(
   'xpack.apm.home.alertsMenu.transactionDuration',
-  { defaultMessage: 'Transaction duration' }
+  { defaultMessage: 'Latency' }
 );
 const transactionErrorRateLabel = i18n.translate(
   'xpack.apm.home.alertsMenu.transactionErrorRate',
@@ -112,7 +112,7 @@ export function AlertingPopoverAndFlyout({
       ],
     },
 
-    // transaction duration panel
+    // latency panel
     {
       id: CREATE_TRANSACTION_DURATION_ALERT_PANEL_ID,
       title: transactionDurationLabel,

--- a/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
+++ b/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
@@ -45,7 +45,7 @@ export function registerApmAlerts(
     description: i18n.translate(
       'xpack.apm.alertTypes.transactionDuration.description',
       {
-        defaultMessage: 'Alert when the latency exceeds a defined threshold.',
+        defaultMessage: 'Alert when the latency of a specific transaction type in a service exceeds a defined threshold.',
       }
     ),
     iconClass: 'bell',

--- a/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
+++ b/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
@@ -45,7 +45,8 @@ export function registerApmAlerts(
     description: i18n.translate(
       'xpack.apm.alertTypes.transactionDuration.description',
       {
-        defaultMessage: 'Alert when the latency of a specific transaction type in a service exceeds a defined threshold.',
+        defaultMessage:
+          'Alert when the latency of a specific transaction type in a service exceeds a defined threshold.',
       }
     ),
     iconClass: 'bell',

--- a/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
+++ b/x-pack/plugins/apm/public/components/alerting/register_apm_alerts.ts
@@ -45,8 +45,7 @@ export function registerApmAlerts(
     description: i18n.translate(
       'xpack.apm.alertTypes.transactionDuration.description',
       {
-        defaultMessage:
-          'Alert when the duration of a specific transaction type in a service exceeds a defined threshold.',
+        defaultMessage: 'Alert when the latency exceeds a defined threshold.',
       }
     ),
     iconClass: 'bell',
@@ -68,8 +67,8 @@ export function registerApmAlerts(
 - Service name: \\{\\{context.serviceName\\}\\}
 - Type: \\{\\{context.transactionType\\}\\}
 - Environment: \\{\\{context.environment\\}\\}
-- Threshold: \\{\\{context.threshold\\}\\}ms
-- Triggered value: \\{\\{context.triggerValue\\}\\} over the last \\{\\{context.interval\\}\\}`,
+- Latency threshold: \\{\\{context.threshold\\}\\}ms
+- Latency observed: \\{\\{context.triggerValue\\}\\} over the last \\{\\{context.interval\\}\\}`,
       }
     ),
   });
@@ -113,8 +112,7 @@ export function registerApmAlerts(
     description: i18n.translate(
       'xpack.apm.alertTypes.transactionDurationAnomaly.description',
       {
-        defaultMessage:
-          'Alert when the overall transaction duration of a service is considered anomalous.',
+        defaultMessage: 'Alert when the latency of a service is abnormal.',
       }
     ),
     iconClass: 'bell',

--- a/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/ServiceStatsList.tsx
+++ b/x-pack/plugins/apm/public/components/app/ServiceMap/Popover/ServiceStatsList.tsx
@@ -41,7 +41,7 @@ export function ServiceStatsList({
       title: i18n.translate(
         'xpack.apm.serviceMap.avgTransDurationPopoverStat',
         {
-          defaultMessage: 'Trans. duration (avg.)',
+          defaultMessage: 'Latency (avg.)',
         }
       ),
       description: isNumber(transactionStats.avgTransactionDuration)
@@ -52,7 +52,7 @@ export function ServiceStatsList({
       title: i18n.translate(
         'xpack.apm.serviceMap.avgReqPerMinutePopoverMetric',
         {
-          defaultMessage: 'Req. per minute (avg.)',
+          defaultMessage: 'Throughput (avg.)',
         }
       ),
       description: asTransactionRate(transactionStats.avgRequestsPerMinute),

--- a/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/anomaly_detection/index.tsx
@@ -75,7 +75,7 @@ export function AnomalyDetection() {
       <EuiSpacer size="l" />
       <EuiText>
         {i18n.translate('xpack.apm.settings.anomalyDetection.descriptionText', {
-          defaultMessage: `Machine Learning's anomaly detection integration enables application health status indicators for services in each configured environment by identifying transaction duration anomalies.`,
+          defaultMessage: `Machine Learning's anomaly detection integration enables application health status indicators for services in each configured environment by identifying anomalies in latency.`,
         })}
       </EuiText>
       <EuiSpacer size="l" />

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -91,7 +91,7 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
           'xpack.apm.tracesTable.impactColumnDescription',
           {
             defaultMessage:
-              '"Impact" is the latency affecting the service the most. It is calcualted as the product of latency and throughput',
+              '"Impact" is the latency affecting end-users the most. It is calcualted as the product of latency and throughput',
           }
         )}
       >

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -68,7 +68,7 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
   {
     field: 'averageResponseTime',
     name: i18n.translate('xpack.apm.tracesTable.avgResponseTimeColumnLabel', {
-      defaultMessage: 'Avg. response time',
+      defaultMessage: 'Latency (avg.)',
     }),
     sortable: true,
     dataType: 'number',
@@ -91,7 +91,7 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
           'xpack.apm.tracesTable.impactColumnDescription',
           {
             defaultMessage:
-              "The most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute.",
+              '"Impact" is the latency affecting the service the most. It is calcualted as the product of latency and throughput',
           }
         )}
       >

--- a/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
+++ b/x-pack/plugins/apm/public/components/app/TraceOverview/TraceList.tsx
@@ -91,7 +91,7 @@ const traceListColumns: Array<ITableColumn<TraceGroup>> = [
           'xpack.apm.tracesTable.impactColumnDescription',
           {
             defaultMessage:
-              '"Impact" is the latency affecting end-users the most. It is calcualted as the product of latency and throughput',
+              'The most used and slowest endpoints in your service. It is the result of multiplying latency and throughput',
           }
         )}
       >

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Distribution/index.tsx
@@ -162,7 +162,7 @@ export function TransactionDistribution({
           {i18n.translate(
             'xpack.apm.transactionDetails.transactionsDurationDistributionChartTitle',
             {
-              defaultMessage: 'Transactions duration distribution',
+              defaultMessage: 'Latency distribution',
             }
           )}{' '}
           <EuiIconTip

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/WaterfallWithSummmary/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -32,7 +32,7 @@ export interface IWaterfall {
   rootTransaction?: Transaction;
 
   /**
-   * Duration in us
+   * Latency in us
    */
   duration: number;
   items: IWaterfallItem[];
@@ -53,7 +53,7 @@ interface IWaterfallItemBase<T, U> {
   parentId?: string;
 
   /**
-   * Duration in us
+   * Latency in us
    */
   duration: number;
 

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/TransactionList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/TransactionList/index.tsx
@@ -126,7 +126,7 @@ export function TransactionList({ items, isLoading }: Props) {
                 'xpack.apm.transactionsTable.impactColumnDescription',
                 {
                   defaultMessage:
-                    '"Impact" is the latency affecting the service the most. It is calcualted as the product of latency and throughput',
+                    '"Impact" is the latency affecting end-users the most. It is calcualted as the product of latency and throughput',
                 }
               )}
             />

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/TransactionList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/TransactionList/index.tsx
@@ -126,7 +126,7 @@ export function TransactionList({ items, isLoading }: Props) {
                 'xpack.apm.transactionsTable.impactColumnDescription',
                 {
                   defaultMessage:
-                    "The most used and slowest endpoints in your service. It's calculated by taking the relative average duration times the number of transactions per minute.",
+                    '"Impact" is the latency affecting the service the most. It is calcualted as the product of latency and throughput',
                 }
               )}
             />

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/TransactionList/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/TransactionList/index.tsx
@@ -126,7 +126,7 @@ export function TransactionList({ items, isLoading }: Props) {
                 'xpack.apm.transactionsTable.impactColumnDescription',
                 {
                   defaultMessage:
-                    '"Impact" is the latency affecting end-users the most. It is calcualted as the product of latency and throughput',
+                    'The most used and slowest endpoints in your service. It is the result of multiplying latency and throughput',
                 }
               )}
             />

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
@@ -62,7 +62,7 @@ export function MLHeader({ hasValidMlLicense, mlJobId }: Props) {
         'xpack.apm.metrics.transactionChart.machineLearningTooltip',
         {
           defaultMessage:
-            'The shaded area shows the expected latency. A red annotation is shown for anomaly scores ≥ 75.',
+            'The stream displays the expected bounds of the average latency. A red vertical annotation indicates anomalies with an anomaly score of 75 or above.',
         }
       )}
     />

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
@@ -62,7 +62,7 @@ export function MLHeader({ hasValidMlLicense, mlJobId }: Props) {
         'xpack.apm.metrics.transactionChart.machineLearningTooltip',
         {
           defaultMessage:
-            'The shaded area shows the expected latency. An red annotation is shown for anomaly scores ≥ 75.',
+            'The shaded area shows the expected latency. A red annotation is shown for anomaly scores ≥ 75.',
         }
       )}
     />

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
@@ -62,7 +62,7 @@ export function MLHeader({ hasValidMlLicense, mlJobId }: Props) {
         'xpack.apm.metrics.transactionChart.machineLearningTooltip',
         {
           defaultMessage:
-            'The stream around the average duration shows the expected bounds. An annotation is shown for anomaly scores ≥ 75.',
+            'The shaded area shows the expected latency. An red annotation is shown for anomaly scores ≥ 75.',
         }
       )}
     />

--- a/x-pack/plugins/apm/server/lib/transactions/get_throughput_charts/transform.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_throughput_charts/transform.ts
@@ -37,7 +37,7 @@ export function getThroughputBuckets({
         .map((bucket) => bucket.count.value)
         .reduce((a, b) => a + b, 0);
 
-      // calculate request/minute
+      // calculate average throughput
       const avg = docCountTotal / durationAsMinutes;
 
       return { key, dataPoints, avg };


### PR DESCRIPTION
Follow-up on https://github.com/elastic/kibana/issues/87483

I noticed we still were using "Req. per min" on the service map, and a couple of other inconsistencies in terminology. I think we agreed to only fix it for Service overview but it seemed like a low-hanging fruit that will make the experience more consistent.