### PR TITLE
Skip snapshot_restore API integration tests in cloud

### DIFF
--- a/x-pack/test/api_integration/apis/management/snapshot_restore/snapshot_restore.ts
+++ b/x-pack/test/api_integration/apis/management/snapshot_restore/snapshot_restore.ts
@@ -24,6 +24,8 @@ export default function ({ getService }: FtrProviderContext) {
   } = registerEsHelpers(getService);
 
   describe('Snapshot Lifecycle Management', function () {
+    this.tags(['skipCloud']); // file system repositories are not supported in cloud
+
     before(async () => {
       try {
         await createRepository(REPO_NAME);


### PR DESCRIPTION
## Summary

This PR disables the snapshot restore API integration tests in cloud.

### Details

The shared file system repository that is used during this test suite is not supported in cloud deployments. I've double checked that with Cloud folks on slack.

Closes #86522
