### PR TITLE
[APM] Fix optimize-tsconfig script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,6 @@ npm-debug.log*
 .ci/bash_standard_lib.sh
 .gradle
 
-# apm plugin
-/x-pack/plugins/apm/tsconfig.json
-apm.tsconfig.json
 ## @cypress/snapshot from apm plugin
 snapshots.js
 

--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/optimize.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/optimize.js
@@ -16,6 +16,7 @@ const { omit } = require('lodash');
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
+const unlink = promisify(fs.unlink);
 
 const {
   xpackRoot,
@@ -72,12 +73,18 @@ async function setIgnoreChanges() {
   }
 }
 
+async function deleteApmTsConfig() {
+  await unlink(path.resolve(kibanaRoot, 'x-pack/plugins/apm', 'tsconfig.json'));
+}
+
 async function optimizeTsConfig() {
   await unoptimizeTsConfig();
 
   await prepareParentTsConfigs();
 
   await addApmFilesToXpackTsConfig();
+
+  await deleteApmTsConfig();
 
   await setIgnoreChanges();
   // eslint-disable-next-line no-console

--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
@@ -16,6 +16,7 @@ const filesToIgnore = [
   path.resolve(xpackRoot, 'tsconfig.json'),
   path.resolve(kibanaRoot, 'tsconfig.json'),
   path.resolve(kibanaRoot, 'tsconfig.base.json'),
+  path.resolve(kibanaRoot, 'x-pack/plugins/apm', 'tsconfig.json'),
 ];
 
 module.exports = {


### PR DESCRIPTION
- Removes x-pack/plugins/apm/tsconfig.json file (so TypeScript will always use the optimized tsconfig.json)
- Make optimisation opt-in for precommit script (so other people are not bothered by it)

I've noticed that A) the optimised version is still faster when giving autocompletion results (~2x as fast), B) having a per-plugin tsconfig file causes vscode to switch between projects which takes a lot of time. I might be holding it wrong, but I think it's worth it to make some changes in the script to make it work again.