### PR TITLE
[Workplace Search] Break out MVP from in-progress app

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.test.tsx
@@ -13,6 +13,8 @@ import { shallow } from 'enzyme';
 
 import { SideNav, SideNavLink } from '../../../shared/layout';
 
+import { ALPHA_PATH } from '../../routes';
+
 import { WorkplaceSearchNav } from './';
 
 describe('WorkplaceSearchNav', () => {
@@ -20,7 +22,7 @@ describe('WorkplaceSearchNav', () => {
     const wrapper = shallow(<WorkplaceSearchNav />);
 
     expect(wrapper.find(SideNav)).toHaveLength(1);
-    expect(wrapper.find(SideNavLink).first().prop('to')).toEqual('/');
+    expect(wrapper.find(SideNavLink).first().prop('to')).toEqual(ALPHA_PATH);
     expect(wrapper.find(SideNavLink)).toHaveLength(6);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/nav.tsx
@@ -14,6 +14,7 @@ import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
 import { SideNav, SideNavLink } from '../../../shared/layout';
 import { NAV } from '../../constants';
 import {
+  ALPHA_PATH,
   SOURCES_PATH,
   SECURITY_PATH,
   ROLE_MAPPINGS_PATH,
@@ -33,7 +34,7 @@ export const WorkplaceSearchNav: React.FC<Props> = ({
   settingsSubNav,
 }) => (
   <SideNav product={WORKPLACE_SEARCH_PLUGIN}>
-    <SideNavLink to="/" isRoot>
+    <SideNavLink to={ALPHA_PATH} isRoot>
       {NAV.OVERVIEW}
     </SideNavLink>
     <SideNavLink to={SOURCES_PATH} subNav={sourcesSubNav}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -17,7 +17,7 @@ import { Layout } from '../shared/layout';
 
 import { WorkplaceSearchHeaderActions } from './components/layout';
 import { ErrorState } from './views/error_state';
-import { Overview } from './views/overview';
+import { Overview as OverviewMVP } from './views/overview_mvp';
 import { SetupGuide } from './views/setup_guide';
 
 import { WorkplaceSearch, WorkplaceSearchUnconfigured, WorkplaceSearchConfigured } from './';
@@ -60,7 +60,7 @@ describe('WorkplaceSearchConfigured', () => {
     const wrapper = shallow(<WorkplaceSearchConfigured />);
 
     expect(wrapper.find(Layout).first().prop('readOnlyMode')).toBeFalsy();
-    expect(wrapper.find(Overview)).toHaveLength(1);
+    expect(wrapper.find(OverviewMVP)).toHaveLength(1);
     expect(mockKibanaValues.renderHeaderActions).toHaveBeenCalledWith(WorkplaceSearchHeaderActions);
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -32,7 +32,7 @@ import { SourceSubNav } from './views/content_sources/components/source_sub_nav'
 import { ErrorState } from './views/error_state';
 import { GroupsRouter } from './views/groups';
 import { GroupSubNav } from './views/groups/components/group_sub_nav';
-import { Overview } from './views/overview';
+import { Overview as OverviewMVP } from './views/overview_mvp';
 import { Security } from './views/security';
 import { SettingsRouter } from './views/settings';
 import { SettingsSubNav } from './views/settings/components/settings_sub_nav';
@@ -78,7 +78,7 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
         <SetupGuide />
       </Route>
       <Route exact path="/">
-        {errorConnecting ? <ErrorState /> : <Overview />}
+        {errorConnecting ? <ErrorState /> : <OverviewMVP />}
       </Route>
       <Route path={PERSONAL_SOURCES_PATH}>
         {/* TODO: replace Layout with PrivateSourcesLayout (needs to be created) */}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -20,6 +20,7 @@ import { NotFound } from '../shared/not_found';
 import { AppLogic } from './app_logic';
 import { WorkplaceSearchNav, WorkplaceSearchHeaderActions } from './components/layout';
 import {
+  ALPHA_PATH,
   GROUPS_PATH,
   SETUP_GUIDE_PATH,
   SOURCES_PATH,
@@ -32,6 +33,7 @@ import { SourceSubNav } from './views/content_sources/components/source_sub_nav'
 import { ErrorState } from './views/error_state';
 import { GroupsRouter } from './views/groups';
 import { GroupSubNav } from './views/groups/components/group_sub_nav';
+import { Overview } from './views/overview';
 import { Overview as OverviewMVP } from './views/overview_mvp';
 import { Security } from './views/security';
 import { SettingsRouter } from './views/settings';
@@ -93,6 +95,11 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
           readOnlyMode={readOnlyMode}
         >
           <SourcesRouter />
+        </Layout>
+      </Route>
+      <Route path={ALPHA_PATH}>
+        <Layout navigation={<WorkplaceSearchNav />} restrictWidth readOnlyMode={readOnlyMode}>
+          <Overview />
         </Layout>
       </Route>
       <Route path={GROUPS_PATH}>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.ts
@@ -57,6 +57,7 @@ export const GROUPS_PATH = '/groups';
 export const GROUP_PATH = `${GROUPS_PATH}/:groupId`;
 export const GROUP_SOURCE_PRIORITIZATION_PATH = `${GROUPS_PATH}/:groupId/source_prioritization`;
 
+export const ALPHA_PATH = '/alpha';
 export const SOURCES_PATH = '/sources';
 export const PERSONAL_SOURCES_PATH = `${PERSONAL_PATH}${SOURCES_PATH}`;
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.test.tsx
@@ -13,7 +13,9 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiEmptyPrompt, EuiButton, EuiButtonEmpty } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiButtonEmpty } from '@elastic/eui';
+
+import { EuiButtonTo, EuiButtonEmptyTo } from '../../../shared/react_router_helpers';
 
 import { OnboardingCard } from './onboarding_card';
 
@@ -35,11 +37,11 @@ describe('OnboardingCard', () => {
     const wrapper = shallow(<OnboardingCard {...cardProps} actionPath="/some_path" />);
     const prompt = wrapper.find(EuiEmptyPrompt).dive();
 
-    expect(prompt.find(EuiButton)).toHaveLength(1);
-    expect(prompt.find(EuiButtonEmpty)).toHaveLength(0);
+    expect(prompt.find(EuiButtonTo)).toHaveLength(1);
+    expect(prompt.find(EuiButtonEmptyTo)).toHaveLength(0);
 
     const button = prompt.find('[data-test-subj="actionButton"]');
-    expect(button.prop('href')).toBe('http://localhost:3002/ws/some_path');
+    expect(button.prop('to')).toBe('/some_path');
 
     button.simulate('click');
     expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
@@ -49,7 +51,7 @@ describe('OnboardingCard', () => {
     const wrapper = shallow(<OnboardingCard {...cardProps} complete />);
     const prompt = wrapper.find(EuiEmptyPrompt).dive();
 
-    expect(prompt.find(EuiButton)).toHaveLength(0);
+    expect(prompt.find(EuiButtonTo)).toHaveLength(0);
     expect(prompt.find(EuiButtonEmpty)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_card.tsx
@@ -16,12 +16,9 @@ import {
   EuiPanel,
   EuiEmptyPrompt,
   IconType,
-  EuiButtonProps,
-  EuiButtonEmptyProps,
-  EuiLinkProps,
 } from '@elastic/eui';
 
-import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { EuiButtonTo, EuiButtonEmptyTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
 
 interface OnboardingCardProps {
@@ -50,25 +47,22 @@ export const OnboardingCard: React.FC<OnboardingCardProps> = ({
       action: 'clicked',
       metric: 'onboarding_card_button',
     });
-  const buttonActionProps = actionPath
-    ? {
-        onClick,
-        href: getWorkplaceSearchUrl(actionPath),
-        target: '_blank',
-        'data-test-subj': testSubj,
-      }
-    : {
-        'data-test-subj': testSubj,
-      };
 
-  const emptyButtonProps = {
-    ...buttonActionProps,
-  } as EuiButtonEmptyProps & EuiLinkProps;
-  const fillButtonProps = {
-    ...buttonActionProps,
-    color: 'secondary',
-    fill: true,
-  } as EuiButtonProps & EuiLinkProps;
+  const completeButton = actionPath ? (
+    <EuiButtonEmptyTo to={actionPath} data-test-subj={testSubj} onClick={onClick}>
+      {actionTitle}
+    </EuiButtonEmptyTo>
+  ) : (
+    <EuiButtonEmpty data-test-subj={testSubj}>{actionTitle}</EuiButtonEmpty>
+  );
+
+  const incompleteButton = actionPath ? (
+    <EuiButtonTo to={actionPath} data-test-subj={testSubj} onClick={onClick}>
+      {actionTitle}
+    </EuiButtonTo>
+  ) : (
+    <EuiButton data-test-subj={testSubj}>{actionTitle}</EuiButton>
+  );
 
   return (
     <EuiFlexItem>
@@ -78,13 +72,7 @@ export const OnboardingCard: React.FC<OnboardingCardProps> = ({
           iconColor={complete ? 'secondary' : 'subdued'}
           title={<h3>{title}</h3>}
           body={description}
-          actions={
-            complete ? (
-              <EuiButtonEmpty {...emptyButtonProps}>{actionTitle}</EuiButtonEmpty>
-            ) : (
-              <EuiButton {...fillButtonProps}>{actionTitle}</EuiButton>
-            )
-          }
+          actions={complete ? completeButton : incompleteButton}
         />
       </EuiPanel>
     </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx
@@ -11,20 +11,17 @@ import { useValues, useActions } from 'kea';
 
 import {
   EuiSpacer,
-  EuiButtonEmpty,
   EuiTitle,
   EuiPanel,
   EuiIcon,
   EuiFlexGrid,
   EuiFlexItem,
   EuiFlexGroup,
-  EuiButtonEmptyProps,
-  EuiLinkProps,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { EuiButtonEmptyTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
 import sharedSourcesIcon from '../../components/shared/assets/source_icons/share_circle.svg';
@@ -144,14 +141,6 @@ export const OrgNameOnboarding: React.FC = () => {
       metric: 'org_name_change_button',
     });
 
-  const buttonProps = {
-    onClick,
-    target: '_blank',
-    color: 'primary',
-    href: getWorkplaceSearchUrl(ORG_SETTINGS_PATH),
-    'data-test-subj': 'orgNameChangeButton',
-  } as EuiButtonEmptyProps & EuiLinkProps;
-
   return (
     <EuiPanel paddingSize="l">
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
@@ -169,12 +158,16 @@ export const OrgNameOnboarding: React.FC = () => {
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty {...buttonProps}>
+          <EuiButtonEmptyTo
+            to={ORG_SETTINGS_PATH}
+            onClick={onClick}
+            data-test-subj="orgNameChangeButton"
+          >
             <FormattedMessage
               id="xpack.enterpriseSearch.workplaceSearch.orgNameOnboarding.buttonLabel"
               defaultMessage="Name your organization"
             />
-          </EuiButtonEmpty>
+          </EuiButtonEmptyTo>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
@@ -5,20 +5,17 @@
  * 2.0.
  */
 
-// TODO: Remove EuiPage & EuiPageBody before exposing full app
-
 import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { Loading } from '../../../shared/loading';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
-import { ProductButton } from '../../components/shared/product_button';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
 
 import { OnboardingSteps } from './onboarding_steps';
@@ -76,11 +73,7 @@ export const Overview: React.FC = () => {
       <SetPageChrome />
       <SendTelemetry action="viewed" metric="overview" />
 
-      <ViewContentHeader
-        title={headerTitle}
-        description={headerDescription}
-        action={<ProductButton />}
-      />
+      <ViewContentHeader title={headerTitle} description={headerDescription} />
       {!hideOnboarding && <OnboardingSteps />}
       <EuiSpacer size="xl" />
       <OrganizationStats />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
@@ -72,22 +72,20 @@ export const Overview: React.FC = () => {
   const headerDescription = hideOnboarding ? HEADER_DESCRIPTION : ONBOARDING_HEADER_DESCRIPTION;
 
   return (
-    <EuiPage restrictWidth>
+    <>
       <SetPageChrome />
       <SendTelemetry action="viewed" metric="overview" />
 
-      <EuiPageBody>
-        <ViewContentHeader
-          title={headerTitle}
-          description={headerDescription}
-          action={<ProductButton />}
-        />
-        {!hideOnboarding && <OnboardingSteps />}
-        <EuiSpacer size="xl" />
-        <OrganizationStats />
-        <EuiSpacer size="xl" />
-        <RecentActivity />
-      </EuiPageBody>
-    </EuiPage>
+      <ViewContentHeader
+        title={headerTitle}
+        description={headerDescription}
+        action={<ProductButton />}
+      />
+      {!hideOnboarding && <OnboardingSteps />}
+      <EuiSpacer size="xl" />
+      <OrganizationStats />
+      <EuiSpacer size="xl" />
+      <RecentActivity />
+    </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview_logic.ts
@@ -7,6 +7,7 @@
 
 import { kea, MakeLogicType } from 'kea';
 
+import { flashAPIErrors } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 
 import { FeedActivity } from './recent_activity';
@@ -102,8 +103,12 @@ export const OverviewLogic = kea<MakeLogicType<OverviewValues, OverviewActions>>
   },
   listeners: ({ actions }) => ({
     initializeOverview: async () => {
-      const response = await HttpLogic.values.http.get('/api/workplace_search/overview');
-      actions.setServerData(response);
+      try {
+        const response = await HttpLogic.values.http.get('/api/workplace_search/overview');
+        actions.setServerData(response);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.test.tsx
@@ -13,8 +13,10 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
+import { EuiEmptyPrompt } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
+
+import { EuiLinkTo } from '../../../shared/react_router_helpers';
 
 import { setMockValues } from './__mocks__';
 import { RecentActivity, RecentActivityItem } from './recent_activity';
@@ -60,7 +62,7 @@ describe('RecentActivity', () => {
 
     expect(wrapper.find('.activity--error')).toHaveLength(1);
     expect(wrapper.find('.activity--error__label')).toHaveLength(1);
-    expect(wrapper.find(EuiLink).prop('color')).toEqual('danger');
+    expect(wrapper.find(EuiLinkTo).prop('color')).toEqual('danger');
   });
 
   it('renders recent activity message for default org name', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/recent_activity.tsx
@@ -10,10 +10,10 @@ import React from 'react';
 import { useValues, useActions } from 'kea';
 import moment from 'moment';
 
-import { EuiEmptyPrompt, EuiLink, EuiPanel, EuiSpacer, EuiLinkProps } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
 import { AppLogic } from '../../app_logic';
 import { ContentSection } from '../../components/shared/content_section';
@@ -95,19 +95,15 @@ export const RecentActivityItem: React.FC<FeedActivity> = ({
       metric: 'recent_activity_source_details_link',
     });
 
-  const linkProps = {
-    onClick,
-    target: '_blank',
-    href: getWorkplaceSearchUrl(getContentSourcePath(SOURCE_DETAILS_PATH, sourceId, true)),
-    external: true,
-    color: status === 'error' ? 'danger' : 'primary',
-    'data-test-subj': 'viewSourceDetailsLink',
-  } as EuiLinkProps;
-
   return (
     <div className={`activity ${status ? `activity--${status}` : ''}`}>
       <div className="activity__message">
-        <EuiLink {...linkProps}>
+        <EuiLinkTo
+          onClick={onClick}
+          color={status === 'error' ? 'danger' : 'primary'}
+          to={getContentSourcePath(SOURCE_DETAILS_PATH, sourceId, true)}
+          data-test-subj="viewSourceDetailsLink"
+        >
           {id} {message}
           {status === 'error' && (
             <span className="activity--error__label">
@@ -118,7 +114,7 @@ export const RecentActivityItem: React.FC<FeedActivity> = ({
               />
             </span>
           )}
-        </EuiLink>
+        </EuiLinkTo>
       </div>
       <div className="activity__date">{moment.utc(timestamp).fromNow()}</div>
     </div>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.test.tsx
@@ -13,6 +13,8 @@ import { shallow } from 'enzyme';
 
 import { EuiCard } from '@elastic/eui';
 
+import { EuiCardTo } from '../../../shared/react_router_helpers';
+
 import { StatisticCard } from './statistic_card';
 
 const props = {
@@ -29,6 +31,6 @@ describe('StatisticCard', () => {
   it('renders clickable card', () => {
     const wrapper = shallow(<StatisticCard {...props} actionPath="/foo" />);
 
-    expect(wrapper.find(EuiCard).prop('href')).toBe('http://localhost:3002/ws/foo');
+    expect(wrapper.find(EuiCardTo).prop('to')).toBe('/foo');
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/statistic_card.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { EuiCard, EuiFlexItem, EuiTitle, EuiTextColor } from '@elastic/eui';
 
-import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { EuiCardTo } from '../../../shared/react_router_helpers';
 
 interface StatisticCardProps {
   title: string;
@@ -18,28 +18,31 @@ interface StatisticCardProps {
 }
 
 export const StatisticCard: React.FC<StatisticCardProps> = ({ title, count = 0, actionPath }) => {
-  const linkProps = actionPath
-    ? {
-        href: getWorkplaceSearchUrl(actionPath),
-        target: '_blank',
-        rel: 'noopener',
+  const linkableCard = (
+    <EuiCardTo
+      to={actionPath || ''}
+      layout="horizontal"
+      title={title}
+      titleSize="xs"
+      description={
+        <EuiTitle size="l">
+          <EuiTextColor color="default">{count}</EuiTextColor>
+        </EuiTitle>
       }
-    : {};
-  // TODO: When we port this destination to Kibana, we'll want to create a EuiReactRouterCard component (see shared/react_router_helpers/eui_link.tsx)
-
-  return (
-    <EuiFlexItem>
-      <EuiCard
-        {...linkProps}
-        layout="horizontal"
-        title={title}
-        titleSize="xs"
-        description={
-          <EuiTitle size="l">
-            <EuiTextColor color={actionPath ? 'default' : 'subdued'}>{count}</EuiTextColor>
-          </EuiTitle>
-        }
-      />
-    </EuiFlexItem>
+    />
   );
+  const card = (
+    <EuiCard
+      layout="horizontal"
+      title={title}
+      titleSize="xs"
+      description={
+        <EuiTitle size="l">
+          <EuiTextColor color="subdued">{count}</EuiTextColor>
+        </EuiTitle>
+      }
+    />
+  );
+
+  return <EuiFlexItem>{actionPath ? linkableCard : card}</EuiFlexItem>;
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/__mocks__/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { setMockValues, mockOverviewValues, mockActions } from './overview_logic.mock';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/__mocks__/overview_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/__mocks__/overview_logic.mock.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_INITIAL_APP_DATA } from '../../../../../../common/__mocks__';
+import { setMockValues as setMockKeaValues, setMockActions } from '../../../../__mocks__/kea.mock';
+
+const { workplaceSearch: mockAppValues } = DEFAULT_INITIAL_APP_DATA;
+
+export const mockOverviewValues = {
+  accountsCount: 0,
+  activityFeed: [],
+  canCreateContentSources: false,
+  hasOrgSources: false,
+  hasUsers: false,
+  isOldAccount: false,
+  pendingInvitationsCount: 0,
+  personalSourcesCount: 0,
+  sourcesCount: 0,
+  dataLoading: true,
+};
+
+export const mockActions = {
+  initializeOverview: jest.fn(() => ({})),
+};
+
+const mockValues = { ...mockOverviewValues, ...mockAppValues, isFederatedAuth: true };
+
+setMockActions({ ...mockActions });
+setMockKeaValues({ ...mockValues });
+
+export const setMockValues = (values: object) => {
+  setMockKeaValues({ ...mockValues, ...values });
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { Overview } from './overview';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_card.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import '../../../__mocks__/kea.mock';
+import '../../../__mocks__/enterprise_search_url.mock';
+import { mockTelemetryActions } from '../../../__mocks__';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiEmptyPrompt, EuiButton, EuiButtonEmpty } from '@elastic/eui';
+
+import { OnboardingCard } from './onboarding_card';
+
+const cardProps = {
+  title: 'My card',
+  icon: 'icon',
+  description: 'this is a card',
+  actionTitle: 'action',
+  testSubj: 'actionButton',
+};
+
+describe('OnboardingCard', () => {
+  it('renders', () => {
+    const wrapper = shallow(<OnboardingCard {...cardProps} />);
+    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+  });
+
+  it('renders an action button', () => {
+    const wrapper = shallow(<OnboardingCard {...cardProps} actionPath="/some_path" />);
+    const prompt = wrapper.find(EuiEmptyPrompt).dive();
+
+    expect(prompt.find(EuiButton)).toHaveLength(1);
+    expect(prompt.find(EuiButtonEmpty)).toHaveLength(0);
+
+    const button = prompt.find('[data-test-subj="actionButton"]');
+    expect(button.prop('href')).toBe('http://localhost:3002/ws/some_path');
+
+    button.simulate('click');
+    expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
+  });
+
+  it('renders an empty button when onboarding is completed', () => {
+    const wrapper = shallow(<OnboardingCard {...cardProps} complete />);
+    const prompt = wrapper.find(EuiEmptyPrompt).dive();
+
+    expect(prompt.find(EuiButton)).toHaveLength(0);
+    expect(prompt.find(EuiButtonEmpty)).toHaveLength(1);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_card.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useActions } from 'kea';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexItem,
+  EuiPanel,
+  EuiEmptyPrompt,
+  IconType,
+  EuiButtonProps,
+  EuiButtonEmptyProps,
+  EuiLinkProps,
+} from '@elastic/eui';
+
+import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../shared/telemetry';
+
+interface OnboardingCardProps {
+  title: React.ReactNode;
+  icon: React.ReactNode;
+  description: React.ReactNode;
+  actionTitle: React.ReactNode;
+  testSubj: string;
+  actionPath?: string;
+  complete?: boolean;
+}
+
+export const OnboardingCard: React.FC<OnboardingCardProps> = ({
+  title,
+  icon,
+  description,
+  actionTitle,
+  testSubj,
+  actionPath,
+  complete,
+}) => {
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
+
+  const onClick = () =>
+    sendWorkplaceSearchTelemetry({
+      action: 'clicked',
+      metric: 'onboarding_card_button',
+    });
+  const buttonActionProps = actionPath
+    ? {
+        onClick,
+        href: getWorkplaceSearchUrl(actionPath),
+        target: '_blank',
+        'data-test-subj': testSubj,
+      }
+    : {
+        'data-test-subj': testSubj,
+      };
+
+  const emptyButtonProps = {
+    ...buttonActionProps,
+  } as EuiButtonEmptyProps & EuiLinkProps;
+  const fillButtonProps = {
+    ...buttonActionProps,
+    color: 'secondary',
+    fill: true,
+  } as EuiButtonProps & EuiLinkProps;
+
+  return (
+    <EuiFlexItem>
+      <EuiPanel>
+        <EuiEmptyPrompt
+          iconType={complete ? 'checkInCircleFilled' : (icon as IconType)}
+          iconColor={complete ? 'secondary' : 'subdued'}
+          title={<h3>{title}</h3>}
+          body={description}
+          actions={
+            complete ? (
+              <EuiButtonEmpty {...emptyButtonProps}>{actionTitle}</EuiButtonEmpty>
+            ) : (
+              <EuiButton {...fillButtonProps}>{actionTitle}</EuiButton>
+            )
+          }
+        />
+      </EuiPanel>
+    </EuiFlexItem>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_steps.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_steps.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockTelemetryActions } from '../../../__mocks__';
+
+import './__mocks__/overview_logic.mock';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { SOURCES_PATH, USERS_PATH } from '../../routes';
+
+import { setMockValues } from './__mocks__';
+import { OnboardingCard } from './onboarding_card';
+import { OnboardingSteps, OrgNameOnboarding } from './onboarding_steps';
+
+const account = {
+  id: '1',
+  isAdmin: true,
+  canCreatePersonalSources: true,
+  groups: [],
+  isCurated: false,
+  canCreateInvitations: true,
+};
+
+describe('OnboardingSteps', () => {
+  describe('Shared Sources', () => {
+    it('renders 0 sources state', () => {
+      setMockValues({ canCreateContentSources: true });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      expect(wrapper.find(OnboardingCard)).toHaveLength(1);
+      expect(wrapper.find(OnboardingCard).prop('actionPath')).toBe(SOURCES_PATH);
+      expect(wrapper.find(OnboardingCard).prop('description')).toBe(
+        'Add shared sources for your organization to start searching.'
+      );
+    });
+
+    it('renders completed sources state', () => {
+      setMockValues({ sourcesCount: 2, hasOrgSources: true });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      expect(wrapper.find(OnboardingCard).prop('description')).toEqual(
+        'You have added 2 shared sources. Happy searching.'
+      );
+    });
+
+    it('disables link when the user cannot create sources', () => {
+      setMockValues({ canCreateContentSources: false });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      expect(wrapper.find(OnboardingCard).prop('actionPath')).toBe(undefined);
+    });
+  });
+
+  describe('Users & Invitations', () => {
+    it('renders 0 users when not on federated auth', () => {
+      setMockValues({
+        isFederatedAuth: false,
+        account,
+        accountsCount: 0,
+        hasUsers: false,
+      });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      expect(wrapper.find(OnboardingCard)).toHaveLength(2);
+      expect(wrapper.find(OnboardingCard).last().prop('actionPath')).toBe(USERS_PATH);
+      expect(wrapper.find(OnboardingCard).last().prop('description')).toEqual(
+        'Invite your colleagues into this organization to search with you.'
+      );
+    });
+
+    it('renders completed users state', () => {
+      setMockValues({
+        isFederatedAuth: false,
+        account,
+        accountsCount: 1,
+        hasUsers: true,
+      });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      expect(wrapper.find(OnboardingCard).last().prop('description')).toEqual(
+        'Nice, you’ve invited colleagues to search with you.'
+      );
+    });
+
+    it('disables link when the user cannot create invitations', () => {
+      setMockValues({
+        isFederatedAuth: false,
+        account: {
+          ...account,
+          canCreateInvitations: false,
+        },
+      });
+      const wrapper = shallow(<OnboardingSteps />);
+      expect(wrapper.find(OnboardingCard).last().prop('actionPath')).toBe(undefined);
+    });
+  });
+
+  describe('Org Name', () => {
+    it('renders button to change name', () => {
+      setMockValues({
+        organization: {
+          name: 'foo',
+          defaultOrgName: 'foo',
+        },
+      });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      const button = wrapper
+        .find(OrgNameOnboarding)
+        .dive()
+        .find('[data-test-subj="orgNameChangeButton"]');
+
+      button.simulate('click');
+      expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
+    });
+
+    it('hides card when name has been changed', () => {
+      setMockValues({
+        organization: {
+          name: 'foo',
+          defaultOrgName: 'bar',
+        },
+      });
+      const wrapper = shallow(<OnboardingSteps />);
+
+      expect(wrapper.find(OrgNameOnboarding)).toHaveLength(0);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_steps.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/onboarding_steps.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues, useActions } from 'kea';
+
+import {
+  EuiSpacer,
+  EuiButtonEmpty,
+  EuiTitle,
+  EuiPanel,
+  EuiIcon,
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiButtonEmptyProps,
+  EuiLinkProps,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
+import sharedSourcesIcon from '../../components/shared/assets/source_icons/share_circle.svg';
+import { ContentSection } from '../../components/shared/content_section';
+import { SOURCES_PATH, USERS_PATH, ORG_SETTINGS_PATH } from '../../routes';
+
+import { OnboardingCard } from './onboarding_card';
+import { OverviewLogic } from './overview_logic';
+
+const SOURCES_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingSourcesCard.title',
+  { defaultMessage: 'Shared sources' }
+);
+
+const USERS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingUsersCard.title',
+  { defaultMessage: 'Users & invitations' }
+);
+
+const ONBOARDING_SOURCES_CARD_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingSourcesCard.description',
+  { defaultMessage: 'Add shared sources for your organization to start searching.' }
+);
+
+const USERS_CARD_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewUsersCard.title',
+  { defaultMessage: 'Nice, you’ve invited colleagues to search with you.' }
+);
+
+const ONBOARDING_USERS_CARD_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingUsersCard.description',
+  { defaultMessage: 'Invite your colleagues into this organization to search with you.' }
+);
+
+export const OnboardingSteps: React.FC = () => {
+  const {
+    isFederatedAuth,
+    organization: { name, defaultOrgName },
+    account: { isCurated, canCreateInvitations },
+  } = useValues(AppLogic);
+
+  const {
+    hasUsers,
+    hasOrgSources,
+    canCreateContentSources,
+    accountsCount,
+    sourcesCount,
+  } = useValues(OverviewLogic);
+
+  const accountsPath =
+    !isFederatedAuth && (canCreateInvitations || isCurated) ? USERS_PATH : undefined;
+  const sourcesPath = canCreateContentSources || isCurated ? SOURCES_PATH : undefined;
+
+  const SOURCES_CARD_DESCRIPTION = i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.sourcesOnboardingCard.description',
+    {
+      defaultMessage:
+        'You have added {sourcesCount, number} shared {sourcesCount, plural, one {source} other {sources}}. Happy searching.',
+      values: { sourcesCount },
+    }
+  );
+
+  return (
+    <ContentSection>
+      <EuiFlexGrid columns={isFederatedAuth ? 1 : 2}>
+        <OnboardingCard
+          title={SOURCES_TITLE}
+          testSubj="sharedSourcesButton"
+          icon={sharedSourcesIcon}
+          description={
+            hasOrgSources ? SOURCES_CARD_DESCRIPTION : ONBOARDING_SOURCES_CARD_DESCRIPTION
+          }
+          actionTitle={i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.sourcesOnboardingCard.buttonLabel',
+            {
+              defaultMessage: 'Add {label} sources',
+              values: { label: sourcesCount > 0 ? 'more' : '' },
+            }
+          )}
+          actionPath={sourcesPath}
+          complete={hasOrgSources}
+        />
+        {!isFederatedAuth && (
+          <OnboardingCard
+            title={USERS_TITLE}
+            testSubj="usersButton"
+            icon="user"
+            description={hasUsers ? USERS_CARD_DESCRIPTION : ONBOARDING_USERS_CARD_DESCRIPTION}
+            actionTitle={i18n.translate(
+              'xpack.enterpriseSearch.workplaceSearch.usersOnboardingCard.buttonLabel',
+              {
+                defaultMessage: 'Invite {label} users',
+                values: { label: accountsCount > 0 ? 'more' : '' },
+              }
+            )}
+            actionPath={accountsPath}
+            complete={hasUsers}
+          />
+        )}
+      </EuiFlexGrid>
+      {name === defaultOrgName && (
+        <>
+          <EuiSpacer />
+          <OrgNameOnboarding />
+        </>
+      )}
+    </ContentSection>
+  );
+};
+
+export const OrgNameOnboarding: React.FC = () => {
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
+
+  const onClick = () =>
+    sendWorkplaceSearchTelemetry({
+      action: 'clicked',
+      metric: 'org_name_change_button',
+    });
+
+  const buttonProps = {
+    onClick,
+    target: '_blank',
+    color: 'primary',
+    href: getWorkplaceSearchUrl(ORG_SETTINGS_PATH),
+    'data-test-subj': 'orgNameChangeButton',
+  } as EuiButtonEmptyProps & EuiLinkProps;
+
+  return (
+    <EuiPanel paddingSize="l">
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
+        <EuiFlexItem className="eui-hideFor--xs eui-hideFor--s" grow={false}>
+          <EuiIcon type="training" color="subdued" size="xl" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="xs">
+            <h4>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.workplaceSearch.orgNameOnboarding.description"
+                defaultMessage="Before inviting your colleagues, name your organization to improve recognition."
+              />
+            </h4>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty {...buttonProps}>
+            <FormattedMessage
+              id="xpack.enterpriseSearch.workplaceSearch.orgNameOnboarding.buttonLabel"
+              defaultMessage="Name your organization"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/organization_stats.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/organization_stats.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import './__mocks__/overview_logic.mock';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiFlexGrid } from '@elastic/eui';
+
+import { setMockValues } from './__mocks__';
+import { OrganizationStats } from './organization_stats';
+import { StatisticCard } from './statistic_card';
+
+describe('OrganizationStats', () => {
+  it('renders', () => {
+    const wrapper = shallow(<OrganizationStats />);
+
+    expect(wrapper.find(StatisticCard)).toHaveLength(2);
+    expect(wrapper.find(EuiFlexGrid).prop('columns')).toEqual(2);
+  });
+
+  it('renders additional cards for federated auth', () => {
+    setMockValues({ isFederatedAuth: false });
+    const wrapper = shallow(<OrganizationStats />);
+
+    expect(wrapper.find(StatisticCard)).toHaveLength(4);
+    expect(wrapper.find(EuiFlexGrid).prop('columns')).toEqual(4);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/organization_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/organization_stats.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues } from 'kea';
+
+import { EuiFlexGrid } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { AppLogic } from '../../app_logic';
+import { ContentSection } from '../../components/shared/content_section';
+import { SOURCES_PATH, USERS_PATH } from '../../routes';
+
+import { OverviewLogic } from './overview_logic';
+import { StatisticCard } from './statistic_card';
+
+export const OrganizationStats: React.FC = () => {
+  const { isFederatedAuth } = useValues(AppLogic);
+
+  const { sourcesCount, pendingInvitationsCount, accountsCount, personalSourcesCount } = useValues(
+    OverviewLogic
+  );
+
+  return (
+    <ContentSection
+      title={
+        <FormattedMessage
+          id="xpack.enterpriseSearch.workplaceSearch.organizationStats.title"
+          defaultMessage="Usage statistics"
+        />
+      }
+      headerSpacer="m"
+    >
+      <EuiFlexGrid columns={isFederatedAuth ? 2 : 4}>
+        <StatisticCard
+          title={i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.organizationStats.sharedSources',
+            { defaultMessage: 'Shared sources' }
+          )}
+          count={sourcesCount}
+          actionPath={SOURCES_PATH}
+        />
+        {!isFederatedAuth && (
+          <>
+            <StatisticCard
+              title={i18n.translate(
+                'xpack.enterpriseSearch.workplaceSearch.organizationStats.invitations',
+                { defaultMessage: 'Invitations' }
+              )}
+              count={pendingInvitationsCount}
+              actionPath={USERS_PATH}
+            />
+            <StatisticCard
+              title={i18n.translate(
+                'xpack.enterpriseSearch.workplaceSearch.organizationStats.activeUsers',
+                { defaultMessage: 'Active users' }
+              )}
+              count={accountsCount}
+              actionPath={USERS_PATH}
+            />
+          </>
+        )}
+        <StatisticCard
+          title={i18n.translate(
+            'xpack.enterpriseSearch.workplaceSearch.organizationStats.privateSources',
+            { defaultMessage: 'Private sources' }
+          )}
+          count={personalSourcesCount}
+        />
+      </EuiFlexGrid>
+    </ContentSection>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import '../../../__mocks__/react_router_history.mock';
+import './__mocks__/overview_logic.mock';
+
+import React from 'react';
+
+import { shallow, mount } from 'enzyme';
+
+import { Loading } from '../../../shared/loading';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
+
+import { mockActions, setMockValues } from './__mocks__';
+import { OnboardingSteps } from './onboarding_steps';
+import { OrganizationStats } from './organization_stats';
+import { Overview } from './overview';
+import { RecentActivity } from './recent_activity';
+
+describe('Overview', () => {
+  describe('non-happy-path states', () => {
+    it('isLoading', () => {
+      const wrapper = shallow(<Overview />);
+
+      expect(wrapper.find(Loading)).toHaveLength(1);
+    });
+  });
+
+  describe('happy-path states', () => {
+    it('calls initialize function', async () => {
+      mount(<Overview />);
+
+      expect(mockActions.initializeOverview).toHaveBeenCalled();
+    });
+
+    it('renders onboarding state', () => {
+      setMockValues({ dataLoading: false });
+      const wrapper = shallow(<Overview />);
+
+      expect(wrapper.find(ViewContentHeader)).toHaveLength(1);
+      expect(wrapper.find(OnboardingSteps)).toHaveLength(1);
+      expect(wrapper.find(OrganizationStats)).toHaveLength(1);
+      expect(wrapper.find(RecentActivity)).toHaveLength(1);
+    });
+
+    it('renders when onboarding complete', () => {
+      setMockValues({
+        dataLoading: false,
+        hasUsers: true,
+        hasOrgSources: true,
+        isOldAccount: true,
+        organization: {
+          name: 'foo',
+          defaultOrgName: 'bar',
+        },
+      });
+      const wrapper = shallow(<Overview />);
+
+      expect(wrapper.find(OnboardingSteps)).toHaveLength(0);
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// TODO: Remove EuiPage & EuiPageBody before exposing full app
+
+import React, { useEffect } from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { Loading } from '../../../shared/loading';
+import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
+import { ProductButton } from '../../components/shared/product_button';
+import { ViewContentHeader } from '../../components/shared/view_content_header';
+
+import { OnboardingSteps } from './onboarding_steps';
+import { OrganizationStats } from './organization_stats';
+import { OverviewLogic } from './overview_logic';
+import { RecentActivity } from './recent_activity';
+
+const ONBOARDING_HEADER_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingHeader.title',
+  { defaultMessage: 'Get started with Workplace Search' }
+);
+
+const HEADER_TITLE = i18n.translate('xpack.enterpriseSearch.workplaceSearch.overviewHeader.title', {
+  defaultMessage: 'Organization overview',
+});
+
+const ONBOARDING_HEADER_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewOnboardingHeader.description',
+  { defaultMessage: 'Complete the following to set up your organization.' }
+);
+
+const HEADER_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.overviewHeader.description',
+  { defaultMessage: "Your organizations's statistics and activity" }
+);
+
+export const Overview: React.FC = () => {
+  const {
+    organization: { name: orgName, defaultOrgName },
+  } = useValues(AppLogic);
+
+  const { initializeOverview } = useActions(OverviewLogic);
+  const { dataLoading, hasUsers, hasOrgSources, isOldAccount } = useValues(OverviewLogic);
+
+  useEffect(() => {
+    initializeOverview();
+  }, [initializeOverview]);
+
+  // TODO: Remove div wrapper once the Overview page is using the full Layout
+  if (dataLoading) {
+    return (
+      <div style={{ height: '90vh' }}>
+        <Loading />
+      </div>
+    );
+  }
+
+  const hideOnboarding = hasUsers && hasOrgSources && isOldAccount && orgName !== defaultOrgName;
+
+  const headerTitle = hideOnboarding ? HEADER_TITLE : ONBOARDING_HEADER_TITLE;
+  const headerDescription = hideOnboarding ? HEADER_DESCRIPTION : ONBOARDING_HEADER_DESCRIPTION;
+
+  return (
+    <EuiPage restrictWidth>
+      <SetPageChrome />
+      <SendTelemetry action="viewed" metric="overview" />
+
+      <EuiPageBody>
+        <ViewContentHeader
+          title={headerTitle}
+          description={headerDescription}
+          action={<ProductButton />}
+        />
+        {!hideOnboarding && <OnboardingSteps />}
+        <EuiSpacer size="xl" />
+        <OrganizationStats />
+        <EuiSpacer size="xl" />
+        <RecentActivity />
+      </EuiPageBody>
+    </EuiPage>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview_logic.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogicMounter, mockHttpValues } from '../../../__mocks__';
+
+import { mockOverviewValues } from './__mocks__';
+import { OverviewLogic } from './overview_logic';
+
+describe('OverviewLogic', () => {
+  const { mount } = new LogicMounter(OverviewLogic);
+  const { http } = mockHttpValues;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mount();
+  });
+
+  it('has expected default values', () => {
+    expect(OverviewLogic.values).toEqual(mockOverviewValues);
+  });
+
+  describe('setServerData', () => {
+    const feed = [{ foo: 'bar' }] as any;
+
+    const data = {
+      accountsCount: 1,
+      activityFeed: feed,
+      canCreateContentSources: true,
+      hasOrgSources: true,
+      hasUsers: true,
+      isOldAccount: true,
+      pendingInvitationsCount: 1,
+      personalSourcesCount: 1,
+      sourcesCount: 1,
+    };
+
+    beforeEach(() => {
+      OverviewLogic.actions.setServerData(data);
+    });
+
+    it('will set `dataLoading` to false', () => {
+      expect(OverviewLogic.values.dataLoading).toEqual(false);
+    });
+
+    it('will set server values', () => {
+      expect(OverviewLogic.values.hasUsers).toEqual(true);
+      expect(OverviewLogic.values.hasOrgSources).toEqual(true);
+      expect(OverviewLogic.values.canCreateContentSources).toEqual(true);
+      expect(OverviewLogic.values.isOldAccount).toEqual(true);
+      expect(OverviewLogic.values.sourcesCount).toEqual(1);
+      expect(OverviewLogic.values.pendingInvitationsCount).toEqual(1);
+      expect(OverviewLogic.values.accountsCount).toEqual(1);
+      expect(OverviewLogic.values.personalSourcesCount).toEqual(1);
+      expect(OverviewLogic.values.activityFeed).toEqual(feed);
+    });
+  });
+
+  describe('initializeOverview', () => {
+    it('calls API and sets values', async () => {
+      const setServerDataSpy = jest.spyOn(OverviewLogic.actions, 'setServerData');
+
+      await OverviewLogic.actions.initializeOverview();
+
+      expect(http.get).toHaveBeenCalledWith('/api/workplace_search/overview');
+      expect(setServerDataSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview_logic.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { HttpLogic } from '../../../shared/http';
+
+import { FeedActivity } from './recent_activity';
+
+interface OverviewServerData {
+  hasUsers: boolean;
+  hasOrgSources: boolean;
+  canCreateContentSources: boolean;
+  isOldAccount: boolean;
+  sourcesCount: number;
+  pendingInvitationsCount: number;
+  accountsCount: number;
+  personalSourcesCount: number;
+  activityFeed: FeedActivity[];
+}
+
+interface OverviewActions {
+  setServerData(serverData: OverviewServerData): OverviewServerData;
+  initializeOverview(): void;
+}
+
+interface OverviewValues extends OverviewServerData {
+  dataLoading: boolean;
+}
+
+export const OverviewLogic = kea<MakeLogicType<OverviewValues, OverviewActions>>({
+  path: ['enterprise_search', 'workplace_search', 'overview_logic'],
+  actions: {
+    setServerData: (serverData) => serverData,
+    initializeOverview: () => null,
+  },
+  reducers: {
+    hasUsers: [
+      false,
+      {
+        setServerData: (_, { hasUsers }) => hasUsers,
+      },
+    ],
+    hasOrgSources: [
+      false,
+      {
+        setServerData: (_, { hasOrgSources }) => hasOrgSources,
+      },
+    ],
+    canCreateContentSources: [
+      false,
+      {
+        setServerData: (_, { canCreateContentSources }) => canCreateContentSources,
+      },
+    ],
+    isOldAccount: [
+      false,
+      {
+        setServerData: (_, { isOldAccount }) => isOldAccount,
+      },
+    ],
+    sourcesCount: [
+      0,
+      {
+        setServerData: (_, { sourcesCount }) => sourcesCount,
+      },
+    ],
+    pendingInvitationsCount: [
+      0,
+      {
+        setServerData: (_, { pendingInvitationsCount }) => pendingInvitationsCount,
+      },
+    ],
+    accountsCount: [
+      0,
+      {
+        setServerData: (_, { accountsCount }) => accountsCount,
+      },
+    ],
+    personalSourcesCount: [
+      0,
+      {
+        setServerData: (_, { personalSourcesCount }) => personalSourcesCount,
+      },
+    ],
+    activityFeed: [
+      [],
+      {
+        setServerData: (_, { activityFeed }) => activityFeed,
+      },
+    ],
+    dataLoading: [
+      true,
+      {
+        setServerData: () => false,
+      },
+    ],
+  },
+  listeners: ({ actions }) => ({
+    initializeOverview: async () => {
+      const response = await HttpLogic.values.http.get('/api/workplace_search/overview');
+      actions.setServerData(response);
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/overview_logic.ts
@@ -7,6 +7,7 @@
 
 import { kea, MakeLogicType } from 'kea';
 
+import { flashAPIErrors } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 
 import { FeedActivity } from './recent_activity';
@@ -102,8 +103,12 @@ export const OverviewLogic = kea<MakeLogicType<OverviewValues, OverviewActions>>
   },
   listeners: ({ actions }) => ({
     initializeOverview: async () => {
-      const response = await HttpLogic.values.http.get('/api/workplace_search/overview');
-      actions.setServerData(response);
+      try {
+        const response = await HttpLogic.values.http.get('/api/workplace_search/overview');
+        actions.setServerData(response);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
     },
   }),
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/recent_activity.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/recent_activity.scss
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+.activity {
+  display: flex;
+  justify-content: space-between;
+  padding: $euiSizeM;
+  font-size: $euiFontSizeS;
+
+  &--error {
+    font-weight: $euiFontWeightSemiBold;
+    color: $euiColorDanger;
+    background: rgba($euiColorDanger, .1);
+
+    &__label {
+      margin-left: $euiSizeS * 1.75;
+      font-weight: $euiFontWeightRegular;
+      text-decoration: underline;
+      opacity: .7;
+    }
+  }
+
+  &__message {
+    flex-grow: 1;
+  }
+
+  &__date {
+    flex-grow: 0;
+  }
+
+  & + & {
+    border-top: $euiBorderThin;
+  }
+}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/recent_activity.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/recent_activity.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockTelemetryActions } from '../../../__mocks__';
+
+import './__mocks__/overview_logic.mock';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiEmptyPrompt, EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { setMockValues } from './__mocks__';
+import { RecentActivity, RecentActivityItem } from './recent_activity';
+
+const organization = { name: 'foo', defaultOrgName: 'bar' };
+
+const activityFeed = [
+  {
+    id: 'demo',
+    sourceId: 'd2d2d23d',
+    message: 'was successfully connected',
+    target: 'http://localhost:3002/ws/org/sources',
+    timestamp: '2020-06-24 16:34:16',
+  },
+];
+
+describe('RecentActivity', () => {
+  it('renders with no activityFeed data', () => {
+    const wrapper = shallow(<RecentActivity />);
+
+    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+
+    // Branch coverage - renders without error for custom org name
+    setMockValues({ organization });
+    shallow(<RecentActivity />);
+  });
+
+  it('renders an activityFeed with links', () => {
+    setMockValues({ activityFeed });
+    const wrapper = shallow(<RecentActivity />);
+    const activity = wrapper.find(RecentActivityItem).dive();
+
+    expect(activity).toHaveLength(1);
+
+    const link = activity.find('[data-test-subj="viewSourceDetailsLink"]');
+    link.simulate('click');
+    expect(mockTelemetryActions.sendWorkplaceSearchTelemetry).toHaveBeenCalled();
+  });
+
+  it('renders activity item error state', () => {
+    const props = { ...activityFeed[0], status: 'error' };
+    const wrapper = shallow(<RecentActivityItem {...props} />);
+
+    expect(wrapper.find('.activity--error')).toHaveLength(1);
+    expect(wrapper.find('.activity--error__label')).toHaveLength(1);
+    expect(wrapper.find(EuiLink).prop('color')).toEqual('danger');
+  });
+
+  it('renders recent activity message for default org name', () => {
+    setMockValues({
+      organization: {
+        name: 'foo',
+        defaultOrgName: 'foo',
+      },
+    });
+    const wrapper = shallow(<RecentActivity />);
+    const emptyPrompt = wrapper.find(EuiEmptyPrompt).dive();
+
+    expect(emptyPrompt.find(FormattedMessage).prop('defaultMessage')).toEqual(
+      'Your organization has no recent activity'
+    );
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/recent_activity.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/recent_activity.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { useValues, useActions } from 'kea';
+import moment from 'moment';
+
+import { EuiEmptyPrompt, EuiLink, EuiPanel, EuiSpacer, EuiLinkProps } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+
+import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+import { TelemetryLogic } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
+import { ContentSection } from '../../components/shared/content_section';
+import { RECENT_ACTIVITY_TITLE } from '../../constants';
+import { SOURCE_DETAILS_PATH, getContentSourcePath } from '../../routes';
+
+import { OverviewLogic } from './overview_logic';
+
+import './recent_activity.scss';
+
+export interface FeedActivity {
+  status?: string;
+  id: string;
+  message: string;
+  timestamp: string;
+  sourceId: string;
+}
+
+export const RecentActivity: React.FC = () => {
+  const {
+    organization: { name, defaultOrgName },
+  } = useValues(AppLogic);
+
+  const { activityFeed } = useValues(OverviewLogic);
+
+  return (
+    <ContentSection title={RECENT_ACTIVITY_TITLE} headerSpacer="m">
+      <EuiPanel>
+        {activityFeed.length > 0 ? (
+          <>
+            {activityFeed.map((props: FeedActivity, index) => (
+              <RecentActivityItem {...props} key={index} />
+            ))}
+          </>
+        ) : (
+          <>
+            <EuiSpacer size="xl" />
+            <EuiEmptyPrompt
+              iconType="clock"
+              iconColor="subdued"
+              titleSize="s"
+              title={
+                <h3>
+                  {name === defaultOrgName ? (
+                    <FormattedMessage
+                      id="xpack.enterpriseSearch.workplaceSearch.activityFeedEmptyDefault.title"
+                      defaultMessage="Your organization has no recent activity"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="xpack.enterpriseSearch.workplaceSearch.activityFeedNamedDefault.title"
+                      defaultMessage="{name} has no recent activity"
+                      values={{ name }}
+                    />
+                  )}
+                </h3>
+              }
+            />
+            <EuiSpacer size="xl" />
+          </>
+        )}
+      </EuiPanel>
+    </ContentSection>
+  );
+};
+
+export const RecentActivityItem: React.FC<FeedActivity> = ({
+  id,
+  status,
+  message,
+  timestamp,
+  sourceId,
+}) => {
+  const { sendWorkplaceSearchTelemetry } = useActions(TelemetryLogic);
+
+  const onClick = () =>
+    sendWorkplaceSearchTelemetry({
+      action: 'clicked',
+      metric: 'recent_activity_source_details_link',
+    });
+
+  const linkProps = {
+    onClick,
+    target: '_blank',
+    href: getWorkplaceSearchUrl(getContentSourcePath(SOURCE_DETAILS_PATH, sourceId, true)),
+    external: true,
+    color: status === 'error' ? 'danger' : 'primary',
+    'data-test-subj': 'viewSourceDetailsLink',
+  } as EuiLinkProps;
+
+  return (
+    <div className={`activity ${status ? `activity--${status}` : ''}`}>
+      <div className="activity__message">
+        <EuiLink {...linkProps}>
+          {id} {message}
+          {status === 'error' && (
+            <span className="activity--error__label">
+              {' '}
+              <FormattedMessage
+                id="xpack.enterpriseSearch.workplaceSearch.recentActivitySourceLink.linkLabel"
+                defaultMessage="View Source"
+              />
+            </span>
+          )}
+        </EuiLink>
+      </div>
+      <div className="activity__date">{moment.utc(timestamp).fromNow()}</div>
+    </div>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/statistic_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/statistic_card.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import '../../../__mocks__/enterprise_search_url.mock';
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiCard } from '@elastic/eui';
+
+import { StatisticCard } from './statistic_card';
+
+const props = {
+  title: 'foo',
+};
+
+describe('StatisticCard', () => {
+  it('renders', () => {
+    const wrapper = shallow(<StatisticCard {...props} />);
+
+    expect(wrapper.find(EuiCard)).toHaveLength(1);
+  });
+
+  it('renders clickable card', () => {
+    const wrapper = shallow(<StatisticCard {...props} actionPath="/foo" />);
+
+    expect(wrapper.find(EuiCard).prop('href')).toBe('http://localhost:3002/ws/foo');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/statistic_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview_mvp/statistic_card.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiCard, EuiFlexItem, EuiTitle, EuiTextColor } from '@elastic/eui';
+
+import { getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
+
+interface StatisticCardProps {
+  title: string;
+  count?: number;
+  actionPath?: string;
+}
+
+export const StatisticCard: React.FC<StatisticCardProps> = ({ title, count = 0, actionPath }) => {
+  const linkProps = actionPath
+    ? {
+        href: getWorkplaceSearchUrl(actionPath),
+        target: '_blank',
+        rel: 'noopener',
+      }
+    : {};
+  // TODO: When we port this destination to Kibana, we'll want to create a EuiReactRouterCard component (see shared/react_router_helpers/eui_link.tsx)
+
+  return (
+    <EuiFlexItem>
+      <EuiCard
+        {...linkProps}
+        layout="horizontal"
+        title={title}
+        titleSize="xs"
+        description={
+          <EuiTitle size="l">
+            <EuiTextColor color={actionPath ? 'default' : 'subdued'}>{count}</EuiTextColor>
+          </EuiTitle>
+        }
+      />
+    </EuiFlexItem>
+  );
+};


### PR DESCRIPTION
## Summary

This PR takes the existing Overview MVP that users see publicly in Kibana and adds it to the in-progress app, known moving forward as `alpha`. The existing MVP was cloned and renamed `overview_mvp` and the `overview` folder now houses the working Overview section as it will be once the transition is complete. 

**Notes**
- A new temporary route was added that will let stakeholders test the app in its entirety. Previously clicking "Overview" would take you back to the MVP, with no way back into the alpha.

**Before (Still existing at the root of Workplace Search in Kibana)**
![image](https://user-images.githubusercontent.com/1869731/107573556-4a039980-6bb3-11eb-9645-269408fd0beb.png)

**After (Accessible on by navigating directly to new route)**
![2021-02-10_15-20-07 (1)](https://user-images.githubusercontent.com/1869731/107573802-9e0e7e00-6bb3-11eb-8946-77aba47b0e6b.gif)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios