### PR TITLE
[APM] Extracting custom link flaky test.

### DIFF
--- a/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateEditCustomLinkFlyout/DeleteButton.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateEditCustomLinkFlyout/DeleteButton.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React from 'react';
+import { DeleteButton } from './DeleteButton';
+import { fireEvent, render } from '@testing-library/react';
+import { MockApmPluginContextWrapper } from '../../../../../../context/apm_plugin/mock_apm_plugin_context';
+import { act } from 'react-dom/test-utils';
+import * as apmApi from '../../../../../../services/rest/createCallApmApi';
+
+describe('Delete custom link', () => {
+  beforeAll(() => {
+    jest.spyOn(apmApi, 'callApmApi').mockResolvedValue({});
+  });
+  it('deletes a custom link', async () => {
+    const onDeleteMock = jest.fn();
+    const { getByText } = render(
+      <MockApmPluginContextWrapper>
+        <DeleteButton onDelete={onDeleteMock} customLinkId="1" />
+      </MockApmPluginContextWrapper>
+    );
+    await act(async () => {
+      fireEvent.click(getByText('Delete'));
+    });
+    expect(onDeleteMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateEditCustomLinkFlyout/DeleteButton.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateEditCustomLinkFlyout/DeleteButton.test.tsx
@@ -3,12 +3,12 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import React from 'react';
-import { DeleteButton } from './DeleteButton';
 import { fireEvent, render } from '@testing-library/react';
-import { MockApmPluginContextWrapper } from '../../../../../../context/apm_plugin/mock_apm_plugin_context';
+import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { MockApmPluginContextWrapper } from '../../../../../../context/apm_plugin/mock_apm_plugin_context';
 import * as apmApi from '../../../../../../services/rest/createCallApmApi';
+import { DeleteButton } from './DeleteButton';
 
 describe('Delete custom link', () => {
   beforeAll(() => {

--- a/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/index.test.tsx
@@ -4,12 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import {
-  fireEvent,
-  render,
-  RenderResult,
-  waitFor,
-} from '@testing-library/react';
+import { fireEvent, render, RenderResult } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { CustomLinkOverview } from '.';

--- a/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/index.test.tsx
@@ -219,31 +219,6 @@ describe('CustomLink', () => {
       expect(saveCustomLinkSpy).toHaveBeenCalledTimes(1);
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/75106
-    it.skip('deletes a custom link', async () => {
-      const mockContext = getMockAPMContext({ canSave: true });
-      const component = render(
-        <LicenseContext.Provider value={goldLicense}>
-          <MockApmPluginContextWrapper value={mockContext}>
-            <CustomLinkOverview />
-          </MockApmPluginContextWrapper>
-        </LicenseContext.Provider>
-      );
-      expect(component.queryByText('Create link')).not.toBeInTheDocument();
-      const editButtons = component.getAllByLabelText('Edit');
-      expect(editButtons.length).toEqual(2);
-      act(() => {
-        fireEvent.click(editButtons[0]);
-      });
-      await waitFor(() =>
-        expect(component.queryByText('Create link')).toBeInTheDocument()
-      );
-      await act(async () => {
-        fireEvent.click(component.getByText('Delete'));
-      });
-      expect(refetch).toHaveBeenCalled();
-    });
-
     describe('Filters', () => {
       const addFilterField = (component: RenderResult, amount: number) => {
         for (let i = 1; i <= amount; i++) {


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/75106

I couldn't simulate the problem. I'll try to fix it by extracting to a new unit test where only the specific component is tested.