### PR TITLE
[Visualize Library] Align visualizations links to the left in Safari

### DIFF
--- a/src/plugins/visualize/public/application/components/visualize_listing.scss
+++ b/src/plugins/visualize/public/application/components/visualize_listing.scss
@@ -16,6 +16,10 @@
   margin-left: $euiSizeS;
 }
 
+.visListingTable__titleLink {
+  text-align: left;
+}
+
 .visListingCallout {
   max-width: 1000px;
   width: 100%;

--- a/src/plugins/visualize/public/application/utils/get_table_columns.tsx
+++ b/src/plugins/visualize/public/application/utils/get_table_columns.tsx
@@ -85,7 +85,7 @@ export const getTableColumns = (
     render: (field: string, { editApp, editUrl, title, error }: VisualizationListItem) =>
       // In case an error occurs i.e. the vis has wrong type, we render the vis but without the link
       !error ? (
-        <RedirectAppLinks application={application}>
+        <RedirectAppLinks application={application} className="visListingTable__titleLink">
           <EuiLink
             href={getVisualizeListItemLink(application, kbnUrlStateStorage, editApp, editUrl)}
             data-test-subj={`visListingTitleLink-${title.split(' ').join('-')}`}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/92176 

Fixes wrong alignment of visualizations links in Safari browser.

![image](https://user-images.githubusercontent.com/31325372/108833446-e24f4480-75dd-11eb-92b4-4bb305e7da2a.png)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
