### PR TITLE
[Enterprise Search] Add eslint import/order rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1122,7 +1122,7 @@ module.exports = {
         'import/order': [
           'error',
           {
-            groups: ['unknown', 'builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+            groups: ['unknown', ['builtin', 'external'], 'internal', 'parent', 'sibling', 'index'],
             pathGroups: [
               {
                 pattern:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1119,6 +1119,39 @@ module.exports = {
       // All files
       files: ['x-pack/plugins/enterprise_search/**/*.{ts,tsx}'],
       rules: {
+        'import/order': [
+          'error',
+          {
+            groups: ['unknown', 'builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+            pathGroups: [
+              {
+                pattern:
+                  '{../../../../../../,../../../../../,../../../../,../../../,../../,../}{common/,*}__mocks__{*,/**}',
+                group: 'unknown',
+              },
+              {
+                pattern: '{**,.}/*.mock',
+                group: 'unknown',
+              },
+              {
+                pattern: 'react*',
+                group: 'external',
+                position: 'before',
+              },
+              {
+                pattern: '{@elastic/**,@kbn/**,src/**}',
+                group: 'internal',
+              },
+            ],
+            pathGroupsExcludedImportTypes: [],
+            alphabetize: {
+              order: 'asc',
+              caseInsensitive: true,
+            },
+            'newlines-between': 'always-and-inside-groups',
+          },
+        ],
+        'import/newline-after-import': 'error',
         'react-hooks/exhaustive-deps': 'off',
         'react/jsx-boolean-value': ['error', 'never'],
       },

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
@@ -11,11 +11,11 @@
  * NOTE: These variable names MUST start with 'mock*' in order for
  * Jest to accept its use within a jest.mock()
  */
+import { mockFlashMessagesValues, mockFlashMessagesActions } from './flash_messages_logic.mock';
+import { mockHttpValues } from './http_logic.mock';
 import { mockKibanaValues } from './kibana_logic.mock';
 import { mockLicensingValues } from './licensing_logic.mock';
-import { mockHttpValues } from './http_logic.mock';
 import { mockTelemetryActions } from './telemetry_logic.mock';
-import { mockFlashMessagesValues, mockFlashMessagesActions } from './flash_messages_logic.mock';
 
 export const mockAllValues = {
   ...mockKibanaValues,

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_logic.mock.ts
@@ -6,6 +6,7 @@
  */
 
 import { chartPluginMock } from '../../../../../../src/plugins/charts/public/mocks';
+
 import { mockHistory } from './';
 
 export const mockKibanaValues = {

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/mount_async.mock.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/mount_async.mock.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+
 import { mount, ReactWrapper } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
 import { mountWithIntl } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/mount_with_i18n.mock.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/mount_with_i18n.mock.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { mount } from 'enzyme';
+
 import { I18nProvider } from '@kbn/i18n/react';
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/shallow_with_i18n.mock.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/shallow_with_i18n.mock.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow, mount, ReactWrapper } from 'enzyme';
+
 import { I18nProvider, __IntlProvider } from '@kbn/i18n/react';
 
 // Use fake component to extract `intl` property to use in tests.

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
+import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
 import { LogicMounter } from '../__mocks__';
 
-import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
 import { AppLogic } from './app_logic';
 
 describe('AppLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -8,6 +8,7 @@
 import { kea, MakeLogicType } from 'kea';
 
 import { InitialAppData } from '../../../common/types';
+
 import { ConfiguredLimits, Account, Role } from './types';
 
 import { getRoleAbilities } from './utils/role';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_layout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_layout.test.tsx
@@ -11,14 +11,15 @@ import { mockKibanaValues, setMockValues, setMockActions, rerender } from '../..
 
 import React from 'react';
 import { useParams } from 'react-router-dom';
+
 import { shallow } from 'enzyme';
 
-import { Loading } from '../../../shared/loading';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { Loading } from '../../../shared/loading';
 import { LogRetentionCallout } from '../log_retention';
-import { AnalyticsHeader, AnalyticsUnavailable } from './components';
 
 import { AnalyticsLayout } from './analytics_layout';
+import { AnalyticsHeader, AnalyticsUnavailable } from './components';
 
 describe('AnalyticsLayout', () => {
   const { history } = mockKibanaValues;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_layout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_layout.tsx
@@ -7,17 +7,20 @@
 
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+
 import { useValues, useActions } from 'kea';
+
 import { EuiSpacer } from '@elastic/eui';
 
-import { KibanaLogic } from '../../../shared/kibana';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { KibanaLogic } from '../../../shared/kibana';
 import { Loading } from '../../../shared/loading';
 
 import { LogRetentionCallout, LogRetentionOptions } from '../log_retention';
 
-import { AnalyticsLogic } from './';
 import { AnalyticsHeader, AnalyticsUnavailable } from './components';
+
+import { AnalyticsLogic } from './';
 
 interface Props {
   title: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_logic.test.ts
@@ -19,6 +19,7 @@ jest.mock('../engine', () => ({
 import { nextTick } from '@kbn/test/jest';
 
 import { DEFAULT_START_DATE, DEFAULT_END_DATE } from './constants';
+
 import { AnalyticsLogic } from './';
 
 describe('AnalyticsLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_logic.ts
@@ -8,9 +8,9 @@
 import { kea, MakeLogicType } from 'kea';
 import queryString from 'query-string';
 
-import { KibanaLogic } from '../../../shared/kibana';
-import { HttpLogic } from '../../../shared/http';
 import { flashAPIErrors } from '../../../shared/flash_messages';
+import { HttpLogic } from '../../../shared/http';
+import { KibanaLogic } from '../../../shared/kibana';
 import { EngineLogic } from '../engine';
 
 import { DEFAULT_START_DATE, DEFAULT_END_DATE } from './constants';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/analytics_router.test.tsx
@@ -8,8 +8,10 @@
 import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
-import { shallow } from 'enzyme';
+
 import { Route, Switch } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
 
 import { AnalyticsRouter } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_cards.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_cards.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiStat } from '@elastic/eui';
 
 import { AnalyticsCards } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_cards.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_cards.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiStat } from '@elastic/eui';
 
 interface Props {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_chart.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_chart.test.tsx
@@ -8,7 +8,9 @@
 import { mockKibanaValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { Chart, Settings, LineSeries, Axis } from '@elastic/charts';
 
 import { AnalyticsChart } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_chart.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_chart.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
 import moment from 'moment';
+
 import { Chart, Settings, LineSeries, CurveType, Axis } from '@elastic/charts';
 
 import { KibanaLogic } from '../../../../shared/kibana';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_header.test.tsx
@@ -8,13 +8,16 @@
 import { setMockValues, mockKibanaValues } from '../../../../__mocks__';
 
 import React, { ReactElement } from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
 import moment, { Moment } from 'moment';
+
 import { EuiPageHeader, EuiSelect, EuiDatePickerRange, EuiButton } from '@elastic/eui';
 
 import { LogRetentionTooltip } from '../../log_retention';
 
 import { DEFAULT_START_DATE, DEFAULT_END_DATE } from '../constants';
+
 import { AnalyticsHeader } from './';
 
 describe('AnalyticsHeader', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_header.tsx
@@ -6,12 +6,11 @@
  */
 
 import React, { useState } from 'react';
+
 import { useValues } from 'kea';
-
-import queryString from 'query-string';
 import moment from 'moment';
+import queryString from 'query-string';
 
-import { i18n } from '@kbn/i18n';
 import {
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -23,11 +22,12 @@ import {
   EuiDatePicker,
   EuiButton,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
+import { AnalyticsLogic } from '../';
 import { KibanaLogic } from '../../../../shared/kibana';
 import { LogRetentionTooltip, LogRetentionOptions } from '../../log_retention';
 
-import { AnalyticsLogic } from '../';
 import { DEFAULT_START_DATE, DEFAULT_END_DATE, SERVER_DATE_FORMAT } from '../constants';
 import { convertTagsToSelectOptions } from '../utils';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_search.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_search.test.tsx
@@ -9,7 +9,9 @@ import { mockKibanaValues } from '../../../../__mocks__';
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFieldSearch } from '@elastic/eui';
 
 import { AnalyticsSearch } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_search.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_search.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useState } from 'react';
+
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiFieldSearch, EuiButton, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { KibanaLogic } from '../../../../shared/kibana';
 import { ENGINE_ANALYTICS_QUERY_DETAIL_PATH } from '../../../routes';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_section.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_section.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { AnalyticsSection } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/analytics_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/analytics_table.test.tsx
@@ -9,6 +9,7 @@ import { mountWithIntl, mockKibanaValues } from '../../../../../__mocks__';
 import '../../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { EuiBasicTable, EuiBadge, EuiEmptyPrompt } from '@elastic/eui';
 
 import { AnalyticsTable } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/analytics_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/analytics_table.tsx
@@ -6,10 +6,12 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiBasicTable, EuiBasicTableColumn, EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { Query } from '../../types';
+
 import {
   TERM_COLUMN_PROPS,
   TAGS_COLUMN,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/inline_tags_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/inline_tags_list.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiBadge, EuiToolTip } from '@elastic/eui';
 
 import { InlineTagsList } from './inline_tags_list';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/inline_tags_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/inline_tags_list.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiBadgeGroup, EuiBadge, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { Query } from '../../types';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/query_clicks_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/query_clicks_table.test.tsx
@@ -9,6 +9,7 @@ import { mountWithIntl } from '../../../../../__mocks__';
 import '../../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { EuiBasicTable, EuiLink, EuiBadge, EuiEmptyPrompt } from '@elastic/eui';
 
 import { QueryClicksTable } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/query_clicks_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/query_clicks_table.tsx
@@ -7,15 +7,16 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiBasicTable, EuiBasicTableColumn, EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 import { ENGINE_DOCUMENT_DETAIL_PATH } from '../../../../routes';
-import { generateEnginePath } from '../../../engine';
 import { DOCUMENTS_TITLE } from '../../../documents';
+import { generateEnginePath } from '../../../engine';
 
 import { QueryClick } from '../../types';
+
 import { FIRST_COLUMN_PROPS, TAGS_COLUMN, COUNT_COLUMN_PROPS } from './shared_columns';
 
 interface Props {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.test.tsx
@@ -9,6 +9,7 @@ import { mountWithIntl, mockKibanaValues } from '../../../../../__mocks__';
 import '../../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { EuiBasicTable, EuiBadge, EuiEmptyPrompt } from '@elastic/eui';
 
 import { RecentQueriesTable } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.tsx
@@ -7,11 +7,12 @@
 
 import React from 'react';
 
+import { EuiBasicTable, EuiBasicTableColumn, EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedDate, FormattedTime } from '@kbn/i18n/react';
-import { EuiBasicTable, EuiBasicTableColumn, EuiEmptyPrompt } from '@elastic/eui';
 
 import { RecentQuery } from '../../types';
+
 import {
   TERM_COLUMN_PROPS,
   TAGS_COLUMN,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/shared_columns.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/shared_columns.tsx
@@ -6,14 +6,15 @@
  */
 
 import React from 'react';
+
 import { i18n } from '@kbn/i18n';
 
-import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 import { KibanaLogic } from '../../../../../shared/kibana';
+import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 import { ENGINE_ANALYTICS_QUERY_DETAIL_PATH } from '../../../../routes';
 import { generateEnginePath } from '../../../engine';
-
 import { Query, RecentQuery } from '../../types';
+
 import { InlineTagsList } from './inline_tags_list';
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_unavailable.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_unavailable.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiEmptyPrompt } from '@elastic/eui';
 
 import { FlashMessages } from '../../../../shared/flash_messages';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_unavailable.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_unavailable.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { FlashMessages } from '../../../../shared/flash_messages';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/constants.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+
 import { i18n } from '@kbn/i18n';
 
 export const ANALYTICS_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/utils.ts
@@ -6,11 +6,12 @@
  */
 
 import moment from 'moment';
-import { i18n } from '@kbn/i18n';
-import { EuiSelectProps } from '@elastic/eui';
 
-import { SERVER_DATE_FORMAT } from './constants';
+import { EuiSelectProps } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { ChartData } from './components/analytics_chart';
+import { SERVER_DATE_FORMAT } from './constants';
 
 interface ConvertToChartData {
   data: number[];

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/analytics.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/analytics.test.tsx
@@ -9,6 +9,7 @@ import { setMockValues } from '../../../../__mocks__';
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import {
@@ -18,6 +19,7 @@ import {
   AnalyticsTable,
   RecentQueriesTable,
 } from '../components';
+
 import { Analytics, ViewAllButton } from './analytics';
 
 describe('Analytics overview', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/analytics.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/analytics.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiSpacer, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 import {
@@ -21,6 +22,8 @@ import {
 } from '../../../routes';
 import { generateEnginePath } from '../../engine';
 
+import { AnalyticsLayout } from '../analytics_layout';
+import { AnalyticsSection, AnalyticsTable, RecentQueriesTable } from '../components';
 import {
   ANALYTICS_TITLE,
   TOTAL_QUERIES,
@@ -32,9 +35,7 @@ import {
   TOP_QUERIES_NO_CLICKS,
   RECENT_QUERIES,
 } from '../constants';
-import { AnalyticsLayout } from '../analytics_layout';
-import { AnalyticsSection, AnalyticsTable, RecentQueriesTable } from '../components';
-import { AnalyticsLogic, AnalyticsCards, AnalyticsChart, convertToChartData } from '../';
+import { AnalyticsLogic, AnalyticsCards, AnalyticsChart, convertToChartData } from '../index';
 
 export const Analytics: React.FC = () => {
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/query_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/query_detail.test.tsx
@@ -10,12 +10,14 @@ import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
 import { useParams } from 'react-router-dom';
+
 import { shallow } from 'enzyme';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
 
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsCards, AnalyticsChart, QueryClicksTable } from '../components';
+
 import { QueryDetail } from './';
 
 describe('QueryDetail', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/query_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/query_detail.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
 import { BreadcrumbTrail } from '../../../../shared/kibana_chrome/generate_breadcrumbs';
@@ -17,7 +18,7 @@ import { useDecodedParams } from '../../../utils/encode_path_params';
 
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsSection, QueryClicksTable } from '../components';
-import { AnalyticsLogic, AnalyticsCards, AnalyticsChart, convertToChartData } from '../';
+import { AnalyticsLogic, AnalyticsCards, AnalyticsChart, convertToChartData } from '../index';
 
 const QUERY_DETAIL_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.engine.analytics.queryDetail.title',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/recent_queries.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/recent_queries.test.tsx
@@ -8,9 +8,11 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { RecentQueriesTable } from '../components';
+
 import { RecentQueries } from './';
 
 describe('RecentQueries', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/recent_queries.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/recent_queries.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { RECENT_QUERIES } from '../constants';
+import { AnalyticsLogic } from '../';
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsSearch, RecentQueriesTable } from '../components';
-import { AnalyticsLogic } from '../';
+import { RECENT_QUERIES } from '../constants';
 
 export const RecentQueries: React.FC = () => {
   const { recentQueries } = useValues(AnalyticsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries.test.tsx
@@ -8,9 +8,11 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { AnalyticsTable } from '../components';
+
 import { TopQueries } from './';
 
 describe('TopQueries', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { TOP_QUERIES } from '../constants';
+import { AnalyticsLogic } from '../';
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsSearch, AnalyticsTable } from '../components';
-import { AnalyticsLogic } from '../';
+import { TOP_QUERIES } from '../constants';
 
 export const TopQueries: React.FC = () => {
   const { topQueries } = useValues(AnalyticsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_clicks.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_clicks.test.tsx
@@ -8,9 +8,11 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { AnalyticsTable } from '../components';
+
 import { TopQueriesNoClicks } from './';
 
 describe('TopQueriesNoClicks', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_clicks.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_clicks.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { TOP_QUERIES_NO_CLICKS } from '../constants';
+import { AnalyticsLogic } from '../';
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsSearch, AnalyticsTable } from '../components';
-import { AnalyticsLogic } from '../';
+import { TOP_QUERIES_NO_CLICKS } from '../constants';
 
 export const TopQueriesNoClicks: React.FC = () => {
   const { topQueriesNoClicks } = useValues(AnalyticsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_results.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_results.test.tsx
@@ -8,9 +8,11 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { AnalyticsTable } from '../components';
+
 import { TopQueriesNoResults } from './';
 
 describe('TopQueriesNoResults', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_results.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_no_results.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { TOP_QUERIES_NO_RESULTS } from '../constants';
+import { AnalyticsLogic } from '../';
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsSearch, AnalyticsTable } from '../components';
-import { AnalyticsLogic } from '../';
+import { TOP_QUERIES_NO_RESULTS } from '../constants';
 
 export const TopQueriesNoResults: React.FC = () => {
   const { topQueriesNoResults } = useValues(AnalyticsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_with_clicks.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_with_clicks.test.tsx
@@ -8,9 +8,11 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { AnalyticsTable } from '../components';
+
 import { TopQueriesWithClicks } from './';
 
 describe('TopQueriesWithClicks', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_with_clicks.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/views/top_queries_with_clicks.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { TOP_QUERIES_WITH_CLICKS } from '../constants';
+import { AnalyticsLogic } from '../';
 import { AnalyticsLayout } from '../analytics_layout';
 import { AnalyticsSearch, AnalyticsTable } from '../components';
-import { AnalyticsLogic } from '../';
+import { TOP_QUERIES_WITH_CLICKS } from '../constants';
 
 export const TopQueriesWithClicks: React.FC = () => {
   const { topQueriesWithClicks } = useValues(AnalyticsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/constants.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { DOCS_PREFIX } from '../../routes';
 
 export const CREDENTIALS_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.test.tsx
@@ -9,12 +9,15 @@ import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
 import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { Credentials } from './credentials';
 import { EuiCopy, EuiLoadingContent, EuiPageContentBody } from '@elastic/eui';
 
 import { externalUrl } from '../../../shared/enterprise_search_url';
+
+import { Credentials } from './credentials';
+
 import { CredentialsFlyout } from './credentials_flyout';
 
 describe('Credentials', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useActions, useValues } from 'kea';
 
 import {
@@ -24,14 +25,14 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { FlashMessages } from '../../../shared/flash_messages';
-
-import { CredentialsLogic } from './credentials_logic';
 import { externalUrl } from '../../../shared/enterprise_search_url/external_url';
+import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+
 import { CREDENTIALS_TITLE } from './constants';
-import { CredentialsList } from './credentials_list';
 import { CredentialsFlyout } from './credentials_flyout';
+import { CredentialsList } from './credentials_list';
+import { CredentialsLogic } from './credentials_logic';
 
 export const Credentials: React.FC = () => {
   const { initializeCredentialsData, resetCredentials, showCredentialsForm } = useActions(

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/body.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/body.test.tsx
@@ -8,12 +8,15 @@
 import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlyoutBody, EuiForm } from '@elastic/eui';
 
 import { ApiTokenTypes } from '../constants';
 import { defaultApiToken } from '../credentials_logic';
 
+import { CredentialsFlyoutBody } from './body';
 import {
   FormKeyName,
   FormKeyType,
@@ -21,7 +24,6 @@ import {
   FormKeyEngineAccess,
   FormKeyUpdateWarning,
 } from './form_components';
-import { CredentialsFlyoutBody } from './body';
 
 describe('CredentialsFlyoutBody', () => {
   const values = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/body.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/body.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import { EuiFlyoutBody, EuiForm } from '@elastic/eui';
 
 import { FlashMessages } from '../../../../shared/flash_messages';
-import { CredentialsLogic } from '../credentials_logic';
 import { ApiTokenTypes } from '../constants';
+import { CredentialsLogic } from '../credentials_logic';
 
 import {
   FormKeyName,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlyoutFooter, EuiButtonEmpty } from '@elastic/eui';
 
 import { CredentialsFlyoutFooter } from './footer';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/footer.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import {
   EuiFlyoutFooter,
   EuiFlexGroup,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_engine_access.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_engine_access.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues, setMockActions, rerender } from '../../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiRadio, EuiCheckbox } from '@elastic/eui';
 
 import { FormKeyEngineAccess, EngineSelection } from './key_engine_access';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_engine_access.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_engine_access.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import {
   EuiFormRow,
   EuiRadio,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_name.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_name.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues, setMockActions } from '../../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFieldText, EuiFormRow } from '@elastic/eui';
 
 import { FormKeyName } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_name.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_name.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import { EuiFormRow, EuiFieldText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_read_write_access.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_read_write_access.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues, setMockActions } from '../../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCheckbox } from '@elastic/eui';
 
 import { FormKeyReadWriteAccess } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_read_write_access.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_read_write_access.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import { EuiCheckbox, EuiText, EuiTitle, EuiSpacer, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_type.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_type.test.tsx
@@ -8,10 +8,13 @@
 import { setMockValues, setMockActions } from '../../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiSelect } from '@elastic/eui';
 
 import { ApiTokenTypes, TOKEN_TYPE_INFO } from '../../constants';
+
 import { FormKeyType } from './';
 
 describe('FormKeyType', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_type.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_type.tsx
@@ -6,13 +6,15 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import { EuiFormRow, EuiSelect, EuiText, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { AppLogic } from '../../../../app_logic';
-import { CredentialsLogic } from '../../credentials_logic';
 import { TOKEN_TYPE_DESCRIPTION, TOKEN_TYPE_INFO, DOCS_HREF } from '../../constants';
+import { CredentialsLogic } from '../../credentials_logic';
 
 export const FormKeyType: React.FC = () => {
   const { myRole } = useValues(AppLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_update_warning.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_update_warning.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCallOut } from '@elastic/eui';
 
 import { FormKeyUpdateWarning } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_update_warning.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/form_components/key_update_warning.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiSpacer, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/header.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlyoutHeader } from '@elastic/eui';
 
 import { ApiTokenTypes } from '../constants';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/header.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
+
 import { EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { CredentialsLogic } from '../credentials_logic';
 import { FLYOUT_ARIA_LABEL_ID } from '../constants';
+import { CredentialsLogic } from '../credentials_logic';
 
 export const CredentialsFlyoutHeader: React.FC = () => {
   const { activeApiToken } = useValues(CredentialsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/index.test.tsx
@@ -8,7 +8,9 @@
 import { setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlyout } from '@elastic/eui';
 
 import { CredentialsFlyout } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_flyout/index.tsx
@@ -6,14 +6,17 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
+
 import { EuiPortal, EuiFlyout } from '@elastic/eui';
 
-import { CredentialsLogic } from '../credentials_logic';
 import { FLYOUT_ARIA_LABEL_ID } from '../constants';
-import { CredentialsFlyoutHeader } from './header';
+import { CredentialsLogic } from '../credentials_logic';
+
 import { CredentialsFlyoutBody } from './body';
 import { CredentialsFlyoutFooter } from './footer';
+import { CredentialsFlyoutHeader } from './header';
 
 export const CredentialsFlyout: React.FC = () => {
   const { hideCredentialsForm } = useActions(CredentialsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.test.tsx
@@ -8,15 +8,18 @@
 import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiBasicTable, EuiCopy, EuiEmptyPrompt } from '@elastic/eui';
 
-import { ApiToken } from '../types';
-import { ApiTokenTypes } from '../constants';
-
 import { HiddenText } from '../../../../shared/hidden_text';
+import { ApiTokenTypes } from '../constants';
+import { ApiToken } from '../types';
+
 import { Key } from './key';
-import { CredentialsList } from './credentials_list';
+
+import { CredentialsList } from './';
 
 describe('Credentials', () => {
   const apiToken: ApiToken = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
@@ -6,19 +6,21 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiBasicTable, EuiBasicTableColumn, EuiCopy, EuiEmptyPrompt } from '@elastic/eui';
-import { CriteriaWithPagination } from '@elastic/eui/src/components/basic_table/basic_table';
+
 import { useActions, useValues } from 'kea';
 
+import { EuiBasicTable, EuiBasicTableColumn, EuiCopy, EuiEmptyPrompt } from '@elastic/eui';
+import { CriteriaWithPagination } from '@elastic/eui/src/components/basic_table/basic_table';
 import { i18n } from '@kbn/i18n';
 
-import { CredentialsLogic } from '../credentials_logic';
-import { Key } from './key';
 import { HiddenText } from '../../../../shared/hidden_text';
-import { ApiToken } from '../types';
 import { TOKEN_TYPE_DISPLAY_NAMES } from '../constants';
-import { apiTokenSort } from '../utils/api_token_sort';
+import { CredentialsLogic } from '../credentials_logic';
+import { ApiToken } from '../types';
 import { getModeDisplayText, getEnginesDisplayText } from '../utils';
+import { apiTokenSort } from '../utils/api_token_sort';
+
+import { Key } from './key';
 
 export const CredentialsList: React.FC = () => {
   const { deleteApiKey, fetchCredentials, showCredentialsForm } = useActions(CredentialsLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/key.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/key.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiButtonIcon } from '@elastic/eui';
 
 import { Key } from './key';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/key.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/key.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../app_logic', () => ({
 import { nextTick } from '@kbn/test/jest';
 
 import { AppLogic } from '../../app_logic';
+
 import { ApiTokenTypes } from './constants';
 
 import { CredentialsLogic } from './credentials_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
@@ -7,19 +7,19 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { formatApiName } from '../../utils/format_api_name';
-import { ApiTokenTypes, CREATE_MESSAGE, UPDATE_MESSAGE, DELETE_MESSAGE } from './constants';
-
-import { HttpLogic } from '../../../shared/http';
+import { Meta } from '../../../../../common/types';
 import {
   clearFlashMessages,
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
+import { HttpLogic } from '../../../shared/http';
 import { AppLogic } from '../../app_logic';
-
-import { Meta } from '../../../../../common/types';
 import { Engine } from '../../types';
+import { formatApiName } from '../../utils/format_api_name';
+
+import { ApiTokenTypes, CREATE_MESSAGE, UPDATE_MESSAGE, DELETE_MESSAGE } from './constants';
+
 import { ApiToken, CredentialsDetails, TokenReadWrite } from './types';
 
 export const defaultApiToken: ApiToken = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/types.ts
@@ -6,6 +6,7 @@
  */
 
 import { Engine } from '../../types';
+
 import { ApiTokenTypes } from './constants';
 
 export interface CredentialsDetails {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/utils/api_token_sort.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/utils/api_token_sort.test.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { apiTokenSort } from '.';
 import { ApiTokenTypes } from '../constants';
 
 import { ApiToken } from '../types';
+
+import { apiTokenSort } from '.';
 
 describe('apiTokenSort', () => {
   const apiToken: ApiToken = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/utils/get_engines_display_text.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/utils/get_engines_display_text.test.tsx
@@ -6,22 +6,24 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { getEnginesDisplayText } from './get_engines_display_text';
-import { ApiToken } from '../types';
 import { ApiTokenTypes } from '../constants';
+import { ApiToken } from '../types';
 
-const apiToken: ApiToken = {
-  name: '',
-  type: ApiTokenTypes.Private,
-  read: true,
-  write: true,
-  access_all_engines: true,
-  engines: ['engine1', 'engine2', 'engine3'],
-};
+import { getEnginesDisplayText } from './get_engines_display_text';
 
 describe('getEnginesDisplayText', () => {
+  const apiToken: ApiToken = {
+    name: '',
+    type: ApiTokenTypes.Private,
+    read: true,
+    write: true,
+    access_all_engines: true,
+    engines: ['engine1', 'engine2', 'engine3'],
+  };
+
   it('returns "--" when the token is an admin token', () => {
     const wrapper = shallow(
       <div>{getEnginesDisplayText({ ...apiToken, type: ApiTokenTypes.Admin })}</div>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/utils/get_engines_display_text.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/utils/get_engines_display_text.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { ApiTokenTypes, ALL } from '../constants';
 import { ApiToken } from '../types';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.test.tsx
@@ -9,7 +9,9 @@ import '../../../../__mocks__/enterprise_search_url.mock';
 import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiCode, EuiCodeBlock, EuiButtonEmpty } from '@elastic/eui';
 
 import { ApiCodeExample, FlyoutHeader, FlyoutBody, FlyoutFooter } from './api_code_example';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/api_code_example.tsx
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import dedent from 'dedent';
 import React from 'react';
+
+import dedent from 'dedent';
+
 import { useValues, useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
 import {
   EuiFlyoutHeader,
   EuiTitle,
@@ -27,18 +27,19 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { getEnterpriseSearchUrl } from '../../../../shared/enterprise_search_url';
+import { DOCS_PREFIX } from '../../../routes';
 import { EngineLogic } from '../../engine';
 import { EngineDetails } from '../../engine/types';
-
-import { DOCS_PREFIX } from '../../../routes';
 import {
   DOCUMENTS_API_JSON_EXAMPLE,
   FLYOUT_ARIA_LABEL_ID,
   FLYOUT_CANCEL_BUTTON,
 } from '../constants';
-import { DocumentCreationLogic } from '../';
+import { DocumentCreationLogic } from '../index';
 
 export const ApiCodeExample: React.FC = () => (
   <>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.test.tsx
@@ -8,10 +8,13 @@
 import { setMockValues, setMockActions, rerender } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiTextArea, EuiButtonEmpty, EuiButton } from '@elastic/eui';
 
 import { Errors } from '../creation_response_components';
+
 import { PasteJsonText, FlyoutHeader, FlyoutBody, FlyoutFooter } from './paste_json_text';
 
 describe('PasteJsonText', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import {
   EuiFlyoutHeader,
   EuiTitle,
@@ -22,12 +22,13 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { AppLogic } from '../../../app_logic';
 
 import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CANCEL_BUTTON, FLYOUT_CONTINUE_BUTTON } from '../constants';
 import { Errors } from '../creation_response_components';
-import { DocumentCreationLogic } from '../';
+import { DocumentCreationLogic } from '../index';
 
 import './paste_json_text.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.test.tsx
@@ -8,10 +8,13 @@
 import { setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiButtonEmpty } from '@elastic/eui';
 
 import { DocumentCreationButtons } from '../';
+
 import { ShowCreationModes } from './';
 
 describe('ShowCreationModes', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/show_creation_modes.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import {
   EuiFlyoutHeader,
   EuiTitle,
@@ -16,9 +16,10 @@ import {
   EuiFlyoutFooter,
   EuiButtonEmpty,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CANCEL_BUTTON } from '../constants';
-import { DocumentCreationLogic, DocumentCreationButtons } from '../';
+import { DocumentCreationLogic, DocumentCreationButtons } from '../index';
 
 export const ShowCreationModes: React.FC = () => {
   const { closeDocumentCreation } = useActions(DocumentCreationLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.test.tsx
@@ -8,10 +8,13 @@
 import { setMockValues, setMockActions, rerender } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFilePicker, EuiButtonEmpty, EuiButton } from '@elastic/eui';
 
 import { Errors } from '../creation_response_components';
+
 import { UploadJsonFile, FlyoutHeader, FlyoutBody, FlyoutFooter } from './upload_json_file';
 
 describe('UploadJsonFile', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import {
   EuiFlyoutHeader,
   EuiTitle,
@@ -22,12 +22,13 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { AppLogic } from '../../../app_logic';
 
 import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CANCEL_BUTTON, FLYOUT_CONTINUE_BUTTON } from '../constants';
 import { Errors } from '../creation_response_components';
-import { DocumentCreationLogic } from '../';
+import { DocumentCreationLogic } from '../index';
 
 export const UploadJsonFile: React.FC = () => (
   <>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/errors.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCallOut } from '@elastic/eui';
 
 import { Errors } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/errors.tsx
@@ -6,12 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
 import { EuiCallOut } from '@elastic/eui';
 
 import { DOCUMENT_CREATION_ERRORS, DOCUMENT_CREATION_WARNINGS } from '../constants';
-import { DocumentCreationLogic } from '../';
+import { DocumentCreationLogic } from '../index';
 
 export const Errors: React.FC = () => {
   const { errors, warnings } = useValues(DocumentCreationLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary.test.tsx
@@ -8,15 +8,19 @@
 import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlyoutBody, EuiCallOut, EuiButton } from '@elastic/eui';
 
+import { FlyoutHeader, FlyoutBody, FlyoutFooter } from './summary';
 import {
   InvalidDocumentsSummary,
   ValidDocumentsSummary,
   SchemaFieldsSummary,
 } from './summary_sections';
-import { Summary, FlyoutHeader, FlyoutBody, FlyoutFooter } from './summary';
+
+import { Summary } from './';
 
 describe('Summary', () => {
   const values = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import {
   EuiFlyoutHeader,
   EuiTitle,
@@ -19,10 +19,11 @@ import {
   EuiFlexItem,
   EuiButton,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
+import { DocumentCreationLogic } from '../';
 import { FLYOUT_ARIA_LABEL_ID, FLYOUT_CLOSE_BUTTON, DOCUMENT_CREATION_ERRORS } from '../constants';
 import { DocumentCreationStep } from '../types';
-import { DocumentCreationLogic } from '../';
 
 import {
   InvalidDocumentsSummary,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_documents.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_documents.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCodeBlock, EuiCallOut } from '@elastic/eui';
 
 import { ExampleDocumentJson, MoreDocumentsText } from './summary_documents';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_documents.tsx
@@ -7,8 +7,8 @@
 
 import React, { Fragment } from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiCodeBlock, EuiCallOut, EuiTitle, EuiText, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 interface ExampleDocumentJsonProps {
   document: object;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_section.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_section.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { ReactElement } from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiAccordion, EuiIcon } from '@elastic/eui';
 
 import { SummarySectionAccordion, SummarySectionEmpty } from './summary_section';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_sections.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_sections.test.tsx
@@ -8,11 +8,13 @@
 import { setMockValues } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiBadge } from '@elastic/eui';
-import { SummarySectionAccordion, SummarySectionEmpty } from './summary_section';
+
 import { ExampleDocumentJson, MoreDocumentsText } from './summary_documents';
+import { SummarySectionAccordion, SummarySectionEmpty } from './summary_section';
 
 import {
   InvalidDocumentsSummary,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_sections.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_response_components/summary_sections.tsx
@@ -6,15 +6,16 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { DocumentCreationLogic } from '../';
 
-import { SummarySectionAccordion, SummarySectionEmpty } from './summary_section';
 import { ExampleDocumentJson, MoreDocumentsText } from './summary_documents';
+import { SummarySectionAccordion, SummarySectionEmpty } from './summary_section';
 
 export const InvalidDocumentsSummary: React.FC = () => {
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.test.tsx
@@ -9,8 +9,11 @@ import { setMockActions } from '../../../__mocks__/kea.mock';
 import '../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCard } from '@elastic/eui';
+
 import { EuiCardTo } from '../../../shared/react_router_helpers';
 
 import { DocumentCreationButtons } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_buttons.tsx
@@ -6,10 +6,9 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
 import {
   EuiText,
   EuiCode,
@@ -20,6 +19,8 @@ import {
   EuiCard,
   EuiIcon,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { EuiCardTo } from '../../../shared/react_router_helpers';
 import { DOCS_PREFIX, ENGINE_CRAWLER_PATH } from '../../routes';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlyout } from '@elastic/eui';
 
 import {
@@ -18,9 +20,8 @@ import {
   UploadJsonFile,
 } from './creation_mode_components';
 import { Summary } from './creation_response_components';
-import { DocumentCreationStep } from './types';
-
 import { DocumentCreationFlyout, FlyoutContent } from './document_creation_flyout';
+import { DocumentCreationStep } from './types';
 
 describe('DocumentCreationFlyout', () => {
   const values = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_flyout.tsx
@@ -6,14 +6,12 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
 
 import { EuiPortal, EuiFlyout } from '@elastic/eui';
 
-import { DocumentCreationLogic } from './';
-import { DocumentCreationStep } from './types';
 import { FLYOUT_ARIA_LABEL_ID } from './constants';
-
 import {
   ShowCreationModes,
   ApiCodeExample,
@@ -21,6 +19,9 @@ import {
   UploadJsonFile,
 } from './creation_mode_components';
 import { Summary } from './creation_response_components';
+import { DocumentCreationStep } from './types';
+
+import { DocumentCreationLogic } from './';
 
 export const DocumentCreationFlyout: React.FC = () => {
   const { closeDocumentCreation } = useActions(DocumentCreationLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.test.ts
@@ -7,13 +7,9 @@
 
 import { LogicMounter, mockHttpValues } from '../../../__mocks__';
 
-import { nextTick } from '@kbn/test/jest';
 import dedent from 'dedent';
 
-jest.mock('./utils', () => ({
-  readUploadedFileAsText: jest.fn(),
-}));
-import { readUploadedFileAsText } from './utils';
+import { nextTick } from '@kbn/test/jest';
 
 jest.mock('../engine', () => ({
   EngineLogic: { values: { engineName: 'test-engine' } },
@@ -21,6 +17,12 @@ jest.mock('../engine', () => ({
 
 import { DOCUMENTS_API_JSON_EXAMPLE } from './constants';
 import { DocumentCreationStep } from './types';
+
+jest.mock('./utils', () => ({
+  readUploadedFileAsText: jest.fn(),
+}));
+import { readUploadedFileAsText } from './utils';
+
 import { DocumentCreationLogic } from './';
 
 describe('DocumentCreationLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { kea, MakeLogicType } from 'kea';
 import dedent from 'dedent';
+import { kea, MakeLogicType } from 'kea';
 import { isPlainObject, chunk, uniq } from 'lodash';
 
 import { HttpLogic } from '../../../shared/http';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.test.tsx
@@ -8,10 +8,13 @@
 import { setMockActions } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiButton } from '@elastic/eui';
 
 import { DocumentCreationFlyout } from '../document_creation';
+
 import { DocumentCreationButton } from './document_creation_button';
 
 describe('DocumentCreationButton', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_creation_button.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { DocumentCreationLogic, DocumentCreationFlyout } from '../document_creation';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.test.tsx
@@ -10,13 +10,16 @@ import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
 import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 
 import React from 'react';
-import { shallow } from 'enzyme';
 import { useParams } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
+
 import { EuiPageContent, EuiBasicTable } from '@elastic/eui';
 
 import { Loading } from '../../../shared/loading';
-import { DocumentDetail } from '.';
 import { ResultFieldValue } from '../result';
+
+import { DocumentDetail } from '.';
 
 describe('DocumentDetail', () => {
   const values = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail.tsx
@@ -6,8 +6,9 @@
  */
 
 import React, { useEffect } from 'react';
-import { useActions, useValues } from 'kea';
 import { useParams } from 'react-router-dom';
+
+import { useActions, useValues } from 'kea';
 
 import {
   EuiButton,
@@ -21,15 +22,15 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { Loading } from '../../../shared/loading';
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { Loading } from '../../../shared/loading';
 import { useDecodedParams } from '../../utils/encode_path_params';
 import { ResultFieldValue } from '../result';
 
+import { DOCUMENTS_TITLE } from './constants';
 import { DocumentDetailLogic } from './document_detail_logic';
 import { FieldDetails } from './types';
-import { DOCUMENTS_TITLE } from './constants';
 
 const DOCUMENT_DETAIL_TITLE = (documentId: string) =>
   i18n.translate('xpack.enterpriseSearch.appSearch.documentDetail.title', {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
@@ -15,8 +15,9 @@ import { mockEngineValues } from '../../__mocks__';
 
 import { nextTick } from '@kbn/test/jest';
 
-import { DocumentDetailLogic } from './document_detail_logic';
 import { InternalSchemaTypes } from '../../../shared/types';
+
+import { DocumentDetailLogic } from './document_detail_logic';
 
 describe('DocumentDetailLogic', () => {
   const { mount } = new LogicMounter(DocumentDetailLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.ts
@@ -6,11 +6,12 @@
  */
 
 import { kea, MakeLogicType } from 'kea';
+
 import { i18n } from '@kbn/i18n';
 
 import { flashAPIErrors, setQueuedSuccessMessage } from '../../../shared/flash_messages';
-import { KibanaLogic } from '../../../shared/kibana';
 import { HttpLogic } from '../../../shared/http';
+import { KibanaLogic } from '../../../shared/kibana';
 
 import { ENGINE_DOCUMENTS_PATH } from '../../routes';
 import { EngineLogic, generateEnginePath } from '../engine';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.test.tsx
@@ -8,10 +8,12 @@
 import { setMockValues } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { DocumentCreationButton } from './document_creation_button';
 import { SearchExperience } from './search_experience';
+
 import { Documents } from '.';
 
 describe('Documents', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/documents.tsx
@@ -7,16 +7,19 @@
 
 import React from 'react';
 
-import { EuiPageHeader, EuiPageHeaderSection, EuiTitle, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { useValues } from 'kea';
+
+import { EuiPageHeader, EuiPageHeaderSection, EuiTitle, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { DocumentCreationButton } from './document_creation_button';
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { FlashMessages } from '../../../shared/flash_messages';
-import { DOCUMENTS_TITLE } from './constants';
-import { EngineLogic } from '../engine';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+
 import { AppLogic } from '../../app_logic';
+import { EngineLogic } from '../engine';
+
+import { DOCUMENTS_TITLE } from './constants';
+import { DocumentCreationButton } from './document_creation_button';
 import { SearchExperience } from './search_experience';
 
 interface Props {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_search_ui_config.ts
@@ -6,6 +6,7 @@
  */
 
 import { Schema } from '../../../../shared/types';
+
 import { Fields } from './types';
 
 export const buildSearchUIConfig = (apiConnector: object, schema: Schema, fields: Fields) => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_sort_options.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/build_sort_options.ts
@@ -7,8 +7,8 @@
 
 import { flatten } from 'lodash';
 
-import { Fields, SortOption, SortDirection } from './types';
 import { ASCENDING, DESCENDING } from './constants';
+import { Fields, SortOption, SortDirection } from './types';
 
 const fieldNameToSortOptions = (fieldName: string): SortOption[] =>
   ['asc', 'desc'].map((direction) => ({

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_callout.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiButton } from '@elastic/eui';
 
 import { CustomizationCallout } from './customization_callout';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_callout.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
 
 import { EuiButton, EuiFlexGroup, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 interface Props {
   onClick(): void;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues, setMockActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
 
 import { CustomizationModal } from './customization_modal';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/customization_modal.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState, useMemo } from 'react';
 
+import { useValues } from 'kea';
+
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -21,7 +23,6 @@ import {
   EuiOverlayMask,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { useValues } from 'kea';
 
 import { EngineLogic } from '../../engine';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/hooks.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/hooks.test.tsx
@@ -25,8 +25,9 @@ jest.mock('react', () => ({
 }));
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+
 import { mount, ReactWrapper } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
 import { useSearchContextState, useSearchContextActions } from './hooks';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/pagination.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/pagination.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow } from 'enzyme';
+
 // @ts-expect-error types are not available for this package yet
 import { Paging, ResultsPerPage } from '@elastic/react-search-ui';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/pagination.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/pagination.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 // @ts-expect-error types are not available for this package yet
 import { Paging, ResultsPerPage } from '@elastic/react-search-ui';
+
 import { PagingView, ResultsPerPageView } from './views';
 
 export const Pagination: React.FC<{ 'aria-label': string }> = ({ 'aria-label': ariaLabel }) => (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.test.tsx
@@ -8,21 +8,24 @@
 import '../../../../__mocks__/enterprise_search_url.mock';
 import { setMockValues } from '../../../../__mocks__';
 
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+// @ts-expect-error types are not available for this package yet
+import { SearchProvider, Facet } from '@elastic/react-search-ui';
+
 jest.mock('../../../../shared/use_local_storage', () => ({
   useLocalStorage: jest.fn(),
 }));
 import { useLocalStorage } from '../../../../shared/use_local_storage';
 
-import React from 'react';
-// @ts-expect-error types are not available for this package yet
-import { SearchProvider, Facet } from '@elastic/react-search-ui';
-import { shallow, ShallowWrapper } from 'enzyme';
-
 import { CustomizationCallout } from './customization_callout';
 import { CustomizationModal } from './customization_modal';
+
 import { Fields } from './types';
 
-import { SearchExperience } from './search_experience';
+import { SearchExperience } from './';
 
 describe('SearchExperience', () => {
   const values = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience.tsx
@@ -7,13 +7,14 @@
 
 import React, { useState } from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { useValues } from 'kea';
+
 import { EuiButton, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 // @ts-expect-error types are not available for this package yet;
 import { SearchProvider, SearchBox, Sorting, Facet } from '@elastic/react-search-ui';
 // @ts-expect-error types are not available for this package yet
 import AppSearchAPIConnector from '@elastic/search-ui-app-search-connector';
+import { i18n } from '@kbn/i18n';
 
 import './search_experience.scss';
 
@@ -21,14 +22,14 @@ import { externalUrl } from '../../../../shared/enterprise_search_url';
 import { useLocalStorage } from '../../../../shared/use_local_storage';
 import { EngineLogic } from '../../engine';
 
-import { Fields, SortOption } from './types';
-import { SearchBoxView, SortingView, MultiCheckboxFacetsView } from './views';
-import { SearchExperienceContent } from './search_experience_content';
 import { buildSearchUIConfig } from './build_search_ui_config';
-import { CustomizationCallout } from './customization_callout';
-import { CustomizationModal } from './customization_modal';
 import { buildSortOptions } from './build_sort_options';
 import { ASCENDING, DESCENDING } from './constants';
+import { CustomizationCallout } from './customization_callout';
+import { CustomizationModal } from './customization_modal';
+import { SearchExperienceContent } from './search_experience_content';
+import { Fields, SortOption } from './types';
+import { SearchBoxView, SortingView, MultiCheckboxFacetsView } from './views';
 
 const RECENTLY_UPLOADED = i18n.translate(
   'xpack.enterpriseSearch.appSearch.documents.search.sortBy.option.recentlyUploaded',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.test.tsx
@@ -6,18 +6,20 @@
  */
 
 import { setMockValues } from '../../../../__mocks__/kea.mock';
-import { setMockSearchContextState } from './__mocks__/hooks.mock';
 
 import React from 'react';
 
 import { shallow, mount } from 'enzyme';
+
 // @ts-expect-error types are not available for this package yet
 import { Results } from '@elastic/react-search-ui';
 
-import { ResultView } from './views';
-import { Pagination } from './pagination';
 import { SchemaTypes } from '../../../../shared/types';
+
+import { setMockSearchContextState } from './__mocks__/hooks.mock';
+import { Pagination } from './pagination';
 import { SearchExperienceContent } from './search_experience_content';
+import { ResultView } from './views';
 
 describe('SearchExperienceContent', () => {
   const searchState = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/search_experience_content.tsx
@@ -7,20 +7,22 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
+import { useValues } from 'kea';
+
 import { EuiFlexGroup, EuiSpacer, EuiButton, EuiEmptyPrompt } from '@elastic/eui';
 // @ts-expect-error types are not available for this package yet
 import { Results, Paging, ResultsPerPage } from '@elastic/react-search-ui';
-import { useValues } from 'kea';
+import { i18n } from '@kbn/i18n';
 
-import { ResultView } from './views';
-import { Pagination } from './pagination';
-import { useSearchContextState } from './hooks';
-import { DocumentCreationButton } from '../document_creation_button';
 import { AppLogic } from '../../../app_logic';
-import { EngineLogic } from '../../engine';
 import { DOCS_PREFIX } from '../../../routes';
+import { EngineLogic } from '../../engine';
 import { Result } from '../../result/types';
+import { DocumentCreationButton } from '../document_creation_button';
+
+import { useSearchContextState } from './hooks';
+import { Pagination } from './pagination';
+import { ResultView } from './views';
 
 export const SearchExperienceContent: React.FC = () => {
   const { resultSearchTerm, totalResults, wasSearched } = useSearchContextState();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/paging_view.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/paging_view.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow } from 'enzyme';
+
 import { EuiPagination } from '@elastic/eui';
 
 import { PagingView } from './paging_view';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/result_view.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/result_view.test.tsx
@@ -9,9 +9,10 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { ResultView } from '.';
 import { SchemaTypes } from '../../../../../shared/types';
 import { Result } from '../../../result/result';
+
+import { ResultView } from '.';
 
 describe('ResultView', () => {
   const result = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/result_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/result_view.tsx
@@ -7,9 +7,9 @@
 
 import React from 'react';
 
-import { Result as ResultType } from '../../../result/types';
 import { Schema } from '../../../../../shared/types';
 import { Result } from '../../../result/result';
+import { Result as ResultType } from '../../../result/types';
 
 export interface Props {
   result: ResultType;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/results_per_page_view.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/results_per_page_view.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow } from 'enzyme';
+
 import { EuiSelect } from '@elastic/eui';
 
 import { ResultsPerPageView } from '.';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/results_per_page_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/results_per_page_view.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiSelect, EuiSelectOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 const wrapResultsPerPageOptionForEuiSelect: (option: number) => EuiSelectOption = (option) => ({
   text: option,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/search_box_view.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/search_box_view.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow } from 'enzyme';
+
 import { EuiFieldSearch } from '@elastic/eui';
 
 import { SearchBoxView } from './search_box_view';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/sorting_view.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/sorting_view.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { shallow } from 'enzyme';
+
 import { EuiSelect } from '@elastic/eui';
 
 import { SortingView } from '.';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/sorting_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/search_experience/views/sorting_view.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiSelect, EuiSelectOption } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 interface Option {
   label: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.ts
@@ -10,6 +10,7 @@ import { kea, MakeLogicType } from 'kea';
 import { HttpLogic } from '../../../shared/http';
 
 import { IIndexingStatus } from '../../../shared/types';
+
 import { EngineDetails } from './types';
 
 interface EngineValues {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.test.tsx
@@ -9,7 +9,9 @@ import { setMockValues, rerender } from '../../../__mocks__';
 import { mockEngineValues } from '../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiBadge, EuiIcon } from '@elastic/eui';
 
 import { EngineNav } from './engine_nav';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -6,11 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
 import { EuiText, EuiBadge, EuiIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
+import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
 import { SideNavLink, SideNavItem } from '../../../shared/layout';
 import { AppLogic } from '../../app_logic';
 import {
@@ -27,22 +29,22 @@ import {
   ENGINE_SEARCH_UI_PATH,
   ENGINE_API_LOGS_PATH,
 } from '../../routes';
-import { getAppSearchUrl } from '../../../shared/enterprise_search_url';
-import { ENGINES_TITLE } from '../engines';
-import { OVERVIEW_TITLE } from '../engine_overview';
 import { ANALYTICS_TITLE } from '../analytics';
-import { DOCUMENTS_TITLE } from '../documents';
-import { SCHEMA_TITLE } from '../schema';
-import { CRAWLER_TITLE } from '../crawler';
-import { RELEVANCE_TUNING_TITLE } from '../relevance_tuning';
-import { SYNONYMS_TITLE } from '../synonyms';
-import { CURATIONS_TITLE } from '../curations';
-import { RESULT_SETTINGS_TITLE } from '../result_settings';
-import { SEARCH_UI_TITLE } from '../search_ui';
 import { API_LOGS_TITLE } from '../api_logs';
+import { CRAWLER_TITLE } from '../crawler';
+import { CURATIONS_TITLE } from '../curations';
+import { DOCUMENTS_TITLE } from '../documents';
+import { OVERVIEW_TITLE } from '../engine_overview';
+import { ENGINES_TITLE } from '../engines';
+import { RELEVANCE_TUNING_TITLE } from '../relevance_tuning';
+import { RESULT_SETTINGS_TITLE } from '../result_settings';
+import { SCHEMA_TITLE } from '../schema';
+import { SEARCH_UI_TITLE } from '../search_ui';
+import { SYNONYMS_TITLE } from '../synonyms';
+
+import { EngineDetails } from './types';
 
 import { EngineLogic, generateEnginePath } from './';
-import { EngineDetails } from './types';
 
 import './engine_nav.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -6,17 +6,18 @@
  */
 
 import '../../../__mocks__/react_router_history.mock';
-import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 import { mockFlashMessageHelpers, setMockValues, setMockActions } from '../../../__mocks__';
+import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 import { mockEngineValues } from '../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
 import { Switch, Redirect, useParams } from 'react-router-dom';
 
+import { shallow } from 'enzyme';
+
 import { Loading } from '../../../shared/loading';
-import { EngineOverview } from '../engine_overview';
 import { AnalyticsRouter } from '../analytics';
+import { EngineOverview } from '../engine_overview';
 import { RelevanceTuning } from '../relevance_tuning';
 
 import { EngineRouter } from './engine_router';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -7,12 +7,14 @@
 
 import React, { useEffect } from 'react';
 import { Route, Switch, Redirect, useParams } from 'react-router-dom';
+
 import { useValues, useActions } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { setQueuedErrorMessage } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { Loading } from '../../../shared/loading';
 import { AppLogic } from '../../app_logic';
 
 // TODO: Uncomment and add more routes as we migrate them
@@ -31,13 +33,11 @@ import {
   // ENGINE_SEARCH_UI_PATH,
   // ENGINE_API_LOGS_PATH,
 } from '../../routes';
-import { ENGINES_TITLE } from '../engines';
-import { OVERVIEW_TITLE } from '../engine_overview';
-
-import { Loading } from '../../../shared/loading';
-import { EngineOverview } from '../engine_overview';
 import { AnalyticsRouter } from '../analytics';
 import { DocumentDetail, Documents } from '../documents';
+import { OVERVIEW_TITLE } from '../engine_overview';
+import { EngineOverview } from '../engine_overview';
+import { ENGINES_TITLE } from '../engines';
 import { RelevanceTuning } from '../relevance_tuning';
 
 import { EngineLogic } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/types.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { ApiToken } from '../credentials/types';
 import { Schema, SchemaConflicts, IIndexingStatus } from '../../../shared/types';
+import { ApiToken } from '../credentials/types';
 
 export interface Engine {
   name: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/recent_api_logs.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/recent_api_logs.test.tsx
@@ -8,6 +8,7 @@
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/recent_api_logs.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/recent_api_logs.tsx
@@ -17,9 +17,9 @@ import {
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 import { ENGINE_API_LOGS_PATH } from '../../../routes';
+import { RECENT_API_EVENTS } from '../../api_logs/constants';
 import { generateEnginePath } from '../../engine';
 
-import { RECENT_API_EVENTS } from '../../api_logs/constants';
 import { VIEW_API_LOGS } from '../constants';
 
 export const RecentApiLogs: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_charts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_charts.test.tsx
@@ -9,6 +9,7 @@ import { setMockValues } from '../../../../__mocks__/kea.mock';
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_charts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_charts.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
 import {
@@ -21,12 +22,12 @@ import {
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 import { ENGINE_ANALYTICS_PATH, ENGINE_API_LOGS_PATH } from '../../../routes';
+import { AnalyticsChart, convertToChartData } from '../../analytics';
+import { TOTAL_QUERIES, TOTAL_API_OPERATIONS } from '../../analytics/constants';
 import { generateEnginePath } from '../../engine';
 
-import { TOTAL_QUERIES, TOTAL_API_OPERATIONS } from '../../analytics/constants';
 import { VIEW_ANALYTICS, VIEW_API_LOGS, LAST_7_DAYS } from '../constants';
-import { AnalyticsChart, convertToChartData } from '../../analytics';
-import { EngineOverviewLogic } from '../';
+import { EngineOverviewLogic } from '../index';
 
 export const TotalCharts: React.FC = () => {
   const { startDate, queriesPerDay, operationsPerDay } = useValues(EngineOverviewLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_stats.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_stats.test.tsx
@@ -8,9 +8,11 @@
 import { setMockValues } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { AnalyticsCards } from '../../analytics';
+
 import { TotalStats } from './total_stats';
 
 describe('TotalStats', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/total_stats.tsx
@@ -6,12 +6,12 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { TOTAL_QUERIES, TOTAL_DOCUMENTS, TOTAL_CLICKS } from '../../analytics/constants';
 import { AnalyticsCards } from '../../analytics';
-
-import { EngineOverviewLogic } from '../';
+import { TOTAL_QUERIES, TOTAL_DOCUMENTS, TOTAL_CLICKS } from '../../analytics/constants';
+import { EngineOverviewLogic } from '../index';
 
 export const TotalStats: React.FC = () => {
   const { totalQueries, documentCount, totalClicks } = useValues(EngineOverviewLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/unavailable_prompt.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/unavailable_prompt.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiEmptyPrompt } from '@elastic/eui';
 
 import { UnavailablePrompt } from './unavailable_prompt';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/unavailable_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/components/unavailable_prompt.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiEmptyPrompt } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 export const UnavailablePrompt: React.FC = () => (
   <EuiEmptyPrompt

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
@@ -9,11 +9,14 @@ import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { Loading } from '../../../shared/loading';
+
 import { EmptyEngineOverview } from './engine_overview_empty';
 import { EngineOverviewMetrics } from './engine_overview_metrics';
+
 import { EngineOverview } from './';
 
 describe('EngineOverview', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
@@ -6,15 +6,18 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useActions, useValues } from 'kea';
 
+import { Loading } from '../../../shared/loading';
 import { AppLogic } from '../../app_logic';
 import { EngineLogic } from '../engine';
-import { Loading } from '../../../shared/loading';
+
+import { EmptyEngineOverview } from './engine_overview_empty';
+
+import { EngineOverviewMetrics } from './engine_overview_metrics';
 
 import { EngineOverviewLogic } from './';
-import { EmptyEngineOverview } from './engine_overview_empty';
-import { EngineOverviewMetrics } from './engine_overview_metrics';
 
 export const EngineOverview: React.FC = () => {
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.test.tsx
@@ -6,12 +6,15 @@
  */
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiButton } from '@elastic/eui';
 
 import { docLinks } from '../../../shared/doc_links';
 
 import { DocumentCreationButtons, DocumentCreationFlyout } from '../document_creation';
+
 import { EmptyEngineOverview } from './engine_overview_empty';
 
 describe('EmptyEngineOverview', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_empty.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
 import {
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -15,6 +14,7 @@ import {
   EuiTitle,
   EuiButton,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { DOCS_PREFIX } from '../../routes';
 import { DocumentCreationButtons, DocumentCreationFlyout } from '../document_creation';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_metrics.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_metrics.test.tsx
@@ -8,6 +8,7 @@
 import { setMockValues } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { UnavailablePrompt, TotalStats, TotalCharts, RecentApiLogs } from './components';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_metrics.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_metrics.tsx
@@ -6,14 +6,15 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiPageHeader, EuiTitle, EuiSpacer } from '@elastic/eui';
-
-import { EngineOverviewLogic } from './';
+import { i18n } from '@kbn/i18n';
 
 import { UnavailablePrompt, TotalStats, TotalCharts, RecentApiLogs } from './components';
+
+import { EngineOverviewLogic } from './';
 
 export const EngineOverviewMetrics: React.FC = () => {
   const { apiLogsUnavailable } = useValues(EngineOverviewLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/assets/icons.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/assets/icons.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EngineIcon } from './engine_icon';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.test.tsx
@@ -9,7 +9,9 @@ import '../../../../__mocks__/kea.mock';
 import { mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';
 
 import { EmptyState } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
@@ -6,13 +6,15 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
+
 import { EuiPageContent, EuiEmptyPrompt, EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { TelemetryLogic } from '../../../../shared/telemetry';
 import { getAppSearchUrl } from '../../../../shared/enterprise_search_url';
 import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
+import { TelemetryLogic } from '../../../../shared/telemetry';
 import { CREATE_ENGINES_PATH } from '../../../routes';
 
 import { EnginesOverviewHeader } from './header';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/header.test.tsx
@@ -10,6 +10,7 @@ import '../../../../__mocks__/enterprise_search_url.mock';
 import { mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EnginesOverviewHeader } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/header.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
+
 import {
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -17,8 +19,8 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { TelemetryLogic } from '../../../../shared/telemetry';
 import { getAppSearchUrl } from '../../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../../shared/telemetry';
 
 export const EnginesOverviewHeader: React.FC = () => {
   const { sendAppSearchTelemetry } = useActions(TelemetryLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/loading_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/loading_state.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiLoadingContent } from '@elastic/eui';
 
 import { LoadingState } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/loading_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/loading_state.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+
 import { EuiPageContent, EuiSpacer, EuiLoadingContent } from '@elastic/eui';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
+
 import { EnginesOverviewHeader } from './header';
 
 export const LoadingState: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_logic.test.ts
@@ -10,6 +10,7 @@ import { LogicMounter, mockHttpValues } from '../../../__mocks__';
 import { nextTick } from '@kbn/test/jest';
 
 import { EngineDetails } from '../engine/types';
+
 import { EnginesLogic } from './';
 
 describe('EnginesLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -9,6 +9,7 @@ import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions, rerender } from '../../../__mocks__';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { LoadingState, EmptyState } from './components';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useValues, useActions } from 'kea';
+
 import {
   EuiPageContent,
   EuiPageContentHeader,
@@ -15,17 +17,17 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { LicensingLogic } from '../../../shared/licensing';
+import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 
 import { EngineIcon } from './assets/engine_icon';
 import { MetaEngineIcon } from './assets/meta_engine_icon';
-import { ENGINES_TITLE, META_ENGINES_TITLE } from './constants';
 import { EnginesOverviewHeader, LoadingState, EmptyState } from './components';
-import { EnginesTable } from './engines_table';
+import { ENGINES_TITLE, META_ENGINES_TITLE } from './constants';
 import { EnginesLogic } from './engines_logic';
+import { EnginesTable } from './engines_table';
 
 import './engines_overview.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
@@ -9,10 +9,13 @@ import '../../../__mocks__/enterprise_search_url.mock';
 import { mockTelemetryActions, mountWithIntl } from '../../../__mocks__';
 
 import React from 'react';
+
 import { EuiBasicTable, EuiPagination, EuiButtonEmpty } from '@elastic/eui';
+
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 
 import { EngineDetails } from '../engine/types';
+
 import { EnginesTable } from './engines_table';
 
 describe('EnginesTable', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -6,18 +6,19 @@
  */
 
 import React from 'react';
-import { useActions } from 'kea';
-import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
-import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
-import { i18n } from '@kbn/i18n';
 
-import { TelemetryLogic } from '../../../shared/telemetry';
-import { EuiLinkTo } from '../../../shared/react_router_helpers';
-import { generateEncodedPath } from '../../utils/encode_path_params';
-import { ENGINE_PATH } from '../../routes';
+import { useActions } from 'kea';
+
+import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
 
 import { ENGINES_PAGE_SIZE } from '../../../../../common/constants';
+import { EuiLinkTo } from '../../../shared/react_router_helpers';
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { UNIVERSAL_LANGUAGE } from '../../constants';
+import { ENGINE_PATH } from '../../routes';
+import { generateEncodedPath } from '../../utils/encode_path_params';
 import { EngineDetails } from '../engine/types';
 
 interface EnginesTablePagination {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/error_connecting/error_connecting.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/error_connecting/error_connecting.test.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ErrorStatePrompt } from '../../../shared/error_state';
+
 import { ErrorConnecting } from './';
 
 describe('ErrorConnecting', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/error_connecting/error_connecting.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/error_connecting/error_connecting.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiPageContent } from '@elastic/eui';
 
 import { ErrorStatePrompt } from '../../../shared/error_state';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/library/library.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/library/library.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiSpacer,
   EuiPageHeader,
@@ -13,7 +15,6 @@ import {
   EuiPageContentBody,
   EuiPageContent,
 } from '@elastic/eui';
-import React from 'react';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { Schema } from '../../../shared/types';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.test.tsx
@@ -6,14 +6,16 @@
  */
 
 import '../../../../__mocks__/shallow_useeffect.mock';
-import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
-import { mountWithIntl } from '../../../../__mocks__';
+import { setMockValues, setMockActions, mountWithIntl } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 
 import { LogRetentionOptions } from '../';
+
 import { LogRetentionCallout } from './';
 
 describe('LogRetentionCallout', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
@@ -6,11 +6,12 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useValues, useActions } from 'kea';
 
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 
 import { EuiLinkTo } from '../../../../shared/react_router_helpers';
 
@@ -19,7 +20,7 @@ import { SETTINGS_PATH } from '../../../routes';
 import { ANALYTICS_TITLE } from '../../analytics';
 import { API_LOGS_TITLE } from '../../api_logs';
 
-import { LogRetentionLogic, LogRetentionOptions, renderLogRetentionDate } from '../';
+import { LogRetentionLogic, LogRetentionOptions, renderLogRetentionDate } from '../index';
 
 const TITLE_MAP = {
   [LogRetentionOptions.Analytics]: ANALYTICS_TITLE,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.test.tsx
@@ -9,10 +9,13 @@ import '../../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow, mount } from 'enzyme';
+
 import { EuiIconTip } from '@elastic/eui';
 
 import { LogRetentionOptions, LogRetentionMessage } from '../';
+
 import { LogRetentionTooltip } from './';
 
 describe('LogRetentionTooltip', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useValues, useActions } from 'kea';
 
-import { i18n } from '@kbn/i18n';
 import { EuiIconTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { LogRetentionLogic, LogRetentionMessage, LogRetentionOptions } from '../';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
@@ -10,7 +10,8 @@ import { LogicMounter, mockHttpValues, mockFlashMessageHelpers } from '../../../
 import { nextTick } from '@kbn/test/jest';
 
 import { LogRetentionOptions } from './types';
-import { LogRetentionLogic } from './log_retention_logic';
+
+import { LogRetentionLogic } from './';
 
 describe('LogRetentionLogic', () => {
   const { mount } = new LogicMounter(LogRetentionLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.ts
@@ -7,8 +7,8 @@
 
 import { kea, MakeLogicType } from 'kea';
 
-import { HttpLogic } from '../../../shared/http';
 import { flashAPIErrors } from '../../../shared/flash_messages';
+import { HttpLogic } from '../../../shared/http';
 
 import { LogRetentionOptions, LogRetention, LogRetentionServer } from './types';
 import { convertLogRetentionFromServerToClient } from './utils/convert_log_retention';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/constants.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/constants.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { FormattedDate, FormattedMessage } from '@kbn/i18n/react';
+
 import { i18n } from '@kbn/i18n';
+import { FormattedDate, FormattedMessage } from '@kbn/i18n/react';
 
 import { LogRetentionOptions, LogRetentionSettings, LogRetentionPolicy } from '../types';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/log_retention_message.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/log_retention_message.test.tsx
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { setMockValues } from '../../../../__mocks__/kea.mock';
-import { mountWithIntl } from '../../../../__mocks__';
+import { setMockValues, mountWithIntl } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { LogRetentionOptions } from '../types';
+
 import { LogRetentionMessage } from './';
 
 describe('LogRetentionMessage', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/log_retention_message.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/messaging/log_retention_message.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
 import { AppLogic } from '../../../app_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import {
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -14,8 +15,8 @@ import {
   EuiPageContent,
 } from '@elastic/eui';
 
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 
 import { RELEVANCE_TUNING_TITLE } from './constants';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -9,7 +9,7 @@ import { LogicMounter } from '../../../__mocks__';
 
 import { BoostType } from './types';
 
-import { RelevanceTuningLogic } from './relevance_tuning_logic';
+import { RelevanceTuningLogic } from './';
 
 describe('RelevanceTuningLogic', () => {
   const { mount } = new LogicMounter(RelevanceTuningLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
@@ -6,15 +6,17 @@
  */
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiPanel } from '@elastic/eui';
 
-import { ResultField } from './result_field';
-import { ResultHeader } from './result_header';
 import { ReactRouterHelper } from '../../../shared/react_router_helpers/eui_components';
 import { SchemaTypes } from '../../../shared/types';
 
 import { Result } from './result';
+import { ResultField } from './result_field';
+import { ResultHeader } from './result_header';
 
 describe('Result', () => {
   const props = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
+
 import classNames from 'classnames';
 
 import './result.scss';
@@ -14,13 +15,14 @@ import { EuiPanel, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { ReactRouterHelper } from '../../../shared/react_router_helpers/eui_components';
-import { generateEncodedPath } from '../../utils/encode_path_params';
-import { ENGINE_DOCUMENT_DETAIL_PATH } from '../../routes';
 
 import { Schema } from '../../../shared/types';
-import { FieldValue, Result as ResultType } from './types';
+import { ENGINE_DOCUMENT_DETAIL_PATH } from '../../routes';
+import { generateEncodedPath } from '../../utils/encode_path_params';
+
 import { ResultField } from './result_field';
 import { ResultHeader } from './result_header';
+import { FieldValue, Result as ResultType } from './types';
 
 interface Props {
   result: ResultType;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_field.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_field.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ResultField } from './result_field';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_field.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_field.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
-import { ResultFieldValue } from '.';
+
 import { FieldType, Raw, Snippet } from './types';
+
+import { ResultFieldValue } from '.';
 
 import './result_field.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_field_value.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_field_value.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { ResultFieldValue } from '.';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_header.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ResultHeader } from './result_header';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_header_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result_header_item.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { mount } from 'enzyme';
 
 import { ResultHeaderItem } from './result_header_item';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { GenericConfirmationModal } from './generic_confirmation_modal';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/generic_confirmation_modal.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { ReactNode, useState } from 'react';
-import { i18n } from '@kbn/i18n';
 
 import {
   EuiButton,
@@ -21,6 +20,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 interface GenericConfirmationModalProps {
   description: ReactNode;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.test.tsx
@@ -8,9 +8,11 @@
 import { setMockActions, setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { LogRetentionOptions } from '../../log_retention';
+
 import { GenericConfirmationModal } from './generic_confirmation_modal';
 import { LogRetentionConfirmationModal } from './log_retention_confirmation_modal';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_confirmation_modal.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
 
-import { EuiTextColor, EuiOverlayMask } from '@elastic/eui';
 import { useActions, useValues } from 'kea';
 
+import { EuiTextColor, EuiOverlayMask } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { LogRetentionLogic, LogRetentionOptions } from '../../log_retention';
+
 import { GenericConfirmationModal } from './generic_confirmation_modal';
 
 export const LogRetentionConfirmationModal: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.test.tsx
@@ -9,9 +9,11 @@ import '../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { LogRetention } from '../../log_retention/types';
+
 import { LogRetentionPanel } from './log_retention_panel';
 
 describe('<LogRetentionPanel />', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/log_retention/log_retention_panel.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useEffect } from 'react';
-import { i18n } from '@kbn/i18n';
+
+import { useActions, useValues } from 'kea';
 
 import { EuiLink, EuiSpacer, EuiSwitch, EuiText, EuiTextColor, EuiTitle } from '@elastic/eui';
-import { useActions, useValues } from 'kea';
+import { i18n } from '@kbn/i18n';
 
 import { DOCS_PREFIX } from '../../../routes';
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiPageContentBody } from '@elastic/eui';
 
 import { Settings } from './settings';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/settings/settings.tsx
@@ -15,10 +15,11 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
-import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 
 import { LogRetentionPanel, LogRetentionConfirmationModal } from './log_retention';
+
 import { SETTINGS_TITLE } from './';
 
 export const Settings: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.test.tsx
@@ -6,10 +6,12 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SetupGuideLayout } from '../../../shared/setup_guide';
+
 import { SetupGuide } from './';
 
 describe('SetupGuide', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
@@ -6,15 +6,17 @@
  */
 
 import React from 'react';
+
 import { EuiSpacer, EuiTitle, EuiText } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { DOCS_PREFIX } from '../../routes';
+
 import GettingStarted from './assets/getting_started.png';
 
 export const SetupGuide: React.FC = () => (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
@@ -11,13 +11,16 @@ import { setMockValues, setMockActions } from '../__mocks__';
 
 import React from 'react';
 import { Redirect } from 'react-router-dom';
+
 import { shallow } from 'enzyme';
 
 import { Layout, SideNav, SideNavLink } from '../shared/layout';
-import { SetupGuide } from './components/setup_guide';
-import { ErrorConnecting } from './components/error_connecting';
-import { EnginesOverview } from './components/engines';
+
 import { EngineRouter } from './components/engine';
+import { EnginesOverview } from './components/engines';
+import { ErrorConnecting } from './components/error_connecting';
+import { SetupGuide } from './components/setup_guide';
+
 import { AppSearch, AppSearchUnconfigured, AppSearchConfigured, AppSearchNav } from './';
 
 describe('AppSearch', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
@@ -7,18 +7,26 @@
 
 import React, { useEffect } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
+
 import { useActions, useValues } from 'kea';
 
-import { getAppSearchUrl } from '../shared/enterprise_search_url';
-import { KibanaLogic } from '../shared/kibana';
-import { HttpLogic } from '../shared/http';
-import { AppLogic } from './app_logic';
-import { InitialAppData } from '../../../common/types';
-
 import { APP_SEARCH_PLUGIN } from '../../../common/constants';
+import { InitialAppData } from '../../../common/types';
+import { getAppSearchUrl } from '../shared/enterprise_search_url';
+import { HttpLogic } from '../shared/http';
+import { KibanaLogic } from '../shared/kibana';
 import { Layout, SideNav, SideNavLink } from '../shared/layout';
-import { EngineNav, EngineRouter } from './components/engine';
+import { NotFound } from '../shared/not_found';
 
+import { AppLogic } from './app_logic';
+import { Credentials, CREDENTIALS_TITLE } from './components/credentials';
+import { EngineNav, EngineRouter } from './components/engine';
+import { EnginesOverview, ENGINES_TITLE } from './components/engines';
+import { ErrorConnecting } from './components/error_connecting';
+import { Library } from './components/library';
+import { ROLE_MAPPINGS_TITLE } from './components/role_mappings';
+import { Settings, SETTINGS_TITLE } from './components/settings';
+import { SetupGuide } from './components/setup_guide';
 import {
   ROOT_PATH,
   SETUP_GUIDE_PATH,
@@ -29,15 +37,6 @@ import {
   ENGINE_PATH,
   LIBRARY_PATH,
 } from './routes';
-
-import { SetupGuide } from './components/setup_guide';
-import { ErrorConnecting } from './components/error_connecting';
-import { NotFound } from '../shared/not_found';
-import { EnginesOverview, ENGINES_TITLE } from './components/engines';
-import { Settings, SETTINGS_TITLE } from './components/settings';
-import { Credentials, CREDENTIALS_TITLE } from './components/credentials';
-import { ROLE_MAPPINGS_TITLE } from './components/role_mappings';
-import { Library } from './components/library';
 
 export const AppSearch: React.FC<InitialAppData> = (props) => {
   const { config } = useValues(KibanaLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.test.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ErrorStatePrompt } from '../../../shared/error_state';
+
 import { ErrorConnecting } from './';
 
 describe('ErrorConnecting', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/error_connecting/error_connecting.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
+
 import { EuiPage, EuiPageContent } from '@elastic/eui';
 
-import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { ErrorStatePrompt } from '../../../shared/error_state';
+import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 
 export const ErrorConnecting: React.FC = () => (
   <EuiPage restrictWidth>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.test.tsx
@@ -8,11 +8,13 @@
 import { setMockValues, mockTelemetryActions } from '../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCard } from '@elastic/eui';
-import { EuiButtonTo } from '../../../shared/react_router_helpers';
+
 import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
 
 import { ProductCard } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_card/product_card.tsx
@@ -6,14 +6,16 @@
  */
 
 import React from 'react';
+
 import { useValues, useActions } from 'kea';
 import { snakeCase } from 'lodash';
-import { i18n } from '@kbn/i18n';
-import { EuiCard, EuiTextColor } from '@elastic/eui';
 
+import { EuiCard, EuiTextColor } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { KibanaLogic } from '../../../shared/kibana';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
-import { KibanaLogic } from '../../../shared/kibana';
 
 import './product_card.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.test.tsx
@@ -8,11 +8,13 @@
 import { setMockValues } from '../../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiPage } from '@elastic/eui';
 
-import { SetupGuideCta } from '../setup_guide';
 import { ProductCard } from '../product_card';
+import { SetupGuideCta } from '../setup_guide';
 
 import { ProductSelector } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/product_selector/product_selector.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
+
 import {
   EuiPage,
   EuiPageBody,
@@ -25,11 +27,10 @@ import { KibanaLogic } from '../../../shared/kibana';
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 
-import { ProductCard } from '../product_card';
-import { SetupGuideCta } from '../setup_guide';
-
 import AppSearchImage from '../../assets/app_search.png';
 import WorkplaceSearchImage from '../../assets/workplace_search.png';
+import { ProductCard } from '../product_card';
+import { SetupGuideCta } from '../setup_guide';
 
 interface ProductSelectorProps {
   access: {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.test.tsx
@@ -6,10 +6,12 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SetupGuideLayout } from '../../../shared/setup_guide';
+
 import { SetupGuide } from './';
 
 describe('SetupGuide', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide.tsx
@@ -6,14 +6,16 @@
  */
 
 import React from 'react';
+
 import { EuiSpacer, EuiTitle, EuiText } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { ENTERPRISE_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetEnterpriseSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SendEnterpriseSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+
 import GettingStarted from './assets/getting_started.png';
 
 export const SetupGuide: React.FC = () => (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SetupGuideCta } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/components/setup_guide/setup_guide_cta.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiFlexGroup, EuiFlexItem, EuiTitle, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { EuiPanelTo } from '../../../shared/react_router_helpers';
 
 import CtaImage from './assets/getting_started.png';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.test.tsx
@@ -5,15 +5,17 @@
  * 2.0.
  */
 
-import React from 'react';
-import { shallow } from 'enzyme';
-
 import { setMockValues, rerender } from '../__mocks__';
 
-import { EnterpriseSearch } from './';
-import { SetupGuide } from './components/setup_guide';
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
 import { ErrorConnecting } from './components/error_connecting';
 import { ProductSelector } from './components/product_selector';
+import { SetupGuide } from './components/setup_guide';
+
+import { EnterpriseSearch } from './';
 
 describe('EnterpriseSearch', () => {
   it('renders the Setup Guide and Product Selector', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search/index.tsx
@@ -7,18 +7,17 @@
 
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+
 import { useValues } from 'kea';
 
-import { KibanaLogic } from '../shared/kibana';
 import { InitialAppData } from '../../../common/types';
-
 import { HttpLogic } from '../shared/http';
-
-import { ROOT_PATH, SETUP_GUIDE_PATH } from './routes';
+import { KibanaLogic } from '../shared/kibana';
 
 import { ErrorConnecting } from './components/error_connecting';
 import { ProductSelector } from './components/product_selector';
 import { SetupGuide } from './components/setup_guide';
+import { ROOT_PATH, SETUP_GUIDE_PATH } from './routes';
 
 import './index.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.test.tsx
@@ -6,17 +6,19 @@
  */
 
 import React from 'react';
+
 import { getContext } from 'kea';
 
-import { coreMock } from 'src/core/public/mocks';
-import { licensingMock } from '../../../licensing/public/mocks';
+import { coreMock } from '../../../../../src/core/public/mocks';
 import { chartPluginMock } from '../../../../../src/plugins/charts/public/mocks';
+import { licensingMock } from '../../../licensing/public/mocks';
+
+import { AppSearch } from './app_search';
+import { EnterpriseSearch } from './enterprise_search';
+import { KibanaLogic } from './shared/kibana';
+import { WorkplaceSearch } from './workplace_search';
 
 import { renderApp, renderHeaderActions } from './';
-import { EnterpriseSearch } from './enterprise_search';
-import { AppSearch } from './app_search';
-import { WorkplaceSearch } from './workplace_search';
-import { KibanaLogic } from './shared/kibana';
 
 describe('renderApp', () => {
   const kibanaDeps = {

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -7,21 +7,23 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { Store } from 'redux';
+import { Router } from 'react-router-dom';
+
 import { getContext, resetContext } from 'kea';
+import { Store } from 'redux';
+
 import { I18nProvider } from '@kbn/i18n/react';
 
-import { AppMountParameters, CoreStart } from 'src/core/public';
-import { PluginsStart, ClientConfigType, ClientData } from '../plugin';
+import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
 import { InitialAppData } from '../../common/types';
+import { PluginsStart, ClientConfigType, ClientData } from '../plugin';
 
+import { externalUrl } from './shared/enterprise_search_url';
+import { mountFlashMessagesLogic } from './shared/flash_messages';
+import { mountHttpLogic } from './shared/http';
 import { mountKibanaLogic } from './shared/kibana';
 import { mountLicensingLogic } from './shared/licensing';
-import { mountHttpLogic } from './shared/http';
-import { mountFlashMessagesLogic } from './shared/flash_messages';
-import { externalUrl } from './shared/enterprise_search_url';
 
 /**
  * This file serves as a reusable wrapper to share Kibana-level context and other helpers

--- a/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.test.tsx
@@ -8,7 +8,9 @@
 import '../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiEmptyPrompt } from '@elastic/eui';
 
 import { ErrorStatePrompt } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/error_state/error_state_prompt.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
+
 import { EuiEmptyPrompt, EuiCode } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { EuiButtonTo } from '../react_router_helpers';
 import { KibanaLogic } from '../../shared/kibana';
+import { EuiButtonTo } from '../react_router_helpers';
 
 import './error_state_prompt.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues } from '../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiCallOut } from '@elastic/eui';
 
 import { FlashMessages } from './flash_messages';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { Fragment } from 'react';
+
 import { useValues } from 'kea';
+
 import { EuiCallOut, EuiCallOutProps, EuiSpacer } from '@elastic/eui';
 
 import { FlashMessagesLogic } from './flash_messages_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.test.ts
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
+import { mockKibanaValues } from '../../__mocks__/kibana_logic.mock';
+
 import { resetContext } from 'kea';
 
-import { mockKibanaValues } from '../../__mocks__/kibana_logic.mock';
 const { history } = mockKibanaValues;
 
-import { FlashMessagesLogic, mountFlashMessagesLogic, IFlashMessage } from './flash_messages_logic';
+import { FlashMessagesLogic, mountFlashMessagesLogic } from './flash_messages_logic';
+import { IFlashMessage } from './types';
 
 describe('FlashMessagesLogic', () => {
   const mount = () => mountFlashMessagesLogic();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages_logic.ts
@@ -6,15 +6,10 @@
  */
 
 import { kea, MakeLogicType } from 'kea';
-import { ReactNode } from 'react';
 
 import { KibanaLogic } from '../kibana';
 
-export interface IFlashMessage {
-  type: 'success' | 'info' | 'warning' | 'error';
-  message: ReactNode;
-  description?: ReactNode;
-}
+import { IFlashMessage } from './types';
 
 interface FlashMessagesValues {
   messages: IFlashMessage[];

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.test.ts
@@ -8,6 +8,7 @@
 import '../../__mocks__/kibana_logic.mock';
 
 import { FlashMessagesLogic } from './flash_messages_logic';
+
 import { flashAPIErrors } from './handle_api_errors';
 
 describe('flashAPIErrors', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/handle_api_errors.ts
@@ -7,7 +7,8 @@
 
 import { HttpResponse } from 'src/core/public';
 
-import { FlashMessagesLogic, IFlashMessage } from './flash_messages_logic';
+import { FlashMessagesLogic } from './flash_messages_logic';
+import { IFlashMessage } from './types';
 
 /**
  * The API errors we are handling can come from one of two ways:

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/index.ts
@@ -6,7 +6,8 @@
  */
 
 export { FlashMessages } from './flash_messages';
-export { FlashMessagesLogic, IFlashMessage, mountFlashMessagesLogic } from './flash_messages_logic';
+export { FlashMessagesLogic, mountFlashMessagesLogic } from './flash_messages_logic';
+export { IFlashMessage } from './types';
 export { flashAPIErrors } from './handle_api_errors';
 export {
   setSuccessMessage,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/types.ts
@@ -5,14 +5,10 @@
  * 2.0.
  */
 
-import React from 'react';
+import { ReactNode } from 'react';
 
-import { EuiLoadingSpinner } from '@elastic/eui';
-
-import './loading.scss';
-
-export const Loading: React.FC = () => (
-  <div className="enterpriseSearchLoading">
-    <EuiLoadingSpinner size="xl" />
-  </div>
-);
+export interface IFlashMessage {
+  type: 'success' | 'info' | 'warning' | 'error';
+  message: ReactNode;
+  description?: ReactNode;
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { HiddenText } from '.';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/hidden_text/hidden_text.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, ReactElement } from 'react';
+
 import { i18n } from '@kbn/i18n';
 
 interface ChildrenProps {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.test.tsx
@@ -9,13 +9,14 @@ import '../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiPanel } from '@elastic/eui';
 
+import { IndexingStatus } from './indexing_status';
 import { IndexingStatusContent } from './indexing_status_content';
 import { IndexingStatusErrors } from './indexing_status_errors';
-import { IndexingStatus } from './indexing_status';
 
 describe('IndexingStatus', () => {
   const getItemDetailPath = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.tsx
@@ -11,11 +11,11 @@ import { useValues, useActions } from 'kea';
 
 import { EuiPanel, EuiSpacer } from '@elastic/eui';
 
+import { IIndexingStatus } from '../types';
+
 import { IndexingStatusContent } from './indexing_status_content';
 import { IndexingStatusErrors } from './indexing_status_errors';
 import { IndexingStatusLogic } from './indexing_status_logic';
-
-import { IIndexingStatus } from '../types';
 
 export interface IIndexingStatusProps {
   viewLinkPath: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_content.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiProgress, EuiTitle } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCallOut } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.ts
@@ -7,9 +7,9 @@
 
 import { kea, MakeLogicType } from 'kea';
 
+import { flashAPIErrors } from '../flash_messages';
 import { HttpLogic } from '../http';
 import { IIndexingStatus } from '../types';
-import { flashAPIErrors } from '../flash_messages';
 
 interface IndexingStatusProps {
   statusPath: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.test.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { resetContext } from 'kea';
-
 import { mockKibanaValues } from '../../__mocks__';
+
+import { resetContext } from 'kea';
 
 import { KibanaLogic, mountKibanaLogic } from './kibana_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
+import { FC } from 'react';
+
+import { History } from 'history';
 import { kea, MakeLogicType } from 'kea';
 
-import { FC } from 'react';
-import { History } from 'history';
-import { ApplicationStart, ChromeBreadcrumb } from 'src/core/public';
-import { ChartsPluginStart } from 'src/plugins/charts/public';
+import { ApplicationStart, ChromeBreadcrumb } from '../../../../../../../src/core/public';
+import { ChartsPluginStart } from '../../../../../../../src/plugins/charts/public';
 import { CloudSetup } from '../../../../../cloud/public';
 
 import { HttpLogic } from '../http';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -6,10 +6,8 @@
  */
 
 import { useValues } from 'kea';
-import { EuiBreadcrumb } from '@elastic/eui';
 
-import { KibanaLogic } from '../kibana';
-import { HttpLogic } from '../http';
+import { EuiBreadcrumb } from '@elastic/eui';
 
 import {
   ENTERPRISE_SEARCH_PLUGIN,
@@ -18,6 +16,8 @@ import {
 } from '../../../../common/constants';
 
 import { stripLeadingSlash } from '../../../../common/strip_slashes';
+import { HttpLogic } from '../http';
+import { KibanaLogic } from '../kibana';
 import { letBrowserHandleEvent, createHref } from '../react_router_helpers';
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.test.tsx
@@ -9,6 +9,7 @@ import '../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, mockKibanaValues, mockHistory } from '../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 jest.mock('./generate_breadcrumbs', () => ({

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useValues } from 'kea';
 
 import { KibanaLogic } from '../kibana';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiPageSideBar, EuiButton, EuiPageBody, EuiCallOut } from '@elastic/eui';
 
 import { Layout, INavContext } from './layout';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/layout.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+
 import classNames from 'classnames';
 
 import { EuiPage, EuiPageSideBar, EuiPageBody, EuiButton, EuiCallOut } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.test.tsx
@@ -9,11 +9,13 @@ import '../../__mocks__/react_router_history.mock';
 
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+
 import { shallow } from 'enzyme';
 
 import { EuiLink } from '@elastic/eui';
-import { EuiLinkTo } from '../react_router_helpers';
+
 import { ENTERPRISE_SEARCH_PLUGIN, APP_SEARCH_PLUGIN } from '../../../../common/constants';
+import { EuiLinkTo } from '../react_router_helpers';
 
 import { SideNav, SideNavLink, SideNavItem } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/side_nav.tsx
@@ -7,14 +7,15 @@
 
 import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
+
 import classNames from 'classnames';
 
-import { i18n } from '@kbn/i18n';
 import { EuiIcon, EuiTitle, EuiText, EuiLink } from '@elastic/eui'; // TODO: Remove EuiLink after full Kibana transition
-import { EuiLinkTo } from '../react_router_helpers';
+import { i18n } from '@kbn/i18n';
 
 import { ENTERPRISE_SEARCH_PLUGIN } from '../../../../common/constants';
 import { stripTrailingSlash } from '../../../../common/strip_slashes';
+import { EuiLinkTo } from '../react_router_helpers';
 
 import { NavContext, INavContext } from './layout';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiLoadingSpinner } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/not_found/not_found.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/not_found/not_found.test.tsx
@@ -8,12 +8,14 @@
 import { setMockValues } from '../../__mocks__/kea.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiButton as EuiButtonExternal, EuiEmptyPrompt } from '@elastic/eui';
 
 import { APP_SEARCH_PLUGIN, WORKPLACE_SEARCH_PLUGIN } from '../../../../common/constants';
 import { SetAppSearchChrome } from '../kibana_chrome';
+
 import { AppSearchLogo } from './assets/app_search_logo';
 import { WorkplaceSearchLogo } from './assets/workplace_search_logo';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/not_found/not_found.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/not_found/not_found.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
-import { i18n } from '@kbn/i18n';
+
 import {
   EuiPageContent,
   EuiEmptyPrompt,
@@ -16,6 +17,7 @@ import {
   EuiFlexItem,
   EuiButton,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import {
   APP_SEARCH_PLUGIN,
@@ -23,11 +25,11 @@ import {
   LICENSED_SUPPORT_URL,
 } from '../../../../common/constants';
 
-import { EuiButtonTo } from '../react_router_helpers';
-import { BreadcrumbTrail } from '../kibana_chrome/generate_breadcrumbs';
 import { SetAppSearchChrome, SetWorkplaceSearchChrome } from '../kibana_chrome';
-import { SendAppSearchTelemetry, SendWorkplaceSearchTelemetry } from '../telemetry';
+import { BreadcrumbTrail } from '../kibana_chrome/generate_breadcrumbs';
 import { LicensingLogic } from '../licensing';
+import { EuiButtonTo } from '../react_router_helpers';
+import { SendAppSearchTelemetry, SendWorkplaceSearchTelemetry } from '../telemetry';
 
 import { AppSearchLogo } from './assets/app_search_logo';
 import { WorkplaceSearchLogo } from './assets/workplace_search_logo';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { httpServiceMock } from 'src/core/public/mocks';
 import { mockHistory } from '../../__mocks__';
+
+import { httpServiceMock } from 'src/core/public/mocks';
 
 import { createHref } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/create_href.ts
@@ -6,6 +6,7 @@
  */
 
 import { History } from 'history';
+
 import { HttpSetup } from 'src/core/public';
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.test.tsx
@@ -7,11 +7,13 @@
 
 import '../../__mocks__/kea.mock';
 
-import React from 'react';
-import { shallow, mount } from 'enzyme';
-import { EuiLink, EuiButton, EuiButtonEmpty, EuiPanel, EuiCard } from '@elastic/eui';
-
 import { mockKibanaValues, mockHistory } from '../../__mocks__';
+
+import React from 'react';
+
+import { shallow, mount } from 'enzyme';
+
+import { EuiLink, EuiButton, EuiButtonEmpty, EuiPanel, EuiCard } from '@elastic/eui';
 
 import { EuiLinkTo, EuiButtonTo, EuiButtonEmptyTo, EuiPanelTo, EuiCardTo } from './eui_components';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/react_router_helpers/eui_components.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
+
 import {
   EuiLink,
   EuiButton,
@@ -20,8 +22,9 @@ import {
 } from '@elastic/eui';
 import { EuiPanelProps } from '@elastic/eui/src/components/panel/panel';
 
-import { KibanaLogic } from '../kibana';
 import { HttpLogic } from '../http';
+import { KibanaLogic } from '../kibana';
+
 import { letBrowserHandleEvent, createHref } from './';
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_add_field_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_add_field_modal.test.tsx
@@ -6,15 +6,16 @@
  */
 
 import React from 'react';
+
 import { shallow, mount } from 'enzyme';
+
+import { EuiFieldText, EuiModal, EuiSelect } from '@elastic/eui';
 
 import { NUMBER } from '../constants/field_types';
 
 import { FIELD_NAME_CORRECTED_PREFIX } from './constants';
 
 import { SchemaAddFieldModal } from './';
-
-import { EuiFieldText, EuiModal, EuiSelect } from '@elastic/eui';
 
 describe('SchemaAddFieldModal', () => {
   const addNewField = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_errors_accordion.test.tsx
@@ -6,11 +6,13 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiAccordion, EuiTableRow } from '@elastic/eui';
 
 import { EuiLinkTo } from '../react_router_helpers';
+
 import { SchemaErrorsAccordion } from './schema_errors_accordion';
 
 describe('SchemaErrorsAccordion', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_existing_field.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/schema/schema_existing_field.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiSelect } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.test.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
-import { shallow } from 'enzyme';
-import { EuiSteps, EuiLink } from '@elastic/eui';
-
 import { mountWithIntl } from '../../../__mocks__';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiSteps, EuiLink } from '@elastic/eui';
 
 import { CloudSetupInstructions } from './instructions';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { FormattedMessage } from '@kbn/i18n/react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiPageContent, EuiSteps, EuiText, EuiLink, EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { docLinks } from '../../doc_links';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.test.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
-import { shallow } from 'enzyme';
-import { EuiSteps, EuiLink } from '@elastic/eui';
-
 import { mountWithIntl } from '../../__mocks__';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiSteps, EuiLink } from '@elastic/eui';
 
 import { SetupInstructions } from './instructions';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/instructions.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { FormattedMessage } from '@kbn/i18n/react';
-import { i18n } from '@kbn/i18n';
+
 import {
   EuiPageContent,
   EuiSpacer,
@@ -18,6 +17,8 @@ import {
   EuiAccordion,
   EuiLink,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 interface Props {
   productName: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.test.tsx
@@ -8,11 +8,13 @@
 import { setMockValues, rerender } from '../../__mocks__';
 
 import React from 'react';
+
 import { shallow, ShallowWrapper } from 'enzyme';
+
 import { EuiIcon } from '@elastic/eui';
 
-import { SetupInstructions } from './instructions';
 import { CloudSetupInstructions } from './cloud/instructions';
+import { SetupInstructions } from './instructions';
 
 import { SetupGuideLayout } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/setup_guide/setup_guide.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
 import {
@@ -22,9 +23,9 @@ import {
 
 import { KibanaLogic } from '../kibana';
 
-import { SetupInstructions } from './instructions';
 import { CloudSetupInstructions } from './cloud/instructions';
 import { SETUP_GUIDE_TITLE } from './constants';
+import { SetupInstructions } from './instructions';
 import './setup_guide.scss';
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/shared/table_header/table_header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/table_header/table_header.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiTableHeader, EuiTableHeaderCell } from '@elastic/eui';
 
 import { TableHeader } from './table_header';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.test.tsx
@@ -9,6 +9,7 @@ import '../../__mocks__/shallow_useeffect.mock';
 import { mockTelemetryActions } from '../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/send_telemetry.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { useActions } from 'kea';
 
 import { TelemetryLogic, SendTelemetryHelper } from './telemetry_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/telemetry/telemetry_logic.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { JSON_HEADER as headers } from '../../../../common/constants';
 import { LogicMounter, mockHttpValues } from '../../__mocks__';
+
+import { JSON_HEADER as headers } from '../../../../common/constants';
 
 import { TelemetryLogic } from './telemetry_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/truncate/truncate.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/truncate/truncate.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { TruncatedContent } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/__mocks__/content_sources.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/__mocks__/content_sources.mock.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { mergeServerAndStaticData } from '../views/content_sources/sources_logic';
-import { staticSourceData } from '../views/content_sources/source_data';
 import { groups } from './groups.mock';
+
+import { staticSourceData } from '../views/content_sources/source_data';
+import { mergeServerAndStaticData } from '../views/content_sources/sources_logic';
 
 export const contentSources = [
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
+import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
 import { LogicMounter } from '../__mocks__';
 
-import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
 import { AppLogic } from './app_logic';
 
 describe('AppLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.test.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import { externalUrl } from '../../../shared/enterprise_search_url';
-
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiButtonEmpty } from '@elastic/eui';
+
+import { externalUrl } from '../../../shared/enterprise_search_url';
 
 import { WorkplaceSearchHeaderActions } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.tsx
@@ -6,10 +6,10 @@
  */
 
 import React from 'react';
+
 import { EuiButtonEmpty, EuiText } from '@elastic/eui';
 
 import { externalUrl, getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
-
 import { NAV } from '../../constants';
 
 export const WorkplaceSearchHeaderActions: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.test.tsx
@@ -8,9 +8,11 @@
 import '../../../__mocks__/enterprise_search_url.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SideNav, SideNavLink } from '../../../shared/layout';
+
 import { WorkplaceSearchNav } from './';
 
 describe('WorkplaceSearchNav', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
@@ -12,9 +12,7 @@ import { EuiSpacer } from '@elastic/eui';
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
 import { SideNav, SideNavLink } from '../../../shared/layout';
-
 import { NAV } from '../../constants';
-
 import {
   SOURCES_PATH,
   SECURITY_PATH,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/api_key.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/api_key/api_key.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCodeBlock, EuiFormLabel } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/component_loader/component_loader.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiLoadingSpinner, EuiTextColor } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/content_section/content_section.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/content_section/content_section.test.tsx
@@ -6,11 +6,14 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiSpacer } from '@elastic/eui';
 
-import { ContentSection } from './';
 import { ViewContentHeader } from '../view_content_header';
+
+import { ContentSection } from './';
 
 const props = {
   children: <div className="children" />,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/content_section/content_section.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/content_section/content_section.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
 
 import { SpacerSizeTypes } from '../../../types';
-
 import { ViewContentHeader } from '../view_content_header';
 
 import './content_section.scss';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/credential_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/credential_item/credential_item.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCopy, EuiButtonIcon, EuiFieldText } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/license_badge/license_badge.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/license_badge/license_badge.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiBadge } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/license_callout/license_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/license_callout/license_callout.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiLink, EuiText } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.test.tsx
@@ -9,7 +9,9 @@ import '../../../../__mocks__/kea.mock';
 import { mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/product_button/product_button.tsx
@@ -6,13 +6,14 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
 
 import { EuiButton, EuiButtonProps, EuiLinkProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { TelemetryLogic } from '../../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../../shared/telemetry';
 
 export const ProductButton: React.FC = () => {
   const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ApiKey } from '../api_key';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_config_fields/source_config_fields.tsx
@@ -16,7 +16,6 @@ import {
   CLIENT_ID_LABEL,
   CLIENT_SECRET_LABEL,
 } from '../../../constants';
-
 import { ApiKey } from '../api_key';
 import { CredentialItem } from '../credential_item';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_icon/source_icon.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_icon/source_icon.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiIcon } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.test.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
+import { contentSources } from '../../../__mocks__/content_sources.mock';
+
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiTableRow, EuiSwitch, EuiIcon } from '@elastic/eui';
-import { contentSources } from '../../../__mocks__/content_sources.mock';
 
 import { SourceIcon } from '../source_icon';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -26,14 +26,13 @@ import {
 
 import { EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { SOURCE_STATUSES as statuses } from '../../../constants';
-import { ContentSourceDetails } from '../../../types';
 import {
   ADD_SOURCE_PATH,
   SOURCE_DETAILS_PATH,
   getContentSourcePath,
   getSourcesPath,
 } from '../../../routes';
-
+import { ContentSourceDetails } from '../../../types';
 import { SourceIcon } from '../source_icon';
 
 import './source_row.scss';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/sources_table/sources_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/sources_table/sources_table.test.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
+import { contentSources } from '../../../__mocks__/content_sources.mock';
+
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiTable } from '@elastic/eui';
-import { TableHeader } from '../../../../shared/table_header/table_header';
-import { contentSources } from '../../../__mocks__/content_sources.mock';
 
+import { TableHeader } from '../../../../shared/table_header/table_header';
 import { SourceRow } from '../source_row';
 
 import { SourcesTable } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/sources_table/sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/sources_table/sources_table.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import { EuiTable, EuiTableBody } from '@elastic/eui';
 
 import { TableHeader } from '../../../../shared/table_header/table_header';
-import { SourceRow, ISourceRow } from '../source_row';
 import { ContentSourceDetails } from '../../../types';
+import { SourceRow, ISourceRow } from '../source_row';
 
 interface SourcesTableProps extends ISourceRow {
   sources: ContentSourceDetails[];

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/table_pagination_bar/table_pagination_bar.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/table_pagination_bar/table_pagination_bar.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiFlexGroup, EuiTablePagination } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/user_icon/user_icon.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/user_icon/user_icon.test.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import React from 'react';
-import { shallow } from 'enzyme';
-
 import { users } from '../../../__mocks__/users.mock';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
 
 import { UserIcon } from './user_icon';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/user_row/user_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/user_row/user_row.test.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
+import { users } from '../../../__mocks__/users.mock';
+
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiTableRow } from '@elastic/eui';
-
-import { users } from '../../../__mocks__/users.mock';
 
 import { UserRow } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/view_content_header/view_content_header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/view_content_header/view_content_header.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlexGroup } from '@elastic/eui';
 
 import { ViewContentHeader } from './';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/view_content_header/view_content_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/view_content_header/view_content_header.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, EuiSpacer } from '@elastic/eui';
-
 import { FlexGroupAlignItems } from '@elastic/eui/src/components/flex/flex_group';
 
 interface ViewContentHeaderProps {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -10,13 +10,15 @@ import { setMockValues, setMockActions, mockKibanaValues } from '../__mocks__';
 
 import React from 'react';
 import { Redirect } from 'react-router-dom';
+
 import { shallow } from 'enzyme';
 
 import { Layout } from '../shared/layout';
+
 import { WorkplaceSearchHeaderActions } from './components/layout';
-import { SetupGuide } from './views/setup_guide';
 import { ErrorState } from './views/error_state';
 import { Overview } from './views/overview';
+import { SetupGuide } from './views/setup_guide';
 
 import { WorkplaceSearch, WorkplaceSearchUnconfigured, WorkplaceSearchConfigured } from './';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -7,16 +7,18 @@
 
 import React, { useEffect } from 'react';
 import { Route, Redirect, Switch, useLocation } from 'react-router-dom';
+
 import { useActions, useValues } from 'kea';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../common/constants';
 import { InitialAppData } from '../../../common/types';
-import { KibanaLogic } from '../shared/kibana';
 import { HttpLogic } from '../shared/http';
-import { AppLogic } from './app_logic';
+import { KibanaLogic } from '../shared/kibana';
 import { Layout } from '../shared/layout';
-import { WorkplaceSearchNav, WorkplaceSearchHeaderActions } from './components/layout';
+import { NotFound } from '../shared/not_found';
 
+import { AppLogic } from './app_logic';
+import { WorkplaceSearchNav, WorkplaceSearchHeaderActions } from './components/layout';
 import {
   GROUPS_PATH,
   SETUP_GUIDE_PATH,
@@ -25,19 +27,16 @@ import {
   ORG_SETTINGS_PATH,
   SECURITY_PATH,
 } from './routes';
-
-import { SetupGuide } from './views/setup_guide';
-import { ErrorState } from './views/error_state';
-import { NotFound } from '../shared/not_found';
-import { Overview } from './views/overview';
-import { GroupsRouter } from './views/groups';
-import { Security } from './views/security';
 import { SourcesRouter } from './views/content_sources';
-import { SettingsRouter } from './views/settings';
-
-import { GroupSubNav } from './views/groups/components/group_sub_nav';
 import { SourceSubNav } from './views/content_sources/components/source_sub_nav';
+import { ErrorState } from './views/error_state';
+import { GroupsRouter } from './views/groups';
+import { GroupSubNav } from './views/groups/components/group_sub_nav';
+import { Overview } from './views/overview';
+import { Security } from './views/security';
+import { SettingsRouter } from './views/settings';
 import { SettingsSubNav } from './views/settings/components/settings_sub_nav';
+import { SetupGuide } from './views/setup_guide';
 
 export const WorkplaceSearch: React.FC<InitialAppData> = (props) => {
   const { config } = useValues(KibanaLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiLink } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -7,10 +7,10 @@
 
 import '../../../../../__mocks__/shallow_useeffect.mock';
 import { mockKibanaValues, setMockActions, setMockValues } from '../../../../../__mocks__';
-
 import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { Loading } from '../../../../../shared/loading';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -9,16 +9,16 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { AppLogic } from '../../../../app_logic';
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { Loading } from '../../../../../shared/loading';
+import { AppLogic } from '../../../../app_logic';
 import { CUSTOM_SERVICE_TYPE } from '../../../../constants';
-import { staticSourceData } from '../../source_data';
-import { AddSourceLogic, AddSourceProps, AddSourceSteps } from './add_source_logic';
-import { SourceDataItem } from '../../../../types';
 import { SOURCE_ADDED_PATH, getSourcesPath } from '../../../../routes';
+import { SourceDataItem } from '../../../../types';
+import { staticSourceData } from '../../source_data';
 
 import { AddSourceHeader } from './add_source_header';
+import { AddSourceLogic, AddSourceProps, AddSourceSteps } from './add_source_logic';
 import { ConfigCompleted } from './config_completed';
 import { ConfigurationIntro } from './configuration_intro';
 import { ConfigureCustom } from './configure_custom';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_header.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_header.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiText, EuiTextColor } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiEmptyPrompt, EuiFieldSearch } from '@elastic/eui';
@@ -21,15 +22,14 @@ import { EuiEmptyPrompt, EuiFieldSearch } from '@elastic/eui';
 import { Loading } from '../../../../../../applications/shared/loading';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 
+import { AddSourceList } from './add_source_list';
+import { AvailableSourcesList } from './available_sources_list';
+import { ConfiguredSourcesList } from './configured_sources_list';
 import {
   ADD_SOURCE_NEW_SOURCE_DESCRIPTION,
   ADD_SOURCE_ORG_SOURCE_DESCRIPTION,
   ADD_SOURCE_PRIVATE_SOURCE_DESCRIPTION,
 } from './constants';
-
-import { AddSourceList } from './add_source_list';
-import { AvailableSourcesList } from './available_sources_list';
-import { ConfiguredSourcesList } from './configured_sources_list';
 
 describe('AddSourceList', () => {
   const initializeSources = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
@@ -18,15 +18,18 @@ import {
   EuiPanel,
   EuiEmptyPrompt,
 } from '@elastic/eui';
-import noSharedSourcesIcon from '../../../../assets/share_circle.svg';
 
+import { Loading } from '../../../../../../applications/shared/loading';
 import { AppLogic } from '../../../../app_logic';
+import noSharedSourcesIcon from '../../../../assets/share_circle.svg';
 import { ContentSection } from '../../../../components/shared/content_section';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
-import { Loading } from '../../../../../../applications/shared/loading';
 import { CUSTOM_SERVICE_TYPE } from '../../../../constants';
 import { SourceDataItem } from '../../../../types';
+import { SourcesLogic } from '../../sources_logic';
 
+import { AvailableSourcesList } from './available_sources_list';
+import { ConfiguredSourcesList } from './configured_sources_list';
 import {
   ADD_SOURCE_NEW_SOURCE_DESCRIPTION,
   ADD_SOURCE_ORG_SOURCE_DESCRIPTION,
@@ -38,10 +41,6 @@ import {
   ADD_SOURCE_EMPTY_TITLE,
   ADD_SOURCE_EMPTY_BODY,
 } from './constants';
-
-import { SourcesLogic } from '../../sources_logic';
-import { AvailableSourcesList } from './available_sources_list';
-import { ConfiguredSourcesList } from './configured_sources_list';
 
 export const AddSourceList: React.FC = () => {
   const { contentSources, dataLoading, availableSources, configuredSources } = useValues(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -11,20 +11,18 @@ import {
   mockHttpValues,
   mockKibanaValues,
 } from '../../../../../__mocks__';
+import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 
-import { AppLogic } from '../../../../app_logic';
+import { nextTick } from '@kbn/test/jest';
 
 jest.mock('../../../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
+import { AppLogic } from '../../../../app_logic';
 
 import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
 import { CustomSource } from '../../../../types';
 import { SourcesLogic } from '../../sources_logic';
-
-import { nextTick } from '@kbn/test/jest';
-
-import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 
 import {
   AddSourceLogic,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -13,16 +13,16 @@ import {
 } from '../../../../../__mocks__';
 
 import { AppLogic } from '../../../../app_logic';
+
 jest.mock('../../../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
 
+import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
+import { CustomSource } from '../../../../types';
 import { SourcesLogic } from '../../sources_logic';
 
 import { nextTick } from '@kbn/test/jest';
-
-import { CustomSource } from '../../../../types';
-import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
 
 import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -5,33 +5,27 @@
  * 2.0.
  */
 
+import { Search } from 'history';
+import { kea, MakeLogicType } from 'kea';
 import { keys, pickBy } from 'lodash';
 
-import { kea, MakeLogicType } from 'kea';
-
-import { Search } from 'history';
-
 import { i18n } from '@kbn/i18n';
-
 import { HttpFetchQuery } from 'src/core/public';
-
-import { HttpLogic } from '../../../../../shared/http';
-import { KibanaLogic } from '../../../../../shared/kibana';
-import { parseQueryParams } from '../../../../../shared/query_params';
 
 import {
   flashAPIErrors,
   setSuccessMessage,
   clearFlashMessages,
 } from '../../../../../shared/flash_messages';
-
-import { staticSourceData } from '../../source_data';
-import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
-import { CUSTOM_SERVICE_TYPE, WORKPLACE_SEARCH_URL_PREFIX } from '../../../../constants';
-
+import { HttpLogic } from '../../../../../shared/http';
+import { KibanaLogic } from '../../../../../shared/kibana';
+import { parseQueryParams } from '../../../../../shared/query_params';
 import { AppLogic } from '../../../../app_logic';
-import { SourcesLogic } from '../../sources_logic';
+import { CUSTOM_SERVICE_TYPE, WORKPLACE_SEARCH_URL_PREFIX } from '../../../../constants';
+import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
 import { CustomSource } from '../../../../types';
+import { staticSourceData } from '../../source_data';
+import { SourcesLogic } from '../../sources_logic';
 
 export interface AddSourceProps {
   sourceIndex: number;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.test.tsx
@@ -7,10 +7,10 @@
 
 import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues } from '../../../../../__mocks__';
-
 import { mergedAvailableSources } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCard, EuiToolTip, EuiTitle } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
+import { useValues } from 'kea';
 
 import {
   EuiCard,
@@ -18,15 +18,13 @@ import {
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
-
-import { useValues } from 'kea';
+import { i18n } from '@kbn/i18n';
 
 import { LicensingLogic } from '../../../../../shared/licensing';
 import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
-
 import { SourceIcon } from '../../../../components/shared/source_icon';
-import { SourceDataItem } from '../../../../types';
 import { ADD_CUSTOM_PATH, getSourcesPath } from '../../../../routes';
+import { SourceDataItem } from '../../../../types';
 
 import {
   AVAILABLE_SOURCE_EMPTY_STATE,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ConfigCompleted } from './config_completed';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_completed.tsx
@@ -7,9 +7,6 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiButton,
   EuiFlexGroup,
@@ -20,15 +17,16 @@ import {
   EuiText,
   EuiTextAlign,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
+import { EuiLinkTo, EuiButtonTo } from '../../../../../shared/react_router_helpers';
 import {
   getSourcesPath,
   ADD_SOURCE_PATH,
   SECURITY_PATH,
   PRIVATE_SOURCES_DOCS_URL,
 } from '../../../../routes';
-
-import { EuiLinkTo, EuiButtonTo } from '../../../../../shared/react_router_helpers';
 
 import {
   CONFIG_COMPLETED_PRIVATE_SOURCES_DOCS_LINK,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_docs_links.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_docs_links.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiButtonEmpty } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_docs_links.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/config_docs_links.tsx
@@ -7,9 +7,8 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
-
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { DOCUMENTATION_LINK_TITLE } from '../../../../constants';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configuration_intro.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configuration_intro.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiText, EuiTitle } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configuration_intro.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configuration_intro.tsx
@@ -7,9 +7,6 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiBadge,
   EuiButton,
@@ -20,6 +17,10 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import connectionIllustration from '../../../../assets/connection_illustration.svg';
 
 import {
   CONFIG_INTRO_ALT_TEXT,
@@ -30,8 +31,6 @@ import {
   CONFIG_INTRO_STEP2_TITLE,
   CONFIG_INTRO_STEP2_TEXT,
 } from './constants';
-
-import connectionIllustration from '../../../../assets/connection_illustration.svg';
 
 interface ConfigurationIntroProps {
   header: React.ReactNode;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_custom.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_custom.test.tsx
@@ -9,6 +9,7 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiForm, EuiFieldText } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_custom.tsx
@@ -9,8 +9,6 @@ import React, { ChangeEvent, FormEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiButton,
   EuiFieldText,
@@ -20,8 +18,10 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { CUSTOM_SOURCE_DOCS_URL } from '../../../../routes';
+
 import { AddSourceLogic } from './add_source_logic';
 import { CONFIG_CUSTOM_BUTTON } from './constants';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_oauth.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_oauth.test.tsx
@@ -9,6 +9,7 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCheckboxGroup } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_oauth.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_oauth.tsx
@@ -6,10 +6,10 @@
  */
 
 import React, { useEffect, useState, FormEvent } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { Location } from 'history';
 import { useActions, useValues } from 'kea';
-import { useLocation } from 'react-router-dom';
 
 import {
   EuiButton,
@@ -19,13 +19,12 @@ import {
   EuiFormRow,
   EuiSpacer,
 } from '@elastic/eui';
-
 import { EuiCheckboxGroupIdToSelectedMap } from '@elastic/eui/src/components/form/checkbox/checkbox_group';
 
-import { parseQueryParams } from '../../../../../../applications/shared/query_params';
 import { Loading } from '../../../../../../applications/shared/loading';
-import { AddSourceLogic } from './add_source_logic';
+import { parseQueryParams } from '../../../../../../applications/shared/query_params';
 
+import { AddSourceLogic } from './add_source_logic';
 import { CONFIG_OAUTH_LABEL, CONFIG_OAUTH_BUTTON } from './constants';
 
 interface OauthQueryParams {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.test.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
+import { mergedConfiguredSources } from '../../../../__mocks__/content_sources.mock';
+
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiPanel } from '@elastic/eui';
-
-import { mergedConfiguredSources } from '../../../../__mocks__/content_sources.mock';
 
 import { ConfiguredSourcesList } from './configured_sources_list';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.tsx
@@ -21,8 +21,8 @@ import {
 
 import { EuiButtonEmptyTo } from '../../../../../shared/react_router_helpers';
 import { SourceIcon } from '../../../../components/shared/source_icon';
-import { SourceDataItem } from '../../../../types';
 import { getSourcesPath } from '../../../../routes';
+import { SourceDataItem } from '../../../../types';
 
 import {
   CONFIGURED_SOURCES_LIST_UNCONNECTED_TOOLTIP,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.test.tsx
@@ -9,12 +9,14 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiBadge, EuiCallOut, EuiSwitch } from '@elastic/eui';
 
 import { FeatureIds } from '../../../../types';
 import { staticSourceData } from '../../source_data';
+
 import { ConnectInstance } from './connect_instance';
 
 describe('ConnectInstance', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/connect_instance.tsx
@@ -8,8 +8,6 @@
 import React, { useState, useEffect, FormEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
 
 import {
   EuiButton,
@@ -27,16 +25,16 @@ import {
   EuiBadge,
   EuiBadgeGroup,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { LicensingLogic } from '../../../../../../applications/shared/licensing';
-
 import { AppLogic } from '../../../../app_logic';
-import { AddSourceLogic } from './add_source_logic';
-import { FeatureIds, Configuration, Features } from '../../../../types';
 import { DOCUMENT_PERMISSIONS_DOCS_URL } from '../../../../routes';
-import { SourceFeatures } from './source_features';
-
+import { FeatureIds, Configuration, Features } from '../../../../types';
 import { LEARN_MORE_LINK } from '../../constants';
+
+import { AddSourceLogic } from './add_source_logic';
 import {
   CONNECT_REMOTE,
   CONNECT_PRIVATE,
@@ -47,6 +45,7 @@ import {
   CONNECT_NOT_SYNCED_TITLE,
   CONNECT_NOT_SYNCED_TEXT,
 } from './constants';
+import { SourceFeatures } from './source_features';
 
 interface ConnectInstanceProps {
   header: React.ReactNode;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/re_authenticate.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/re_authenticate.test.tsx
@@ -9,6 +9,7 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ReAuthenticate } from './re_authenticate';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/re_authenticate.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/re_authenticate.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { useEffect, useState, FormEvent } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { Location } from 'history';
 import { useActions, useValues } from 'kea';
-import { useLocation } from 'react-router-dom';
-import { i18n } from '@kbn/i18n';
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { parseQueryParams } from '../../../../../../applications/shared/query_params';
 
 import { AddSourceLogic } from './add_source_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_config.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_config.test.tsx
@@ -7,18 +7,18 @@
 
 import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions, setMockValues } from '../../../../../__mocks__';
+import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiSteps, EuiButton, EuiButtonEmpty } from '@elastic/eui';
 
-import { sourceConfigData } from '../../../../__mocks__/content_sources.mock';
+import { ApiKey } from '../../../../components/shared/api_key';
 import { staticSourceData } from '../../source_data';
 
-import { ApiKey } from '../../../../components/shared/api_key';
 import { ConfigDocsLinks } from './config_docs_links';
-
 import { SaveConfig } from './save_config';
 
 describe('SaveConfig', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_config.tsx
@@ -8,7 +8,6 @@
 import React, { FormEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
-import { i18n } from '@kbn/i18n';
 
 import {
   EuiButton,
@@ -21,7 +20,10 @@ import {
   EuiSpacer,
   EuiSteps,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
+import { LicensingLogic } from '../../../../../../applications/shared/licensing';
+import { ApiKey } from '../../../../components/shared/api_key';
 import {
   PUBLIC_KEY_LABEL,
   CONSUMER_KEY_LABEL,
@@ -31,16 +33,11 @@ import {
   CLIENT_SECRET_LABEL,
   REMOVE_BUTTON,
 } from '../../../../constants';
-
-import { OAUTH_SAVE_CONFIG_BUTTON, OAUTH_BACK_BUTTON, OAUTH_STEP_2 } from './constants';
-
-import { LicensingLogic } from '../../../../../../applications/shared/licensing';
-
-import { ApiKey } from '../../../../components/shared/api_key';
-import { AddSourceLogic } from './add_source_logic';
 import { Configuration } from '../../../../types';
 
+import { AddSourceLogic } from './add_source_logic';
 import { ConfigDocsLinks } from './config_docs_links';
+import { OAUTH_SAVE_CONFIG_BUTTON, OAUTH_BACK_BUTTON, OAUTH_STEP_2 } from './constants';
 
 interface SaveConfigProps {
   header: React.ReactNode;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiLink, EuiPanel, EuiTitle } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
@@ -7,9 +7,6 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -22,12 +19,12 @@ import {
   EuiLink,
   EuiPanel,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 import { CredentialItem } from '../../../../components/shared/credential_item';
 import { LicenseBadge } from '../../../../components/shared/license_badge';
-
-import { CustomSource } from '../../../../types';
 import {
   SOURCES_PATH,
   SOURCE_DISPLAY_SETTINGS_PATH,
@@ -36,7 +33,7 @@ import {
   getContentSourcePath,
   getSourcesPath,
 } from '../../../../routes';
-
+import { CustomSource } from '../../../../types';
 import { ACCESS_TOKEN_LABEL, ID_LABEL, LEARN_CUSTOM_FEATURES_BUTTON } from '../../constants';
 
 import {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.test.tsx
@@ -11,9 +11,9 @@ import React from 'react';
 
 import { EuiPanel } from '@elastic/eui';
 
-import { SourceFeatures } from './source_features';
-
 import { staticSourceData } from '../../source_data';
+
+import { SourceFeatures } from './source_features';
 
 describe('SourceFeatures', () => {
   const { features, objTypes } = staticSourceData[0];

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/source_features.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 
 import { useValues } from 'kea';
-import { FormattedMessage } from '@kbn/i18n/react';
 
 import {
   EuiFlexGroup,
@@ -19,13 +18,13 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { LicensingLogic } from '../../../../../../applications/shared/licensing';
-
 import { AppLogic } from '../../../../app_logic';
 import { LicenseBadge } from '../../../../components/shared/license_badge';
-import { Features, FeatureIds } from '../../../../types';
 import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../../routes';
+import { Features, FeatureIds } from '../../../../types';
 
 import {
   SOURCE_FEATURES_SEARCHABLE,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/custom_source_icon.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/custom_source_icon.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { CustomSourceIcon } from './custom_source_icon';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings.test.tsx
@@ -8,24 +8,21 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { mockKibanaValues } from '../../../../../__mocks__';
-
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
 import { unmountHandler } from '../../../../../__mocks__/shallow_useeffect.mock';
-
-import { shallow } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
 
-import { EuiButton, EuiTabbedContent } from '@elastic/eui';
+import { shallow } from 'enzyme';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { EuiButton, EuiTabbedContent } from '@elastic/eui';
 
 import { Loading } from '../../../../../shared/loading';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
 
-import { FieldEditorModal } from './field_editor_modal';
-
 import { DisplaySettings } from './display_settings';
+import { FieldEditorModal } from './field_editor_modal';
 
 describe('DisplaySettings', () => {
   const { navigateToUrl } = mockKibanaValues;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings.tsx
@@ -19,21 +19,18 @@ import {
   EuiTabbedContentTab,
 } from '@elastic/eui';
 
+import { clearFlashMessages } from '../../../../../shared/flash_messages';
+import { KibanaLogic } from '../../../../../shared/kibana';
+import { Loading } from '../../../../../shared/loading';
+import { AppLogic } from '../../../../app_logic';
+import { ViewContentHeader } from '../../../../components/shared/view_content_header';
+import { SAVE_BUTTON } from '../../../../constants';
 import {
   DISPLAY_SETTINGS_RESULT_DETAIL_PATH,
   DISPLAY_SETTINGS_SEARCH_RESULT_PATH,
   getContentSourcePath,
 } from '../../../../routes';
 
-import { clearFlashMessages } from '../../../../../shared/flash_messages';
-
-import { KibanaLogic } from '../../../../../shared/kibana';
-import { AppLogic } from '../../../../app_logic';
-
-import { Loading } from '../../../../../shared/loading';
-import { ViewContentHeader } from '../../../../components/shared/view_content_header';
-
-import { SAVE_BUTTON } from '../../../../constants';
 import {
   UNSAVED_MESSAGE,
   DISPLAY_SETTINGS_TITLE,
@@ -43,9 +40,7 @@ import {
   SEARCH_RESULTS_LABEL,
   RESULT_DETAIL_LABEL,
 } from './constants';
-
 import { DisplaySettingsLogic } from './display_settings_logic';
-
 import { FieldEditorModal } from './field_editor_modal';
 import { ResultDetail } from './result_detail';
 import { SearchResults } from './search_results';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.test.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { LogicMounter } from '../../../../../__mocks__/kea.mock';
-
 import { mockFlashMessageHelpers, mockHttpValues } from '../../../../../__mocks__';
+import { LogicMounter } from '../../../../../__mocks__/kea.mock';
 
 const contentSource = { id: 'source123' };
 jest.mock('../../source_logic', () => ({
@@ -15,6 +14,7 @@ jest.mock('../../source_logic', () => ({
 }));
 
 import { AppLogic } from '../../../../app_logic';
+
 jest.mock('../../../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
@@ -22,8 +22,8 @@ jest.mock('../../../../app_logic', () => ({
 import { nextTick } from '@kbn/test/jest';
 
 import { exampleResult } from '../../../../__mocks__/content_sources.mock';
-import { LEAVE_UNASSIGNED_FIELD } from './constants';
 
+import { LEAVE_UNASSIGNED_FIELD } from './constants';
 import { DisplaySettingsLogic, defaultSearchResultConfig } from './display_settings_logic';
 
 describe('DisplaySettingsLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.test.ts
@@ -5,23 +5,20 @@
  * 2.0.
  */
 
-import { mockFlashMessageHelpers, mockHttpValues } from '../../../../../__mocks__';
-import { LogicMounter } from '../../../../../__mocks__/kea.mock';
+import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../../../../__mocks__';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+
+import { nextTick } from '@kbn/test/jest';
 
 const contentSource = { id: 'source123' };
 jest.mock('../../source_logic', () => ({
   SourceLogic: { values: { contentSource } },
 }));
 
-import { AppLogic } from '../../../../app_logic';
-
 jest.mock('../../../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
-
-import { nextTick } from '@kbn/test/jest';
-
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { AppLogic } from '../../../../app_logic';
 
 import { LEAVE_UNASSIGNED_FIELD } from './constants';
 import { DisplaySettingsLogic, defaultSearchResultConfig } from './display_settings_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_logic.ts
@@ -5,24 +5,23 @@
  * 2.0.
  */
 
-import { cloneDeep, isEqual, differenceBy } from 'lodash';
 import { DropResult } from 'react-beautiful-dnd';
 
 import { kea, MakeLogicType } from 'kea';
-
-import { HttpLogic } from '../../../../../shared/http';
+import { cloneDeep, isEqual, differenceBy } from 'lodash';
 
 import {
   setSuccessMessage,
   clearFlashMessages,
   flashAPIErrors,
 } from '../../../../../shared/flash_messages';
-
+import { HttpLogic } from '../../../../../shared/http';
 import { AppLogic } from '../../../../app_logic';
+import { DetailField, SearchResultConfig, OptionValue, Result } from '../../../../types';
 import { SourceLogic } from '../../source_logic';
 
-import { DetailField, SearchResultConfig, OptionValue, Result } from '../../../../types';
 import { LEAVE_UNASSIGNED_FIELD, SUCCESS_MESSAGE } from './constants';
+
 export interface DisplaySettingsResponseProps {
   sourceName: string;
   searchResultConfig: SearchResultConfig;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_router.test.tsx
@@ -10,12 +10,11 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues } from '../../../../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
-
 import { Route, Switch } from 'react-router-dom';
 
-import { DisplaySettings } from './display_settings';
+import { shallow } from 'enzyme';
 
+import { DisplaySettings } from './display_settings';
 import { DisplaySettingsRouter } from './display_settings_router';
 
 describe('DisplaySettingsRouter', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/display_settings_router.tsx
@@ -6,12 +6,11 @@
  */
 
 import React from 'react';
-
-import { useValues } from 'kea';
 import { Route, Switch } from 'react-router-dom';
 
-import { AppLogic } from '../../../../app_logic';
+import { useValues } from 'kea';
 
+import { AppLogic } from '../../../../app_logic';
 import {
   DISPLAY_SETTINGS_RESULT_DETAIL_PATH,
   DISPLAY_SETTINGS_SEARCH_RESULT_PATH,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.test.tsx
@@ -8,11 +8,11 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues } from '../../../../../__mocks__';
-import { shallow } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { shallow } from 'enzyme';
 
 import { ExampleResultDetailCard } from './example_result_detail_card';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_result_detail_card.tsx
@@ -14,9 +14,8 @@ import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiTitle } from '@elasti
 
 import { URL_LABEL } from '../../../../constants';
 
-import { DisplaySettingsLogic } from './display_settings_logic';
-
 import { CustomSourceIcon } from './custom_source_icon';
+import { DisplaySettingsLogic } from './display_settings_logic';
 import { TitleField } from './title_field';
 
 export const ExampleResultDetailCard: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_search_result_group.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_search_result_group.test.tsx
@@ -8,14 +8,13 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues } from '../../../../../__mocks__';
-import { shallow } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { shallow } from 'enzyme';
 
 import { CustomSourceIcon } from './custom_source_icon';
-
 import { ExampleSearchResultGroup } from './example_search_result_group';
 
 describe('ExampleSearchResultGroup', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_search_result_group.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_search_result_group.tsx
@@ -7,15 +7,15 @@
 
 import React from 'react';
 
-import { isColorDark, hexToRgb } from '@elastic/eui';
 import classNames from 'classnames';
 import { useValues } from 'kea';
 
+import { isColorDark, hexToRgb } from '@elastic/eui';
+
 import { DESCRIPTION_LABEL } from '../../../../constants';
 
-import { DisplaySettingsLogic } from './display_settings_logic';
-
 import { CustomSourceIcon } from './custom_source_icon';
+import { DisplaySettingsLogic } from './display_settings_logic';
 import { SubtitleField } from './subtitle_field';
 import { TitleField } from './title_field';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_standout_result.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_standout_result.test.tsx
@@ -8,14 +8,13 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues } from '../../../../../__mocks__';
-import { shallow } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { shallow } from 'enzyme';
 
 import { CustomSourceIcon } from './custom_source_icon';
-
 import { ExampleStandoutResult } from './example_standout_result';
 
 describe('ExampleStandoutResult', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_standout_result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/example_standout_result.tsx
@@ -14,9 +14,8 @@ import { isColorDark, hexToRgb } from '@elastic/eui';
 
 import { DESCRIPTION_LABEL } from '../../../../constants';
 
-import { DisplaySettingsLogic } from './display_settings_logic';
-
 import { CustomSourceIcon } from './custom_source_icon';
+import { DisplaySettingsLogic } from './display_settings_logic';
 import { SubtitleField } from './subtitle_field';
 import { TitleField } from './title_field';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/field_editor_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/field_editor_modal.test.tsx
@@ -8,13 +8,13 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
-import { shallow } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
 
-import { EuiModal, EuiSelect, EuiFieldText } from '@elastic/eui';
+import { shallow } from 'enzyme';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { EuiModal, EuiSelect, EuiFieldText } from '@elastic/eui';
 
 import { FieldEditorModal } from './field_editor_modal';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.test.tsx
@@ -6,10 +6,8 @@
  */
 
 import '../../../../../__mocks__/shallow_useeffect.mock';
-
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
-
-import { shallow, mount } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 /**
  * Mocking necessary due to console warnings from react d-n-d, which EUI uses
@@ -41,9 +39,9 @@ jest.mock('react-beautiful-dnd', () => ({
 
 import React from 'react';
 
-import { EuiTextColor } from '@elastic/eui';
+import { shallow, mount } from 'enzyme';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
+import { EuiTextColor } from '@elastic/eui';
 
 import { ExampleResultDetailCard } from './example_result_detail_card';
 import { ResultDetail } from './result_detail';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.test.tsx
@@ -8,6 +8,7 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
+
 import { shallow, mount } from 'enzyme';
 
 /**
@@ -45,7 +46,6 @@ import { EuiTextColor } from '@elastic/eui';
 import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import { ExampleResultDetailCard } from './example_result_detail_card';
-
 import { ResultDetail } from './result_detail';
 
 describe('ResultDetail', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/result_detail.tsx
@@ -28,10 +28,9 @@ import {
 } from '@elastic/eui';
 
 import { ADD_FIELD_LABEL, EDIT_FIELD_LABEL, REMOVE_FIELD_LABEL } from '../../../../constants';
+
 import { VISIBLE_FIELDS_TITLE, EMPTY_FIELDS_DESCRIPTION, PREVIEW_TITLE } from './constants';
-
 import { DisplaySettingsLogic } from './display_settings_logic';
-
 import { ExampleResultDetailCard } from './example_result_detail_card';
 
 export const ResultDetail: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/search_results.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/search_results.test.tsx
@@ -8,16 +8,15 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
-import { shallow } from 'enzyme';
+import { exampleResult } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
 
-import { exampleResult } from '../../../../__mocks__/content_sources.mock';
-
-import { ExampleSearchResultGroup } from './example_search_result_group';
-import { ExampleStandoutResult } from './example_standout_result';
+import { shallow } from 'enzyme';
 
 import { LEAVE_UNASSIGNED_FIELD } from './constants';
+import { ExampleSearchResultGroup } from './example_search_result_group';
+import { ExampleStandoutResult } from './example_standout_result';
 import { SearchResults } from './search_results';
 
 describe('SearchResults', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/search_results.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/search_results.tsx
@@ -21,9 +21,8 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
-import { DisplaySettingsLogic } from './display_settings_logic';
-
 import { DESCRIPTION_LABEL } from '../../../../constants';
+
 import {
   LEAVE_UNASSIGNED_FIELD,
   SEARCH_RESULTS_TITLE,
@@ -34,7 +33,7 @@ import {
   STANDARD_RESULTS_TITLE,
   STANDARD_RESULTS_DESCRIPTION,
 } from './constants';
-
+import { DisplaySettingsLogic } from './display_settings_logic';
 import { ExampleSearchResultGroup } from './example_search_result_group';
 import { ExampleStandoutResult } from './example_standout_result';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/subtitle_field.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/subtitle_field.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SubtitleField } from './subtitle_field';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/title_field.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/display_settings/title_field.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { TitleField } from './title_field';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.test.tsx
@@ -8,13 +8,13 @@
 import '../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues } from '../../../../__mocks__';
+import { fullContentSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiEmptyPrompt, EuiPanel, EuiTable } from '@elastic/eui';
-
-import { fullContentSources } from '../../../__mocks__/content_sources.mock';
 
 import { Loading } from '../../../../shared/loading';
 import { ComponentLoader } from '../../../components/shared/component_loader';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/overview.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -30,7 +28,21 @@ import {
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
+import { Loading } from '../../../../shared/loading';
+import { EuiPanelTo } from '../../../../shared/react_router_helpers';
+import { AppLogic } from '../../../app_logic';
+import aclImage from '../../../assets/supports_acl.svg';
+import { ComponentLoader } from '../../../components/shared/component_loader';
+import { CredentialItem } from '../../../components/shared/credential_item';
+import { LicenseBadge } from '../../../components/shared/license_badge';
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
+import {
+  RECENT_ACTIVITY_TITLE,
+  CREDENTIALS_TITLE,
+  DOCUMENTATION_LINK_TITLE,
+} from '../../../constants';
 import {
   CUSTOM_SOURCE_DOCS_URL,
   DOCUMENT_PERMISSIONS_DOCS_URL,
@@ -38,12 +50,6 @@ import {
   EXTERNAL_IDENTITIES_DOCS_URL,
   getGroupPath,
 } from '../../../routes';
-
-import {
-  RECENT_ACTIVITY_TITLE,
-  CREDENTIALS_TITLE,
-  DOCUMENTATION_LINK_TITLE,
-} from '../../../constants';
 import {
   SOURCES_NO_CONTENT_TITLE,
   CONTENT_SUMMARY_TITLE,
@@ -70,17 +76,6 @@ import {
   DOC_PERMISSIONS_DESCRIPTION,
   CUSTOM_CALLOUT_TITLE,
 } from '../constants';
-
-import { AppLogic } from '../../../app_logic';
-
-import { ComponentLoader } from '../../../components/shared/component_loader';
-import { CredentialItem } from '../../../components/shared/credential_item';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
-import { LicenseBadge } from '../../../components/shared/license_badge';
-import { Loading } from '../../../../shared/loading';
-import { EuiPanelTo } from '../../../../shared/react_router_helpers';
-
-import aclImage from '../../../assets/supports_acl.svg';
 import { SourceLogic } from '../source_logic';
 
 export const Overview: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.test.tsx
@@ -8,21 +8,20 @@
 import '../../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
+import { mostRecentIndexJob } from '../../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiEmptyPrompt, EuiFieldSearch } from '@elastic/eui';
-
-import { mostRecentIndexJob } from '../../../../__mocks__/content_sources.mock';
 
 import { IndexingStatus } from '../../../../../shared/indexing_status';
 import { Loading } from '../../../../../shared/loading';
 import { SchemaAddFieldModal } from '../../../../../shared/schema/schema_add_field_modal';
 
-import { SchemaFieldsTable } from './schema_fields_table';
-
 import { Schema } from './schema';
+import { SchemaFieldsTable } from './schema_fields_table';
 
 describe('Schema', () => {
   const initializeSchema = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema.tsx
@@ -20,17 +20,12 @@ import {
   EuiPanel,
 } from '@elastic/eui';
 
-import { getReindexJobRoute } from '../../../../routes';
-import { AppLogic } from '../../../../app_logic';
-
-import { Loading } from '../../../../../shared/loading';
-import { ViewContentHeader } from '../../../../components/shared/view_content_header';
-
-import { SchemaAddFieldModal } from '../../../../../shared/schema/schema_add_field_modal';
 import { IndexingStatus } from '../../../../../shared/indexing_status';
-
-import { SchemaFieldsTable } from './schema_fields_table';
-import { SchemaLogic } from './schema_logic';
+import { Loading } from '../../../../../shared/loading';
+import { SchemaAddFieldModal } from '../../../../../shared/schema/schema_add_field_modal';
+import { AppLogic } from '../../../../app_logic';
+import { ViewContentHeader } from '../../../../components/shared/view_content_header';
+import { getReindexJobRoute } from '../../../../routes';
 
 import {
   SCHEMA_ADD_FIELD_BUTTON,
@@ -42,6 +37,8 @@ import {
   SCHEMA_EMPTY_SCHEMA_TITLE,
   SCHEMA_EMPTY_SCHEMA_DESCRIPTION,
 } from './constants';
+import { SchemaFieldsTable } from './schema_fields_table';
+import { SchemaLogic } from './schema_logic';
 
 export const Schema: React.FC = () => {
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.test.tsx
@@ -10,8 +10,9 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
 import { useParams } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
 
 import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_change_errors.tsx
@@ -14,8 +14,9 @@ import { EuiSpacer } from '@elastic/eui';
 
 import { SchemaErrorsAccordion } from '../../../../../shared/schema/schema_errors_accordion';
 import { ViewContentHeader } from '../../../../components/shared/view_content_header';
-import { SchemaLogic } from './schema_logic';
+
 import { SCHEMA_ERRORS_HEADING } from './constants';
+import { SchemaLogic } from './schema_logic';
 
 export const SchemaChangeErrors: React.FC = () => {
   const { activeReindexJobId, sourceId } = useParams() as {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.test.tsx
@@ -10,6 +10,7 @@ import '../../../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SchemaExistingField } from '../../../../../shared/schema/schema_existing_field';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_fields_table.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -21,13 +19,15 @@ import {
   EuiTableRow,
   EuiTableRowCell,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { SchemaExistingField } from '../../../../../shared/schema/schema_existing_field';
-import { SchemaLogic } from './schema_logic';
+
 import {
   SCHEMA_ERRORS_TABLE_FIELD_NAME_HEADER,
   SCHEMA_ERRORS_TABLE_DATA_TYPE_HEADER,
 } from './constants';
+import { SchemaLogic } from './schema_logic';
 
 export const SchemaFieldsTable: React.FC = () => {
   const { updateExistingFieldType } = useActions(SchemaLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -14,7 +14,6 @@ jest.mock('../../source_logic', () => ({
   SourceLogic: { values: { contentSource } },
 }));
 
-import { AppLogic } from '../../../../app_logic';
 jest.mock('../../../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
@@ -23,15 +22,16 @@ const spyScrollTo = jest.fn();
 Object.defineProperty(global.window, 'scrollTo', { value: spyScrollTo });
 
 import { mostRecentIndexJob } from '../../../../__mocks__/content_sources.mock';
+
 import { TEXT } from '../../../../../shared/constants/field_types';
 import { ADD, UPDATE } from '../../../../../shared/constants/operations';
+import { AppLogic } from '../../../../app_logic';
 
 import {
   SCHEMA_FIELD_ERRORS_ERROR_MESSAGE,
   SCHEMA_FIELD_ADDED_MESSAGE,
   SCHEMA_UPDATED_MESSAGE,
 } from './constants';
-
 import { SchemaLogic, dataTypeOptions } from './schema_logic';
 
 describe('SchemaLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../../../../__mocks__';
+import { mostRecentIndexJob } from '../../../../__mocks__/content_sources.mock';
 
 import { nextTick } from '@kbn/test/jest';
 
@@ -20,8 +21,6 @@ jest.mock('../../../../app_logic', () => ({
 
 const spyScrollTo = jest.fn();
 Object.defineProperty(global.window, 'scrollTo', { value: spyScrollTo });
-
-import { mostRecentIndexJob } from '../../../../__mocks__/content_sources.mock';
 
 import { TEXT } from '../../../../../shared/constants/field_types';
 import { ADD, UPDATE } from '../../../../../shared/constants/operations';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -5,23 +5,20 @@
  * 2.0.
  */
 
-import { cloneDeep, isEqual } from 'lodash';
 import { kea, MakeLogicType } from 'kea';
-
-import { HttpLogic } from '../../../../../shared/http';
+import { cloneDeep, isEqual } from 'lodash';
 
 import { TEXT } from '../../../../../shared/constants/field_types';
 import { ADD, UPDATE } from '../../../../../shared/constants/operations';
-import { IndexJob, TOperation, Schema, SchemaTypes } from '../../../../../shared/types';
-import { OptionValue } from '../../../../types';
-
 import {
   flashAPIErrors,
   setSuccessMessage,
   clearFlashMessages,
 } from '../../../../../shared/flash_messages';
-
+import { HttpLogic } from '../../../../../shared/http';
+import { IndexJob, TOperation, Schema, SchemaTypes } from '../../../../../shared/types';
 import { AppLogic } from '../../../../app_logic';
+import { OptionValue } from '../../../../types';
 import { SourceLogic } from '../../source_logic';
 
 import {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.test.tsx
@@ -10,9 +10,9 @@ import '../../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions } from '../../../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
-
 import { useLocation } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
 
 import { Loading } from '../../../../shared/loading';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -6,10 +6,10 @@
  */
 
 import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { Location } from 'history';
 import { useActions } from 'kea';
-import { useLocation } from 'react-router-dom';
 
 import { Loading } from '../../../../shared/loading';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.test.tsx
@@ -8,8 +8,11 @@
 import '../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../__mocks__';
+import { fullContentSources, contentItems } from '../../../__mocks__/content_sources.mock';
+import { meta } from '../../../__mocks__/meta.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import {
@@ -21,12 +24,9 @@ import {
   EuiLink,
 } from '@elastic/eui';
 
-import { meta } from '../../../__mocks__/meta.mock';
-import { fullContentSources, contentItems } from '../../../__mocks__/content_sources.mock';
-
+import { Loading } from '../../../../../applications/shared/loading';
 import { DEFAULT_META } from '../../../../shared/constants';
 import { ComponentLoader } from '../../../components/shared/component_loader';
-import { Loading } from '../../../../../applications/shared/loading';
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 
 import { SourceContent } from './source_content';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
@@ -34,14 +34,11 @@ import { FormattedMessage } from '@kbn/i18n/react';
 import { Loading } from '../../../../../applications/shared/loading';
 import { TruncatedContent } from '../../../../shared/truncate';
 import { ComponentLoader } from '../../../components/shared/component_loader';
-import { CUSTOM_SOURCE_DOCS_URL } from '../../../routes';
-import { SourceContentItem } from '../../../types';
-
-const MAX_LENGTH = 28;
-
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import { CUSTOM_SERVICE_TYPE } from '../../../constants';
+import { CUSTOM_SOURCE_DOCS_URL } from '../../../routes';
+import { SourceContentItem } from '../../../types';
 import {
   NO_CONTENT_MESSAGE,
   CUSTOM_DOCUMENTATION_LINK,
@@ -53,6 +50,8 @@ import {
   CONTENT_LOADING_TEXT,
 } from '../constants';
 import { SourceLogic } from '../source_logic';
+
+const MAX_LENGTH = 28;
 
 export const SourceContent: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_content.tsx
@@ -11,9 +11,6 @@ import { useActions, useValues } from 'kea';
 import { startCase } from 'lodash';
 import moment from 'moment';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -31,19 +28,19 @@ import {
   EuiTableRowCell,
   EuiLink,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
+import { Loading } from '../../../../../applications/shared/loading';
+import { TruncatedContent } from '../../../../shared/truncate';
+import { ComponentLoader } from '../../../components/shared/component_loader';
 import { CUSTOM_SOURCE_DOCS_URL } from '../../../routes';
 import { SourceContentItem } from '../../../types';
 
-import { TruncatedContent } from '../../../../shared/truncate';
-
 const MAX_LENGTH = 28;
 
-import { ComponentLoader } from '../../../components/shared/component_loader';
-import { Loading } from '../../../../../applications/shared/loading';
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
-
 import { CUSTOM_SERVICE_TYPE } from '../../../constants';
 import {
   NO_CONTENT_MESSAGE,
@@ -55,7 +52,6 @@ import {
   SOURCE_CONTENT_TITLE,
   CONTENT_LOADING_TEXT,
 } from '../constants';
-
 import { SourceLogic } from '../source_logic';
 
 export const SourceContent: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_info_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_info_card.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiBadge, EuiHealth, EuiText, EuiTitle } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_info_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_info_card.tsx
@@ -18,7 +18,6 @@ import {
 } from '@elastic/eui';
 
 import { SourceIcon } from '../../../components/shared/source_icon';
-
 import { REMOTE_SOURCE_LABEL, CREATED_LABEL, STATUS_LABEL, READY_TEXT } from '../constants';
 
 interface SourceInfoCardProps {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
@@ -8,13 +8,13 @@
 import '../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../__mocks__';
+import { fullContentSources, sourceConfigData } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiConfirmModal } from '@elastic/eui';
-
-import { fullContentSources, sourceConfigData } from '../../../__mocks__/content_sources.mock';
 
 import { SourceConfigFields } from '../../../components/shared/source_config_fields';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -6,12 +6,10 @@
  */
 
 import React, { useEffect, useState, ChangeEvent, FormEvent } from 'react';
+import { Link } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 import { isEmpty } from 'lodash';
-import { Link } from 'react-router-dom';
-
-import { FormattedMessage } from '@kbn/i18n/react';
 
 import {
   EuiButton,
@@ -23,7 +21,12 @@ import {
   EuiFlexItem,
   EuiFormRow,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
+import { AppLogic } from '../../../app_logic';
+import { ContentSection } from '../../../components/shared/content_section';
+import { SourceConfigFields } from '../../../components/shared/source_config_fields';
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import {
   CANCEL_BUTTON,
   OK_BUTTON,
@@ -31,6 +34,8 @@ import {
   SAVE_CHANGES_BUTTON,
   REMOVE_BUTTON,
 } from '../../../constants';
+import { SourceDataItem } from '../../../types';
+import { AddSourceLogic } from '../components/add_source/add_source_logic';
 import {
   SOURCE_SETTINGS_TITLE,
   SOURCE_SETTINGS_DESCRIPTION,
@@ -41,16 +46,7 @@ import {
   SOURCE_REMOVE_TITLE,
   SOURCE_REMOVE_DESCRIPTION,
 } from '../constants';
-
-import { ContentSection } from '../../../components/shared/content_section';
-import { SourceConfigFields } from '../../../components/shared/source_config_fields';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
-
-import { SourceDataItem } from '../../../types';
-import { AppLogic } from '../../../app_logic';
-import { AddSourceLogic } from '../components/add_source/add_source_logic';
 import { staticSourceData } from '../source_data';
-
 import { SourceLogic } from '../source_logic';
 
 export const SourceSettings: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_sub_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_sub_nav.test.tsx
@@ -8,12 +8,13 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { CUSTOM_SERVICE_TYPE } from '../../../constants';
-import { SourceSubNav } from './source_sub_nav';
-
 import { SideNavLink } from '../../../../shared/layout';
+import { CUSTOM_SERVICE_TYPE } from '../../../constants';
+
+import { SourceSubNav } from './source_sub_nav';
 
 describe('SourceSubNav', () => {
   it('renders empty when no group id present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_sub_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_sub_nav.tsx
@@ -6,15 +6,12 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
+import { SideNavLink } from '../../../../shared/layout';
 import { AppLogic } from '../../../app_logic';
 import { NAV, CUSTOM_SERVICE_TYPE } from '../../../constants';
-
-import { SourceLogic } from '../source_logic';
-
-import { SideNavLink } from '../../../../shared/layout';
-
 import {
   getContentSourcePath,
   SOURCE_DETAILS_PATH,
@@ -23,6 +20,7 @@ import {
   SOURCE_DISPLAY_SETTINGS_PATH,
   SOURCE_SETTINGS_PATH,
 } from '../../../routes';
+import { SourceLogic } from '../source_logic';
 
 export const SourceSubNav: React.FC = () => {
   const { isOrganization } = useValues(AppLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/organization_sources.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/organization_sources.test.tsx
@@ -8,18 +8,16 @@
 import '../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../__mocks__';
-
-import { shallow } from 'enzyme';
+import { contentSources } from '../../__mocks__/content_sources.mock';
 
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 
-import { contentSources } from '../../__mocks__/content_sources.mock';
+import { shallow } from 'enzyme';
 
 import { Loading } from '../../../shared/loading';
 import { SourcesTable } from '../../components/shared/sources_table';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
-
 import { ADD_SOURCE_PATH, getSourcesPath } from '../../routes';
 
 import { OrganizationSources } from './organization_sources';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/organization_sources.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/organization_sources.tsx
@@ -6,11 +6,16 @@
  */
 
 import React, { useEffect } from 'react';
-
-import { useActions, useValues } from 'kea';
 import { Link, Redirect } from 'react-router-dom';
 
+import { useActions, useValues } from 'kea';
+
 import { EuiButton } from '@elastic/eui';
+
+import { Loading } from '../../../shared/loading';
+import { ContentSection } from '../../components/shared/content_section';
+import { SourcesTable } from '../../components/shared/sources_table';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
 import { ADD_SOURCE_PATH, getSourcesPath } from '../../routes';
 
 import {
@@ -18,14 +23,7 @@ import {
   ORG_SOURCES_HEADER_TITLE,
   ORG_SOURCES_HEADER_DESCRIPTION,
 } from './constants';
-
-import { Loading } from '../../../shared/loading';
-import { ContentSection } from '../../components/shared/content_section';
-import { SourcesTable } from '../../components/shared/sources_table';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
-
 import { SourcesLogic } from './sources_logic';
-
 import { SourcesView } from './sources_view';
 
 export const OrganizationSources: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/private_sources.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/private_sources.tsx
@@ -13,10 +13,14 @@ import { EuiCallOut, EuiEmptyPrompt, EuiSpacer, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { LicensingLogic } from '../../../../applications/shared/licensing';
-
-import { ADD_SOURCE_PATH, getSourcesPath } from '../../routes';
-
+import { Loading } from '../../../shared/loading';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { AppLogic } from '../../app_logic';
 import noSharedSourcesIcon from '../../assets/share_circle.svg';
+import { ContentSection } from '../../components/shared/content_section';
+import { SourcesTable } from '../../components/shared/sources_table';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
+import { ADD_SOURCE_PATH, getSourcesPath } from '../../routes';
 
 import {
   AND,
@@ -34,16 +38,8 @@ import {
   LICENSE_CALLOUT_TITLE,
   LICENSE_CALLOUT_DESCRIPTION,
 } from './constants';
-
-import { Loading } from '../../../shared/loading';
-import { EuiButtonTo } from '../../../shared/react_router_helpers';
-import { ContentSection } from '../../components/shared/content_section';
-import { SourcesTable } from '../../components/shared/sources_table';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
-
-import { AppLogic } from '../../app_logic';
-import { SourcesView } from './sources_view';
 import { SourcesLogic } from './sources_logic';
+import { SourcesView } from './sources_view';
 
 // TODO: Remove this after links in Kibana sidenav
 interface SidebarLink {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_data.tsx
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 
+import { SOURCE_NAMES, SOURCE_OBJ_TYPES, GITHUB_LINK_TITLE } from '../../constants';
 import {
   ADD_BOX_PATH,
   ADD_CONFLUENCE_PATH,
@@ -62,10 +63,7 @@ import {
   ZENDESK_DOCS_URL,
   CUSTOM_SOURCE_DOCS_URL,
 } from '../../routes';
-
 import { FeatureIds, SourceDataItem } from '../../types';
-
-import { SOURCE_NAMES, SOURCE_OBJ_TYPES, GITHUB_LINK_TITLE } from '../../constants';
 
 const connectStepDescription = {
   attachments: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../__mocks__';
 
 import { AppLogic } from '../../app_logic';
+
 jest.mock('../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.test.ts
@@ -12,17 +12,16 @@ import {
   mockKibanaValues,
   expectedAsyncError,
 } from '../../../__mocks__';
-
-import { AppLogic } from '../../app_logic';
-
-jest.mock('../../app_logic', () => ({
-  AppLogic: { values: { isOrganization: true } },
-}));
-
 import { fullContentSources, contentItems } from '../../__mocks__/content_sources.mock';
 import { meta } from '../../__mocks__/meta.mock';
 
 import { DEFAULT_META } from '../../../shared/constants';
+
+jest.mock('../../app_logic', () => ({
+  AppLogic: { values: { isOrganization: true } },
+}));
+import { AppLogic } from '../../app_logic';
+
 import { NOT_FOUND_PATH } from '../../routes';
 
 import { SourceLogic } from './source_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_logic.ts
@@ -9,17 +9,15 @@ import { kea, MakeLogicType } from 'kea';
 
 import { i18n } from '@kbn/i18n';
 
-import { HttpLogic } from '../../../shared/http';
-import { KibanaLogic } from '../../../shared/kibana';
-
+import { DEFAULT_META } from '../../../shared/constants';
 import {
   flashAPIErrors,
   setSuccessMessage,
   setQueuedSuccessMessage,
   clearFlashMessages,
 } from '../../../shared/flash_messages';
-
-import { DEFAULT_META } from '../../../shared/constants';
+import { HttpLogic } from '../../../shared/http';
+import { KibanaLogic } from '../../../shared/kibana';
 import { AppLogic } from '../../app_logic';
 import { NOT_FOUND_PATH, SOURCES_PATH, getSourcesPath } from '../../routes';
 import { ContentSourceFullData, Meta, DocumentSummaryItem, SourceContentItem } from '../../types';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.test.tsx
@@ -8,20 +8,17 @@
 import '../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../__mocks__';
-
-import React from 'react';
-import { shallow } from 'enzyme';
-import { useParams } from 'react-router-dom';
-
-import { Route, Switch } from 'react-router-dom';
-
 import { contentSources } from '../../__mocks__/content_sources.mock';
 
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
+
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-
-import { NAV } from '../../constants';
-
 import { Loading } from '../../../shared/loading';
+import { NAV } from '../../constants';
 
 import { DisplaySettingsRouter } from './components/display_settings';
 import { Overview } from './components/overview';
@@ -29,7 +26,6 @@ import { Schema } from './components/schema';
 import { SchemaChangeErrors } from './components/schema/schema_change_errors';
 import { SourceContent } from './components/source_content';
 import { SourceSettings } from './components/source_settings';
-
 import { SourceRouter } from './source_router';
 
 describe('SourceRouter', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/source_router.tsx
@@ -6,24 +6,19 @@
  */
 
 import React, { useEffect } from 'react';
+import { Route, Switch, useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
 import moment from 'moment';
-import { Route, Switch, useParams } from 'react-router-dom';
 
 import { EuiButton, EuiCallOut, EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
 
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { Loading } from '../../../shared/loading';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
-
+import { AppLogic } from '../../app_logic';
 import { NAV } from '../../constants';
-
-import {
-  SOURCE_DISABLED_CALLOUT_TITLE,
-  SOURCE_DISABLED_CALLOUT_DESCRIPTION,
-  SOURCE_DISABLED_CALLOUT_BUTTON,
-} from './constants';
-
+import { CUSTOM_SERVICE_TYPE } from '../../constants';
 import {
   ENT_SEARCH_LICENSE_MANAGEMENT,
   REINDEX_JOB_PATH,
@@ -36,13 +31,6 @@ import {
   getSourcesPath,
 } from '../../routes';
 
-import { AppLogic } from '../../app_logic';
-
-import { Loading } from '../../../shared/loading';
-
-import { CUSTOM_SERVICE_TYPE } from '../../constants';
-import { SourceLogic } from './source_logic';
-
 import { DisplaySettingsRouter } from './components/display_settings';
 import { Overview } from './components/overview';
 import { Schema } from './components/schema';
@@ -50,6 +38,12 @@ import { SchemaChangeErrors } from './components/schema/schema_change_errors';
 import { SourceContent } from './components/source_content';
 import { SourceInfoCard } from './components/source_info_card';
 import { SourceSettings } from './components/source_settings';
+import {
+  SOURCE_DISABLED_CALLOUT_TITLE,
+  SOURCE_DISABLED_CALLOUT_DESCRIPTION,
+  SOURCE_DISABLED_CALLOUT_BUTTON,
+} from './constants';
+import { SourceLogic } from './source_logic';
 
 export const SourceRouter: React.FC = () => {
   const { sourceId } = useParams() as { sourceId: string };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.test.ts
@@ -11,14 +11,12 @@ import {
   mockHttpValues,
   expectedAsyncError,
 } from '../../../__mocks__';
-
-import { AppLogic } from '../../app_logic';
+import { configuredSources, contentSources } from '../../__mocks__/content_sources.mock';
 
 jest.mock('../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));
-
-import { configuredSources, contentSources } from '../../__mocks__/content_sources.mock';
+import { AppLogic } from '../../app_logic';
 
 import { SourcesLogic, fetchSourceStatuses, POLLING_INTERVAL } from './sources_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../__mocks__';
 
 import { AppLogic } from '../../app_logic';
+
 jest.mock('../../app_logic', () => ({
   AppLogic: { values: { isOrganization: true } },
 }));

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_logic.ts
@@ -5,21 +5,17 @@
  * 2.0.
  */
 
-import { cloneDeep, findIndex } from 'lodash';
-
 import { kea, MakeLogicType } from 'kea';
+import { cloneDeep, findIndex } from 'lodash';
 
 import { i18n } from '@kbn/i18n';
 
-import { HttpLogic } from '../../../shared/http';
-
 import { flashAPIErrors, setQueuedSuccessMessage } from '../../../shared/flash_messages';
-
+import { HttpLogic } from '../../../shared/http';
+import { AppLogic } from '../../app_logic';
 import { Connector, ContentSourceDetails, ContentSourceStatus, SourceDataItem } from '../../types';
 
 import { staticSourceData } from './source_data';
-
-import { AppLogic } from '../../app_logic';
 
 interface ServerStatuses {
   [key: string]: string;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.test.tsx
@@ -10,9 +10,9 @@ import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
-
 import { Route, Switch, Redirect } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
 
 import { ADD_SOURCE_PATH, PERSONAL_SOURCES_PATH, SOURCES_PATH, getSourcesPath } from '../../routes';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
@@ -6,16 +6,16 @@
  */
 
 import React, { useEffect } from 'react';
+import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 
 import { Location } from 'history';
 import { useActions, useValues } from 'kea';
-import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
-
-import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 
 import { LicensingLogic } from '../../../../applications/shared/licensing';
-
+import { FlashMessages } from '../../../shared/flash_messages';
+import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
 import { NAV } from '../../constants';
 import {
   ADD_SOURCE_PATH,
@@ -26,17 +26,13 @@ import {
   getSourcesPath,
 } from '../../routes';
 
-import { FlashMessages } from '../../../shared/flash_messages';
-
-import { AppLogic } from '../../app_logic';
-import { staticSourceData } from './source_data';
-import { SourcesLogic } from './sources_logic';
-
 import { AddSource, AddSourceList } from './components/add_source';
 import { SourceAdded } from './components/source_added';
 import { OrganizationSources } from './organization_sources';
 import { PrivateSources } from './private_sources';
+import { staticSourceData } from './source_data';
 import { SourceRouter } from './source_router';
+import { SourcesLogic } from './sources_logic';
 
 import './sources.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.test.tsx
@@ -9,9 +9,9 @@ import '../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../__mocks__';
 
-import { shallow } from 'enzyme';
-
 import React from 'react';
+
+import { shallow } from 'enzyme';
 
 import { EuiModal } from '@elastic/eui';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_view.tsx
@@ -9,9 +9,6 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
-
 import {
   EuiButton,
   EuiLink,
@@ -25,10 +22,11 @@ import {
   EuiOverlayMask,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { Loading } from '../../../shared/loading';
 import { SourceIcon } from '../../components/shared/source_icon';
-
 import { EXTERNAL_IDENTITIES_DOCS_URL, DOCUMENT_PERMISSIONS_DOCS_URL } from '../../routes';
 
 import {
@@ -36,7 +34,6 @@ import {
   DOCUMENT_PERMISSIONS_LINK,
   UNDERSTAND_BUTTON,
 } from './constants';
-
 import { SourcesLogic } from './sources_logic';
 
 interface SourcesViewProps {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/error_state/error_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/error_state/error_state.test.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { ErrorStatePrompt } from '../../../shared/error_state';
+
 import { ErrorState } from './';
 
 describe('ErrorState', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/error_state/error_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/error_state/error_state.tsx
@@ -8,6 +8,7 @@
 // TODO: Remove EuiPage & EuiPageBody before exposing full app
 
 import React from 'react';
+
 import { EuiPage, EuiPageBody, EuiPageContent } from '@elastic/eui';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/__mocks__/groups_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/__mocks__/groups_logic.mock.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { ContentSource, User, Group } from '../../../types';
-
 import { DEFAULT_META } from '../../../../shared/constants';
+import { ContentSource, User, Group } from '../../../types';
 
 export const mockGroupsValues = {
   groups: [] as Group[],

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/add_group_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/add_group_modal.test.tsx
@@ -8,11 +8,12 @@
 import { setMockValues, setMockActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { AddGroupModal } from './add_group_modal';
-
 import { EuiModal, EuiOverlayMask } from '@elastic/eui';
+
+import { AddGroupModal } from './add_group_modal';
 
 describe('AddGroupModal', () => {
   const closeNewGroupModal = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/add_group_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/add_group_modal.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 
 import { useActions, useValues } from 'kea';
-import { i18n } from '@kbn/i18n';
 
 import {
   EuiButton,
@@ -22,9 +21,9 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { CANCEL_BUTTON } from '../../../constants';
-
 import { GroupsLogic } from '../groups_logic';
 
 const ADD_GROUP_HEADER = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/clear_filters_link.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/clear_filters_link.test.tsx
@@ -8,11 +8,12 @@
 import { setMockActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { ClearFiltersLink } from './clear_filters_link';
-
 import { EuiLink } from '@elastic/eui';
+
+import { ClearFiltersLink } from './clear_filters_link';
 
 describe('ClearFiltersLink', () => {
   const resetGroupsFilters = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/clear_filters_link.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/clear_filters_link.tsx
@@ -8,9 +8,9 @@
 import React from 'react';
 
 import { useActions } from 'kea';
-import { i18n } from '@kbn/i18n';
 
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { GroupsLogic } from '../groups_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_list.test.tsx
@@ -8,13 +8,14 @@
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiFieldSearch, EuiFilterSelectItem, EuiCard, EuiPopoverTitle } from '@elastic/eui';
 
-import { FilterableUsersList } from './filterable_users_list';
-
 import { User } from '../../../types';
+
+import { FilterableUsersList } from './filterable_users_list';
 
 const mockSetState = jest.fn();
 const useStateMock: any = (initState: any) => [initState, mockSetState];

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_list.tsx
@@ -7,8 +7,6 @@
 
 import React, { useState } from 'react';
 
-import { i18n } from '@kbn/i18n';
-
 import {
   EuiCard,
   EuiFieldSearch,
@@ -17,6 +15,7 @@ import {
   EuiPopoverTitle,
   EuiSpacer,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { User } from '../../../types';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_popover.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_popover.test.tsx
@@ -9,12 +9,13 @@ import { setMockActions } from '../../../../__mocks__';
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { FilterableUsersPopover } from './filterable_users_popover';
-import { FilterableUsersList } from './filterable_users_list';
-
 import { EuiFilterGroup, EuiPopover } from '@elastic/eui';
+
+import { FilterableUsersList } from './filterable_users_list';
+import { FilterableUsersPopover } from './filterable_users_popover';
 
 const closePopover = jest.fn();
 const addFilteredUser = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_popover.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/filterable_users_popover.tsx
@@ -12,8 +12,8 @@ import { useActions } from 'kea';
 import { EuiFilterGroup, EuiPopover } from '@elastic/eui';
 
 import { User } from '../../../types';
-
 import { GroupsLogic } from '../groups_logic';
+
 import { FilterableUsersList } from './filterable_users_list';
 
 interface FilterableUsersPopoverProps {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.test.tsx
@@ -6,15 +6,16 @@
  */
 
 import { setMockValues } from '../../../../__mocks__';
-import { groups } from '../../../__mocks__/groups.mock';
 import { contentSources } from '../../../__mocks__/content_sources.mock';
+import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { GroupManagerModal } from './group_manager_modal';
-
 import { EuiOverlayMask, EuiModal, EuiEmptyPrompt } from '@elastic/eui';
+
+import { GroupManagerModal } from './group_manager_modal';
 
 const hideModal = jest.fn();
 const selectAll = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_manager_modal.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -26,15 +24,13 @@ import {
   EuiOverlayMask,
   EuiSpacer,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
-
-import { Group } from '../../../types';
+import noSharedSourcesIcon from '../../../assets/share_circle.svg';
 import { CANCEL_BUTTON } from '../../../constants';
 import { SOURCES_PATH } from '../../../routes';
-
-import noSharedSourcesIcon from '../../../assets/share_circle.svg';
-
+import { Group } from '../../../types';
 import { GroupLogic } from '../group_logic';
 import { GroupsLogic } from '../groups_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
@@ -9,20 +9,21 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
+import { EuiFieldText } from '@elastic/eui';
+
+import { Loading } from '../../../../shared/loading';
+import { ContentSection } from '../../../components/shared/content_section';
+import { SourcesTable } from '../../../components/shared/sources_table';
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
 
 import {
   GroupOverview,
   EMPTY_SOURCES_DESCRIPTION,
   EMPTY_USERS_DESCRIPTION,
 } from './group_overview';
-
-import { ContentSection } from '../../../components/shared/content_section';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
-import { SourcesTable } from '../../../components/shared/sources_table';
-import { Loading } from '../../../../shared/loading';
-
-import { EuiFieldText } from '@elastic/eui';
 
 const deleteGroup = jest.fn();
 const showSharedSourcesModal = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import {
   EuiButton,
   EuiConfirmModal,
@@ -22,19 +20,18 @@ import {
   EuiSpacer,
   EuiHorizontalRule,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
-import { CANCEL_BUTTON } from '../../../constants';
-
-import { AppLogic } from '../../../app_logic';
-import { TruncatedContent } from '../../../../shared/truncate';
-import { ContentSection } from '../../../components/shared/content_section';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import { Loading } from '../../../../shared/loading';
+import { TruncatedContent } from '../../../../shared/truncate';
+import { AppLogic } from '../../../app_logic';
+import { ContentSection } from '../../../components/shared/content_section';
 import { SourcesTable } from '../../../components/shared/sources_table';
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
+import { CANCEL_BUTTON } from '../../../constants';
+import { GroupLogic, MAX_NAME_LENGTH } from '../group_logic';
 
 import { GroupUsersTable } from './group_users_table';
-
-import { GroupLogic, MAX_NAME_LENGTH } from '../group_logic';
 
 export const EMPTY_SOURCES_DESCRIPTION = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.groups.overview.emptySourcesDescription',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.test.tsx
@@ -9,13 +9,14 @@ import { setMockValues } from '../../../../__mocks__';
 import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
+import { EuiTableRow } from '@elastic/eui';
+
 import { GroupRow, NO_USERS_MESSAGE, NO_SOURCES_MESSAGE } from './group_row';
 import { GroupUsers } from './group_users';
-
-import { EuiTableRow } from '@elastic/eui';
 
 describe('GroupRow', () => {
   beforeEach(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row.tsx
@@ -6,21 +6,20 @@
  */
 
 import React from 'react';
-import moment from 'moment';
-import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
+import { useValues } from 'kea';
+import moment from 'moment';
 
 import { EuiTableRow, EuiTableRowCell, EuiIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
-import { TruncatedContent } from '../../../../shared/truncate';
 import { EuiLinkTo } from '../../../../shared/react_router_helpers';
-
-import { Group } from '../../../types';
-
+import { TruncatedContent } from '../../../../shared/truncate';
 import { AppLogic } from '../../../app_logic';
 import { getGroupPath } from '../../../routes';
+import { Group } from '../../../types';
 import { MAX_NAME_LENGTH } from '../group_logic';
+
 import { GroupSources } from './group_sources';
 import { GroupUsers } from './group_users';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_sources_dropdown.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_sources_dropdown.test.tsx
@@ -8,12 +8,13 @@
 import { contentSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
+import { EuiFilterGroup } from '@elastic/eui';
 
 import { GroupRowSourcesDropdown } from './group_row_sources_dropdown';
 import { SourceOptionItem } from './source_option_item';
-
-import { EuiFilterGroup } from '@elastic/eui';
 
 const onButtonClick = jest.fn();
 const closePopover = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_sources_dropdown.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_sources_dropdown.tsx
@@ -7,9 +7,8 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
-
 import { EuiFilterGroup, EuiPopover, EuiPopoverTitle, EuiButtonEmpty } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { ContentSource } from '../../../types';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_users_dropdown.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_users_dropdown.test.tsx
@@ -9,12 +9,13 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow, mount } from 'enzyme';
 
 import { EuiLoadingContent, EuiButtonEmpty } from '@elastic/eui';
 
-import { GroupRowUsersDropdown } from './group_row_users_dropdown';
 import { FilterableUsersPopover } from './filterable_users_popover';
+import { GroupRowUsersDropdown } from './group_row_users_dropdown';
 
 const fetchGroupUsers = jest.fn();
 const onButtonClick = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_users_dropdown.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_row_users_dropdown.tsx
@@ -12,6 +12,7 @@ import { useActions, useValues } from 'kea';
 import { EuiLoadingContent, EuiButtonEmpty } from '@elastic/eui';
 
 import { GroupsLogic } from '../groups_logic';
+
 import { FilterableUsersPopover } from './filterable_users_popover';
 
 interface GroupRowUsersDropdownProps {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_source_prioritization.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_source_prioritization.test.tsx
@@ -9,13 +9,14 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
+import { EuiTable, EuiEmptyPrompt, EuiRange } from '@elastic/eui';
 
 import { Loading } from '../../../../shared/loading';
 
 import { GroupSourcePrioritization } from './group_source_prioritization';
-
-import { EuiTable, EuiEmptyPrompt, EuiRange } from '@elastic/eui';
 
 const updatePriority = jest.fn();
 const saveGroupSourcePrioritization = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_source_prioritization.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_source_prioritization.tsx
@@ -9,8 +9,6 @@ import React, { ChangeEvent, MouseEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import {
   EuiButton,
   EuiEmptyPrompt,
@@ -26,14 +24,13 @@ import {
   EuiTableRow,
   EuiTableRowCell,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { Loading } from '../../../../shared/loading';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import { SourceIcon } from '../../../components/shared/source_icon';
-
-import { GroupLogic } from '../group_logic';
-
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import { ContentSource } from '../../../types';
+import { GroupLogic } from '../group_logic';
 
 const HEADER_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.groups.sourceProioritization.headerTitle',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sources.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sources.test.tsx
@@ -8,14 +8,14 @@
 import { contentSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { GroupSources } from './group_sources';
-import { GroupRowSourcesDropdown } from './group_row_sources_dropdown';
-
 import { SourceIcon } from '../../../components/shared/source_icon';
-
 import { ContentSourceDetails } from '../../../types';
+
+import { GroupRowSourcesDropdown } from './group_row_sources_dropdown';
+import { GroupSources } from './group_sources';
 
 describe('GroupSources', () => {
   it('renders', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sources.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sources.tsx
@@ -9,7 +9,6 @@ import React, { useState } from 'react';
 
 import { SourceIcon } from '../../../components/shared/source_icon';
 import { MAX_TABLE_ROW_ICONS } from '../../../constants';
-
 import { ContentSource } from '../../../types';
 
 import { GroupRowSourcesDropdown } from './group_row_sources_dropdown';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sub_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sub_nav.test.tsx
@@ -8,11 +8,12 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { GroupSubNav } from './group_sub_nav';
-
 import { SideNavLink } from '../../../../shared/layout';
+
+import { GroupSubNav } from './group_sub_nav';
 
 describe('GroupSubNav', () => {
   it('renders empty when no group id present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sub_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_sub_nav.tsx
@@ -6,14 +6,13 @@
  */
 
 import React from 'react';
+
 import { useValues } from 'kea';
 
-import { GroupLogic } from '../group_logic';
-import { NAV } from '../../../constants';
-
 import { SideNavLink } from '../../../../shared/layout';
-
+import { NAV } from '../../../constants';
 import { getGroupPath, getGroupSourcePrioritizationPath } from '../../../routes';
+import { GroupLogic } from '../group_logic';
 
 export const GroupSubNav: React.FC = () => {
   const {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users.test.tsx
@@ -8,14 +8,14 @@
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
+import { UserIcon } from '../../../components/shared/user_icon';
 import { User } from '../../../types';
 
-import { GroupUsers } from './group_users';
 import { GroupRowUsersDropdown } from './group_row_users_dropdown';
-
-import { UserIcon } from '../../../components/shared/user_icon';
+import { GroupUsers } from './group_users';
 
 const props = {
   groupUsers: users,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users.tsx
@@ -9,7 +9,6 @@ import React, { useState } from 'react';
 
 import { UserIcon } from '../../../components/shared/user_icon';
 import { MAX_TABLE_ROW_ICONS } from '../../../constants';
-
 import { User } from '../../../types';
 
 import { GroupRowUsersDropdown } from './group_row_users_dropdown';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.test.tsx
@@ -9,14 +9,15 @@ import { setMockValues } from '../../../../__mocks__';
 import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
+import { EuiTable, EuiTablePagination } from '@elastic/eui';
+
+import { TableHeader } from '../../../../shared/table_header';
 import { User } from '../../../types';
 
 import { GroupUsersTable } from './group_users_table';
-import { TableHeader } from '../../../../shared/table_header';
-
-import { EuiTable, EuiTablePagination } from '@elastic/eui';
 
 const group = groups[0];
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_users_table.tsx
@@ -9,17 +9,14 @@ import React, { useState } from 'react';
 
 import { useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import { EuiTable, EuiTableBody, EuiTablePagination } from '@elastic/eui';
 import { Pager } from '@elastic/eui';
-
-import { User } from '../../../types';
+import { i18n } from '@kbn/i18n';
 
 import { TableHeader } from '../../../../shared/table_header';
-import { UserRow } from '../../../components/shared/user_row';
-
 import { AppLogic } from '../../../app_logic';
+import { UserRow } from '../../../components/shared/user_row';
+import { User } from '../../../types';
 import { GroupLogic } from '../group_logic';
 
 const USERS_PER_PAGE = 10;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.test.tsx
@@ -8,18 +8,18 @@
 import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { groups } from '../../../__mocks__/groups.mock';
 
-import { DEFAULT_META } from '../../../../shared/constants';
-
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
+import { EuiTable, EuiTableHeaderCell } from '@elastic/eui';
+
+import { DEFAULT_META } from '../../../../shared/constants';
 import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 
-import { GroupsTable } from './groups_table';
-import { GroupRow } from './group_row';
 import { ClearFiltersLink } from './clear_filters_link';
-
-import { EuiTable, EuiTableHeaderCell } from '@elastic/eui';
+import { GroupRow } from './group_row';
+import { GroupsTable } from './groups_table';
 
 const setActivePage = jest.fn();
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/groups_table.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import {
   EuiSpacer,
   EuiTable,
@@ -18,14 +16,14 @@ import {
   EuiTableHeader,
   EuiTableHeaderCell,
 } from '@elastic/eui';
-
-import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
+import { i18n } from '@kbn/i18n';
 
 import { AppLogic } from '../../../app_logic';
+import { TablePaginationBar } from '../../../components/shared/table_pagination_bar';
 import { GroupsLogic } from '../groups_logic';
-import { GroupRow } from './group_row';
 
 import { ClearFiltersLink } from './clear_filters_link';
+import { GroupRow } from './group_row';
 
 const GROUP_TABLE_HEADER = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.groups.groupsTable.groupTableHeader',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/manage_users_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/manage_users_modal.test.tsx
@@ -9,11 +9,12 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { ManageUsersModal } from './manage_users_modal';
 import { FilterableUsersList } from './filterable_users_list';
 import { GroupManagerModal } from './group_manager_modal';
+import { ManageUsersModal } from './manage_users_modal';
 
 const addGroupUser = jest.fn();
 const removeGroupUser = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/shared_sources_modal.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/shared_sources_modal.test.tsx
@@ -9,10 +9,11 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { groups } from '../../../__mocks__/groups.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { SharedSourcesModal } from './shared_sources_modal';
 import { GroupManagerModal } from './group_manager_modal';
+import { SharedSourcesModal } from './shared_sources_modal';
 import { SourcesList } from './sources_list';
 
 const group = groups[0];

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.test.tsx
@@ -8,13 +8,13 @@
 import { contentSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { SourceOptionItem } from './source_option_item';
-
 import { TruncatedContent } from '../../../../shared/truncate';
-
 import { SourceIcon } from '../../../components/shared/source_icon';
+
+import { SourceOptionItem } from './source_option_item';
 
 describe('SourceOptionItem', () => {
   it('renders', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/source_option_item.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { TruncatedContent } from '../../../../shared/truncate';
-
 import { SourceIcon } from '../../../components/shared/source_icon';
 import { ContentSource } from '../../../types';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/sources_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/sources_list.test.tsx
@@ -8,11 +8,12 @@
 import { contentSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { SourcesList } from './sources_list';
-
 import { EuiFilterSelectItem } from '@elastic/eui';
+
+import { SourcesList } from './sources_list';
 
 const addFilteredSource = jest.fn();
 const removeFilteredSource = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_sources_dropdown.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_sources_dropdown.test.tsx
@@ -9,11 +9,11 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { contentSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { TableFilterSourcesDropdown } from './table_filter_sources_dropdown';
-
 import { SourcesList } from './sources_list';
+import { TableFilterSourcesDropdown } from './table_filter_sources_dropdown';
 
 const addFilteredSource = jest.fn();
 const removeFilteredSource = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_sources_dropdown.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_sources_dropdown.tsx
@@ -9,11 +9,11 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
+import { EuiFilterButton, EuiFilterGroup, EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { EuiFilterButton, EuiFilterGroup, EuiPopover } from '@elastic/eui';
-
 import { GroupsLogic } from '../groups_logic';
+
 import { SourcesList } from './sources_list';
 
 const FILTER_SOURCES_BUTTON_TEXT = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_users_dropdown.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_users_dropdown.test.tsx
@@ -9,10 +9,11 @@ import { setMockActions, setMockValues } from '../../../../__mocks__';
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { TableFilterUsersDropdown } from './table_filter_users_dropdown';
 import { FilterableUsersPopover } from './filterable_users_popover';
+import { TableFilterUsersDropdown } from './table_filter_users_dropdown';
 
 const closeFilterUsersDropdown = jest.fn();
 const toggleFilterUsersDropdown = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_users_dropdown.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filter_users_dropdown.tsx
@@ -9,11 +9,11 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
+import { EuiFilterButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { EuiFilterButton } from '@elastic/eui';
-
 import { GroupsLogic } from '../groups_logic';
+
 import { FilterableUsersPopover } from './filterable_users_popover';
 
 const FILTER_USERS_BUTTON_TEXT = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.test.tsx
@@ -8,13 +8,14 @@
 import { setMockActions, setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { TableFilters } from './table_filters';
-
 import { EuiFieldSearch } from '@elastic/eui';
+
 import { TableFilterSourcesDropdown } from './table_filter_sources_dropdown';
 import { TableFilterUsersDropdown } from './table_filter_users_dropdown';
+import { TableFilters } from './table_filters';
 
 const setFilterValue = jest.fn();
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/table_filters.tsx
@@ -9,9 +9,8 @@ import React, { ChangeEvent } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { i18n } from '@kbn/i18n';
-
 import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { AppLogic } from '../../../app_logic';
 import { GroupsLogic } from '../groups_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/user_option_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/user_option_item.test.tsx
@@ -8,12 +8,14 @@
 import { users } from '../../../__mocks__/users.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { UserOptionItem } from './user_option_item';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
 import { UserIcon } from '../../../components/shared/user_icon';
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { UserOptionItem } from './user_option_item';
 
 const user = users[0];
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.test.ts
@@ -11,14 +11,14 @@ import {
   mockFlashMessageHelpers,
   mockHttpValues,
 } from '../../../__mocks__';
+import { groups } from '../../__mocks__/groups.mock';
 
 import { nextTick } from '@kbn/test/jest';
 
-import { groups } from '../../__mocks__/groups.mock';
+import { GROUPS_PATH } from '../../routes';
+
 import { mockGroupValues } from './__mocks__/group_logic.mock';
 import { GroupLogic } from './group_logic';
-
-import { GROUPS_PATH } from '../../routes';
 
 describe('GroupLogic', () => {
   const { mount } = new LogicMounter(GroupLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_logic.ts
@@ -7,10 +7,9 @@
 
 import { kea, MakeLogicType } from 'kea';
 import { isEqual } from 'lodash';
+
 import { i18n } from '@kbn/i18n';
 
-import { HttpLogic } from '../../../shared/http';
-import { KibanaLogic } from '../../../shared/kibana';
 import {
   clearFlashMessages,
   flashAPIErrors,
@@ -18,9 +17,9 @@ import {
   setQueuedSuccessMessage,
   setQueuedErrorMessage,
 } from '../../../shared/flash_messages';
-
+import { HttpLogic } from '../../../shared/http';
+import { KibanaLogic } from '../../../shared/kibana';
 import { GROUPS_PATH } from '../../routes';
-
 import { ContentSourceDetails, GroupDetails, User, SourcePriority } from '../../types';
 
 export const MAX_NAME_LENGTH = 40;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_router.test.tsx
@@ -7,25 +7,21 @@
 
 import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../__mocks__';
-
-import React from 'react';
-import { shallow } from 'enzyme';
-
-import { Route, Switch } from 'react-router-dom';
-
 import { groups } from '../../__mocks__/groups.mock';
 
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
+
+import { FlashMessages } from '../../../shared/flash_messages';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 
 import { GroupOverview } from './components/group_overview';
 import { GroupSourcePrioritization } from './components/group_source_prioritization';
-
-import { GroupRouter } from './group_router';
-
-import { FlashMessages } from '../../../shared/flash_messages';
-
 import { ManageUsersModal } from './components/manage_users_modal';
 import { SharedSourcesModal } from './components/shared_sources_modal';
+import { GroupRouter } from './group_router';
 
 describe('GroupRouter', () => {
   const initializeGroup = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/group_router.tsx
@@ -6,23 +6,21 @@
  */
 
 import React, { useEffect } from 'react';
+import { Route, Switch, useParams } from 'react-router-dom';
 
 import { useActions, useValues } from 'kea';
-import { Route, Switch, useParams } from 'react-router-dom';
 
 import { FlashMessages } from '../../../shared/flash_messages';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
-
-import { GROUP_SOURCE_PRIORITIZATION_PATH, GROUP_PATH } from '../../routes';
 import { NAV } from '../../constants';
-import { GroupLogic } from './group_logic';
-
-import { ManageUsersModal } from './components/manage_users_modal';
-import { SharedSourcesModal } from './components/shared_sources_modal';
+import { GROUP_SOURCE_PRIORITIZATION_PATH, GROUP_PATH } from '../../routes';
 
 import { GroupOverview } from './components/group_overview';
 import { GroupSourcePrioritization } from './components/group_source_prioritization';
+import { ManageUsersModal } from './components/manage_users_modal';
+import { SharedSourcesModal } from './components/shared_sources_modal';
+import { GroupLogic } from './group_logic';
 
 export const GroupRouter: React.FC = () => {
   const { groupId } = useParams() as { groupId: string };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.test.tsx
@@ -11,23 +11,22 @@ import { groups } from '../../__mocks__/groups.mock';
 import { meta } from '../../__mocks__/meta.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
-import { Groups } from './groups';
+import { EuiFieldSearch, EuiLoadingSpinner } from '@elastic/eui';
 
-import { ViewContentHeader } from '../../components/shared/view_content_header';
-import { Loading } from '../../../shared/loading';
+import { DEFAULT_META } from '../../../shared/constants';
 import { FlashMessages } from '../../../shared/flash_messages';
+import { Loading } from '../../../shared/loading';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
 
 import { AddGroupModal } from './components/add_group_modal';
 import { ClearFiltersLink } from './components/clear_filters_link';
 import { GroupsTable } from './components/groups_table';
 import { TableFilters } from './components/table_filters';
-
-import { DEFAULT_META } from '../../../shared/constants';
-
-import { EuiFieldSearch, EuiLoadingSpinner } from '@elastic/eui';
-import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { Groups } from './groups';
 
 const getSearchResults = jest.fn();
 const openNewGroupModal = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -8,26 +8,22 @@
 import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
-import { i18n } from '@kbn/i18n';
 
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
-import { EuiButtonTo } from '../../../shared/react_router_helpers';
-
-import { AppLogic } from '../../app_logic';
-
-import { Loading } from '../../../shared/loading';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
-
-import { getGroupPath, USERS_PATH } from '../../routes';
+import { i18n } from '@kbn/i18n';
 
 import { FlashMessages, FlashMessagesLogic } from '../../../shared/flash_messages';
-
-import { GroupsLogic } from './groups_logic';
+import { Loading } from '../../../shared/loading';
+import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { AppLogic } from '../../app_logic';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
+import { getGroupPath, USERS_PATH } from '../../routes';
 
 import { AddGroupModal } from './components/add_group_modal';
 import { ClearFiltersLink } from './components/clear_filters_link';
 import { GroupsTable } from './components/groups_table';
 import { TableFilters } from './components/table_filters';
+import { GroupsLogic } from './groups_logic';
 
 export const Groups: React.FC = () => {
   const { messages } = useValues(FlashMessagesLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.test.ts
@@ -6,15 +6,15 @@
  */
 
 import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../../__mocks__';
+import { contentSources } from '../../__mocks__/content_sources.mock';
+import { groups } from '../../__mocks__/groups.mock';
+import { users } from '../../__mocks__/users.mock';
 
 import { nextTick } from '@kbn/test/jest';
 
-import { DEFAULT_META } from '../../../shared/constants';
 import { JSON_HEADER as headers } from '../../../../../common/constants';
+import { DEFAULT_META } from '../../../shared/constants';
 
-import { groups } from '../../__mocks__/groups.mock';
-import { contentSources } from '../../__mocks__/content_sources.mock';
-import { users } from '../../__mocks__/users.mock';
 import { mockGroupsValues } from './__mocks__/groups_logic.mock';
 import { GroupsLogic } from './groups_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_logic.ts
@@ -6,21 +6,19 @@
  */
 
 import { kea, MakeLogicType } from 'kea';
+
 import { i18n } from '@kbn/i18n';
 
-import { HttpLogic } from '../../../shared/http';
-
+import { JSON_HEADER as headers } from '../../../../../common/constants';
+import { Meta } from '../../../../../common/types';
+import { DEFAULT_META } from '../../../shared/constants';
 import {
   clearFlashMessages,
   flashAPIErrors,
   setSuccessMessage,
 } from '../../../shared/flash_messages';
-
+import { HttpLogic } from '../../../shared/http';
 import { ContentSource, Group, User } from '../../types';
-
-import { JSON_HEADER as headers } from '../../../../../common/constants';
-import { DEFAULT_META } from '../../../shared/constants';
-import { Meta } from '../../../../../common/types';
 
 export const MAX_NAME_LENGTH = 40;
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_router.test.tsx
@@ -9,14 +9,13 @@ import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions } from '../../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
-
 import { Route, Switch } from 'react-router-dom';
 
-import { GroupsRouter } from './groups_router';
+import { shallow } from 'enzyme';
 
 import { GroupRouter } from './group_router';
 import { Groups } from './groups';
+import { GroupsRouter } from './groups_router';
 
 describe('GroupsRouter', () => {
   const initializeGroups = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups_router.tsx
@@ -6,21 +6,18 @@
  */
 
 import React, { useEffect } from 'react';
+import { Route, Switch } from 'react-router-dom';
 
 import { useActions } from 'kea';
 
-import { Route, Switch } from 'react-router-dom';
-
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
-
-import { GROUP_PATH, GROUPS_PATH } from '../../routes';
 import { NAV } from '../../constants';
-
-import { GroupsLogic } from './groups_logic';
+import { GROUP_PATH, GROUPS_PATH } from '../../routes';
 
 import { GroupRouter } from './group_router';
 import { Groups } from './groups';
+import { GroupsLogic } from './groups_logic';
 
 import './groups.scss';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/__mocks__/overview_logic.mock.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { setMockValues as setMockKeaValues, setMockActions } from '../../../../__mocks__/kea.mock';
 import { DEFAULT_INITIAL_APP_DATA } from '../../../../../../common/__mocks__';
+import { setMockValues as setMockKeaValues, setMockActions } from '../../../../__mocks__/kea.mock';
 
 const { workplaceSearch: mockAppValues } = DEFAULT_INITIAL_APP_DATA;
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.test.tsx
@@ -10,6 +10,7 @@ import '../../../__mocks__/enterprise_search_url.mock';
 import { mockTelemetryActions } from '../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiEmptyPrompt, EuiButton, EuiButtonEmpty } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { useActions } from 'kea';
 
 import {
@@ -20,8 +21,8 @@ import {
   EuiLinkProps,
 } from '@elastic/eui';
 
-import { TelemetryLogic } from '../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../shared/telemetry';
 
 interface OnboardingCardProps {
   title: React.ReactNode;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.test.tsx
@@ -6,16 +6,18 @@
  */
 
 import { mockTelemetryActions } from '../../../__mocks__';
+
 import './__mocks__/overview_logic.mock';
-import { setMockValues } from './__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SOURCES_PATH, USERS_PATH } from '../../routes';
 
-import { OnboardingSteps, OrgNameOnboarding } from './onboarding_steps';
+import { setMockValues } from './__mocks__';
 import { OnboardingCard } from './onboarding_card';
+import { OnboardingSteps, OrgNameOnboarding } from './onboarding_steps';
 
 const account = {
   id: '1',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n/react';
+
 import { useValues, useActions } from 'kea';
 
 import {
@@ -22,17 +21,18 @@ import {
   EuiButtonEmptyProps,
   EuiLinkProps,
 } from '@elastic/eui';
-import sharedSourcesIcon from '../../components/shared/assets/source_icons/share_circle.svg';
-import { TelemetryLogic } from '../../../shared/telemetry';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
+import sharedSourcesIcon from '../../components/shared/assets/source_icons/share_circle.svg';
+import { ContentSection } from '../../components/shared/content_section';
 import { SOURCES_PATH, USERS_PATH, ORG_SETTINGS_PATH } from '../../routes';
 
-import { ContentSection } from '../../components/shared/content_section';
-
-import { AppLogic } from '../../app_logic';
-import { OverviewLogic } from './overview_logic';
-
 import { OnboardingCard } from './onboarding_card';
+import { OverviewLogic } from './overview_logic';
 
 const SOURCES_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingSourcesCard.title',

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.test.tsx
@@ -6,12 +6,14 @@
  */
 
 import './__mocks__/overview_logic.mock';
-import { setMockValues } from './__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiFlexGrid } from '@elastic/eui';
 
+import { setMockValues } from './__mocks__';
 import { OrganizationStats } from './organization_stats';
 import { StatisticCard } from './statistic_card';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/organization_stats.tsx
@@ -6,18 +6,18 @@
  */
 
 import React from 'react';
-import { EuiFlexGrid } from '@elastic/eui';
+
 import { useValues } from 'kea';
 
-import { FormattedMessage } from '@kbn/i18n/react';
+import { EuiFlexGrid } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
+import { AppLogic } from '../../app_logic';
 import { ContentSection } from '../../components/shared/content_section';
 import { SOURCES_PATH, USERS_PATH } from '../../routes';
 
-import { AppLogic } from '../../app_logic';
 import { OverviewLogic } from './overview_logic';
-
 import { StatisticCard } from './statistic_card';
 
 export const OrganizationStats: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.test.tsx
@@ -7,18 +7,19 @@
 
 import '../../../__mocks__/react_router_history.mock';
 import './__mocks__/overview_logic.mock';
-import { mockActions, setMockValues } from './__mocks__';
 
 import React from 'react';
+
 import { shallow, mount } from 'enzyme';
 
 import { Loading } from '../../../shared/loading';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
 
+import { mockActions, setMockValues } from './__mocks__';
 import { OnboardingSteps } from './onboarding_steps';
 import { OrganizationStats } from './organization_stats';
-import { RecentActivity } from './recent_activity';
 import { Overview } from './overview';
+import { RecentActivity } from './recent_activity';
 
 describe('Overview', () => {
   describe('non-happy-path states', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
@@ -8,22 +8,22 @@
 // TODO: Remove EuiPage & EuiPageBody before exposing full app
 
 import React, { useEffect } from 'react';
-import { EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+
 import { useActions, useValues } from 'kea';
 
+import { EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
-import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
-
-import { AppLogic } from '../../app_logic';
-import { OverviewLogic } from './overview_logic';
-
 import { Loading } from '../../../shared/loading';
+import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
 import { ProductButton } from '../../components/shared/product_button';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
 
 import { OnboardingSteps } from './onboarding_steps';
 import { OrganizationStats } from './organization_stats';
+import { OverviewLogic } from './overview_logic';
 import { RecentActivity } from './recent_activity';
 
 const ONBOARDING_HEADER_TITLE = i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
@@ -6,6 +6,7 @@
  */
 
 import { kea, MakeLogicType } from 'kea';
+
 import { HttpLogic } from '../../../shared/http';
 
 import { FeedActivity } from './recent_activity';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.test.tsx
@@ -6,15 +6,17 @@
  */
 
 import { mockTelemetryActions } from '../../../__mocks__';
+
 import './__mocks__/overview_logic.mock';
-import { setMockValues } from './__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
+import { setMockValues } from './__mocks__';
 import { RecentActivity, RecentActivityItem } from './recent_activity';
 
 const organization = { name: 'foo', defaultOrgName: 'bar' };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.tsx
@@ -7,19 +7,19 @@
 
 import React from 'react';
 
-import moment from 'moment';
 import { useValues, useActions } from 'kea';
+import moment from 'moment';
 
 import { EuiEmptyPrompt, EuiLink, EuiPanel, EuiSpacer, EuiLinkProps } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { ContentSection } from '../../components/shared/content_section';
-import { TelemetryLogic } from '../../../shared/telemetry';
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
-import { SOURCE_DETAILS_PATH, getContentSourcePath } from '../../routes';
-import { RECENT_ACTIVITY_TITLE } from '../../constants';
-
+import { TelemetryLogic } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
+import { ContentSection } from '../../components/shared/content_section';
+import { RECENT_ACTIVITY_TITLE } from '../../constants';
+import { SOURCE_DETAILS_PATH, getContentSourcePath } from '../../routes';
+
 import { OverviewLogic } from './overview_logic';
 
 import './recent_activity.scss';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.test.tsx
@@ -8,6 +8,7 @@
 import '../../../__mocks__/enterprise_search_url.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiCard } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiCard, EuiFlexItem, EuiTitle, EuiTextColor } from '@elastic/eui';
 
 import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.test.tsx
@@ -8,7 +8,9 @@
 import { setMockValues } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
+
 import { EuiSwitch } from '@elastic/eui';
 
 import { PrivateSourcesTable } from './private_sources_table';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -24,11 +24,10 @@ import {
   EuiTableRowCell,
   EuiSpacer,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { LicensingLogic } from '../../../../shared/licensing';
-import { SecurityLogic, PrivateSourceSection } from '../security_logic';
 import {
   REMOTE_SOURCES_TOGGLE_TEXT,
   REMOTE_SOURCES_TABLE_DESCRIPTION,
@@ -38,6 +37,7 @@ import {
   STANDARD_SOURCES_EMPTY_TABLE_TITLE,
   SOURCE,
 } from '../../../constants';
+import { SecurityLogic, PrivateSourceSection } from '../security_logic';
 
 interface PrivateSourcesTableProps {
   sourceType: 'remote' | 'standard';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.test.tsx
@@ -9,11 +9,14 @@ import { setMockValues, setMockActions } from '../../../__mocks__';
 import { unmountHandler } from '../../../__mocks__/shallow_useeffect.mock';
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { EuiSwitch, EuiConfirmModal } from '@elastic/eui';
-import { Loading } from '../../../shared/loading';
 
+import { shallow } from 'enzyme';
+
+import { EuiSwitch, EuiConfirmModal } from '@elastic/eui';
+
+import { Loading } from '../../../shared/loading';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
+
 import { Security } from './security';
 
 describe('Security', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -23,15 +23,11 @@ import {
   EuiOverlayMask,
 } from '@elastic/eui';
 
-import { LicensingLogic } from '../../../shared/licensing';
 import { FlashMessages } from '../../../shared/flash_messages';
-import { LicenseCallout } from '../../components/shared/license_callout';
+import { LicensingLogic } from '../../../shared/licensing';
 import { Loading } from '../../../shared/loading';
+import { LicenseCallout } from '../../components/shared/license_callout';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
-import { SecurityLogic } from './security_logic';
-
-import { PrivateSourcesTable } from './components/private_sources_table';
-
 import {
   SECURITY_UNSAVED_CHANGES_MESSAGE,
   RESET_BUTTON,
@@ -45,6 +41,9 @@ import {
   CONFIRM_CHANGES_TEXT,
   PRIVATE_SOURCES_UPDATE_CONFIRMATION_TEXT,
 } from '../../constants';
+
+import { PrivateSourcesTable } from './components/private_sources_table';
+import { SecurityLogic } from './security_logic';
 
 export const Security: React.FC = () => {
   const [confirmModalVisible, setConfirmModalVisibility] = useState(false);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.test.ts
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
 import { mockHttpValues, mockFlashMessageHelpers } from '../../../__mocks__';
-import { SecurityLogic } from './security_logic';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
+
 import { nextTick } from '@kbn/test/jest';
+
+import { SecurityLogic } from './security_logic';
 
 describe('SecurityLogic', () => {
   const { http } = mockHttpValues;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security_logic.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
+import { kea, MakeLogicType } from 'kea';
 import { cloneDeep } from 'lodash';
 import { isEqual } from 'lodash';
-
-import { kea, MakeLogicType } from 'kea';
 
 import {
   clearFlashMessages,
@@ -17,7 +16,6 @@ import {
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { AppLogic } from '../../app_logic';
-
 import { SOURCE_RESTRICTIONS_SUCCESS_MESSAGE } from '../../constants';
 
 export interface PrivateSource {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/connectors.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/connectors.test.tsx
@@ -8,10 +8,10 @@
 import '../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../__mocks__';
-
 import { configuredSources } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { Loading } from '../../../../shared/loading';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/connectors.tsx
@@ -19,12 +19,11 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { EuiButtonEmptyTo } from '../../../../shared/react_router_helpers';
 import { Loading } from '../../../../shared/loading';
-import { SourceIcon } from '../../../components/shared/source_icon';
+import { EuiButtonEmptyTo } from '../../../../shared/react_router_helpers';
 import { LicenseCallout } from '../../../components/shared/license_callout';
+import { SourceIcon } from '../../../components/shared/source_icon';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
-
 import {
   CONFIGURE_BUTTON,
   CONNECTORS_HEADER_TITLE,
@@ -36,9 +35,7 @@ import {
 } from '../../../constants';
 import { getSourcesPath } from '../../../routes';
 import { SourceDataItem } from '../../../types';
-
 import { staticSourceData } from '../../content_sources/source_data';
-
 import { SettingsLogic } from '../settings_logic';
 
 export const Connectors: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.test.tsx
@@ -10,6 +10,7 @@ import '../../../../__mocks__/shallow_useeffect.mock';
 import { setMockValues, setMockActions } from '../../../../__mocks__';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiFieldText } from '@elastic/eui';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/customize.tsx
@@ -11,16 +11,14 @@ import { useActions, useValues } from 'kea';
 
 import { EuiButton, EuiFieldText, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 
+import { ContentSection } from '../../../components/shared/content_section';
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import {
   CUSTOMIZE_HEADER_TITLE,
   CUSTOMIZE_HEADER_DESCRIPTION,
   CUSTOMIZE_NAME_LABEL,
   CUSTOMIZE_NAME_BUTTON,
 } from '../../../constants';
-
-import { ContentSection } from '../../../components/shared/content_section';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
-
 import { SettingsLogic } from '../settings_logic';
 
 export const Customize: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/oauth_application.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/oauth_application.test.tsx
@@ -8,17 +8,18 @@
 import '../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../__mocks__';
+import { oauthApplication } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiModal, EuiForm } from '@elastic/eui';
 
-import { oauthApplication } from '../../../__mocks__/content_sources.mock';
-import { OAUTH_DESCRIPTION, REDIRECT_INSECURE_ERROR_TEXT } from '../../../constants';
-
 import { CredentialItem } from '../../../components/shared/credential_item';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
+import { OAUTH_DESCRIPTION, REDIRECT_INSECURE_ERROR_TEXT } from '../../../constants';
+
 import { OauthApplication } from './oauth_application';
 
 describe('OauthApplication', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/oauth_application.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/oauth_application.tsx
@@ -26,7 +26,11 @@ import {
   EuiText,
 } from '@elastic/eui';
 
-import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../routes';
+import { LicensingLogic } from '../../../../shared/licensing';
+import { ContentSection } from '../../../components/shared/content_section';
+import { CredentialItem } from '../../../components/shared/credential_item';
+import { LicenseBadge } from '../../../components/shared/license_badge';
+import { ViewContentHeader } from '../../../components/shared/view_content_header';
 import {
   CLIENT_ID_LABEL,
   CLIENT_SECRET_LABEL,
@@ -48,12 +52,7 @@ import {
   LICENSE_MODAL_DESCRIPTION,
   LICENSE_MODAL_LINK,
 } from '../../../constants';
-
-import { LicensingLogic } from '../../../../shared/licensing';
-import { ContentSection } from '../../../components/shared/content_section';
-import { LicenseBadge } from '../../../components/shared/license_badge';
-import { ViewContentHeader } from '../../../components/shared/view_content_header';
-import { CredentialItem } from '../../../components/shared/credential_item';
+import { ENT_SEARCH_LICENSE_MANAGEMENT } from '../../../routes';
 import { SettingsLogic } from '../settings_logic';
 
 export const OauthApplication: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/settings_sub_nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/settings_sub_nav.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SideNavLink } from '../../../../shared/layout';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/settings_sub_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/settings_sub_nav.tsx
@@ -7,10 +7,8 @@
 
 import React from 'react';
 
-import { NAV } from '../../../constants';
-
 import { SideNavLink } from '../../../../shared/layout';
-
+import { NAV } from '../../../constants';
 import {
   ORG_SETTINGS_CUSTOMIZE_PATH,
   ORG_SETTINGS_CONNECTORS_PATH,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.test.tsx
@@ -8,16 +8,17 @@
 import '../../../../__mocks__/shallow_useeffect.mock';
 
 import { setMockValues, setMockActions } from '../../../../__mocks__';
+import { sourceConfigData } from '../../../__mocks__/content_sources.mock';
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { EuiConfirmModal } from '@elastic/eui';
 
-import { sourceConfigData } from '../../../__mocks__/content_sources.mock';
-
 import { Loading } from '../../../../shared/loading';
 import { SaveConfig } from '../../content_sources/components/add_source/save_config';
+
 import { SourceConfig } from './source_config';
 
 describe('SourceConfig', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/components/source_config.tsx
@@ -8,18 +8,16 @@
 import React, { useEffect, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
-import { i18n } from '@kbn/i18n';
 
 import { EuiConfirmModal, EuiOverlayMask } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import { Loading } from '../../../../shared/loading';
 import { SourceDataItem } from '../../../types';
-import { staticSourceData } from '../../content_sources/source_data';
-import { AddSourceLogic } from '../../content_sources/components/add_source/add_source_logic';
-
 import { AddSourceHeader } from '../../content_sources/components/add_source/add_source_header';
+import { AddSourceLogic } from '../../content_sources/components/add_source/add_source_logic';
 import { SaveConfig } from '../../content_sources/components/add_source/save_config';
-
+import { staticSourceData } from '../../content_sources/source_data';
 import { SettingsLogic } from '../settings_logic';
 
 interface SourceConfigProps {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.test.ts
@@ -5,15 +5,14 @@
  * 2.0.
  */
 
-import { LogicMounter } from '../../../__mocks__/kea.mock';
-
 import { mockFlashMessageHelpers, mockHttpValues, mockKibanaValues } from '../../../__mocks__';
+import { LogicMounter } from '../../../__mocks__/kea.mock';
+import { configuredSources, oauthApplication } from '../../__mocks__/content_sources.mock';
 
 import { nextTick } from '@kbn/test/jest';
 
-import { configuredSources, oauthApplication } from '../../__mocks__/content_sources.mock';
-
 import { ORG_UPDATED_MESSAGE, OAUTH_APP_UPDATED_MESSAGE } from '../../constants';
+
 import { SettingsLogic } from './settings_logic';
 
 describe('SettingsLogic', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -6,6 +6,7 @@
  */
 
 import { kea, MakeLogicType } from 'kea';
+
 import { i18n } from '@kbn/i18n';
 
 import {
@@ -14,13 +15,11 @@ import {
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
-import { KibanaLogic } from '../../../shared/kibana';
 import { HttpLogic } from '../../../shared/http';
-
-import { Connector } from '../../types';
+import { KibanaLogic } from '../../../shared/kibana';
 import { ORG_UPDATED_MESSAGE, OAUTH_APP_UPDATED_MESSAGE } from '../../constants';
-
 import { ORG_SETTINGS_CONNECTORS_PATH } from '../../routes';
+import { Connector } from '../../types';
 
 interface IOauthApplication {
   name: string;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_router.test.tsx
@@ -10,19 +10,17 @@ import '../../../__mocks__/shallow_useeffect.mock';
 import { setMockActions } from '../../../__mocks__';
 
 import React from 'react';
-import { shallow } from 'enzyme';
-
 import { Route, Redirect, Switch } from 'react-router-dom';
 
-import { staticSourceData } from '../content_sources/source_data';
+import { shallow } from 'enzyme';
 
 import { FlashMessages } from '../../../shared/flash_messages';
+import { staticSourceData } from '../content_sources/source_data';
 
 import { Connectors } from './components/connectors';
 import { Customize } from './components/customize';
 import { OauthApplication } from './components/oauth_application';
 import { SourceConfig } from './components/source_config';
-
 import { SettingsRouter } from './settings_router';
 
 describe('SettingsRouter', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_router.tsx
@@ -6,26 +6,23 @@
  */
 
 import React, { useEffect } from 'react';
-
-import { useActions } from 'kea';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
+import { useActions } from 'kea';
+
+import { FlashMessages } from '../../../shared/flash_messages';
 import {
   ORG_SETTINGS_PATH,
   ORG_SETTINGS_CUSTOMIZE_PATH,
   ORG_SETTINGS_CONNECTORS_PATH,
   ORG_SETTINGS_OAUTH_APPLICATION_PATH,
 } from '../../routes';
-
-import { FlashMessages } from '../../../shared/flash_messages';
+import { staticSourceData } from '../content_sources/source_data';
 
 import { Connectors } from './components/connectors';
 import { Customize } from './components/customize';
 import { OauthApplication } from './components/oauth_application';
 import { SourceConfig } from './components/source_config';
-
-import { staticSourceData } from '../content_sources/source_data';
-
 import { SettingsLogic } from './settings_logic';
 
 export const SettingsRouter: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.test.tsx
@@ -6,10 +6,12 @@
  */
 
 import React from 'react';
+
 import { shallow } from 'enzyme';
 
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SetupGuideLayout } from '../../../shared/setup_guide';
+
 import { SetupGuide } from './';
 
 describe('SetupGuide', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/setup_guide/setup_guide.tsx
@@ -6,18 +6,19 @@
  */
 
 import React from 'react';
+
 import { EuiSpacer, EuiTitle, EuiText, EuiButton, EuiLink } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
-import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { SetupGuideLayout, SETUP_GUIDE_TITLE } from '../../../shared/setup_guide';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { DOCS_PREFIX } from '../../routes';
 
 import GettingStarted from './assets/getting_started.png';
 
-import { DOCS_PREFIX } from '../../routes';
 const GETTING_STARTED_LINK_URL = `${DOCS_PREFIX}/workplace-search-getting-started.html`;
 
 export const SetupGuide: React.FC = () => {

--- a/x-pack/plugins/enterprise_search/public/index.ts
+++ b/x-pack/plugins/enterprise_search/public/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { PluginInitializerContext } from 'src/core/public';
+
 import { EnterpriseSearchPlugin } from './plugin';
 
 export const plugin = (initializerContext: PluginInitializerContext) => {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -12,15 +12,15 @@ import {
   HttpSetup,
   Plugin,
   PluginInitializerContext,
-} from 'src/core/public';
-import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
+  DEFAULT_APP_CATEGORIES,
+} from '../../../../src/core/public';
+import { ChartsPluginStart } from '../../../../src/plugins/charts/public';
 import {
   FeatureCatalogueCategory,
   HomePublicPluginSetup,
 } from '../../../../src/plugins/home/public';
 import { CloudSetup } from '../../cloud/public';
 import { LicensingPluginStart } from '../../licensing/public';
-import { ChartsPluginStart } from '../../../../src/plugins/charts/public';
 
 import {
   APP_SEARCH_PLUGIN,

--- a/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts
+++ b/x-pack/plugins/enterprise_search/server/__mocks__/router.mock.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { httpServiceMock, httpServerMock } from 'src/core/server/mocks';
 import {
   IRouter,
   KibanaRequest,
   RequestHandlerContext,
   RouteValidatorConfig,
 } from 'src/core/server';
+import { httpServiceMock, httpServerMock } from 'src/core/server/mocks';
 
 /**
  * Test helper that mocks Kibana's router and DRYs out various helper (callRoute, schema validation)

--- a/x-pack/plugins/enterprise_search/server/__mocks__/routerDependencies.mock.ts
+++ b/x-pack/plugins/enterprise_search/server/__mocks__/routerDependencies.mock.ts
@@ -6,6 +6,7 @@
  */
 
 import { loggingSystemMock } from 'src/core/server/mocks';
+
 import { ConfigType } from '../';
 
 export const mockLogger = loggingSystemMock.createLogger().get();

--- a/x-pack/plugins/enterprise_search/server/collectors/app_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/collectors/app_search/telemetry.ts
@@ -6,6 +6,7 @@
  */
 
 import { get } from 'lodash';
+
 import { SavedObjectsServiceStart, Logger } from 'src/core/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 

--- a/x-pack/plugins/enterprise_search/server/collectors/enterprise_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/collectors/enterprise_search/telemetry.ts
@@ -6,6 +6,7 @@
  */
 
 import { get } from 'lodash';
+
 import { SavedObjectsServiceStart, Logger } from 'src/core/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 

--- a/x-pack/plugins/enterprise_search/server/collectors/workplace_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/collectors/workplace_search/telemetry.ts
@@ -6,6 +6,7 @@
  */
 
 import { get } from 'lodash';
+
 import { SavedObjectsServiceStart, Logger } from 'src/core/server';
 import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
 

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { PluginInitializerContext, PluginConfigDescriptor } from 'src/core/server';
 import { schema, TypeOf } from '@kbn/config-schema';
+import { PluginInitializerContext, PluginConfigDescriptor } from 'src/core/server';
+
 import { EnterpriseSearchPlugin } from './plugin';
 
 export const plugin = (initializerContext: PluginInitializerContext) => {

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
+import { spacesMock } from '../../../spaces/server/mocks';
+
+import { checkAccess } from './check_access';
+
 jest.mock('./enterprise_search_config_api', () => ({
   callEnterpriseSearchConfigAPI: jest.fn(),
 }));
 import { callEnterpriseSearchConfigAPI } from './enterprise_search_config_api';
-
-import { checkAccess } from './check_access';
-import { spacesMock } from '../../../spaces/server/mocks';
 
 const enabledSpace = {
   id: 'space',

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -6,9 +6,10 @@
  */
 
 import { KibanaRequest, Logger } from 'src/core/server';
-import { SpacesPluginStart } from '../../../spaces/server';
+
 import { SecurityPluginSetup } from '../../../security/server';
-import { ConfigType } from '../';
+import { SpacesPluginStart } from '../../../spaces/server';
+import { ConfigType } from '../index';
 
 import { callEnterpriseSearchConfigAPI } from './enterprise_search_config_api';
 

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -5,14 +5,15 @@
  * 2.0.
  */
 
+import { DEFAULT_INITIAL_APP_DATA } from '../../common/__mocks__';
+
 jest.mock('node-fetch');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const fetchMock = require('node-fetch') as jest.Mock;
+import fetch from 'node-fetch';
+
 const { Response } = jest.requireActual('node-fetch');
 
 import { loggingSystemMock } from 'src/core/server/mocks';
 
-import { DEFAULT_INITIAL_APP_DATA } from '../../common/__mocks__';
 import { callEnterpriseSearchConfigAPI } from './enterprise_search_config_api';
 
 describe('callEnterpriseSearchConfigAPI', () => {
@@ -101,7 +102,7 @@ describe('callEnterpriseSearchConfigAPI', () => {
   });
 
   it('calls the config API endpoint', async () => {
-    fetchMock.mockImplementationOnce((url: string) => {
+    ((fetch as unknown) as jest.Mock).mockImplementationOnce((url: string) => {
       expect(url).toEqual('http://localhost:3002/api/ent/v2/internal/client_config');
       return Promise.resolve(new Response(JSON.stringify(mockResponse)));
     });
@@ -117,7 +118,7 @@ describe('callEnterpriseSearchConfigAPI', () => {
   });
 
   it('falls back without error when data is unavailable', async () => {
-    fetchMock.mockImplementationOnce((url: string) => Promise.resolve(new Response('{}')));
+    ((fetch as unknown) as jest.Mock).mockReturnValueOnce(Promise.resolve(new Response('{}')));
 
     expect(await callEnterpriseSearchConfigAPI(mockDependencies)).toEqual({
       access: {
@@ -180,21 +181,17 @@ describe('callEnterpriseSearchConfigAPI', () => {
     const config = { host: '' };
 
     expect(await callEnterpriseSearchConfigAPI({ ...mockDependencies, config })).toEqual({});
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('handles server errors', async () => {
-    fetchMock.mockImplementationOnce(() => {
-      return Promise.reject('500');
-    });
+    ((fetch as unknown) as jest.Mock).mockReturnValueOnce(Promise.reject('500'));
     expect(await callEnterpriseSearchConfigAPI(mockDependencies)).toEqual({});
     expect(mockDependencies.log.error).toHaveBeenCalledWith(
       'Could not perform access check to Enterprise Search: 500'
     );
 
-    fetchMock.mockImplementationOnce(() => {
-      return Promise.resolve('Bad Data');
-    });
+    ((fetch as unknown) as jest.Mock).mockReturnValueOnce(Promise.resolve('Bad Data'));
     expect(await callEnterpriseSearchConfigAPI(mockDependencies)).toEqual({});
     expect(mockDependencies.log.error).toHaveBeenCalledWith(
       'Could not perform access check to Enterprise Search: TypeError: response.json is not a function'
@@ -212,7 +209,7 @@ describe('callEnterpriseSearchConfigAPI', () => {
     );
 
     // Timeout
-    fetchMock.mockImplementationOnce(async () => {
+    ((fetch as unknown) as jest.Mock).mockImplementationOnce(async () => {
       jest.advanceTimersByTime(250);
       return Promise.reject({ name: 'AbortError' });
     });

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -9,11 +9,12 @@ import AbortController from 'abort-controller';
 import fetch from 'node-fetch';
 
 import { KibanaRequest, Logger } from 'src/core/server';
-import { ConfigType } from '../';
-import { Access } from './check_access';
 
-import { InitialAppData } from '../../common/types';
 import { stripTrailingSlash } from '../../common/strip_slashes';
+import { InitialAppData } from '../../common/types';
+import { ConfigType } from '../index';
+
+import { Access } from './check_access';
 
 interface Params {
   request: KibanaRequest;

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { mockConfig, mockLogger } from '../__mocks__';
+
 import { JSON_HEADER, READ_ONLY_MODE_HEADER } from '../../common/constants';
 
 import { EnterpriseSearchRequestHandler } from './enterprise_search_request_handler';
@@ -13,6 +14,7 @@ import { EnterpriseSearchRequestHandler } from './enterprise_search_request_hand
 jest.mock('node-fetch');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fetchMock = require('node-fetch') as jest.Mock;
+
 const { Response } = jest.requireActual('node-fetch');
 
 const responseMock = {

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_request_handler.ts
@@ -7,6 +7,7 @@
 
 import fetch, { Response } from 'node-fetch';
 import querystring from 'querystring';
+
 import {
   RequestHandler,
   RequestHandlerContext,
@@ -14,8 +15,9 @@ import {
   KibanaResponseFactory,
   Logger,
 } from 'src/core/server';
-import { ConfigType } from '../index';
+
 import { JSON_HEADER, READ_ONLY_MODE_HEADER } from '../../common/constants';
+import { ConfigType } from '../index';
 
 interface ConstructorDependencies {
   config: ConfigType;

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -13,37 +13,39 @@ import {
   SavedObjectsServiceStart,
   IRouter,
   KibanaRequest,
-} from 'src/core/server';
-import { UsageCollectionSetup } from 'src/plugins/usage_collection/server';
-import { SpacesPluginStart } from '../../spaces/server';
-import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/server';
-import { SecurityPluginSetup } from '../../security/server';
+  DEFAULT_APP_CATEGORIES,
+} from '../../../../src/core/server';
+import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '../../features/server';
+import { SecurityPluginSetup } from '../../security/server';
+import { SpacesPluginStart } from '../../spaces/server';
 
 import {
   ENTERPRISE_SEARCH_PLUGIN,
   APP_SEARCH_PLUGIN,
   WORKPLACE_SEARCH_PLUGIN,
 } from '../common/constants';
-import { ConfigType } from './';
+
+import { registerTelemetryUsageCollector as registerASTelemetryUsageCollector } from './collectors/app_search/telemetry';
+import { registerTelemetryUsageCollector as registerESTelemetryUsageCollector } from './collectors/enterprise_search/telemetry';
+import { registerTelemetryUsageCollector as registerWSTelemetryUsageCollector } from './collectors/workplace_search/telemetry';
+
 import { checkAccess } from './lib/check_access';
 import {
   EnterpriseSearchRequestHandler,
   IEnterpriseSearchRequestHandler,
 } from './lib/enterprise_search_request_handler';
 
-import { enterpriseSearchTelemetryType } from './saved_objects/enterprise_search/telemetry';
-import { registerTelemetryUsageCollector as registerESTelemetryUsageCollector } from './collectors/enterprise_search/telemetry';
-import { registerTelemetryRoute } from './routes/enterprise_search/telemetry';
+import { registerAppSearchRoutes } from './routes/app_search';
 import { registerConfigDataRoute } from './routes/enterprise_search/config_data';
+import { registerTelemetryRoute } from './routes/enterprise_search/telemetry';
+import { registerWorkplaceSearchRoutes } from './routes/workplace_search';
 
 import { appSearchTelemetryType } from './saved_objects/app_search/telemetry';
-import { registerTelemetryUsageCollector as registerASTelemetryUsageCollector } from './collectors/app_search/telemetry';
-import { registerAppSearchRoutes } from './routes/app_search';
-
+import { enterpriseSearchTelemetryType } from './saved_objects/enterprise_search/telemetry';
 import { workplaceSearchTelemetryType } from './saved_objects/workplace_search/telemetry';
-import { registerTelemetryUsageCollector as registerWSTelemetryUsageCollector } from './collectors/workplace_search/telemetry';
-import { registerWorkplaceSearchRoutes } from './routes/workplace_search';
+
+import { ConfigType } from './';
 
 interface PluginsSetup {
   usageCollection?: UsageCollectionSetup;

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/engines.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/engines.ts
@@ -7,8 +7,8 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { RouteDependencies } from '../../plugin';
 import { ENGINES_PAGE_SIZE } from '../../../common/constants';
+import { RouteDependencies } from '../../plugin';
 
 interface EnginesResponse {
   results: object[];

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/index.ts
@@ -7,12 +7,12 @@
 
 import { RouteDependencies } from '../../plugin';
 
-import { registerEnginesRoutes } from './engines';
-import { registerCredentialsRoutes } from './credentials';
-import { registerSettingsRoutes } from './settings';
 import { registerAnalyticsRoutes } from './analytics';
+import { registerCredentialsRoutes } from './credentials';
 import { registerDocumentsRoutes, registerDocumentRoutes } from './documents';
+import { registerEnginesRoutes } from './engines';
 import { registerSearchSettingsRoutes } from './search_settings';
+import { registerSettingsRoutes } from './settings';
 
 export const registerAppSearchRoutes = (dependencies: RouteDependencies) => {
   registerEnginesRoutes(dependencies);

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { RouteDependencies } from '../../plugin';
 import { callEnterpriseSearchConfigAPI } from '../../lib/enterprise_search_config_api';
+import { RouteDependencies } from '../../plugin';
 
 export function registerConfigDataRoute({ router, config, log }: RouteDependencies) {
   router.get(

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { loggingSystemMock, savedObjectsServiceMock } from 'src/core/server/mocks';
 import { MockRouter, mockLogger, mockDependencies } from '../../__mocks__';
+
+import { loggingSystemMock, savedObjectsServiceMock } from 'src/core/server/mocks';
 
 jest.mock('../../collectors/lib/telemetry', () => ({
   incrementUICounter: jest.fn(),

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
@@ -7,12 +7,13 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { RouteDependencies } from '../../plugin';
-import { incrementUICounter } from '../../collectors/lib/telemetry';
-
-import { ES_TELEMETRY_NAME } from '../../collectors/enterprise_search/telemetry';
 import { AS_TELEMETRY_NAME } from '../../collectors/app_search/telemetry';
+import { ES_TELEMETRY_NAME } from '../../collectors/enterprise_search/telemetry';
+import { incrementUICounter } from '../../collectors/lib/telemetry';
 import { WS_TELEMETRY_NAME } from '../../collectors/workplace_search/telemetry';
+
+import { RouteDependencies } from '../../plugin';
+
 const productToTelemetryMap = {
   enterprise_search: ES_TELEMETRY_NAME,
   app_search: AS_TELEMETRY_NAME,

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/index.ts
@@ -7,11 +7,11 @@
 
 import { RouteDependencies } from '../../plugin';
 
-import { registerOverviewRoute } from './overview';
 import { registerGroupsRoutes } from './groups';
-import { registerSourcesRoutes } from './sources';
-import { registerSettingsRoutes } from './settings';
+import { registerOverviewRoute } from './overview';
 import { registerSecurityRoutes } from './security';
+import { registerSettingsRoutes } from './settings';
+import { registerSourcesRoutes } from './sources';
 
 export const registerWorkplaceSearchRoutes = (dependencies: RouteDependencies) => {
   registerOverviewRoute(dependencies);

--- a/x-pack/plugins/enterprise_search/server/saved_objects/app_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/saved_objects/app_search/telemetry.ts
@@ -8,6 +8,7 @@
 /* istanbul ignore file */
 
 import { SavedObjectsType } from 'src/core/server';
+
 import { AS_TELEMETRY_NAME } from '../../collectors/app_search/telemetry';
 
 export const appSearchTelemetryType: SavedObjectsType = {

--- a/x-pack/plugins/enterprise_search/server/saved_objects/enterprise_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/saved_objects/enterprise_search/telemetry.ts
@@ -8,6 +8,7 @@
 /* istanbul ignore file */
 
 import { SavedObjectsType } from 'src/core/server';
+
 import { ES_TELEMETRY_NAME } from '../../collectors/enterprise_search/telemetry';
 
 export const enterpriseSearchTelemetryType: SavedObjectsType = {

--- a/x-pack/plugins/enterprise_search/server/saved_objects/workplace_search/telemetry.ts
+++ b/x-pack/plugins/enterprise_search/server/saved_objects/workplace_search/telemetry.ts
@@ -8,6 +8,7 @@
 /* istanbul ignore file */
 
 import { SavedObjectsType } from 'src/core/server';
+
 import { WS_TELEMETRY_NAME } from '../../collectors/workplace_search/telemetry';
 
 export const workplaceSearchTelemetryType: SavedObjectsType = {


### PR DESCRIPTION
## Summary

Thanks to @byronhulcher's initiative, we should now have better living through automation:

- VSCode will automatically alert for import order issues
- Run `node scripts/eslint x-pack/plugins/enterprise_search --fix` (from kibana root) or update your IDE to auto-fix on save

Here's a quick list of what we now enforce:

- Order, generally following external/absolute -> internal/relative ordering
- Alphabetical order (within order groups)
- Newlines between each order group. You can optionally sub-organize within a group with extra newlines.

An example set of imports:

```js
/**
 * License header
 */

// All mock files (live within a `__mock__` folder, or direct `./something.mock` imports) should come first,
// to ensure mocks work as expected & avoid potential edge cases with mock hoisting
import { someSharedMock } from '../../../../__mocks__';
import { someLocalMock } from './some.mock';

// We created a rule to pull React out to the top of external imports as a standard for React component views
// Note that this in combination with our newline rule makes it so there's newlines between React + other externals :(
import React, { useEffect } from 'react';
import { Route } from 'react-router-dom';

// All other `external` imports
import { shallow } from 'enzyme';
import { useValues } from 'kea';
import { get } from 'lodash';

// `internal` (a.k.a Elastic) imports
import { EuiButton } from '@elastic/eui';
import { i18n } from '@kbn/i18n';
import { FormattedMessage } from '@kbn/i18n/react';

// `parent` imports
import { AnotherHelper }  '../../../shared/helpers/another';
import { SomeHelper } from '../../../shared/helpers/some';
import { RandomParent } from '../parent';

// `sibling` imports
import { SomeConstant } from './constants';
import { SomeSiblingComponent } from './some_sibling';
import { SomeType } from './types';

// `index` import
import { ThisComponent } from './';
```

The number of lines changed is probably too many to reasonably request a review for, so feel free to skim sections that only apply to you (e.g. WS/AS teams), or follow by-commit.

### Resources used during PR

- https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
- https://dev.to/mjmaix/clean-eslint-import-management-for-reactjs-230h
- Glob testers: https://www.digitalocean.com/community/tools/glob, https://codepen.io/mrmlnc/pen/OXQjrZ

### Checklist

- [x] Linting passes
- [x] All unit tests pass as before
- [x] Kibana is able to start (no errors with imports)