### PR TITLE
[coverage] change worker, save json files in original path

### DIFF
--- a/.ci/Jenkinsfile_coverage
+++ b/.ci/Jenkinsfile_coverage
@@ -10,7 +10,7 @@ kibanaPipeline(timeoutMinutes: 240) {
       "TIME_STAMP=${timestamp}",
       'CODE_COVERAGE=1', // Enables coverage.  Needed for multiple ci scripts, such as remote.ts, test/scripts/*.sh, schema.js, etc.
     ]) {
-      workers.base(name: 'coverage-worker', size: 'l', ramDisk: false, bootstrapped: false) {
+      workers.base(name: 'coverage-worker', size: 'xl', ramDisk: false, bootstrapped: false) {
         catchError {
 
           kibanaPipeline.bash("""

--- a/test/functional/services/remote/remote.ts
+++ b/test/functional/services/remote/remote.ts
@@ -37,14 +37,21 @@ export async function RemoteProvider({ getService }: FtrProviderContext) {
   };
 
   const writeCoverage = (coverageJson: string) => {
-    if (!Fs.existsSync(coverageDir)) {
-      Fs.mkdirSync(coverageDir, { recursive: true });
+    // on CI we make hard link clone and run tests from kibana${process.env.CI_GROUP} root path
+    const re = new RegExp(`kibana${process.env.CI_GROUP}`, 'g');
+    const dir = process.env.CI ? coverageDir.replace(re, 'kibana') : coverageDir;
+
+    if (!Fs.existsSync(dir)) {
+      Fs.mkdirSync(dir, { recursive: true });
     }
+
     const id = coverageCounter++;
     const timestamp = Date.now();
-    const path = resolve(coverageDir, `${id}.${timestamp}.coverage.json`);
+    const path = resolve(dir, `${id}.${timestamp}.coverage.json`);
     log.info('writing coverage to', path);
-    Fs.writeFileSync(path, JSON.stringify(JSON.parse(coverageJson), null, 2));
+
+    const jsonString = process.env.CI ? coverageJson.replace(re, 'kibana') : coverageJson;
+    Fs.writeFileSync(path, JSON.stringify(JSON.parse(jsonString), null, 2));
   };
 
   const browserConfig: BrowserConfig = {

--- a/test/scripts/jenkins_ci_group.sh
+++ b/test/scripts/jenkins_ci_group.sh
@@ -29,14 +29,6 @@ else
   echo " -> running tests from the clone folder"
   node scripts/functional_tests --debug --include-tag "ciGroup$CI_GROUP"  --exclude-tag "skipCoverage" || true;
 
-  if [[ -d target/kibana-coverage/functional ]]; then
-    echo " -> replacing kibana${CI_GROUP} with kibana in json files"
-    sed -i "s|kibana${CI_GROUP}|kibana|g" target/kibana-coverage/functional/*.json
-    echo " -> copying coverage to the original folder"
-    mkdir -p ../kibana/target/kibana-coverage/functional
-    mv target/kibana-coverage/functional/* ../kibana/target/kibana-coverage/functional/
-  fi
-
   echo " -> moving junit output, silently fail in case of no report"
   mkdir -p ../kibana/target/junit
   mv target/junit/* ../kibana/target/junit/ || echo "copying junit failed"

--- a/test/scripts/jenkins_unit.sh
+++ b/test/scripts/jenkins_unit.sh
@@ -28,7 +28,7 @@ if [[ -z "$CODE_COVERAGE" ]] ; then
   ./test/scripts/checks/test_hardening.sh
 else
   echo " -> Running jest tests with coverage"
-  node scripts/jest --ci --verbose --maxWorkers=6 --coverage || true;
+  node scripts/jest --ci --verbose --maxWorkers=8 --coverage || true;
 
   echo " -> Running jest integration tests with coverage"
   node scripts/jest_integration --ci --verbose --coverage || true;

--- a/test/scripts/jenkins_xpack_ci_group.sh
+++ b/test/scripts/jenkins_xpack_ci_group.sh
@@ -25,14 +25,6 @@ else
   echo " -> running tests from the clone folder"
   node scripts/functional_tests --debug --include-tag "ciGroup$CI_GROUP"  --exclude-tag "skipCoverage" || true;
 
-  if [[ -d ../target/kibana-coverage/functional ]]; then
-    echo " -> replacing kibana${CI_GROUP} with kibana in json files"
-    sed -i "s|kibana${CI_GROUP}|kibana|g" ../target/kibana-coverage/functional/*.json
-    echo " -> copying coverage to the original folder"
-    mkdir -p ../../kibana/target/kibana-coverage/functional
-    mv ../target/kibana-coverage/functional/* ../../kibana/target/kibana-coverage/functional/
-  fi
-
   echo " -> moving junit output, silently fail in case of no report"
   mkdir -p ../../kibana/target/junit
   mv ../target/junit/* ../../kibana/target/junit/ || echo "copying junit failed"


### PR DESCRIPTION
## Summary

Issue: job time is over 4h

Functional tests improvement:
On CI we make hard link clone and run tests from multiple folders (`kibana1`, `kibana2`, etc) to avoid failures while running tests from source. In the end, we were copying files to original kibana path and modify it to list original path. It usually takes 2-8 min depending on files count.

This PR changes logic so that json string is updated with original path and file is stored in `kibana` path

Jest tests improvement:
In order to speed up run, PR changes worker size to `xl`. As a result jest run drops from 2h 4 min to 1h 49 min: -12%


[Job](https://kibana-ci.elastic.co/job/elastic+kibana+qa-research/194/) was completed within 3h 59min