### PR TITLE
added index raw doc option

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/es_index/es_index.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/es_index/es_index.tsx
@@ -54,17 +54,24 @@ export function getActionType(): ActionTypeModel<EsIndexConfig, unknown, IndexAc
     ): GenericValidationResult<IndexActionParams> => {
       const errors = {
         documents: new Array<string>(),
+        indexRawData: new Array<string>(),
       };
       const validationResult = { errors };
-      if (!actionParams.documents?.length || Object.keys(actionParams.documents[0]).length === 0) {
-        errors.documents.push(
-          i18n.translate(
-            'xpack.triggersActionsUI.components.builtinActionTypes.error.requiredDocumentJson',
-            {
-              defaultMessage: 'Document is required and should be a valid JSON object.',
-            }
-          )
-        );
+      if (!actionParams.indexRawData) {
+        // only require a document if raw isn't checked
+        if (
+          !actionParams.documents?.length ||
+          Object.keys(actionParams.documents[0]).length === 0
+        ) {
+          errors.documents.push(
+            i18n.translate(
+              'xpack.triggersActionsUI.components.builtinActionTypes.error.requiredDocumentJson',
+              {
+                defaultMessage: 'Document is required and should be a valid JSON object.',
+              }
+            )
+          );
+        }
       }
       return validationResult;
     },

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/es_index/es_index_params.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/es_index/es_index_params.tsx
@@ -3,8 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-import React from 'react';
-import { EuiLink } from '@elastic/eui';
+import React, { Fragment } from 'react';
+import { EuiLink, EuiSwitch, EuiSpacer, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { ActionParamsProps } from '../../../../types';
@@ -20,7 +20,7 @@ export const IndexParamsFields = ({
   errors,
 }: ActionParamsProps<IndexActionParams>) => {
   const { docLinks } = useKibana().services;
-  const { documents } = actionParams;
+  const { documents, indexRawData } = actionParams;
 
   const onDocumentsChange = (updatedDocuments: string) => {
     try {
@@ -33,51 +33,79 @@ export const IndexParamsFields = ({
   };
 
   return (
-    <JsonEditorWithMessageVariables
-      messageVariables={messageVariables}
-      paramsProperty={'documents'}
-      data-test-subj="documentToIndex"
-      inputTargetValue={
-        documents === null
-          ? '{}' // need this to trigger validation
-          : documents && documents.length > 0
-          ? ((documents[0] as unknown) as string)
-          : undefined
-      }
-      label={i18n.translate(
-        'xpack.triggersActionsUI.components.builtinActionTypes.indexAction.documentsFieldLabel',
-        {
-          defaultMessage: 'Document to index',
+    <Fragment>
+      <EuiSwitch
+        data-test-subj="indexRawCheckbox"
+        checked={indexRawData || false}
+        onChange={(e) => {
+          editAction('indexRawData', e.target.checked, index);
+        }}
+        label={
+          <>
+            <FormattedMessage
+              id="xpack.triggersActionsUI.components.builtinActionTypes.indexAction.indexRawDataLabel"
+              defaultMessage="Index Raw Data"
+            />{' '}
+            <EuiIconTip
+              position="right"
+              type="questionInCircle"
+              content={i18n.translate(
+                'xpack.triggersActionsUI.components.builtinActionTypes.indexAction.indexRawDataTooltip',
+                {
+                  defaultMessage: 'Index a document that contains all raw Alerting data',
+                }
+              )}
+            />
+          </>
         }
-      )}
-      aria-label={i18n.translate(
-        'xpack.triggersActionsUI.components.builtinActionTypes.indexAction.jsonDocAriaLabel',
-        {
-          defaultMessage: 'Code editor',
+      />
+      <EuiSpacer size="m" />
+      <JsonEditorWithMessageVariables
+        messageVariables={messageVariables}
+        paramsProperty={'documents'}
+        data-test-subj="documentToIndex"
+        inputTargetValue={
+          documents === null
+            ? '{}' // need this to trigger validation
+            : documents && documents.length > 0
+            ? ((documents[0] as unknown) as string)
+            : undefined
         }
-      )}
-      errors={errors.documents as string[]}
-      onDocumentsChange={onDocumentsChange}
-      helpText={
-        <EuiLink
-          href={`${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/index-action-type.html#index-action-configuration`}
-          target="_blank"
-        >
-          <FormattedMessage
-            id="xpack.triggersActionsUI.components.builtinActionTypes.indexAction.indexDocumentHelpLabel"
-            defaultMessage="Index document example."
-          />
-        </EuiLink>
-      }
-      onBlur={() => {
-        if (
-          !(documents && documents.length > 0 ? ((documents[0] as unknown) as string) : undefined)
-        ) {
-          // set document as empty to turn on the validation for non empty valid JSON object
-          onDocumentsChange('{}');
+        label={i18n.translate(
+          'xpack.triggersActionsUI.components.builtinActionTypes.indexAction.documentsFieldLabel',
+          {
+            defaultMessage: 'Document to index',
+          }
+        )}
+        aria-label={i18n.translate(
+          'xpack.triggersActionsUI.components.builtinActionTypes.indexAction.jsonDocAriaLabel',
+          {
+            defaultMessage: 'Code editor',
+          }
+        )}
+        errors={errors.documents as string[]}
+        onDocumentsChange={onDocumentsChange}
+        helpText={
+          <EuiLink
+            href={`${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/index-action-type.html#index-action-configuration`}
+            target="_blank"
+          >
+            <FormattedMessage
+              id="xpack.triggersActionsUI.components.builtinActionTypes.indexAction.indexDocumentHelpLabel"
+              defaultMessage="Index document example."
+            />
+          </EuiLink>
         }
-      }}
-    />
+        onBlur={() => {
+          if (
+            !(documents && documents.length > 0 ? ((documents[0] as unknown) as string) : undefined)
+          ) {
+            // set document as empty to turn on the validation for non empty valid JSON object
+            onDocumentsChange('{}');
+          }
+        }}
+      />
+    </Fragment>
   );
 };
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/builtin_action_types/types.ts
@@ -40,6 +40,7 @@ export interface PagerDutyActionParams {
 
 export interface IndexActionParams {
   documents: Array<Record<string, any>>;
+  indexRawData: boolean;
 }
 
 export enum ServerLogLevelOptions {


### PR DESCRIPTION
## Summary

THIS IS JUST A POC, NOT TO BE MERGED

This adds an option to index a Raw document of all the alert's available actionVariables into a single document as-is when the alert fires.


<img width="475" alt="Screenshot 2021-01-20 at 18 25 29" src="https://user-images.githubusercontent.com/386208/105218403-04702580-5b4d-11eb-9125-9e4d4802f966.png">
<img width="816" alt="Screenshot 2021-01-20 at 18 26 03" src="https://user-images.githubusercontent.com/386208/105218426-0a660680-5b4d-11eb-90a4-477b19cf6b09.png">
<img width="1871" alt="Screenshot 2021-01-20 at 18 26 11" src="https://user-images.githubusercontent.com/386208/105218432-0cc86080-5b4d-11eb-9e8c-9f56c9243208.png">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be whitelisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)