### PR TITLE
[7.x] [FTR] add custom runner and config to run load tests (#88409)

### DIFF
--- a/test/scripts/jenkins_build_load_testing.sh
+++ b/test/scripts/jenkins_build_load_testing.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+cd "$KIBANA_DIR"
+source src/dev/ci_setup/setup_env.sh
+
+if [[ ! "$TASK_QUEUE_PROCESS_ID" ]]; then
+  ./test/scripts/jenkins_xpack_build_plugins.sh
+fi
+
+# doesn't persist, also set in kibanaPipeline.groovy
+export KBN_NP_PLUGINS_BUILT=true
+
+echo " -> building and extracting default Kibana distributable for use in functional tests"
+cd "$KIBANA_DIR"
+node scripts/build --debug --no-oss
+linuxBuild="$(find "$KIBANA_DIR/target" -name 'kibana-*-linux-x86_64.tar.gz')"
+installDir="$KIBANA_DIR/install/kibana"
+mkdir -p "$installDir"
+tar -xzf "$linuxBuild" -C "$installDir" --strip=1
+
+mkdir -p "$WORKSPACE/kibana-build-xpack"
+cp -pR install/kibana/. $WORKSPACE/kibana-build-xpack/
+
+echo " -> test setup"
+source test/scripts/jenkins_test_setup_xpack.sh
+
+echo " -> run gatling load testing"
+node scripts/functional_tests \
+    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+    --config test/load/config.ts

--- a/x-pack/test/load/config.ts
+++ b/x-pack/test/load/config.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { resolve } from 'path';
+
+import { FtrConfigProviderContext } from '@kbn/test/types/ftr';
+import { GatlingTestRunner } from './runner';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const kibanaCommonTestsConfig = await readConfigFile(
+    require.resolve('../../../test/common/config.js')
+  );
+  const xpackFunctionalTestsConfig = await readConfigFile(
+    require.resolve('../functional/config.js')
+  );
+
+  return {
+    ...kibanaCommonTestsConfig.getAll(),
+
+    testRunner: GatlingTestRunner,
+
+    esArchiver: {
+      directory: resolve(__dirname, 'es_archives'),
+    },
+
+    screenshots: {
+      directory: resolve(__dirname, 'screenshots'),
+    },
+
+    esTestCluster: {
+      ...xpackFunctionalTestsConfig.get('esTestCluster'),
+      serverArgs: [...xpackFunctionalTestsConfig.get('esTestCluster.serverArgs')],
+    },
+
+    kbnTestServer: {
+      ...xpackFunctionalTestsConfig.get('kbnTestServer'),
+      sourceArgs: [
+        ...xpackFunctionalTestsConfig.get('kbnTestServer.sourceArgs'),
+        '--no-base-path',
+        '--env.name=development',
+      ],
+    },
+  };
+}

--- a/x-pack/test/load/runner.ts
+++ b/x-pack/test/load/runner.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { withProcRunner } from '@kbn/dev-utils';
+import { resolve } from 'path';
+import { REPO_ROOT } from '@kbn/utils';
+import { FtrProviderContext } from './../functional/ftr_provider_context';
+
+export async function GatlingTestRunner({ getService }: FtrProviderContext) {
+  const log = getService('log');
+  const gatlingProjectRootPath = resolve(REPO_ROOT, '../kibana-load-testing');
+
+  await withProcRunner(log, async (procs) => {
+    await procs.run('gatling', {
+      cmd: 'mvn',
+      args: [
+        'clean',
+        '-q',
+        '-Dmaven.test.failure.ignore=true',
+        'compile',
+        'gatling:test',
+        '-q',
+        '-Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney',
+      ],
+      cwd: gatlingProjectRootPath,
+      env: {
+        ...process.env,
+      },
+      wait: true,
+    });
+  });
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [FTR] add custom runner and config to run load tests (#88409)