### PR TITLE
[Discover] Always request unmapped fields in a single doc view and a context view

### DIFF
--- a/src/plugins/discover/public/application/angular/context/api/anchor.js
+++ b/src/plugins/discover/public/application/angular/context/api/anchor.js
@@ -32,7 +32,7 @@ export function fetchAnchorProvider(indexPatterns, searchSource, useNewFieldsApi
       .setField('sort', sort);
     if (useNewFieldsApi) {
       searchSource.removeField('fieldsFromSource');
-      searchSource.setField('fields', ['*']);
+      searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
     }
     const response = await searchSource.fetch();
 

--- a/src/plugins/discover/public/application/angular/context/api/anchor.test.js
+++ b/src/plugins/discover/public/application/angular/context/api/anchor.test.js
@@ -154,7 +154,7 @@ describe('context app', function () {
         const removeFieldsSpy = searchSourceStub.removeField.withArgs('fieldsFromSource');
         expect(setFieldsSpy.calledOnce).toBe(true);
         expect(removeFieldsSpy.calledOnce).toBe(true);
-        expect(setFieldsSpy.firstCall.args[1]).toEqual(['*']);
+        expect(setFieldsSpy.firstCall.args[1]).toEqual([{ field: '*', include_unmapped: 'true' }]);
       });
     });
   });

--- a/src/plugins/discover/public/application/angular/context/api/context.ts
+++ b/src/plugins/discover/public/application/angular/context/api/context.ts
@@ -114,7 +114,7 @@ function fetchContextProvider(indexPatterns: IndexPatternsContract, useNewFields
     const searchSource = await data.search.searchSource.create();
     if (useNewFieldsApi) {
       searchSource.removeField('fieldsFromSource');
-      searchSource.setField('fields', ['*']);
+      searchSource.setField('fields', [{ field: '*', include_unmapped: 'true' }]);
     }
     return searchSource
       .setParent(undefined)

--- a/src/plugins/discover/public/application/components/doc/use_es_doc_search.test.tsx
+++ b/src/plugins/discover/public/application/components/doc/use_es_doc_search.test.tsx
@@ -67,7 +67,10 @@ describe('Test of <Doc /> helper / hook', () => {
         "_source": false,
         "docvalue_fields": Array [],
         "fields": Array [
-          "*",
+          Object {
+            "field": "*",
+            "include_unmapped": "true",
+          },
         ],
         "query": Object {
           "ids": Object {

--- a/src/plugins/discover/public/application/components/doc/use_es_doc_search.ts
+++ b/src/plugins/discover/public/application/components/doc/use_es_doc_search.ts
@@ -39,7 +39,7 @@ export function buildSearchBody(
     },
     stored_fields: computedFields.storedFields,
     _source: !useNewFieldsApi,
-    fields: useNewFieldsApi ? ['*'] : undefined,
+    fields: useNewFieldsApi ? [{ field: '*', include_unmapped: 'true' }] : undefined,
     script_fields: computedFields.scriptFields,
     docvalue_fields: computedFields.docvalueFields,
   };


### PR DESCRIPTION
## Summary
Partially fixes: https://github.com/elastic/kibana/issues/91688 

As a quick fix, we'll always request unmapped fields if using the fields API in the single document view and a single doc view.

### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
~- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
~- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list]~(https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
~- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
