### PR TITLE
[Lens] Fix overlowing content on a chart for charts and table

### DIFF
--- a/x-pack/plugins/lens/public/drag_drop/drag_drop.scss
+++ b/x-pack/plugins/lens/public/drag_drop/drag_drop.scss
@@ -84,6 +84,8 @@
 .lnsDragDrop__container {
   position: relative;
   overflow: visible !important; // sass-lint:disable-line no-important
+  width: 100%;
+  height: 100%;
 }
 
 .lnsDragDrop__reorderableDrop {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -10,7 +10,15 @@ import classNames from 'classnames';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { Ast } from '@kbn/interpreter/common';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiButtonEmpty, EuiLink } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiButtonEmpty,
+  EuiLink,
+  EuiPageContentBody,
+} from '@elastic/eui';
 import { CoreStart, CoreSetup } from 'kibana/public';
 import {
   DataPublicPluginStart,
@@ -320,10 +328,10 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
         value={dropProps.value}
         order={dropProps.order}
       >
-        <div>
+        <EuiPageContentBody className="lnsWorkspacePanelWrapper__pageContentBody">
           {renderVisualization()}
           {Boolean(suggestionForDraggedField) && expression !== null && renderEmptyWorkspace()}
-        </div>
+        </EuiPageContentBody>
       </DragDrop>
     </WorkspacePanelWrapper>
   );

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.scss
@@ -32,8 +32,8 @@
 .lnsWorkspacePanel__dragDrop {
   width: 100%;
   height: 100%;
-  border: 1px solid $euiColorLightShade;
-  border-radius: 4px;
+  border: $euiBorderThin;
+  border-radius: $euiBorderRadius;
 
   &.lnsDragDrop-isDropTarget {
     @include lnsDroppable;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.scss
@@ -10,6 +10,7 @@
   position: relative; // For positioning the dnd overlay
   min-height: $euiSizeXXL * 10;
   overflow: visible;
+  border: none;
 
   .lnsWorkspacePanelWrapper__pageContentBody {
     @include euiScrollBar;
@@ -29,19 +30,33 @@
 }
 
 .lnsWorkspacePanel__dragDrop {
-  // Disable the coloring of the DnD for this element as we'll
-  // Color the whole panel instead
-  background-color: transparent !important; // sass-lint:disable-line no-important
-  border: none !important; // sass-lint:disable-line no-important
   width: 100%;
   height: 100%;
-}
+  border: 1px solid $euiColorLightShade;
+  border-radius: 4px;
 
-.lnsExpressionRenderer {
-  .lnsDragDrop-isDropTarget & {
-    transition: filter $euiAnimSpeedNormal ease-in-out, opacity $euiAnimSpeedNormal ease-in-out;
-    filter: blur($euiSizeXS);
-    opacity: .25;
+  &.lnsDragDrop-isDropTarget {
+    @include lnsDroppable;
+    @include lnsDroppableActive;
+
+    p {
+      transition: filter $euiAnimSpeedFast ease-in-out;
+      filter: blur(5px);
+    }
+
+    .lnsExpressionRenderer {
+      transition: filter $euiAnimSpeedNormal ease-in-out, opacity $euiAnimSpeedNormal ease-in-out;
+      filter: blur($euiSizeXS);
+      opacity: .25;
+    }
+  }
+
+  &.lnsDragDrop-isActiveDropTarget {
+    @include lnsDroppableActiveHover;
+
+    .lnsDropIllustration__hand {
+      animation: lnsWorkspacePanel__illustrationPulseContinuous 1.5s ease-in-out 0s infinite normal forwards;
+    }
   }
 }
 
@@ -55,24 +70,6 @@
   justify-content: center;
   align-items: center;
   transition: background-color $euiAnimSpeedFast ease-in-out;
-
-  .lnsDragDrop-isDropTarget & {
-    @include lnsDroppable;
-    @include lnsDroppableActive;
-
-    p {
-      transition: filter $euiAnimSpeedFast ease-in-out;
-      filter: blur(5px);
-    }
-  }
-
-  .lnsDragDrop-isActiveDropTarget & {
-    @include lnsDroppableActiveHover;
-
-    .lnsDropIllustration__hand {
-      animation: lnsWorkspacePanel__illustrationPulseContinuous 1.5s ease-in-out 0s infinite normal forwards;
-    }
-  }
 }
 
 .lnsWorkspacePanelWrapper__toolbar {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.tsx
@@ -9,13 +9,7 @@ import './workspace_panel_wrapper.scss';
 
 import React, { useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
-import {
-  EuiPageContent,
-  EuiPageContentBody,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiScreenReaderOnly,
-} from '@elastic/eui';
+import { EuiPageContent, EuiFlexGroup, EuiFlexItem, EuiScreenReaderOnly } from '@elastic/eui';
 import { Datasource, FramePublicAPI, Visualization } from '../../../types';
 import { NativeRenderer } from '../../../native_renderer';
 import { Action } from '../state_management';
@@ -130,9 +124,7 @@ export function WorkspacePanelWrapper({
               })}
           </h1>
         </EuiScreenReaderOnly>
-        <EuiPageContentBody className="lnsWorkspacePanelWrapper__pageContentBody">
-          {children}
-        </EuiPageContentBody>
+        {children}
       </EuiPageContent>
     </>
   );


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/91827
Fixes https://github.com/elastic/kibana/issues/91808


@MichaelMarcialis I also changed the double border that you asked me about in this PR: https://github.com/elastic/kibana/pull/90546  and simplified CSS a bit. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
