### PR TITLE
[Discover] Respect default column setting

### DIFF
--- a/src/plugins/discover/public/application/angular/helpers/state_helpers.ts
+++ b/src/plugins/discover/public/application/angular/helpers/state_helpers.ts
@@ -7,6 +7,7 @@
  */
 
 import { IUiSettingsClient } from 'src/core/public';
+import { isEqual } from 'lodash';
 import { SEARCH_FIELDS_FROM_SOURCE, DEFAULT_COLUMNS_SETTING } from '../../../../common';
 
 /**
@@ -25,9 +26,15 @@ export function handleSourceColumnState<TState extends { columns?: string[] }>(
   const defaultColumns = uiSettings.get(DEFAULT_COLUMNS_SETTING);
   if (useNewFieldsApi) {
     // if fields API is used, filter out the source column
+    let cleanedColumns = state.columns.filter((column) => column !== '_source');
+    if (cleanedColumns.length === 0 && !isEqual(defaultColumns, ['_source'])) {
+      cleanedColumns = defaultColumns;
+      // defaultColumns could still contain _source
+      cleanedColumns = cleanedColumns.filter((column) => column !== '_source');
+    }
     return {
       ...state,
-      columns: state.columns.filter((column) => column !== '_source'),
+      columns: cleanedColumns,
     };
   } else if (state.columns.length === 0) {
     // if _source fetching is used and there are no column, switch back to default columns


### PR DESCRIPTION
## Summary

Kinda fixes: https://github.com/elastic/kibana/issues/92018

This bug has actually been present since at least 7.10. The default column setting was not respected even before the introduction of the Fields API. This PR fixes the root issue: if you change a column in the advanced settings and then go back to Discover, the new column will be respected. However, if after that, you change the default column again, it won't be respected.

The problem is how we sync app state and state from URL:
https://github.com/elastic/kibana/blob/543bf1bf1d86d81d13fd55c44e33f1d22268a0d9/src/plugins/discover/public/application/angular/discover_state.ts#L176

and I'm not sure there's an easy fix. GIven we don't know how much this feature is used at all, I think this is okish for now.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
