### PR TITLE
[Discover] Add missing key to DocViewer table

### DIFF
--- a/src/plugins/discover/public/application/components/table/table.tsx
+++ b/src/plugins/discover/public/application/components/table/table.tsx
@@ -101,9 +101,8 @@ export function DocViewTable({
               ? 'nested'
               : indexPattern.fields.getByName(field)?.type;
             return (
-              <React.Fragment>
+              <React.Fragment key={field}>
                 <DocViewTableRow
-                  key={field}
                   field={field}
                   fieldMapping={mapping(field)}
                   fieldType={String(fieldType)}


### PR DESCRIPTION
## Summary

Remove console warning when opening a doc in the document table: 

<img width="651" alt="Bildschirmfoto 2021-02-05 um 05 47 42" src="https://user-images.githubusercontent.com/463851/106992897-cb08fe00-6779-11eb-874f-84a38e0df1cf.png">
