### PR TITLE
[7.x] [load testing] add env vars to pass simulations and repo rootPath (#89544)

### DIFF
--- a/test/scripts/jenkins_build_load_testing.sh
+++ b/test/scripts/jenkins_build_load_testing.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+while getopts s: flag
+do
+    case "${flag}" in
+        s) simulations=${OPTARG};;
+    esac
+done
+echo "Simulation classes: $simulations";
+
 cd "$KIBANA_DIR"
 source src/dev/ci_setup/setup_env.sh
 
@@ -25,6 +33,7 @@ echo " -> test setup"
 source test/scripts/jenkins_test_setup_xpack.sh
 
 echo " -> run gatling load testing"
+export GATLING_SIMULATIONS="$simulations"
 node scripts/functional_tests \
-    --kibana-install-dir "$KIBANA_INSTALL_DIR" \
-    --config test/load/config.ts
+  --kibana-install-dir "$KIBANA_INSTALL_DIR" \
+  --config test/load/config.ts

--- a/x-pack/test/load/runner.ts
+++ b/x-pack/test/load/runner.ts
@@ -8,23 +8,57 @@
 import { withProcRunner } from '@kbn/dev-utils';
 import { resolve } from 'path';
 import { REPO_ROOT } from '@kbn/utils';
+import Fs from 'fs';
+import { createFlagError } from '@kbn/dev-utils';
 import { FtrProviderContext } from './../functional/ftr_provider_context';
 
+const baseSimulationPath = 'src/test/scala/org/kibanaLoadTest/simulation';
+const simulationPackage = 'org.kibanaLoadTest.simulation';
+const simulationFIleExtension = '.scala';
+const gatlingProjectRootPath: string =
+  process.env.GATLING_PROJECT_PATH || resolve(REPO_ROOT, '../kibana-load-testing');
+const simulationEntry: string = process.env.GATLING_SIMULATIONS || 'DemoJourney';
+
+if (!Fs.existsSync(gatlingProjectRootPath)) {
+  throw createFlagError(
+    `Incorrect path to load testing project: '${gatlingProjectRootPath}'\n
+  Clone 'elastic/kibana-load-testing' and set path using 'GATLING_PROJECT_PATH' env var`
+  );
+}
+
+const dropEmptyLines = (s: string) => s.split(',').filter((i) => i.length > 0);
+const simulationClasses = dropEmptyLines(simulationEntry);
+const simulationsRootPath = resolve(gatlingProjectRootPath, baseSimulationPath);
+
+simulationClasses.map((className) => {
+  const simulationClassPath = resolve(
+    simulationsRootPath,
+    className.replace('.', '/') + simulationFIleExtension
+  );
+  if (!Fs.existsSync(simulationClassPath)) {
+    throw createFlagError(`Simulation class is not found: '${simulationClassPath}'`);
+  }
+});
+
+/**
+ *
+ * GatlingTestRunner is used to run load simulation against local Kibana instance
+ *
+ * Use GATLING_SIMULATIONS to pass comma-separated class names
+ * Use GATLING_PROJECT_PATH to override path to 'kibana-load-testing' project
+ */
 export async function GatlingTestRunner({ getService }: FtrProviderContext) {
   const log = getService('log');
-  const gatlingProjectRootPath = resolve(REPO_ROOT, '../kibana-load-testing');
 
   await withProcRunner(log, async (procs) => {
-    await procs.run('gatling', {
+    await procs.run('mvn: clean compile', {
       cmd: 'mvn',
       args: [
-        'clean',
-        '-q',
+        '-Dmaven.wagon.http.retryHandler.count=3',
         '-Dmaven.test.failure.ignore=true',
-        'compile',
-        'gatling:test',
         '-q',
-        '-Dgatling.simulationClass=org.kibanaLoadTest.simulation.DemoJourney',
+        'clean',
+        'compile',
       ],
       cwd: gatlingProjectRootPath,
       env: {
@@ -32,5 +66,20 @@ export async function GatlingTestRunner({ getService }: FtrProviderContext) {
       },
       wait: true,
     });
+    for (const simulationClass of simulationClasses) {
+      await procs.run('gatling: test', {
+        cmd: 'mvn',
+        args: [
+          'gatling:test',
+          '-q',
+          `-Dgatling.simulationClass=${simulationPackage}.${simulationClass}`,
+        ],
+        cwd: gatlingProjectRootPath,
+        env: {
+          ...process.env,
+        },
+        wait: true,
+      });
+    }
   });
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [load testing] add env vars to pass simulations and repo rootPath (#89544)