### PR TITLE
[APM] Fix hidden search bar in error pages while loading

### DIFF
--- a/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/ErrorGroupDetails/index.tsx
@@ -60,6 +60,45 @@ function getShortGroupId(errorGroupId?: string) {
   return errorGroupId.slice(0, 5);
 }
 
+function ErrorGroupHeader({
+  groupId,
+  isUnhandled,
+}: {
+  groupId: string;
+  isUnhandled?: boolean;
+}) {
+  return (
+    <>
+      <ApmHeader>
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiTitle>
+              <h1>
+                {i18n.translate('xpack.apm.errorGroupDetails.errorGroupTitle', {
+                  defaultMessage: 'Error group {errorGroupId}',
+                  values: {
+                    errorGroupId: getShortGroupId(groupId),
+                  },
+                })}
+              </h1>
+            </EuiTitle>
+          </EuiFlexItem>
+          {isUnhandled && (
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="warning">
+                {i18n.translate('xpack.apm.errorGroupDetails.unhandledLabel', {
+                  defaultMessage: 'Unhandled',
+                })}
+              </EuiBadge>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </ApmHeader>
+      <SearchBar />
+    </>
+  );
+}
+
 type ErrorGroupDetailsProps = RouteComponentProps<{
   groupId: string;
   serviceName: string;
@@ -101,7 +140,7 @@ export function ErrorGroupDetails({ location, match }: ErrorGroupDetailsProps) {
   useTrackPageview({ app: 'apm', path: 'error_group_details', delay: 15000 });
 
   if (!errorGroupData || !errorDistributionData) {
-    return null;
+    return <ErrorGroupHeader groupId={groupId} />;
   }
 
   // If there are 0 occurrences, show only distribution chart w. empty message
@@ -114,32 +153,7 @@ export function ErrorGroupDetails({ location, match }: ErrorGroupDetailsProps) {
 
   return (
     <>
-      <ApmHeader>
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiTitle>
-              <h1>
-                {i18n.translate('xpack.apm.errorGroupDetails.errorGroupTitle', {
-                  defaultMessage: 'Error group {errorGroupId}',
-                  values: {
-                    errorGroupId: getShortGroupId(groupId),
-                  },
-                })}
-              </h1>
-            </EuiTitle>
-          </EuiFlexItem>
-          {isUnhandled && (
-            <EuiFlexItem grow={false}>
-              <EuiBadge color="warning">
-                {i18n.translate('xpack.apm.errorGroupDetails.unhandledLabel', {
-                  defaultMessage: 'Unhandled',
-                })}
-              </EuiBadge>
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-      </ApmHeader>
-      <SearchBar />
+      <ErrorGroupHeader groupId={groupId} isUnhandled={isUnhandled} />
       <EuiPage>
         <EuiPageBody>
           <EuiPanel>

--- a/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/error_group_overview/index.tsx
@@ -68,7 +68,7 @@ export function ErrorGroupOverview({ serviceName }: ErrorGroupOverviewProps) {
   useTrackPageview({ app: 'apm', path: 'error_group_overview', delay: 15000 });
 
   if (!errorDistributionData || !errorGroupListData) {
-    return null;
+    return <SearchBar />;
   }
 
   return (


### PR DESCRIPTION
Closes #84476.

Displays the search bar header even if data has not loaded. This allows the user to modify the date range if the current date range results in a timeout.

![Screen Shot 2021-03-01 at 5 04 10 PM](https://user-images.githubusercontent.com/1967266/109565658-a31a6b00-7a97-11eb-8532-6312e6317b50.png)
![Screen Shot 2021-03-01 at 5 03 55 PM](https://user-images.githubusercontent.com/1967266/109565659-a44b9800-7a97-11eb-9d54-23b7ca6ad01d.png)
