### PR TITLE
[APM] Disable Create custom link button on Transaction details page for read-only users

### DIFF
--- a/x-pack/plugins/apm/common/custom_link/index.ts
+++ b/x-pack/plugins/apm/common/custom_link/index.ts
@@ -12,3 +12,11 @@ export const INVALID_LICENSE = i18n.translate(
       "To create custom links, you must be subscribed to an Elastic Gold license or above. With it, you'll have the ability to create custom links to improve your workflow when analyzing your services.",
   }
 );
+
+export const NO_PERMISSION_LABEL = i18n.translate(
+  'xpack.apm.settings.customizeUI.customLink.noPermissionTooltipLabel',
+  {
+    defaultMessage:
+      "Your user role doesn't have permissions to create custom links",
+  }
+);

--- a/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateCustomLinkButton.tsx
+++ b/x-pack/plugins/apm/public/components/app/Settings/CustomizeUI/CustomLink/CreateCustomLinkButton.tsx
@@ -6,24 +6,14 @@
 import { EuiButton, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
+import { NO_PERMISSION_LABEL } from '../../../../../../common/custom_link';
 import { useApmPluginContext } from '../../../../../context/apm_plugin/use_apm_plugin_context';
 
 export function CreateCustomLinkButton({ onClick }: { onClick: () => void }) {
   const { core } = useApmPluginContext();
   const canSave = core.application.capabilities.apm.save;
   return (
-    <EuiToolTip
-      content={
-        !canSave &&
-        i18n.translate(
-          'xpack.apm.settings.customizeUI.customLink.noPermissionTooltipLabel',
-          {
-            defaultMessage:
-              "Your user role doesn't have permissions to create custom links",
-          }
-        )
-      }
-    >
+    <EuiToolTip content={!canSave && NO_PERMISSION_LABEL}>
       <EuiButton
         color="primary"
         fill

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/CustomLinkToolbar.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/CustomLinkToolbar.test.tsx
@@ -7,17 +7,33 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { MockApmPluginContextWrapper } from '../../../../context/apm_plugin/mock_apm_plugin_context';
+import { ApmPluginContextValue } from '../../../../context/apm_plugin/apm_plugin_context';
+import {
+  mockApmPluginContextValue,
+  MockApmPluginContextWrapper,
+} from '../../../../context/apm_plugin/mock_apm_plugin_context';
 import {
   expectTextsInDocument,
   expectTextsNotInDocument,
 } from '../../../../utils/testHelpers';
 import { CustomLinkToolbar } from './CustomLinkToolbar';
 
+function getMockAPMContext({ canSave }: { canSave: boolean }) {
+  return ({
+    ...mockApmPluginContextValue,
+    core: {
+      ...mockApmPluginContextValue.core,
+      application: { capabilities: { apm: { save: canSave }, ml: {} } },
+    },
+  } as unknown) as ApmPluginContextValue;
+}
+
 function Wrapper({ children }: { children?: ReactNode }) {
   return (
     <MemoryRouter>
-      <MockApmPluginContextWrapper>{children}</MockApmPluginContextWrapper>
+      <MockApmPluginContextWrapper value={getMockAPMContext({ canSave: true })}>
+        {children}
+      </MockApmPluginContextWrapper>
     </MemoryRouter>
   );
 }

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/CustomLinkToolbar.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/CustomLinkToolbar.tsx
@@ -12,6 +12,8 @@ import {
   EuiIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { NO_PERMISSION_LABEL } from '../../../../../common/custom_link';
+import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { APMLink } from '../../Links/apm/APMLink';
 
 export function CustomLinkToolbar({
@@ -21,6 +23,9 @@ export function CustomLinkToolbar({
   onClickCreate: () => void;
   showCreateButton?: boolean;
 }) {
+  const { core } = useApmPluginContext();
+  const canSave = !!core.application.capabilities.apm.save;
+
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
@@ -42,17 +47,20 @@ export function CustomLinkToolbar({
             </EuiToolTip>
           </EuiFlexItem>
           {showCreateButton && (
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                iconType="plusInCircle"
-                size="xs"
-                onClick={onClickCreate}
-              >
-                {i18n.translate('xpack.apm.customLink.buttom.create.title', {
-                  defaultMessage: 'Create',
-                })}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
+            <EuiToolTip content={!canSave && NO_PERMISSION_LABEL}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  isDisabled={!canSave}
+                  iconType="plusInCircle"
+                  size="xs"
+                  onClick={onClickCreate}
+                >
+                  {i18n.translate('xpack.apm.customLink.buttom.create.title', {
+                    defaultMessage: 'Create',
+                  })}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiToolTip>
           )}
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/CustomLinkMenuSection/index.tsx
@@ -13,6 +13,9 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
+import { EuiToolTip } from '@elastic/eui';
+import { NO_PERMISSION_LABEL } from '../../../../../common/custom_link';
+import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import {
   ActionMenuDivider,
   Section,
@@ -147,6 +150,9 @@ function BottomSection({
   toggleShowAll: () => void;
   onClickCreate: () => void;
 }) {
+  const { core } = useApmPluginContext();
+  const canSave = !!core.application.capabilities.apm.save;
+
   if (status === FETCH_STATUS.LOADING) {
     return <LoadingStatePrompt />;
   }
@@ -154,7 +160,7 @@ function BottomSection({
   // render empty prompt if there are no custom links
   if (isEmpty(customLinks)) {
     return (
-      <EuiFlexGroup>
+      <EuiFlexGroup responsive={false} direction="column" gutterSize="none">
         <EuiFlexItem>
           <EuiText size="xs" grow={false} style={{ width: px(300) }}>
             {i18n.translate('xpack.apm.customLink.empty', {
@@ -163,15 +169,20 @@ function BottomSection({
             })}
           </EuiText>
           <EuiSpacer size="s" />
-          <EuiButtonEmpty
-            iconType="plusInCircle"
-            size="xs"
-            onClick={onClickCreate}
-          >
-            {i18n.translate('xpack.apm.customLink.buttom.create', {
-              defaultMessage: 'Create custom link',
-            })}
-          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem style={{ alignItems: 'center' }}>
+          <EuiToolTip content={!canSave && NO_PERMISSION_LABEL}>
+            <EuiButtonEmpty
+              isDisabled={!canSave}
+              iconType="plusInCircle"
+              size="xs"
+              onClick={onClickCreate}
+            >
+              {i18n.translate('xpack.apm.customLink.buttom.create', {
+                defaultMessage: 'Create custom link',
+              })}
+            </EuiButtonEmpty>
+          </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/TransactionActionMenu.test.tsx
@@ -9,7 +9,11 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { License } from '../../../../../licensing/common/license';
 import { Transaction } from '../../../../typings/es_schemas/ui/transaction';
-import { MockApmPluginContextWrapper } from '../../../context/apm_plugin/mock_apm_plugin_context';
+import { ApmPluginContextValue } from '../../../context/apm_plugin/apm_plugin_context';
+import {
+  mockApmPluginContextValue,
+  MockApmPluginContextWrapper,
+} from '../../../context/apm_plugin/mock_apm_plugin_context';
 import { LicenseContext } from '../../../context/license/license_context';
 import * as hooks from '../../../hooks/use_fetcher';
 import * as apmApi from '../../../services/rest/createCallApmApi';
@@ -20,10 +24,22 @@ import {
 import { TransactionActionMenu } from './TransactionActionMenu';
 import * as Transactions from './__fixtures__/mockData';
 
+function getMockAPMContext({ canSave }: { canSave: boolean }) {
+  return ({
+    ...mockApmPluginContextValue,
+    core: {
+      ...mockApmPluginContextValue.core,
+      application: { capabilities: { apm: { save: canSave }, ml: {} } },
+    },
+  } as unknown) as ApmPluginContextValue;
+}
+
 function Wrapper({ children }: { children?: React.ReactNode }) {
   return (
     <MemoryRouter>
-      <MockApmPluginContextWrapper>{children}</MockApmPluginContextWrapper>
+      <MockApmPluginContextWrapper value={getMockAPMContext({ canSave: true })}>
+        {children}
+      </MockApmPluginContextWrapper>
     </MemoryRouter>
   );
 }


### PR DESCRIPTION
closes #88468

<img width="373" alt="Screenshot 2021-01-15 at 16 48 47" src="https://user-images.githubusercontent.com/55978943/104750033-d0af8d00-5753-11eb-8d07-d83eae36fe36.png">
<img width="423" alt="Screenshot 2021-01-15 at 16 49 04" src="https://user-images.githubusercontent.com/55978943/104750034-d1e0ba00-5753-11eb-8abb-d5805175d833.png">
