### PR TITLE
[Discover][Doc] Implement usage of fields search when discover:searchFieldsFromSource is set to false

### DIFF
--- a/src/plugins/discover/public/application/components/doc/doc.test.tsx
+++ b/src/plugins/discover/public/application/components/doc/doc.test.tsx
@@ -13,6 +13,7 @@ import { mountWithIntl } from '@kbn/test/jest';
 import { ReactWrapper } from 'enzyme';
 import { findTestSubject } from '@elastic/eui/lib/test';
 import { Doc, DocProps } from './doc';
+import { SEARCH_FIELDS_FROM_SOURCE as mockSearchFieldsFromSource } from '../../../../common';
 
 const mockSearchApi = jest.fn();
 
@@ -34,6 +35,13 @@ jest.mock('../../../kibana_services', () => {
           apis: {
             indexExists: 'mockUrl',
           },
+        },
+      },
+      uiSettings: {
+        get: (key: string) => {
+          if (key === mockSearchFieldsFromSource) {
+            return false;
+          }
         },
       },
     }),

--- a/src/plugins/discover/public/application/components/doc/use_es_doc_search.test.tsx
+++ b/src/plugins/discover/public/application/components/doc/use_es_doc_search.test.tsx
@@ -6,6 +6,14 @@
  * Side Public License, v 1.
  */
 
+import { renderHook, act } from '@testing-library/react-hooks';
+import { buildSearchBody, useEsDocSearch, ElasticRequestState } from './use_es_doc_search';
+import { DocProps } from './doc';
+import { Observable } from 'rxjs';
+import { SEARCH_FIELDS_FROM_SOURCE as mockSearchFieldsFromSource } from '../../../../common';
+
+const mockSearchResult = new Observable();
+
 jest.mock('../../../kibana_services', () => ({
   getServices: () => ({
     data: {
@@ -24,16 +32,9 @@ jest.mock('../../../kibana_services', () => ({
     },
   }),
 }));
-import { renderHook, act } from '@testing-library/react-hooks';
-import { buildSearchBody, useEsDocSearch, ElasticRequestState } from './use_es_doc_search';
-import { DocProps } from './doc';
-import { Observable } from 'rxjs';
-import { SEARCH_FIELDS_FROM_SOURCE as mockSearchFieldsFromSource } from '../../../../common';
-
-const mockSearchResult = new Observable();
 
 describe('Test of <Doc /> helper / hook', () => {
-  test('buildSearchBody with _source', () => {
+  test('buildSearchBody given useNewFieldsApi is false', () => {
     const indexPattern = {
       getComputedFields: () => ({ storedFields: [], scriptFields: [], docvalueFields: [] }),
     } as any;
@@ -56,7 +57,7 @@ describe('Test of <Doc /> helper / hook', () => {
     `);
   });
 
-  test('buildSearchBody with fields', () => {
+  test('buildSearchBody useNewFieldsApi is true', () => {
     const indexPattern = {
       getComputedFields: () => ({ storedFields: [], scriptFields: [], docvalueFields: [] }),
     } as any;


### PR DESCRIPTION
## Summary

This PR enables the usage of `search` `fields` param in Discover's doc view, when you select `View single doc` in an expanded document of Discover's data grid. 

### Testing
1. Make sure in Advanced settings, `doc_table:legacy` is set to true, and `discover:searchFieldsFromSource` is set to off
2. Navigate to Discover
3. Select a Index Pattern, make sure to adapt the time range for documents to be displayed
4. Expand a single document, click on `View single doc`
5. Take a look at the JSON tab, then `fields` should be displayed instead of `_source` like this:
<img width="1356" alt="Bildschirmfoto 2021-02-17 um 14 19 10" src="https://user-images.githubusercontent.com/463851/108227422-2bb31600-713e-11eb-9e88-08881a5f489f.png">

Part of #88426


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios