### PR TITLE
Pass service node name in query for instance table links

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/Links/apm/MetricOverviewLink.tsx
+++ b/x-pack/plugins/apm/public/components/shared/Links/apm/MetricOverviewLink.tsx
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { EuiLink } from '@elastic/eui';
 import React from 'react';
 import { APMQueryParams } from '../url_helpers';
-import { APMLinkExtendProps, useAPMHref } from './APMLink';
+import { APMLink, APMLinkExtendProps, useAPMHref } from './APMLink';
 
 const persistedFilters: Array<keyof APMQueryParams> = [
   'host',
@@ -29,6 +28,5 @@ interface Props extends APMLinkExtendProps {
 }
 
 export function MetricOverviewLink({ serviceName, ...rest }: Props) {
-  const href = useMetricOverviewHref(serviceName);
-  return <EuiLink href={href} {...rest} />;
+  return <APMLink path={`/services/${serviceName}/metrics`} {...rest} />;
 }


### PR DESCRIPTION
For a non-Java service, the previous link was like:

```
http://localhost:5601/kbn/app/apm/services/opbeans-python/metrics?rangeFrom=now-15m&rangeTo=now
```

which did not filter by the `service.node.name`.

It now is:

```
http://localhost:5601/kbn/app/apm/services/opbeans-python/metrics?kuery=service.node.name:%226a7f116fe344aee7e92fceeb426cbfdf6a534a8e3ba6345c16a47793eba6daf5%22&rangeFrom=now-15m&rangeTo=now
````

Which links to the metrics page with the filter applied.

The component is using a `MetricOverviewLink` which was using a `EuiLink` and passing throught the props, including `mergeQuery`, which includes the `kuery` parameter.

Replace the `EuiLink` with an `APMLink` which does use the `mergeQuery` prop and does pass the parameters through correctly.

Looks like this was changed to an `EuiLink` by a refactor in #86986.

Since we'll be making some further changes to how `kuery` is handled in #84526, I'm just making the minimal change to fix this bug at this time.

Fixes #89528.
