### PR TITLE
[7.11] [Fleet]: ignore 404, check if there are transforms in results. (#80721)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/remove.ts
@@ -31,7 +31,7 @@ export const deleteTransforms = async (
       // get the index the transform
       const transformResponse: {
         count: number;
-        transforms: Array<{
+        transforms?: Array<{
           dest: {
             index: string;
           };
@@ -39,6 +39,7 @@ export const deleteTransforms = async (
       } = await callCluster('transport.request', {
         method: 'GET',
         path: `/_transform/${transformId}`,
+        ignore: [404],
       });
 
       await stopTransforms([transformId], callCluster);

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/transform.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/transform.test.ts
@@ -164,6 +164,7 @@ describe('test transform install', () => {
         {
           method: 'GET',
           path: '/_transform/endpoint.metadata_current-default-0.15.0-dev.0',
+          ignore: [404],
         },
       ],
       [
@@ -450,6 +451,7 @@ describe('test transform install', () => {
         {
           method: 'GET',
           path: '/_transform/endpoint.metadata-current-default-0.15.0-dev.0',
+          ignore: [404],
         },
       ],
       [


### PR DESCRIPTION
Backport of #80721 into `7.11`

This is a moderately old PR, that was backported to `7.10` in the day, but was not backported to `7.x`, so when `7.11` was created, it also lacked this.

This is an important fix for two reported 7.11 bugs: https://github.com/elastic/kibana/issues/88630 and https://github.com/elastic/kibana/issues/88249