### PR TITLE
[EPM] Ignore missing asset errors on remove.

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
@@ -115,7 +115,10 @@ async function deleteAssets(
   try {
     await Promise.all(deletePromises);
   } catch (err) {
-    logger.error(err);
+    // in the rollback case, partial installs are likely, so missing assets are not an error
+    if (!savedObjectsClient.errors.isNotFoundError(err)) {
+      logger.error(err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

This changes the behaviour of EPM to not log errors about non-existing assets during removal. This was found in relation to  https://github.com/elastic/kibana/issues/88475 but is not the root cause.

### How to test this

Have a package with a Kibana asset that will trigger an error during installation. One way to do so is to run a local registry, and change the `migration_version` of a Kibana dashboard to a version higher than the running Kibana. As an example, I used
```
"migrationVersion": {
    "dashboard": "8.12.3"
  },
```
on an Apache dashboard, running against `master`.

Navigate to Fleet -> Integrations -> Apache (or whatever package you're using to reproduce the error) -> Settings and install the package using the "Install Apache assets" button.

Verify that you get an error about an incompatible dashboard both in the UI and in the Kibana logs.

Verify that you did NOT get an error about a missing Kibana dashboard during rollback.

Verify that the package is not installed after this operation, i.e. that rollback was successful.

**NOTE:** for this PR, **do not test installing the package with the big blue "Add Apache" button**. This will call the `package_policies` API endpoint, and that code path is still broken, see https://github.com/elastic/kibana/issues/88475 . I'm working on a fix for that as well.

