### PR TITLE
[App Search] Remove external/popout icon from Create Engine CTA

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
@@ -52,7 +52,6 @@ export const EmptyState: React.FC = () => {
           actions={
             <EuiButtonTo
               data-test-subj="EmptyStateCreateFirstEngineCta"
-              iconType="popout"
               fill
               to={ENGINE_CREATION_PATH}
               onClick={() =>


### PR DESCRIPTION
## Summary

Now that create engine button is no longer linking externally to the standalone UI, we no longer need this icon.

I missed this while reviewing #89816, totally my bad!

### Before
<img width="1134" alt="" src="https://user-images.githubusercontent.com/549407/108760474-8fed2580-7502-11eb-85fe-d2d8ed1c5b7a.png">

### After
<img width="1124" alt="" src="https://user-images.githubusercontent.com/549407/108760529-9f6c6e80-7502-11eb-9f34-ebea791e43c9.png">