### PR TITLE
Removing experimental warning from Vega reference page.

### DIFF
--- a/docs/user/dashboard/vega-reference.asciidoc
+++ b/docs/user/dashboard/vega-reference.asciidoc
@@ -1,8 +1,6 @@
 [[vega-reference]]
 == Vega reference
 
-experimental[]
-
 For additional *Vega* and *Vega-Lite* information, refer to the reference sections.
 
 [float]


### PR DESCRIPTION
With Vega being GA in 7.10, I'm removing the experimental warning from the Vega reference page: https://www.elastic.co/guide/en/kibana/7.10/vega-reference.html

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
![image](https://user-images.githubusercontent.com/47378401/106175531-12283b00-614b-11eb-9fdb-ff8768ae6874.png)

![image](https://user-images.githubusercontent.com/47378401/106175439-fc1a7a80-614a-11eb-84d7-a7521b5d1bed.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
