### PR TITLE
[7.12] v1 migrations: drop fleet-agent-events during a migration (#92188)

### DIFF
--- a/src/core/server/saved_objects/migrations/core/elastic_index.test.ts
+++ b/src/core/server/saved_objects/migrations/core/elastic_index.test.ts
@@ -432,7 +432,18 @@ describe('ElasticIndex', () => {
       expect(await read()).toEqual([]);
 
       expect(client.search).toHaveBeenCalledWith({
-        body: { size: 100 },
+        body: {
+          size: 100,
+          query: {
+            bool: {
+              must_not: {
+                term: {
+                  type: 'fleet-agent-events',
+                },
+              },
+            },
+          },
+        },
         index,
         scroll: '5m',
       });

--- a/src/core/server/saved_objects/migrations/core/elastic_index.ts
+++ b/src/core/server/saved_objects/migrations/core/elastic_index.ts
@@ -67,6 +67,20 @@ export function reader(
   const scroll = scrollDuration;
   let scrollId: string | undefined;
 
+  // When migrating from the outdated index we use a read query which excludes
+  // saved objects which are no longer used. These saved objects will still be
+  // kept in the outdated index for backup purposes, but won't be availble in
+  // the upgraded index.
+  const excludeUnusedTypes = {
+    bool: {
+      must_not: {
+        term: {
+          type: 'fleet-agent-events', // https://github.com/elastic/kibana/issues/91869
+        },
+      },
+    },
+  };
+
   const nextBatch = () =>
     scrollId !== undefined
       ? client.scroll<SearchResponse<SavedObjectsRawDocSource>>({
@@ -74,7 +88,10 @@ export function reader(
           scroll_id: scrollId,
         })
       : client.search<SearchResponse<SavedObjectsRawDocSource>>({
-          body: { size: batchSize },
+          body: {
+            size: batchSize,
+            query: excludeUnusedTypes,
+          },
           index,
           scroll,
         });

--- a/x-pack/plugins/fleet/common/constants/agent.ts
+++ b/x-pack/plugins/fleet/common/constants/agent.ts
@@ -6,6 +6,8 @@
  */
 
 export const AGENT_SAVED_OBJECT_TYPE = 'fleet-agents';
+// TODO: Remove this saved object type. Core will drop any saved objects of
+// this type during migrations. See https://github.com/elastic/kibana/issues/91869
 export const AGENT_EVENT_SAVED_OBJECT_TYPE = 'fleet-agent-events';
 export const AGENT_ACTION_SAVED_OBJECT_TYPE = 'fleet-agent-actions';
 

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -124,6 +124,8 @@ const getSavedObjectTypes = (
       '7.10.0': migrateAgentActionToV7100(encryptedSavedObjects),
     },
   },
+  // TODO: Remove this saved object type. Core will drop any saved objects of
+  // this type during migrations. See https://github.com/elastic/kibana/issues/91869
   [AGENT_EVENT_SAVED_OBJECT_TYPE]: {
     name: AGENT_EVENT_SAVED_OBJECT_TYPE,
     hidden: false,


### PR DESCRIPTION
Backports the following commits to 7.12:
 - v1 migrations: drop fleet-agent-events during a migration (#92188)