### PR TITLE
[7.x] [Metrics UI] Fix ignoreLookback behavior for Snapshot API (#91169)

### DIFF
--- a/x-pack/plugins/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
+++ b/x-pack/plugins/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
@@ -8,7 +8,6 @@
 import { uniq } from 'lodash';
 import { InfraTimerangeInput } from '../../../../common/http_api';
 import { ESSearchClient } from '../../../lib/metrics/types';
-import { getIntervalInSeconds } from '../../../utils/get_interval_in_seconds';
 import { calculateMetricInterval } from '../../../utils/calculate_metric_interval';
 import { getMetricsAggregations, InfraSnapshotRequestOptions } from './get_metrics_aggregations';
 import {
@@ -19,9 +18,6 @@ import { getDatasetForField } from '../../metrics_explorer/lib/get_dataset_for_f
 
 const createInterval = async (client: ESSearchClient, options: InfraSnapshotRequestOptions) => {
   const { timerange } = options;
-  if (timerange.forceInterval && timerange.interval) {
-    return getIntervalInSeconds(timerange.interval);
-  }
   const aggregations = getMetricsAggregations(options);
   const modules = await aggregationsToModules(client, aggregations, options);
   return Math.max(
@@ -44,14 +40,21 @@ export const createTimeRangeWithInterval = async (
   options: InfraSnapshotRequestOptions
 ): Promise<InfraTimerangeInput> => {
   const { timerange } = options;
-  const calculatedInterval = await createInterval(client, options);
-  if (timerange.ignoreLookback) {
+  if (timerange.forceInterval) {
     return {
-      interval: `${calculatedInterval}s`,
+      interval: timerange.interval,
       from: timerange.from,
       to: timerange.to,
     };
   }
+  if (timerange.ignoreLookback) {
+    return {
+      interval: 'modules',
+      from: timerange.from,
+      to: timerange.to,
+    };
+  }
+  const calculatedInterval = await createInterval(client, options);
   const lookbackSize = Math.max(timerange.lookbackSize || 5, 5);
   return {
     interval: `${calculatedInterval}s`,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Fix ignoreLookback behavior for Snapshot API (#91169)