### PR TITLE
[7.x] Add size param to search for previous threshold signals (#90810)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold_find_previous_signals.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/threshold_find_previous_signals.ts
@@ -48,6 +48,7 @@ export const findPreviousThresholdSignals = async ({
     threshold: {
       terms: {
         field: 'signal.threshold_result.value',
+        size: 10000,
       },
       aggs: {
         lastSignalTimestamp: {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add size param to search for previous threshold signals (#90810)