### PR TITLE
[Workplace Search] Update routes to use new encodePathParams helper

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -20,10 +20,10 @@ interface ConstructorDependencies {
   config: ConfigType;
   log: Logger;
 }
-interface RequestParams<ResponseBody> {
+interface RequestParams {
   path: string;
   params?: object;
-  hasValidData?: (body?: ResponseBody) => boolean;
+  hasValidData?: Function;
 }
 interface ErrorResponse {
   message: string;
@@ -32,7 +32,7 @@ interface ErrorResponse {
   };
 }
 export interface IEnterpriseSearchRequestHandler {
-  createRequest(requestParams?: object): RequestHandler<unknown, unknown, unknown>;
+  createRequest(requestParams?: RequestParams): RequestHandler<unknown, unknown, unknown>;
 }
 
 /**
@@ -53,11 +53,7 @@ export class EnterpriseSearchRequestHandler {
     this.enterpriseSearchUrl = config.host as string;
   }
 
-  createRequest<ResponseBody>({
-    path,
-    params = {},
-    hasValidData = () => true,
-  }: RequestParams<ResponseBody>) {
+  createRequest({ path, params = {}, hasValidData = () => true }: RequestParams) {
     return async (
       _context: RequestHandlerContext,
       request: KibanaRequest<unknown, unknown, unknown>,

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.test.ts
@@ -22,9 +22,6 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/groups',
@@ -35,7 +32,9 @@ describe('groups routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/groups',
       });
@@ -60,16 +59,19 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        body: {
-          group_name: 'group',
-        },
-      };
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/groups',
-        ...mockRequest,
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            group_name: 'group',
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -92,24 +94,8 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        body: {
-          page: {
-            current: 1,
-            size: 1,
-          },
-          search: {
-            query: 'foo',
-            content_source_ids: ['123', '234'],
-            user_ids: ['345', '456'],
-          },
-        },
-      };
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/groups/search',
-        ...mockRequest,
       });
     });
 
@@ -150,30 +136,20 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/groups/{id}',
-        payload: 'params',
       });
 
       registerGroupRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123',
+        path: '/ws/org/groups/:id',
       });
     });
   });
@@ -183,15 +159,6 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    const mockPayload = {
-      group: {
-        name: 'group',
-      },
-    };
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
         path: '/api/workplace_search/groups/{id}',
@@ -202,19 +169,24 @@ describe('groups routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-        body: mockPayload,
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123',
-        body: mockPayload,
+        path: '/ws/org/groups/:id',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            group: {
+              name: 'group',
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -227,7 +199,6 @@ describe('groups routes', () => {
       mockRouter = new MockRouter({
         method: 'delete',
         path: '/api/workplace_search/groups/{id}',
-        payload: 'params',
       });
 
       registerGroupRoute({
@@ -237,16 +208,8 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123',
+        path: '/ws/org/groups/:id',
       });
     });
   });
@@ -256,30 +219,20 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/groups/{id}/group_users',
-        payload: 'params',
       });
 
       registerGroupUsersRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123/group_users',
+        path: '/ws/org/groups/:id/group_users',
       });
     });
   });
@@ -302,18 +255,20 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          content_source_ids: ['123', '234'],
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123/share',
-        body: mockRequest.body,
+        path: '/ws/org/groups/:id/share',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          params: { id: '123' },
+          body: {
+            content_source_ids: ['123', '234'],
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -336,18 +291,20 @@ describe('groups routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          user_ids: ['123', '234'],
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123/assign',
-        body: mockRequest.body,
+        path: '/ws/org/groups/:id/assign',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          params: { id: '123' },
+          body: {
+            user_ids: ['123', '234'],
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -357,15 +314,6 @@ describe('groups routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    const mockPayload = {
-      group: {
-        content_source_boosts: [['boost'], ['boost2', 'boost3']],
-      },
-    };
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
         path: '/api/workplace_search/groups/{id}/boosts',
@@ -376,19 +324,22 @@ describe('groups routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-        body: mockPayload,
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/groups/123/update_source_boosts',
-        body: mockPayload,
+        path: '/ws/org/groups/:id/update_source_boosts',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            content_source_boosts: [['boost'], ['boost2', 'boost3']],
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/groups.ts
@@ -28,12 +28,9 @@ export function registerGroupsRoute({ router, enterpriseSearchRequestHandler }: 
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/groups',
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups',
+    })
   );
 }
 
@@ -58,12 +55,9 @@ export function registerSearchGroupsRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/groups/search',
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/search',
+    })
   );
 }
 
@@ -77,11 +71,9 @@ export function registerGroupRoute({ router, enterpriseSearchRequestHandler }: R
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id',
+    })
   );
 
   router.put(
@@ -98,12 +90,9 @@ export function registerGroupRoute({ router, enterpriseSearchRequestHandler }: R
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id',
+    })
   );
 
   router.delete(
@@ -115,11 +104,9 @@ export function registerGroupRoute({ router, enterpriseSearchRequestHandler }: R
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id',
+    })
   );
 }
 
@@ -136,11 +123,9 @@ export function registerGroupUsersRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}/group_users`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id/group_users',
+    })
   );
 }
 
@@ -160,12 +145,9 @@ export function registerShareGroupRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}/share`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id/share',
+    })
   );
 }
 
@@ -185,12 +167,9 @@ export function registerAssignGroupRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}/assign`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id/assign',
+    })
   );
 }
 
@@ -212,12 +191,9 @@ export function registerBoostsGroupRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/groups/${request.params.id}/update_source_boosts`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/groups/:id/update_source_boosts',
+    })
   );
 }
 

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.test.ts
@@ -18,22 +18,18 @@ describe('settings routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/settings',
-        payload: 'params',
       });
 
       registerOrgSettingsRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      mockRouter.callRoute({});
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/settings',
       });
@@ -45,9 +41,6 @@ describe('settings routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
         path: '/api/workplace_search/org/settings/customize',
@@ -58,18 +51,18 @@ describe('settings routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        body: {
-          name: 'foo',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/settings/customize',
-        body: mockRequest.body,
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: { name: 'foo' } };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -79,9 +72,6 @@ describe('settings routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
         path: '/api/workplace_search/org/settings/oauth_application',
@@ -92,22 +82,26 @@ describe('settings routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        body: {
-          oauth_application: {
-            name: 'foo',
-            confidential: true,
-            redirect_uri: 'http://foo.bar',
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/settings/oauth_application',
-        body: mockRequest.body,
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            oauth_application: {
+              name: 'foo',
+              confidential: true,
+              redirect_uri: 'http://foo.bar',
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/settings.ts
@@ -17,11 +17,9 @@ export function registerOrgSettingsRoute({
       path: '/api/workplace_search/org/settings',
       validate: false,
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/settings',
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings',
+    })
   );
 }
 
@@ -38,12 +36,9 @@ export function registerOrgSettingsCustomizeRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/settings/customize',
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/customize',
+    })
   );
 }
 
@@ -64,12 +59,9 @@ export function registerOrgSettingsOauthApplicationRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/settings/oauth_application',
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/oauth_application',
+    })
   );
 }
 

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -57,22 +57,18 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources',
-        payload: 'params',
       });
 
       registerAccountSourcesRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      mockRouter.callRoute({});
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/sources',
       });
@@ -84,22 +80,18 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources/status',
-        payload: 'params',
       });
 
       registerAccountSourcesStatusRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      mockRouter.callRoute({});
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/sources/status',
       });
@@ -111,30 +103,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources/{id}',
-        payload: 'params',
       });
 
       registerAccountSourceRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123',
+        path: '/ws/sources/:id',
       });
     });
   });
@@ -147,7 +129,6 @@ describe('sources routes', () => {
       mockRouter = new MockRouter({
         method: 'delete',
         path: '/api/workplace_search/account/sources/{id}',
-        payload: 'params',
       });
 
       registerAccountSourceRoute({
@@ -157,16 +138,8 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123',
+        path: '/ws/sources/:id',
       });
     });
   });
@@ -189,22 +162,24 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        body: {
-          service_type: 'google',
-          name: 'Google',
-          login: 'user',
-          password: 'changeme',
-          organizations: 'swiftype',
-          indexPermissions: true,
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/sources/form_create',
-        body: mockRequest.body,
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            service_type: 'google',
+            name: 'Google',
+            login: 'user',
+            password: 'changeme',
+            organizations: ['swiftype'],
+            indexPermissions: true,
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -227,24 +202,25 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          query: 'foo',
-          page: {
-            current: 1,
-            size: 10,
-            total_pages: 1,
-            total_results: 10,
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/documents',
-        body: mockRequest.body,
+        path: '/ws/sources/:id/documents',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            query: 'foo',
+            page: {
+              current: 1,
+              size: 10,
+              total_pages: 1,
+              total_results: 10,
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -254,30 +230,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources/{id}/federated_summary',
-        payload: 'params',
       });
 
       registerAccountSourceFederatedSummaryRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/federated_summary',
+        path: '/ws/sources/:id/federated_summary',
       });
     });
   });
@@ -287,30 +253,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources/{id}/reauth_prepare',
-        payload: 'params',
       });
 
       registerAccountSourceReauthPrepareRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/reauth_prepare',
+        path: '/ws/sources/:id/reauth_prepare',
       });
     });
   });
@@ -333,20 +289,21 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          content_source: {
-            name: 'foo',
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/settings',
-        body: mockRequest.body,
+        path: '/ws/sources/:id/settings',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            content_source: {
+              name: 'foo',
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -356,63 +313,43 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/pre_sources/{id}',
-        payload: 'params',
       });
 
       registerAccountPreSourceRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/pre_content_sources/123',
+        path: '/ws/pre_content_sources/:id',
       });
     });
   });
 
-  describe('GET /api/workplace_search/account/sources/{service_type}/prepare', () => {
+  describe('GET /api/workplace_search/account/sources/{serviceType}/prepare', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/account/sources/{service_type}/prepare',
-        payload: 'params',
+        path: '/api/workplace_search/account/sources/{serviceType}/prepare',
       });
 
       registerAccountPrepareSourcesRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          service_type: 'zendesk',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/zendesk/prepare',
+        path: '/ws/sources/:serviceType/prepare',
       });
     });
   });
@@ -422,9 +359,6 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
         path: '/api/workplace_search/account/sources/{id}/searchable',
@@ -435,21 +369,22 @@ describe('sources routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-        body: {
-          searchable: true,
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/searchable',
-        body: mockRequest.body,
+        path: '/ws/sources/:id/searchable',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            searchable: true,
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -459,30 +394,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources/{id}/display_settings/config',
-        payload: 'params',
       });
 
       registerAccountSourceDisplaySettingsConfig({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/display_settings/config',
+        path: '/ws/sources/:id/display_settings/config',
       });
     });
   });
@@ -505,26 +430,28 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          titleField: 'foo',
-          subtitleField: 'bar',
-          descriptionField: 'this is a thing',
-          urlField: 'http://youknowfor.search',
-          color: '#aaa',
-          detailFields: {
-            fieldName: 'myField',
-            label: 'My Field',
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/display_settings/config',
-        body: mockRequest.body,
+        path: '/ws/sources/:id/display_settings/config',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            titleField: 'foo',
+            subtitleField: 'bar',
+            descriptionField: 'this is a thing',
+            urlField: 'http://youknowfor.search',
+            urlFieldIsLinkable: true,
+            color: '#aaa',
+            detailFields: {
+              fieldName: 'myField',
+              label: 'My Field',
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -534,30 +461,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/account/sources/{id}/schemas',
-        payload: 'params',
       });
 
       registerAccountSourceSchemasRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/schemas',
+        path: '/ws/sources/:id/schemas',
       });
     });
   });
@@ -580,84 +497,70 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {},
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/schemas',
-        body: mockRequest.body,
+        path: '/ws/sources/:id/schemas',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: { someSchemaKey: 'text' } };
+        mockRouter.shouldValidate(request);
       });
     });
   });
 
-  describe('GET /api/workplace_search/account/sources/{source_id}/reindex_job/{job_id}', () => {
+  describe('GET /api/workplace_search/account/sources/{sourceId}/reindex_job/{jobId}', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/account/sources/{source_id}/reindex_job/{job_id}',
-        payload: 'params',
+        path: '/api/workplace_search/account/sources/{sourceId}/reindex_job/{jobId}',
       });
 
       registerAccountSourceReindexJobRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
+    it('creates a request handler', () => {
       const mockRequest = {
         params: {
-          source_id: '123',
-          job_id: '345',
+          sourceId: '123',
+          jobId: '345',
         },
       };
 
       mockRouter.callRoute(mockRequest);
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/reindex_job/345',
+        path: '/ws/sources/:sourceId/reindex_job/:jobId',
       });
     });
   });
 
-  describe('GET /api/workplace_search/account/sources/{source_id}/reindex_job/{job_id}/status', () => {
+  describe('GET /api/workplace_search/account/sources/{sourceId}/reindex_job/{jobId}/status', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/account/sources/{source_id}/reindex_job/{job_id}/status',
-        payload: 'params',
+        path: '/api/workplace_search/account/sources/{sourceId}/reindex_job/{jobId}/status',
       });
 
       registerAccountSourceReindexJobStatusRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          source_id: '123',
-          job_id: '345',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/sources/123/reindex_job/345/status',
+        path: '/ws/sources/:sourceId/reindex_job/:jobId/status',
       });
     });
   });
@@ -667,22 +570,18 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources',
-        payload: 'params',
       });
 
       registerOrgSourcesRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      mockRouter.callRoute({});
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/sources',
       });
@@ -694,22 +593,18 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources/status',
-        payload: 'params',
       });
 
       registerOrgSourcesStatusRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      mockRouter.callRoute({});
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/sources/status',
       });
@@ -721,30 +616,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources/{id}',
-        payload: 'params',
       });
 
       registerOrgSourceRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123',
+        path: '/ws/org/sources/:id',
       });
     });
   });
@@ -757,7 +642,6 @@ describe('sources routes', () => {
       mockRouter = new MockRouter({
         method: 'delete',
         path: '/api/workplace_search/org/sources/{id}',
-        payload: 'params',
       });
 
       registerOrgSourceRoute({
@@ -767,16 +651,8 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123',
+        path: '/ws/org/sources/:id',
       });
     });
   });
@@ -799,22 +675,24 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        body: {
-          service_type: 'google',
-          name: 'Google',
-          login: 'user',
-          password: 'changeme',
-          organizations: 'swiftype',
-          indexPermissions: true,
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/sources/form_create',
-        body: mockRequest.body,
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            service_type: 'google',
+            name: 'Google',
+            login: 'user',
+            password: 'changeme',
+            organizations: ['swiftype'],
+            indexPermissions: true,
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -837,24 +715,25 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          query: 'foo',
-          page: {
-            current: 1,
-            size: 10,
-            total_pages: 1,
-            total_results: 10,
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/documents',
-        body: mockRequest.body,
+        path: '/ws/org/sources/:id/documents',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            query: 'foo',
+            page: {
+              current: 1,
+              size: 10,
+              total_pages: 1,
+              total_results: 10,
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -864,30 +743,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources/{id}/federated_summary',
-        payload: 'params',
       });
 
       registerOrgSourceFederatedSummaryRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/federated_summary',
+        path: '/ws/org/sources/:id/federated_summary',
       });
     });
   });
@@ -897,30 +766,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources/{id}/reauth_prepare',
-        payload: 'params',
       });
 
       registerOrgSourceReauthPrepareRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/reauth_prepare',
+        path: '/ws/org/sources/:id/reauth_prepare',
       });
     });
   });
@@ -943,20 +802,21 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          content_source: {
-            name: 'foo',
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/settings',
-        body: mockRequest.body,
+        path: '/ws/org/sources/:id/settings',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            content_source: {
+              name: 'foo',
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -966,63 +826,43 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/pre_sources/{id}',
-        payload: 'params',
       });
 
       registerOrgPreSourceRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/pre_content_sources/123',
+        path: '/ws/org/pre_content_sources/:id',
       });
     });
   });
 
-  describe('GET /api/workplace_search/org/sources/{service_type}/prepare', () => {
+  describe('GET /api/workplace_search/org/sources/{serviceType}/prepare', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/org/sources/{service_type}/prepare',
-        payload: 'params',
+        path: '/api/workplace_search/org/sources/{serviceType}/prepare',
       });
 
       registerOrgPrepareSourcesRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          service_type: 'zendesk',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/zendesk/prepare',
+        path: '/ws/org/sources/:serviceType/prepare',
       });
     });
   });
@@ -1032,9 +872,6 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
         path: '/api/workplace_search/org/sources/{id}/searchable',
@@ -1045,21 +882,22 @@ describe('sources routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-        body: {
-          searchable: true,
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/searchable',
-        body: mockRequest.body,
+        path: '/ws/org/sources/:id/searchable',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            searchable: true,
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -1069,30 +907,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources/{id}/display_settings/config',
-        payload: 'params',
       });
 
       registerOrgSourceDisplaySettingsConfig({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/display_settings/config',
+        path: '/ws/org/sources/:id/display_settings/config',
       });
     });
   });
@@ -1115,26 +943,28 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {
-          titleField: 'foo',
-          subtitleField: 'bar',
-          descriptionField: 'this is a thing',
-          urlField: 'http://youknowfor.search',
-          color: '#aaa',
-          detailFields: {
-            fieldName: 'myField',
-            label: 'My Field',
-          },
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/display_settings/config',
-        body: mockRequest.body,
+        path: '/ws/org/sources/:id/display_settings/config',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            titleField: 'foo',
+            subtitleField: 'bar',
+            descriptionField: 'this is a thing',
+            urlField: 'http://youknowfor.search',
+            urlFieldIsLinkable: true,
+            color: '#aaa',
+            detailFields: {
+              fieldName: 'myField',
+              label: 'My Field',
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
       });
     });
   });
@@ -1144,30 +974,20 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/sources/{id}/schemas',
-        payload: 'params',
       });
 
       registerOrgSourceSchemasRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          id: '123',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/schemas',
+        path: '/ws/org/sources/:id/schemas',
       });
     });
   });
@@ -1190,84 +1010,61 @@ describe('sources routes', () => {
     });
 
     it('creates a request handler', () => {
-      const mockRequest = {
-        params: { id: '123' },
-        body: {},
-      };
-
-      mockRouter.callRoute(mockRequest);
-
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/schemas',
-        body: mockRequest.body,
+        path: '/ws/org/sources/:id/schemas',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: { someSchemaKey: 'number' } };
+        mockRouter.shouldValidate(request);
       });
     });
   });
 
-  describe('GET /api/workplace_search/org/sources/{source_id}/reindex_job/{job_id}', () => {
+  describe('GET /api/workplace_search/org/sources/{sourceId}/reindex_job/{jobId}', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/org/sources/{source_id}/reindex_job/{job_id}',
-        payload: 'params',
+        path: '/api/workplace_search/org/sources/{sourceId}/reindex_job/{jobId}',
       });
 
       registerOrgSourceReindexJobRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          source_id: '123',
-          job_id: '345',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/reindex_job/345',
+        path: '/ws/org/sources/:sourceId/reindex_job/:jobId',
       });
     });
   });
 
-  describe('GET /api/workplace_search/org/sources/{source_id}/reindex_job/{job_id}/status', () => {
+  describe('GET /api/workplace_search/org/sources/{sourceId}/reindex_job/{jobId}/status', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/org/sources/{source_id}/reindex_job/{job_id}/status',
-        payload: 'params',
+        path: '/api/workplace_search/org/sources/{sourceId}/reindex_job/{jobId}/status',
       });
 
       registerOrgSourceReindexJobStatusRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          source_id: '123',
-          job_id: '345',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/sources/123/reindex_job/345/status',
+        path: '/ws/org/sources/:sourceId/reindex_job/:jobId/status',
       });
     });
   });
@@ -1277,9 +1074,6 @@ describe('sources routes', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
         path: '/api/workplace_search/org/settings/connectors',
@@ -1289,59 +1083,46 @@ describe('sources routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      mockRouter.callRoute({});
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/settings/connectors',
       });
     });
   });
 
-  describe('GET /api/workplace_search/org/settings/connectors/{service_type}', () => {
+  describe('GET /api/workplace_search/org/settings/connectors/{serviceType}', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'get',
-        path: '/api/workplace_search/org/settings/connectors/{service_type}',
-        payload: 'params',
+        path: '/api/workplace_search/org/settings/connectors/{serviceType}',
       });
 
       registerOrgSourceOauthConfigurationRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          service_type: 'zendesk',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/settings/connectors/zendesk',
+        path: '/ws/org/settings/connectors/:serviceType',
       });
     });
   });
 
-  describe('POST /api/workplace_search/org/settings/connectors/{service_type}', () => {
+  describe('POST /api/workplace_search/org/settings/connectors/{serviceType}', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'post',
-        path: '/api/workplace_search/org/settings/connectors/{service_type}',
+        path: '/api/workplace_search/org/settings/connectors/{serviceType}',
         payload: 'body',
       });
 
@@ -1349,34 +1130,30 @@ describe('sources routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          service_type: 'zendesk',
-        },
-        body: mockConfig,
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/settings/connectors/zendesk',
-        body: mockRequest.body,
+        path: '/ws/org/settings/connectors/:serviceType',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: mockConfig };
+        mockRouter.shouldValidate(request);
       });
     });
   });
 
-  describe('PUT /api/workplace_search/org/settings/connectors/{service_type}', () => {
+  describe('PUT /api/workplace_search/org/settings/connectors/{serviceType}', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'put',
-        path: '/api/workplace_search/org/settings/connectors/{service_type}',
+        path: '/api/workplace_search/org/settings/connectors/{serviceType}',
         payload: 'body',
       });
 
@@ -1384,52 +1161,41 @@ describe('sources routes', () => {
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          service_type: 'zendesk',
-        },
-        body: mockConfig,
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/settings/connectors/zendesk',
-        body: mockRequest.body,
+        path: '/ws/org/settings/connectors/:serviceType',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: mockConfig };
+        mockRouter.shouldValidate(request);
       });
     });
   });
 
-  describe('DELETE /api/workplace_search/org/settings/connectors/{service_type}', () => {
+  describe('DELETE /api/workplace_search/org/settings/connectors/{serviceType}', () => {
     let mockRouter: MockRouter;
 
     beforeEach(() => {
       jest.clearAllMocks();
-    });
-
-    it('creates a request handler', () => {
       mockRouter = new MockRouter({
         method: 'delete',
-        path: '/api/workplace_search/org/settings/connectors/{service_type}',
-        payload: 'params',
+        path: '/api/workplace_search/org/settings/connectors/{serviceType}',
       });
 
       registerOrgSourceOauthConfigurationRoute({
         ...mockDependencies,
         router: mockRouter.router,
       });
+    });
 
-      const mockRequest = {
-        params: {
-          service_type: 'zendesk',
-        },
-      };
-
-      mockRouter.callRoute(mockRequest);
-
+    it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/ws/org/settings/connectors/zendesk',
+        path: '/ws/org/settings/connectors/:serviceType',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -59,11 +59,9 @@ export function registerAccountSourcesRoute({
       path: '/api/workplace_search/account/sources',
       validate: false,
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/sources',
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources',
+    })
   );
 }
 
@@ -76,11 +74,9 @@ export function registerAccountSourcesStatusRoute({
       path: '/api/workplace_search/account/sources/status',
       validate: false,
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/sources/status',
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/status',
+    })
   );
 }
 
@@ -97,11 +93,9 @@ export function registerAccountSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id',
+    })
   );
 
   router.delete(
@@ -113,11 +107,9 @@ export function registerAccountSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id',
+    })
   );
 }
 
@@ -139,12 +131,9 @@ export function registerAccountCreateSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/sources/form_create',
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/form_create',
+    })
   );
 }
 
@@ -165,12 +154,9 @@ export function registerAccountSourceDocumentsRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/documents`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/documents',
+    })
   );
 }
 
@@ -187,11 +173,9 @@ export function registerAccountSourceFederatedSummaryRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/federated_summary`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/federated_summary',
+    })
   );
 }
 
@@ -208,11 +192,9 @@ export function registerAccountSourceReauthPrepareRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/reauth_prepare`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/reauth_prepare',
+    })
   );
 }
 
@@ -234,12 +216,9 @@ export function registerAccountSourceSettingsRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/settings`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/settings',
+    })
   );
 }
 
@@ -256,11 +235,9 @@ export function registerAccountPreSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/pre_content_sources/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/pre_content_sources/:id',
+    })
   );
 }
 
@@ -270,18 +247,16 @@ export function registerAccountPrepareSourcesRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/account/sources/{service_type}/prepare',
+      path: '/api/workplace_search/account/sources/{serviceType}/prepare',
       validate: {
         params: schema.object({
-          service_type: schema.string(),
+          serviceType: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.service_type}/prepare`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:serviceType/prepare',
+    })
   );
 }
 
@@ -301,12 +276,9 @@ export function registerAccountSourceSearchableRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/searchable`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/searchable',
+    })
   );
 }
 
@@ -323,11 +295,9 @@ export function registerAccountSourceDisplaySettingsConfig({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/display_settings/config`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/display_settings/config',
+    })
   );
 
   router.post(
@@ -340,12 +310,9 @@ export function registerAccountSourceDisplaySettingsConfig({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/display_settings/config`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/display_settings/config',
+    })
   );
 }
 
@@ -362,11 +329,9 @@ export function registerAccountSourceSchemasRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/schemas`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/schemas',
+    })
   );
 
   router.post(
@@ -379,12 +344,9 @@ export function registerAccountSourceSchemasRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.id}/schemas`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:id/schemas',
+    })
   );
 }
 
@@ -394,19 +356,17 @@ export function registerAccountSourceReindexJobRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/account/sources/{source_id}/reindex_job/{job_id}',
+      path: '/api/workplace_search/account/sources/{sourceId}/reindex_job/{jobId}',
       validate: {
         params: schema.object({
-          source_id: schema.string(),
-          job_id: schema.string(),
+          sourceId: schema.string(),
+          jobId: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.source_id}/reindex_job/${request.params.job_id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:sourceId/reindex_job/:jobId',
+    })
   );
 }
 
@@ -416,19 +376,17 @@ export function registerAccountSourceReindexJobStatusRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/account/sources/{source_id}/reindex_job/{job_id}/status',
+      path: '/api/workplace_search/account/sources/{sourceId}/reindex_job/{jobId}/status',
       validate: {
         params: schema.object({
-          source_id: schema.string(),
-          job_id: schema.string(),
+          sourceId: schema.string(),
+          jobId: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/sources/${request.params.source_id}/reindex_job/${request.params.job_id}/status`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:sourceId/reindex_job/:jobId/status',
+    })
   );
 }
 
@@ -441,11 +399,9 @@ export function registerOrgSourcesRoute({
       path: '/api/workplace_search/org/sources',
       validate: false,
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/sources',
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources',
+    })
   );
 }
 
@@ -458,11 +414,9 @@ export function registerOrgSourcesStatusRoute({
       path: '/api/workplace_search/org/sources/status',
       validate: false,
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/sources/status',
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/status',
+    })
   );
 }
 
@@ -479,11 +433,9 @@ export function registerOrgSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id',
+    })
   );
 
   router.delete(
@@ -495,11 +447,9 @@ export function registerOrgSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id',
+    })
   );
 }
 
@@ -521,12 +471,9 @@ export function registerOrgCreateSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/sources/form_create',
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/form_create',
+    })
   );
 }
 
@@ -547,12 +494,9 @@ export function registerOrgSourceDocumentsRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/documents`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/documents',
+    })
   );
 }
 
@@ -569,11 +513,9 @@ export function registerOrgSourceFederatedSummaryRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/federated_summary`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/federated_summary',
+    })
   );
 }
 
@@ -590,11 +532,9 @@ export function registerOrgSourceReauthPrepareRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/reauth_prepare`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/reauth_prepare',
+    })
   );
 }
 
@@ -616,12 +556,9 @@ export function registerOrgSourceSettingsRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/settings`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/settings',
+    })
   );
 }
 
@@ -638,11 +575,9 @@ export function registerOrgPreSourceRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/pre_content_sources/${request.params.id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/pre_content_sources/:id',
+    })
   );
 }
 
@@ -652,18 +587,16 @@ export function registerOrgPrepareSourcesRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/org/sources/{service_type}/prepare',
+      path: '/api/workplace_search/org/sources/{serviceType}/prepare',
       validate: {
         params: schema.object({
-          service_type: schema.string(),
+          serviceType: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.service_type}/prepare`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:serviceType/prepare',
+    })
   );
 }
 
@@ -683,12 +616,9 @@ export function registerOrgSourceSearchableRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/searchable`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/searchable',
+    })
   );
 }
 
@@ -705,11 +635,9 @@ export function registerOrgSourceDisplaySettingsConfig({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/display_settings/config`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/display_settings/config',
+    })
   );
 
   router.post(
@@ -722,12 +650,9 @@ export function registerOrgSourceDisplaySettingsConfig({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/display_settings/config`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/display_settings/config',
+    })
   );
 }
 
@@ -744,11 +669,9 @@ export function registerOrgSourceSchemasRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/schemas`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/schemas',
+    })
   );
 
   router.post(
@@ -761,12 +684,9 @@ export function registerOrgSourceSchemasRoute({
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.id}/schemas`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:id/schemas',
+    })
   );
 }
 
@@ -776,19 +696,17 @@ export function registerOrgSourceReindexJobRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/org/sources/{source_id}/reindex_job/{job_id}',
+      path: '/api/workplace_search/org/sources/{sourceId}/reindex_job/{jobId}',
       validate: {
         params: schema.object({
-          source_id: schema.string(),
-          job_id: schema.string(),
+          sourceId: schema.string(),
+          jobId: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.source_id}/reindex_job/${request.params.job_id}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:sourceId/reindex_job/:jobId',
+    })
   );
 }
 
@@ -798,19 +716,17 @@ export function registerOrgSourceReindexJobStatusRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/org/sources/{source_id}/reindex_job/{job_id}/status',
+      path: '/api/workplace_search/org/sources/{sourceId}/reindex_job/{jobId}/status',
       validate: {
         params: schema.object({
-          source_id: schema.string(),
-          job_id: schema.string(),
+          sourceId: schema.string(),
+          jobId: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/sources/${request.params.source_id}/reindex_job/${request.params.job_id}/status`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:sourceId/reindex_job/:jobId/status',
+    })
   );
 }
 
@@ -823,11 +739,9 @@ export function registerOrgSourceOauthConfigurationsRoute({
       path: '/api/workplace_search/org/settings/connectors',
       validate: false,
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: '/ws/org/settings/connectors',
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors',
+    })
   );
 }
 
@@ -837,70 +751,60 @@ export function registerOrgSourceOauthConfigurationRoute({
 }: RouteDependencies) {
   router.get(
     {
-      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      path: '/api/workplace_search/org/settings/connectors/{serviceType}',
       validate: {
         params: schema.object({
-          service_type: schema.string(),
+          serviceType: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/settings/connectors/${request.params.service_type}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors/:serviceType',
+    })
   );
 
   router.post(
     {
-      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      path: '/api/workplace_search/org/settings/connectors/{serviceType}',
       validate: {
         params: schema.object({
-          service_type: schema.string(),
+          serviceType: schema.string(),
         }),
         body: oAuthConfigSchema,
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/settings/connectors/${request.params.service_type}`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors/:serviceType',
+    })
   );
 
   router.put(
     {
-      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      path: '/api/workplace_search/org/settings/connectors/{serviceType}',
       validate: {
         params: schema.object({
-          service_type: schema.string(),
+          serviceType: schema.string(),
         }),
         body: oAuthConfigSchema,
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/settings/connectors/${request.params.service_type}`,
-        body: request.body,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors/:serviceType',
+    })
   );
 
   router.delete(
     {
-      path: '/api/workplace_search/org/settings/connectors/{service_type}',
+      path: '/api/workplace_search/org/settings/connectors/{serviceType}',
       validate: {
         params: schema.object({
-          service_type: schema.string(),
+          serviceType: schema.string(),
         }),
       },
     },
-    async (context, request, response) => {
-      return enterpriseSearchRequestHandler.createRequest({
-        path: `/ws/org/settings/connectors/${request.params.service_type}`,
-      })(context, request, response);
-    }
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors/:serviceType',
+    })
   );
 }
 


### PR DESCRIPTION
## Summary

This PR is the Workplace Search follow up for https://github.com/elastic/kibana/pull/88648. The `encodePathParams` helper simplifies path forwarding like so:

### Before:
```js
    async (context, request, response) => {
      return enterpriseSearchRequestHandler.createRequest({
        path: `/ws/sources/${request.params.id}/something`,
      })(context, request, response);
    }
```

### After
```js
    enterpriseSearchRequestHandler.createRequest({
      path: '/ws/sources/:id/something',
    })
```

It also contains various cleanup changes which I'll highlight individually in review comments below.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios