### PR TITLE
[Enterprise Search] Automatically mock shared logic files

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/flash_messages_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/flash_messages_logic.mock.ts
@@ -26,6 +26,7 @@ export const mockFlashMessageHelpers = {
 };
 
 jest.mock('../shared/flash_messages', () => ({
+  ...(jest.requireActual('../shared/flash_messages') as object),
   ...mockFlashMessageHelpers,
   FlashMessagesLogic: {
     values: mockFlashMessagesValues,

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/flash_messages_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/flash_messages_logic.mock.ts
@@ -16,7 +16,17 @@ export const mockFlashMessagesActions = {
   clearQueuedMessages: jest.fn(),
 };
 
+export const mockFlashMessageHelpers = {
+  flashAPIErrors: jest.fn(),
+  setSuccessMessage: jest.fn(),
+  setErrorMessage: jest.fn(),
+  setQueuedSuccessMessage: jest.fn(),
+  setQueuedErrorMessage: jest.fn(),
+  clearFlashMessages: jest.fn(),
+};
+
 jest.mock('../shared/flash_messages', () => ({
+  ...mockFlashMessageHelpers,
   FlashMessagesLogic: {
     values: mockFlashMessagesValues,
     actions: mockFlashMessagesActions,

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/flash_messages_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/flash_messages_logic.mock.ts
@@ -15,3 +15,10 @@ export const mockFlashMessagesActions = {
   setQueuedMessages: jest.fn(),
   clearQueuedMessages: jest.fn(),
 };
+
+jest.mock('../shared/flash_messages', () => ({
+  FlashMessagesLogic: {
+    values: mockFlashMessagesValues,
+    actions: mockFlashMessagesActions,
+  },
+}));

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/http_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/http_logic.mock.ts
@@ -11,3 +11,7 @@ export const mockHttpValues = {
   errorConnecting: false,
   readOnlyMode: false,
 };
+
+jest.mock('../shared/http', () => ({
+  HttpLogic: { values: mockHttpValues },
+}));

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
@@ -9,7 +9,11 @@ export { mockKibanaValues } from './kibana_logic.mock';
 export { mockLicensingValues } from './licensing_logic.mock';
 export { mockHttpValues } from './http_logic.mock';
 export { mockTelemetryActions } from './telemetry_logic.mock';
-export { mockFlashMessagesValues, mockFlashMessagesActions } from './flash_messages_logic.mock';
+export {
+  mockFlashMessagesValues,
+  mockFlashMessagesActions,
+  mockFlashMessageHelpers,
+} from './flash_messages_logic.mock';
 export {
   mockAllValues,
   mockAllActions,

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_logic.mock.ts
@@ -20,3 +20,7 @@ export const mockKibanaValues = {
   setDocTitle: jest.fn(),
   renderHeaderActions: jest.fn(),
 };
+
+jest.mock('../shared/kibana', () => ({
+  KibanaLogic: { values: mockKibanaValues },
+}));

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/licensing_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/licensing_logic.mock.ts
@@ -11,3 +11,7 @@ export const mockLicensingValues = {
   hasPlatinumLicense: false,
   hasGoldLicense: false,
 };
+
+jest.mock('../shared/licensing', () => ({
+  LicensingLogic: { values: mockLicensingValues },
+}));

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/telemetry_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/telemetry_logic.mock.ts
@@ -12,5 +12,6 @@ export const mockTelemetryActions = {
 };
 
 jest.mock('../shared/telemetry', () => ({
+  ...(jest.requireActual('../shared/telemetry') as object),
   TelemetryLogic: { actions: mockTelemetryActions },
 }));

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/telemetry_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/telemetry_logic.mock.ts
@@ -10,3 +10,7 @@ export const mockTelemetryActions = {
   sendAppSearchTelemetry: jest.fn(),
   sendWorkplaceSearchTelemetry: jest.fn(),
 };
+
+jest.mock('../shared/telemetry', () => ({
+  TelemetryLogic: { actions: mockTelemetryActions },
+}));

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -4,23 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: mockHttpValues },
-}));
-const { http } = mockHttpValues;
-
-jest.mock('../../../shared/flash_messages', () => ({
-  FlashMessagesLogic: { actions: { clearFlashMessages: jest.fn() } },
-  setSuccessMessage: jest.fn(),
-  flashAPIErrors: jest.fn(),
-}));
 import {
-  FlashMessagesLogic,
-  setSuccessMessage,
-  flashAPIErrors,
-} from '../../../shared/flash_messages';
+  LogicMounter,
+  mockFlashMessageHelpers,
+  mockHttpValues,
+  expectedAsyncError,
+} from '../../../__mocks__';
 
 jest.mock('../../app_logic', () => ({
   AppLogic: {
@@ -34,6 +23,10 @@ import { ApiTokenTypes } from './constants';
 import { CredentialsLogic } from './credentials_logic';
 
 describe('CredentialsLogic', () => {
+  const { mount } = new LogicMounter(CredentialsLogic);
+  const { http } = mockHttpValues;
+  const { clearFlashMessages, setSuccessMessage, flashAPIErrors } = mockFlashMessageHelpers;
+
   const DEFAULT_VALUES = {
     activeApiToken: {
       name: '',
@@ -55,8 +48,6 @@ describe('CredentialsLogic', () => {
     shouldShowCredentialsForm: false,
     fullEngineAccessChecked: false,
   };
-
-  const { mount } = new LogicMounter(CredentialsLogic);
 
   const newToken = {
     id: 1,
@@ -955,7 +946,7 @@ describe('CredentialsLogic', () => {
       describe('listener side-effects', () => {
         it('should clear flashMessages whenever the credentials form flyout is opened', () => {
           CredentialsLogic.actions.showCredentialsForm();
-          expect(FlashMessagesLogic.actions.clearFlashMessages).toHaveBeenCalled();
+          expect(clearFlashMessages).toHaveBeenCalled();
         });
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
@@ -11,7 +11,7 @@ import { ApiTokenTypes, CREATE_MESSAGE, UPDATE_MESSAGE, DELETE_MESSAGE } from '.
 
 import { HttpLogic } from '../../../shared/http';
 import {
-  FlashMessagesLogic,
+  clearFlashMessages,
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
@@ -227,7 +227,7 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
   }),
   listeners: ({ actions, values }) => ({
     showCredentialsForm: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     initializeCredentialsData: () => {
       actions.fetchCredentials();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
@@ -4,38 +4,31 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: mockHttpValues },
-}));
-const { http } = mockHttpValues;
+import {
+  LogicMounter,
+  mockHttpValues,
+  mockKibanaValues,
+  mockFlashMessageHelpers,
+  expectedAsyncError,
+} from '../../../__mocks__';
 
 jest.mock('../engine', () => ({
   EngineLogic: { values: { engineName: 'engine1' } },
 }));
 
-jest.mock('../../../shared/kibana', () => ({
-  KibanaLogic: { values: { navigateToUrl: jest.fn() } },
-}));
-import { KibanaLogic } from '../../../shared/kibana';
-
-jest.mock('../../../shared/flash_messages', () => ({
-  setQueuedSuccessMessage: jest.fn(),
-  flashAPIErrors: jest.fn(),
-}));
-import { setQueuedSuccessMessage, flashAPIErrors } from '../../../shared/flash_messages';
-
 import { DocumentDetailLogic } from './document_detail_logic';
 import { InternalSchemaTypes } from '../../../shared/types';
 
 describe('DocumentDetailLogic', () => {
+  const { mount } = new LogicMounter(DocumentDetailLogic);
+  const { http } = mockHttpValues;
+  const { navigateToUrl } = mockKibanaValues;
+  const { setQueuedSuccessMessage, flashAPIErrors } = mockFlashMessageHelpers;
+
   const DEFAULT_VALUES = {
     dataLoading: true,
     fields: [],
   };
-
-  const { mount } = new LogicMounter(DocumentDetailLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -84,7 +77,7 @@ describe('DocumentDetailLogic', () => {
         await expectedAsyncError(promise);
 
         expect(flashAPIErrors).toHaveBeenCalledWith('An error occurred', { isQueued: true });
-        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith('/engines/engine1/documents');
+        expect(navigateToUrl).toHaveBeenCalledWith('/engines/engine1/documents');
       });
     });
 
@@ -112,7 +105,7 @@ describe('DocumentDetailLogic', () => {
         expect(setQueuedSuccessMessage).toHaveBeenCalledWith(
           'Successfully marked document for deletion. It will be deleted momentarily.'
         );
-        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith('/engines/engine1/documents');
+        expect(navigateToUrl).toHaveBeenCalledWith('/engines/engine1/documents');
       });
 
       it('will do nothing if not confirmed', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -6,14 +6,12 @@
 
 import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: mockHttpValues },
-}));
-const { http } = mockHttpValues;
-
 import { EngineLogic } from './';
 
 describe('EngineLogic', () => {
+  const { mount } = new LogicMounter(EngineLogic);
+  const { http } = mockHttpValues;
+
   const mockEngineData = {
     name: 'some-engine',
     type: 'default',
@@ -44,8 +42,6 @@ describe('EngineLogic', () => {
     hasUnconfirmedSchemaFields: false,
     engineNotFound: false,
   };
-
-  const { mount } = new LogicMounter(EngineLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -6,16 +6,11 @@
 
 import '../../../__mocks__/react_router_history.mock';
 import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
-import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
+import { mockFlashMessageHelpers, setMockValues, setMockActions } from '../../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Switch, Redirect, useParams } from 'react-router-dom';
-
-jest.mock('../../../shared/flash_messages', () => ({
-  setQueuedErrorMessage: jest.fn(),
-}));
-import { setQueuedErrorMessage } from '../../../shared/flash_messages';
 
 import { Loading } from '../../../shared/loading';
 import { EngineOverview } from '../engine_overview';
@@ -58,6 +53,7 @@ describe('EngineRouter', () => {
   });
 
   it('redirects to engines list and flashes an error if the engine param was not found', () => {
+    const { setQueuedErrorMessage } = mockFlashMessageHelpers;
     setMockValues({ ...values, engineNotFound: true, engineName: '404-engine' });
     const wrapper = shallow(<EngineRouter />);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
@@ -4,17 +4,12 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: mockHttpValues },
-}));
-const { http } = mockHttpValues;
-
-jest.mock('../../../shared/flash_messages', () => ({
-  flashAPIErrors: jest.fn(),
-}));
-import { flashAPIErrors } from '../../../shared/flash_messages';
+import {
+  LogicMounter,
+  mockHttpValues,
+  mockFlashMessageHelpers,
+  expectedAsyncError,
+} from '../../../__mocks__';
 
 jest.mock('../engine', () => ({
   EngineLogic: { values: { engineName: 'some-engine' } },
@@ -23,6 +18,10 @@ jest.mock('../engine', () => ({
 import { EngineOverviewLogic } from './';
 
 describe('EngineOverviewLogic', () => {
+  const { mount, unmount } = new LogicMounter(EngineOverviewLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+
   const mockEngineMetrics = {
     apiLogsUnavailable: true,
     documentCount: 10,
@@ -44,8 +43,6 @@ describe('EngineOverviewLogic', () => {
     totalQueries: 0,
     timeoutId: null,
   };
-
-  const { mount, unmount } = new LogicMounter(EngineOverviewLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_logic.test.ts
@@ -4,17 +4,15 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: { http: { get: jest.fn() } } },
-}));
-import { HttpLogic } from '../../../shared/http';
+import { LogicMounter, mockHttpValues } from '../../../__mocks__';
 
 import { EngineDetails } from '../engine/types';
 import { EnginesLogic } from './';
 
 describe('EnginesLogic', () => {
+  const { mount } = new LogicMounter(EnginesLogic);
+  const { http } = mockHttpValues;
+
   const DEFAULT_VALUES = {
     dataLoading: true,
     engines: [],
@@ -42,8 +40,6 @@ describe('EnginesLogic', () => {
       },
     },
   };
-
-  const { mount } = new LogicMounter(EnginesLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -129,14 +125,14 @@ describe('EnginesLogic', () => {
     describe('loadEngines', () => {
       it('should call the engines API endpoint and set state based on the results', async () => {
         const promise = Promise.resolve(MOCK_ENGINES_API_RESPONSE);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValueOnce(promise);
+        http.get.mockReturnValueOnce(promise);
         mount({ enginesPage: 10 });
         jest.spyOn(EnginesLogic.actions, 'onEnginesLoad');
 
         EnginesLogic.actions.loadEngines();
         await promise;
 
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith('/api/app_search/engines', {
+        expect(http.get).toHaveBeenCalledWith('/api/app_search/engines', {
           query: { type: 'indexed', pageIndex: 10 },
         });
         expect(EnginesLogic.actions.onEnginesLoad).toHaveBeenCalledWith({
@@ -149,14 +145,14 @@ describe('EnginesLogic', () => {
     describe('loadMetaEngines', () => {
       it('should call the engines API endpoint and set state based on the results', async () => {
         const promise = Promise.resolve(MOCK_ENGINES_API_RESPONSE);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValueOnce(promise);
+        http.get.mockReturnValueOnce(promise);
         mount({ metaEnginesPage: 99 });
         jest.spyOn(EnginesLogic.actions, 'onMetaEnginesLoad');
 
         EnginesLogic.actions.loadMetaEngines();
         await promise;
 
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith('/api/app_search/engines', {
+        expect(http.get).toHaveBeenCalledWith('/api/app_search/engines', {
           query: { type: 'meta', pageIndex: 99 },
         });
         expect(EnginesLogic.actions.onMetaEnginesLoad).toHaveBeenCalledWith({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
@@ -4,22 +4,21 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: { values: mockHttpValues },
-}));
-const { http } = mockHttpValues;
-
-jest.mock('../../../shared/flash_messages', () => ({
-  flashAPIErrors: jest.fn(),
-}));
-import { flashAPIErrors } from '../../../shared/flash_messages';
+import {
+  LogicMounter,
+  mockHttpValues,
+  mockFlashMessageHelpers,
+  expectedAsyncError,
+} from '../../../__mocks__';
 
 import { LogRetentionOptions } from './types';
 import { LogRetentionLogic } from './log_retention_logic';
 
 describe('LogRetentionLogic', () => {
+  const { mount } = new LogicMounter(LogRetentionLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
+
   const TYPICAL_SERVER_LOG_RETENTION = {
     analytics: {
       disabled_at: null,
@@ -51,8 +50,6 @@ describe('LogRetentionLogic', () => {
     openedModal: null,
     isLogRetentionUpdating: false,
   };
-
-  const { mount } = new LogicMounter(LogRetentionLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.test.tsx
@@ -4,14 +4,13 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import '../../__mocks__/kea.mock';
+import { setMockValues } from '../../__mocks__/kea.mock';
 
-import { useValues } from 'kea';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { EuiCallOut } from '@elastic/eui';
 
-import { FlashMessages } from './';
+import { FlashMessages } from './flash_messages';
 
 describe('FlashMessages', () => {
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('FlashMessages', () => {
   });
 
   it('does not render if no messages exist', () => {
-    (useValues as jest.Mock).mockImplementationOnce(() => ({ messages: [] }));
+    setMockValues({ messages: [] });
 
     const wrapper = shallow(<FlashMessages />);
 
@@ -38,7 +37,7 @@ describe('FlashMessages', () => {
       { type: 'warning', message: 'Uh oh' },
       { type: 'info', message: 'Testing multiples of same type' },
     ];
-    (useValues as jest.Mock).mockImplementationOnce(() => ({ messages: mockMessages }));
+    setMockValues({ messages: mockMessages });
 
     const wrapper = shallow(<FlashMessages />);
 
@@ -49,7 +48,7 @@ describe('FlashMessages', () => {
   });
 
   it('renders any children', () => {
-    (useValues as jest.Mock).mockImplementationOnce(() => ({ messages: [{ type: 'success' }] }));
+    setMockValues({ messages: [{ type: 'success' }] });
 
     const wrapper = shallow(
       <FlashMessages>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
@@ -6,12 +6,10 @@
 
 import { resetContext } from 'kea';
 
-import { mockHistory } from '../../__mocks__';
-jest.mock('../kibana', () => ({
-  KibanaLogic: { values: { history: mockHistory } },
-}));
+import { mockKibanaValues } from '../../__mocks__/kibana_logic.mock';
+const { history } = mockKibanaValues;
 
-import { FlashMessagesLogic, mountFlashMessagesLogic, IFlashMessage } from './';
+import { FlashMessagesLogic, mountFlashMessagesLogic, IFlashMessage } from './flash_messages_logic';
 
 describe('FlashMessagesLogic', () => {
   const mount = () => mountFlashMessagesLogic();
@@ -98,7 +96,7 @@ describe('FlashMessagesLogic', () => {
     describe('on mount', () => {
       it('listens for history changes and clears messages on change', () => {
         mount();
-        expect(mockHistory.listen).toHaveBeenCalled();
+        expect(history.listen).toHaveBeenCalled();
 
         FlashMessagesLogic.actions.setQueuedMessages(['queuedMessages'] as any);
         jest.spyOn(FlashMessagesLogic.actions, 'clearFlashMessages');
@@ -106,7 +104,7 @@ describe('FlashMessagesLogic', () => {
         jest.spyOn(FlashMessagesLogic.actions, 'clearQueuedMessages');
         jest.spyOn(FlashMessagesLogic.actions, 'setHistoryListener');
 
-        const mockHistoryChange = (mockHistory.listen.mock.calls[0] as any)[0];
+        const mockHistoryChange = (history.listen.mock.calls[0] as any)[0];
         mockHistoryChange();
         expect(FlashMessagesLogic.actions.clearFlashMessages).toHaveBeenCalled();
         expect(FlashMessagesLogic.actions.setFlashMessages).toHaveBeenCalledWith([
@@ -119,7 +117,7 @@ describe('FlashMessagesLogic', () => {
     describe('on unmount', () => {
       it('removes history listener', () => {
         const mockUnlistener = jest.fn();
-        mockHistory.listen.mockReturnValueOnce(mockUnlistener);
+        history.listen.mockReturnValueOnce(mockUnlistener);
 
         const unmount = mount();
         unmount();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
@@ -4,16 +4,9 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-jest.mock('./', () => ({
-  FlashMessagesLogic: {
-    actions: {
-      setFlashMessages: jest.fn(),
-      setQueuedMessages: jest.fn(),
-    },
-  },
-}));
-import { FlashMessagesLogic } from './';
+import '../../__mocks__/kibana_logic.mock';
 
+import { FlashMessagesLogic } from './flash_messages_logic';
 import { flashAPIErrors } from './handle_api_errors';
 
 describe('flashAPIErrors', () => {
@@ -30,6 +23,9 @@ describe('flashAPIErrors', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    FlashMessagesLogic.mount();
+    jest.spyOn(FlashMessagesLogic.actions, 'setFlashMessages');
+    jest.spyOn(FlashMessagesLogic.actions, 'setQueuedMessages');
   });
 
   it('converts API errors into flash messages', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
@@ -6,7 +6,7 @@
 
 import { HttpResponse } from 'src/core/public';
 
-import { FlashMessagesLogic, IFlashMessage } from './';
+import { FlashMessagesLogic, IFlashMessage } from './flash_messages_logic';
 
 /**
  * The API errors we are handling can come from one of two ways:

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.test.ts
@@ -4,26 +4,22 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { mockHistory } from '../../__mocks__';
-jest.mock('../kibana', () => ({
-  KibanaLogic: { values: { history: mockHistory } },
-}));
+import '../../__mocks__/kibana_logic.mock';
 
+import { FlashMessagesLogic } from './flash_messages_logic';
 import {
-  FlashMessagesLogic,
-  mountFlashMessagesLogic,
   setSuccessMessage,
   setErrorMessage,
   setQueuedSuccessMessage,
   setQueuedErrorMessage,
   clearFlashMessages,
-} from './';
+} from './set_message_helpers';
 
 describe('Flash Message Helpers', () => {
   const message = 'I am a message';
 
   beforeEach(() => {
-    mountFlashMessagesLogic();
+    FlashMessagesLogic.mount();
   });
 
   it('setSuccessMessage()', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/set_message_helpers.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { FlashMessagesLogic } from './';
+import { FlashMessagesLogic } from './flash_messages_logic';
 
 export const setSuccessMessage = (message: string) => {
   FlashMessagesLogic.actions.setFlashMessages({

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
@@ -4,26 +4,19 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { resetContext } from 'kea';
-
-import { expectedAsyncError } from '../../__mocks__';
-
-jest.mock('../http', () => ({
-  HttpLogic: {
-    values: { http: { get: jest.fn() } },
-  },
-}));
-import { HttpLogic } from '../http';
-
-jest.mock('../flash_messages', () => ({
-  flashAPIErrors: jest.fn(),
-}));
-import { flashAPIErrors } from '../flash_messages';
+import {
+  LogicMounter,
+  mockFlashMessageHelpers,
+  mockHttpValues,
+  expectedAsyncError,
+} from '../../__mocks__';
 
 import { IndexingStatusLogic } from './indexing_status_logic';
 
 describe('IndexingStatusLogic', () => {
-  let unmount: any;
+  const { mount, unmount } = new LogicMounter(IndexingStatusLogic);
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
 
   const mockStatusResponse = {
     percentageComplete: 50,
@@ -33,8 +26,7 @@ describe('IndexingStatusLogic', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    resetContext({});
-    unmount = IndexingStatusLogic.mount();
+    mount();
   });
 
   it('has expected default values', () => {
@@ -66,12 +58,12 @@ describe('IndexingStatusLogic', () => {
     it('calls API and sets values', async () => {
       const setIndexingStatusSpy = jest.spyOn(IndexingStatusLogic.actions, 'setIndexingStatus');
       const promise = Promise.resolve(mockStatusResponse);
-      (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+      http.get.mockReturnValue(promise);
 
       IndexingStatusLogic.actions.fetchIndexingStatus({ statusPath, onComplete });
       jest.advanceTimersByTime(TIMEOUT);
 
-      expect(HttpLogic.values.http.get).toHaveBeenCalledWith(statusPath);
+      expect(http.get).toHaveBeenCalledWith(statusPath);
       await promise;
 
       expect(setIndexingStatusSpy).toHaveBeenCalledWith(mockStatusResponse);
@@ -79,7 +71,7 @@ describe('IndexingStatusLogic', () => {
 
     it('handles error', async () => {
       const promise = Promise.reject('An error occured');
-      (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+      http.get.mockReturnValue(promise);
 
       IndexingStatusLogic.actions.fetchIndexingStatus({ statusPath, onComplete });
       jest.advanceTimersByTime(TIMEOUT);
@@ -91,7 +83,7 @@ describe('IndexingStatusLogic', () => {
 
     it('handles indexing complete state', async () => {
       const promise = Promise.resolve({ ...mockStatusResponse, percentageComplete: 100 });
-      (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+      http.get.mockReturnValue(promise);
       IndexingStatusLogic.actions.fetchIndexingStatus({ statusPath, onComplete });
       jest.advanceTimersByTime(TIMEOUT);
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
@@ -6,10 +6,7 @@
 
 import { resetContext } from 'kea';
 
-import { mockKibanaValues, mockHttpValues } from '../../__mocks__';
-jest.mock('../http', () => ({
-  HttpLogic: { values: { http: mockHttpValues.http } },
-}));
+import { mockKibanaValues } from '../../__mocks__';
 
 import { KibanaLogic, mountKibanaLogic } from './kibana_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
@@ -7,14 +7,13 @@
 import { resetContext } from 'kea';
 
 import { JSON_HEADER as headers } from '../../../../common/constants';
-import { mockHttpValues } from '../../__mocks__';
-jest.mock('../http', () => ({
-  HttpLogic: { values: { http: mockHttpValues.http } },
-}));
+import { mockHttpValues } from '../../__mocks__/http_logic.mock';
 
 import { TelemetryLogic } from './';
 
 describe('Telemetry logic', () => {
+  const { http } = mockHttpValues;
+
   beforeEach(() => {
     jest.clearAllMocks();
     resetContext({});
@@ -29,14 +28,14 @@ describe('Telemetry logic', () => {
         product: 'enterprise_search',
       });
 
-      expect(mockHttpValues.http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
+      expect(http.put).toHaveBeenCalledWith('/api/enterprise_search/stats', {
         headers,
         body: '{"product":"enterprise_search","action":"viewed","metric":"setup_guide"}',
       });
     });
 
     it('throws an error if the telemetry endpoint fails', async () => {
-      mockHttpValues.http.put.mockImplementationOnce(() => Promise.reject());
+      http.put.mockImplementationOnce(() => Promise.reject());
 
       // To capture thrown errors, we have to call the listener fn directly
       // instead of using `TelemetryLogic.actions.sendTelemetry` - this is

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -4,16 +4,10 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import '../../../../../__mocks__/kea.mock';
 import '../../../../../__mocks__/shallow_useeffect.mock';
+import { mockKibanaValues, setMockActions, setMockValues } from '../../../../../__mocks__';
 
-import { setMockActions, setMockValues } from '../../../../../__mocks__';
 import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
-
-jest.mock('../../../../../shared/kibana', () => ({
-  KibanaLogic: { values: { navigateToUrl: jest.fn() } },
-}));
-import { KibanaLogic } from '../../../../../shared/kibana';
 
 import React from 'react';
 import { shallow } from 'enzyme';
@@ -32,6 +26,7 @@ import { SaveConfig } from './save_config';
 import { SaveCustom } from './save_custom';
 
 describe('AddSourceList', () => {
+  const { navigateToUrl } = mockKibanaValues;
   const initializeAddSource = jest.fn();
   const setAddSourceStep = jest.fn();
   const saveSourceConfig = jest.fn((_, setConfigCompletedStep) => {
@@ -83,9 +78,7 @@ describe('AddSourceList', () => {
     const wrapper = shallow(<AddSource sourceIndex={1} />);
     wrapper.find(ConfigCompleted).prop('advanceStep')();
 
-    expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(
-      '/sources/add/confluence_cloud/connect'
-    );
+    expect(navigateToUrl).toHaveBeenCalledWith('/sources/add/confluence_cloud/connect');
     expect(setAddSourceStep).toHaveBeenCalledWith(AddSourceSteps.ConnectInstanceStep);
   });
 
@@ -112,9 +105,7 @@ describe('AddSourceList', () => {
     const wrapper = shallow(<AddSource sourceIndex={1} connect />);
     wrapper.find(ConnectInstance).prop('onFormCreated')('foo');
 
-    expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(
-      '/sources/add/confluence_cloud/connect'
-    );
+    expect(navigateToUrl).toHaveBeenCalledWith('/sources/add/confluence_cloud/connect');
   });
 
   it('renders Configure Custom step', () => {
@@ -137,9 +128,7 @@ describe('AddSourceList', () => {
 
     wrapper.find(ConfigureOauth).prop('onFormCreated')('foo');
 
-    expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(
-      '/sources/add/confluence_cloud/connect'
-    );
+    expect(navigateToUrl).toHaveBeenCalledWith('/sources/add/confluence_cloud/connect');
   });
 
   it('renders Save Custom step', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -6,22 +6,11 @@
 
 import { resetContext } from 'kea';
 
-import { mockHttpValues, expectedAsyncError } from '../../../../../__mocks__';
-
-jest.mock('../../../../../shared/http', () => ({
-  HttpLogic: {
-    values: { http: mockHttpValues.http },
-  },
-}));
-import { HttpLogic } from '../../../../../shared/http';
-
-jest.mock('../../../../../shared/flash_messages', () => ({
-  FlashMessagesLogic: { actions: { clearFlashMessages: jest.fn(), setQueuedMessages: jest.fn() } },
-  flashAPIErrors: jest.fn(),
-  setSuccessMessage: jest.fn(),
-  setQueuedSuccessMessage: jest.fn(),
-}));
-import { FlashMessagesLogic, flashAPIErrors } from '../../../../../shared/flash_messages';
+import {
+  mockFlashMessageHelpers,
+  mockHttpValues,
+  expectedAsyncError,
+} from '../../../../../__mocks__';
 
 import { AppLogic } from '../../../../app_logic';
 jest.mock('../../../../app_logic', () => ({
@@ -41,6 +30,9 @@ import {
 } from './add_source_logic';
 
 describe('AddSourceLogic', () => {
+  const { http } = mockHttpValues;
+  const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
+
   const defaultValues = {
     addSourceCurrentStep: AddSourceSteps.ConfigIntroStep,
     addSourceProps: {},
@@ -76,8 +68,6 @@ describe('AddSourceLogic', () => {
   };
 
   const CUSTOM_SERVICE_TYPE_INDEX = 17;
-
-  const clearFlashMessagesSpy = jest.spyOn(FlashMessagesLogic.actions, 'clearFlashMessages');
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -283,10 +273,10 @@ describe('AddSourceLogic', () => {
         it('calls API and sets values', async () => {
           const setSourceConfigDataSpy = jest.spyOn(AddSourceLogic.actions, 'setSourceConfigData');
           const promise = Promise.resolve(sourceConfigData);
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceConfigData('github');
-          expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+          expect(http.get).toHaveBeenCalledWith(
             '/api/workplace_search/org/settings/connectors/github'
           );
           await promise;
@@ -295,7 +285,7 @@ describe('AddSourceLogic', () => {
 
         it('handles error', async () => {
           const promise = Promise.reject('this is an error');
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceConfigData('github');
           await expectedAsyncError(promise);
@@ -314,15 +304,13 @@ describe('AddSourceLogic', () => {
             'setSourceConnectData'
           );
           const promise = Promise.resolve(sourceConnectData);
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceConnectData('github', successCallback);
 
-          expect(clearFlashMessagesSpy).toHaveBeenCalled();
+          expect(clearFlashMessages).toHaveBeenCalled();
           expect(AddSourceLogic.values.buttonLoading).toEqual(true);
-          expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
-            '/api/workplace_search/org/sources/github/prepare'
-          );
+          expect(http.get).toHaveBeenCalledWith('/api/workplace_search/org/sources/github/prepare');
           await promise;
           expect(setSourceConnectDataSpy).toHaveBeenCalledWith(sourceConnectData);
           expect(successCallback).toHaveBeenCalledWith(sourceConnectData.oauthUrl);
@@ -334,14 +322,14 @@ describe('AddSourceLogic', () => {
           AddSourceLogic.actions.setSourceIndexPermissionsValue(true);
           AddSourceLogic.actions.getSourceConnectData('github', successCallback);
 
-          expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+          expect(http.get).toHaveBeenCalledWith(
             '/api/workplace_search/org/sources/github/prepare?subdomain=subdomain&index_permissions=true'
           );
         });
 
         it('handles error', async () => {
           const promise = Promise.reject('this is an error');
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceConnectData('github', successCallback);
           await expectedAsyncError(promise);
@@ -357,11 +345,11 @@ describe('AddSourceLogic', () => {
             'setSourceConnectData'
           );
           const promise = Promise.resolve(sourceConnectData);
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceReConnectData('github');
 
-          expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+          expect(http.get).toHaveBeenCalledWith(
             '/api/workplace_search/org/sources/github/reauth_prepare'
           );
           await promise;
@@ -370,7 +358,7 @@ describe('AddSourceLogic', () => {
 
         it('handles error', async () => {
           const promise = Promise.reject('this is an error');
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getSourceReConnectData('github');
           await expectedAsyncError(promise);
@@ -386,20 +374,18 @@ describe('AddSourceLogic', () => {
             'setPreContentSourceConfigData'
           );
           const promise = Promise.resolve(config);
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getPreContentSourceConfigData('123');
 
-          expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
-            '/api/workplace_search/org/pre_sources/123'
-          );
+          expect(http.get).toHaveBeenCalledWith('/api/workplace_search/org/pre_sources/123');
           await promise;
           expect(setPreContentSourceConfigDataSpy).toHaveBeenCalledWith(config);
         });
 
         it('handles error', async () => {
           const promise = Promise.reject('this is an error');
-          (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+          http.get.mockReturnValue(promise);
 
           AddSourceLogic.actions.getPreContentSourceConfigData('123');
           await expectedAsyncError(promise);
@@ -430,14 +416,14 @@ describe('AddSourceLogic', () => {
           const setButtonNotLoadingSpy = jest.spyOn(AddSourceLogic.actions, 'setButtonNotLoading');
           const setSourceConfigDataSpy = jest.spyOn(AddSourceLogic.actions, 'setSourceConfigData');
           const promise = Promise.resolve({ sourceConfigData });
-          (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
+          http.put.mockReturnValue(promise);
 
           AddSourceLogic.actions.saveSourceConfig(true, successCallback);
 
-          expect(clearFlashMessagesSpy).toHaveBeenCalled();
+          expect(clearFlashMessages).toHaveBeenCalled();
           expect(AddSourceLogic.values.buttonLoading).toEqual(true);
           expect(
-            HttpLogic.values.http.put
+            http.put
           ).toHaveBeenCalledWith(
             `/api/workplace_search/org/settings/connectors/${sourceConfigData.serviceType}`,
             { body: JSON.stringify({ params }) }
@@ -462,17 +448,14 @@ describe('AddSourceLogic', () => {
             consumer_key: sourceConfigData.configuredFields?.consumerKey,
           };
 
-          expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-            '/api/workplace_search/org/settings/connectors',
-            {
-              body: JSON.stringify({ params: createParams }),
-            }
-          );
+          expect(http.post).toHaveBeenCalledWith('/api/workplace_search/org/settings/connectors', {
+            body: JSON.stringify({ params: createParams }),
+          });
         });
 
         it('handles error', async () => {
           const promise = Promise.reject('this is an error');
-          (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
+          http.put.mockReturnValue(promise);
 
           AddSourceLogic.actions.saveSourceConfig(true);
           await expectedAsyncError(promise);
@@ -514,18 +497,15 @@ describe('AddSourceLogic', () => {
           const setButtonNotLoadingSpy = jest.spyOn(AddSourceLogic.actions, 'setButtonNotLoading');
           const setCustomSourceDataSpy = jest.spyOn(AddSourceLogic.actions, 'setCustomSourceData');
           const promise = Promise.resolve({ sourceConfigData });
-          (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+          http.post.mockReturnValue(promise);
 
           AddSourceLogic.actions.createContentSource(serviceType, successCallback, errorCallback);
 
-          expect(clearFlashMessagesSpy).toHaveBeenCalled();
+          expect(clearFlashMessages).toHaveBeenCalled();
           expect(AddSourceLogic.values.buttonLoading).toEqual(true);
-          expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-            '/api/workplace_search/org/create_source',
-            {
-              body: JSON.stringify({ ...params }),
-            }
-          );
+          expect(http.post).toHaveBeenCalledWith('/api/workplace_search/org/create_source', {
+            body: JSON.stringify({ ...params }),
+          });
           await promise;
           expect(setCustomSourceDataSpy).toHaveBeenCalledWith({ sourceConfigData });
           expect(successCallback).toHaveBeenCalled();
@@ -534,7 +514,7 @@ describe('AddSourceLogic', () => {
 
         it('handles error', async () => {
           const promise = Promise.reject('this is an error');
-          (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+          http.post.mockReturnValue(promise);
 
           AddSourceLogic.actions.createContentSource(serviceType, successCallback, errorCallback);
           await expectedAsyncError(promise);
@@ -553,7 +533,7 @@ describe('AddSourceLogic', () => {
       it('getSourceConnectData', () => {
         AddSourceLogic.actions.getSourceConnectData('github', jest.fn());
 
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+        expect(http.get).toHaveBeenCalledWith(
           '/api/workplace_search/account/sources/github/prepare'
         );
       });
@@ -561,7 +541,7 @@ describe('AddSourceLogic', () => {
       it('getSourceReConnectData', () => {
         AddSourceLogic.actions.getSourceReConnectData('123');
 
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+        expect(http.get).toHaveBeenCalledWith(
           '/api/workplace_search/account/sources/123/reauth_prepare'
         );
       });
@@ -569,20 +549,15 @@ describe('AddSourceLogic', () => {
       it('getPreContentSourceConfigData', () => {
         AddSourceLogic.actions.getPreContentSourceConfigData('123');
 
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
-          '/api/workplace_search/account/pre_sources/123'
-        );
+        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/account/pre_sources/123');
       });
 
       it('createContentSource', () => {
         AddSourceLogic.actions.createContentSource('github', jest.fn());
 
-        expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-          '/api/workplace_search/account/create_source',
-          {
-            body: JSON.stringify({ service_type: 'github' }),
-          }
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/workplace_search/account/create_source', {
+          body: JSON.stringify({ service_type: 'github' }),
+        });
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -15,7 +15,7 @@ import { HttpLogic } from '../../../../../shared/http';
 import {
   flashAPIErrors,
   setSuccessMessage,
-  FlashMessagesLogic,
+  clearFlashMessages,
 } from '../../../../../shared/flash_messages';
 
 import { staticSourceData } from '../../source_data';
@@ -348,7 +348,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       }
     },
     getSourceConnectData: async ({ serviceType, successCallback }) => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
       const { isOrganization } = AppLogic.values;
       const { subdomainValue: subdomain, indexPermissionsValue: indexPermissions } = values;
 
@@ -399,7 +399,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       }
     },
     saveSourceConfig: async ({ isUpdating, successCallback }) => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
       const {
         sourceConfigData: { serviceType },
         baseUrlValue,
@@ -447,7 +447,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       }
     },
     createContentSource: async ({ serviceType, successCallback, errorCallback }) => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
       const { isOrganization } = AppLogic.values;
       const route = isOrganization
         ? '/api/workplace_search/org/create_source'

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -6,32 +6,12 @@
 
 import { resetContext } from 'kea';
 
-import { expectedAsyncError } from '../../../__mocks__';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: {
-    values: { http: { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() } },
-  },
-}));
-import { HttpLogic } from '../../../shared/http';
-
-jest.mock('../../../shared/flash_messages', () => ({
-  FlashMessagesLogic: { actions: { clearFlashMessages: jest.fn(), setQueuedMessages: jest.fn() } },
-  flashAPIErrors: jest.fn(),
-  setSuccessMessage: jest.fn(),
-  setQueuedSuccessMessage: jest.fn(),
-}));
 import {
-  FlashMessagesLogic,
-  flashAPIErrors,
-  setSuccessMessage,
-  setQueuedSuccessMessage,
-} from '../../../shared/flash_messages';
-
-jest.mock('../../../shared/kibana', () => ({
-  KibanaLogic: { values: { navigateToUrl: jest.fn() } },
-}));
-import { KibanaLogic } from '../../../shared/kibana';
+  mockKibanaValues,
+  mockFlashMessageHelpers,
+  mockHttpValues,
+  expectedAsyncError,
+} from '../../../__mocks__';
 
 import { groups } from '../../__mocks__/groups.mock';
 import { mockGroupValues } from './__mocks__/group_logic.mock';
@@ -40,11 +20,20 @@ import { GroupLogic } from './group_logic';
 import { GROUPS_PATH } from '../../routes';
 
 describe('GroupLogic', () => {
+  const { http } = mockHttpValues;
+  const { navigateToUrl } = mockKibanaValues;
+  const {
+    clearFlashMessages,
+    flashAPIErrors,
+    setSuccessMessage,
+    setQueuedSuccessMessage,
+    setQueuedErrorMessage,
+  } = mockFlashMessageHelpers;
+
   const group = groups[0];
   const sourceIds = ['123', '124'];
   const userIds = ['1z1z'];
   const sourcePriorities = { [sourceIds[0]]: 1, [sourceIds[1]]: 0.5 };
-  const clearFlashMessagesSpy = jest.spyOn(FlashMessagesLogic.actions, 'clearFlashMessages');
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -242,40 +231,34 @@ describe('GroupLogic', () => {
       it('calls API and sets values', async () => {
         const onInitializeGroupSpy = jest.spyOn(GroupLogic.actions, 'onInitializeGroup');
         const promise = Promise.resolve(group);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupLogic.actions.initializeGroup(sourceIds[0]);
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith('/api/workplace_search/groups/123');
+        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/groups/123');
         await promise;
         expect(onInitializeGroupSpy).toHaveBeenCalledWith(group);
       });
 
       it('handles 404 error', async () => {
         const promise = Promise.reject({ response: { status: 404 } });
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupLogic.actions.initializeGroup(sourceIds[0]);
         await expectedAsyncError(promise);
 
-        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
-        expect(FlashMessagesLogic.actions.setQueuedMessages).toHaveBeenCalledWith({
-          type: 'error',
-          message: 'Unable to find group with ID: "123".',
-        });
+        expect(navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
+        expect(setQueuedErrorMessage).toHaveBeenCalledWith('Unable to find group with ID: "123".');
       });
 
       it('handles non-404 error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupLogic.actions.initializeGroup(sourceIds[0]);
         await expectedAsyncError(promise);
 
-        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
-        expect(FlashMessagesLogic.actions.setQueuedMessages).toHaveBeenCalledWith({
-          type: 'error',
-          message: 'this is an error',
-        });
+        expect(navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
+        expect(setQueuedErrorMessage).toHaveBeenCalledWith('this is an error');
       });
     });
 
@@ -285,15 +268,13 @@ describe('GroupLogic', () => {
       });
       it('deletes a group', async () => {
         const promise = Promise.resolve(true);
-        (HttpLogic.values.http.delete as jest.Mock).mockReturnValue(promise);
+        http.delete.mockReturnValue(promise);
 
         GroupLogic.actions.deleteGroup();
-        expect(HttpLogic.values.http.delete).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/123'
-        );
+        expect(http.delete).toHaveBeenCalledWith('/api/workplace_search/groups/123');
 
         await promise;
-        expect(KibanaLogic.values.navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
+        expect(navigateToUrl).toHaveBeenCalledWith(GROUPS_PATH);
         expect(setQueuedSuccessMessage).toHaveBeenCalledWith(
           'Group "group" was successfully deleted.'
         );
@@ -301,7 +282,7 @@ describe('GroupLogic', () => {
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.delete as jest.Mock).mockReturnValue(promise);
+        http.delete.mockReturnValue(promise);
 
         GroupLogic.actions.deleteGroup();
         await expectedAsyncError(promise);
@@ -318,10 +299,10 @@ describe('GroupLogic', () => {
       it('updates name', async () => {
         const onGroupNameChangedSpy = jest.spyOn(GroupLogic.actions, 'onGroupNameChanged');
         const promise = Promise.resolve(group);
-        (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
+        http.put.mockReturnValue(promise);
 
         GroupLogic.actions.updateGroupName();
-        expect(HttpLogic.values.http.put).toHaveBeenCalledWith('/api/workplace_search/groups/123', {
+        expect(http.put).toHaveBeenCalledWith('/api/workplace_search/groups/123', {
           body: JSON.stringify({ group: { name: 'new name' } }),
         });
 
@@ -334,7 +315,7 @@ describe('GroupLogic', () => {
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
+        http.put.mockReturnValue(promise);
 
         GroupLogic.actions.updateGroupName();
         await expectedAsyncError(promise);
@@ -351,15 +332,12 @@ describe('GroupLogic', () => {
       it('updates name', async () => {
         const onGroupSourcesSavedSpy = jest.spyOn(GroupLogic.actions, 'onGroupSourcesSaved');
         const promise = Promise.resolve(group);
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupSources();
-        expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/123/share',
-          {
-            body: JSON.stringify({ content_source_ids: sourceIds }),
-          }
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/workplace_search/groups/123/share', {
+          body: JSON.stringify({ content_source_ids: sourceIds }),
+        });
 
         await promise;
         expect(onGroupSourcesSavedSpy).toHaveBeenCalledWith(group);
@@ -370,7 +348,7 @@ describe('GroupLogic', () => {
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupSources();
         await expectedAsyncError(promise);
@@ -386,15 +364,12 @@ describe('GroupLogic', () => {
       it('updates name', async () => {
         const onGroupUsersSavedSpy = jest.spyOn(GroupLogic.actions, 'onGroupUsersSaved');
         const promise = Promise.resolve(group);
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupUsers();
-        expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/123/assign',
-          {
-            body: JSON.stringify({ user_ids: userIds }),
-          }
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/workplace_search/groups/123/assign', {
+          body: JSON.stringify({ user_ids: userIds }),
+        });
 
         await promise;
         expect(onGroupUsersSavedSpy).toHaveBeenCalledWith(group);
@@ -405,7 +380,7 @@ describe('GroupLogic', () => {
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupUsers();
         await expectedAsyncError(promise);
@@ -424,20 +399,17 @@ describe('GroupLogic', () => {
           'onGroupPrioritiesChanged'
         );
         const promise = Promise.resolve(group);
-        (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
+        http.put.mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupSourcePrioritization();
-        expect(HttpLogic.values.http.put).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/123/boosts',
-          {
-            body: JSON.stringify({
-              content_source_boosts: [
-                [sourceIds[0], 1],
-                [sourceIds[1], 0.5],
-              ],
-            }),
-          }
-        );
+        expect(http.put).toHaveBeenCalledWith('/api/workplace_search/groups/123/boosts', {
+          body: JSON.stringify({
+            content_source_boosts: [
+              [sourceIds[0], 1],
+              [sourceIds[1], 0.5],
+            ],
+          }),
+        });
 
         await promise;
         expect(setSuccessMessage).toHaveBeenCalledWith(
@@ -448,7 +420,7 @@ describe('GroupLogic', () => {
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.put as jest.Mock).mockReturnValue(promise);
+        http.put.mockReturnValue(promise);
 
         GroupLogic.actions.saveGroupSourcePrioritization();
         await expectedAsyncError(promise);
@@ -462,7 +434,7 @@ describe('GroupLogic', () => {
         GroupLogic.actions.showConfirmDeleteModal();
 
         expect(GroupLogic.values.confirmDeleteModalVisible).toEqual(true);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
 
@@ -471,7 +443,7 @@ describe('GroupLogic', () => {
         GroupLogic.actions.showSharedSourcesModal();
 
         expect(GroupLogic.values.sharedSourcesModalVisible).toEqual(true);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
 
@@ -480,7 +452,7 @@ describe('GroupLogic', () => {
         GroupLogic.actions.showManageUsersModal();
 
         expect(GroupLogic.values.manageUsersModalVisible).toEqual(true);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
 
@@ -488,7 +460,7 @@ describe('GroupLogic', () => {
       it('clears flash messages', () => {
         GroupLogic.actions.resetFlashMessages();
 
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
@@ -10,13 +10,14 @@ import { i18n } from '@kbn/i18n';
 
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
-
 import {
-  FlashMessagesLogic,
+  clearFlashMessages,
   flashAPIErrors,
   setSuccessMessage,
   setQueuedSuccessMessage,
+  setQueuedErrorMessage,
 } from '../../../shared/flash_messages';
+
 import { GROUPS_PATH } from '../../routes';
 
 import { ContentSourceDetails, GroupDetails, User, SourcePriority } from '../../types';
@@ -223,10 +224,7 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
         );
 
         const error = e.response?.status === 404 ? NOT_FOUND_MESSAGE : e;
-        FlashMessagesLogic.actions.setQueuedMessages({
-          type: 'error',
-          message: error,
-        });
+        setQueuedErrorMessage(error);
 
         KibanaLogic.values.navigateToUrl(GROUPS_PATH);
       }
@@ -360,16 +358,16 @@ export const GroupLogic = kea<MakeLogicType<GroupValues, GroupActions>>({
       }
     },
     showConfirmDeleteModal: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     showManageUsersModal: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     showSharedSourcesModal: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     resetFlashMessages: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
@@ -6,23 +6,7 @@
 
 import { resetContext } from 'kea';
 
-import { expectedAsyncError } from '../../../__mocks__';
-
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: {
-    values: { http: { get: jest.fn(), post: jest.fn() } },
-  },
-}));
-import { HttpLogic } from '../../../shared/http';
-
-jest.mock('../../../shared/flash_messages', () => ({
-  FlashMessagesLogic: { actions: { clearFlashMessages: jest.fn(), setQueuedMessages: jest.fn() } },
-  flashAPIErrors: jest.fn(),
-  setSuccessMessage: jest.fn(),
-  setQueuedSuccessMessage: jest.fn(),
-}));
-import { FlashMessagesLogic, flashAPIErrors } from '../../../shared/flash_messages';
-
+import { mockFlashMessageHelpers, mockHttpValues, expectedAsyncError } from '../../../__mocks__';
 import { DEFAULT_META } from '../../../shared/constants';
 import { JSON_HEADER as headers } from '../../../../../common/constants';
 
@@ -37,7 +21,9 @@ const TIMEOUT = 400;
 const delay = () => new Promise((resolve) => setTimeout(resolve, TIMEOUT));
 
 describe('GroupsLogic', () => {
-  const clearFlashMessagesSpy = jest.spyOn(FlashMessagesLogic.actions, 'clearFlashMessages');
+  const { http } = mockHttpValues;
+  const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
+
   const groupsResponse = {
     results: groups,
     meta: DEFAULT_META,
@@ -229,17 +215,17 @@ describe('GroupsLogic', () => {
       it('calls API and sets values', async () => {
         const onInitializeGroupsSpy = jest.spyOn(GroupsLogic.actions, 'onInitializeGroups');
         const promise = Promise.resolve(groupsResponse);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupsLogic.actions.initializeGroups();
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith('/api/workplace_search/groups');
+        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/groups');
         await promise;
         expect(onInitializeGroupsSpy).toHaveBeenCalledWith(groupsResponse);
       });
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupsLogic.actions.initializeGroups();
         await expectedAsyncError(promise);
@@ -269,14 +255,11 @@ describe('GroupsLogic', () => {
       it('calls API and sets values', async () => {
         const setSearchResultsSpy = jest.spyOn(GroupsLogic.actions, 'setSearchResults');
         const promise = Promise.resolve(groups);
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupsLogic.actions.getSearchResults();
         await delay();
-        expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/search',
-          payload
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/workplace_search/groups/search', payload);
         await promise;
         expect(setSearchResultsSpy).toHaveBeenCalledWith(groups);
       });
@@ -286,22 +269,19 @@ describe('GroupsLogic', () => {
         GroupsLogic.actions.setActivePage(2);
         const setSearchResultsSpy = jest.spyOn(GroupsLogic.actions, 'setSearchResults');
         const promise = Promise.resolve(groups);
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupsLogic.actions.getSearchResults(true);
         // Account for `breakpoint` that debounces filter value.
         await delay();
-        expect(HttpLogic.values.http.post).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/search',
-          payload
-        );
+        expect(http.post).toHaveBeenCalledWith('/api/workplace_search/groups/search', payload);
         await promise;
         expect(setSearchResultsSpy).toHaveBeenCalledWith(groups);
       });
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupsLogic.actions.getSearchResults();
         await expectedAsyncError(promise);
@@ -315,19 +295,17 @@ describe('GroupsLogic', () => {
       it('calls API and sets values', async () => {
         const setGroupUsersSpy = jest.spyOn(GroupsLogic.actions, 'setGroupUsers');
         const promise = Promise.resolve(users);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupsLogic.actions.fetchGroupUsers('123');
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
-          '/api/workplace_search/groups/123/group_users'
-        );
+        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/groups/123/group_users');
         await promise;
         expect(setGroupUsersSpy).toHaveBeenCalledWith(users);
       });
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        http.get.mockReturnValue(promise);
 
         GroupsLogic.actions.fetchGroupUsers('123');
         await expectedAsyncError(promise);
@@ -342,10 +320,10 @@ describe('GroupsLogic', () => {
         GroupsLogic.actions.setNewGroupName(GROUP_NAME);
         const setNewGroupSpy = jest.spyOn(GroupsLogic.actions, 'setNewGroup');
         const promise = Promise.resolve(groups[0]);
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupsLogic.actions.saveNewGroup();
-        expect(HttpLogic.values.http.post).toHaveBeenCalledWith('/api/workplace_search/groups', {
+        expect(http.post).toHaveBeenCalledWith('/api/workplace_search/groups', {
           body: JSON.stringify({ group_name: GROUP_NAME }),
           headers,
         });
@@ -355,7 +333,7 @@ describe('GroupsLogic', () => {
 
       it('handles error', async () => {
         const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.post as jest.Mock).mockReturnValue(promise);
+        http.post.mockReturnValue(promise);
 
         GroupsLogic.actions.saveNewGroup();
         await expectedAsyncError(promise);
@@ -388,7 +366,7 @@ describe('GroupsLogic', () => {
 
         expect(GroupsLogic.values.newGroupModalOpen).toEqual(true);
         expect(GroupsLogic.values.newGroup).toEqual(null);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
 
@@ -400,7 +378,7 @@ describe('GroupsLogic', () => {
         expect(GroupsLogic.values.filteredUsers).toEqual([]);
         expect(GroupsLogic.values.filterValue).toEqual('');
         expect(GroupsLogic.values.groupsMeta).toEqual(DEFAULT_META);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
 
@@ -409,7 +387,7 @@ describe('GroupsLogic', () => {
         GroupsLogic.actions.toggleFilterSourcesDropdown();
 
         expect(GroupsLogic.values.filterSourcesDropdownOpen).toEqual(true);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
 
@@ -418,7 +396,7 @@ describe('GroupsLogic', () => {
         GroupsLogic.actions.toggleFilterUsersDropdown();
 
         expect(GroupsLogic.values.filterUsersDropdownOpen).toEqual(true);
-        expect(clearFlashMessagesSpy).toHaveBeenCalled();
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { HttpLogic } from '../../../shared/http';
 
 import {
-  FlashMessagesLogic,
+  clearFlashMessages,
   flashAPIErrors,
   setSuccessMessage,
 } from '../../../shared/flash_messages';
@@ -339,16 +339,16 @@ export const GroupsLogic = kea<MakeLogicType<GroupsValues, GroupsActions>>({
       actions.getSearchResults();
     },
     openNewGroupModal: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     resetGroupsFilters: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     toggleFilterSourcesDropdown: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
     toggleFilterUsersDropdown: () => {
-      FlashMessagesLogic.actions.clearFlashMessages();
+      clearFlashMessages();
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.test.ts
@@ -6,13 +6,14 @@
 
 import { resetContext } from 'kea';
 
-jest.mock('../../../shared/http', () => ({ HttpLogic: { values: { http: { get: jest.fn() } } } }));
-import { HttpLogic } from '../../../shared/http';
+import { mockHttpValues } from '../../../__mocks__';
 
 import { mockOverviewValues } from './__mocks__';
 import { OverviewLogic } from './overview_logic';
 
 describe('OverviewLogic', () => {
+  const { http } = mockHttpValues;
+
   beforeEach(() => {
     jest.clearAllMocks();
     resetContext({});
@@ -65,7 +66,7 @@ describe('OverviewLogic', () => {
 
       await OverviewLogic.actions.initializeOverview();
 
-      expect(HttpLogic.values.http.get).toHaveBeenCalledWith('/api/workplace_search/overview');
+      expect(http.get).toHaveBeenCalledWith('/api/workplace_search/overview');
       expect(setServerDataSpy).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

Part 2 of my Jest cleanup: I've mentioned recently after seeing a ton of `jest.mock('../../../shared/kibana')` (or `http`, or `flash_messages`, etc.) cruft at the top of our logic files that it would be really nice to clean up / DRY out said mocks. We already do this for our React component tests via mocking `useValues` and `useActions`, but we didn't have this for our actual Kea logic tests that directly connected/grabbed values from other files (e.g. `SomeLogic.value.someValue`).

Well, I was yesterday years old when I learned that [jest.mock() is relative to the test file](https://stackoverflow.com/a/44466329/4294462), not to the actual file being tested... meaning that we can definitely DRY out mocking our logic. I decided to accomplish this by directly mocking each shared logic file in its `__mocks__/*_logic.mock.ts` (see 93b7242). This means that importing any mocks from our `__mocks__` folder will automatically mock the logic file for you. Check out the following code diff example:

```js
jest.mock('../../../shared/kibana', () => ({
  KibanaLogic: { values: { history: { location: { search: '' } } } },
}));
import { KibanaLogic } from '../../../shared/kibana';

jest.mock('../../../shared/http', () => ({
  HttpLogic: { values: { http: { get: jest.fn() } } },
}));
import { HttpLogic } from '../../../shared/http';

jest.mock('../../../shared/flash_messages', () => ({
  flashAPIErrors: jest.fn(),
}));
import { flashAPIErrors } from '../../../shared/flash_messages';
```
becomes:
```js
import { mockKibanaValues, mockHttpValues, mockFlashMessageHelpers } from '../../../__mocks__';

const { history } = mockKibanaValues;
const { http } = mockHttpValues;
const { flashAPIErrors } = mockFlashMessageHelpers;
```

The latter is hopefully much cleaner and nicer to use - we shouldn't have to manually mock `XLogic.values` or `YLogic.actions` in the future, we just have to pull the existing mocked actions/values from our mock helpers. 🎉 

### Following along

I recommend following this PR by-commit since it touches so many different files.

### A warning about this approach

It's a fairly "hungry" change. I wasn't super familiar with how imports worked previously (I thought you had to statically import the entire file to get the `jest.mock()` functionality), but I'm definitely more familiar now. So here's the warning:

⚠️  **Any time that you import _anything_ from the `__mocks__` index folder, you are now automatically importing all the mocks for every single one of these shared logic files.** ⚠️ 

For the most part, this shouldn't be a huge deal. Mocks are a way of life in unit testing unless we are attempting to unit test the logic file itself, in which case we have a few options:

- Work around importing all mocks by importing only a very specific file within `__mocks__`, e.g. import specifically `__mocks__/http_logic.mock` which still retains the Kibana logic file as-is for example.
- Import all the `__mocks__`, but retain importing the actual file by importing from the `*_logic.ts` file directly - e.g., `import { HttpLogic } from 'shared/http/http_logic` instead of `shared/http` (since our mocks are mocking the `index.ts` obj, not the actual files).

See b49b877 as an example of the folder most affected by this hungry mocking - because some of these files do require pulling from the `__mocks__` folder to mock other logic/kea/etc, I had to change all test files to import the code they were testing directly from their source files to fix the tests.

Again, to reiterate, this should mostly only affect shared logic files, and I don't anticipate us adding a whole lot more of those. I think the tradeoff there (some extra consideration) vs 90% of the rest of the app gaining nicer dev QOL is worth it.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios