### PR TITLE
[Discover] Show unmapped fields when reading from source

### DIFF
--- a/src/plugins/discover/public/application/components/sidebar/lib/group_fields.test.ts
+++ b/src/plugins/discover/public/application/components/sidebar/lib/group_fields.test.ts
@@ -47,6 +47,7 @@ const fieldCounts = {
   category: 1,
   currency: 1,
   customer_birth_date: 1,
+  unknown_field: 1,
 };
 
 describe('group_fields', function () {
@@ -232,7 +233,7 @@ describe('group_fields', function () {
 
     const actual = groupFields(
       fieldsWithUnmappedField as IndexPatternField[],
-      ['customer_birth_date', 'currency', 'unknown'],
+      ['customer_birth_date', 'currency'],
       5,
       fieldCounts,
       fieldFilterState,
@@ -240,5 +241,31 @@ describe('group_fields', function () {
       false
     );
     expect(actual.unpopular).toEqual([]);
+  });
+
+  it('includes unmapped fields when reading from source', function () {
+    const fieldFilterState = getDefaultFieldFilter();
+    const fieldsWithUnmappedField = [...fields];
+    fieldsWithUnmappedField.push({
+      name: 'unknown_field',
+      type: 'unknown',
+      esTypes: ['unknown'],
+      count: 0,
+      scripted: false,
+      searchable: false,
+      aggregatable: false,
+      readFromDocValues: false,
+    });
+
+    const actual = groupFields(
+      fieldsWithUnmappedField as IndexPatternField[],
+      ['customer_birth_date', 'currency'],
+      5,
+      fieldCounts,
+      fieldFilterState,
+      false,
+      undefined
+    );
+    expect(actual.unpopular.map((field) => field.name)).toEqual(['unknown_field']);
   });
 });

--- a/src/plugins/discover/public/application/components/sidebar/lib/group_fields.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/lib/group_fields.tsx
@@ -64,7 +64,9 @@ export function groupFields(
     } else if (field.type !== '_source') {
       // do not show unmapped fields unless explicitly specified
       // do not add subfields to this list
-      if ((field.type !== 'unknown' || showUnmappedFields) && !isSubfield) {
+      if (useNewFieldsApi && (field.type !== 'unknown' || showUnmappedFields) && !isSubfield) {
+        result.unpopular.push(field);
+      } else if (!useNewFieldsApi) {
         result.unpopular.push(field);
       }
     }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/91697

This PR shows unmapped fields in discover sidebar when reading fields from source.


### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)~
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
