### PR TITLE
[APM] `transactions.kubernetes.pod` can be undefined

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/sections.ts
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/sections.ts
@@ -54,7 +54,7 @@ export const getSections = ({
   urlParams: IUrlParams;
 }) => {
   const hostName = transaction.host?.hostname;
-  const podId = transaction.kubernetes?.pod.uid;
+  const podId = transaction.kubernetes?.pod?.uid;
   const containerId = transaction.container?.id;
 
   const time = Math.round(transaction.timestamp.us / 1000);

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/kubernetes.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/kubernetes.ts
@@ -5,5 +5,5 @@
  */
 
 export interface Kubernetes {
-  pod: { uid: string; [key: string]: unknown };
+  pod?: { uid: string; [key: string]: unknown };
 }


### PR DESCRIPTION
## Summary

We've been notified about some errors where the transaction view doesn't load because the `transactions.kubernetes` payload looks like this:

```
"kubernetes": {
  "namespace": "ci1-sass"
}
```

This PR makes `kubernetes.pod` an optional parameter in the Types definitions to make sure every logic validates it exists before reaching to its internal properties.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

# Release Notes

Fixes issue that may show empty Transaction page in the APM app.
