### PR TITLE
[Security_Solution][Resolver] Fix Text Overflow

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/view/panels/breadcrumbs.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/breadcrumbs.tsx
@@ -11,7 +11,6 @@ import { EuiBreadcrumb, EuiBetaBadge } from '@elastic/eui';
 import React, { memo, useMemo } from 'react';
 import { BetaHeader, ThemedBreadcrumbs } from './styles';
 import { useColors } from '../use_colors';
-import { GeneratedText } from '../generated_text';
 
 /**
  * Breadcrumb menu
@@ -21,7 +20,8 @@ export const Breadcrumbs = memo(function ({ breadcrumbs }: { breadcrumbs: EuiBre
   const crumbsWithLastSubject: EuiBreadcrumb[] = useMemo(() => {
     const lastcrumb = breadcrumbs.slice(-1).map((crumb) => {
       crumb['data-test-subj'] = 'resolver:breadcrumbs:last';
-      crumb.text = <GeneratedText>{crumb.text}</GeneratedText>;
+      // Manually set here as setting truncate={true} on ThemedBreadcrumbs truncates all parts of the full path
+      crumb.truncate = true;
       return crumb;
     });
     return [...breadcrumbs.slice(0, -1), ...lastcrumb];


### PR DESCRIPTION
## Summary

Previous fix here: https://github.com/elastic/kibana/pull/86905, was incorrect: This PR fixes: elastic/eui#6277 by using `EuiBreadcrumb`'s truncate functionality

Examples of non-spaced text truncation:

<img width="546" alt="Screen Shot 2021-01-19 at 9 43 28 AM" src="https://user-images.githubusercontent.com/17211684/105050050-57f24e80-5a3b-11eb-954d-e6c2dfb7a8b8.png">

<img width="397" alt="Screen Shot 2021-01-19 at 9 41 39 AM" src="https://user-images.githubusercontent.com/17211684/105050061-5cb70280-5a3b-11eb-9b9d-66ea56f096bc.png">
