### PR TITLE
Change Remote Clusters Cloud message to clarify that it's Elastic Cloud.

### DIFF
--- a/x-pack/plugins/remote_clusters/public/application/sections/components/remote_cluster_form/remote_cluster_form.js
+++ b/x-pack/plugins/remote_clusters/public/application/sections/components/remote_cluster_form/remote_cluster_form.js
@@ -528,7 +528,7 @@ export class RemoteClusterForm extends Component {
                   title={
                     <FormattedMessage
                       id="xpack.remoteClusters.cloudClusterInformationTitle"
-                      defaultMessage="Use proxy mode for Elasticsearch Cloud deployment"
+                      defaultMessage="Use proxy mode for Elastic Cloud deployment"
                     />
                   }
                 >


### PR DESCRIPTION
When using Remote Clusters on Cloud, the proxy mode text originally stated "Use proxy mode for Elasticsearch Cloud deployment". Per feedback from @zanbel, this should be "Use proxy mode for Elastic Cloud deployment".