### PR TITLE
[coverage] increase timeout to 5h

### DIFF
--- a/.ci/Jenkinsfile_coverage
+++ b/.ci/Jenkinsfile_coverage
@@ -3,7 +3,7 @@
 library 'kibana-pipeline-library'
 kibanaLibrary.load() // load from the Jenkins instance
 
-kibanaPipeline(timeoutMinutes: 240) {
+kibanaPipeline(timeoutMinutes: 300) {
   catchErrors {
     def timestamp = new Date(currentBuild.startTimeInMillis).format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
     withEnv([


### PR DESCRIPTION
## Summary

[Code coverage job](https://kibana-ci.elastic.co/job/elastic+kibana+code-coverage/) is failing because it takes a bit longer than 4h. PR increases timeout up to 5h as a workaround while we are searching for ways to speed up coverage run.
 
At the moment I think it is caused by combination of jest tests single run and slower kbn bootstrap.