### PR TITLE
Timelion reads raw field list from saved object, should grab from index pattern api

### DIFF
--- a/src/plugins/vis_type_timelion/public/components/timelion_expression_input_helpers.test.ts
+++ b/src/plugins/vis_type_timelion/public/components/timelion_expression_input_helpers.test.ts
@@ -8,14 +8,12 @@
 
 import { SUGGESTION_TYPE, suggest } from './timelion_expression_input_helpers';
 import { getArgValueSuggestions } from '../helpers/arg_value_suggestions';
-import { setIndexPatterns, setSavedObjectsClient } from '../helpers/plugin_services';
+import { setIndexPatterns } from '../helpers/plugin_services';
 import { IndexPatternsContract } from 'src/plugins/data/public';
-import { SavedObjectsClient } from 'kibana/public';
 import { ITimelionFunction } from '../../common/types';
 
 describe('Timelion expression suggestions', () => {
   setIndexPatterns({} as IndexPatternsContract);
-  setSavedObjectsClient({} as SavedObjectsClient);
 
   const argValueSuggestions = getArgValueSuggestions();
 

--- a/src/plugins/vis_type_timelion/public/helpers/arg_value_suggestions.ts
+++ b/src/plugins/vis_type_timelion/public/helpers/arg_value_suggestions.ts
@@ -59,7 +59,9 @@ export function getArgValueSuggestions() {
     es: {
       async index(partial: string) {
         const search = partial ? `${partial}*` : '*';
-        return (await indexPatterns.find(search, 25)).map(({ title }) => ({
+        const size = 25;
+
+        return (await indexPatterns.find(search, size)).map(({ title }) => ({
           name: title,
         }));
       },

--- a/src/plugins/vis_type_timelion/public/helpers/arg_value_suggestions.ts
+++ b/src/plugins/vis_type_timelion/public/helpers/arg_value_suggestions.ts
@@ -7,9 +7,9 @@
  */
 
 import { get } from 'lodash';
-import { getIndexPatterns, getSavedObjectsClient } from './plugin_services';
+import { getIndexPatterns } from './plugin_services';
 import { TimelionFunctionArgs } from '../../common/types';
-import { indexPatterns as indexPatternsUtils, IndexPatternAttributes } from '../../../data/public';
+import { indexPatterns as indexPatternsUtils } from '../../../data/public';
 
 export interface Location {
   min: number;
@@ -32,7 +32,6 @@ export interface FunctionArg {
 
 export function getArgValueSuggestions() {
   const indexPatterns = getIndexPatterns();
-  const savedObjectsClient = getSavedObjectsClient();
 
   async function getIndexPattern(functionArgs: FunctionArg[]) {
     const indexPatternArg = functionArgs.find(({ name }) => name === 'index');
@@ -42,22 +41,9 @@ export function getArgValueSuggestions() {
     }
     const indexPatternTitle = get(indexPatternArg, 'value.text');
 
-    const { savedObjects } = await savedObjectsClient.find<IndexPatternAttributes>({
-      type: 'index-pattern',
-      fields: ['title'],
-      search: `"${indexPatternTitle}"`,
-      searchFields: ['title'],
-      perPage: 10,
-    });
-    const indexPatternSavedObject = savedObjects.find(
-      ({ attributes }) => attributes.title === indexPatternTitle
+    return (await indexPatterns.find(indexPatternTitle)).find(
+      (index) => index.title === indexPatternTitle
     );
-    if (!indexPatternSavedObject) {
-      // index argument does not match an index pattern
-      return;
-    }
-
-    return await indexPatterns.get(indexPatternSavedObject.id);
   }
 
   function containsFieldName(partial: string, field: { name: string }) {
@@ -73,18 +59,9 @@ export function getArgValueSuggestions() {
     es: {
       async index(partial: string) {
         const search = partial ? `${partial}*` : '*';
-        const resp = await savedObjectsClient.find<IndexPatternAttributes>({
-          type: 'index-pattern',
-          fields: ['title', 'type'],
-          search: `${search}`,
-          searchFields: ['title'],
-          perPage: 25,
-        });
-        return resp.savedObjects
-          .filter((savedObject) => !savedObject.get('type'))
-          .map((savedObject) => {
-            return { name: savedObject.attributes.title };
-          });
+        return (await indexPatterns.find(search, 25)).map(({ title }) => ({
+          name: title,
+        }));
       },
       async metric(partial: string, functionArgs: FunctionArg[]) {
         if (!partial || !partial.includes(':')) {

--- a/src/plugins/vis_type_timelion/public/helpers/plugin_services.ts
+++ b/src/plugins/vis_type_timelion/public/helpers/plugin_services.ts
@@ -7,7 +7,6 @@
  */
 
 import type { IndexPatternsContract, ISearchStart } from 'src/plugins/data/public';
-import type { SavedObjectsClientContract } from 'kibana/public';
 import { createGetterSetter } from '../../../kibana_utils/public';
 
 export const [getIndexPatterns, setIndexPatterns] = createGetterSetter<IndexPatternsContract>(
@@ -15,8 +14,3 @@ export const [getIndexPatterns, setIndexPatterns] = createGetterSetter<IndexPatt
 );
 
 export const [getDataSearch, setDataSearch] = createGetterSetter<ISearchStart>('Search');
-
-export const [
-  getSavedObjectsClient,
-  setSavedObjectsClient,
-] = createGetterSetter<SavedObjectsClientContract>('SavedObjectsClient');

--- a/src/plugins/vis_type_timelion/public/plugin.ts
+++ b/src/plugins/vis_type_timelion/public/plugin.ts
@@ -25,7 +25,7 @@ import { VisualizationsSetup } from '../../visualizations/public';
 
 import { getTimelionVisualizationConfig } from './timelion_vis_fn';
 import { getTimelionVisDefinition } from './timelion_vis_type';
-import { setIndexPatterns, setSavedObjectsClient, setDataSearch } from './helpers/plugin_services';
+import { setIndexPatterns, setDataSearch } from './helpers/plugin_services';
 import { ConfigSchema } from '../config';
 
 import { getArgValueSuggestions } from './helpers/arg_value_suggestions';
@@ -92,7 +92,6 @@ export class TimelionVisPlugin
 
   public start(core: CoreStart, plugins: TimelionVisStartDependencies) {
     setIndexPatterns(plugins.data.indexPatterns);
-    setSavedObjectsClient(core.savedObjects.client);
     setDataSearch(plugins.data.search);
 
     return {

--- a/src/plugins/vis_type_timelion/server/plugin.ts
+++ b/src/plugins/vis_type_timelion/server/plugin.ts
@@ -46,7 +46,9 @@ export interface TimelionPluginStartDeps {
 export class Plugin {
   constructor(private readonly initializerContext: PluginInitializerContext) {}
 
-  public async setup(core: CoreSetup): Promise<RecursiveReadonly<PluginSetupContract>> {
+  public async setup(
+    core: CoreSetup<TimelionPluginStartDeps>
+  ): Promise<RecursiveReadonly<PluginSetupContract>> {
     const config = await this.initializerContext.config
       .create<TypeOf<typeof configSchema>>()
       .pipe(first())

--- a/src/plugins/vis_type_timelion/server/routes/run.ts
+++ b/src/plugins/vis_type_timelion/server/routes/run.ts
@@ -18,6 +18,7 @@ import getNamespacesSettings from '../lib/get_namespaced_settings';
 import getTlConfig from '../handlers/lib/tl_config';
 import { TimelionFunctionInterface } from '../types';
 import { ConfigManager } from '../lib/config_manager';
+import { TimelionPluginStartDeps } from '../plugin';
 
 const timelionDefaults = getNamespacesSettings();
 
@@ -32,7 +33,7 @@ export function runRoute(
     logger: Logger;
     getFunction: (name: string) => TimelionFunctionInterface;
     configManager: ConfigManager;
-    core: CoreSetup;
+    core: CoreSetup<TimelionPluginStartDeps>;
   }
 ) {
   router.post(
@@ -77,17 +78,22 @@ export function runRoute(
     },
     router.handleLegacyErrors(async (context, request, response) => {
       try {
+        const [, { data }] = await core.getStartServices();
         const uiSettings = await context.core.uiSettings.client.getAll();
+        const indexPatternsService = await data.indexPatterns.indexPatternsServiceFactory(
+          context.core.savedObjects.client,
+          context.core.elasticsearch.client.asCurrentUser
+        );
 
         const tlConfig = getTlConfig({
           context,
           request,
           settings: _.defaults(uiSettings, timelionDefaults), // Just in case they delete some setting.
           getFunction,
+          getIndexPatternsService: () => indexPatternsService,
           getStartServices: core.getStartServices,
           allowedGraphiteUrls: configManager.getGraphiteUrls(),
           esShardTimeout: configManager.getEsShardTimeout(),
-          savedObjectsClient: context.core.savedObjects.client,
         });
         const chainRunner = chainRunnerFn(tlConfig);
         const sheet = await Bluebird.all(chainRunner.processRequest(request.body));

--- a/src/plugins/vis_type_timelion/server/series_functions/es/es.test.js
+++ b/src/plugins/vis_type_timelion/server/series_functions/es/es.test.js
@@ -22,16 +22,12 @@ import { UI_SETTINGS } from '../../../../data/server';
 describe('es', () => {
   let tlConfig;
 
-  function stubRequestAndServer(response, indexPatternSavedObjects = []) {
+  function stubRequestAndServer(response) {
     return {
       context: { search: { search: jest.fn().mockReturnValue(of(response)) } },
-      savedObjectsClient: {
-        find: function () {
-          return Promise.resolve({
-            saved_objects: indexPatternSavedObjects,
-          });
-        },
-      },
+      getIndexPatternsService: () => ({
+        find: async () => [],
+      }),
     };
   }
 

--- a/src/plugins/vis_type_timelion/server/series_functions/es/index.js
+++ b/src/plugins/vis_type_timelion/server/series_functions/es/index.js
@@ -96,23 +96,12 @@ export default new Datasource('es', {
       kibana: true,
       fit: 'nearest',
     });
+    const indexPatternsService = tlConfig.getIndexPatternsService();
+    const indexPatternSpec = (await indexPatternsService.find(config.index)).find(
+      (index) => index.title === config.index
+    );
 
-    const findResp = await tlConfig.savedObjectsClient.find({
-      type: 'index-pattern',
-      fields: ['title', 'fields'],
-      search: `"${config.index}"`,
-      search_fields: ['title'],
-    });
-    const indexPatternSavedObject = findResp.saved_objects.find((savedObject) => {
-      return savedObject.attributes.title === config.index;
-    });
-    let scriptedFields = [];
-    if (indexPatternSavedObject) {
-      const fields = JSON.parse(indexPatternSavedObject.attributes.fields);
-      scriptedFields = fields.filter((field) => {
-        return field.scripted;
-      });
-    }
+    const scriptedFields = indexPatternSpec?.getScriptedFields() ?? [];
 
     const esShardTimeout = tlConfig.esShardTimeout;
 


### PR DESCRIPTION
Closes: #84387

## Summary
`Timelion` reads the index pattern field list from the index pattern saved object. Instead use the index pattern service to load the index pattern.

## Dev/Testing notes
`savedObjectsClient`  was changed to `indexPatterns` service in following places: 
- `arg_value_suggestions.ts `
  To test suggestions please you can use the following timeline expressions. 
   Index suggestions: 
   ![image](https://user-images.githubusercontent.com/20072247/106586361-68d1b280-6559-11eb-8e1d-4852e584a39b.png)
   Fields suggestions: 
  ![image](https://user-images.githubusercontent.com/20072247/106586400-771fce80-6559-11eb-8580-cd59a8b199bf.png)


- series_functions/es/index.js
   Scripted fields suggestions: 
   ![image](https://user-images.githubusercontent.com/20072247/106586775-e695be00-6559-11eb-92a7-d99e572c9bb1.png)
