### PR TITLE
[7.x] [ci] disable firefox scripts from security cypress job (#92483)

### DIFF
--- a/.ci/Jenkinsfile_security_cypress
+++ b/.ci/Jenkinsfile_security_cypress
@@ -17,7 +17,9 @@ kibanaPipeline(timeoutMinutes: 180) {
 
         workers.ci(name: job, size: 'l', ramDisk: true) {
           kibanaPipeline.bash('test/scripts/jenkins_xpack_build_kibana.sh', 'Build Default Distributable')
-          kibanaPipeline.functionalTestProcess(job, 'test/scripts/jenkins_security_solution_cypress.sh')()
+          kibanaPipeline.functionalTestProcess(job, 'test/scripts/jenkins_security_solution_cypress_chrome.sh')()
+          // Temporarily disabled to figure out test flake
+          // kibanaPipeline.functionalTestProcess(job, 'test/scripts/jenkins_security_solution_cypress_firefox.sh')()
         }
       }
     }

--- a/vars/tasks.groovy
+++ b/vars/tasks.groovy
@@ -127,7 +127,8 @@ def functionalXpack(Map params = [:]) {
     ]) {
       if (githubPr.isPr()) {
         task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressChrome', './test/scripts/jenkins_security_solution_cypress_chrome.sh'))
-        task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressFirefox', './test/scripts/jenkins_security_solution_cypress_firefox.sh'))
+        // Temporarily disabled to figure out test flake
+        // task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressFirefox', './test/scripts/jenkins_security_solution_cypress_firefox.sh'))
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ci] disable firefox scripts from security cypress job (#92483)