### PR TITLE
fix signal summary view truncation

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/summary_view.tsx
@@ -122,8 +122,8 @@ const getSummary = ({
         }
         const linkValueField =
           item.linkField != null && data.find((d) => d.field === item.linkField);
-        const linkValue = getOr(null, 'originalValue.0', linkValueField);
-        const value = getOr(null, 'originalValue.0', field);
+        const linkValue = getOr(null, 'originalValue', linkValueField);
+        const value = getOr(null, 'originalValue', field);
         const category = field.category;
         const fieldType = get(`${category}.fields.${field.field}.type`, browserFields) as string;
         const description = {


### PR DESCRIPTION
## Summary

FIxes https://github.com/elastic/kibana/issues/90539

When clicking to view signal summary, values are being truncated. This raises questions as to whether there were any changes upstream where values that we expected to be arrays are coming down as strings now.

### Bug
<img width="398" alt="truncation_bug" src="https://user-images.githubusercontent.com/10927944/107249287-11fc2b00-69e8-11eb-953d-f978094acb25.png">

### Fix
![Screen Shot 2021-02-08 at 8 27 08 AM](https://user-images.githubusercontent.com/10927944/107249334-20e2dd80-69e8-11eb-85ef-9b5e21bb847d.png)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)