### PR TITLE
[Lens] Fix "Advanced options" popover state

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/time_scaling.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/time_scaling.tsx
@@ -90,7 +90,7 @@ export function TimeScaling({
               iconSide="right"
               data-test-subj="indexPattern-time-scaling-popover"
               onClick={() => {
-                setPopoverOpen(true);
+                setPopoverOpen(!popoverOpen);
               }}
             >
               {i18n.translate('xpack.lens.indexPattern.timeScale.advancedSettings', {


### PR DESCRIPTION
Super simple fix - The old code wouldn't allow to close the popover after opening it by clicking on the button again.