### PR TITLE
add log min limit option to value axis options

### DIFF
--- a/src/plugins/vis_type_xy/public/config/get_axis.ts
+++ b/src/plugins/vis_type_xy/public/config/get_axis.ts
@@ -167,21 +167,22 @@ function getAxisDomain<S extends XScaleType | YScaleType>(
     return;
   }
 
-  const { min, max, defaultYExtents, boundsMargin } = scale;
-  const fit = defaultYExtents;
+  const { min, max, defaultYExtents, boundsMargin, useLogMinLimit } = scale;
+  const fit = defaultYExtents || useLogMinLimit;
   const padding = boundsMargin;
+  const logMinLimit = useLogMinLimit ? scale.logMinLimit : undefined;
 
   if (!isNil(min) && !isNil(max)) {
-    return { fit, padding, min, max };
+    return { fit, logMinLimit, padding, min, max };
   }
 
   if (!isNil(min)) {
-    return { fit, padding, min };
+    return { fit, logMinLimit, padding, min };
   }
 
   if (!isNil(max)) {
-    return { fit, padding, max };
+    return { fit, logMinLimit, padding, max };
   }
 
-  return { fit, padding };
+  return { fit, logMinLimit, padding };
 }

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/custom_extents_options.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/custom_extents_options.tsx
@@ -9,6 +9,8 @@
 import React, { useCallback, useEffect } from 'react';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { EuiIconTip } from '@elastic/eui';
 
 import { NumberInputOption, SwitchOption } from '../../../../../../vis_default_editor/public';
 
@@ -21,6 +23,7 @@ export interface CustomExtentsOptionsProps {
   setMultipleValidity(paramName: string, isValid: boolean): void;
   setValueAxis<T extends keyof ValueAxis>(paramName: T, value: ValueAxis[T]): void;
   setValueAxisScale: SetScale;
+  showLogOptions: boolean;
 }
 
 function CustomExtentsOptions({
@@ -28,6 +31,7 @@ function CustomExtentsOptions({
   setMultipleValidity,
   setValueAxis,
   setValueAxisScale,
+  showLogOptions,
 }: CustomExtentsOptionsProps) {
   const invalidBoundsMarginMessage = i18n.translate(
     'visTypeXy.controls.pointSeries.valueAxes.scaleToDataBounds.minNeededBoundsMargin',
@@ -65,6 +69,26 @@ function CustomExtentsOptions({
     },
     [axisScale, setValueAxis]
   );
+
+  const setAxisLogMinLimit = useCallback(
+    (paramName: 'logMinLimit', value: number | '') => {
+      setValueAxisScale(paramName, value === '' ? 1 : value);
+    },
+    [setValueAxisScale]
+  );
+
+  const setUselogLimit = useCallback(
+    (paramName: 'useLogMinLimit', value: boolean) => {
+      setValueAxisScale(paramName, value);
+    },
+    [setValueAxisScale]
+  );
+
+  useEffect(() => {
+    if (!showLogOptions) {
+      setUselogLimit('useLogMinLimit', false);
+    }
+  }, [setUselogLimit, showLogOptions]);
 
   useEffect(() => {
     setMultipleValidity('boundsMargin', isBoundsMarginValid);
@@ -119,6 +143,37 @@ function CustomExtentsOptions({
           setScale={setValueAxisScale}
           setMultipleValidity={setMultipleValidity}
         />
+      )}
+
+      {showLogOptions && (
+        <>
+          <SwitchOption
+            label={i18n.translate('visTypeXy.controls.pointSeries.valueAxes.setAxisLogMinLimit', {
+              defaultMessage: 'Set log min limit',
+            })}
+            paramName="useLogMinLimit"
+            value={axisScale.useLogMinLimit}
+            setValue={setUselogLimit}
+          />
+
+          {axisScale.useLogMinLimit && (
+            <NumberInputOption
+              label={
+                <>
+                  <FormattedMessage
+                    id="visTypeXy.controls.pointSeries.valueAxes.LogMinLimit"
+                    defaultMessage="Log min limit"
+                  />{' '}
+                  <EuiIconTip content="Absolute value to limit visible data on a log scale." />
+                </>
+              }
+              isInvalid={(axisScale.logMinLimit ?? 1) <= 0}
+              paramName="logMinLimit"
+              value={axisScale.logMinLimit}
+              setValue={setAxisLogMinLimit}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axes_panel.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axes_panel.tsx
@@ -20,9 +20,10 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
-import { SeriesParam, ValueAxis } from '../../../../types';
+import { ChartMode, ScaleType, SeriesParam, ValueAxis } from '../../../../types';
 import { ValueAxisOptions } from './value_axis_options';
 import { SetParamByIndex } from '.';
+import { ChartType } from '../../../../../common';
 
 export interface ValueAxesPanelProps {
   addValueAxis: () => ValueAxis;
@@ -94,6 +95,22 @@ function ValueAxesPanel(props: ValueAxesPanelProps) {
     },
     [getSeries]
   );
+
+  const shouldShowLogOptions = useCallback(
+    (axis: ValueAxis) => {
+      if (axis.scale.type !== ScaleType.Log) return false;
+
+      const isFirst = valueAxes[0].id === axis.id;
+      const series = seriesParams.filter(
+        (serie) => serie.valueAxis === axis.id || (isFirst && !serie.valueAxis)
+      );
+      return series.some(
+        (serie) => serie.type === ChartType.Line && serie.mode === ChartMode.Normal
+      );
+    },
+    [seriesParams, valueAxes]
+  );
+
   return (
     <EuiPanel paddingSize="s">
       <EuiFlexGroup gutterSize="none" justifyContent="spaceBetween" alignItems="baseline">
@@ -145,6 +162,7 @@ function ValueAxesPanel(props: ValueAxesPanelProps) {
             <ValueAxisOptions
               axis={axis}
               index={index}
+              showLogOptions={shouldShowLogOptions(axis)}
               valueAxis={valueAxes[index]}
               onValueAxisPositionChanged={props.onValueAxisPositionChanged}
               setParamByIndex={props.setParamByIndex}

--- a/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axis_options.tsx
+++ b/src/plugins/vis_type_xy/public/editor/components/options/metrics_axes/value_axis_options.tsx
@@ -35,6 +35,7 @@ export interface ValueAxisOptionsParams {
   onValueAxisPositionChanged: (index: number, value: ValueAxis['position']) => void;
   setParamByIndex: SetParamByIndex;
   valueAxis: ValueAxis;
+  showLogOptions: boolean;
   setMultipleValidity: (paramName: string, isValid: boolean) => void;
 }
 
@@ -45,6 +46,7 @@ export function ValueAxisOptions({
   onValueAxisPositionChanged,
   setParamByIndex,
   setMultipleValidity,
+  showLogOptions,
 }: ValueAxisOptionsParams) {
   const setValueAxis = useCallback(
     <T extends keyof ValueAxis>(paramName: T, value: ValueAxis[T]) =>
@@ -188,6 +190,7 @@ export function ValueAxisOptions({
           <EuiSpacer size="m" />
           <CustomExtentsOptions
             axisScale={axis.scale}
+            showLogOptions={showLogOptions}
             setMultipleValidity={setMultipleValidity}
             setValueAxisScale={setValueAxisScale}
             setValueAxis={setValueAxis}

--- a/src/plugins/vis_type_xy/public/types/param.ts
+++ b/src/plugins/vis_type_xy/public/types/param.ts
@@ -29,6 +29,8 @@ export interface Scale {
   mode?: AxisMode;
   setYExtents?: boolean;
   type: ScaleType;
+  useLogMinLimit?: boolean;
+  logMinLimit?: number;
 }
 
 export interface CategoryAxis {


### PR DESCRIPTION
## Summary

fixes #83917

Add option to `Y-Axes` config in visualize xy charts to set a log min limit to contain log data using an explicit limit and not the kibana implicit limit of `1`.

This option is **only** available when an axes config is linked to one or more non-stacked line series. This is to discourage bad practices for area charts and stacked lines.

**Note:** When `Set log min limit` is disabled, the implied value of `1` will be used.

https://user-images.githubusercontent.com/19007109/113789174-46e4df80-9704-11eb-91bb-447971622f73.mp4


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
