### PR TITLE
prevent jest leaking into the prod build

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern.test.ts
@@ -14,11 +14,8 @@ import { dataPluginMock } from '../../../../../src/plugins/data/public/mocks';
 import { Ast } from '@kbn/interpreter/common';
 import { chartPluginMock } from '../../../../../src/plugins/charts/public/mocks';
 import { getFieldByNameFactory } from './pure_helpers';
-import {
-  operationDefinitionMap,
-  getErrorMessages,
-  createMockedReferenceOperation,
-} from './operations';
+import { operationDefinitionMap, getErrorMessages } from './operations';
+import { createMockedReferenceOperation } from './operations/mocks';
 
 jest.mock('./loader');
 jest.mock('../id_generator');

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/index.ts
@@ -32,5 +32,3 @@ export {
   DerivativeIndexPatternColumn,
   MovingAverageIndexPatternColumn,
 } from './definitions';
-
-export { createMockedReferenceOperation } from './mocks';


### PR DESCRIPTION
@qn895 stumbled upon the problem that when you import `lens` types in a plugin, `x-pack/test` project fails type check. It's turned out that `jest` types leak into the global space and conflict with `mocha` types declared in FTR.
Also, I suspect jest might be built into the lens distributable. 