### PR TITLE
Add searchDuration to EQL and Threshold rules

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/signals/signal_rule_alert_type.ts
@@ -12,6 +12,7 @@ import isEmpty from 'lodash/isEmpty';
 import { chain, tryCatch } from 'fp-ts/lib/TaskEither';
 import { flow } from 'fp-ts/lib/function';
 
+import { performance } from 'perf_hooks';
 import { toError, toPromise } from '../../../../common/fp_utils';
 
 import {
@@ -50,6 +51,7 @@ import {
   hasTimestampFields,
   hasReadIndexPrivileges,
   getRuleRangeTuples,
+  makeFloatString,
 } from './utils';
 import { signalParamsSchema } from './signal_params_schema';
 import { siemRuleActionGroups } from './siem_rule_action_groups';
@@ -401,7 +403,11 @@ export const signalRulesAlertType = ({
             lists: exceptionItems ?? [],
           });
 
-          const { searchResult: thresholdResults, searchErrors } = await findThresholdSignals({
+          const {
+            searchResult: thresholdResults,
+            searchErrors,
+            searchDuration: thresholdSearchDuration,
+          } = await findThresholdSignals({
             inputIndexPattern: inputIndex,
             from,
             to,
@@ -456,6 +462,7 @@ export const signalRulesAlertType = ({
               createdSignalsCount: createdItemsCount,
               createdSignals: createdItems,
               bulkCreateTimes: bulkCreateDuration ? [bulkCreateDuration] : [],
+              searchAfterTimes: [thresholdSearchDuration],
             }),
           ]);
         } else if (isThreatMatchRule(type)) {
@@ -589,10 +596,14 @@ export const signalRulesAlertType = ({
             exceptionItems ?? [],
             eventCategoryOverride
           );
+          const eqlSignalSearchStart = performance.now();
           const response: EqlSignalSearchResponse = await services.callCluster(
             'transport.request',
             request
           );
+          const eqlSignalSearchEnd = performance.now();
+          const eqlSearchDuration = makeFloatString(eqlSignalSearchEnd - eqlSignalSearchStart);
+          result.searchAfterTimes = [eqlSearchDuration];
           let newSignals: WrappedSignalHit[] | undefined;
           if (response.hits.sequences !== undefined) {
             newSignals = response.hits.sequences.reduce(
@@ -633,7 +644,6 @@ export const signalRulesAlertType = ({
 
             const fromInMs = parseScheduleDates(`now-${interval}`)?.format('x');
             const toInMs = parseScheduleDates('now')?.format('x');
-
             const resultsLink = getNotificationResultsLink({
               from: fromInMs,
               to: toInMs,


### PR DESCRIPTION
Closes #82861.

## Summary

This commit ensures that the Query Time column in the Rule Management table is filled for EQL and Threshold rules.

### Checklist

Delete any items that are not applicable to this PR.
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

