### PR TITLE
[XY] Enables page reload toast for the legacyChartsLibrary setting

### DIFF
--- a/src/plugins/vis_type_xy/server/plugin.ts
+++ b/src/plugins/vis_type_xy/server/plugin.ts
@@ -20,6 +20,7 @@ export const uiSettingsConfig: Record<string, UiSettingsParams<boolean>> = {
     name: i18n.translate('visTypeXy.advancedSettings.visualization.legacyChartsLibrary.name', {
       defaultMessage: 'Legacy charts library',
     }),
+    requiresPageReload: true,
     value: false,
     description: i18n.translate(
       'visTypeXy.advancedSettings.visualization.legacyChartsLibrary.description',


### PR DESCRIPTION
## Summary

Resolves #92804

Enables the `requiredPageReload ` flag in order for the following toast to be visible.

![image](https://user-images.githubusercontent.com/17003240/109160779-e797c500-777e-11eb-8360-dcaaed09d28d.png)
