### PR TITLE
Disable v2 migrations to speed-up FTR

### DIFF
--- a/test/api_integration/apis/saved_objects/find.ts
+++ b/test/api_integration/apis/saved_objects/find.ts
@@ -40,7 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
                 {
                   type: 'visualization',
                   id: 'dd7caf20-9efd-11e7-acb3-3dab96693fab',
-                  version: 'WzE4LDJd',
+                  version: 'WzIsMV0=',
                   attributes: {
                     title: 'Count of requests',
                   },
@@ -137,7 +137,7 @@ export default function ({ getService }: FtrProviderContext) {
                   {
                     type: 'visualization',
                     id: 'dd7caf20-9efd-11e7-acb3-3dab96693fab',
-                    version: 'WzE4LDJd',
+                    version: 'WzIsMV0=',
                     attributes: {
                       title: 'Count of requests',
                     },
@@ -174,7 +174,7 @@ export default function ({ getService }: FtrProviderContext) {
                   {
                     type: 'visualization',
                     id: 'dd7caf20-9efd-11e7-acb3-3dab96693fab',
-                    version: 'WzE4LDJd',
+                    version: 'WzIsMV0=',
                     attributes: {
                       title: 'Count of requests',
                     },
@@ -256,7 +256,7 @@ export default function ({ getService }: FtrProviderContext) {
                     migrationVersion: resp.body.saved_objects[0].migrationVersion,
                     coreMigrationVersion: KIBANA_VERSION,
                     updated_at: '2017-09-21T18:51:23.794Z',
-                    version: 'WzE4LDJd',
+                    version: 'WzIsMV0=',
                   },
                 ],
               });

--- a/test/api_integration/apis/saved_objects/find.ts
+++ b/test/api_integration/apis/saved_objects/find.ts
@@ -209,7 +209,7 @@ export default function ({ getService }: FtrProviderContext) {
                     score: 0,
                     type: 'visualization',
                     updated_at: '2017-09-21T18:51:23.794Z',
-                    version: 'WzIyLDJd',
+                    version: 'WzYsMV0=',
                   },
                 ],
               });

--- a/test/api_integration/apis/saved_objects_management/find.ts
+++ b/test/api_integration/apis/saved_objects_management/find.ts
@@ -42,7 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
                 {
                   type: 'visualization',
                   id: 'dd7caf20-9efd-11e7-acb3-3dab96693fab',
-                  version: 'WzE4LDJd',
+                  version: 'WzIsMV0=',
                   attributes: {
                     title: 'Count of requests',
                   },

--- a/test/api_integration/config.js
+++ b/test/api_integration/config.js
@@ -31,6 +31,7 @@ export default async function ({ readConfigFile }) {
         '--server.xsrf.disableProtection=true',
         '--server.compression.referrerWhitelist=["some-host.com"]',
         `--savedObjects.maxImportExportSize=10001`,
+        '--migrations.enableV2=false',
       ],
     },
   };

--- a/test/common/config.js
+++ b/test/common/config.js
@@ -59,6 +59,7 @@ export default function () {
         ...(!!process.env.CODE_COVERAGE
           ? [`--plugin-path=${path.join(__dirname, 'fixtures', 'plugins', 'coverage')}`]
           : []),
+        '--migrations.enableV2=false',
       ],
     },
     services,

--- a/test/plugin_functional/test_suites/saved_objects_management/find.ts
+++ b/test/plugin_functional/test_suites/saved_objects_management/find.ts
@@ -46,7 +46,8 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
                   },
                   references: [],
                   updated_at: '2021-02-11T18:51:23.794Z',
-                  version: 'WzIsMl0=',
+                  version: 'WzAsMV0=',
+                  coreMigrationVersion: '8.0.0',
                   namespaces: ['default'],
                   score: 0,
                   meta: {

--- a/x-pack/test/reporting_api_integration/reporting_without_security.config.ts
+++ b/x-pack/test/reporting_api_integration/reporting_without_security.config.ts
@@ -40,6 +40,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.reporting.capture.maxAttempts=1`,
         `--xpack.reporting.csv.maxSizeBytes=2850`,
         `--xpack.security.enabled=false`,
+        '--migrations.enableV2=false',
       ],
     },
   };


### PR DESCRIPTION
## Summary

v2 migrations causes the CI run to take 15 minutes longer on average which consumes significant CI resources. Until https://github.com/elastic/kibana/issues/89368 is closed, one option is to disable the new algorithm to reduce resource consumption in the short term.

@spalger This PR disables v2 migrations on FTR without reverting the other changes. Keeping it in draft until we make a decision.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
