### PR TITLE
[Lens] remove test warnings from console

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_panel.test.tsx
@@ -8,7 +8,14 @@
 import { ReactWrapper, ShallowWrapper } from 'enzyme';
 import React, { ChangeEvent, MouseEvent } from 'react';
 import { act } from 'react-dom/test-utils';
-import { EuiComboBox, EuiListGroupItemProps, EuiListGroup, EuiRange } from '@elastic/eui';
+import {
+  EuiComboBox,
+  EuiListGroupItemProps,
+  EuiListGroup,
+  EuiRange,
+  EuiSelect,
+  EuiButtonIcon,
+} from '@elastic/eui';
 import { DataPublicPluginStart } from '../../../../../../src/plugins/data/public';
 import {
   IndexPatternDimensionEditorComponent,
@@ -24,8 +31,6 @@ import { OperationMetadata } from '../../types';
 import { DateHistogramIndexPatternColumn } from '../operations/definitions/date_histogram';
 import { getFieldByNameFactory } from '../pure_helpers';
 import { TimeScaling } from './time_scaling';
-import { EuiSelect } from '@elastic/eui';
-import { EuiButtonIcon } from '@elastic/eui';
 import { DimensionEditor } from './dimension_editor';
 
 jest.mock('../loader');
@@ -742,6 +747,8 @@ describe('IndexPatternDimensionEditorPanel', () => {
     });
 
     it('should leave error state when switching from incomplete state to fieldless operation', () => {
+      // @ts-expect-error
+      window['__react-beautiful-dnd-disable-dev-warnings'] = true; // issue with enzyme & react-beautiful-dnd throwing errors: https://github.com/atlassian/react-beautiful-dnd/issues/1593
       wrapper = mount(<IndexPatternDimensionEditorComponent {...defaultProps} />);
 
       wrapper

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/ranges/ranges.test.tsx
@@ -33,6 +33,19 @@ import { RangePopover } from './advanced_editor';
 import { DragDropBuckets } from '../shared_components';
 import { getFieldByNameFactory } from '../../../pure_helpers';
 
+// mocking random id generator function
+jest.mock('@elastic/eui', () => {
+  const original = jest.requireActual('@elastic/eui');
+
+  return {
+    ...original,
+    htmlIdGenerator: (fn: unknown) => {
+      let counter = 0;
+      return () => counter++;
+    },
+  };
+});
+
 const dataPluginMockValue = dataPluginMock.createStartContract();
 // need to overwrite the formatter field first
 dataPluginMockValue.fieldFormats.deserialize = jest.fn().mockImplementation(({ params }) => {


### PR DESCRIPTION
## Summary
Removes warnings when testing: 
1. for dimension panel:
![image](https://user-images.githubusercontent.com/4283304/108204190-c7835880-7123-11eb-9f11-388130c2f01e.png)

2. for ranges editor: 
![image](https://user-images.githubusercontent.com/4283304/108204301-ea157180-7123-11eb-8536-eed10f04591f.png)

