### PR TITLE
[APM] Exclude cypress from APM-only tsconfig

### DIFF
--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/tsconfig.json
@@ -4,7 +4,11 @@
     "./plugins/observability/**/*",
     "./typings/**/*"
   ],
-  "exclude": ["**/__fixtures__/**/*", "./plugins/apm/e2e/cypress/**/*"],
+  "exclude": [
+    "**/__fixtures__/**/*",
+    "./plugins/apm/e2e",
+    "./plugins/apm/ftr_e2e"
+  ],
   "compilerOptions": {
     "noErrorTruncation": true
   }


### PR DESCRIPTION
If the ftr_e2e folder is not excluded from the optimized tsconfig, global cypress type are included and create a bunch of errors.