### PR TITLE
[7.x] [Fleet]: ignore 404, check if there are transforms in results. (#80721)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/remove.ts
@@ -31,7 +31,7 @@ export const deleteTransforms = async (
       // get the index the transform
       const transformResponse: {
         count: number;
-        transforms: Array<{
+        transforms?: Array<{
           dest: {
             index: string;
           };
@@ -39,6 +39,7 @@ export const deleteTransforms = async (
       } = await callCluster('transport.request', {
         method: 'GET',
         path: `/_transform/${transformId}`,
+        ignore: [404],
       });
 
       await stopTransforms([transformId], callCluster);

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -164,6 +164,7 @@ describe('test transform install', () => {
         {
           method: 'GET',
           path: '/_transform/endpoint.metadata_current-default-0.15.0-dev.0',
+          ignore: [404],
         },
       ],
       [
@@ -450,6 +451,7 @@ describe('test transform install', () => {
         {
           method: 'GET',
           path: '/_transform/endpoint.metadata-current-default-0.15.0-dev.0',
+          ignore: [404],
         },
       ],
       [


### PR DESCRIPTION
This is catching up a dropped backport from #80721 into `7.x`.

This fixes reported issues https://github.com/elastic/kibana/issues/88249 and https://github.com/elastic/kibana/issues/88630 , where 404s on `GET /_transform/<id>` were not being ignored.