### PR TITLE
[Core][SO] - Updating SO _find filter parser to take into consideration multi-fields

### DIFF
--- a/src/core/server/saved_objects/service/lib/filter_utils.ts
+++ b/src/core/server/saved_objects/service/lib/filter_utils.ts
@@ -205,7 +205,7 @@ export const hasFilterKeyError = (
   return null;
 };
 
-export const fieldDefined = (indexMappings: IndexMapping, key: string) => {
+export const fieldDefined = (indexMappings: IndexMapping, key: string): boolean => {
   const mappingKey = 'properties.' + key.split('.').join('.properties.');
   const potentialKey = get(indexMappings, mappingKey);
 
@@ -214,14 +214,16 @@ export const fieldDefined = (indexMappings: IndexMapping, key: string) => {
   // such as `x.attributes.field.text` where `field` is mapped to both text
   // and keyword
   if (potentialKey == null) {
-    const indexOfLastProperties = mappingKey.lastIndexOf('properties');
+    const propertiesAttribute = 'properties';
+    const indexOfLastProperties = mappingKey.lastIndexOf(propertiesAttribute);
     const fieldMapping = mappingKey.substr(0, indexOfLastProperties);
-    // The 11 here refers to the length of `properties.`
-    const fieldType = mappingKey.substr(mappingKey.lastIndexOf('properties') + 11);
-
+    const fieldType = mappingKey.substr(
+      mappingKey.lastIndexOf(propertiesAttribute) + `${propertiesAttribute}.`.length
+    );
     const mapping = `${fieldMapping}fields.${fieldType}`;
-    return get(indexMappings, mapping) != null;
-  }
 
-  return get(indexMappings, mappingKey) != null;
+    return get(indexMappings, mapping) != null;
+  } else {
+    return true;
+  }
 };


### PR DESCRIPTION
## Summary

This PR addresses the bug https://github.com/elastic/kibana/issues/90985 . Please see link for bug details.

TLDR: SO _find filter does not take into consideration that filter string can refer to multi-fields which should be parsed differently. This addition adds to the helper method that checks if there are any errors in the filter formatting.

Without this patch I'm blocked on https://github.com/elastic/kibana/pull/88701 that requires being able to filter by `.text`.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
