### PR TITLE
Discover: Add handling for source column

### DIFF
--- a/src/plugins/discover/public/application/angular/context.js
+++ b/src/plugins/discover/public/application/angular/context.js
@@ -65,6 +65,7 @@ function ContextAppRouteController($routeParams, $scope, $route) {
     storeInSessionStorage: getServices().uiSettings.get('state:storeInSessionStorage'),
     history: getServices().history(),
     toasts: getServices().core.notifications.toasts,
+    uiSettings: getServices().core.uiSettings,
   });
   this.state = { ...appState.getState() };
   this.anchorId = $routeParams.id;

--- a/src/plugins/discover/public/application/angular/context_state.test.ts
+++ b/src/plugins/discover/public/application/angular/context_state.test.ts
@@ -6,10 +6,12 @@
  * Side Public License, v 1.
  */
 
+import { IUiSettingsClient } from 'kibana/public';
 import { getState } from './context_state';
 import { createBrowserHistory, History } from 'history';
 import { FilterManager, Filter } from '../../../../data/public';
 import { coreMock } from '../../../../../core/public/mocks';
+import { SEARCH_FIELDS_FROM_SOURCE } from '../../../common';
 const setupMock = coreMock.createSetup();
 
 describe('Test Discover Context State', () => {
@@ -23,6 +25,10 @@ describe('Test Discover Context State', () => {
       defaultStepSize: '4',
       timeFieldName: 'time',
       history,
+      uiSettings: {
+        get: <T>(key: string) =>
+          ((key === SEARCH_FIELDS_FROM_SOURCE ? true : ['_source']) as unknown) as T,
+      } as IUiSettingsClient,
     });
     state.startSync();
   });

--- a/src/plugins/discover/public/application/angular/discover.js
+++ b/src/plugins/discover/public/application/angular/discover.js
@@ -110,7 +110,7 @@ app.config(($routeProvider) => {
         const history = getHistory();
         const savedSearchId = $route.current.params.id;
         return data.indexPatterns.ensureDefaultIndexPattern(history).then(() => {
-          const { appStateContainer } = getState({ history });
+          const { appStateContainer } = getState({ history, uiSettings: config });
           const { index } = appStateContainer.getState();
           return Promise.props({
             ip: loadIndexPattern(index, data.indexPatterns, config),
@@ -195,6 +195,7 @@ function discoverController($route, $scope, Promise) {
     storeInSessionStorage: config.get('state:storeInSessionStorage'),
     history,
     toasts: core.notifications.toasts,
+    uiSettings: config,
   });
 
   const {

--- a/src/plugins/discover/public/application/angular/discover_state.test.ts
+++ b/src/plugins/discover/public/application/angular/discover_state.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { IUiSettingsClient } from 'kibana/public';
 import {
   getState,
   GetStateReturn,
@@ -14,10 +15,16 @@ import {
 import { createBrowserHistory, History } from 'history';
 import { dataPluginMock } from '../../../../data/public/mocks';
 import { SavedSearch } from '../../saved_searches';
+import { SEARCH_FIELDS_FROM_SOURCE } from '../../../common';
 
 let history: History;
 let state: GetStateReturn;
 const getCurrentUrl = () => history.createHref(history.location);
+
+const uiSettingsMock = {
+  get: <T>(key: string) =>
+    ((key === SEARCH_FIELDS_FROM_SOURCE ? true : ['_source']) as unknown) as T,
+} as IUiSettingsClient;
 
 describe('Test discover state', () => {
   beforeEach(async () => {
@@ -26,6 +33,7 @@ describe('Test discover state', () => {
     state = getState({
       getStateDefaults: () => ({ index: 'test' }),
       history,
+      uiSettings: uiSettingsMock,
     });
     await state.replaceUrlAppState({});
     await state.startSync();
@@ -81,6 +89,7 @@ describe('Test discover state with legacy migration', () => {
     state = getState({
       getStateDefaults: () => ({ index: 'test' }),
       history,
+      uiSettings: uiSettingsMock,
     });
     expect(state.appStateContainer.getState()).toMatchInlineSnapshot(`
       Object {
@@ -106,6 +115,7 @@ describe('createSearchSessionRestorationDataProvider', () => {
     data: mockDataPlugin,
     appStateContainer: getState({
       history: createBrowserHistory(),
+      uiSettings: uiSettingsMock,
     }).appStateContainer,
     getSavedSearch: () => mockSavedSearch,
   });

--- a/src/plugins/discover/public/application/angular/helpers/index.ts
+++ b/src/plugins/discover/public/application/angular/helpers/index.ts
@@ -8,3 +8,4 @@
 
 export { buildPointSeriesData } from './point_series';
 export { formatRow } from './row_formatter';
+export { handleSourceColumnState } from './state_helpers';

--- a/src/plugins/discover/public/application/angular/helpers/state_helpers.ts
+++ b/src/plugins/discover/public/application/angular/helpers/state_helpers.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { IUiSettingsClient } from 'src/core/public';
+import { SEARCH_FIELDS_FROM_SOURCE, DEFAULT_COLUMNS_SETTING } from '../../../../common';
+
+/**
+ * Makes sure the current state is not referencing the source column when using the fields api
+ * @param state
+ * @param uiSettings
+ */
+export function handleSourceColumnState<TState extends { columns?: string[] }>(
+  state: TState,
+  uiSettings: IUiSettingsClient
+): TState {
+  if (!state.columns) {
+    return state;
+  }
+  const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
+  const defaultColumns = uiSettings.get(DEFAULT_COLUMNS_SETTING);
+  if (useNewFieldsApi) {
+    // if fields API is used, filter out the source column
+    return {
+      ...state,
+      columns: state.columns.filter((column) => column !== '_source'),
+    };
+  } else if (state.columns.length === 0) {
+    // if _source fetching is used and there are no column, switch back to default columns
+    // this can happen if the fields API was previously used
+    return {
+      ...state,
+      columns: [...defaultColumns],
+    };
+  }
+
+  return state;
+}

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid.tsx
@@ -315,7 +315,8 @@ export const DiscoverGrid = ({
           <DiscoverGridFlyout
             indexPattern={indexPattern}
             hit={expandedDoc}
-            columns={columns}
+            // if default columns are used, dont make them part of the URL - the context state handling will take care to restore them
+            columns={defaultColumns ? [] : columns}
             onFilter={onFilter}
             onRemoveColumn={onRemoveColumn}
             onAddColumn={onAddColumn}

--- a/test/functional/apps/discover/_shared_links.ts
+++ b/test/functional/apps/discover/_shared_links.ts
@@ -77,7 +77,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             '/app/discover?_t=1453775307251#' +
             '/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time' +
             ":(from:'2015-09-19T06:31:44.000Z',to:'2015-09" +
-            "-23T18:31:44.000Z'))&_a=(columns:!(_source),filters:!(),index:'logstash-" +
+            "-23T18:31:44.000Z'))&_a=(columns:!(),filters:!(),index:'logstash-" +
             "*',interval:auto,query:(language:kuery,query:'')" +
             ",sort:!(!('@timestamp',desc)))";
           const actualUrl = await PageObjects.share.getSharedUrl();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/91493
Fixes https://github.com/elastic/kibana/issues/91633

Makes sure the column list is always in sync with the current state of fields vs source fetching (removing the source column if it is present)