### PR TITLE
[Uptime-UX] Added nav search keywords for uptime and user experience app

### DIFF
--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -162,7 +162,24 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
       order: 8500,
       euiIconType: 'logoObservability',
       category: DEFAULT_APP_CATEGORIES.observability,
-
+      meta: {
+        keywords: [
+          'RUM',
+          'Real User Monitoring',
+          'DEM',
+          'Digital Experience Monitoring',
+          'EUM',
+          'End User Monitoring',
+          'UX',
+          'Javascript',
+          'APM',
+          'Mobile',
+          'digital',
+          'performance',
+          'web performance',
+          'web perf',
+        ],
+      },
       async mount(params: AppMountParameters<unknown>) {
         // Load application bundle and Get start service
         const [{ renderApp }, [coreStart, corePlugins]] = await Promise.all([

--- a/x-pack/plugins/uptime/public/apps/plugin.ts
+++ b/x-pack/plugins/uptime/public/apps/plugin.ts
@@ -87,6 +87,28 @@ export class UptimePlugin
       order: 8400,
       title: PLUGIN.TITLE,
       category: DEFAULT_APP_CATEGORIES.observability,
+      meta: {
+        keywords: [
+          'Synthetics',
+          'pings',
+          'checks',
+          'availability',
+          'response duration',
+          'response time',
+          'outside in',
+          'reachability',
+          'reachable',
+          'digital',
+          'performance',
+          'web performance',
+          'web perf',
+        ],
+        searchDeepLinks: [
+          { id: 'Down monitors', title: 'Down monitors', path: '/?statusFilter=down' },
+          { id: 'Certificates', title: 'TLS Certificates', path: '/certificates' },
+          { id: 'Settings', title: 'Settings', path: '/settings' },
+        ],
+      },
       mount: async (params: AppMountParameters) => {
         const [coreStart, corePlugins] = await core.getStartServices();
 


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/uptime/issues/256

Added nav search keywords for uptime and user experience app

User can search for uptime using following keywords

```
          'Synthetics',
          'pings',
          'checks',
          'availability',
          'response duration',
          'response time',
          'outside in',
          'reachability',
          'reachable',
          'digital',
          'performance',
          'web performance',
          'web perf',
```

and these deep links are also added
```

          { id: 'Down monitors', title: 'Down monitors', path: '/?statusFilter=down' },
          { id: 'Certificates', title: 'TLS Certificates', path: '/certificates' },
          { id: 'Settings', title: 'Settings', path: '/settings' },
```

User can search for UX app using following keywords
```

          'RUM',
          'Real User Monitoring',
          'DEM',
          'Digital Experience Monitoring',
          'EUM',
          'End User Monitoring',
          'UX',
          'Javascript',
          'APM',
          'Mobile',
          'digital',
          'performance',
          'web performance',
          'web perf',
```

Screenshots:

![image](https://user-images.githubusercontent.com/3505601/107235465-fe22ea00-6a24-11eb-8f66-057626ea631e.png)


![image](https://user-images.githubusercontent.com/3505601/107235493-0713bb80-6a25-11eb-8813-557950edb140.png)

