### PR TITLE
[Search Sessions] Add searchSessionId to Vega's inspector 

### DIFF
--- a/src/plugins/vis_type_vega/public/data_model/search_api.ts
+++ b/src/plugins/vis_type_vega/public/data_model/search_api.ts
@@ -45,7 +45,10 @@ export class SearchAPI {
         });
 
         if (this.inspectorAdapters) {
-          requestResponders[requestId] = this.inspectorAdapters.requests.start(requestId, request);
+          requestResponders[requestId] = this.inspectorAdapters.requests.start(requestId, {
+            ...request,
+            searchSessionId: this.searchSessionId,
+          });
           requestResponders[requestId].json(params.body);
         }
 


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/61738

While playing with search sessions I noticed that Vega uses inspector, but we don't pass `searchSessionId` into it

This pr add `searchSessionId` into Vega's inspector: 

![Screenshot 2021-01-20 at 14 55 11](https://user-images.githubusercontent.com/7784120/105186231-c9acc400-5b31-11eb-8ef9-b487d662affb.png)
