### PR TITLE
[Lens] Median as default function

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -319,7 +319,7 @@ describe('IndexPattern Data Source suggestions', () => {
                       sourceField: 'timestamp',
                     }),
                     id2: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'bytes',
                     }),
                   },
@@ -400,7 +400,7 @@ describe('IndexPattern Data Source suggestions', () => {
                   columnOrder: ['id1'],
                   columns: {
                     id1: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'bytes',
                     }),
                   },
@@ -542,7 +542,7 @@ describe('IndexPattern Data Source suggestions', () => {
                       sourceField: 'timestamp',
                     }),
                     id1: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'bytes',
                     }),
                   },
@@ -624,7 +624,7 @@ describe('IndexPattern Data Source suggestions', () => {
                   columnOrder: ['id1'],
                   columns: {
                     id1: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'bytes',
                     }),
                   },
@@ -914,7 +914,7 @@ describe('IndexPattern Data Source suggestions', () => {
                   columns: {
                     cola: initialState.layers.currentLayer.columns.cola,
                     colb: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'memory',
                     }),
                   },
@@ -934,7 +934,7 @@ describe('IndexPattern Data Source suggestions', () => {
                     cola: initialState.layers.currentLayer.columns.cola,
                     colb: initialState.layers.currentLayer.columns.colb,
                     newid: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'memory',
                     }),
                   },
@@ -979,7 +979,7 @@ describe('IndexPattern Data Source suggestions', () => {
                   columns: {
                     ...modifiedState.layers.currentLayer.columns,
                     newid: expect.objectContaining({
-                      operationType: 'avg',
+                      operationType: 'median',
                       sourceField: 'memory',
                     }),
                   },
@@ -2039,7 +2039,7 @@ describe('IndexPattern Data Source suggestions', () => {
           table: expect.objectContaining({
             columns: [
               expect.objectContaining({
-                operation: expect.objectContaining({ label: 'Sum of field1' }),
+                operation: expect.objectContaining({ label: 'Median of field1' }),
               }),
             ],
           }),

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
@@ -181,6 +181,7 @@ export const sumOperation = buildMetricOperation<SumIndexPatternColumn>({
 
 export const medianOperation = buildMetricOperation<MedianIndexPatternColumn>({
   type: 'median',
+  priority: 3,
   displayName: i18n.translate('xpack.lens.indexPattern.median', {
     defaultMessage: 'Median',
   }),

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/operations.test.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/operations.test.ts
@@ -156,14 +156,14 @@ describe('getOperationTypesForField', () => {
   });
 
   describe('getAvailableOperationsByMetaData', () => {
-    it('should put the average operation first', () => {
+    it('should put the median operation first', () => {
       const numberOperation = getAvailableOperationsByMetadata(expectedIndexPatterns[1]).find(
         ({ operationMetaData }) =>
           !operationMetaData.isBucketed && operationMetaData.dataType === 'number'
       )!;
       expect(numberOperation.operations[0]).toEqual(
         expect.objectContaining({
-          operationType: 'avg',
+          operationType: 'median',
         })
       );
     });
@@ -240,6 +240,11 @@ describe('getOperationTypesForField', () => {
             "operations": Array [
               Object {
                 "field": "bytes",
+                "operationType": "median",
+                "type": "field",
+              },
+              Object {
+                "field": "bytes",
                 "operationType": "avg",
                 "type": "field",
               },
@@ -287,11 +292,6 @@ describe('getOperationTypesForField', () => {
               Object {
                 "field": "source",
                 "operationType": "cardinality",
-                "type": "field",
-              },
-              Object {
-                "field": "bytes",
-                "operationType": "median",
                 "type": "field",
               },
               Object {

--- a/x-pack/test/functional/apps/discover/visualize_field.ts
+++ b/x-pack/test/functional/apps/discover/visualize_field.ts
@@ -52,7 +52,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await retry.try(async () => {
         const dimensions = await testSubjects.findAll('lns-dimensionTrigger');
         expect(dimensions).to.have.length(2);
-        expect(await dimensions[1].getVisibleText()).to.be('Average of bytes');
+        expect(await dimensions[1].getVisibleText()).to.be('Median of bytes');
       });
     });
 

--- a/x-pack/test/functional/apps/lens/drag_and_drop.ts
+++ b/x-pack/test/functional/apps/lens/drag_and_drop.ts
@@ -149,7 +149,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
         await PageObjects.lens.dragFieldWithKeyboard('bytes', 4);
         expect(await PageObjects.lens.getDimensionTriggersTexts('lnsXY_yDimensionPanel')).to.eql([
           'Count of records',
-          'Average of bytes',
+          'Median of bytes',
         ]);
         await PageObjects.lens.dragFieldWithKeyboard('@message.raw', 1, true);
         expect(
@@ -169,7 +169,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
         await PageObjects.lens.dimensionKeyboardDragDrop('lnsXY_yDimensionPanel', 0, 1);
         expect(await PageObjects.lens.getDimensionTriggersTexts('lnsXY_yDimensionPanel')).to.eql([
           'Count of records',
-          'Average of bytes',
+          'Median of bytes',
           'Count of records [1]',
         ]);
 


### PR DESCRIPTION
As discussed offline, median is a better default function than average.

This PR makes sure to pick median over average in cases the user didn't specify a function (e.g. when dragging a field into the workspace)