### PR TITLE
Use doc link service in Stack Monitoring

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -182,7 +182,12 @@ export class DocLinksService {
           guide: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/maps.html`,
         },
         monitoring: {
+          alertsCluster: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/cluster-alerts.html`,
           alertsKibana: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/kibana-alerts.html`,
+          alertsKibanaCpuThreshold: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-cpu-threshold`,
+          alertsKibanaDiskThreshold: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-disk-usage-threshold`,
+          alertsKibanaJvmThreshold: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-jvm-memory-threshold`,
+          alertsKibanaMissingData: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-missing-monitoring-data`,
           monitorElasticsearch: `${ELASTICSEARCH_DOCS}configuring-metricbeat.html`,
           monitorKibana: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/monitoring-metricbeat.html`,
         },

--- a/x-pack/plugins/monitoring/public/alerts/ccr_read_exceptions_alert/index.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/ccr_read_exceptions_alert/index.tsx
@@ -37,7 +37,7 @@ export function createCCRReadExceptionsAlertType(): AlertTypeModel<ValidateOptio
     description: ALERT_DETAILS[ALERT_CCR_READ_EXCEPTIONS].description,
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/kibana-alerts.html`;
+      return `${docLinks.links.monitoring.alertsKibana}`;
     },
     alertParamsExpression: (props: Props) => (
       <Expression {...props} paramDetails={ALERT_DETAILS[ALERT_CCR_READ_EXCEPTIONS].paramDetails} />

--- a/x-pack/plugins/monitoring/public/alerts/cpu_usage_alert/cpu_usage_alert.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/cpu_usage_alert/cpu_usage_alert.tsx
@@ -16,7 +16,7 @@ export function createCpuUsageAlertType(): AlertTypeModel<MonitoringAlertTypePar
     description: ALERT_DETAILS[ALERT_CPU_USAGE].description,
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-cpu-threshold`;
+      return `${docLinks.links.monitoring.alertsKibanaCpuThreshold}`;
     },
     alertParamsExpression: (props: Props) => (
       <Expression {...props} paramDetails={ALERT_DETAILS[ALERT_CPU_USAGE].paramDetails} />

--- a/x-pack/plugins/monitoring/public/alerts/disk_usage_alert/index.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/disk_usage_alert/index.tsx
@@ -18,7 +18,7 @@ export function createDiskUsageAlertType(): AlertTypeModel<MonitoringAlertTypePa
     description: ALERT_DETAILS[ALERT_DISK_USAGE].description,
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-disk-usage-threshold`;
+      return `${docLinks.links.monitoring.alertsKibanaDiskThreshold}`;
     },
     alertParamsExpression: (props: Props) => (
       <Expression {...props} paramDetails={ALERT_DETAILS[ALERT_DISK_USAGE].paramDetails} />

--- a/x-pack/plugins/monitoring/public/alerts/legacy_alert/legacy_alert.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/legacy_alert/legacy_alert.tsx
@@ -18,7 +18,7 @@ export function createLegacyAlertTypes(): AlertTypeModel[] {
       description: LEGACY_ALERT_DETAILS[legacyAlert].description,
       iconClass: 'bell',
       documentationUrl(docLinks) {
-        return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/cluster-alerts.html`;
+        return `${docLinks.links.monitoring.alertsCluster}`;
       },
       alertParamsExpression: () => (
         <Fragment>

--- a/x-pack/plugins/monitoring/public/alerts/memory_usage_alert/index.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/memory_usage_alert/index.tsx
@@ -18,7 +18,7 @@ export function createMemoryUsageAlertType(): AlertTypeModel<MonitoringAlertType
     description: ALERT_DETAILS[ALERT_MEMORY_USAGE].description,
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-jvm-memory-threshold`;
+      return `${docLinks.links.monitoring.alertsKibanaJvmThreshold}`;
     },
     alertParamsExpression: (props: Props) => (
       <Expression {...props} paramDetails={ALERT_DETAILS[ALERT_MEMORY_USAGE].paramDetails} />

--- a/x-pack/plugins/monitoring/public/alerts/missing_monitoring_data_alert/missing_monitoring_data_alert.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/missing_monitoring_data_alert/missing_monitoring_data_alert.tsx
@@ -16,7 +16,7 @@ export function createMissingMonitoringDataAlertType(): AlertTypeModel {
     description: ALERT_DETAILS[ALERT_MISSING_MONITORING_DATA].description,
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/kibana-alerts.html#kibana-alerts-missing-monitoring-data`;
+      return `${docLinks.links.monitoring.alertsKibanaMissingData}`;
     },
     alertParamsExpression: (props: any) => (
       <Expression

--- a/x-pack/plugins/monitoring/public/alerts/thread_pool_rejections_alert/index.tsx
+++ b/x-pack/plugins/monitoring/public/alerts/thread_pool_rejections_alert/index.tsx
@@ -31,7 +31,7 @@ export function createThreadPoolRejectionsAlertType(
     description: threadPoolAlertDetails.description,
     iconClass: 'bell',
     documentationUrl(docLinks) {
-      return `${docLinks.ELASTIC_WEBSITE_URL}guide/en/kibana/${docLinks.DOC_LINK_VERSION}/kibana-alerts.html`;
+      return `${docLinks.links.monitoring.alertsKibana}`;
     },
     alertParamsExpression: (props: Props) => (
       <>


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/88107
This PR uses doc link service keywords instead of hard-coded URLs in Stack Monitoring alerts, so that they're easier to maintain.
