### PR TITLE
[APM] Correlations style polish in prep for release

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/correlations_table.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/correlations_table.tsx
@@ -63,14 +63,14 @@ export function CorrelationsTable<T extends SignificantTerm>({
   const history = useHistory();
   const columns: Array<EuiBasicTableColumn<T>> = [
     {
-      width: '100px',
+      width: '116px',
       field: 'impact',
       name: i18n.translate(
         'xpack.apm.correlations.correlationsTable.impactLabel',
         { defaultMessage: 'Impact' }
       ),
       render: (_: any, term: T) => {
-        return <ImpactBar value={term.impact * 100} />;
+        return <ImpactBar size="m" value={term.impact * 100} />;
       },
     },
     {

--- a/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
@@ -102,7 +102,7 @@ export function ErrorCorrelations({ onClose }: Props) {
     <>
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <EuiText size="s">
+          <EuiText size="s" color="subdued">
             <p>
               {i18n.translate('xpack.apm.correlations.error.description', {
                 defaultMessage:

--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -99,6 +99,19 @@ export function Correlations() {
                   />
                 </h2>
               </EuiTitle>
+              <EuiTabs style={{ marginBottom: '-25px' }}>
+                {tabs.map(({ key, label }) => (
+                  <EuiTab
+                    key={key}
+                    isSelected={key === currentTab}
+                    onClick={() => {
+                      setCurrentTab(key);
+                    }}
+                  >
+                    {label}
+                  </EuiTab>
+                ))}
+              </EuiTabs>
             </EuiFlyoutHeader>
             <EuiFlyoutBody>
               <CorrelationsMetricsLicenseCheck>

--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -140,21 +140,6 @@ export function Correlations() {
                   </>
                 ) : null}
 
-                <EuiSpacer />
-                <EuiTabs>
-                  {tabs.map(({ key, label }) => (
-                    <EuiTab
-                      key={key}
-                      isSelected={key === currentTab}
-                      onClick={() => {
-                        setCurrentTab(key);
-                      }}
-                    >
-                      {label}
-                    </EuiTab>
-                  ))}
-                </EuiTabs>
-                <EuiSpacer />
                 <TabContent onClose={() => setIsFlyoutVisible(false)} />
               </CorrelationsMetricsLicenseCheck>
             </EuiFlyoutBody>

--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -128,7 +128,7 @@ export function Correlations() {
                       <EuiLink
                         href={createHref(history, { query: { kuery: '' } })}
                       >
-                        <EuiButtonEmpty iconType="cross">
+                        <EuiButtonEmpty size="xs" iconType="cross">
                           {i18n.translate(
                             'xpack.apm.correlations.clearFiltersLabel',
                             { defaultMessage: 'Clear' }

--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -66,7 +66,6 @@ export function Correlations() {
         onClick={() => {
           setIsFlyoutVisible(true);
         }}
-        iconType="visTagCloud"
       >
         {i18n.translate('xpack.apm.correlations.buttonLabel', {
           defaultMessage: 'View correlations',

--- a/x-pack/plugins/apm/public/components/app/correlations/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/index.tsx
@@ -117,7 +117,7 @@ export function Correlations() {
               <CorrelationsMetricsLicenseCheck>
                 {urlParams.kuery ? (
                   <>
-                    <EuiCallOut size="m">
+                    <EuiCallOut size="s">
                       <span>
                         {i18n.translate(
                           'xpack.apm.correlations.filteringByLabel',

--- a/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
@@ -249,6 +249,7 @@ function LatencyDistributionChart({
           yScaleType={ScaleType.Linear}
           xAccessor={'x'}
           yAccessors={['y']}
+          color={theme.eui.euiColorVis1}
           data={data?.overall?.distribution || []}
           minBarHeight={5}
           tickFormat={(d) => `${roundFloat(d)}%`}
@@ -270,7 +271,7 @@ function LatencyDistributionChart({
             yScaleType={ScaleType.Linear}
             xAccessor={'x'}
             yAccessors={['y']}
-            color={theme.eui.euiColorAccent}
+            color={theme.eui.euiColorVis2}
             data={getSelectedDistribution(data, selectedSignificantTerm)}
             minBarHeight={5}
             tickFormat={(d) => `${roundFloat(d)}%`}

--- a/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
@@ -109,7 +109,7 @@ export function LatencyCorrelations({ onClose }: Props) {
     <>
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <EuiText size="s">
+          <EuiText size="s" color="subdued">
             <p>
               {i18n.translate('xpack.apm.correlations.latency.description', {
                 defaultMessage:


### PR DESCRIPTION
## Summary

Some clean-up and polish styles for the new Correlations feature that has come up in testing.

<img width="836" alt="Screenshot 2021-02-23 at 20 25 02" src="https://user-images.githubusercontent.com/4104278/108896510-51945b00-7615-11eb-85de-c692db254254.png">

- [x] Removed the icon from the "View correlations" button
- [x] Moved the tabs to the FlyoutHeader
- [x] Removed unneeded spacers in the content
- [x] Reduced the filtering by callout and button
- [x] Made the introduction text color `subdued` to make it less noisy
- [x] Reduced ImpactBar size and extended width so the bar itself is `100`
- [x] Changed the selected term visualization color to `euiColorVis2` because the `euiColorAccent` is not great for visualizations.
- [x] Changed the latency distribution visualization color to `euiColorVis1` to make it consistent with the Transactions visualization colors in the other charts.

