### PR TITLE
[alerting][actions] change isESOUsingEphemeralEncryptionKey determination using status API

### DIFF
--- a/x-pack/plugins/alerts/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner.ts
@@ -144,12 +144,15 @@ export class TaskRunner<
     return fakeRequest;
   }
 
-  private getServicesWithSpaceLevelPermissions(
+  private async getServicesWithSpaceLevelPermissions(
     spaceId: string,
     apiKey: RawAlert['apiKey']
-  ): [Services, PublicMethodsOf<AlertsClient>] {
+  ): Promise<[Services, PublicMethodsOf<AlertsClient>]> {
     const request = this.getFakeKibanaRequest(spaceId, apiKey);
-    return [this.context.getServices(request), this.context.getAlertsClientWithRequest(request)];
+    return [
+      this.context.getServices(request),
+      await this.context.getAlertsClientWithRequest(request),
+    ];
   }
 
   private getExecutionHandler(
@@ -408,7 +411,10 @@ export class TaskRunner<
     } catch (err) {
       throw new ErrorWithReason(AlertExecutionStatusErrorReasons.Decrypt, err);
     }
-    const [services, alertsClient] = this.getServicesWithSpaceLevelPermissions(spaceId, apiKey);
+    const [services, alertsClient] = await this.getServicesWithSpaceLevelPermissions(
+      spaceId,
+      apiKey
+    );
 
     let alert: SanitizedAlert<Params>;
 

--- a/x-pack/plugins/alerts/server/task_runner/task_runner_factory.ts
+++ b/x-pack/plugins/alerts/server/task_runner/task_runner_factory.ts
@@ -30,7 +30,7 @@ import { NormalizedAlertType } from '../alert_type_registry';
 export interface TaskRunnerContext {
   logger: Logger;
   getServices: GetServicesFunction;
-  getAlertsClientWithRequest(request: KibanaRequest): PublicMethodsOf<AlertsClient>;
+  getAlertsClientWithRequest(request: KibanaRequest): Promise<PublicMethodsOf<AlertsClient>>;
   actionsPlugin: ActionsPluginStartContract;
   eventLogger: IEventLogger;
   encryptedSavedObjectsClient: EncryptedSavedObjectsClient;

--- a/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.js
+++ b/x-pack/plugins/monitoring/server/lib/cluster/get_clusters_from_request.js
@@ -118,7 +118,7 @@ export async function getClustersFromRequest(
 
     // add alerts data
     if (isInCodePath(codePaths, [CODE_PATH_ALERTS])) {
-      const alertsClient = req.getAlertsClient();
+      const alertsClient = await req.getAlertsClient();
       for (const cluster of clusters) {
         const verification = verifyMonitoringLicense(req.server);
         if (!verification.enabled) {

--- a/x-pack/plugins/monitoring/server/plugin.ts
+++ b/x-pack/plugins/monitoring/server/plugin.ts
@@ -320,9 +320,9 @@ export class Plugin {
             getKibanaStatsCollector: () => this.legacyShimDependencies.kibanaStatsCollector,
             getUiSettingsService: () => context.core.uiSettings.client,
             getActionTypeRegistry: () => context.actions?.listTypes(),
-            getAlertsClient: () => {
+            getAlertsClient: async () => {
               try {
-                return plugins.alerts.getAlertsClientWithRequest(req);
+                return await plugins.alerts.getAlertsClientWithRequest(req);
               } catch (err) {
                 // If security is disabled, this call will throw an error unless a certain config is set for dist builds
                 return null;

--- a/x-pack/plugins/monitoring/server/routes/api/v1/alerts/enable.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/alerts/enable.ts
@@ -42,7 +42,7 @@ export function enableAlertsRoute(_server: unknown, npRoute: RouteDependencies) 
           }
         }
 
-        const alertsClient = context.alerting?.getAlertsClient();
+        const alertsClient = await context.alerting?.getAlertsClient();
         const actionsClient = context.actions?.getActionsClient();
         const types = context.actions?.listTypes();
         if (!alertsClient || !actionsClient || !types) {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/alerts/status.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/alerts/status.ts
@@ -33,7 +33,7 @@ export function alertStatusRoute(server: any, npRoute: RouteDependencies) {
       try {
         const { clusterUuid } = request.params;
         const { alertTypeIds, filters } = request.body;
-        const alertsClient = context.alerting?.getAlertsClient();
+        const alertsClient = await context.alerting?.getAlertsClient();
         if (!alertsClient) {
           return response.ok({ body: undefined });
         }

--- a/x-pack/plugins/monitoring/server/types.ts
+++ b/x-pack/plugins/monitoring/server/types.ts
@@ -104,7 +104,7 @@ export interface LegacyRequest {
   getKibanaStatsCollector: () => any;
   getUiSettingsService: () => any;
   getActionTypeRegistry: () => any;
-  getAlertsClient: () => any;
+  getAlertsClient: () => Promise<any>;
   getActionsClient: () => any;
   server: LegacyServer;
 }

--- a/x-pack/plugins/security_solution/server/endpoint/ingest_integration.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/ingest_integration.ts
@@ -129,7 +129,7 @@ export const getPackagePolicyCreateCallback = (
         // @ts-expect-error
         context,
         appClient,
-        alerts.getAlertsClientWithRequest(request),
+        await alerts.getAlertsClientWithRequest(request),
         frameworkRequest,
         maxTimelineImportExportSize,
         exceptionsClient


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
