### PR TITLE
[APM UI] Remove unnecessary package usage 

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Links/apm/ExternalLinks.ts
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/ExternalLinks.ts
@@ -3,7 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import url from 'url';
 
 export const getTraceUrl = ({
   traceId,
@@ -14,8 +13,8 @@ export const getTraceUrl = ({
   rangeFrom: string;
   rangeTo: string;
 }) => {
-  return url.format({
-    pathname: `/link-to/trace/${traceId}`,
-    query: { rangeFrom, rangeTo },
-  });
+  return (
+    `/link-to/trace/${traceId}?` +
+    new URLSearchParams({ rangeFrom, rangeTo }).toString()
+  );
 };


### PR DESCRIPTION
## Summary

While refactoring https://github.com/elastic/kibana/pull/88645, i realised that this export is using an unnecessary package url. 

Node url package is anyway too old and i think it already removed from node, so it's a good riddance in any case.

This improves page load bundle size 
![image](https://user-images.githubusercontent.com/3505601/105027942-acec8f80-5a50-11eb-860c-b26998d10a78.png)

