### PR TITLE
[Lens] Fix runtime validation error message

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -515,7 +515,7 @@ export const InnerVisualizationWrapper = ({
                       </p>
 
                       {localState.expandError ? (
-                        <p className="eui-textBreakAll">visibleErrorMessage</p>
+                        <p className="eui-textBreakAll">{visibleErrorMessage}</p>
                       ) : null}
                     </>
                   }


### PR DESCRIPTION
## Summary

In #91878 validation layout has been rewritten but the `visibleErrorMessage` variable has not been correctly wrapped in JSX. This leads to lack of context on runtime errors like EsErrors which could be useful to the user to debug the problem.

This PR addresses that problem.