### PR TITLE
[APM] Bug: Service overview - Sparkline loading state icons has changed

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -76,7 +76,7 @@ export function SparkPlot({
               justifyContent: 'center',
             }}
           >
-            <EuiIcon type="visLine" color={theme.eui.euiColorLightShade} />
+            <EuiIcon type="visLine" color={theme.eui.euiColorMediumShade} />
           </div>
         ) : (
           <Chart size={chartSize}>

--- a/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/spark_plot/index.tsx
@@ -68,7 +68,16 @@ export function SparkPlot({
     <EuiFlexGroup gutterSize="m" responsive={false}>
       <EuiFlexItem grow={false}>
         {!series || series.every((point) => point.y === null) ? (
-          <EuiIcon type="visLine" color="subdued" style={chartSize} />
+          <div
+            style={{
+              ...chartSize,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <EuiIcon type="visLine" color={theme.eui.euiColorLightShade} />
+          </div>
         ) : (
           <Chart size={chartSize}>
             <Settings


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/91806

<img width="1558" alt="Screenshot 2021-02-18 at 11 39 36" src="https://user-images.githubusercontent.com/55978943/108395442-c6b1fb80-71e3-11eb-86eb-3a6c4dcc39d9.png">
<img width="1086" alt="Screenshot 2021-02-18 at 11 40 57" src="https://user-images.githubusercontent.com/55978943/108395450-c9145580-71e3-11eb-903e-55d7572ba4bb.png">
