### PR TITLE
Use correct environment in anomaly detection setup link

### DIFF
--- a/x-pack/plugins/apm/public/application/action_menu/anomaly_detection_setup_link.tsx
+++ b/x-pack/plugins/apm/public/application/action_menu/anomaly_detection_setup_link.tsx
@@ -30,8 +30,9 @@ export type AnomalyDetectionApiResponse = APIReturnType<'GET /api/apm/settings/a
 const DEFAULT_DATA = { jobs: [], hasLegacyJobs: false };
 
 export function AnomalyDetectionSetupLink() {
-  const { uiFilters } = useUrlParams();
-  const environment = uiFilters.environment;
+  const {
+    urlParams: { environment },
+  } = useUrlParams();
   const { core } = useApmPluginContext();
   const canGetJobs = !!core.application.capabilities.ml?.canGetJobs;
   const license = useLicenseContext();


### PR DESCRIPTION
This was still using `uiFilters.environment` instead of environment, so the warning would never show.
