### PR TITLE
[App Search] Standardize date/timestamps displayed in tables

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.test.tsx
@@ -48,9 +48,9 @@ describe('RecentQueriesTable', () => {
     expect(tableContent).toContain('""');
 
     expect(tableContent).toContain('Time');
-    expect(tableContent).toContain('1/3/1970');
-    expect(tableContent).toContain('1/2/1970');
-    expect(tableContent).toContain('1/1/1970');
+    expect(tableContent).toContain('Jan 3, 1970');
+    expect(tableContent).toContain('Jan 2, 1970');
+    expect(tableContent).toContain('Jan 1, 1970');
 
     expect(tableContent).toContain('Analytics tags');
     expect(tableContent).toContain('tagA');

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/analytics/components/analytics_tables/recent_queries_table.tsx
@@ -9,8 +9,8 @@ import React from 'react';
 
 import { EuiBasicTable, EuiBasicTableColumn, EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedDate, FormattedTime } from '@kbn/i18n/react';
 
+import { FormattedDateTime } from '../../../../utils/formatted_date_time';
 import { RecentQuery } from '../../types';
 
 import {
@@ -36,15 +36,10 @@ export const RecentQueriesTable: React.FC<Props> = ({ items }) => {
     name: i18n.translate('xpack.enterpriseSearch.appSearch.engine.analytics.table.timeColumn', {
       defaultMessage: 'Time',
     }),
-    render: (timestamp: RecentQuery['timestamp']) => {
-      const date = new Date(timestamp);
-      return (
-        <>
-          <FormattedDate value={date} /> <FormattedTime value={date} />
-        </>
-      );
-    },
-    width: '175px',
+    render: (timestamp: RecentQuery['timestamp']) => (
+      <FormattedDateTime date={new Date(timestamp)} />
+    ),
+    width: '200px',
   };
 
   const RESULTS_COLUMN = {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/utils.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { convertToDate } from './utils';
+
+describe('convertToDate', () => {
+  it('converts the English-only server timestamps to a parseable Date', () => {
+    const serverDateString = 'January 01, 1970 at 12:00PM';
+    const date = convertToDate(serverDateString);
+
+    expect(date).toBeInstanceOf(Date);
+    expect(date.getFullYear()).toEqual(1970);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/utils.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// The server API feels us an English datestring, but we want to convert
+// it to an actual Date() instance so that we can localize date formats.
+export const convertToDate = (serverDateString: string): Date => {
+  const readableDateString = serverDateString
+    .replace(' at ', ' ')
+    .replace('PM', ' PM')
+    .replace('AM', ' AM');
+  return new Date(readableDateString);
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.test.tsx
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { mockKibanaValues, setMockActions, setMockValues } from '../../../../__mocks__';
+import {
+  mountWithIntl,
+  mockKibanaValues,
+  setMockActions,
+  setMockValues,
+} from '../../../../__mocks__';
 import '../../../__mocks__/engine_logic.mock';
 
 import React from 'react';
 
-import { shallow, mount, ReactWrapper } from 'enzyme';
+import { shallow, ReactWrapper } from 'enzyme';
 
 import { EuiBasicTable, EuiEmptyPrompt } from '@elastic/eui';
 
@@ -71,7 +76,7 @@ describe('Curations', () => {
   });
 
   it('calls loadCurations on page load', () => {
-    mount(<Curations />);
+    mountWithIntl(<Curations />);
 
     expect(actions.loadCurations).toHaveBeenCalledTimes(1);
   });
@@ -95,7 +100,7 @@ describe('Curations', () => {
       let wrapper: ReactWrapper;
 
       beforeAll(() => {
-        wrapper = mount(<CurationsTable />);
+        wrapper = mountWithIntl(<CurationsTable />);
       });
 
       it('renders queries and last updated columns', () => {
@@ -106,8 +111,8 @@ describe('Curations', () => {
         expect(tableContent).toContain('mountains, valleys');
 
         expect(tableContent).toContain('Last updated');
-        expect(tableContent).toContain('January 1, 1970 at 12:00PM');
-        expect(tableContent).toContain('January 2, 1970 at 12:00PM');
+        expect(tableContent).toContain('Jan 1, 1970 12:00 PM');
+        expect(tableContent).toContain('Jan 2, 1970 12:00 PM');
       });
 
       it('renders queries with curation links', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
@@ -25,11 +25,13 @@ import { KibanaLogic } from '../../../../shared/kibana';
 import { Loading } from '../../../../shared/loading';
 import { EuiButtonTo, EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { ENGINE_CURATIONS_NEW_PATH, ENGINE_CURATION_PATH } from '../../../routes';
+import { FormattedDateTime } from '../../../utils/formatted_date_time';
 import { generateEnginePath } from '../../engine';
 
 import { CURATIONS_OVERVIEW_TITLE, CREATE_NEW_CURATION_TITLE } from '../constants';
 import { CurationsLogic } from '../curations_logic';
 import { Curation } from '../types';
+import { convertToDate } from '../utils';
 
 export const Curations: React.FC = () => {
   const { dataLoading, curations, meta } = useValues(CurationsLogic);
@@ -101,6 +103,7 @@ export const CurationsTable: React.FC = () => {
       ),
       width: '30%',
       dataType: 'string',
+      render: (dateString: string) => <FormattedDateTime date={convertToDate(dateString)} />,
     },
     {
       width: '120px',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -11,7 +11,7 @@ import { useActions } from 'kea';
 
 import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
+import { FormattedMessage, FormattedNumber } from '@kbn/i18n/react';
 
 import { ENGINES_PAGE_SIZE } from '../../../../../common/constants';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
@@ -19,6 +19,7 @@ import { TelemetryLogic } from '../../../shared/telemetry';
 import { UNIVERSAL_LANGUAGE } from '../../constants';
 import { ENGINE_PATH } from '../../routes';
 import { generateEncodedPath } from '../../utils/encode_path_params';
+import { FormattedDateTime } from '../../utils/formatted_date_time';
 import { EngineDetails } from '../engine/types';
 
 interface EnginesTablePagination {
@@ -83,8 +84,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
       ),
       dataType: 'string',
       render: (dateString: string) => (
-        // e.g., Jan 1, 1970
-        <FormattedDate value={new Date(dateString)} year="numeric" month="short" day="numeric" />
+        <FormattedDateTime date={new Date(dateString)} hasTime={false} />
       ),
     },
     {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -83,9 +83,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
         }
       ),
       dataType: 'string',
-      render: (dateString: string) => (
-        <FormattedDateTime date={new Date(dateString)} hasTime={false} />
-      ),
+      render: (dateString: string) => <FormattedDateTime date={new Date(dateString)} hideTime />,
     },
     {
       field: 'language',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.test.tsx
@@ -18,4 +18,11 @@ describe('FormattedDateTime', () => {
 
     expect(wrapper.text()).toEqual('Jan 1, 1970 12:00 PM');
   });
+
+  it('optionally excludes time if hasTime={false} is passed', () => {
+    const date = new Date('1970-01-01T12:00:00');
+    const wrapper = mountWithIntl(<FormattedDateTime date={date} hasTime={false} />);
+
+    expect(wrapper.text()).toEqual('Jan 1, 1970');
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.test.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mountWithIntl } from '../../../__mocks__';
+
+import React from 'react';
+
+import { FormattedDateTime } from './';
+
+describe('FormattedDateTime', () => {
+  it('renders a standard i18n-friendly combined date & time stamp', () => {
+    const date = new Date('1970-01-01T12:00:00');
+    const wrapper = mountWithIntl(<FormattedDateTime date={date} />);
+
+    expect(wrapper.text()).toEqual('Jan 1, 1970 12:00 PM');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.test.tsx
@@ -19,9 +19,9 @@ describe('FormattedDateTime', () => {
     expect(wrapper.text()).toEqual('Jan 1, 1970 12:00 PM');
   });
 
-  it('optionally excludes time if hasTime={false} is passed', () => {
+  it('does not render time if hideTime is passed', () => {
     const date = new Date('1970-01-01T12:00:00');
-    const wrapper = mountWithIntl(<FormattedDateTime date={date} hasTime={false} />);
+    const wrapper = mountWithIntl(<FormattedDateTime date={date} hideTime />);
 
     expect(wrapper.text()).toEqual('Jan 1, 1970');
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.tsx
@@ -9,9 +9,19 @@ import React from 'react';
 
 import { FormattedDate, FormattedTime } from '@kbn/i18n/react';
 
-export const FormattedDateTime: React.FC<{ date: Date }> = ({ date }) => (
+interface Props {
+  date: Date;
+  hasTime?: boolean;
+}
+
+export const FormattedDateTime: React.FC<Props> = ({ date, hasTime = true }) => (
   <>
-    <FormattedDate value={date} year="numeric" month="short" day="numeric" />{' '}
-    <FormattedTime value={date} />
+    <FormattedDate value={date} year="numeric" month="short" day="numeric" />
+    {hasTime && (
+      <>
+        {' '}
+        <FormattedTime value={date} />
+      </>
+    )}
   </>
 );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.tsx
@@ -11,13 +11,13 @@ import { FormattedDate, FormattedTime } from '@kbn/i18n/react';
 
 interface Props {
   date: Date;
-  hasTime?: boolean;
+  hideTime?: boolean;
 }
 
-export const FormattedDateTime: React.FC<Props> = ({ date, hasTime = true }) => (
+export const FormattedDateTime: React.FC<Props> = ({ date, hideTime = false }) => (
   <>
     <FormattedDate value={date} year="numeric" month="short" day="numeric" />
-    {hasTime && (
+    {!hideTime && (
       <>
         {' '}
         <FormattedTime value={date} />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/formatted_date_time/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { FormattedDate, FormattedTime } from '@kbn/i18n/react';
+
+export const FormattedDateTime: React.FC<{ date: Date }> = ({ date }) => (
+  <>
+    <FormattedDate value={date} year="numeric" month="short" day="numeric" />{' '}
+    <FormattedTime value={date} />
+  </>
+);


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/91565#discussion_r577143574: This PR adds a new `<FormattedDateTime />` helper that takes a `Date` instance and renders date/time strings in the same i18n friendly format across our app.

Here is a quick shortlist of all `EuiBasicTable` instances in App Search where we display some kind of date/time string:

- Engines/meta engines table
- Analytics > Recent Queries table
- Curations table
- (NYI) Recent API Logs table - **Note:** we will likely not be using this specific helper for that table, as it uses a "X seconds ago" / "X minutes ago" format. That will _likely_ use react-intl's [FormattedRelativeTime](https://formatjs.io/docs/react-intl/components/#formattedrelativetime) component instead.

## Before/after screenshots

### Analytics Recent Queries
Before / ent-search standalone UI:
<img width="353" alt="" src="https://user-images.githubusercontent.com/549407/108771328-5ae7cf80-7510-11eb-9090-ee902686b867.png">

After / Kibana:
<img width="489" alt="" src="https://user-images.githubusercontent.com/549407/108770962-d2692f00-750f-11eb-8d6f-c590c0f2b56e.png">

### Curations
Before / non-i18n string from server API:
<img width="670" alt="" src="https://user-images.githubusercontent.com/549407/108771384-705cf980-7510-11eb-9a2e-0c304196b87c.png">

After/Kibana (localized date):
<img width="601" alt="" src="https://user-images.githubusercontent.com/549407/108771907-24f71b00-7511-11eb-9b27-6a111030ef68.png">
<img width="612" alt="" src="https://user-images.githubusercontent.com/549407/108771220-37248980-7510-11eb-8887-bd15f3efec6f.png">

### Engines/meta engines (should be the same)
Before:
<img width="437" alt="Screen Shot 2021-02-22 at 1 16 33 PM" src="https://user-images.githubusercontent.com/549407/108771470-91254f00-7510-11eb-98a9-abf7c7932630.png">

After:
<img width="462" alt="" src="https://user-images.githubusercontent.com/549407/108771236-3be93d80-7510-11eb-9948-4305e511b79e.png">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios