### PR TITLE
[7.11] [APM] `transactions.kubernetes.pod` can be undefined (#90044)

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/sections.ts
+++ b/x-pack/plugins/apm/public/components/shared/TransactionActionMenu/sections.ts
@@ -54,7 +54,7 @@ export const getSections = ({
   urlParams: IUrlParams;
 }) => {
   const hostName = transaction.host?.hostname;
-  const podId = transaction.kubernetes?.pod.uid;
+  const podId = transaction.kubernetes?.pod?.uid;
   const containerId = transaction.container?.id;
 
   const time = Math.round(transaction.timestamp.us / 1000);

--- a/x-pack/plugins/apm/typings/es_schemas/raw/fields/kubernetes.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/fields/kubernetes.ts
@@ -5,6 +5,6 @@
  */
 
 export interface Kubernetes {
-  pod: { uid: string; [key: string]: unknown };
+  pod?: { uid: string; [key: string]: unknown };
   [key: string]: unknown;
 }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [APM] `transactions.kubernetes.pod` can be undefined (#90044)