### PR TITLE
[APM] Fixes duplicate ML job creation for existing environments (#85023)

### DIFF
--- a/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
+++ b/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
@@ -65,7 +65,28 @@ export const createAnomalyDetectionJobsRoute = createRoute({
       throw Boom.forbidden(ML_ERRORS.INVALID_LICENSE);
     }
 
+    // const jobs = await getAnomalyDetectionJobs(setup, context.logger);
+    // const existingMLJobEnvironments = jobs.map(
+    //   ({ environment }) => environment
+    // );
+    // const requestedEnvironmentsWithoutMLJobs = environments.filter(
+    //   (env) => !existingMLJobEnvironments.includes(env)
+    // );
+    // if (requestedEnvironmentsWithoutMLJobs.length) {
+    //   await createAnomalyDetectionJobs(
+    //     setup,
+    //     requestedEnvironmentsWithoutMLJobs,
+    //     context.logger
+    //   );
+    // } else {
+    //   context.logger.warn(
+    //     `ML jobs already exist for environments: ${JSON.stringify(
+    //       environments
+    //     )}`
+    //   );
+    // }
     await createAnomalyDetectionJobs(setup, environments, context.logger);
+
     notifyFeatureUsage({
       licensingPlugin: context.licensing,
       featureName: 'ml',

--- a/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
+++ b/x-pack/plugins/apm/server/routes/settings/anomaly_detection.ts
@@ -65,26 +65,6 @@ export const createAnomalyDetectionJobsRoute = createRoute({
       throw Boom.forbidden(ML_ERRORS.INVALID_LICENSE);
     }
 
-    // const jobs = await getAnomalyDetectionJobs(setup, context.logger);
-    // const existingMLJobEnvironments = jobs.map(
-    //   ({ environment }) => environment
-    // );
-    // const requestedEnvironmentsWithoutMLJobs = environments.filter(
-    //   (env) => !existingMLJobEnvironments.includes(env)
-    // );
-    // if (requestedEnvironmentsWithoutMLJobs.length) {
-    //   await createAnomalyDetectionJobs(
-    //     setup,
-    //     requestedEnvironmentsWithoutMLJobs,
-    //     context.logger
-    //   );
-    // } else {
-    //   context.logger.warn(
-    //     `ML jobs already exist for environments: ${JSON.stringify(
-    //       environments
-    //     )}`
-    //   );
-    // }
     await createAnomalyDetectionJobs(setup, environments, context.logger);
 
     notifyFeatureUsage({


### PR DESCRIPTION
Closes #85023.

Checks for existing ML jobs for the currently selected environments in the API before creating a duplicate jobs. This was only happening on the client-side previously.

Example:
```
Pre-condition: ML Jobs already exist for APM environments: "test" & "prod"
---
POST /api/apm/settings/anomaly-detection/jobs
{ "environments": [ "test", "prod", "staging" ] }
---
server    log   [14:49:58.851] [warning][apm][plugins] Skipping creation of existing ML jobs for environments: [test,prod]}
server    log   [14:49:58.853] [info][apm][plugins] Creating ML anomaly detection jobs for environments: [staging].
```