### PR TITLE
[Discover] Fix persistence of "hide/show chart" in saved search

### DIFF
--- a/src/plugins/discover/public/application/helpers/persist_saved_search.ts
+++ b/src/plugins/discover/public/application/helpers/persist_saved_search.ts
@@ -49,7 +49,7 @@ export async function persistSavedSearch(
   if (state.grid) {
     savedSearch.grid = state.grid;
   }
-  if (state.hideChart) {
+  if (typeof state.hideChart !== 'undefined') {
     savedSearch.hideChart = state.hideChart;
   }
 

--- a/test/functional/apps/discover/_discover_histogram.ts
+++ b/test/functional/apps/discover/_discover_histogram.ts
@@ -97,15 +97,25 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(canvasExists).to.be(false);
       await PageObjects.discover.saveSearch(savedSearch);
       await PageObjects.header.waitUntilLoadingHasFinished();
+
+      await PageObjects.discover.clickNewSearchButton();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      await PageObjects.discover.loadSavedSearch('persisted hidden histogram');
+      await PageObjects.header.waitUntilLoadingHasFinished();
       canvasExists = await elasticChart.canvasExists();
       expect(canvasExists).to.be(false);
       await testSubjects.click('discoverChartToggle');
       canvasExists = await elasticChart.canvasExists();
       expect(canvasExists).to.be(true);
-      await PageObjects.discover.clickResetSavedSearchButton();
+      await PageObjects.discover.saveSearch('persisted hidden histogram');
+      await PageObjects.header.waitUntilLoadingHasFinished();
+
+      await PageObjects.discover.clickNewSearchButton();
+      await PageObjects.discover.loadSavedSearch('persisted hidden histogram');
       await PageObjects.header.waitUntilLoadingHasFinished();
       canvasExists = await elasticChart.canvasExists();
-      expect(canvasExists).to.be(false);
+      expect(canvasExists).to.be(true);
     });
   });
 }


### PR DESCRIPTION
We had previously written a functional test for this case, but the previous functional test was wrongly written. I tested this functional test with and without the change here and the test _only_ passes with my fix here.

Steps to verify:

1. Open Discover and hide the chart
2. Save the search
3. Show the chart
4. Save again
5. Chart should be showing

Fixes https://github.com/elastic/kibana/issues/92708

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
