### PR TITLE
Migrate security page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -21,6 +21,7 @@ interface AppValues extends WorkplaceSearchInitialData {
 interface AppActions {
   initializeAppData(props: InitialAppData): InitialAppData;
   setContext(isOrganization: boolean): boolean;
+  setSourceRestriction(canCreatePersonalSources: boolean): boolean;
 }
 
 const emptyOrg = {} as Organization;
@@ -34,6 +35,7 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       isFederatedAuth,
     }),
     setContext: (isOrganization) => isOrganization,
+    setSourceRestriction: (canCreatePersonalSources: boolean) => canCreatePersonalSources,
   },
   reducers: {
     hasInitialized: [
@@ -64,6 +66,10 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       emptyAccount,
       {
         initializeAppData: (_, { workplaceSearch }) => workplaceSearch?.account || emptyAccount,
+        setSourceRestriction: (state, canCreatePersonalSources) => ({
+          ...state,
+          canCreatePersonalSources,
+        }),
       },
     ],
   },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
@@ -45,9 +45,7 @@ export const WorkplaceSearchNav: React.FC<Props> = ({
     <SideNavLink isExternal to={getWorkplaceSearchUrl(`#${ROLE_MAPPINGS_PATH}`)}>
       {NAV.ROLE_MAPPINGS}
     </SideNavLink>
-    <SideNavLink isExternal to={getWorkplaceSearchUrl(`#${SECURITY_PATH}`)}>
-      {NAV.SECURITY}
-    </SideNavLink>
+    <SideNavLink to={SECURITY_PATH}>{NAV.SECURITY}</SideNavLink>
     <SideNavLink subNav={settingsSubNav} to={ORG_SETTINGS_PATH}>
       {NAV.SETTINGS}
     </SideNavLink>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -289,6 +289,87 @@ export const DOCUMENTATION_LINK_TITLE = i18n.translate(
   }
 );
 
+export const PRIVATE_SOURCES_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.privateSources.description',
+  {
+    defaultMessage:
+      'Private sources are connected by users in your organization to create a personalized search experience.',
+  }
+);
+
+export const PRIVATE_SOURCES_TOGGLE_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.privateSourcesToggle.description',
+  {
+    defaultMessage: 'Enable private sources for your organization',
+  }
+);
+
+export const REMOTE_SOURCES_TOGGLE_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.remoteSourcesToggle.text',
+  {
+    defaultMessage: 'Enable remote private sources',
+  }
+);
+
+export const REMOTE_SOURCES_TABLE_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.remoteSourcesTable.description',
+  {
+    defaultMessage:
+      'Remote sources synchronize and store a limited amount of data on disk, with a low impact on storage resources.',
+  }
+);
+
+export const REMOTE_SOURCES_EMPTY_TABLE_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.remoteSourcesEmptyTable.title',
+  {
+    defaultMessage: 'No remote private sources configured yet',
+  }
+);
+
+export const STANDARD_SOURCES_TOGGLE_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.standardSourcesToggle.text',
+  {
+    defaultMessage: 'Enable standard private sources',
+  }
+);
+
+export const STANDARD_SOURCES_TABLE_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.standardSourcesTable.description',
+  {
+    defaultMessage:
+      'Standard sources synchronize and store all searchable data on disk, with a directly correlated impact on storage resources.',
+  }
+);
+
+export const STANDARD_SOURCES_EMPTY_TABLE_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.standardSourcesEmptyTable.title',
+  {
+    defaultMessage: 'No standard private sources configured yet',
+  }
+);
+
+export const SECURITY_UNSAVED_CHANGES_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.unsavedChanges.message',
+  {
+    defaultMessage:
+      'Your private sources settings have not been saved. Are you sure you want to leave?',
+  }
+);
+
+export const PRIVATE_SOURCES_UPDATE_CONFIRMATION_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.privateSourcesUpdateConfirmation.text',
+  {
+    defaultMessage: 'Updates to private source configuration will take effect immediately.',
+  }
+);
+
+export const SOURCE_RESTRICTIONS_SUCCESS_MESSAGE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.security.sourceRestrictionsSuccess.message',
+  {
+    defaultMessage: 'Successfully updated source restrictions.',
+  }
+);
+
 export const PUBLIC_KEY_LABEL = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.publicKey.label',
   {
@@ -379,6 +460,20 @@ export const SAVE_CHANGES_BUTTON = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.saveChanges.button',
   {
     defaultMessage: 'Save changes',
+  }
+);
+
+export const SAVE_SETTINGS_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.saveSettings.button',
+  {
+    defaultMessage: 'Save settings',
+  }
+);
+
+export const KEEP_EDITING_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.keepEditing.button',
+  {
+    defaultMessage: 'Keep editing',
   }
 );
 
@@ -493,6 +588,10 @@ export const UPDATE_BUTTON = i18n.translate(
   }
 );
 
+export const RESET_BUTTON = i18n.translate('xpack.enterpriseSearch.workplaceSearch.reset.button', {
+  defaultMessage: 'Reset',
+});
+
 export const CONFIGURE_BUTTON = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.configure.button',
   {
@@ -522,10 +621,28 @@ export const PRIVATE_PLATINUM_LICENSE_CALLOUT = i18n.translate(
   }
 );
 
+export const SOURCE = i18n.translate('xpack.enterpriseSearch.workplaceSearch.source.text', {
+  defaultMessage: 'Source',
+});
+
 export const PRIVATE_SOURCE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.privateSource.text',
   {
     defaultMessage: 'Private Source',
+  }
+);
+
+export const PRIVATE_SOURCES = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.privateSources.text',
+  {
+    defaultMessage: 'Private Sources',
+  }
+);
+
+export const CONFIRM_CHANGES_TEXT = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.confirmChanges.text',
+  {
+    defaultMessage: 'Confirm changes',
   }
 );
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -22,6 +22,7 @@ import {
   SOURCES_PATH,
   PERSONAL_SOURCES_PATH,
   ORG_SETTINGS_PATH,
+  SECURITY_PATH,
 } from './routes';
 
 import { SetupGuide } from './views/setup_guide';
@@ -29,6 +30,7 @@ import { ErrorState } from './views/error_state';
 import { NotFound } from '../shared/not_found';
 import { Overview } from './views/overview';
 import { GroupsRouter } from './views/groups';
+import { Security } from './views/security';
 import { SourcesRouter } from './views/content_sources';
 import { SettingsRouter } from './views/settings';
 
@@ -100,6 +102,11 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
           readOnlyMode={readOnlyMode}
         >
           <GroupsRouter />
+        </Layout>
+      </Route>
+      <Route path={SECURITY_PATH}>
+        <Layout navigation={<WorkplaceSearchNav />} restrictWidth readOnlyMode={readOnlyMode}>
+          <Security />
         </Layout>
       </Route>
       <Route path={ORG_SETTINGS_PATH}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../../__mocks__/kea.mock';
+import '../../../../__mocks__/shallow_useeffect.mock';
+
+import { setMockValues } from '../../../../__mocks__';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EuiSwitch } from '@elastic/eui';
+
+import { PrivateSourcesTable } from './private_sources_table';
+
+describe('PrivateSourcesTable', () => {
+  beforeEach(() => {
+    setMockValues({ hasPlatinumLicense: true, isEnabled: true });
+  });
+
+  const props = {
+    sourceSection: { isEnabled: true, contentSources: [] },
+    updateSource: jest.fn(),
+    updateEnabled: jest.fn(),
+  };
+
+  it('renders', () => {
+    const wrapper = shallow(<PrivateSourcesTable {...props} sourceType="standard" />);
+
+    expect(wrapper.find(EuiSwitch)).toHaveLength(1);
+  });
+
+  it('handles switches clicks', () => {
+    const wrapper = shallow(
+      <PrivateSourcesTable
+        {...props}
+        sourceSection={{
+          isEnabled: false,
+          contentSources: [{ id: 'gmail', isEnabled: true, name: 'Gmail' }],
+        }}
+        sourceType="remote"
+      />
+    );
+
+    const sectionSwitch = wrapper.find(EuiSwitch).first();
+    const sourceSwitch = wrapper.find(EuiSwitch).last();
+
+    const event = { target: { value: true } };
+    sectionSwitch.prop('onChange')(event as any);
+    sourceSwitch.prop('onChange')(event as any);
+
+    expect(props.updateEnabled).toHaveBeenCalled();
+    expect(props.updateSource).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.test.tsx
@@ -4,9 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import '../../../../__mocks__/kea.mock';
-import '../../../../__mocks__/shallow_useeffect.mock';
-
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -29,8 +29,8 @@ import { SecurityLogic, PrivateSourceSection } from '../security_logic';
 interface PrivateSourcesTableProps {
   sourceType: 'remote' | 'standard';
   sourceSection: PrivateSourceSection;
-  updateSource(sourceId: string, isEnabled: boolean);
-  updateEnabled(isEnabled: boolean);
+  updateSource(sourceId: string, isEnabled: boolean): void;
+  updateEnabled(isEnabled: boolean): void;
 }
 
 const REMOTE_TABLE_SUBHEAD =

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -24,6 +24,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
+import { LicensingLogic } from '../../../../shared/licensing';
 import { SecurityLogic, PrivateSourceSection } from '../security_logic';
 
 interface PrivateSourcesTableProps {
@@ -56,11 +57,12 @@ export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
   updateSource,
   updateEnabled,
 }) => {
-  const { isLocked, isEnabled } = useValues(SecurityLogic);
+  const { hasPlatinumLicense } = useValues(LicensingLogic);
+  const { isEnabled } = useValues(SecurityLogic);
 
   const isRemote = sourceType === 'remote';
   const hasSources = contentSources.length > 0;
-  const panelDisabled = !isEnabled || isLocked;
+  const panelDisabled = !isEnabled || !hasPlatinumLicense;
   const sectionDisabled = !sectionEnabled;
 
   const panelClass = classNames('euiPanel--outline euiPanel--noShadow', {
@@ -90,7 +92,7 @@ export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
         <EuiSwitch
           checked={sectionEnabled}
           onChange={(e) => updateEnabled(e.target.checked)}
-          disabled={!isEnabled || isLocked}
+          disabled={!isEnabled || !hasPlatinumLicense}
           showLabel={false}
           label={`${sourceType} Sources Toggle`}
           data-test-subj={`${sourceType}EnabledToggle`}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -23,9 +23,20 @@ import {
   EuiTableRowCell,
   EuiSpacer,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
 import { LicensingLogic } from '../../../../shared/licensing';
 import { SecurityLogic, PrivateSourceSection } from '../security_logic';
+import {
+  REMOTE_SOURCES_TOGGLE_TEXT,
+  REMOTE_SOURCES_TABLE_DESCRIPTION,
+  REMOTE_SOURCES_EMPTY_TABLE_TITLE,
+  STANDARD_SOURCES_TOGGLE_TEXT,
+  STANDARD_SOURCES_TABLE_DESCRIPTION,
+  STANDARD_SOURCES_EMPTY_TABLE_TITLE,
+  SOURCE,
+} from '../../../constants';
 
 interface PrivateSourcesTableProps {
   sourceType: 'remote' | 'standard';
@@ -34,21 +45,38 @@ interface PrivateSourcesTableProps {
   updateEnabled(isEnabled: boolean): void;
 }
 
-const REMOTE_TABLE_SUBHEAD =
-  'Remote sources synchronize and store a limited amount of data on disk, with a low impact on storage resources.';
-const STANDARD_TABLE_SUBHEAD =
-  'Standard sources synchronize and store all searchable data on disk, with a directly correlated impact on storage resources.';
-const REMOTE_EMPTY_SUBHEAD = (
-  <>
-    Once configured, remote private sources are <strong>enabled by default</strong>, and users can
-    immediately connect the source from their Personal Dashboard.
-  </>
+const REMOTE_SOURCES_EMPTY_TABLE_DESCRIPTION = (
+  <FormattedMessage
+    id="xpack.enterpriseSearch.workplaceSearch.security.remoteSourcesEmptyTable.description"
+    defaultMessage="Once configured, remote private sources are {enabledStrong}, and users can immediately connect the source from their Personal Dashboard."
+    values={{
+      enabledStrong: (
+        <strong>
+          {i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.security.remoteSourcesEmptyTable.enabledStrong',
+            { defaultMessage: 'enabled by default' }
+          )}
+        </strong>
+      ),
+    }}
+  />
 );
-const STANDARD_EMPTY_SUBHEAD = (
-  <>
-    Once configured, standard private sources <strong>are not enabled by default</strong>, and must
-    be activated before users are allowed to connect the source from their Personal Dashboard.
-  </>
+
+const STANDARD_SOURCES_EMPTY_TABLE_DESCRIPTION = (
+  <FormattedMessage
+    id="xpack.enterpriseSearch.workplaceSearch.security.standardSourcesEmptyTable.description"
+    defaultMessage="Once configured, standard private sources are {notEnabledStrong}, and must be activated before users are allowed to connect the source from their Personal Dashboard."
+    values={{
+      notEnabledStrong: (
+        <strong>
+          {i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.security.standardSourcesEmptyTable.notEnabledStrong',
+            { defaultMessage: 'not enabled by default' }
+          )}
+        </strong>
+      ),
+    }}
+  />
 );
 
 export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
@@ -76,10 +104,14 @@ export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
       <EuiSpacer />
       <EuiPanel className="euiPanel--inset euiPanel--noShadow euiPanel--outline">
         <EuiText textAlign="center" color="subdued" size="s">
-          <strong>No {sourceType} private sources configured yet</strong>
+          <strong>
+            {isRemote ? REMOTE_SOURCES_EMPTY_TABLE_TITLE : STANDARD_SOURCES_EMPTY_TABLE_TITLE}
+          </strong>
         </EuiText>
         <EuiText textAlign="center" color="subdued" size="s">
-          {isRemote ? REMOTE_EMPTY_SUBHEAD : STANDARD_EMPTY_SUBHEAD}
+          {isRemote
+            ? REMOTE_SOURCES_EMPTY_TABLE_DESCRIPTION
+            : STANDARD_SOURCES_EMPTY_TABLE_DESCRIPTION}
         </EuiText>
       </EuiPanel>
     </>
@@ -101,10 +133,10 @@ export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiText size="s">
-          <h4>Enable {sourceType} private sources</h4>
+          <h4>{isRemote ? REMOTE_SOURCES_TOGGLE_TEXT : STANDARD_SOURCES_TOGGLE_TEXT}</h4>
         </EuiText>
         <EuiText color="subdued" size="s">
-          {isRemote ? REMOTE_TABLE_SUBHEAD : STANDARD_TABLE_SUBHEAD}
+          {isRemote ? REMOTE_SOURCES_TABLE_DESCRIPTION : STANDARD_SOURCES_TABLE_DESCRIPTION}
         </EuiText>
         {!hasSources && emptyState}
       </EuiFlexItem>
@@ -116,7 +148,7 @@ export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
       <EuiSpacer />
       <EuiTable className={tableClass}>
         <EuiTableHeader>
-          <EuiTableHeaderCell>Source</EuiTableHeaderCell>
+          <EuiTableHeaderCell>{SOURCE}</EuiTableHeaderCell>
           <EuiTableHeaderCell />
         </EuiTableHeader>
         <EuiTableBody>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+
+import classNames from 'classnames';
+import { useValues } from 'kea';
+
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSwitch,
+  EuiText,
+  EuiTable,
+  EuiTableBody,
+  EuiTableHeader,
+  EuiTableHeaderCell,
+  EuiTableRow,
+  EuiTableRowCell,
+  EuiSpacer,
+} from '@elastic/eui';
+
+import { SecurityLogic, PrivateSourceSection } from '../SecurityLogic';
+
+interface PrivateSourcesTableProps {
+  sourceType: 'remote' | 'standard';
+  sourceSection: PrivateSourceSection;
+  updateSource(sourceId: string, isEnabled: boolean);
+  updateEnabled(isEnabled: boolean);
+}
+
+const REMOTE_TABLE_SUBHEAD =
+  'Remote sources synchronize and store a limited amount of data on disk, with a low impact on storage resources.';
+const STANDARD_TABLE_SUBHEAD =
+  'Standard sources synchronize and store all searchable data on disk, with a directly correlated impact on storage resources.';
+const REMOTE_EMPTY_SUBHEAD = (
+  <>
+    Once configured, remote private sources are <strong>enabled by default</strong>, and users can
+    immediately connect the source from their Personal Dashboard.
+  </>
+);
+const STANDARD_EMPTY_SUBHEAD = (
+  <>
+    Once configured, standard private sources <strong>are not enabled by default</strong>, and must
+    be activated before users are allowed to connect the source from their Personal Dashboard.
+  </>
+);
+
+export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
+  sourceType,
+  sourceSection: { isEnabled: sectionEnabled, contentSources },
+  updateSource,
+  updateEnabled,
+}) => {
+  const { isLocked, isEnabled } = useValues(SecurityLogic);
+
+  const isRemote = sourceType === 'remote';
+  const hasSources = contentSources.length > 0;
+  const panelDisabled = !isEnabled || isLocked;
+  const sectionDisabled = !sectionEnabled;
+
+  const panelClass = classNames('euiPanel--outline euiPanel--noShadow', {
+    'euiPanel--disabled': panelDisabled,
+  });
+
+  const tableClass = classNames({ 'euiTable--disabled': sectionDisabled });
+
+  const emptyState = (
+    <>
+      <EuiSpacer />
+      <EuiPanel className="euiPanel--inset euiPanel--noShadow euiPanel--outline">
+        <EuiText textAlign="center" color="subdued" size="s">
+          <strong>No {sourceType} private sources configured yet</strong>
+        </EuiText>
+        <EuiText textAlign="center" color="subdued" size="s">
+          {isRemote ? REMOTE_EMPTY_SUBHEAD : STANDARD_EMPTY_SUBHEAD}
+        </EuiText>
+      </EuiPanel>
+    </>
+  );
+
+  const sectionHeading = (
+    <EuiFlexGroup alignItems="flexStart" justifyContent="flexStart" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <EuiSpacer size="xs" />
+        <EuiSwitch
+          checked={sectionEnabled}
+          onChange={(e) => updateEnabled(e.target.checked)}
+          disabled={!isEnabled || isLocked}
+          showLabel={false}
+          label={`${sourceType} Sources Toggle`}
+          data-test-subj={`${sourceType}EnabledToggle`}
+          compressed
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText size="s">
+          <h4>Enable {sourceType} private sources</h4>
+        </EuiText>
+        <EuiText color="subdued" size="s">
+          {isRemote ? REMOTE_TABLE_SUBHEAD : STANDARD_TABLE_SUBHEAD}
+        </EuiText>
+        {!hasSources && emptyState}
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const sourcesTable = (
+    <>
+      <EuiSpacer />
+      <EuiTable className={tableClass}>
+        <EuiTableHeader>
+          <EuiTableHeaderCell>Source</EuiTableHeaderCell>
+          <EuiTableHeaderCell />
+        </EuiTableHeader>
+        <EuiTableBody>
+          {contentSources.map((source, i) => (
+            <EuiTableRow key={i}>
+              <EuiTableRowCell>{source.name}</EuiTableRowCell>
+              <EuiTableRowCell>
+                <EuiSwitch
+                  checked={!!source.isEnabled}
+                  disabled={sectionDisabled}
+                  onChange={(e) => updateSource(source.id, e.target.checked)}
+                  showLabel={false}
+                  label={`${source.name} Toggle`}
+                  data-test-subj={`${sourceType}SourceToggle`}
+                  compressed
+                />
+              </EuiTableRowCell>
+            </EuiTableRow>
+          ))}
+        </EuiTableBody>
+      </EuiTable>
+    </>
+  );
+
+  return (
+    <EuiPanel className={panelClass}>
+      {sectionHeading}
+      {hasSources && sourcesTable}
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -24,7 +24,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { SecurityLogic, PrivateSourceSection } from '../SecurityLogic';
+import { SecurityLogic, PrivateSourceSection } from '../security_logic';
 
 interface PrivateSourcesTableProps {
   sourceType: 'remote' | 'standard';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { Security } from './security';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import '../../../__mocks__/kea.mock';
+import '../../../__mocks__/shallow_useeffect.mock';
+
+import { setMockValues, setMockActions } from '../../../__mocks__';
+import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { EuiSwitch, EuiConfirmModal } from '@elastic/eui';
+import { Loading } from '../../../shared/loading';
+
+import { ViewContentHeader } from '../../components/shared/view_content_header';
+import { Security } from './security';
+
+describe('Security', () => {
+  const initializeSourceRestrictions = jest.fn();
+  const updatePrivateSourcesEnabled = jest.fn();
+  const updateRemoteEnabled = jest.fn();
+  const updateRemoteSource = jest.fn();
+  const updateStandardEnabled = jest.fn();
+  const updateStandardSource = jest.fn();
+  const saveSourceRestrictions = jest.fn();
+  const resetState = jest.fn();
+
+  const mockValues = {
+    isEnabled: true,
+    remote: { isEnabled: true, contentSources: [] },
+    standard: { isEnabled: true, contentSources: [] },
+    dataLoading: false,
+    unsavedChanges: false,
+    hasPlatinumLicense: true,
+  };
+
+  beforeEach(() => {
+    setMockValues(mockValues);
+    setMockActions({
+      initializeSourceRestrictions,
+      updatePrivateSourcesEnabled,
+      updateRemoteEnabled,
+      updateRemoteSource,
+      updateStandardEnabled,
+      updateStandardSource,
+      saveSourceRestrictions,
+      resetState,
+    });
+  });
+
+  it('renders on Basic license', () => {
+    setMockValues({ ...mockValues, hasPlatinumLicense: false });
+    const wrapper = shallow(<Security />);
+
+    expect(wrapper.find(ViewContentHeader)).toHaveLength(1);
+    expect(wrapper.find(EuiSwitch).prop('disabled')).toEqual(true);
+  });
+
+  it('renders on Platinum license', () => {
+    const wrapper = shallow(<Security />);
+
+    expect(wrapper.find(ViewContentHeader)).toHaveLength(1);
+    expect(wrapper.find(EuiSwitch).prop('disabled')).toEqual(false);
+  });
+
+  it('returns Loading when loading', () => {
+    setMockValues({ ...mockValues, dataLoading: true });
+    const wrapper = shallow(<Security />);
+
+    expect(wrapper.find(Loading)).toHaveLength(1);
+  });
+
+  it('handles window.onbeforeunload change', () => {
+    setMockValues({ ...mockValues, unsavedChanges: true });
+    shallow(<Security />);
+
+    expect(window.onbeforeunload!({} as any)).toEqual(
+      'Your private sources settings have not been saved. Are you sure you want to leave?'
+    );
+  });
+
+  it('handles window.onbeforeunload unmount', () => {
+    setMockValues({ ...mockValues, unsavedChanges: true });
+    shallow(<Security />);
+
+    unmountHandler();
+
+    expect(window.onbeforeunload).toEqual(null);
+  });
+
+  it('handles switch click', () => {
+    const wrapper = shallow(<Security />);
+
+    const privateSourcesSwitch = wrapper.find(EuiSwitch);
+    const event = { target: { checked: true } };
+    privateSourcesSwitch.prop('onChange')(event as any);
+
+    expect(updatePrivateSourcesEnabled).toHaveBeenCalled();
+  });
+
+  it('handles confirmModal submission', () => {
+    setMockValues({ ...mockValues, unsavedChanges: true });
+    const wrapper = shallow(<Security />);
+
+    const header = wrapper.find(ViewContentHeader).dive();
+    header.find('[data-test-subj="SaveSettingsButton"]').prop('onClick')!({} as any);
+    const modal = wrapper.find(EuiConfirmModal);
+    modal.prop('onConfirm')!({} as any);
+
+    expect(saveSourceRestrictions).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
@@ -4,9 +4,6 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import '../../../__mocks__/kea.mock';
-import '../../../__mocks__/shallow_useeffect.mock';
-
 import { setMockValues, setMockActions } from '../../../__mocks__';
 import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+import classNames from 'classnames';
+import { useActions, useValues } from 'kea';
+
+import { Prompt } from 'react-router-dom';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSwitch,
+  EuiText,
+  EuiSpacer,
+  EuiPanel,
+} from '@elastic/eui';
+
+import ConfirmModal from 'shared/components/ConfirmModal';
+import FlashMessages from 'shared/components/FlashMessages';
+
+import {
+  AppView,
+  LicenseCallout,
+  Loading,
+  SidebarNavigation,
+  ViewContentHeader,
+} from 'workplace_search/components';
+import { SecurityLogic } from './SecurityLogic';
+
+import { PrivateSourcesTable } from './components/PrivateSourcesTable';
+
+const UNSAVED_MESSAGE =
+  'Your private sources settings have not been saved. Are you sure you want to leave?';
+
+export const Security: React.FC = () => {
+  const [confirmModalVisible, setConfirmModalVisibility] = useState(false);
+
+  const hideConfirmModal = () => setConfirmModalVisibility(false);
+  const showConfirmModal = () => setConfirmModalVisibility(true);
+
+  const {
+    initializeSourceRestrictions,
+    updatePrivateSourcesEnabled,
+    updateRemoteEnabled,
+    updateRemoteSource,
+    updateStandardEnabled,
+    updateStandardSource,
+    saveSourceRestrictions,
+    resetState,
+  } = useActions(SecurityLogic);
+
+  const {
+    isEnabled,
+    isLocked,
+    remote,
+    standard,
+    dataLoading,
+    flashMessages,
+    unsavedChanges,
+  } = useValues(SecurityLogic);
+
+  useEffect(() => {
+    initializeSourceRestrictions();
+  }, []);
+
+  useEffect(() => {
+    window.onbeforeunload = unsavedChanges ? () => UNSAVED_MESSAGE : null;
+    return () => {
+      window.onbeforeunload = null;
+    };
+  }, [unsavedChanges]);
+
+  if (dataLoading) return <Loading />;
+
+  const panelClass = classNames('euiPanel--noShadow', { 'euiPanel--disabled': isLocked });
+
+  const savePrivateSources = () => {
+    saveSourceRestrictions();
+    hideConfirmModal();
+  };
+
+  const headerActions = (
+    <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="m">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty disabled={!unsavedChanges} onClick={resetState}>
+          Reset
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiButton
+          disabled={isLocked || !unsavedChanges}
+          onClick={showConfirmModal}
+          fill
+          data-test-subj="SaveSettingsButton"
+        >
+          Save settings
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const sidebar = (
+    <SidebarNavigation
+      title="Security"
+      description="Manage content source connection rules and information access for your organization."
+    />
+  );
+
+  const header = (
+    <>
+      <ViewContentHeader
+        title="Private sources"
+        alignItems="flexStart"
+        description="Private sources are connected by users in your organization to create a personalized search experience."
+        action={headerActions}
+      />
+      <EuiSpacer />
+    </>
+  );
+
+  const allSourcesToggle = (
+    <EuiPanel paddingSize="none" className={panelClass}>
+      <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiSwitch
+            checked={isEnabled}
+            onChange={(e) => updatePrivateSourcesEnabled(e.target.checked)}
+            disabled={isLocked}
+            showLabel={false}
+            label="Private Sources Toggle"
+            data-test-subj="PrivateSourcesToggle"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="s">
+            <h4>Enable private sources for your organization</h4>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+
+  const platinumLicenseCallout = (
+    <>
+      <EuiSpacer size="s" />
+      <LicenseCallout message="Private sources require a Platinum license." />
+    </>
+  );
+
+  const sourceTables = (
+    <>
+      <EuiSpacer size="xl" />
+      <PrivateSourcesTable
+        sourceType="remote"
+        sourceSection={remote}
+        updateEnabled={updateRemoteEnabled}
+        updateSource={updateRemoteSource}
+      />
+      <EuiSpacer size="xxl" />
+      <PrivateSourcesTable
+        sourceType="standard"
+        sourceSection={standard}
+        updateEnabled={updateStandardEnabled}
+        updateSource={updateStandardSource}
+      />
+    </>
+  );
+
+  const confirmModal = (
+    <ConfirmModal
+      title="Confirm changes"
+      onConfirm={savePrivateSources}
+      onCancel={hideConfirmModal}
+      buttonColor="primary"
+      cancelButtonText="Keep editing"
+      confirmButtonText="Save changes"
+    >
+      Updates to private source configuration will take effect immediately.
+    </ConfirmModal>
+  );
+
+  return (
+    <AppView sidebar={sidebar}>
+      <Prompt when={unsavedChanges} message={UNSAVED_MESSAGE} />
+      {flashMessages && <FlashMessages {...flashMessages} />}
+      {header}
+      {allSourcesToggle}
+      {isLocked && platinumLicenseCallout}
+      {sourceTables}
+      {confirmModalVisible && confirmModal}
+    </AppView>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -24,6 +24,7 @@ import {
   EuiOverlayMask,
 } from '@elastic/eui';
 
+import { LicensingLogic } from '../../../shared/licensing';
 import { FlashMessages } from '../../../shared/flash_messages';
 import { LicenseCallout } from '../../components/shared/license_callout';
 import { Loading } from '../../../shared/loading';
@@ -41,6 +42,8 @@ export const Security: React.FC = () => {
   const hideConfirmModal = () => setConfirmModalVisibility(false);
   const showConfirmModal = () => setConfirmModalVisibility(true);
 
+  const { hasPlatinumLicense } = useValues(LicensingLogic);
+
   const {
     initializeSourceRestrictions,
     updatePrivateSourcesEnabled,
@@ -52,9 +55,7 @@ export const Security: React.FC = () => {
     resetState,
   } = useActions(SecurityLogic);
 
-  const { isEnabled, isLocked, remote, standard, dataLoading, unsavedChanges } = useValues(
-    SecurityLogic
-  );
+  const { isEnabled, remote, standard, dataLoading, unsavedChanges } = useValues(SecurityLogic);
 
   useEffect(() => {
     initializeSourceRestrictions();
@@ -69,7 +70,9 @@ export const Security: React.FC = () => {
 
   if (dataLoading) return <Loading />;
 
-  const panelClass = classNames('euiPanel--noShadow', { 'euiPanel--disabled': isLocked });
+  const panelClass = classNames('euiPanel--noShadow', {
+    'euiPanel--disabled': !hasPlatinumLicense,
+  });
 
   const savePrivateSources = () => {
     saveSourceRestrictions();
@@ -85,7 +88,7 @@ export const Security: React.FC = () => {
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiButton
-          disabled={isLocked || !unsavedChanges}
+          disabled={!hasPlatinumLicense || !unsavedChanges}
           onClick={showConfirmModal}
           fill
           data-test-subj="SaveSettingsButton"
@@ -115,7 +118,7 @@ export const Security: React.FC = () => {
           <EuiSwitch
             checked={isEnabled}
             onChange={(e) => updatePrivateSourcesEnabled(e.target.checked)}
-            disabled={isLocked}
+            disabled={!hasPlatinumLicense}
             showLabel={false}
             label="Private Sources Toggle"
             data-test-subj="PrivateSourcesToggle"
@@ -177,7 +180,7 @@ export const Security: React.FC = () => {
       <FlashMessages />
       {header}
       {allSourcesToggle}
-      {isLocked && platinumLicenseCallout}
+      {!hasPlatinumLicense && platinumLicenseCallout}
       {sourceTables}
       {confirmModalVisible && confirmModal}
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -31,8 +31,19 @@ import { SecurityLogic } from './security_logic';
 
 import { PrivateSourcesTable } from './components/private_sources_table';
 
-const UNSAVED_MESSAGE =
-  'Your private sources settings have not been saved. Are you sure you want to leave?';
+import {
+  SECURITY_UNSAVED_CHANGES_MESSAGE,
+  RESET_BUTTON,
+  SAVE_SETTINGS_BUTTON,
+  SAVE_CHANGES_BUTTON,
+  KEEP_EDITING_BUTTON,
+  PRIVATE_SOURCES,
+  PRIVATE_SOURCES_DESCRIPTION,
+  PRIVATE_SOURCES_TOGGLE_DESCRIPTION,
+  PRIVATE_PLATINUM_LICENSE_CALLOUT,
+  CONFIRM_CHANGES_TEXT,
+  PRIVATE_SOURCES_UPDATE_CONFIRMATION_TEXT,
+} from '../../constants';
 
 export const Security: React.FC = () => {
   const [confirmModalVisible, setConfirmModalVisibility] = useState(false);
@@ -60,7 +71,7 @@ export const Security: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    window.onbeforeunload = unsavedChanges ? () => UNSAVED_MESSAGE : null;
+    window.onbeforeunload = unsavedChanges ? () => SECURITY_UNSAVED_CHANGES_MESSAGE : null;
     return () => {
       window.onbeforeunload = null;
     };
@@ -81,7 +92,7 @@ export const Security: React.FC = () => {
     <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="m">
       <EuiFlexItem grow={false}>
         <EuiButtonEmpty disabled={!unsavedChanges} onClick={resetState}>
-          Reset
+          {RESET_BUTTON}
         </EuiButtonEmpty>
       </EuiFlexItem>
       <EuiFlexItem>
@@ -91,7 +102,7 @@ export const Security: React.FC = () => {
           fill
           data-test-subj="SaveSettingsButton"
         >
-          Save settings
+          {SAVE_SETTINGS_BUTTON}
         </EuiButton>
       </EuiFlexItem>
     </EuiFlexGroup>
@@ -100,9 +111,9 @@ export const Security: React.FC = () => {
   const header = (
     <>
       <ViewContentHeader
-        title="Private sources"
+        title={PRIVATE_SOURCES}
         alignItems="flexStart"
-        description="Private sources are connected by users in your organization to create a personalized search experience."
+        description={PRIVATE_SOURCES_DESCRIPTION}
         action={headerActions}
       />
       <EuiSpacer />
@@ -124,7 +135,7 @@ export const Security: React.FC = () => {
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText size="s">
-            <h4>Enable private sources for your organization</h4>
+            <h4>{PRIVATE_SOURCES_TOGGLE_DESCRIPTION}</h4>
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -134,7 +145,7 @@ export const Security: React.FC = () => {
   const platinumLicenseCallout = (
     <>
       <EuiSpacer size="s" />
-      <LicenseCallout message="Private sources require a Platinum license." />
+      <LicenseCallout message={PRIVATE_PLATINUM_LICENSE_CALLOUT} />
     </>
   );
 
@@ -160,14 +171,14 @@ export const Security: React.FC = () => {
   const confirmModal = (
     <EuiOverlayMask>
       <EuiConfirmModal
-        title="Confirm changes"
+        title={CONFIRM_CHANGES_TEXT}
         onConfirm={savePrivateSources}
         onCancel={hideConfirmModal}
         buttonColor="primary"
-        cancelButtonText="Keep editing"
-        confirmButtonText="Save changes"
+        cancelButtonText={KEEP_EDITING_BUTTON}
+        confirmButtonText={SAVE_CHANGES_BUTTON}
       >
-        Updates to private source configuration will take effect immediately.
+        {PRIVATE_SOURCES_UPDATE_CONFIRMATION_TEXT}
       </EuiConfirmModal>
     </EuiOverlayMask>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -24,7 +24,6 @@ import {
   EuiOverlayMask,
 } from '@elastic/eui';
 
-import { AppView, SidebarNavigation } from 'workplace_search/components';
 import { FlashMessages } from '../../../shared/flash_messages';
 import { LicenseCallout } from '../../components/shared/license_callout';
 import { Loading } from '../../../shared/loading';
@@ -95,13 +94,6 @@ export const Security: React.FC = () => {
         </EuiButton>
       </EuiFlexItem>
     </EuiFlexGroup>
-  );
-
-  const sidebar = (
-    <SidebarNavigation
-      title="Security"
-      description="Manage content source connection rules and information access for your organization."
-    />
   );
 
   const header = (
@@ -180,7 +172,7 @@ export const Security: React.FC = () => {
   );
 
   return (
-    <AppView sidebar={sidebar}>
+    <>
       <Prompt when={unsavedChanges} message={UNSAVED_MESSAGE} />
       <FlashMessages />
       {header}
@@ -188,6 +180,6 @@ export const Security: React.FC = () => {
       {isLocked && platinumLicenseCallout}
       {sourceTables}
       {confirmModalVisible && confirmModal}
-    </AppView>
+    </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -9,8 +9,6 @@ import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { useActions, useValues } from 'kea';
 
-import { Prompt } from 'react-router-dom';
-
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -176,7 +174,6 @@ export const Security: React.FC = () => {
 
   return (
     <>
-      <Prompt when={unsavedChanges} message={UNSAVED_MESSAGE} />
       <FlashMessages />
       {header}
       {allSourcesToggle}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -20,9 +20,10 @@ import {
   EuiText,
   EuiSpacer,
   EuiPanel,
+  EuiConfirmModal,
+  EuiOverlayMask,
 } from '@elastic/eui';
 
-import ConfirmModal from 'shared/components/ConfirmModal';
 import { AppView, SidebarNavigation } from 'workplace_search/components';
 import { FlashMessages } from '../../../shared/flash_messages';
 import { LicenseCallout } from '../../components/shared/license_callout';
@@ -164,16 +165,18 @@ export const Security: React.FC = () => {
   );
 
   const confirmModal = (
-    <ConfirmModal
-      title="Confirm changes"
-      onConfirm={savePrivateSources}
-      onCancel={hideConfirmModal}
-      buttonColor="primary"
-      cancelButtonText="Keep editing"
-      confirmButtonText="Save changes"
-    >
-      Updates to private source configuration will take effect immediately.
-    </ConfirmModal>
+    <EuiOverlayMask>
+      <EuiConfirmModal
+        title="Confirm changes"
+        onConfirm={savePrivateSources}
+        onCancel={hideConfirmModal}
+        buttonColor="primary"
+        cancelButtonText="Keep editing"
+        confirmButtonText="Save changes"
+      >
+        Updates to private source configuration will take effect immediately.
+      </EuiConfirmModal>
+    </EuiOverlayMask>
   );
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -23,18 +23,14 @@ import {
 } from '@elastic/eui';
 
 import ConfirmModal from 'shared/components/ConfirmModal';
-import FlashMessages from 'shared/components/FlashMessages';
+import { AppView, SidebarNavigation } from 'workplace_search/components';
+import { FlashMessages } from '../../../shared/flash_messages';
+import { LicenseCallout } from '../../components/shared/license_callout';
+import { Loading } from '../../../shared/loading';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
+import { SecurityLogic } from './security_logic';
 
-import {
-  AppView,
-  LicenseCallout,
-  Loading,
-  SidebarNavigation,
-  ViewContentHeader,
-} from 'workplace_search/components';
-import { SecurityLogic } from './SecurityLogic';
-
-import { PrivateSourcesTable } from './components/PrivateSourcesTable';
+import { PrivateSourcesTable } from './components/private_sources_table';
 
 const UNSAVED_MESSAGE =
   'Your private sources settings have not been saved. Are you sure you want to leave?';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -52,15 +52,9 @@ export const Security: React.FC = () => {
     resetState,
   } = useActions(SecurityLogic);
 
-  const {
-    isEnabled,
-    isLocked,
-    remote,
-    standard,
-    dataLoading,
-    flashMessages,
-    unsavedChanges,
-  } = useValues(SecurityLogic);
+  const { isEnabled, isLocked, remote, standard, dataLoading, unsavedChanges } = useValues(
+    SecurityLogic
+  );
 
   useEffect(() => {
     initializeSourceRestrictions();
@@ -185,7 +179,7 @@ export const Security: React.FC = () => {
   return (
     <AppView sidebar={sidebar}>
       <Prompt when={unsavedChanges} message={UNSAVED_MESSAGE} />
-      {flashMessages && <FlashMessages {...flashMessages} />}
+      <FlashMessages />
       {header}
       {allSourcesToggle}
       {isLocked && platinumLicenseCallout}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { HttpLogic } from '../../../shared/http';
+import { mockHttpValues } from '../../../__mocks__';
+import { flashAPIErrors } from '../../../shared/flash_messages';
+import { SecurityLogic } from './security_logic';
+
+jest.mock('../../../shared/http', () => ({
+  HttpLogic: {
+    values: { http: mockHttpValues.http },
+  },
+}));
+
+jest.mock('../../../shared/flash_messages', () => ({
+  flashAPIErrors: jest.fn(),
+}));
+
+describe('SecurityLogic', () => {
+  const { mount } = new LogicMounter(SecurityLogic);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mount();
+  });
+
+  const defaultValues = {
+    dataLoading: true,
+    cachedServerState: {},
+    isEnabled: false,
+    remote: {},
+    standard: {},
+    unsavedChanges: true,
+  };
+
+  const serverProps = {
+    isEnabled: true,
+    remote: {
+      isEnabled: true,
+      contentSources: [{ id: 'gmail', name: 'Gmail', isEnabled: true }],
+    },
+    standard: {
+      isEnabled: true,
+      contentSources: [{ id: 'one_drive', name: 'OneDrive', isEnabled: true }],
+    },
+  };
+
+  it('has expected default values', () => {
+    expect(SecurityLogic.values).toEqual(defaultValues);
+  });
+
+  describe('actions', () => {
+    it('setServerProps', () => {
+      SecurityLogic.actions.setServerProps(serverProps);
+
+      expect(SecurityLogic.values.isEnabled).toEqual(true);
+    });
+
+    it('setSourceRestrictionsUpdated', () => {
+      SecurityLogic.actions.setSourceRestrictionsUpdated(serverProps);
+
+      expect(SecurityLogic.values.isEnabled).toEqual(true);
+    });
+
+    it('updatePrivateSourcesEnabled', () => {
+      SecurityLogic.actions.updatePrivateSourcesEnabled(false);
+
+      expect(SecurityLogic.values.isEnabled).toEqual(false);
+    });
+
+    it('updateRemoteEnabled', () => {
+      SecurityLogic.actions.updateRemoteEnabled(false);
+
+      expect(SecurityLogic.values.remote.isEnabled).toEqual(false);
+    });
+
+    it('updateStandardEnabled', () => {
+      SecurityLogic.actions.updateStandardEnabled(false);
+
+      expect(SecurityLogic.values.standard.isEnabled).toEqual(false);
+    });
+
+    it('updateRemoteSource', () => {
+      SecurityLogic.actions.setServerProps(serverProps);
+      SecurityLogic.actions.updateRemoteSource('gmail', false);
+
+      expect(SecurityLogic.values.remote.contentSources[0].isEnabled).toEqual(false);
+    });
+
+    it('updateStandardSource', () => {
+      SecurityLogic.actions.setServerProps(serverProps);
+      SecurityLogic.actions.updateStandardSource('one_drive', false);
+
+      expect(SecurityLogic.values.standard.contentSources[0].isEnabled).toEqual(false);
+    });
+  });
+
+  describe('selectors', () => {
+    describe('unsavedChanges', () => {
+      it('returns true while loading', () => {
+        expect(SecurityLogic.values.unsavedChanges).toEqual(true);
+      });
+
+      it('returns false after loading', () => {
+        SecurityLogic.actions.setServerProps(serverProps);
+
+        expect(SecurityLogic.values.unsavedChanges).toEqual(false);
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('initializeSourceRestrictions', () => {
+      it('calls API and sets values', async () => {
+        const setServerPropsSpy = jest.spyOn(SecurityLogic.actions, 'setServerProps');
+        const promise = Promise.resolve(serverProps);
+        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        SecurityLogic.actions.initializeSourceRestrictions();
+
+        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+          '/api/workplace_search/org/security/source_restrictions'
+        );
+        await promise;
+        expect(setServerPropsSpy).toHaveBeenCalledWith(serverProps);
+      });
+
+      it('handles error', async () => {
+        const promise = Promise.reject('this is an error');
+        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+
+        SecurityLogic.actions.initializeSourceRestrictions();
+        try {
+          await promise;
+        } catch {
+          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
+        }
+      });
+    });
+
+    describe('saveSourceRestrictions', () => {
+      it('calls API and sets values', async () => {
+        const promise = Promise.resolve(serverProps);
+        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(promise);
+        SecurityLogic.actions.setSourceRestrictionsUpdated(serverProps);
+        SecurityLogic.actions.saveSourceRestrictions();
+
+        expect(HttpLogic.values.http.patch).toHaveBeenCalledWith(
+          '/api/workplace_search/org/security/source_restrictions',
+          {
+            body: JSON.stringify(serverProps),
+          }
+        );
+      });
+
+      it('handles error', async () => {
+        const promise = Promise.reject('this is an error');
+        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(promise);
+
+        SecurityLogic.actions.saveSourceRestrictions();
+        try {
+          await promise;
+        } catch {
+          expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
+        }
+      });
+    });
+
+    describe('resetState', () => {
+      it('calls API and sets values', async () => {
+        SecurityLogic.actions.setServerProps(serverProps);
+        SecurityLogic.actions.updatePrivateSourcesEnabled(false);
+        SecurityLogic.actions.resetState();
+
+        expect(SecurityLogic.values.isEnabled).toEqual(true);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
@@ -5,23 +5,13 @@
  */
 
 import { LogicMounter } from '../../../__mocks__/kea.mock';
-import { HttpLogic } from '../../../shared/http';
-import { mockHttpValues } from '../../../__mocks__';
-import { flashAPIErrors } from '../../../shared/flash_messages';
+import { mockHttpValues, mockFlashMessageHelpers } from '../../../__mocks__';
 import { SecurityLogic } from './security_logic';
 import { nextTick } from '@kbn/test/jest';
 
-jest.mock('../../../shared/http', () => ({
-  HttpLogic: {
-    values: { http: mockHttpValues.http },
-  },
-}));
-
-jest.mock('../../../shared/flash_messages', () => ({
-  flashAPIErrors: jest.fn(),
-}));
-
 describe('SecurityLogic', () => {
+  const { http } = mockHttpValues;
+  const { flashAPIErrors } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(SecurityLogic);
 
   beforeEach(() => {
@@ -118,10 +108,10 @@ describe('SecurityLogic', () => {
     describe('initializeSourceRestrictions', () => {
       it('calls API and sets values', async () => {
         const setServerPropsSpy = jest.spyOn(SecurityLogic.actions, 'setServerProps');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(Promise.resolve(serverProps));
+        http.get.mockReturnValue(Promise.resolve(serverProps));
         SecurityLogic.actions.initializeSourceRestrictions();
 
-        expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
+        expect(http.get).toHaveBeenCalledWith(
           '/api/workplace_search/org/security/source_restrictions'
         );
         await nextTick();
@@ -129,9 +119,7 @@ describe('SecurityLogic', () => {
       });
 
       it('handles error', async () => {
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(
-          Promise.reject('this is an error')
-        );
+        http.get.mockReturnValue(Promise.reject('this is an error'));
 
         SecurityLogic.actions.initializeSourceRestrictions();
         try {
@@ -144,11 +132,11 @@ describe('SecurityLogic', () => {
 
     describe('saveSourceRestrictions', () => {
       it('calls API and sets values', async () => {
-        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(Promise.resolve(serverProps));
+        http.patch.mockReturnValue(Promise.resolve(serverProps));
         SecurityLogic.actions.setSourceRestrictionsUpdated(serverProps);
         SecurityLogic.actions.saveSourceRestrictions();
 
-        expect(HttpLogic.values.http.patch).toHaveBeenCalledWith(
+        expect(http.patch).toHaveBeenCalledWith(
           '/api/workplace_search/org/security/source_restrictions',
           {
             body: JSON.stringify(serverProps),
@@ -157,9 +145,7 @@ describe('SecurityLogic', () => {
       });
 
       it('handles error', async () => {
-        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(
-          Promise.reject('this is an error')
-        );
+        http.patch.mockReturnValue(Promise.reject('this is an error'));
 
         SecurityLogic.actions.saveSourceRestrictions();
         try {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
@@ -9,6 +9,7 @@ import { HttpLogic } from '../../../shared/http';
 import { mockHttpValues } from '../../../__mocks__';
 import { flashAPIErrors } from '../../../shared/flash_messages';
 import { SecurityLogic } from './security_logic';
+import { nextTick } from '@kbn/test/jest';
 
 jest.mock('../../../shared/http', () => ({
   HttpLogic: {
@@ -117,24 +118,24 @@ describe('SecurityLogic', () => {
     describe('initializeSourceRestrictions', () => {
       it('calls API and sets values', async () => {
         const setServerPropsSpy = jest.spyOn(SecurityLogic.actions, 'setServerProps');
-        const promise = Promise.resolve(serverProps);
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(Promise.resolve(serverProps));
         SecurityLogic.actions.initializeSourceRestrictions();
 
         expect(HttpLogic.values.http.get).toHaveBeenCalledWith(
           '/api/workplace_search/org/security/source_restrictions'
         );
-        await promise;
+        await nextTick();
         expect(setServerPropsSpy).toHaveBeenCalledWith(serverProps);
       });
 
       it('handles error', async () => {
-        const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(promise);
+        (HttpLogic.values.http.get as jest.Mock).mockReturnValue(
+          Promise.reject('this is an error')
+        );
 
         SecurityLogic.actions.initializeSourceRestrictions();
         try {
-          await promise;
+          await nextTick();
         } catch {
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         }
@@ -143,8 +144,7 @@ describe('SecurityLogic', () => {
 
     describe('saveSourceRestrictions', () => {
       it('calls API and sets values', async () => {
-        const promise = Promise.resolve(serverProps);
-        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(promise);
+        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(Promise.resolve(serverProps));
         SecurityLogic.actions.setSourceRestrictionsUpdated(serverProps);
         SecurityLogic.actions.saveSourceRestrictions();
 
@@ -157,12 +157,13 @@ describe('SecurityLogic', () => {
       });
 
       it('handles error', async () => {
-        const promise = Promise.reject('this is an error');
-        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(promise);
+        (HttpLogic.values.http.patch as jest.Mock).mockReturnValue(
+          Promise.reject('this is an error')
+        );
 
         SecurityLogic.actions.saveSourceRestrictions();
         try {
-          await promise;
+          await nextTick();
         } catch {
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
         }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { cloneDeep } from 'lodash';
+import { isEqual } from 'lodash';
+
+import { kea, MakeLogicType } from 'kea';
+
+import http from 'shared/http';
+import routes from 'workplace_search/routes';
+
+import { handleAPIError } from 'app_search/utils/handleAPIError';
+import { IFlashMessagesProps } from 'shared/types';
+
+import { AppLogic } from 'workplace_search/App';
+
+export interface PrivateSource {
+  id: string;
+  name: string;
+  isEnabled: boolean;
+}
+
+export interface PrivateSourceSection {
+  isEnabled: boolean;
+  contentSources: PrivateSource[];
+}
+
+export interface SecurityServerProps {
+  isEnabled: boolean;
+  isLocked: boolean;
+  remote: PrivateSourceSection;
+  standard: PrivateSourceSection;
+}
+
+interface SecurityValues extends SecurityServerProps {
+  dataLoading: boolean;
+  flashMessages: IFlashMessagesProps;
+  unsavedChanges: boolean;
+  cachedServerState: SecurityServerProps;
+}
+
+interface SecurityActions {
+  setServerProps(serverProps: SecurityServerProps): SecurityServerProps;
+  setSourceRestrictionsUpdated(serverProps: SecurityServerProps): SecurityServerProps;
+  setFlashMessages(flashMessages: IFlashMessagesProps): { flashMessages: IFlashMessagesProps };
+  initializeSourceRestrictions(): void;
+  saveSourceRestrictions(): void;
+  updatePrivateSourcesEnabled(isEnabled: boolean): { isEnabled: boolean };
+  updateRemoteEnabled(isEnabled: boolean): { isEnabled: boolean };
+  updateRemoteSource(
+    sourceId: string,
+    isEnabled: boolean
+  ): { sourceId: string; isEnabled: boolean };
+  updateStandardEnabled(isEnabled: boolean): { isEnabled: boolean };
+  updateStandardSource(
+    sourceId: string,
+    isEnabled: boolean
+  ): { sourceId: string; isEnabled: boolean };
+  resetState(): void;
+}
+
+const route = routes.fritoPieOrganizationSecuritySourceRestrictionsPath();
+
+export const SecurityLogic = kea<MakeLogicType<SecurityValues, SecurityActions>>({
+  path: ['enterprise_search', 'workplace_search', 'security_logic'],
+  actions: {
+    setServerProps: (serverProps: SecurityServerProps) => serverProps,
+    setSourceRestrictionsUpdated: (serverProps: SecurityServerProps) => serverProps,
+    setFlashMessages: (flashMessages: IFlashMessagesProps) => ({ flashMessages }),
+    initializeSourceRestrictions: () => true,
+    saveSourceRestrictions: () => null,
+    updatePrivateSourcesEnabled: (isEnabled: boolean) => ({ isEnabled }),
+    updateRemoteEnabled: (isEnabled: boolean) => ({ isEnabled }),
+    updateRemoteSource: (sourceId: string, isEnabled: boolean) => ({ sourceId, isEnabled }),
+    updateStandardEnabled: (isEnabled: boolean) => ({ isEnabled }),
+    updateStandardSource: (sourceId: string, isEnabled: boolean) => ({ sourceId, isEnabled }),
+    resetState: () => null,
+  },
+  reducers: {
+    dataLoading: [
+      true,
+      {
+        setServerProps: () => false,
+      },
+    ],
+    cachedServerState: [
+      {} as SecurityServerProps,
+      {
+        setServerProps: (_, serverProps) => cloneDeep(serverProps),
+        setSourceRestrictionsUpdated: (_, serverProps) => cloneDeep(serverProps),
+      },
+    ],
+    isEnabled: [
+      false,
+      {
+        setServerProps: (_, { isEnabled }) => isEnabled,
+        setSourceRestrictionsUpdated: (_, { isEnabled }) => isEnabled,
+        updatePrivateSourcesEnabled: (_, { isEnabled }) => isEnabled,
+      },
+    ],
+    isLocked: [
+      false,
+      {
+        setServerProps: (_, { isLocked }) => isLocked,
+        setSourceRestrictionsUpdated: (_, { isLocked }) => isLocked,
+      },
+    ],
+    remote: [
+      {} as PrivateSourceSection,
+      {
+        setServerProps: (_, { remote }) => remote,
+        setSourceRestrictionsUpdated: (_, { remote }) => remote,
+        updateRemoteEnabled: (state, { isEnabled }) => ({ ...state, isEnabled }),
+        updateRemoteSource: (state, { sourceId, isEnabled }) =>
+          updateSourceEnabled(state, sourceId, isEnabled),
+      },
+    ],
+    standard: [
+      {} as PrivateSourceSection,
+      {
+        setServerProps: (_, { standard }) => standard,
+        setSourceRestrictionsUpdated: (_, { standard }) => standard,
+        updateStandardEnabled: (state, { isEnabled }) => ({ ...state, isEnabled }),
+        updateStandardSource: (state, { sourceId, isEnabled }) =>
+          updateSourceEnabled(state, sourceId, isEnabled),
+      },
+    ],
+    flashMessages: [
+      {},
+      {
+        setFlashMessages: (_, { flashMessages }) => flashMessages,
+        setSourceRestrictionsUpdated: () => ({
+          success: ['Successfully updated source restrictions.'],
+        }),
+      },
+    ],
+  },
+  selectors: ({ selectors }) => ({
+    unsavedChanges: [
+      () => [
+        selectors.cachedServerState,
+        selectors.isEnabled,
+        selectors.remote,
+        selectors.standard,
+      ],
+      (cached, isEnabled, remote, standard) =>
+        cached.isEnabled !== isEnabled ||
+        !isEqual(cached.remote, remote) ||
+        !isEqual(cached.standard, standard),
+    ],
+  }),
+  listeners: ({ actions, values }) => ({
+    initializeSourceRestrictions: () => {
+      http(route)
+        .then(({ data }) => actions.setServerProps(data))
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    saveSourceRestrictions: () => {
+      const { isEnabled, remote, standard } = values;
+      const serverData = { isEnabled, remote, standard };
+
+      http
+        .patch(route, serverData)
+        .then(({ data }) => {
+          actions.setSourceRestrictionsUpdated(data);
+          AppLogic.actions.setSourceRestriction(isEnabled);
+        })
+        .catch(handleAPIError((messages) => actions.setFlashMessages({ error: messages })));
+    },
+    resetState: () => {
+      actions.setServerProps(cloneDeep(values.cachedServerState));
+      actions.setFlashMessages({});
+    },
+  }),
+});
+
+const updateSourceEnabled = (
+  section: PrivateSourceSection,
+  id: string,
+  isEnabled: boolean
+): PrivateSourceSection => {
+  const updatedSection = { ...section };
+  const sources = updatedSection.contentSources;
+  const sourceIndex = sources.findIndex((source) => source.id === id);
+  updatedSection.contentSources[sourceIndex] = { ...sources[sourceIndex], isEnabled };
+
+  return updatedSection;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -30,7 +30,6 @@ export interface PrivateSourceSection {
 
 export interface SecurityServerProps {
   isEnabled: boolean;
-  isLocked: boolean;
   remote: PrivateSourceSection;
   standard: PrivateSourceSection;
 }
@@ -96,13 +95,6 @@ export const SecurityLogic = kea<MakeLogicType<SecurityValues, SecurityActions>>
         setServerProps: (_, { isEnabled }) => isEnabled,
         setSourceRestrictionsUpdated: (_, { isEnabled }) => isEnabled,
         updatePrivateSourcesEnabled: (_, { isEnabled }) => isEnabled,
-      },
-    ],
-    isLocked: [
-      false,
-      {
-        setServerProps: (_, { isLocked }) => isLocked,
-        setSourceRestrictionsUpdated: (_, { isLocked }) => isLocked,
       },
     ],
     remote: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -17,6 +17,8 @@ import {
 import { HttpLogic } from '../../../shared/http';
 import { AppLogic } from '../../app_logic';
 
+import { SOURCE_RESTRICTIONS_SUCCESS_MESSAGE } from '../../constants';
+
 export interface PrivateSource {
   id: string;
   name: string;
@@ -152,7 +154,7 @@ export const SecurityLogic = kea<MakeLogicType<SecurityValues, SecurityActions>>
       try {
         const response = await http.patch(route, { body });
         actions.setSourceRestrictionsUpdated(response);
-        setSuccessMessage('Successfully updated source restrictions.');
+        setSuccessMessage(SOURCE_RESTRICTIONS_SUCCESS_MESSAGE);
         AppLogic.actions.setSourceRestriction(isEnabled);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -15,7 +15,7 @@ import routes from 'workplace_search/routes';
 import { handleAPIError } from 'app_search/utils/handleAPIError';
 import { IFlashMessagesProps } from 'shared/types';
 
-import { AppLogic } from 'workplace_search/App';
+import { AppLogic } from '../../app_logic';
 
 export interface PrivateSource {
   id: string;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -10,7 +10,6 @@ import { isEqual } from 'lodash';
 import { kea, MakeLogicType } from 'kea';
 
 import http from 'shared/http';
-import routes from 'workplace_search/routes';
 
 import {
   clearFlashMessages,
@@ -62,7 +61,7 @@ interface SecurityActions {
   resetState(): void;
 }
 
-const route = routes.fritoPieOrganizationSecuritySourceRestrictionsPath();
+const route = '/api/workplace_search/org/security/source_restrictions';
 
 export const SecurityLogic = kea<MakeLogicType<SecurityValues, SecurityActions>>({
   path: ['enterprise_search', 'workplace_search', 'security_logic'],

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -10,10 +10,12 @@ import { registerOverviewRoute } from './overview';
 import { registerGroupsRoutes } from './groups';
 import { registerSourcesRoutes } from './sources';
 import { registerSettingsRoutes } from './settings';
+import { registerSecurityRoutes } from './security';
 
 export const registerWorkplaceSearchRoutes = (dependencies: RouteDependencies) => {
   registerOverviewRoute(dependencies);
   registerGroupsRoutes(dependencies);
   registerSourcesRoutes(dependencies);
   registerSettingsRoutes(dependencies);
+  registerSecurityRoutes(dependencies);
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/security.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/security.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MockRouter, mockRequestHandler, mockDependencies } from '../../__mocks__';
+
+import { registerSecurityRoute, registerSecuritySourceRestrictionsRoute } from './security';
+
+describe('security routes', () => {
+  describe('GET /api/workplace_search/org/security', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/security',
+      });
+
+      registerSecurityRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      mockRouter.callRoute({});
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/security',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/security/source_restrictions', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/security/source_restrictions',
+        payload: 'body',
+      });
+
+      registerSecuritySourceRestrictionsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      mockRouter.callRoute({});
+
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/security/source_restrictions',
+      });
+    });
+  });
+
+  describe('PATCH /api/workplace_search/org/security/source_restrictions', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockRouter = new MockRouter({
+        method: 'patch',
+        path: '/api/workplace_search/org/security/source_restrictions',
+        payload: 'body',
+      });
+
+      registerSecuritySourceRestrictionsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/security/source_restrictions',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = {
+          body: {
+            isEnabled: true,
+            remote: {
+              isEnabled: true,
+              contentSources: [{ id: 'gmail', name: 'Gmail', isEnabled: true }],
+            },
+            standard: {
+              isEnabled: false,
+              contentSources: [{ id: 'dropbox', name: 'Dropbox', isEnabled: false }],
+            },
+          },
+        };
+        mockRouter.shouldValidate(request);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/security.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/security.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import { RouteDependencies } from '../../plugin';
+
+export function registerSecurityRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/security',
+      validate: false,
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/security',
+    })
+  );
+}
+
+export function registerSecuritySourceRestrictionsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/security/source_restrictions',
+      validate: false,
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/security/source_restrictions',
+    })
+  );
+
+  router.patch(
+    {
+      path: '/api/workplace_search/org/security/source_restrictions',
+      validate: {
+        body: schema.object({
+          isEnabled: schema.boolean(),
+          remote: schema.object({
+            isEnabled: schema.boolean(),
+            contentSources: schema.arrayOf(
+              schema.object({
+                isEnabled: schema.boolean(),
+                id: schema.string(),
+                name: schema.string(),
+              })
+            ),
+          }),
+          standard: schema.object({
+            isEnabled: schema.boolean(),
+            contentSources: schema.arrayOf(
+              schema.object({
+                isEnabled: schema.boolean(),
+                id: schema.string(),
+                name: schema.string(),
+              })
+            ),
+          }),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/security/source_restrictions',
+    })
+  );
+}
+
+export const registerSecurityRoutes = (dependencies: RouteDependencies) => {
+  registerSecurityRoute(dependencies);
+  registerSecuritySourceRestrictionsRoute(dependencies);
+};


### PR DESCRIPTION
## Summary

This PR migrates the Security tree from ent-search.

![Screen Cast 2021-01-29 at 10 37 46 AM](https://user-images.githubusercontent.com/11838280/106288331-47518d80-621e-11eb-9b8f-098ab4b43457.gif)

Public folder coverage:
![image](https://user-images.githubusercontent.com/11838280/106289782-11ada400-6220-11eb-8a60-fb9a2e27d8ea.png)

Server folder coverage:
![image](https://user-images.githubusercontent.com/11838280/106290210-96002700-6220-11eb-94c5-2ff3d8d1b037.png)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

