### PR TITLE
Adds x-pack to Jest integration tests

### DIFF
--- a/jest.config.integration.js
+++ b/jest.config.integration.js
@@ -9,5 +9,11 @@
 module.exports = {
   preset: '@kbn/test/jest_integration',
   rootDir: '.',
-  roots: ['<rootDir>/src', '<rootDir>/packages'],
+  roots: ['<rootDir>/src', '<rootDir>/packages', '<rootDir>/x-pack'],
+  testPathIgnorePatterns: [
+    '<rootDir>/x-pack/test/',
+
+    // https://github.com/elastic/kibana/issues/108440
+    '<rootDir>/x-pack/plugins/task_manager/server/integration_tests/managed_configuration.test.ts',
+  ],
 };

--- a/x-pack/plugins/global_search/server/routes/integration_tests/get_searchable_types.test.ts
+++ b/x-pack/plugins/global_search/server/routes/integration_tests/get_searchable_types.test.ts
@@ -45,7 +45,7 @@ describe('GET /internal/global_search/searchable_types', () => {
 
   it('calls the handler context with correct parameters', async () => {
     await supertest(httpSetup.server.listener)
-      .post('/internal/global_search/searchable_types')
+      .get('/internal/global_search/searchable_types')
       .expect(200);
 
     expect(globalSearchHandlerContext.getSearchableTypes).toHaveBeenCalledTimes(1);
@@ -55,7 +55,7 @@ describe('GET /internal/global_search/searchable_types', () => {
     globalSearchHandlerContext.getSearchableTypes.mockResolvedValue(['type-a', 'type-b']);
 
     const response = await supertest(httpSetup.server.listener)
-      .post('/internal/global_search/searchable_types')
+      .get('/internal/global_search/searchable_types')
       .expect(200);
 
     expect(response.body).toEqual({
@@ -67,8 +67,8 @@ describe('GET /internal/global_search/searchable_types', () => {
     globalSearchHandlerContext.getSearchableTypes.mockRejectedValue(new Error());
 
     const response = await supertest(httpSetup.server.listener)
-      .post('/internal/global_search/searchable_types')
-      .expect(200);
+      .get('/internal/global_search/searchable_types')
+      .expect(500);
 
     expect(response.body).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
X-Pack integration tests were not running - this re-enables them and fixes the failing tests.