### PR TITLE
[Lens] Remove warning about ordinal x-domain

### DIFF
--- a/x-pack/plugins/lens/public/xy_visualization/__snapshots__/expression.test.tsx.snap
+++ b/x-pack/plugins/lens/public/xy_visualization/__snapshots__/expression.test.tsx.snap
@@ -26,13 +26,6 @@ exports[`xy_expression XYChart component it renders area 1`] = `
         "headerFormatter": [Function],
       }
     }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
-      }
-    }
   />
   <Connect(SpecInstance)
     gridLine={
@@ -227,13 +220,6 @@ exports[`xy_expression XYChart component it renders bar 1`] = `
     tooltip={
       Object {
         "headerFormatter": [Function],
-      }
-    }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
       }
     }
   />
@@ -440,13 +426,6 @@ exports[`xy_expression XYChart component it renders horizontal bar 1`] = `
         "headerFormatter": [Function],
       }
     }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
-      }
-    }
   />
   <Connect(SpecInstance)
     gridLine={
@@ -651,13 +630,6 @@ exports[`xy_expression XYChart component it renders line 1`] = `
         "headerFormatter": [Function],
       }
     }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
-      }
-    }
   />
   <Connect(SpecInstance)
     gridLine={
@@ -852,13 +824,6 @@ exports[`xy_expression XYChart component it renders stacked area 1`] = `
     tooltip={
       Object {
         "headerFormatter": [Function],
-      }
-    }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
       }
     }
   />
@@ -1063,13 +1028,6 @@ exports[`xy_expression XYChart component it renders stacked bar 1`] = `
     tooltip={
       Object {
         "headerFormatter": [Function],
-      }
-    }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
       }
     }
   />
@@ -1282,13 +1240,6 @@ exports[`xy_expression XYChart component it renders stacked horizontal bar 1`] =
     tooltip={
       Object {
         "headerFormatter": [Function],
-      }
-    }
-    xDomain={
-      Object {
-        "max": undefined,
-        "min": undefined,
-        "minInterval": 50,
       }
     }
   />

--- a/x-pack/plugins/lens/public/xy_visualization/expression.test.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/expression.test.tsx
@@ -551,7 +551,7 @@ describe('xy_expression', () => {
       });
     });
 
-    test('it does not use date range if the x is not a time scale', () => {
+    test('it has xDomain undefined if the x is not a time scale or a histogram', () => {
       const { data, args } = sampleArgs();
 
       const component = shallow(
@@ -571,15 +571,10 @@ describe('xy_expression', () => {
         />
       );
       const xDomain = component.find(Settings).prop('xDomain');
-      expect(xDomain).toEqual(
-        expect.objectContaining({
-          min: undefined,
-          max: undefined,
-        })
-      );
+      expect(xDomain).toEqual(undefined);
     });
 
-    test('it uses min interval if passed in', () => {
+    test('it uses min interval if interval is passed in and visualization is histogram', () => {
       const { data, args } = sampleArgs();
 
       const component = shallow(
@@ -589,7 +584,9 @@ describe('xy_expression', () => {
           data={data}
           args={{
             ...args,
-            layers: [{ ...args.layers[0], seriesType: 'line', xScaleType: 'linear' }],
+            layers: [
+              { ...args.layers[0], seriesType: 'line', xScaleType: 'linear', isHistogram: true },
+            ],
           }}
         />
       );

--- a/x-pack/plugins/lens/public/xy_visualization/expression.tsx
+++ b/x-pack/plugins/lens/public/xy_visualization/expression.tsx
@@ -388,11 +388,15 @@ export function XYChart({
   const isTimeViz = data.dateRange && filteredLayers.every((l) => l.xScaleType === 'time');
   const isHistogramViz = filteredLayers.every((l) => l.isHistogram);
 
-  const xDomain = {
-    min: isTimeViz ? data.dateRange?.fromDate.getTime() : undefined,
-    max: isTimeViz ? data.dateRange?.toDate.getTime() : undefined,
-    minInterval,
-  };
+  const xDomain = isTimeViz
+    ? {
+        min: data.dateRange?.fromDate.getTime(),
+        max: data.dateRange?.toDate.getTime(),
+        minInterval,
+      }
+    : isHistogramViz
+    ? { minInterval }
+    : undefined;
 
   const getYAxesTitles = (
     axisSeries: Array<{ layer: string; accessor: string }>,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/93036

For ordinal scale. we shouldn't pass the same object as for histogram or date histogram. It didn't impact the behavior or display of the chart. Passing `undefined` instead of the object fixed the problem. 
