### PR TITLE
[Time to Visualize] Clear All Editor State when Visualize Listing Page Loads

### DIFF
--- a/docs/development/plugins/embeddable/public/kibana-plugin-plugins-embeddable-public.embeddablestatetransfer.cleareditorstate.md
+++ b/docs/development/plugins/embeddable/public/kibana-plugin-plugins-embeddable-public.embeddablestatetransfer.cleareditorstate.md
@@ -9,7 +9,7 @@ Clears the [editor state](./kibana-plugin-plugins-embeddable-public.embeddableed
 <b>Signature:</b>
 
 ```typescript
-clearEditorState(appId: string): void;
+clearEditorState(appId?: string): void;
 ```
 
 ## Parameters

--- a/src/plugins/embeddable/public/lib/state_transfer/embeddable_state_transfer.test.ts
+++ b/src/plugins/embeddable/public/lib/state_transfer/embeddable_state_transfer.test.ts
@@ -44,8 +44,6 @@ describe('embeddable state transfer', () => {
 
   const testAppId = 'testApp';
 
-  const buildKey = (appId: string, key: string) => `${appId}-${key}`;
-
   beforeEach(() => {
     currentAppId$ = new Subject();
     currentAppId$.next(originatingApp);
@@ -86,8 +84,10 @@ describe('embeddable state transfer', () => {
   it('can send an outgoing editor state', async () => {
     await stateTransfer.navigateToEditor(destinationApp, { state: { originatingApp } });
     expect(store.set).toHaveBeenCalledWith(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(destinationApp, EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'superUltraTestDashboard',
+      [EMBEDDABLE_EDITOR_STATE_KEY]: {
+        [destinationApp]: {
+          originatingApp: 'superUltraTestDashboard',
+        },
       },
     });
     expect(application.navigateToApp).toHaveBeenCalledWith('superUltraVisualize', {
@@ -104,8 +104,10 @@ describe('embeddable state transfer', () => {
     });
     expect(store.set).toHaveBeenCalledWith(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
       kibanaIsNowForSports: 'extremeSportsKibana',
-      [buildKey(destinationApp, EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'superUltraTestDashboard',
+      [EMBEDDABLE_EDITOR_STATE_KEY]: {
+        [destinationApp]: {
+          originatingApp: 'superUltraTestDashboard',
+        },
       },
     });
     expect(application.navigateToApp).toHaveBeenCalledWith('superUltraVisualize', {
@@ -125,9 +127,11 @@ describe('embeddable state transfer', () => {
       state: { type: 'coolestType', input: { savedObjectId: '150' } },
     });
     expect(store.set).toHaveBeenCalledWith(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(destinationApp, EMBEDDABLE_PACKAGE_STATE_KEY)]: {
-        type: 'coolestType',
-        input: { savedObjectId: '150' },
+      [EMBEDDABLE_PACKAGE_STATE_KEY]: {
+        [destinationApp]: {
+          type: 'coolestType',
+          input: { savedObjectId: '150' },
+        },
       },
     });
     expect(application.navigateToApp).toHaveBeenCalledWith('superUltraVisualize', {
@@ -144,9 +148,11 @@ describe('embeddable state transfer', () => {
     });
     expect(store.set).toHaveBeenCalledWith(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
       kibanaIsNowForSports: 'extremeSportsKibana',
-      [buildKey(destinationApp, EMBEDDABLE_PACKAGE_STATE_KEY)]: {
-        type: 'coolestType',
-        input: { savedObjectId: '150' },
+      [EMBEDDABLE_PACKAGE_STATE_KEY]: {
+        [destinationApp]: {
+          type: 'coolestType',
+          input: { savedObjectId: '150' },
+        },
       },
     });
     expect(application.navigateToApp).toHaveBeenCalledWith('superUltraVisualize', {
@@ -165,8 +171,10 @@ describe('embeddable state transfer', () => {
 
   it('can fetch an incoming editor state', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'superUltraTestDashboard',
+      [EMBEDDABLE_EDITOR_STATE_KEY]: {
+        [testAppId]: {
+          originatingApp: 'superUltraTestDashboard',
+        },
       },
     });
     const fetchedState = stateTransfer.getIncomingEditorState(testAppId);
@@ -175,14 +183,16 @@ describe('embeddable state transfer', () => {
 
   it('can fetch an incoming editor state and ignore state for other apps', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey('otherApp1', EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'whoops not me',
-      },
-      [buildKey('otherApp2', EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'otherTestDashboard',
-      },
-      [buildKey(testAppId, EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'superUltraTestDashboard',
+      [EMBEDDABLE_EDITOR_STATE_KEY]: {
+        otherApp1: {
+          originatingApp: 'whoops not me',
+        },
+        otherApp2: {
+          originatingApp: 'otherTestDashboard',
+        },
+        [testAppId]: {
+          originatingApp: 'superUltraTestDashboard',
+        },
       },
     });
     const fetchedState = stateTransfer.getIncomingEditorState(testAppId);
@@ -194,8 +204,10 @@ describe('embeddable state transfer', () => {
 
   it('incoming editor state returns undefined when state is not in the right shape', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        helloSportsKibana: 'superUltraTestDashboard',
+      [EMBEDDABLE_EDITOR_STATE_KEY]: {
+        [testAppId]: {
+          helloSportsKibana: 'superUltraTestDashboard',
+        },
       },
     });
     const fetchedState = stateTransfer.getIncomingEditorState(testAppId);
@@ -204,9 +216,11 @@ describe('embeddable state transfer', () => {
 
   it('can fetch an incoming embeddable package state', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_PACKAGE_STATE_KEY)]: {
-        type: 'skisEmbeddable',
-        input: { savedObjectId: '123' },
+      [EMBEDDABLE_PACKAGE_STATE_KEY]: {
+        [testAppId]: {
+          type: 'skisEmbeddable',
+          input: { savedObjectId: '123' },
+        },
       },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
@@ -215,13 +229,15 @@ describe('embeddable state transfer', () => {
 
   it('can fetch an incoming embeddable package state and ignore state for other apps', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_PACKAGE_STATE_KEY)]: {
-        type: 'skisEmbeddable',
-        input: { savedObjectId: '123' },
-      },
-      [buildKey('testApp2', EMBEDDABLE_PACKAGE_STATE_KEY)]: {
-        type: 'crossCountryEmbeddable',
-        input: { savedObjectId: '456' },
+      [EMBEDDABLE_PACKAGE_STATE_KEY]: {
+        [testAppId]: {
+          type: 'skisEmbeddable',
+          input: { savedObjectId: '123' },
+        },
+        testApp2: {
+          type: 'crossCountryEmbeddable',
+          input: { savedObjectId: '456' },
+        },
       },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
@@ -236,7 +252,11 @@ describe('embeddable state transfer', () => {
 
   it('embeddable package state returns undefined when state is not in the right shape', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_PACKAGE_STATE_KEY)]: { kibanaIsFor: 'sports' },
+      [EMBEDDABLE_PACKAGE_STATE_KEY]: {
+        [testAppId]: {
+          kibanaIsFor: 'sports',
+        },
+      },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
     expect(fetchedState).toBeUndefined();
@@ -244,9 +264,11 @@ describe('embeddable state transfer', () => {
 
   it('removes embeddable package key when removeAfterFetch is true', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_PACKAGE_STATE_KEY)]: {
-        type: 'coolestType',
-        input: { savedObjectId: '150' },
+      [EMBEDDABLE_PACKAGE_STATE_KEY]: {
+        [testAppId]: {
+          type: 'coolestType',
+          input: { savedObjectId: '150' },
+        },
       },
       iSHouldStillbeHere: 'doing the sports thing',
     });
@@ -258,8 +280,10 @@ describe('embeddable state transfer', () => {
 
   it('removes editor state key when removeAfterFetch is true', async () => {
     store.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
-      [buildKey(testAppId, EMBEDDABLE_EDITOR_STATE_KEY)]: {
-        originatingApp: 'superCoolFootballDashboard',
+      [EMBEDDABLE_EDITOR_STATE_KEY]: {
+        [testAppId]: {
+          originatingApp: 'superCoolFootballDashboard',
+        },
       },
       iSHouldStillbeHere: 'doing the sports thing',
     });

--- a/src/plugins/embeddable/public/public.api.md
+++ b/src/plugins/embeddable/public/public.api.md
@@ -590,7 +590,7 @@ export class EmbeddableStateTransfer {
     // Warning: (ae-forgotten-export) The symbol "ApplicationStart" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "PublicAppInfo" needs to be exported by the entry point index.d.ts
     constructor(navigateToApp: ApplicationStart['navigateToApp'], currentAppId$: ApplicationStart['currentAppId$'], appList?: ReadonlyMap<string, PublicAppInfo> | undefined, customStorage?: Storage);
-    clearEditorState(appId: string): void;
+    clearEditorState(appId?: string): void;
     getAppNameFromId: (appId: string) => string | undefined;
     getIncomingEditorState(appId: string, removeAfterFetch?: boolean): EmbeddableEditorState | undefined;
     getIncomingEmbeddablePackage(appId: string, removeAfterFetch?: boolean): EmbeddablePackageState | undefined;

--- a/src/plugins/visualize/public/application/components/visualize_listing.tsx
+++ b/src/plugins/visualize/public/application/components/visualize_listing.tsx
@@ -64,8 +64,8 @@ export const VisualizeListing = () => {
   }, [history, pathname, visualizations]);
 
   useMount(() => {
-    // Reset editor state if the visualize listing page is loaded.
-    stateTransferService.clearEditorState(VisualizeConstants.APP_ID);
+    // Reset editor state for all apps if the visualize listing page is loaded.
+    stateTransferService.clearEditorState();
     chrome.setBreadcrumbs([
       {
         text: i18n.translate('visualize.visualizeListingBreadcrumbsTitle', {


### PR DESCRIPTION
## Summary
Followup to https://github.com/elastic/kibana/pull/89804

Fixes an issue where visiting the visualize listing page would not clear editor state for all apps. The new app-specific editor state is now fully cleared on load of the visualize listing page.

### How to test:
1. From a dashboard, create a lens panel. Save and return
2. Also create a maps panel from the dashboard, save and return
3. Also create a visualize panel from the dashboard, save and return
4. Navigate to the Visualize app. Ensure the listing page loads, not the last visualization you were on.
5. Create a new Map, Lens, and Visualization from this page.
6. Each editor **should not** be linked to the originating app.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
