### PR TITLE
[Workplace Search] Fix error message in Schema

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.test.ts
@@ -35,7 +35,12 @@ import { SchemaLogic, dataTypeOptions } from './schema_logic';
 
 describe('SchemaLogic', () => {
   const { http } = mockHttpValues;
-  const { clearFlashMessages, flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
+  const {
+    clearFlashMessages,
+    flashAPIErrors,
+    setSuccessMessage,
+    setErrorMessage,
+  } = mockFlashMessageHelpers;
   const { mount } = new LogicMounter(SchemaLogic);
 
   const defaultValues = {
@@ -298,10 +303,7 @@ describe('SchemaLogic', () => {
         );
         await nextTick();
 
-        expect(flashAPIErrors).toHaveBeenCalledWith({
-          error: 'this is an error',
-          message: SCHEMA_FIELD_ERRORS_ERROR_MESSAGE,
-        });
+        expect(setErrorMessage).toHaveBeenCalledWith(SCHEMA_FIELD_ERRORS_ERROR_MESSAGE);
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/schema/schema_logic.ts
@@ -13,6 +13,7 @@ import { ADD, UPDATE } from '../../../../../shared/constants/operations';
 import {
   flashAPIErrors,
   setSuccessMessage,
+  setErrorMessage,
   clearFlashMessages,
 } from '../../../../../shared/flash_messages';
 import { HttpLogic } from '../../../../../shared/http';
@@ -295,7 +296,7 @@ export const SchemaLogic = kea<MakeLogicType<SchemaValues, SchemaActions>>({
           fieldCoercionErrors: response.fieldCoercionErrors,
         });
       } catch (e) {
-        flashAPIErrors({ ...e, message: SCHEMA_FIELD_ERRORS_ERROR_MESSAGE });
+        setErrorMessage(SCHEMA_FIELD_ERRORS_ERROR_MESSAGE);
       }
     },
     addNewField: ({ fieldName, newFieldType }) => {


### PR DESCRIPTION
In SchemaErrors, we have an edge case where a user navigates to a non-existent schea errors state. When migrating I took a stab at passing the custom message to the `flashAPIErrors` helper. It turns out that since we don’t have to parse an error object, we can just set the error message directly

![image](https://user-images.githubusercontent.com/1869731/107437391-96d46b00-6af4-11eb-84e4-3513127a626f.png)
