### PR TITLE
[Workplace Search] Refactor oauth redirect to persist state params from plugin

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/constants.ts
@@ -282,6 +282,8 @@ export const GITHUB_LINK_TITLE = i18n.translate(
 
 export const CUSTOM_SERVICE_TYPE = 'custom';
 
+export const WORKPLACE_SEARCH_URL_PREFIX = '/app/enterprise_search/workplace_search';
+
 export const DOCUMENTATION_LINK_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.documentation',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -280,6 +280,9 @@ describe('AddSourceLogic', () => {
         session_state: 'session123',
       };
 
+      const queryString =
+        'code=code123&state=%22%7B%22state%22%3A%20%22foo%22%7D%22&session_state=session123';
+
       const response = { serviceName: 'name', indexPermissions: false, serviceType: 'zendesk' };
 
       beforeEach(() => {
@@ -290,7 +293,7 @@ describe('AddSourceLogic', () => {
         const setAddedSourceSpy = jest.spyOn(SourcesLogic.actions, 'setAddedSource');
         const { serviceName, indexPermissions, serviceType } = response;
         http.get.mockReturnValue(Promise.resolve(response));
-        AddSourceLogic.actions.saveSourceParams(params);
+        AddSourceLogic.actions.saveSourceParams(queryString);
         expect(http.get).toHaveBeenCalledWith('/api/workplace_search/sources/create', {
           query: {
             ...params,
@@ -309,7 +312,7 @@ describe('AddSourceLogic', () => {
       it('handles error', async () => {
         http.get.mockReturnValue(Promise.reject('this is an error'));
 
-        AddSourceLogic.actions.saveSourceParams(params);
+        AddSourceLogic.actions.saveSourceParams(queryString);
         await nextTick();
 
         expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -586,7 +586,6 @@ describe('AddSourceLogic', () => {
 
       it('getSourceConnectData', () => {
         const query = {
-          index_permissions: false,
           kibana_host: '',
         };
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -289,7 +289,7 @@ describe('AddSourceLogic', () => {
       it('sends params to server and calls correct methods', async () => {
         const setAddedSourceSpy = jest.spyOn(SourcesLogic.actions, 'setAddedSource');
         const { serviceName, indexPermissions, serviceType } = response;
-        http.get.mockReturnValue(Promise.resolve({ ...response }));
+        http.get.mockReturnValue(Promise.resolve(response));
         AddSourceLogic.actions.saveSourceParams(params);
         expect(http.get).toHaveBeenCalledWith('/api/workplace_search/sources/create', {
           query: {
@@ -483,7 +483,7 @@ describe('AddSourceLogic', () => {
             http.put
           ).toHaveBeenCalledWith(
             `/api/workplace_search/org/settings/connectors/${sourceConfigData.serviceType}`,
-            { body: JSON.stringify({ ...params }) }
+            { body: JSON.stringify(params) }
           );
 
           await nextTick();
@@ -506,7 +506,7 @@ describe('AddSourceLogic', () => {
           };
 
           expect(http.post).toHaveBeenCalledWith('/api/workplace_search/org/settings/connectors', {
-            body: JSON.stringify({ ...createParams }),
+            body: JSON.stringify(createParams),
           });
         });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -4,16 +4,24 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../../../../__mocks__';
+import {
+  LogicMounter,
+  mockFlashMessageHelpers,
+  mockHttpValues,
+  mockKibanaValues,
+} from '../../../../../__mocks__';
 
 import { AppLogic } from '../../../../app_logic';
 jest.mock('../../../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
 
+import { SourcesLogic } from '../../sources_logic';
+
 import { nextTick } from '@kbn/test/jest';
 
 import { CustomSource } from '../../../../types';
+import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
 
 import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 
@@ -28,6 +36,7 @@ import {
 describe('AddSourceLogic', () => {
   const { mount } = new LogicMounter(AddSourceLogic);
   const { http } = mockHttpValues;
+  const { navigateToUrl } = mockKibanaValues;
   const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
 
   const defaultValues = {
@@ -264,6 +273,52 @@ describe('AddSourceLogic', () => {
       });
     });
 
+    describe('saveSourceParams', () => {
+      const params = {
+        code: 'code123',
+        state: '"{"state": "foo"}"',
+        session_state: 'session123',
+      };
+
+      const response = { serviceName: 'name', indexPermissions: false, serviceType: 'zendesk' };
+
+      beforeEach(() => {
+        SourcesLogic.mount();
+      });
+
+      it('sends params to server and calls correct methods', async () => {
+        const setAddedSourceSpy = jest.spyOn(SourcesLogic.actions, 'setAddedSource');
+        const { serviceName, indexPermissions, serviceType } = response;
+        http.get.mockReturnValue(Promise.resolve({ ...response }));
+        AddSourceLogic.actions.saveSourceParams(params);
+        expect(http.get).toHaveBeenCalledWith('/api/workplace_search/sources/create', {
+          query: {
+            ...params,
+            kibana_host: '',
+          },
+        });
+
+        await nextTick();
+
+        expect(setAddedSourceSpy).toHaveBeenCalledWith(serviceName, indexPermissions, serviceType);
+        expect(navigateToUrl).toHaveBeenCalledWith(
+          getSourcesPath(SOURCES_PATH, AppLogic.values.isOrganization)
+        );
+      });
+
+      it('handles error', async () => {
+        http.get.mockReturnValue(Promise.reject('this is an error'));
+
+        AddSourceLogic.actions.saveSourceParams(params);
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
+        expect(navigateToUrl).toHaveBeenCalledWith(
+          getSourcesPath(SOURCES_PATH, AppLogic.values.isOrganization)
+        );
+      });
+    });
+
     describe('organization context', () => {
       describe('getSourceConfigData', () => {
         it('calls API and sets values', async () => {
@@ -301,22 +356,37 @@ describe('AddSourceLogic', () => {
 
           AddSourceLogic.actions.getSourceConnectData('github', successCallback);
 
+          const query = {
+            index_permissions: false,
+            kibana_host: '',
+          };
+
           expect(clearFlashMessages).toHaveBeenCalled();
           expect(AddSourceLogic.values.buttonLoading).toEqual(true);
-          expect(http.get).toHaveBeenCalledWith('/api/workplace_search/org/sources/github/prepare');
+          expect(http.get).toHaveBeenCalledWith(
+            '/api/workplace_search/org/sources/github/prepare',
+            { query }
+          );
           await nextTick();
           expect(setSourceConnectDataSpy).toHaveBeenCalledWith(sourceConnectData);
           expect(successCallback).toHaveBeenCalledWith(sourceConnectData.oauthUrl);
           expect(setButtonNotLoadingSpy).toHaveBeenCalled();
         });
 
-        it('appends query params', () => {
+        it('passes query params', () => {
           AddSourceLogic.actions.setSourceSubdomainValue('subdomain');
           AddSourceLogic.actions.setSourceIndexPermissionsValue(true);
           AddSourceLogic.actions.getSourceConnectData('github', successCallback);
 
+          const query = {
+            index_permissions: true,
+            kibana_host: '',
+            subdomain: 'subdomain',
+          };
+
           expect(http.get).toHaveBeenCalledWith(
-            '/api/workplace_search/org/sources/github/prepare?subdomain=subdomain&index_permissions=true'
+            '/api/workplace_search/org/sources/github/prepare',
+            { query }
           );
         });
 
@@ -413,7 +483,7 @@ describe('AddSourceLogic', () => {
             http.put
           ).toHaveBeenCalledWith(
             `/api/workplace_search/org/settings/connectors/${sourceConfigData.serviceType}`,
-            { body: JSON.stringify({ params }) }
+            { body: JSON.stringify({ ...params }) }
           );
 
           await nextTick();
@@ -436,7 +506,7 @@ describe('AddSourceLogic', () => {
           };
 
           expect(http.post).toHaveBeenCalledWith('/api/workplace_search/org/settings/connectors', {
-            body: JSON.stringify({ params: createParams }),
+            body: JSON.stringify({ ...createParams }),
           });
         });
 
@@ -515,11 +585,16 @@ describe('AddSourceLogic', () => {
       });
 
       it('getSourceConnectData', () => {
+        const query = {
+          index_permissions: false,
+          kibana_host: '',
+        };
+
         AddSourceLogic.actions.getSourceConnectData('github', jest.fn());
 
-        expect(http.get).toHaveBeenCalledWith(
-          '/api/workplace_search/account/sources/github/prepare'
-        );
+        expect(
+          http.get
+        ).toHaveBeenCalledWith('/api/workplace_search/account/sources/github/prepare', { query });
       });
 
       it('getSourceReConnectData', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -51,6 +51,7 @@ export interface OauthParams {
   code: string;
   state: string;
   session_state: string;
+  oauth_verifier?: string;
 }
 
 export interface AddSourceActions {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -8,12 +8,15 @@ import { keys, pickBy } from 'lodash';
 
 import { kea, MakeLogicType } from 'kea';
 
+import { Search } from 'history';
+
 import { i18n } from '@kbn/i18n';
 
 import { HttpFetchQuery } from 'src/core/public';
 
 import { HttpLogic } from '../../../../../shared/http';
 import { KibanaLogic } from '../../../../../shared/kibana';
+import { parseQueryParams } from '../../../../../shared/query_params';
 
 import {
   flashAPIErrors,
@@ -87,7 +90,7 @@ export interface AddSourceActions {
     isUpdating: boolean,
     successCallback?: () => void
   ): { isUpdating: boolean; successCallback?(): void };
-  saveSourceParams(oauthParams: OauthParams): { oauthParams: OauthParams };
+  saveSourceParams(search: Search): { search: Search };
   getSourceConfigData(serviceType: string): { serviceType: string };
   getSourceConnectData(
     serviceType: string,
@@ -195,7 +198,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       isUpdating,
       successCallback,
     }),
-    saveSourceParams: (oauthParams: OauthParams) => ({ oauthParams }),
+    saveSourceParams: (search: Search) => ({ search }),
     createContentSource: (
       serviceType: string,
       successCallback: () => void,
@@ -470,13 +473,13 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         actions.setButtonNotLoading();
       }
     },
-    saveSourceParams: async ({ oauthParams }) => {
+    saveSourceParams: async ({ search }) => {
       const { http } = HttpLogic.values;
       const { isOrganization } = AppLogic.values;
       const { navigateToUrl } = KibanaLogic.values;
       const { setAddedSource } = SourcesLogic.actions;
-
-      const query = { ...oauthParams, kibana_host: kibanaHost };
+      const params = (parseQueryParams(search) as unknown) as OauthParams;
+      const query = { ...params, kibana_host: kibanaHost };
       const route = '/api/workplace_search/sources/create';
 
       try {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -381,9 +381,9 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
 
       const query = {
         kibana_host: kibanaHost,
-        index_permissions: indexPermissions,
       } as HttpFetchQuery;
 
+      if (isOrganization) query.index_permissions = indexPermissions;
       if (subdomain) query.subdomain = subdomain;
 
       try {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -450,7 +450,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
 
       try {
         const response = await http(route, {
-          body: JSON.stringify({ ...params }),
+          body: JSON.stringify(params),
         });
         if (successCallback) successCallback();
         if (isUpdating) {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
@@ -6,22 +6,22 @@
 
 import '../../../../__mocks__/shallow_useeffect.mock';
 
-import { setMockValues, setMockActions, mockFlashMessageHelpers } from '../../../../__mocks__';
+import { setMockActions } from '../../../../__mocks__';
 
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Redirect, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+
+import { Loading } from '../../../../shared/loading';
 
 import { SourceAdded } from './source_added';
 
 describe('SourceAdded', () => {
-  const { setErrorMessage } = mockFlashMessageHelpers;
-  const setAddedSource = jest.fn();
+  const saveSourceParams = jest.fn();
 
   beforeEach(() => {
-    setMockActions({ setAddedSource });
-    setMockValues({ isOrganization: true });
+    setMockActions({ saveSourceParams });
   });
 
   it('renders', () => {
@@ -29,26 +29,7 @@ describe('SourceAdded', () => {
     (useLocation as jest.Mock).mockImplementationOnce(() => ({ search }));
     const wrapper = shallow(<SourceAdded />);
 
-    expect(wrapper.find(Redirect)).toHaveLength(1);
-    expect(setAddedSource).toHaveBeenCalled();
-  });
-
-  describe('hasError', () => {
-    it('passes default error to server', () => {
-      const search = '?name=foo&hasError=true&serviceType=custom&indexPermissions=false';
-      (useLocation as jest.Mock).mockImplementationOnce(() => ({ search }));
-      shallow(<SourceAdded />);
-
-      expect(setErrorMessage).toHaveBeenCalledWith('foo failed to connect.');
-    });
-
-    it('passes custom error to server', () => {
-      const search =
-        '?name=foo&hasError=true&serviceType=custom&indexPermissions=false&errorMessages[]=custom error';
-      (useLocation as jest.Mock).mockImplementationOnce(() => ({ search }));
-      shallow(<SourceAdded />);
-
-      expect(setErrorMessage).toHaveBeenCalledWith('custom error');
-    });
+    expect(wrapper.find(Loading)).toHaveLength(1);
+    expect(saveSourceParams).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -10,10 +10,9 @@ import { Location } from 'history';
 import { useActions } from 'kea';
 import { useLocation } from 'react-router-dom';
 
-import { parseQueryParams } from '../../../../shared/query_params';
 import { Loading } from '../../../../shared/loading';
 
-import { AddSourceLogic, OauthParams } from './add_source/add_source_logic';
+import { AddSourceLogic } from './add_source/add_source_logic';
 
 /**
  * This component merely triggers catchs the redirect from the oauth application and initializes the saving
@@ -22,11 +21,10 @@ import { AddSourceLogic, OauthParams } from './add_source/add_source_logic';
  */
 export const SourceAdded: React.FC = () => {
   const { search } = useLocation() as Location;
-  const params = (parseQueryParams(search) as unknown) as OauthParams;
   const { saveSourceParams } = useActions(AddSourceLogic);
 
   useEffect(() => {
-    saveSourceParams(params);
+    saveSourceParams(search);
   }, []);
 
   return <Loading />;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -4,52 +4,30 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Location } from 'history';
-import { useActions, useValues } from 'kea';
-import { Redirect, useLocation } from 'react-router-dom';
+import { useActions } from 'kea';
+import { useLocation } from 'react-router-dom';
 
-import { i18n } from '@kbn/i18n';
+import { parseQueryParams } from '../../../../shared/query_params';
+import { Loading } from '../../../../shared/loading';
 
-import { setErrorMessage } from '../../../../shared/flash_messages';
+import { AddSourceLogic, OauthParams } from './add_source/add_source_logic';
 
-import { parseQueryParams } from '../../../../../applications/shared/query_params';
-
-import { SOURCES_PATH, getSourcesPath } from '../../../routes';
-
-import { AppLogic } from '../../../app_logic';
-import { SourcesLogic } from '../sources_logic';
-
-interface SourceQueryParams {
-  name: string;
-  hasError: boolean;
-  errorMessages?: string[];
-  serviceType: string;
-  indexPermissions: boolean;
-}
-
+/**
+ * This component merely triggers catchs the redirect from the oauth application and initializes the saving
+ * of the params the oauth plugin sends back. The logic file now redirects back to sources with either a
+ * success or error message upon completion.
+ */
 export const SourceAdded: React.FC = () => {
   const { search } = useLocation() as Location;
-  const { name, hasError, errorMessages, serviceType, indexPermissions } = (parseQueryParams(
-    search
-  ) as unknown) as SourceQueryParams;
-  const { setAddedSource } = useActions(SourcesLogic);
-  const { isOrganization } = useValues(AppLogic);
-  const decodedName = decodeURIComponent(name);
+  const params = (parseQueryParams(search) as unknown) as OauthParams;
+  const { saveSourceParams } = useActions(AddSourceLogic);
 
-  if (hasError) {
-    const defaultError = i18n.translate(
-      'xpack.enterpriseSearch.workplaceSearch.sources.sourceAdded.error',
-      {
-        defaultMessage: '{decodedName} failed to connect.',
-        values: { decodedName },
-      }
-    );
-    setErrorMessage(errorMessages ? errorMessages.join(' ') : defaultError);
-  } else {
-    setAddedSource(decodedName, indexPermissions, serviceType);
-  }
+  useEffect(() => {
+    saveSourceParams(params);
+  }, []);
 
-  return <Redirect to={getSourcesPath(SOURCES_PATH, isOrganization)} />;
+  return <Loading />;
 };

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -39,6 +39,7 @@ import {
   registerOrgSourceReindexJobStatusRoute,
   registerOrgSourceOauthConfigurationsRoute,
   registerOrgSourceOauthConfigurationRoute,
+  registerOauthConnectorParamsRoute,
 } from './sources';
 
 const mockConfig = {
@@ -1092,6 +1093,68 @@ describe('sources routes', () => {
     });
   });
 
+  describe('POST /api/workplace_search/org/settings/connectors', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'post',
+        path: '/api/workplace_search/org/settings/connectors',
+        payload: 'body',
+      });
+
+      registerOrgSourceOauthConfigurationsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: mockConfig };
+        mockRouter.shouldValidate(request);
+      });
+    });
+  });
+
+  describe('PUT /api/workplace_search/org/settings/connectors', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/workplace_search/org/settings/connectors',
+        payload: 'body',
+      });
+
+      registerOrgSourceOauthConfigurationsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/settings/connectors',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { body: mockConfig };
+        mockRouter.shouldValidate(request);
+      });
+    });
+  });
+
   describe('GET /api/workplace_search/org/settings/connectors/{serviceType}', () => {
     let mockRouter: MockRouter;
 
@@ -1196,6 +1259,43 @@ describe('sources routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/settings/connectors/:serviceType',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/sources/create', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/sources/create',
+        payload: 'query',
+      });
+
+      registerOauthConnectorParamsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    const query = {
+      code: 'foo',
+      state: '{foo:"bar"}',
+      session_state: 'baz',
+    };
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/create',
+      });
+    });
+
+    describe('validates', () => {
+      it('correctly', () => {
+        const request = { query };
+        mockRouter.shouldValidate(request);
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -1280,22 +1280,9 @@ describe('sources routes', () => {
       });
     });
 
-    const query = {
-      code: 'foo',
-      state: '{foo:"bar"}',
-      session_state: 'baz',
-    };
-
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/sources/create',
-      });
-    });
-
-    describe('validates', () => {
-      it('correctly', () => {
-        const request = { query };
-        mockRouter.shouldValidate(request);
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -255,7 +255,6 @@ export function registerAccountPrepareSourcesRoute({
         }),
         query: schema.object({
           kibana_host: schema.string(),
-          index_permissions: schema.boolean(),
           subdomain: schema.maybe(schema.string()),
         }),
       },

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -30,9 +30,9 @@ const oAuthConfigSchema = schema.object({
   client_id: schema.maybe(schema.string()),
   client_secret: schema.maybe(schema.string()),
   service_type: schema.string(),
-  private_key: schema.string(),
-  public_key: schema.string(),
-  consumer_key: schema.string(),
+  private_key: schema.maybe(schema.string()),
+  public_key: schema.maybe(schema.string()),
+  consumer_key: schema.maybe(schema.string()),
 });
 
 const displayFieldSchema = schema.object({
@@ -251,6 +251,11 @@ export function registerAccountPrepareSourcesRoute({
       validate: {
         params: schema.object({
           serviceType: schema.string(),
+        }),
+        query: schema.object({
+          kibana_host: schema.string(),
+          index_permissions: schema.boolean(),
+          subdomain: schema.maybe(schema.string()),
         }),
       },
     },
@@ -592,6 +597,11 @@ export function registerOrgPrepareSourcesRoute({
         params: schema.object({
           serviceType: schema.string(),
         }),
+        query: schema.object({
+          kibana_host: schema.string(),
+          index_permissions: schema.boolean(),
+          subdomain: schema.maybe(schema.string()),
+        }),
       },
     },
     enterpriseSearchRequestHandler.createRequest({
@@ -738,6 +748,30 @@ export function registerOrgSourceOauthConfigurationsRoute({
     {
       path: '/api/workplace_search/org/settings/connectors',
       validate: false,
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors',
+    })
+  );
+
+  router.post(
+    {
+      path: '/api/workplace_search/org/settings/connectors',
+      validate: {
+        body: oAuthConfigSchema,
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/settings/connectors',
+    })
+  );
+
+  router.put(
+    {
+      path: '/api/workplace_search/org/settings/connectors',
+      validate: {
+        body: oAuthConfigSchema,
+      },
     },
     enterpriseSearchRequestHandler.createRequest({
       path: '/ws/org/settings/connectors',

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -25,7 +25,7 @@ const pageSchema = schema.object({
   total_results: schema.number(),
 });
 
-const oAuthConfigSchema = schema.object({
+const oauthConfigSchema = schema.object({
   base_url: schema.maybe(schema.string()),
   client_id: schema.maybe(schema.string()),
   client_secret: schema.maybe(schema.string()),
@@ -759,7 +759,7 @@ export function registerOrgSourceOauthConfigurationsRoute({
     {
       path: '/api/workplace_search/org/settings/connectors',
       validate: {
-        body: oAuthConfigSchema,
+        body: oauthConfigSchema,
       },
     },
     enterpriseSearchRequestHandler.createRequest({
@@ -771,7 +771,7 @@ export function registerOrgSourceOauthConfigurationsRoute({
     {
       path: '/api/workplace_search/org/settings/connectors',
       validate: {
-        body: oAuthConfigSchema,
+        body: oauthConfigSchema,
       },
     },
     enterpriseSearchRequestHandler.createRequest({
@@ -805,7 +805,7 @@ export function registerOrgSourceOauthConfigurationRoute({
         params: schema.object({
           serviceType: schema.string(),
         }),
-        body: oAuthConfigSchema,
+        body: oauthConfigSchema,
       },
     },
     enterpriseSearchRequestHandler.createRequest({
@@ -820,7 +820,7 @@ export function registerOrgSourceOauthConfigurationRoute({
         params: schema.object({
           serviceType: schema.string(),
         }),
-        body: oAuthConfigSchema,
+        body: oauthConfigSchema,
       },
     },
     enterpriseSearchRequestHandler.createRequest({

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -50,6 +50,7 @@ const displaySettingsSchema = schema.object({
   detailFields: schema.oneOf([schema.arrayOf(displayFieldSchema), displayFieldSchema]),
 });
 
+// Account routes
 export function registerAccountSourcesRoute({
   router,
   enterpriseSearchRequestHandler,
@@ -395,6 +396,7 @@ export function registerAccountSourceReindexJobStatusRoute({
   );
 }
 
+// Org routes
 export function registerOrgSourcesRoute({
   router,
   enterpriseSearchRequestHandler,
@@ -842,6 +844,30 @@ export function registerOrgSourceOauthConfigurationRoute({
   );
 }
 
+// Same route is used for org and account. `state` passes the context.
+export function registerOauthConnectorParamsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/sources/create',
+      validate: {
+        query: schema.object({
+          kibana_host: schema.string(),
+          code: schema.string(),
+          session_state: schema.string(),
+          state: schema.string(),
+          oauth_verifier: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/create',
+    })
+  );
+}
+
 export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
   registerAccountSourcesRoute(dependencies);
   registerAccountSourcesStatusRoute(dependencies);
@@ -875,4 +901,5 @@ export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
   registerOrgSourceReindexJobStatusRoute(dependencies);
   registerOrgSourceOauthConfigurationsRoute(dependencies);
   registerOrgSourceOauthConfigurationRoute(dependencies);
+  registerOauthConnectorParamsRoute(dependencies);
 };


### PR DESCRIPTION
## Summary

This PR handles the logic to handle the redirect from an oAuth plugin back to Kibana. In ent-search, the server handled capturing the params (`code`, `state`, and `session_state`, and an optional Atlassian param,  `oauth_verifier`) from the oAuth plugins and then redirected to the React SPA. In the Kibana world, the oAuth plugins will be redirecting directly to Kibana. Because of this a new step is needed to pass the params sent from the plugins to the ent-search backend. This PR handles that transition.

**Notes**
- Previously the ent-search server would redirect to `/sources/added` and that component would redirect to the sources list page with either a success or error message. This PR refactors to put a blocking http request before the redirect to handle the persisting of the passed params. 
- All logic for persisting and redirecting has now been moved to the AddSourceLogic module. The AddSource component is now only responsible for capturing the query parameters and then showing a loading spinner until the logic file triggers a redirect. 
- We parse the `kibana_host` from the browser until we can persist it in the config file, or find another way to let the ent-search server know what the host is.
- The query params were not actually working in Kibana. This PR also changes the way query params are set, which is adding a `query` property to the optional `options` object the http methods take.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### closes https://github.com/elastic/workplace-search-team/issues/1489