### PR TITLE
[APM] Domain for charts is based on query range 

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/timeseries_chart.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/timeseries_chart.tsx
@@ -24,15 +24,14 @@ import {
 } from '@elastic/charts';
 import { EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import moment from 'moment';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import d3 from 'd3';
 import { useChartTheme } from '../../../../../observability/public';
 import { asAbsoluteDateTime } from '../../../../common/utils/formatters';
 import { RectCoordinate, TimeSeries } from '../../../../typings/timeseries';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { useTheme } from '../../../hooks/use_theme';
-import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useAnnotationsContext } from '../../../context/annotations/use_annotations_context';
 import { useChartPointerEventContext } from '../../../context/chart_pointer_event/use_chart_pointer_event_context';
 import { unit } from '../../../style/variables';
@@ -78,14 +77,15 @@ export function TimeseriesChart({
   const history = useHistory();
   const { annotations } = useAnnotationsContext();
   const { setPointerEvent, chartRef } = useChartPointerEventContext();
-  const { urlParams } = useUrlParams();
   const theme = useTheme();
   const chartTheme = useChartTheme();
 
-  const { start, end } = urlParams;
+  const xValues = timeseries
+    .map(({ data }) => data.map(({ x }) => x))
+    .flatMap((_) => _);
 
-  const min = moment.utc(start).valueOf();
-  const max = moment.utc(end).valueOf();
+  const min = d3.min(xValues);
+  const max = d3.max(xValues);
 
   const xFormatter = niceTimeFormatter([min, max]);
 

--- a/x-pack/plugins/apm/public/components/shared/charts/timeseries_chart.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/timeseries_chart.tsx
@@ -26,7 +26,6 @@ import { EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import d3 from 'd3';
 import { useChartTheme } from '../../../../../observability/public';
 import { asAbsoluteDateTime } from '../../../../common/utils/formatters';
 import { RectCoordinate, TimeSeries } from '../../../../typings/timeseries';
@@ -80,12 +79,10 @@ export function TimeseriesChart({
   const theme = useTheme();
   const chartTheme = useChartTheme();
 
-  const xValues = timeseries
-    .map(({ data }) => data.map(({ x }) => x))
-    .flatMap((_) => _);
+  const xValues = timeseries.flatMap(({ data }) => data.map(({ x }) => x));
 
-  const min = d3.min(xValues);
-  const max = d3.max(xValues);
+  const min = Math.min(...xValues);
+  const max = Math.max(...xValues);
 
   const xFormatter = niceTimeFormatter([min, max]);
 

--- a/x-pack/plugins/apm/public/context/url_params_context/helpers.test.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/helpers.test.ts
@@ -13,7 +13,7 @@ describe('url_params_context helpers', () => {
   describe('getDateRange', () => {
     describe('with non-rounded dates', () => {
       describe('one minute', () => {
-        it('rounds the values', () => {
+        it('rounds the start value to minute', () => {
           expect(
             helpers.getDateRange({
               state: {},
@@ -21,13 +21,13 @@ describe('url_params_context helpers', () => {
               rangeTo: '2021-01-28T05:48:55.304Z',
             })
           ).toEqual({
-            start: '2021-01-28T05:47:50.000Z',
-            end: '2021-01-28T05:49:00.000Z',
+            start: '2021-01-28T05:47:00.000Z',
+            end: '2021-01-28T05:48:55.304Z',
           });
         });
       });
       describe('one day', () => {
-        it('rounds the values', () => {
+        it('rounds the start value to minute', () => {
           expect(
             helpers.getDateRange({
               state: {},
@@ -35,14 +35,14 @@ describe('url_params_context helpers', () => {
               rangeTo: '2021-01-28T05:46:13.367Z',
             })
           ).toEqual({
-            start: '2021-01-27T03:00:00.000Z',
-            end: '2021-01-28T06:00:00.000Z',
+            start: '2021-01-27T05:46:00.000Z',
+            end: '2021-01-28T05:46:13.367Z',
           });
         });
       });
 
       describe('one year', () => {
-        it('rounds the values', () => {
+        it('rounds the start value to minute', () => {
           expect(
             helpers.getDateRange({
               state: {},
@@ -50,8 +50,8 @@ describe('url_params_context helpers', () => {
               rangeTo: '2021-01-28T05:52:39.741Z',
             })
           ).toEqual({
-            start: '2020-01-01T00:00:00.000Z',
-            end: '2021-02-01T00:00:00.000Z',
+            start: '2020-01-28T05:52:00.000Z',
+            end: '2021-01-28T05:52:39.741Z',
           });
         });
       });

--- a/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
+++ b/x-pack/plugins/apm/public/context/url_params_context/helpers.ts
@@ -6,8 +6,8 @@
  */
 
 import datemath from '@elastic/datemath';
-import { scaleUtc } from 'd3-scale';
 import { compact, pickBy } from 'lodash';
+import moment from 'moment';
 import { IUrlParams } from './types';
 
 function getParsedDate(rawDate?: string, options = {}) {
@@ -42,13 +42,12 @@ export function getDateRange({
     return { start: state.start, end: state.end };
   }
 
-  // Calculate ticks for the time ranges to produce nicely rounded values.
-  const ticks = scaleUtc().domain([start, end]).nice().ticks();
+  // rounds down start to minute
+  const roundedStart = moment(start).startOf('minute');
 
-  // Return the first and last tick values.
   return {
-    start: ticks[0].toISOString(),
-    end: ticks[ticks.length - 1].toISOString(),
+    start: roundedStart.toISOString(),
+    end: end.toISOString(),
   };
 }
 

--- a/x-pack/plugins/apm/public/context/url_params_context/url_params_context.test.tsx
+++ b/x-pack/plugins/apm/public/context/url_params_context/url_params_context.test.tsx
@@ -52,8 +52,8 @@ describe('UrlParamsContext', () => {
     const params = getDataFromOutput(wrapper);
 
     expect([params.start, params.end]).toEqual([
-      '2010-03-15T00:00:00.000Z',
-      '2010-04-11T00:00:00.000Z',
+      '2010-03-15T12:00:00.000Z',
+      '2010-04-10T12:00:00.000Z',
     ]);
   });
 
@@ -71,8 +71,8 @@ describe('UrlParamsContext', () => {
     const params = getDataFromOutput(wrapper);
 
     expect([params.start, params.end]).toEqual([
-      '2009-03-15T00:00:00.000Z',
-      '2009-04-11T00:00:00.000Z',
+      '2009-03-15T12:00:00.000Z',
+      '2009-04-10T12:00:00.000Z',
     ]);
   });
 
@@ -92,7 +92,7 @@ describe('UrlParamsContext', () => {
 
     expect([params.start, params.end]).toEqual([
       '1969-12-31T00:00:00.000Z',
-      '1970-01-01T00:00:00.000Z',
+      '1969-12-31T23:59:59.999Z',
     ]);
 
     nowSpy.mockRestore();
@@ -145,8 +145,8 @@ describe('UrlParamsContext', () => {
     const params = getDataFromOutput(wrapper);
 
     expect([params.start, params.end]).toEqual([
-      '2005-09-19T00:00:00.000Z',
-      '2005-10-23T00:00:00.000Z',
+      '2005-09-20T12:00:00.000Z',
+      '2005-10-21T12:00:00.000Z',
     ]);
   });
 
@@ -196,7 +196,7 @@ describe('UrlParamsContext', () => {
 
     expect([params.start, params.end]).toEqual([
       '2000-06-14T00:00:00.000Z',
-      '2000-06-15T00:00:00.000Z',
+      '2000-06-14T23:59:59.999Z',
     ]);
   });
 });


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/90920

Fixes the rounding problem by not rounding the upper limit, and rounding to minute the lower limit.

<img width="1565" alt="Screenshot 2021-02-17 at 14 48 10" src="https://user-images.githubusercontent.com/55978943/108269248-b47c8280-713b-11eb-9dda-a19b9d6f4e3c.png">
<img width="1569" alt="Screenshot 2021-02-17 at 14 48 36" src="https://user-images.githubusercontent.com/55978943/108269249-b5151900-713b-11eb-831e-953504111f5f.png">
<img width="1562" alt="Screenshot 2021-02-17 at 14 51 21" src="https://user-images.githubusercontent.com/55978943/108269250-b5151900-713b-11eb-86c7-1b0617cdb967.png">

closes #85021 
I also fixed the jumping when changing the time range. Now the x-domain only updates when new data comes in. @formgeist let me know what you think.

Before:
https://user-images.githubusercontent.com/55978943/108269292-c4946200-713b-11eb-99d3-b439b7c3e52b.mov

After:

https://user-images.githubusercontent.com/55978943/108269306-ca8a4300-713b-11eb-8d75-30cdfd702916.mov

