### PR TITLE
[7.12] [ci] disable firefox scripts from security cypress job (#92483)

### DIFF
--- a/.ci/Jenkinsfile_security_cypress
+++ b/.ci/Jenkinsfile_security_cypress
@@ -17,7 +17,9 @@ kibanaPipeline(timeoutMinutes: 180) {
 
         workers.ci(name: job, size: 'l', ramDisk: true) {
           kibanaPipeline.bash('test/scripts/jenkins_xpack_build_kibana.sh', 'Build Default Distributable')
-          kibanaPipeline.functionalTestProcess(job, 'test/scripts/jenkins_security_solution_cypress.sh')()
+          kibanaPipeline.functionalTestProcess(job, 'test/scripts/jenkins_security_solution_cypress_chrome.sh')()
+          // Temporarily disabled to figure out test flake
+          // kibanaPipeline.functionalTestProcess(job, 'test/scripts/jenkins_security_solution_cypress_firefox.sh')()
         }
       }
     }

--- a/vars/tasks.groovy
+++ b/vars/tasks.groovy
@@ -126,7 +126,13 @@ def functionalXpack(Map params = [:]) {
       'x-pack/plugins/triggers_actions_ui/public/application/context/actions_connectors_context.tsx',
     ]) {
       if (githubPr.isPr()) {
+<<<<<<< HEAD
         task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypress', './test/scripts/jenkins_security_solution_cypress.sh'))
+=======
+        task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressChrome', './test/scripts/jenkins_security_solution_cypress_chrome.sh'))
+        // Temporarily disabled to figure out test flake
+        // task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressFirefox', './test/scripts/jenkins_security_solution_cypress_firefox.sh'))
+>>>>>>> d847958fb30... [ci] disable firefox scripts from security cypress job (#92483)
       }
     }
   }

--- a/vars/tasks.groovy
+++ b/vars/tasks.groovy
@@ -126,13 +126,9 @@ def functionalXpack(Map params = [:]) {
       'x-pack/plugins/triggers_actions_ui/public/application/context/actions_connectors_context.tsx',
     ]) {
       if (githubPr.isPr()) {
-<<<<<<< HEAD
-        task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypress', './test/scripts/jenkins_security_solution_cypress.sh'))
-=======
         task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressChrome', './test/scripts/jenkins_security_solution_cypress_chrome.sh'))
         // Temporarily disabled to figure out test flake
         // task(kibanaPipeline.functionalTestProcess('xpack-securitySolutionCypressFirefox', './test/scripts/jenkins_security_solution_cypress_firefox.sh'))
->>>>>>> d847958fb30... [ci] disable firefox scripts from security cypress job (#92483)
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [ci] disable firefox scripts from security cypress job (#92483)