### PR TITLE
Put environment back in uiFilters

### DIFF
--- a/x-pack/plugins/apm/public/context/url_params_context/url_params_context.tsx
+++ b/x-pack/plugins/apm/public/context/url_params_context/url_params_context.tsx
@@ -35,7 +35,10 @@ function useUiFilters(params: IUrlParams): UIFilters {
     (val) => (val ? val.split(',') : [])
   ) as Partial<Record<LocalUIFilterName, string[]>>;
 
-  return useDeepObjectIdentity(localUiFilters);
+  return useDeepObjectIdentity({
+    environment: params.environment,
+    ...localUiFilters,
+  });
 }
 
 const defaultRefresh = (_time: TimeRange) => {};


### PR DESCRIPTION
`environment` is still used in `uiFilters` in UX, but not anywhere else.

It was removed when removing environment from UI filters for the rest of APM and broke UX's environment switcher. Put it back.
