### PR TITLE
[Enterprise Search] Change icon for error in EuiCallouts

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
@@ -17,7 +17,7 @@ const FLASH_MESSAGE_TYPES = {
   success: { color: 'success' as EuiCallOutProps['color'], icon: 'check' },
   info: { color: 'primary' as EuiCallOutProps['color'], icon: 'iInCircle' },
   warning: { color: 'warning' as EuiCallOutProps['color'], icon: 'alert' },
-  error: { color: 'danger' as EuiCallOutProps['color'], icon: 'cross' },
+  error: { color: 'danger' as EuiCallOutProps['color'], icon: 'alert' },
 };
 
 export const FlashMessages: React.FC = ({ children }) => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_errors.tsx
@@ -20,7 +20,7 @@ interface IIndexingStatusErrorsProps {
 export const IndexingStatusErrors: React.FC<IIndexingStatusErrorsProps> = ({ viewLinkPath }) => (
   <EuiCallOut
     color="danger"
-    iconType="cross"
+    iconType="alert"
     title="There was an error"
     data-test-subj="IndexingStatusErrors"
   >


### PR DESCRIPTION
Update error FlashMessage to use the `alert` icon, instead of the `cross`, which looks like a clickable "X".

Also updated theny other case of using `EuiCallout` directly with the `cross` icon.

**Before**
![before](https://user-images.githubusercontent.com/1869731/108913020-06ffe800-75ef-11eb-9e20-8456545b2aae.png)

**After**
![after](https://user-images.githubusercontent.com/1869731/108913025-09624200-75ef-11eb-80ce-9729f8436f1f.png)
