### PR TITLE
Don't clean when running e2e tests

### DIFF
--- a/x-pack/plugins/apm/e2e/ci/prepare-kibana.sh
+++ b/x-pack/plugins/apm/e2e/ci/prepare-kibana.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 E2E_DIR=x-pack/plugins/apm/e2e
-echo "1/2 Install dependencies ..."
+echo "1/2 Install dependencies..."
 # shellcheck disable=SC1091
 source src/dev/ci_setup/setup_env.sh true
-yarn kbn clean && yarn kbn bootstrap
+yarn kbn bootstrap
 
-echo "2/2 Start Kibana ..."
+echo "2/2 Start Kibana..."
 ## Might help to avoid FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 export NODE_OPTIONS="--max-old-space-size=4096"
-nohup node ./scripts/kibana --no-base-path --no-watch --dev --no-dev-config --config ${E2E_DIR}/ci/kibana.e2e.yml > ${E2E_DIR}/kibana.log 2>&1 &
+exec nohup node ./scripts/kibana --no-base-path --no-watch --dev --no-dev-config --config ${E2E_DIR}/ci/kibana.e2e.yml > ${E2E_DIR}/kibana.log 2>&1 &

--- a/x-pack/plugins/apm/e2e/ci/prepare-kibana.sh
+++ b/x-pack/plugins/apm/e2e/ci/prepare-kibana.sh
@@ -10,4 +10,4 @@ yarn kbn bootstrap
 echo "2/2 Start Kibana..."
 ## Might help to avoid FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 export NODE_OPTIONS="--max-old-space-size=4096"
-exec nohup node ./scripts/kibana --no-base-path --no-watch --dev --no-dev-config --config ${E2E_DIR}/ci/kibana.e2e.yml > ${E2E_DIR}/kibana.log 2>&1 &
+nohup node ./scripts/kibana --no-base-path --no-watch --dev --no-dev-config --config ${E2E_DIR}/ci/kibana.e2e.yml > ${E2E_DIR}/kibana.log 2>&1 &


### PR DESCRIPTION
I don't think this is necessary, and since it's run before `bootstrap`, the Bazel tools aren't installed so it fails silently.

Example: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-ui%2Fapm-ui-e2e-tests-mbp%2FPR-89647/detail/PR-89647/21/pipeline/124/

Should fix APM E2E failures.
