### PR TITLE
Show legend on error rate chart

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -77,7 +77,6 @@ export function TransactionErrorRateChart({
             data: errorRates,
             type: 'linemark',
             color: theme.eui.euiColorVis7,
-            hideLegend: true,
             title: i18n.translate('xpack.apm.errorRate.chart.errorRate', {
               defaultMessage: 'Error rate (avg.)',
             }),


### PR DESCRIPTION
This probably was hidden for reasons related to implementing (or deferring the implementation of) comparisons.
