### PR TITLE
[App Search] Refactor AppLogic to initialize data via props rather than action

### DIFF
--- a/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -23,6 +23,10 @@ export const DEFAULT_INITIAL_APP_DATA = {
       },
     },
   },
+  access: {
+    hasAppSearchAccess: true,
+    hasWorkplaceSearchAccess: true,
+  },
   appSearch: {
     accountId: 'some-id-string',
     onboardingComplete: true,

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -19,10 +19,7 @@ export interface InitialAppData {
   ilmEnabled?: boolean;
   isFederatedAuth?: boolean;
   configuredLimits?: ConfiguredLimits;
-  access?: {
-    hasAppSearchAccess: boolean;
-    hasWorkplaceSearchAccess: boolean;
-  };
+  access?: Access;
   appSearch?: AppSearchAccount;
   workplaceSearch?: WorkplaceSearchInitialData;
 }
@@ -30,6 +27,11 @@ export interface InitialAppData {
 export interface ConfiguredLimits {
   appSearch: AppSearchConfiguredLimits;
   workplaceSearch: WorkplaceSearchConfiguredLimits;
+}
+
+export interface Access {
+  hasAppSearchAccess: boolean;
+  hasWorkplaceSearchAccess: boolean;
 }
 
 export interface MetaPage {

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -19,7 +19,7 @@ export interface InitialAppData {
   ilmEnabled?: boolean;
   isFederatedAuth?: boolean;
   configuredLimits?: ConfiguredLimits;
-  access?: Access;
+  access?: ProductAccess;
   appSearch?: AppSearchAccount;
   workplaceSearch?: WorkplaceSearchInitialData;
 }
@@ -29,7 +29,7 @@ export interface ConfiguredLimits {
   workplaceSearch: WorkplaceSearchConfiguredLimits;
 }
 
-export interface Access {
+export interface ProductAccess {
   hasAppSearchAccess: boolean;
   hasWorkplaceSearchAccess: boolean;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
@@ -6,74 +6,68 @@
  */
 
 import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
-import { LogicMounter } from '../__mocks__';
+
+import { resetContext } from 'kea';
 
 import { AppLogic } from './app_logic';
 
 describe('AppLogic', () => {
-  const { mount } = new LogicMounter(AppLogic);
-
-  beforeEach(() => {
-    mount();
-  });
-
-  const DEFAULT_VALUES = {
-    hasInitialized: false,
-    account: {},
-    configuredLimits: {},
-    ilmEnabled: false,
-    myRole: {},
+  const mount = (props = {}) => {
+    AppLogic({ ...DEFAULT_INITIAL_APP_DATA, ...props });
+    AppLogic.mount();
   };
 
-  it('has expected default values', () => {
-    expect(AppLogic.values).toEqual(DEFAULT_VALUES);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetContext({});
   });
 
-  describe('initializeAppData()', () => {
-    it('sets values based on passed props', () => {
-      AppLogic.actions.initializeAppData(DEFAULT_INITIAL_APP_DATA);
+  it('sets values from props', () => {
+    mount();
 
-      expect(AppLogic.values).toEqual({
-        hasInitialized: true,
-        ilmEnabled: true,
-        configuredLimits: {
-          engine: {
-            maxDocumentByteSize: 102400,
-            maxEnginesPerMetaEngine: 15,
-          },
+    expect(AppLogic.values).toEqual({
+      ilmEnabled: true,
+      configuredLimits: {
+        engine: {
+          maxDocumentByteSize: 102400,
+          maxEnginesPerMetaEngine: 15,
         },
-        account: {
-          accountId: 'some-id-string',
-          onboardingComplete: true,
-          role: DEFAULT_INITIAL_APP_DATA.appSearch.role,
-        },
-        myRole: expect.objectContaining({
-          id: 'account_id:somestring|user_oid:somestring',
-          roleType: 'owner',
-          availableRoleTypes: ['owner', 'admin'],
-          credentialTypes: ['admin', 'private', 'search'],
-          canAccessAllEngines: true,
-          canViewAccountCredentials: true,
-          // Truncated for brevity - see utils/role/index.test.ts for full output
-        }),
-      });
-    });
-
-    it('gracefully handles missing initial data', () => {
-      AppLogic.actions.initializeAppData({});
-
-      expect(AppLogic.values).toEqual({
-        ...DEFAULT_VALUES,
-        hasInitialized: true,
-      });
+      },
+      account: {
+        accountId: 'some-id-string',
+        onboardingComplete: true,
+        role: DEFAULT_INITIAL_APP_DATA.appSearch.role,
+      },
+      myRole: expect.objectContaining({
+        id: 'account_id:somestring|user_oid:somestring',
+        roleType: 'owner',
+        availableRoleTypes: ['owner', 'admin'],
+        credentialTypes: ['admin', 'private', 'search'],
+        canAccessAllEngines: true,
+        canViewAccountCredentials: true,
+        // Truncated for brevity - see utils/role/index.test.ts for full output
+      }),
     });
   });
 
-  describe('setOnboardingComplete()', () => {
-    it('sets true', () => {
-      expect(AppLogic.values.account.onboardingComplete).toBeFalsy();
-      AppLogic.actions.setOnboardingComplete();
-      expect(AppLogic.values.account.onboardingComplete).toEqual(true);
+  describe('actions', () => {
+    describe('setOnboardingComplete()', () => {
+      it('sets true', () => {
+        mount({ appSearch: { onboardingComplete: false } });
+
+        AppLogic.actions.setOnboardingComplete();
+        expect(AppLogic.values.account.onboardingComplete).toEqual(true);
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('myRole', () => {
+      it('falls back to an empty object if role is missing', () => {
+        mount({ appSearch: {} });
+
+        expect(AppLogic.values.myRole).toEqual({});
+      });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -15,15 +15,15 @@ import { getRoleAbilities } from './utils/role';
 
 interface AppValues {
   ilmEnabled: boolean;
-  configuredLimits: Partial<ConfiguredLimits>;
-  account: Partial<Account>;
-  myRole: Partial<Role>;
+  configuredLimits: ConfiguredLimits;
+  account: Account;
+  myRole: Role;
 }
 interface AppActions {
   setOnboardingComplete(): boolean;
 }
 
-export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
+export const AppLogic = kea<MakeLogicType<AppValues, AppActions, Required<InitialAppData>>>({
   path: ['enterprise_search', 'app_search', 'app_logic'],
   actions: {
     setOnboardingComplete: () => true,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.ts
@@ -14,53 +14,33 @@ import { ConfiguredLimits, Account, Role } from './types';
 import { getRoleAbilities } from './utils/role';
 
 interface AppValues {
-  hasInitialized: boolean;
   ilmEnabled: boolean;
   configuredLimits: Partial<ConfiguredLimits>;
   account: Partial<Account>;
   myRole: Partial<Role>;
 }
 interface AppActions {
-  initializeAppData(props: InitialAppData): Required<InitialAppData>;
   setOnboardingComplete(): boolean;
 }
 
 export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
   path: ['enterprise_search', 'app_search', 'app_logic'],
   actions: {
-    initializeAppData: (props) => props,
     setOnboardingComplete: () => true,
   },
-  reducers: {
-    hasInitialized: [
-      false,
-      {
-        initializeAppData: () => true,
-      },
-    ],
+  reducers: ({ props }) => ({
     account: [
-      {},
+      props.appSearch,
       {
-        initializeAppData: (_, { appSearch: account }) => account || {},
         setOnboardingComplete: (account) => ({
           ...account,
           onboardingComplete: true,
         }),
       },
     ],
-    configuredLimits: [
-      {},
-      {
-        initializeAppData: (_, { configuredLimits }) => configuredLimits?.appSearch || {},
-      },
-    ],
-    ilmEnabled: [
-      false,
-      {
-        initializeAppData: (_, { ilmEnabled }) => !!ilmEnabled,
-      },
-    ],
-  },
+    configuredLimits: [props.configuredLimits.appSearch, {}],
+    ilmEnabled: [props.ilmEnabled, {}],
+  }),
   selectors: {
     myRole: [
       (selectors) => [selectors.account],

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/paste_json_text.tsx
@@ -55,8 +55,11 @@ export const FlyoutHeader: React.FC = () => {
 };
 
 export const FlyoutBody: React.FC = () => {
-  const { configuredLimits } = useValues(AppLogic);
-  const maxDocumentByteSize = configuredLimits?.engine?.maxDocumentByteSize;
+  const {
+    configuredLimits: {
+      engine: { maxDocumentByteSize },
+    },
+  } = useValues(AppLogic);
 
   const { textInput, errors } = useValues(DocumentCreationLogic);
   const { setTextInput } = useActions(DocumentCreationLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/creation_mode_components/upload_json_file.tsx
@@ -54,8 +54,11 @@ export const FlyoutHeader: React.FC = () => {
 };
 
 export const FlyoutBody: React.FC = () => {
-  const { configuredLimits } = useValues(AppLogic);
-  const maxDocumentByteSize = configuredLimits?.engine?.maxDocumentByteSize;
+  const {
+    configuredLimits: {
+      engine: { maxDocumentByteSize },
+    },
+  } = useValues(AppLogic);
 
   const { isUploading, errors } = useValues(DocumentCreationLogic);
   const { setFileInput } = useActions(DocumentCreationLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/meta_engine_creation/meta_engine_creation.tsx
@@ -56,7 +56,7 @@ const comboBoxOptionToEngineName = (option: EuiComboBoxOptionOption<string>): st
 export const MetaEngineCreation: React.FC = () => {
   const {
     configuredLimits: {
-      engine: { maxEnginesPerMetaEngine } = { maxEnginesPerMetaEngine: Infinity },
+      engine: { maxEnginesPerMetaEngine },
     },
   } = useValues(AppLogic);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
@@ -5,17 +5,20 @@
  * 2.0.
  */
 
-import '../__mocks__/shallow_useeffect.mock';
+import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
 import '../__mocks__/enterprise_search_url.mock';
-import { setMockValues, setMockActions } from '../__mocks__';
+import { setMockValues, rerender } from '../__mocks__';
 
 import React from 'react';
 
 import { Redirect } from 'react-router-dom';
 
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 
 import { Layout, SideNav, SideNavLink } from '../shared/layout';
+
+jest.mock('./app_logic', () => ({ AppLogic: jest.fn() }));
+import { AppLogic } from './app_logic';
 
 import { EngineRouter } from './components/engine';
 import { EngineCreation } from './components/engine_creation';
@@ -52,52 +55,34 @@ describe('AppSearchUnconfigured', () => {
 });
 
 describe('AppSearchConfigured', () => {
-  beforeEach(() => {
-    // Mock resets
+  let wrapper: ShallowWrapper;
+
+  beforeAll(() => {
     setMockValues({ myRole: {} });
-    setMockActions({ initializeAppData: () => {} });
+    wrapper = shallow(<AppSearchConfigured {...DEFAULT_INITIAL_APP_DATA} />);
   });
 
   it('renders with layout', () => {
-    const wrapper = shallow(<AppSearchConfigured />);
-
     expect(wrapper.find(Layout)).toHaveLength(2);
     expect(wrapper.find(Layout).last().prop('readOnlyMode')).toBeFalsy();
     expect(wrapper.find(EnginesOverview)).toHaveLength(1);
     expect(wrapper.find(EngineRouter)).toHaveLength(1);
   });
 
-  it('initializes app data with passed props', () => {
-    const initializeAppData = jest.fn();
-    setMockActions({ initializeAppData });
-
-    shallow(<AppSearchConfigured ilmEnabled />);
-
-    expect(initializeAppData).toHaveBeenCalledWith({ ilmEnabled: true });
-  });
-
-  it('does not re-initialize app data', () => {
-    const initializeAppData = jest.fn();
-    setMockActions({ initializeAppData });
-    setMockValues({ myRole: {}, hasInitialized: true });
-
-    shallow(<AppSearchConfigured />);
-
-    expect(initializeAppData).not.toHaveBeenCalled();
+  it('mounts AppLogic with passed initial data props', () => {
+    expect(AppLogic).toHaveBeenCalledWith(DEFAULT_INITIAL_APP_DATA);
   });
 
   it('renders ErrorConnecting', () => {
     setMockValues({ myRole: {}, errorConnecting: true });
-
-    const wrapper = shallow(<AppSearchConfigured />);
+    rerender(wrapper);
 
     expect(wrapper.find(ErrorConnecting)).toHaveLength(1);
   });
 
   it('passes readOnlyMode state', () => {
     setMockValues({ myRole: {}, readOnlyMode: true });
-
-    const wrapper = shallow(<AppSearchConfigured />);
+    rerender(wrapper);
 
     expect(wrapper.find(Layout).first().prop('readOnlyMode')).toEqual(true);
   });
@@ -106,14 +91,14 @@ describe('AppSearchConfigured', () => {
     describe('canManageEngines', () => {
       it('renders EngineCreation when user canManageEngines is true', () => {
         setMockValues({ myRole: { canManageEngines: true } });
-        const wrapper = shallow(<AppSearchConfigured />);
+        rerender(wrapper);
 
         expect(wrapper.find(EngineCreation)).toHaveLength(1);
       });
 
       it('does not render EngineCreation when user canManageEngines is false', () => {
         setMockValues({ myRole: { canManageEngines: false } });
-        const wrapper = shallow(<AppSearchConfigured />);
+        rerender(wrapper);
 
         expect(wrapper.find(EngineCreation)).toHaveLength(0);
       });
@@ -122,14 +107,14 @@ describe('AppSearchConfigured', () => {
     describe('canManageMetaEngines', () => {
       it('renders MetaEngineCreation when user canManageMetaEngines is true', () => {
         setMockValues({ myRole: { canManageMetaEngines: true } });
-        const wrapper = shallow(<AppSearchConfigured />);
+        rerender(wrapper);
 
         expect(wrapper.find(MetaEngineCreation)).toHaveLength(1);
       });
 
       it('does not render MetaEngineCreation when user canManageMetaEngines is false', () => {
         setMockValues({ myRole: { canManageMetaEngines: false } });
-        const wrapper = shallow(<AppSearchConfigured />);
+        rerender(wrapper);
 
         expect(wrapper.find(MetaEngineCreation)).toHaveLength(0);
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 
-import { useActions, useValues } from 'kea';
+import { useValues } from 'kea';
 
 import { APP_SEARCH_PLUGIN } from '../../../common/constants';
 import { InitialAppData } from '../../../common/types';
@@ -59,16 +59,10 @@ export const AppSearchUnconfigured: React.FC = () => (
 );
 
 export const AppSearchConfigured: React.FC<InitialAppData> = (props) => {
-  const { initializeAppData } = useActions(AppLogic);
   const {
-    hasInitialized,
     myRole: { canManageEngines, canManageMetaEngines },
-  } = useValues(AppLogic);
+  } = useValues(AppLogic(props));
   const { errorConnecting, readOnlyMode } = useValues(HttpLogic);
-
-  useEffect(() => {
-    if (!hasInitialized) initializeAppData(props);
-  }, [hasInitialized]);
 
   return (
     <Switch>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.tsx
@@ -44,7 +44,11 @@ import {
 
 export const AppSearch: React.FC<InitialAppData> = (props) => {
   const { config } = useValues(KibanaLogic);
-  return !config.host ? <AppSearchUnconfigured /> : <AppSearchConfigured {...props} />;
+  return !config.host ? (
+    <AppSearchUnconfigured />
+  ) : (
+    <AppSearchConfigured {...(props as Required<InitialAppData>)} />
+  );
 };
 
 export const AppSearchUnconfigured: React.FC = () => (
@@ -58,7 +62,7 @@ export const AppSearchUnconfigured: React.FC = () => (
   </Switch>
 );
 
-export const AppSearchConfigured: React.FC<InitialAppData> = (props) => {
+export const AppSearchConfigured: React.FC<Required<InitialAppData>> = (props) => {
   const {
     myRole: { canManageEngines, canManageMetaEngines },
   } = useValues(AppLogic(props));

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -9,7 +9,7 @@ import { KibanaRequest, Logger } from 'src/core/server';
 
 import { SecurityPluginSetup } from '../../../security/server';
 import { SpacesPluginStart } from '../../../spaces/server';
-import { Access } from '../../common/types';
+import { ProductAccess } from '../../common/types';
 import { ConfigType } from '../index';
 
 import { callEnterpriseSearchConfigAPI } from './enterprise_search_config_api';
@@ -42,7 +42,7 @@ export const checkAccess = async ({
   spaces,
   request,
   log,
-}: CheckAccess): Promise<Access> => {
+}: CheckAccess): Promise<ProductAccess> => {
   const isRbacEnabled = security?.authz.mode.useRbacForRequest(request) ?? false;
 
   // We can only retrieve the active space when either:

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -9,6 +9,7 @@ import { KibanaRequest, Logger } from 'src/core/server';
 
 import { SecurityPluginSetup } from '../../../security/server';
 import { SpacesPluginStart } from '../../../spaces/server';
+import { Access } from '../../common/types';
 import { ConfigType } from '../index';
 
 import { callEnterpriseSearchConfigAPI } from './enterprise_search_config_api';
@@ -19,10 +20,6 @@ interface CheckAccess {
   spaces?: SpacesPluginStart;
   config: ConfigType;
   log: Logger;
-}
-export interface Access {
-  hasAppSearchAccess: boolean;
-  hasWorkplaceSearchAccess: boolean;
 }
 
 const ALLOW_ALL_PLUGINS = {

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.test.ts
@@ -108,12 +108,12 @@ describe('callEnterpriseSearchConfigAPI', () => {
     });
 
     expect(await callEnterpriseSearchConfigAPI(mockDependencies)).toEqual({
+      ...DEFAULT_INITIAL_APP_DATA,
       access: {
         hasAppSearchAccess: true,
         hasWorkplaceSearchAccess: false,
       },
       publicUrl: 'http://some.vanity.url',
-      ...DEFAULT_INITIAL_APP_DATA,
     });
   });
 

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -14,15 +14,12 @@ import { stripTrailingSlash } from '../../common/strip_slashes';
 import { InitialAppData } from '../../common/types';
 import { ConfigType } from '../index';
 
-import { Access } from './check_access';
-
 interface Params {
   request: KibanaRequest;
   config: ConfigType;
   log: Logger;
 }
 interface Return extends InitialAppData {
-  access?: Access;
   publicUrl?: string;
 }
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/config_data.test.ts
@@ -33,12 +33,8 @@ describe('Enterprise Search Config Data API', () => {
   describe('GET /api/enterprise_search/config_data', () => {
     it('returns an initial set of config data from Enterprise Search', async () => {
       const mockData = {
-        access: {
-          hasAppSearchAccess: true,
-          hasWorkplaceSearchAccess: true,
-        },
-        publicUrl: 'http://localhost:3002',
         ...DEFAULT_INITIAL_APP_DATA,
+        publicUrl: 'http://localhost:3002',
       };
 
       (callEnterpriseSearchConfigAPI as jest.Mock).mockImplementationOnce(() => {


### PR DESCRIPTION
## Summary

I **strongly** recommend following along per-commit in this PR. It's relatively small, but there's some jumps/test cleanups, and I also tried to leave very detailed notes in my commit messages.

### Before

Per recent discovery from @byronhulcher and @JasonStoltz, we were running into "flash" scenarios due to the way we were initializing data in our AppLogic file. Because we were initializing with default empty objs and then calling `initializeAppData` on load, this was leading to the following scenario:

<img width="264" alt="" src="https://user-images.githubusercontent.com/549407/109185182-9a96fd00-7744-11eb-98a9-8c6df9633672.png">

This was particularly problematic on routings wrapped in role capabilities, where one route would briefly and erroneously load before another.

### After

With this new fix, any data in `AppLogic` should only be initialized **once**, never as falsy/undefined (unless something has gone seriously wrong with our config API endpoint, in which case the entirely plugin should not register as loaded):

<img width="236" alt="" src="https://user-images.githubusercontent.com/549407/109185362-cade9b80-7744-11eb-9684-6f3ab0f017f8.png">

Also, we can now refer to configuredLimits without having to add extra logic for potential falsy-ness all the dang time.

## QA

- [x] App runs as before with no regressions, ability checks work as expected

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios