### PR TITLE
[App Search] Standardize table pagination logic/UX

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -81,5 +81,3 @@ export const JSON_HEADER = {
 };
 
 export const READ_ONLY_MODE_HEADER = 'x-ent-search-read-only-mode';
-
-export const ENGINES_PAGE_SIZE = 10;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.test.tsx
@@ -14,6 +14,7 @@ import { shallow } from 'enzyme';
 
 import { EuiCopy, EuiLoadingContent, EuiPageContentBody } from '@elastic/eui';
 
+import { DEFAULT_META } from '../../../shared/constants';
 import { externalUrl } from '../../../shared/enterprise_search_url';
 
 import { Credentials } from './credentials';
@@ -23,10 +24,12 @@ import { CredentialsFlyout } from './credentials_flyout';
 describe('Credentials', () => {
   // Kea mocks
   const values = {
+    meta: DEFAULT_META,
     dataLoading: false,
   };
   const actions = {
-    initializeCredentialsData: jest.fn(),
+    fetchCredentials: jest.fn(),
+    fetchDetails: jest.fn(),
     resetCredentials: jest.fn(),
     showCredentialsForm: jest.fn(),
   };
@@ -42,9 +45,10 @@ describe('Credentials', () => {
     expect(wrapper.find(EuiPageContentBody)).toHaveLength(1);
   });
 
-  it('initializes data on mount', () => {
+  it('fetches data on mount', () => {
     shallow(<Credentials />);
-    expect(actions.initializeCredentialsData).toHaveBeenCalledTimes(1);
+    expect(actions.fetchCredentials).toHaveBeenCalledTimes(1);
+    expect(actions.fetchDetails).toHaveBeenCalledTimes(1);
   });
 
   it('calls resetCredentials on unmount', () => {
@@ -54,7 +58,7 @@ describe('Credentials', () => {
   });
 
   it('renders a limited UI if data is still loading', () => {
-    setMockValues({ dataLoading: true });
+    setMockValues({ ...values, dataLoading: true });
     const wrapper = shallow(<Credentials />);
     expect(wrapper.find('[data-test-subj="CreateAPIKeyButton"]')).toHaveLength(0);
     expect(wrapper.find(EuiLoadingContent)).toHaveLength(1);
@@ -78,13 +82,13 @@ describe('Credentials', () => {
   });
 
   it('will render CredentialsFlyout if shouldShowCredentialsForm is true', () => {
-    setMockValues({ shouldShowCredentialsForm: true });
+    setMockValues({ ...values, shouldShowCredentialsForm: true });
     const wrapper = shallow(<Credentials />);
     expect(wrapper.find(CredentialsFlyout)).toHaveLength(1);
   });
 
   it('will NOT render CredentialsFlyout if shouldShowCredentialsForm is false', () => {
-    setMockValues({ shouldShowCredentialsForm: false });
+    setMockValues({ ...values, shouldShowCredentialsForm: false });
     const wrapper = shallow(<Credentials />);
     expect(wrapper.find(CredentialsFlyout)).toHaveLength(0);
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials.tsx
@@ -35,14 +35,18 @@ import { CredentialsList } from './credentials_list';
 import { CredentialsLogic } from './credentials_logic';
 
 export const Credentials: React.FC = () => {
-  const { initializeCredentialsData, resetCredentials, showCredentialsForm } = useActions(
+  const { fetchCredentials, fetchDetails, resetCredentials, showCredentialsForm } = useActions(
     CredentialsLogic
   );
 
-  const { dataLoading, shouldShowCredentialsForm } = useValues(CredentialsLogic);
+  const { meta, dataLoading, shouldShowCredentialsForm } = useValues(CredentialsLogic);
 
   useEffect(() => {
-    initializeCredentialsData();
+    fetchCredentials();
+  }, [meta.page.current]);
+
+  useEffect(() => {
+    fetchDetails();
     return () => {
       resetCredentials();
     };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.test.tsx
@@ -21,7 +21,7 @@ import { Key } from './key';
 
 import { CredentialsList } from './';
 
-describe('Credentials', () => {
+describe('CredentialsList', () => {
   const apiToken: ApiToken = {
     name: '',
     type: ApiTokenTypes.Private,
@@ -42,10 +42,11 @@ describe('Credentials', () => {
         total_results: 1,
       },
     },
+    isCredentialsDataComplete: true,
   };
   const actions = {
     deleteApiKey: jest.fn(),
-    fetchCredentials: jest.fn(),
+    onPaginate: jest.fn(),
     showCredentialsForm: jest.fn(),
   };
 
@@ -92,9 +93,22 @@ describe('Credentials', () => {
         apiTokens: [],
       });
 
+      const wrapper = shallow(<CredentialsList />)
+        .find(EuiBasicTable)
+        .dive();
+      expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+    });
+  });
+
+  describe('loading state', () => {
+    it('renders as loading when isCredentialsDataComplete is false', () => {
+      setMockValues({
+        ...values,
+        isCredentialsDataComplete: false,
+      });
+
       const wrapper = shallow(<CredentialsList />);
-      expect(wrapper.exists(EuiEmptyPrompt)).toBe(true);
-      expect(wrapper.exists(EuiBasicTable)).toBe(false);
+      expect(wrapper.find(EuiBasicTable).prop('loading')).toBe(true);
     });
   });
 
@@ -120,24 +134,13 @@ describe('Credentials', () => {
         hidePerPageOptions: true,
       });
     });
-
-    it('will default pagination values if `page` is not available', () => {
-      setMockValues({ ...values, meta: {} });
-      const wrapper = shallow(<CredentialsList />);
-      const { pagination } = wrapper.find(EuiBasicTable).props();
-      expect(pagination).toEqual({
-        pageIndex: 0,
-        pageSize: 0,
-        totalItemCount: 0,
-        hidePerPageOptions: true,
-      });
-    });
   });
 
   describe('columns', () => {
     let columns: any[];
 
     beforeAll(() => {
+      setMockValues(values);
       const wrapper = shallow(<CredentialsList />);
       columns = wrapper.find(EuiBasicTable).props().columns;
     });
@@ -269,18 +272,16 @@ describe('Credentials', () => {
   });
 
   describe('onChange', () => {
-    it('will handle pagination by calling `fetchCredentials`', () => {
+    it('will handle pagination by calling `onPaginate`', () => {
       const wrapper = shallow(<CredentialsList />);
-      const { onChange } = wrapper.find(EuiBasicTable).props();
-
-      onChange({
+      wrapper.find(EuiBasicTable).simulate('change', {
         page: {
           size: 10,
           index: 2,
         },
       });
 
-      expect(actions.fetchCredentials).toHaveBeenCalledWith(3);
+      expect(actions.onPaginate).toHaveBeenCalledWith(3);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_list/credentials_list.tsx
@@ -10,10 +10,10 @@ import React, { useMemo } from 'react';
 import { useActions, useValues } from 'kea';
 
 import { EuiBasicTable, EuiBasicTableColumn, EuiCopy, EuiEmptyPrompt } from '@elastic/eui';
-import { CriteriaWithPagination } from '@elastic/eui/src/components/basic_table/basic_table';
 import { i18n } from '@kbn/i18n';
 
 import { HiddenText } from '../../../../shared/hidden_text';
+import { convertMetaToPagination, handlePageChange } from '../../../../shared/table_pagination';
 import { TOKEN_TYPE_DISPLAY_NAMES } from '../constants';
 import { CredentialsLogic } from '../credentials_logic';
 import { ApiToken } from '../types';
@@ -23,9 +23,9 @@ import { apiTokenSort } from '../utils/api_token_sort';
 import { Key } from './key';
 
 export const CredentialsList: React.FC = () => {
-  const { deleteApiKey, fetchCredentials, showCredentialsForm } = useActions(CredentialsLogic);
+  const { deleteApiKey, onPaginate, showCredentialsForm } = useActions(CredentialsLogic);
 
-  const { apiTokens, meta } = useValues(CredentialsLogic);
+  const { apiTokens, meta, isCredentialsDataComplete } = useValues(CredentialsLogic);
 
   const items = useMemo(() => apiTokens.slice().sort(apiTokenSort), [apiTokens]);
 
@@ -109,38 +109,31 @@ export const CredentialsList: React.FC = () => {
     },
   ];
 
-  const pagination = {
-    pageIndex: meta.page ? meta.page.current - 1 : 0,
-    pageSize: meta.page ? meta.page.size : 0,
-    totalItemCount: meta.page ? meta.page.total_results : 0,
-    hidePerPageOptions: true,
-  };
-
-  const onTableChange = ({ page }: CriteriaWithPagination<ApiToken>) => {
-    const { index: current } = page;
-    fetchCredentials(current + 1);
-  };
-
-  return items.length < 1 ? (
-    <EuiEmptyPrompt
-      iconType="editorStrike"
-      title={
-        <h2>
-          {i18n.translate('xpack.enterpriseSearch.appSearch.credentials.empty.title', {
-            defaultMessage: 'No API Keys have been created yet.',
-          })}
-        </h2>
-      }
-      body={i18n.translate('xpack.enterpriseSearch.appSearch.credentials.empty.body', {
-        defaultMessage: 'Click the "Create a key" button to make your first one.',
-      })}
-    />
-  ) : (
+  return (
     <EuiBasicTable
       columns={columns}
       items={items}
-      pagination={pagination}
-      onChange={onTableChange}
+      noItemsMessage={
+        <EuiEmptyPrompt
+          iconType="editorStrike"
+          title={
+            <h2>
+              {i18n.translate('xpack.enterpriseSearch.appSearch.credentials.empty.title', {
+                defaultMessage: 'No API Keys have been created yet.',
+              })}
+            </h2>
+          }
+          body={i18n.translate('xpack.enterpriseSearch.appSearch.credentials.empty.body', {
+            defaultMessage: 'Click the "Create a key" button to make your first one.',
+          })}
+        />
+      }
+      loading={!isCredentialsDataComplete}
+      pagination={{
+        ...convertMetaToPagination(meta),
+        hidePerPageOptions: true,
+      }}
+      onChange={handlePageChange(onPaginate)}
     />
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -7,15 +7,15 @@
 
 import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../../__mocks__';
 
+import { nextTick } from '@kbn/test/jest';
+
+import { DEFAULT_META } from '../../../shared/constants';
+
 jest.mock('../../app_logic', () => ({
   AppLogic: {
     selectors: { myRole: jest.fn(() => ({})) },
-    values: { myRole: jest.fn(() => ({})) },
   },
 }));
-
-import { nextTick } from '@kbn/test/jest';
-
 import { AppLogic } from '../../app_logic';
 
 import { ApiTokenTypes } from './constants';
@@ -43,7 +43,7 @@ describe('CredentialsLogic', () => {
     formErrors: [],
     isCredentialsDataComplete: false,
     isCredentialsDetailsComplete: false,
-    meta: {},
+    meta: DEFAULT_META,
     nameInputBlurred: false,
     shouldShowCredentialsForm: false,
     fullEngineAccessChecked: false,
@@ -208,39 +208,6 @@ describe('CredentialsLogic', () => {
               access_all_engines: false,
               engines: ['someEngine', 'anotherEngine'],
             },
-          });
-        });
-      });
-    });
-
-    describe('onApiKeyDelete', () => {
-      const values = {
-        ...DEFAULT_VALUES,
-        apiTokens: expect.any(Array),
-      };
-
-      describe('apiTokens', () => {
-        it('should remove specified token from apiTokens if name matches', () => {
-          mount({
-            apiTokens: [newToken],
-          });
-
-          CredentialsLogic.actions.onApiKeyDelete(newToken.name);
-          expect(CredentialsLogic.values).toEqual({
-            ...values,
-            apiTokens: [],
-          });
-        });
-
-        it('should not remove specified token from apiTokens if name does not match', () => {
-          mount({
-            apiTokens: [newToken],
-          });
-
-          CredentialsLogic.actions.onApiKeyDelete('foo');
-          expect(CredentialsLogic.values).toEqual({
-            ...values,
-            apiTokens: [newToken],
           });
         });
       });
@@ -467,6 +434,7 @@ describe('CredentialsLogic', () => {
 
       const values = {
         ...DEFAULT_VALUES,
+        dataLoading: false,
         apiTokens: expect.any(Array),
         meta: expect.any(Object),
         isCredentialsDataComplete: expect.any(Boolean),
@@ -514,6 +482,7 @@ describe('CredentialsLogic', () => {
     describe('setCredentialsDetails', () => {
       const values = {
         ...DEFAULT_VALUES,
+        dataLoading: false,
         engines: expect.any(Array),
         isCredentialsDetailsComplete: expect.any(Boolean),
       };
@@ -1038,15 +1007,20 @@ describe('CredentialsLogic', () => {
       });
     });
 
-    describe('initializeCredentialsData', () => {
-      it('should call fetchCredentials and fetchDetails', () => {
-        mount();
-        jest.spyOn(CredentialsLogic.actions, 'fetchCredentials').mockImplementationOnce(() => {});
-        jest.spyOn(CredentialsLogic.actions, 'fetchDetails').mockImplementationOnce(() => {});
+    describe('onPaginate', () => {
+      it('should set meta.page.current', () => {
+        mount({ meta: DEFAULT_META });
 
-        CredentialsLogic.actions.initializeCredentialsData();
-        expect(CredentialsLogic.actions.fetchCredentials).toHaveBeenCalled();
-        expect(CredentialsLogic.actions.fetchDetails).toHaveBeenCalled();
+        CredentialsLogic.actions.onPaginate(5);
+        expect(CredentialsLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          meta: {
+            page: {
+              ...DEFAULT_META.page,
+              current: 5,
+            },
+          },
+        });
       });
     });
 
@@ -1066,10 +1040,11 @@ describe('CredentialsLogic', () => {
         jest.spyOn(CredentialsLogic.actions, 'setCredentialsData').mockImplementationOnce(() => {});
         http.get.mockReturnValue(Promise.resolve({ meta, results }));
 
-        CredentialsLogic.actions.fetchCredentials(2);
+        CredentialsLogic.actions.fetchCredentials();
         expect(http.get).toHaveBeenCalledWith('/api/app_search/credentials', {
           query: {
-            'page[current]': 2,
+            'page[current]': 1,
+            'page[size]': 10,
           },
         });
         await nextTick();
@@ -1117,15 +1092,16 @@ describe('CredentialsLogic', () => {
     describe('deleteApiKey', () => {
       const tokenName = 'abc123';
 
-      it('will call an API endpoint and set the results with the `onApiKeyDelete` action', async () => {
+      it('will call an API endpoint and re-fetch the credentials list', async () => {
         mount();
-        jest.spyOn(CredentialsLogic.actions, 'onApiKeyDelete').mockImplementationOnce(() => {});
+        jest.spyOn(CredentialsLogic.actions, 'fetchCredentials').mockImplementationOnce(() => {});
         http.delete.mockReturnValue(Promise.resolve());
 
         CredentialsLogic.actions.deleteApiKey(tokenName);
         expect(http.delete).toHaveBeenCalledWith(`/api/app_search/credentials/${tokenName}`);
         await nextTick();
-        expect(CredentialsLogic.actions.onApiKeyDelete).toHaveBeenCalledWith(tokenName);
+
+        expect(CredentialsLogic.actions.fetchCredentials).toHaveBeenCalled();
         expect(setSuccessMessage).toHaveBeenCalled();
       });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.ts
@@ -8,12 +8,15 @@
 import { kea, MakeLogicType } from 'kea';
 
 import { Meta } from '../../../../../common/types';
+import { DEFAULT_META } from '../../../shared/constants';
 import {
   clearFlashMessages,
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
+import { updateMetaPageIndex } from '../../../shared/table_pagination';
+
 import { AppLogic } from '../../app_logic';
 import { Engine } from '../../types';
 import { formatApiName } from '../../utils/format_api_name';
@@ -32,7 +35,6 @@ export const defaultApiToken: ApiToken = {
 
 interface CredentialsLogicActions {
   addEngineName(engineName: string): string;
-  onApiKeyDelete(tokenName: string): string;
   onApiTokenCreateSuccess(apiToken: ApiToken): ApiToken;
   onApiTokenError(formErrors: string[]): string[];
   onApiTokenUpdateSuccess(apiToken: ApiToken): ApiToken;
@@ -47,8 +49,8 @@ interface CredentialsLogicActions {
   showCredentialsForm(apiToken?: ApiToken): ApiToken;
   hideCredentialsForm(): { value: boolean };
   resetCredentials(): { value: boolean };
-  initializeCredentialsData(): { value: boolean };
-  fetchCredentials(page?: number): number;
+  onPaginate(newPageIndex: number): { newPageIndex: number };
+  fetchCredentials(): void;
   fetchDetails(): { value: boolean };
   deleteApiKey(tokenName: string): string;
   onApiTokenChange(): void;
@@ -66,7 +68,7 @@ interface CredentialsLogicValues {
   isCredentialsDataComplete: boolean;
   isCredentialsDetailsComplete: boolean;
   fullEngineAccessChecked: boolean;
-  meta: Partial<Meta>;
+  meta: Meta;
   nameInputBlurred: boolean;
   shouldShowCredentialsForm: boolean;
 }
@@ -77,7 +79,6 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
   path: ['enterprise_search', 'app_search', 'credentials_logic'],
   actions: () => ({
     addEngineName: (engineName) => engineName,
-    onApiKeyDelete: (tokenName) => tokenName,
     onApiTokenCreateSuccess: (apiToken) => apiToken,
     onApiTokenError: (formErrors) => formErrors,
     onApiTokenUpdateSuccess: (apiToken) => apiToken,
@@ -92,8 +93,8 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
     showCredentialsForm: (apiToken = { ...defaultApiToken }) => apiToken,
     hideCredentialsForm: false,
     resetCredentials: false,
-    initializeCredentialsData: true,
-    fetchCredentials: (page) => page,
+    onPaginate: (newPageIndex) => ({ newPageIndex }),
+    fetchCredentials: true,
     fetchDetails: true,
     deleteApiKey: (tokenName) => tokenName,
     onApiTokenChange: () => null,
@@ -109,14 +110,13 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
           ...apiTokens.filter((token) => token.name !== apiToken.name),
           apiToken,
         ],
-        onApiKeyDelete: (apiTokens, tokenName) =>
-          apiTokens.filter((token) => token.name !== tokenName),
       },
     ],
     meta: [
-      {},
+      DEFAULT_META,
       {
         setCredentialsData: (_, { meta }) => meta,
+        onPaginate: (state, { newPageIndex }) => updateMetaPageIndex(state, newPageIndex),
       },
     ],
     isCredentialsDetailsComplete: [
@@ -130,6 +130,7 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
       false,
       {
         setCredentialsData: () => true,
+        fetchCredentials: () => false,
         resetCredentials: () => false,
       },
     ],
@@ -218,7 +219,7 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
     dataLoading: [
       () => [selectors.isCredentialsDetailsComplete, selectors.isCredentialsDataComplete],
       (isCredentialsDetailsComplete, isCredentialsDataComplete) => {
-        return isCredentialsDetailsComplete === false || isCredentialsDataComplete === false;
+        return isCredentialsDetailsComplete === false && isCredentialsDataComplete === false;
       },
     ],
     activeApiTokenExists: [
@@ -230,14 +231,14 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
     showCredentialsForm: () => {
       clearFlashMessages();
     },
-    initializeCredentialsData: () => {
-      actions.fetchCredentials();
-      actions.fetchDetails();
-    },
-    fetchCredentials: async (page = 1) => {
+    fetchCredentials: async () => {
       try {
         const { http } = HttpLogic.values;
-        const query = { 'page[current]': page };
+        const { meta } = values;
+        const query = {
+          'page[current]': meta.page.current,
+          'page[size]': meta.page.size,
+        };
         const response = await http.get('/api/app_search/credentials', { query });
         actions.setCredentialsData(response.meta, response.results);
       } catch (e) {
@@ -259,7 +260,7 @@ export const CredentialsLogic = kea<CredentialsLogicType>({
         const { http } = HttpLogic.values;
         await http.delete(`/api/app_search/credentials/${tokenName}`);
 
-        actions.onApiKeyDelete(tokenName);
+        actions.fetchCredentials();
         setSuccessMessage(DELETE_MESSAGE);
       } catch (e) {
         flashAPIErrors(e);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_logic.ts
@@ -9,13 +9,13 @@ import { kea, MakeLogicType } from 'kea';
 
 import { Meta } from '../../../../../common/types';
 import { DEFAULT_META } from '../../../shared/constants';
-
 import {
   clearFlashMessages,
   setSuccessMessage,
   flashAPIErrors,
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
+import { updateMetaPageIndex } from '../../../shared/table_pagination';
 import { EngineLogic } from '../engine';
 
 import { DELETE_MESSAGE, SUCCESS_MESSAGE } from './constants';
@@ -60,11 +60,7 @@ export const CurationsLogic = kea<MakeLogicType<CurationsValues, CurationsAction
       DEFAULT_META,
       {
         onCurationsLoad: (_, { meta }) => meta,
-        onPaginate: (state, { newPageIndex }) => {
-          const newState = { page: { ...state.page } };
-          newState.page.current = newPageIndex;
-          return newState;
-        },
+        onPaginate: (state, { newPageIndex }) => updateMetaPageIndex(state, newPageIndex),
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/views/curations.tsx
@@ -24,6 +24,8 @@ import { FlashMessages } from '../../../../shared/flash_messages';
 import { KibanaLogic } from '../../../../shared/kibana';
 import { Loading } from '../../../../shared/loading';
 import { EuiButtonTo, EuiLinkTo } from '../../../../shared/react_router_helpers';
+import { convertMetaToPagination, handlePageChange } from '../../../../shared/table_pagination';
+
 import { ENGINE_CURATIONS_NEW_PATH, ENGINE_CURATION_PATH } from '../../../routes';
 import { generateEnginePath } from '../../engine';
 
@@ -164,15 +166,10 @@ export const CurationsTable: React.FC = () => {
         />
       }
       pagination={{
-        pageIndex: meta.page.current - 1,
-        pageSize: meta.page.size,
-        totalItemCount: meta.page.total_results,
+        ...convertMetaToPagination(meta),
         hidePerPageOptions: true,
       }}
-      onChange={({ page }: { page: { index: number } }) => {
-        const { index } = page;
-        onPaginate(index + 1); // Note on paging - App Search's API pages start at 1, EuiBasicTables' pages start at 0
-      }}
+      onChange={handlePageChange(onPaginate)}
     />
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_logic.test.ts
@@ -9,6 +9,8 @@ import { LogicMounter, mockHttpValues } from '../../../__mocks__';
 
 import { nextTick } from '@kbn/test/jest';
 
+import { DEFAULT_META } from '../../../shared/constants';
+
 import { EngineDetails } from '../engine/types';
 
 import { EnginesLogic } from './';
@@ -20,11 +22,11 @@ describe('EnginesLogic', () => {
   const DEFAULT_VALUES = {
     dataLoading: true,
     engines: [],
-    enginesTotal: 0,
-    enginesPage: 1,
+    enginesMeta: DEFAULT_META,
+    enginesLoading: true,
     metaEngines: [],
-    metaEnginesTotal: 0,
-    metaEnginesPage: 1,
+    metaEnginesMeta: DEFAULT_META,
+    metaEnginesLoading: true,
   };
 
   const MOCK_ENGINE = {
@@ -33,16 +35,17 @@ describe('EnginesLogic', () => {
     document_count: 50,
     field_count: 10,
   } as EngineDetails;
+  const MOCK_META = {
+    page: {
+      current: 1,
+      size: 10,
+      total_results: 100,
+      total_pages: 10,
+    },
+  };
   const MOCK_ENGINES_API_RESPONSE = {
     results: [MOCK_ENGINE],
-    meta: {
-      page: {
-        current: 1,
-        total_pages: 10,
-        total_results: 100,
-        size: 10,
-      },
-    },
+    meta: MOCK_META,
   };
 
   beforeEach(() => {
@@ -56,112 +59,143 @@ describe('EnginesLogic', () => {
 
   describe('actions', () => {
     describe('onEnginesLoad', () => {
-      describe('dataLoading', () => {
-        it('should be set to false', () => {
-          mount();
-          EnginesLogic.actions.onEnginesLoad({ engines: [], total: 0 });
+      it('should set engines & enginesMeta and set enginesLoading to false', () => {
+        mount();
+        EnginesLogic.actions.onEnginesLoad(MOCK_ENGINES_API_RESPONSE);
 
-          expect(EnginesLogic.values).toEqual({
-            ...DEFAULT_VALUES,
-            dataLoading: false,
-          });
-        });
-      });
-
-      describe('engines & enginesTotal', () => {
-        it('should be set to the provided value', () => {
-          mount();
-          EnginesLogic.actions.onEnginesLoad({ engines: [MOCK_ENGINE], total: 100 });
-
-          expect(EnginesLogic.values).toEqual({
-            ...DEFAULT_VALUES,
-            dataLoading: false,
-            engines: [MOCK_ENGINE],
-            enginesTotal: 100,
-          });
+        expect(EnginesLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          engines: [MOCK_ENGINE],
+          enginesMeta: MOCK_META,
+          enginesLoading: false,
+          dataLoading: false,
         });
       });
     });
 
     describe('onMetaEnginesLoad', () => {
-      describe('engines & enginesTotal', () => {
-        it('should be set to the provided value', () => {
-          mount();
-          EnginesLogic.actions.onMetaEnginesLoad({ engines: [MOCK_ENGINE], total: 1 });
+      it('should set engines & enginesMeta and set enginesLoading to false', () => {
+        mount();
+        EnginesLogic.actions.onMetaEnginesLoad(MOCK_ENGINES_API_RESPONSE);
 
-          expect(EnginesLogic.values).toEqual({
-            ...DEFAULT_VALUES,
-            metaEngines: [MOCK_ENGINE],
-            metaEnginesTotal: 1,
-          });
+        expect(EnginesLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          metaEngines: [MOCK_ENGINE],
+          metaEnginesMeta: MOCK_META,
+          metaEnginesLoading: false,
         });
       });
     });
 
     describe('onEnginesPagination', () => {
-      describe('enginesPage', () => {
-        it('should be set to the provided value', () => {
-          mount();
-          EnginesLogic.actions.onEnginesPagination(2);
+      it('should set enginesMeta.page.current', () => {
+        mount();
+        EnginesLogic.actions.onEnginesPagination(2);
 
-          expect(EnginesLogic.values).toEqual({
-            ...DEFAULT_VALUES,
-            enginesPage: 2,
-          });
+        expect(EnginesLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          enginesMeta: {
+            page: {
+              ...DEFAULT_VALUES.enginesMeta.page,
+              current: 2,
+            },
+          },
         });
       });
     });
 
     describe('onMetaEnginesPagination', () => {
-      describe('metaEnginesPage', () => {
-        it('should be set to the provided value', () => {
-          mount();
-          EnginesLogic.actions.onMetaEnginesPagination(99);
+      it('should set metaEnginesMeta.page.current', () => {
+        mount();
+        EnginesLogic.actions.onMetaEnginesPagination(99);
 
-          expect(EnginesLogic.values).toEqual({
-            ...DEFAULT_VALUES,
-            metaEnginesPage: 99,
-          });
+        expect(EnginesLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          metaEnginesMeta: {
+            page: {
+              ...DEFAULT_VALUES.metaEnginesMeta.page,
+              current: 99,
+            },
+          },
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('loadEngines', () => {
       it('should call the engines API endpoint and set state based on the results', async () => {
         http.get.mockReturnValueOnce(Promise.resolve(MOCK_ENGINES_API_RESPONSE));
-        mount({ enginesPage: 10 });
+        mount();
         jest.spyOn(EnginesLogic.actions, 'onEnginesLoad');
 
         EnginesLogic.actions.loadEngines();
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith('/api/app_search/engines', {
-          query: { type: 'indexed', pageIndex: 10 },
+          query: {
+            type: 'indexed',
+            'page[current]': 1,
+            'page[size]': 10,
+          },
         });
-        expect(EnginesLogic.actions.onEnginesLoad).toHaveBeenCalledWith({
-          engines: [MOCK_ENGINE],
-          total: 100,
-        });
+        expect(EnginesLogic.actions.onEnginesLoad).toHaveBeenCalledWith(MOCK_ENGINES_API_RESPONSE);
       });
     });
 
     describe('loadMetaEngines', () => {
       it('should call the engines API endpoint and set state based on the results', async () => {
         http.get.mockReturnValueOnce(Promise.resolve(MOCK_ENGINES_API_RESPONSE));
-        mount({ metaEnginesPage: 99 });
+        mount();
         jest.spyOn(EnginesLogic.actions, 'onMetaEnginesLoad');
 
         EnginesLogic.actions.loadMetaEngines();
         await nextTick();
 
         expect(http.get).toHaveBeenCalledWith('/api/app_search/engines', {
-          query: { type: 'meta', pageIndex: 99 },
+          query: {
+            type: 'meta',
+            'page[current]': 1,
+            'page[size]': 10,
+          },
         });
-        expect(EnginesLogic.actions.onMetaEnginesLoad).toHaveBeenCalledWith({
-          engines: [MOCK_ENGINE],
-          total: 100,
-        });
+        expect(EnginesLogic.actions.onMetaEnginesLoad).toHaveBeenCalledWith(
+          MOCK_ENGINES_API_RESPONSE
+        );
       });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('dataLoading', () => {
+      it('returns true if enginesLoading is true and engines is empty', () => {
+        mount({
+          enginesLoading: true,
+          engines: [],
+        });
+        expect(EnginesLogic.values.dataLoading).toEqual(true);
+      });
+
+      it('returns false if enginesLoading is true but engines exist', () => {
+        // = the engines table is paginating, which has its own separate table loading indicator
+        mount({
+          enginesLoading: true,
+          engines: [MOCK_ENGINE],
+        });
+        expect(EnginesLogic.values.dataLoading).toEqual(false);
+      });
+
+      it('returns false if engineLoading is false and engines is empty', () => {
+        // = empty prompt state
+        mount({
+          enginesLoading: false,
+          engines: [],
+        });
+        expect(EnginesLogic.values.dataLoading).toEqual(false);
+      });
+
+      // NOTE: dataLoading ignores metaEnginesLoading to prevent a race condition where
+      // meta engines finish fetching before engines and flash an empty prompt state.
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -22,6 +22,7 @@ import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { LicensingLogic } from '../../../shared/licensing';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { convertMetaToPagination, handlePageChange } from '../../../shared/table_pagination';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
 import { ENGINE_CREATION_PATH } from '../../routes';
 
@@ -39,11 +40,11 @@ export const EnginesOverview: React.FC = () => {
   const {
     dataLoading,
     engines,
-    enginesTotal,
-    enginesPage,
+    enginesMeta,
+    enginesLoading,
     metaEngines,
-    metaEnginesTotal,
-    metaEnginesPage,
+    metaEnginesMeta,
+    metaEnginesLoading,
   } = useValues(EnginesLogic);
   const { loadEngines, loadMetaEngines, onEnginesPagination, onMetaEnginesPagination } = useActions(
     EnginesLogic
@@ -51,11 +52,11 @@ export const EnginesOverview: React.FC = () => {
 
   useEffect(() => {
     loadEngines();
-  }, [enginesPage]);
+  }, [enginesMeta.page.current]);
 
   useEffect(() => {
     if (hasPlatinumLicense) loadMetaEngines();
-  }, [hasPlatinumLicense, metaEnginesPage]);
+  }, [hasPlatinumLicense, metaEnginesMeta.page.current]);
 
   if (dataLoading) return <LoadingState />;
   if (!engines.length) return <EmptyState />;
@@ -89,12 +90,13 @@ export const EnginesOverview: React.FC = () => {
         </EuiPageContentHeader>
         <EuiPageContentBody data-test-subj="appSearchEngines">
           <EnginesTable
-            data={engines}
+            items={engines}
+            loading={enginesLoading}
             pagination={{
-              totalEngines: enginesTotal,
-              pageIndex: enginesPage - 1,
-              onPaginate: onEnginesPagination,
+              ...convertMetaToPagination(enginesMeta),
+              hidePerPageOptions: true,
             }}
+            onChange={handlePageChange(onEnginesPagination)}
           />
         </EuiPageContentBody>
 
@@ -110,12 +112,13 @@ export const EnginesOverview: React.FC = () => {
             </EuiPageContentHeader>
             <EuiPageContentBody data-test-subj="appSearchMetaEngines">
               <EnginesTable
-                data={metaEngines}
+                items={metaEngines}
+                loading={metaEnginesLoading}
                 pagination={{
-                  totalEngines: metaEnginesTotal,
-                  pageIndex: metaEnginesPage - 1,
-                  onPaginate: onMetaEnginesPagination,
+                  ...convertMetaToPagination(metaEnginesMeta),
+                  hidePerPageOptions: true,
                 }}
+                onChange={handlePageChange(onMetaEnginesPagination)}
               />
             </EuiPageContentBody>
           </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
@@ -19,8 +19,7 @@ import { EngineDetails } from '../engine/types';
 import { EnginesTable } from './engines_table';
 
 describe('EnginesTable', () => {
-  const onPaginate = jest.fn(); // onPaginate updates the engines API call upstream
-
+  const onChange = jest.fn();
   const data = [
     {
       name: 'test-engine',
@@ -32,113 +31,112 @@ describe('EnginesTable', () => {
     } as EngineDetails,
   ];
   const pagination = {
-    totalEngines: 50,
     pageIndex: 0,
-    onPaginate,
+    pageSize: 10,
+    totalItemCount: 50,
+    hidePerPageOptions: true,
   };
   const props = {
-    data,
+    items: data,
+    loading: false,
     pagination,
+    onChange,
   };
 
-  const wrapper = mountWithIntl(<EnginesTable {...props} />);
-  const table = wrapper.find(EuiBasicTable);
+  describe('basic table', () => {
+    const wrapper = mountWithIntl(<EnginesTable {...props} />);
+    const table = wrapper.find(EuiBasicTable);
 
-  it('renders', () => {
-    expect(table).toHaveLength(1);
-    expect(table.prop('pagination').totalItemCount).toEqual(50);
+    it('renders', () => {
+      expect(table).toHaveLength(1);
+      expect(table.prop('pagination').totalItemCount).toEqual(50);
 
-    const tableContent = table.text();
-    expect(tableContent).toContain('test-engine');
-    expect(tableContent).toContain('Jan 1, 1970');
-    expect(tableContent).toContain('English');
-    expect(tableContent).toContain('99,999');
-    expect(tableContent).toContain('10');
+      const tableContent = table.text();
+      expect(tableContent).toContain('test-engine');
+      expect(tableContent).toContain('Jan 1, 1970');
+      expect(tableContent).toContain('English');
+      expect(tableContent).toContain('99,999');
+      expect(tableContent).toContain('10');
 
-    expect(table.find(EuiPagination).find(EuiButtonEmpty)).toHaveLength(5); // Should display 5 pages at 10 engines per page
-  });
+      expect(table.find(EuiPagination).find(EuiButtonEmpty)).toHaveLength(5); // Should display 5 pages at 10 engines per page
+    });
 
-  it('contains engine links which send telemetry', () => {
-    const engineLinks = wrapper.find(EuiLinkTo);
+    it('contains engine links which send telemetry', () => {
+      const engineLinks = wrapper.find(EuiLinkTo);
 
-    engineLinks.forEach((link) => {
-      expect(link.prop('to')).toEqual('/engines/test-engine');
-      link.simulate('click');
+      engineLinks.forEach((link) => {
+        expect(link.prop('to')).toEqual('/engines/test-engine');
+        link.simulate('click');
 
-      expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalledWith({
-        action: 'clicked',
-        metric: 'engine_table_link',
+        expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalledWith({
+          action: 'clicked',
+          metric: 'engine_table_link',
+        });
       });
+    });
+
+    it('triggers onPaginate', () => {
+      table.prop('onChange')({ page: { index: 4 } });
+      expect(onChange).toHaveBeenCalledWith({ page: { index: 4 } });
     });
   });
 
-  it('triggers onPaginate', () => {
-    table.prop('onChange')({ page: { index: 4 } });
-
-    expect(onPaginate).toHaveBeenCalledWith(5);
-  });
-
-  it('handles empty data', () => {
-    const emptyWrapper = mountWithIntl(
-      <EnginesTable
-        data={[]}
-        pagination={{ totalEngines: 0, pageIndex: 0, onPaginate: () => {} }}
-      />
-    );
-    const emptyTable = emptyWrapper.find(EuiBasicTable);
-
-    expect(emptyTable.prop('pagination').pageIndex).toEqual(0);
+  describe('loading', () => {
+    it('passes the loading prop', () => {
+      const wrapper = mountWithIntl(<EnginesTable {...props} loading />);
+      expect(wrapper.find(EuiBasicTable).prop('loading')).toEqual(true);
+    });
   });
 
   describe('language field', () => {
     it('renders language when available', () => {
-      const wrapperWithLanguage = mountWithIntl(
+      const wrapper = mountWithIntl(
         <EnginesTable
-          data={[
+          {...props}
+          items={[
             {
               ...data[0],
               language: 'German',
               isMeta: false,
             },
           ]}
-          pagination={pagination}
         />
       );
-      const tableContent = wrapperWithLanguage.find(EuiBasicTable).text();
+      const tableContent = wrapper.find(EuiBasicTable).text();
       expect(tableContent).toContain('German');
     });
 
     it('renders the language as Universal if no language is set', () => {
-      const wrapperWithLanguage = mountWithIntl(
+      const wrapper = mountWithIntl(
         <EnginesTable
-          data={[
+          {...props}
+          items={[
             {
               ...data[0],
               language: null,
               isMeta: false,
             },
           ]}
-          pagination={pagination}
         />
       );
-      const tableContent = wrapperWithLanguage.find(EuiBasicTable).text();
+      const tableContent = wrapper.find(EuiBasicTable).text();
       expect(tableContent).toContain('Universal');
     });
 
     it('renders no language text if the engine is a Meta Engine', () => {
-      const wrapperWithLanguage = mountWithIntl(
+      const wrapper = mountWithIntl(
         <EnginesTable
-          data={[
+          {...props}
+          items={[
             {
               ...data[0],
               language: null,
               isMeta: true,
             },
           ]}
-          pagination={pagination}
         />
       );
-      const tableContent = wrapperWithLanguage.find(EuiBasicTable).text();
+      const tableContent = wrapper.find(EuiBasicTable).text();
       expect(tableContent).not.toContain('Universal');
     });
   });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -9,11 +9,10 @@ import React from 'react';
 
 import { useActions } from 'kea';
 
-import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
+import { EuiBasicTable, EuiBasicTableColumn, CriteriaWithPagination } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
 
-import { ENGINES_PAGE_SIZE } from '../../../../../common/constants';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
 import { UNIVERSAL_LANGUAGE } from '../../constants';
@@ -21,24 +20,23 @@ import { ENGINE_PATH } from '../../routes';
 import { generateEncodedPath } from '../../utils/encode_path_params';
 import { EngineDetails } from '../engine/types';
 
-interface EnginesTablePagination {
-  totalEngines: number;
-  pageIndex: number;
-  onPaginate(pageIndex: number): void;
-}
 interface EnginesTableProps {
-  data: EngineDetails[];
-  pagination: EnginesTablePagination;
-}
-interface OnChange {
-  page: {
-    index: number;
+  items: EngineDetails[];
+  loading: boolean;
+  pagination: {
+    pageIndex: number;
+    pageSize: number;
+    totalItemCount: number;
+    hidePerPageOptions: boolean;
   };
+  onChange(criteria: CriteriaWithPagination<EngineDetails>): void;
 }
 
 export const EnginesTable: React.FC<EnginesTableProps> = ({
-  data,
-  pagination: { totalEngines, pageIndex, onPaginate },
+  items,
+  loading,
+  pagination,
+  onChange,
 }) => {
   const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
 
@@ -147,18 +145,11 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
 
   return (
     <EuiBasicTable
-      items={data}
+      items={items}
       columns={columns}
-      pagination={{
-        pageIndex,
-        pageSize: ENGINES_PAGE_SIZE,
-        totalItemCount: totalEngines,
-        hidePerPageOptions: true,
-      }}
-      onChange={({ page }: OnChange) => {
-        const { index } = page;
-        onPaginate(index + 1); // Note on paging - App Search's API pages start at 1, EuiBasicTables' pages start at 0
-      }}
+      loading={loading}
+      pagination={pagination}
+      onChange={onChange}
     />
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/table_pagination/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/table_pagination/index.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { convertMetaToPagination, handlePageChange, updateMetaPageIndex } from './';
+
+describe('convertMetaToPagination', () => {
+  expect(
+    convertMetaToPagination({
+      page: {
+        current: 1,
+        size: 10,
+        total_results: 25,
+        total_pages: 3, // Not used, EuiBasicTable calculates pages on its own
+      },
+    })
+  ).toEqual({
+    pageIndex: 0,
+    pageSize: 10,
+    totalItemCount: 25,
+  });
+});
+
+describe('handlePageChange', () => {
+  it('creates an onChange handler that calls a passed callback with the new page index', () => {
+    const mockCallback = jest.fn();
+    const handler = handlePageChange(mockCallback);
+
+    handler({ page: { index: 0 } });
+    expect(mockCallback).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('updateMetaPageIndex', () => {
+  it('updates meta.page.current without mutating meta.page', () => {
+    const oldMeta = {
+      page: {
+        current: 5,
+        size: 10,
+        total_results: 100,
+        total_pages: 10,
+      },
+      some_other_meta: true,
+    };
+    const newMeta = updateMetaPageIndex(oldMeta, 6);
+
+    expect(newMeta.page.current).toEqual(6);
+    expect(oldMeta.page === newMeta.page).toEqual(false); // Would be true if we had simply done oldMeta.page.current = 6
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/table_pagination/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/table_pagination/index.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Meta } from '../../../../common/types';
+
+/**
+ * Note: App Search's API pages start at 1 & EuiBasicTables' pages start at 0
+ * These helpers both automatically handle off-by-1 conversion in addition to
+ * automatically converting our snake_cased API meta to camelCased EUI props
+ */
+
+export const convertMetaToPagination = (meta: Meta) => ({
+  pageIndex: meta.page.current - 1,
+  pageSize: meta.page.size,
+  totalItemCount: meta.page.total_results,
+});
+
+interface EuiBasicTableOnChange {
+  page: { index: number };
+}
+export const handlePageChange = (paginationCallback: Function) => ({
+  page: { index },
+}: EuiBasicTableOnChange) => {
+  paginationCallback(index + 1);
+};
+
+/**
+ * Helper for updating Kea `meta` state without mutating nested objs
+ */
+
+export const updateMetaPageIndex = (oldState: Meta, newPageIndex: number) => {
+  const newMetaState = { ...oldState, page: { ...oldState.page } };
+  newMetaState.page.current = newPageIndex;
+  return newMetaState;
+};

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.test.ts
@@ -34,11 +34,16 @@ describe('credentials routes', () => {
 
     describe('validates', () => {
       it('correctly', () => {
-        const request = { query: { 'page[current]': 1 } };
+        const request = {
+          query: {
+            'page[current]': 1,
+            'page[size]': 10,
+          },
+        };
         mockRouter.shouldValidate(request);
       });
 
-      it('missing page[current]', () => {
+      it('missing page query params', () => {
         const request = { query: {} };
         mockRouter.shouldThrow(request);
       });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/credentials.ts
@@ -41,6 +41,7 @@ export function registerCredentialsRoutes({
       validate: {
         query: schema.object({
           'page[current]': schema.number(),
+          'page[size]': schema.number(),
         }),
       },
     },

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/engines.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/engines.test.ts
@@ -11,14 +11,11 @@ import { registerEnginesRoutes } from './engines';
 
 describe('engine routes', () => {
   describe('GET /api/app_search/engines', () => {
-    const AUTH_HEADER = 'Basic 123';
     const mockRequest = {
-      headers: {
-        authorization: AUTH_HEADER,
-      },
       query: {
         type: 'indexed',
-        pageIndex: 1,
+        'page[current]': 1,
+        'page[size]': 10,
       },
     };
 
@@ -42,17 +39,6 @@ describe('engine routes', () => {
 
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/as/engines/collection',
-        params: { type: 'indexed', 'page[current]': 1, 'page[size]': 10 },
-        hasValidData: expect.any(Function),
-      });
-    });
-
-    it('passes custom parameters to enterpriseSearchRequestHandler', () => {
-      mockRouter.callRoute({ query: { type: 'meta', pageIndex: 99 } });
-
-      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
-        path: '/as/engines/collection',
-        params: { type: 'meta', 'page[current]': 99, 'page[size]': 10 },
         hasValidData: expect.any(Function),
       });
     });
@@ -84,27 +70,29 @@ describe('engine routes', () => {
 
     describe('validates', () => {
       it('correctly', () => {
-        const request = { query: { type: 'meta', pageIndex: 5 } };
+        const request = {
+          query: {
+            type: 'meta',
+            'page[current]': 5,
+            'page[size]': 10,
+          },
+        };
         mockRouter.shouldValidate(request);
       });
 
-      it('wrong pageIndex type', () => {
-        const request = { query: { type: 'indexed', pageIndex: 'indexed' } };
-        mockRouter.shouldThrow(request);
-      });
-
       it('wrong type string', () => {
-        const request = { query: { type: 'invalid', pageIndex: 1 } };
+        const request = {
+          query: {
+            type: 'invalid',
+            'page[current]': 5,
+            'page[size]': 10,
+          },
+        };
         mockRouter.shouldThrow(request);
       });
 
-      it('missing pageIndex', () => {
-        const request = { query: { type: 'indexed' } };
-        mockRouter.shouldThrow(request);
-      });
-
-      it('missing type', () => {
-        const request = { query: { pageIndex: 1 } };
+      it('missing query params', () => {
+        const request = { query: {} };
         mockRouter.shouldThrow(request);
       });
     });

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/engines.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/engines.ts
@@ -7,7 +7,6 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { ENGINES_PAGE_SIZE } from '../../../common/constants';
 import { RouteDependencies } from '../../plugin';
 
 interface EnginesResponse {
@@ -25,20 +24,14 @@ export function registerEnginesRoutes({
       validate: {
         query: schema.object({
           type: schema.oneOf([schema.literal('indexed'), schema.literal('meta')]),
-          pageIndex: schema.number(),
+          'page[current]': schema.number(),
+          'page[size]': schema.number(),
         }),
       },
     },
     async (context, request, response) => {
-      const { type, pageIndex } = request.query;
-
       return enterpriseSearchRequestHandler.createRequest({
         path: '/as/engines/collection',
-        params: {
-          type,
-          'page[current]': pageIndex,
-          'page[size]': ENGINES_PAGE_SIZE,
-        },
         hasValidData: (body?: EnginesResponse) =>
           Array.isArray(body?.results) && typeof body?.meta?.page?.total_results === 'number',
       })(context, request, response);


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/91565#discussion_r577142498 and https://github.com/elastic/kibana/pull/91565#discussion_r577152950:

This PR started out as a simpler helper to convert our API `meta` blobs into `pagination` props readily consumable by `EuiBasicTable`. It handles snake_casing to camelCasing, prop names, and off-by-one shenanigans:

```
// server API response
meta: {
  page: {
    current: 1,
    size: 10,
    total_results: 1,
  }
}
```
becomes
```
// EuiBasicTable props
pagination={{
  pageIndex: 0,
  pageSize: 10,
  totalItemCount: 1,
}}
```

However... it became a _lot_ more than that the more I QA'd our various table logic and realized we had slightly different ways of handling tables pagination per-view. I'll try to go into more detail in specific PR comments rather than shove everything in the description here. Here's a shortlist of of things I attempted to standardize:

- The presence of a `meta` value, defaulting it to `DEFAULT_META`, and preferring it update this state locally on pagination & reacting to pagination changes (rather than manually calling APIs with a value)
- Making use of `EuiBasicTable`'s `loading` prop to show a UI hint between paging/deleting items:
![loading](https://user-images.githubusercontent.com/549407/108774070-0fcfbb80-7514-11eb-9e10-e4d862c485e4.gif)
- Always preferring to re-fetch via API when deleting items rather than mutating in-memory lists (more accurately handles paginated data)
- Making use of `EuiBasicTable`'s `noItemsMessage` prop (we were previously doing `hasItems ? <SomeEmptyPrompt> : <SomeTable>`)

## Screenshots

Screencaps will be included in detailed comments below for ease of visualization.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios