### PR TITLE
[Workplace Search] Port RoleMappings changes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
@@ -40,7 +40,7 @@ interface Props {
   selectedAuthProviders?: string[];
   availableAuthProviders?: string[];
   elasticsearchRoles: string[];
-  disabled: boolean;
+  disabled?: boolean;
   multipleAuthProvidersConfig: boolean;
   handleAttributeSelectorChange(value: string, elasticsearchRole: string): void;
   handleAttributeValueChange(value: string): void;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiRadio, EuiCallOut } from '@elastic/eui';
+import { EuiRadio } from '@elastic/eui';
 
 import { RoleSelector } from './role_selector';
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.test.tsx
@@ -41,9 +41,7 @@ describe('RoleSelector', () => {
 
   it('renders callout when disabled', () => {
     const wrapper = shallow(<RoleSelector {...props} disabled />);
-    const radio = wrapper.find(EuiRadio);
 
-    expect(radio.dive().find(EuiCallOut)).toHaveLength(1);
     expect(wrapper.find(EuiRadio).prop('checked')).toEqual(false);
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.tsx
@@ -22,7 +22,6 @@ interface Props {
 
 export const RoleSelector: React.FC<Props> = ({
   disabled,
-  disabledText,
   roleType,
   roleTypeOption,
   description,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_selector.tsx
@@ -9,15 +9,7 @@ import React from 'react';
 
 import { startCase } from 'lodash';
 
-import {
-  EuiCallOut,
-  EuiFormRow,
-  EuiRadio,
-  EuiSpacer,
-  EuiText,
-  EuiTextColor,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiFormRow, EuiRadio, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 
 interface Props {
   disabled?: boolean;
@@ -49,13 +41,6 @@ export const RoleSelector: React.FC<Props> = ({
           <EuiTitle size="xs">
             <h4 className="usersLayout__users--roletype">{startCase(roleTypeOption)}</h4>
           </EuiTitle>
-          {disabled && disabledText && (
-            <EuiCallOut
-              size="s"
-              title={<EuiTextColor color="subdued">{disabledText}</EuiTextColor>}
-              iconType="alert"
-            />
-          )}
           <EuiSpacer size="xs" />
           <EuiText size="s">
             <p>{description}</p>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/constants.ts
@@ -38,14 +38,6 @@ export const USER_ROLE_TYPE_DESCRIPTION = i18n.translate(
   }
 );
 
-export const ROLE_SELECTOR_DISABLED_TEXT = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.roleMapping.roleSelectorDisabledText',
-  {
-    defaultMessage:
-      'You need at least one admin role mapping before you can create a user role mapping.',
-  }
-);
-
 export const GROUP_ASSIGNMENT_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.roleMapping.groupAssignmentTitle',
   {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
@@ -37,7 +37,6 @@ import { Role } from '../../types';
 import {
   ADMIN_ROLE_TYPE_DESCRIPTION,
   USER_ROLE_TYPE_DESCRIPTION,
-  ROLE_SELECTOR_DISABLED_TEXT,
   GROUP_ASSIGNMENT_TITLE,
   GROUP_ASSIGNMENT_INVALID_ERROR,
   GROUP_ASSIGNMENT_ALL_GROUPS_LABEL,
@@ -86,7 +85,6 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
     elasticsearchRoles,
     dataLoading,
     roleType,
-    roleMappings,
     attributeValue,
     attributeName,
     availableGroups,
@@ -119,11 +117,6 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
     <EuiButton disabled={!hasGroupAssignment} onClick={handleSaveMapping} fill>
       {SAVE_ROLE_MAPPING_LABEL}
     </EuiButton>
-  );
-
-  const hasAdminRoleMapping = roleMappings.some(
-    ({ roleType: roleMappingRoleType }: { roleType: string }) =>
-      roleMappingRoleType === ('admin' as string)
   );
 
   return (
@@ -160,8 +153,6 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
                   onChange={handleRoleChange}
                   roleTypeOption={type}
                   description={description}
-                  disabled={!(type === 'admin' || hasAdminRoleMapping)}
-                  disabledText={ROLE_SELECTOR_DISABLED_TEXT}
                 />
               ))}
             </EuiPanel>


### PR DESCRIPTION
This PR ports changes from the ent-search RoleMappings to Kibana

Reference PR: https://github.com/elastic/ent-search/pull/3148

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
