### PR TITLE
`actions`/`case` integration test

### DIFF
--- a/src/dev/run_find_plugins_with_circular_deps.ts
+++ b/src/dev/run_find_plugins_with_circular_deps.ts
@@ -20,8 +20,6 @@ interface Options {
 type CircularDepList = Set<string>;
 
 const allowedList: CircularDepList = new Set([
-  'x-pack/plugins/actions -> x-pack/plugins/case',
-  'x-pack/plugins/case -> x-pack/plugins/security_solution',
   'x-pack/plugins/apm -> x-pack/plugins/infra',
   'x-pack/plugins/lists -> x-pack/plugins/security_solution',
   'x-pack/plugins/security -> x-pack/plugins/spaces',

--- a/x-pack/plugins/actions/server/lib/ensure_sufficient_license.ts
+++ b/x-pack/plugins/actions/server/lib/ensure_sufficient_license.ts
@@ -8,7 +8,7 @@ import { LICENSE_TYPE } from '../../../licensing/common/types';
 import { ServerLogActionTypeId, IndexActionTypeId } from '../builtin_action_types';
 import { ActionTypeConfig, ActionTypeSecrets, ActionTypeParams } from '../types';
 
-export const CASE_ACTION_TYPE_ID = '.case';
+const CASE_ACTION_TYPE_ID = '.case';
 
 const ACTIONS_SCOPED_WITHIN_STACK = new Set([
   ServerLogActionTypeId,

--- a/x-pack/plugins/case/common/api/connectors/mappings.ts
+++ b/x-pack/plugins/case/common/api/connectors/mappings.ts
@@ -7,7 +7,6 @@
 /* eslint-disable @kbn/eslint/no-restricted-paths */
 
 import * as rt from 'io-ts';
-import { ElasticUser } from '../../../../security_solution/public/cases/containers/types';
 import {
   PushToServiceApiParams as JiraPushToServiceApiParams,
   Incident as JiraIncident,
@@ -23,6 +22,13 @@ import {
 import { ResilientFieldsRT } from './resilient';
 import { ServiceNowFieldsRT } from './servicenow';
 import { JiraFieldsRT } from './jira';
+
+// Formerly imported from security_solution
+export interface ElasticUser {
+  readonly email?: string | null;
+  readonly fullName?: string | null;
+  readonly username?: string | null;
+}
 
 export {
   JiraPushToServiceApiParams,

--- a/x-pack/plugins/case/server/connectors/case/index.ts
+++ b/x-pack/plugins/case/server/connectors/case/index.ts
@@ -33,7 +33,8 @@ export function getActionType({
   alertsService,
 }: GetActionTypeParams): CaseActionType {
   return {
-    id: '.case',
+    // introducing a change here to see if it triggers an integration test failure
+    id: '.case_v2',
     minimumLicenseRequired: 'basic',
     name: i18n.NAME,
     validate: {

--- a/x-pack/plugins/case/server/connectors/case/index.ts
+++ b/x-pack/plugins/case/server/connectors/case/index.ts
@@ -23,7 +23,6 @@ import { GetActionTypeParams } from '..';
 
 const supportedSubActions: string[] = ['create', 'update', 'addComment'];
 
-export const CASE_ACTION_TYPE_ID = '.case';
 // action type definition
 export function getActionType({
   logger,
@@ -34,7 +33,7 @@ export function getActionType({
   alertsService,
 }: GetActionTypeParams): CaseActionType {
   return {
-    id: CASE_ACTION_TYPE_ID,
+    id: '.case',
     minimumLicenseRequired: 'basic',
     name: i18n.NAME,
     validate: {

--- a/x-pack/plugins/case/server/connectors/index.ts
+++ b/x-pack/plugins/case/server/connectors/index.ts
@@ -21,7 +21,6 @@ import {
 } from '../services';
 
 import { getActionType as getCaseConnector } from './case';
-export { CASE_ACTION_TYPE_ID } from './case';
 
 export interface GetActionTypeParams {
   logger: Logger;

--- a/x-pack/plugins/case/server/index.ts
+++ b/x-pack/plugins/case/server/index.ts
@@ -8,7 +8,6 @@ import { PluginInitializerContext } from 'kibana/server';
 import { ConfigSchema } from './config';
 import { CasePlugin } from './plugin';
 
-export { CASE_ACTION_TYPE_ID } from './connectors';
 export { CaseRequestContext } from './types';
 export const config = { schema: ConfigSchema };
 export const plugin = (initializerContext: PluginInitializerContext) =>


### PR DESCRIPTION
## Summary
The `actions` code base has special handling for the `case` plugin. It does this by referring to the action ID `'.case'`, which is used by the `case` plugin.

In the past, the `case` plugin exported a string, which was imported and used by the `actions` plugin. This is no longer true. Each plugin hard codes that string. This leaves us open to a refactoring bug: if either plugin were to change that string literal, the feature would no longer work.

We could define the string once, in `actions`, and import it in `cases`. However a different approach would be to define an integration test. The advantage of having a test is that it could ensure that the functionality works and wouldn't necessarily require any coupling in the implementation. In other words, if the two plugins have the ID defined differently, the feature will not work, but if they are defined the same, there is no guarantee that the feature will work (without a test.)

## Steps
First, I'm making a draft PR where I change the string ID in the `case` plugin but not in the `actions` plugin. If this fails tests already, then no work needs to be done. If it doesn't fail, we could consider adding an integration test (or sharing the string reference between code bases.)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be whitelisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
