### PR TITLE
[Snapshot Restore] Remove cloud validation for slm policy

### DIFF
--- a/x-pack/plugins/snapshot_restore/__jest__/client_integration/policy_add.test.ts
+++ b/x-pack/plugins/snapshot_restore/__jest__/client_integration/policy_add.test.ts
@@ -78,29 +78,51 @@ describe('<PolicyAdd />', () => {
         test('should require a policy name', async () => {
           const { form, find } = testBed;
 
+          // Verify required validation
           form.setInputValue('nameInput', '');
           find('nameInput').simulate('blur');
-
           expect(form.getErrorsMessages()).toEqual(['Policy name is required.']);
+
+          // Enter valid policy name and verify no error messages
+          form.setInputValue('nameInput', 'my_policy');
+          find('nameInput').simulate('blur');
+
+          expect(form.getErrorsMessages()).toEqual([]);
         });
 
-        test('should require a snapshot name', () => {
+        test('should require a snapshot name that is lowercase', () => {
           const { form, find } = testBed;
 
+          // Verify required validation
           form.setInputValue('snapshotNameInput', '');
           find('snapshotNameInput').simulate('blur');
-
           expect(form.getErrorsMessages()).toEqual(['Snapshot name is required.']);
+
+          // Verify lowercase validation
+          form.setInputValue('snapshotNameInput', 'MY_SNAPSHOT');
+          find('snapshotNameInput').simulate('blur');
+          expect(form.getErrorsMessages()).toEqual(['Snapshot name needs to be lowercase.']);
+
+          // Enter valid snapshot name and verify no error messages
+          form.setInputValue('snapshotNameInput', 'my_snapshot');
+          find('snapshotNameInput').simulate('blur');
+
+          expect(form.getErrorsMessages()).toEqual([]);
         });
 
         it('should require a schedule', () => {
           const { form, find } = testBed;
 
+          // Verify required validation
           find('showAdvancedCronLink').simulate('click');
           form.setInputValue('advancedCronInput', '');
           find('advancedCronInput').simulate('blur');
-
           expect(form.getErrorsMessages()).toEqual(['Schedule is required.']);
+
+          // Enter valid schedule and verify no error messages
+          form.setInputValue('advancedCronInput', '0 30 1 * * ?');
+          find('advancedCronInput').simulate('blur');
+          expect(form.getErrorsMessages()).toEqual([]);
         });
       });
 

--- a/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/index.ts
+++ b/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/index.ts
@@ -6,13 +6,16 @@
  */
 
 import { SlmPolicyPayload } from '../../../../../common/types';
-import { PolicyValidation } from '../../../services/validation';
+import { PolicyValidation, ValidatePolicyHelperData } from '../../../services/validation';
 
 export interface StepProps {
   policy: SlmPolicyPayload;
   indices: string[];
   dataStreams: string[];
-  updatePolicy: (updatedSettings: Partial<SlmPolicyPayload>, validationHelperData?: any) => void;
+  updatePolicy: (
+    updatedSettings: Partial<SlmPolicyPayload>,
+    validationHelperData?: ValidatePolicyHelperData
+  ) => void;
   isEditing: boolean;
   currentUrl: string;
   errors: PolicyValidation['errors'];

--- a/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/components/policy_form/steps/step_logistics.tsx
@@ -46,11 +46,8 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
   const {
     error: errorLoadingRepositories,
     isLoading: isLoadingRepositories,
-    data: { repositories, managedRepository } = {
+    data: { repositories } = {
       repositories: [],
-      managedRepository: {
-        name: undefined,
-      },
     },
     resendRequest: reloadRepositories,
   } = useLoadRepositories();
@@ -119,16 +116,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
           fullWidth
           onBlur={() => setTouched({ ...touched, name: true })}
           onChange={(e) => {
-            updatePolicy(
-              {
-                name: e.target.value,
-              },
-              {
-                managedRepository,
-                isEditing,
-                policyName: policy.name,
-              }
-            );
+            updatePolicy({
+              name: e.target.value,
+            });
           }}
           placeholder={i18n.translate(
             'xpack.snapshotRestore.policyForm.stepLogistics.namePlaceholder',
@@ -251,16 +241,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
       );
     } else {
       if (!policy.repository) {
-        updatePolicy(
-          {
-            repository: repositories[0].name,
-          },
-          {
-            managedRepository,
-            isEditing,
-            policyName: policy.name,
-          }
-        );
+        updatePolicy({
+          repository: repositories[0].name,
+        });
       }
     }
 
@@ -286,16 +269,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
         value={!doesRepositoryExist ? '' : policy.repository}
         onBlur={() => setTouched({ ...touched, repository: true })}
         onChange={(e) => {
-          updatePolicy(
-            {
-              repository: e.target.value,
-            },
-            {
-              managedRepository,
-              isEditing,
-              policyName: policy.name,
-            }
-          );
+          updatePolicy({
+            repository: e.target.value,
+          });
         }}
         fullWidth
         data-test-subj="repositorySelect"
@@ -354,16 +330,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
           defaultValue={policy.snapshotName}
           fullWidth
           onChange={(e) => {
-            updatePolicy(
-              {
-                snapshotName: e.target.value,
-              },
-              {
-                managedRepository,
-                isEditing,
-                policyName: policy.name,
-              }
-            );
+            updatePolicy({
+              snapshotName: e.target.value,
+            });
           }}
           onBlur={() => setTouched({ ...touched, snapshotName: true })}
           placeholder={i18n.translate(
@@ -433,16 +402,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
               defaultValue={policy.schedule}
               fullWidth
               onChange={(e) => {
-                updatePolicy(
-                  {
-                    schedule: e.target.value,
-                  },
-                  {
-                    managedRepository,
-                    isEditing,
-                    policyName: policy.name,
-                  }
-                );
+                updatePolicy({
+                  schedule: e.target.value,
+                });
               }}
               onBlur={() => setTouched({ ...touched, schedule: true })}
               placeholder={DEFAULT_POLICY_SCHEDULE}
@@ -456,16 +418,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
             <EuiLink
               onClick={() => {
                 setIsAdvancedCronVisible(false);
-                updatePolicy(
-                  {
-                    schedule: simpleCron.expression,
-                  },
-                  {
-                    managedRepository,
-                    isEditing,
-                    policyName: policy.name,
-                  }
-                );
+                updatePolicy({
+                  schedule: simpleCron.expression,
+                });
               }}
               data-test-subj="showBasicCronLink"
             >
@@ -493,16 +448,9 @@ export const PolicyStepLogistics: React.FunctionComponent<StepProps> = ({
                 frequency,
               });
               setFieldToPreferredValueMap(newFieldToPreferredValueMap);
-              updatePolicy(
-                {
-                  schedule: expression,
-                },
-                {
-                  managedRepository,
-                  isEditing,
-                  policyName: policy.name,
-                }
-              );
+              updatePolicy({
+                schedule: expression,
+              });
             }}
           />
 

--- a/x-pack/plugins/snapshot_restore/public/application/services/validation/validate_policy.ts
+++ b/x-pack/plugins/snapshot_restore/public/application/services/validation/validate_policy.ts
@@ -28,12 +28,6 @@ const isSnapshotNameNotLowerCase = (str: string): boolean => {
 };
 
 export interface ValidatePolicyHelperData {
-  managedRepository?: {
-    name: string;
-    policy: string;
-  };
-  isEditing?: boolean;
-  policyName?: string;
   /**
    * Whether to block on the indices configured for this snapshot.
    *
@@ -58,13 +52,7 @@ export const validatePolicy = (
   const i18n = textService.i18n;
 
   const { name, snapshotName, schedule, repository, config, retention } = policy;
-  const {
-    managedRepository,
-    isEditing,
-    policyName,
-    validateIndicesCount,
-    repositoryDoesNotExist,
-  } = validationHelperData;
+  const { validateIndicesCount, repositoryDoesNotExist } = validationHelperData;
 
   const validation: PolicyValidation = {
     isValid: true,
@@ -156,22 +144,6 @@ export const validatePolicy = (
     validation.errors.minCount.push(
       i18n.translate('xpack.snapshotRestore.policyValidation.invalidMinCountErrorMessage', {
         defaultMessage: 'Minimum count cannot be greater than maximum count.',
-      })
-    );
-  }
-
-  if (
-    managedRepository &&
-    managedRepository.name === repository &&
-    managedRepository.policy &&
-    !(isEditing && managedRepository.policy === policyName)
-  ) {
-    validation.errors.repository.push(
-      i18n.translate('xpack.snapshotRestore.policyValidation.invalidRepoErrorMessage', {
-        defaultMessage: 'Policy "{policyName}" is already associated with this repository.',
-        values: {
-          policyName: managedRepository.policy,
-        },
       })
     );
   }

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -19866,7 +19866,6 @@
     "xpack.snapshotRestore.policyValidation.invalidNegativeDeleteAfterErrorMessage": "次の期間後削除は負数にすることができません。",
     "xpack.snapshotRestore.policyValidation.invalidNegativeMaxCountErrorMessage": "最大カウントは負数にすることができません。",
     "xpack.snapshotRestore.policyValidation.invalidNegativeMinCountErrorMessage": "最小カウントは負数にすることができません。",
-    "xpack.snapshotRestore.policyValidation.invalidRepoErrorMessage": "ポリシー\"{policyName}\"は既にこのリポジトリに関連付けられています。",
     "xpack.snapshotRestore.policyValidation.nameRequiredErroMessage": "ポリシー名が必要です。",
     "xpack.snapshotRestore.policyValidation.repositoryRequiredErrorMessage": "レポジトリが必要です。",
     "xpack.snapshotRestore.policyValidation.scheduleRequiredErrorMessage": "スケジュールが必要です。",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -19912,7 +19912,6 @@
     "xpack.snapshotRestore.policyValidation.invalidNegativeDeleteAfterErrorMessage": "“在指定时间后删除”不能为负。",
     "xpack.snapshotRestore.policyValidation.invalidNegativeMaxCountErrorMessage": "“最大计数”不能为负。",
     "xpack.snapshotRestore.policyValidation.invalidNegativeMinCountErrorMessage": "“最小计数”不能为负。",
-    "xpack.snapshotRestore.policyValidation.invalidRepoErrorMessage": "策略“{policyName}”已与此存储库关联。",
     "xpack.snapshotRestore.policyValidation.nameRequiredErroMessage": "策略名称必填。",
     "xpack.snapshotRestore.policyValidation.repositoryRequiredErrorMessage": "存储库必填。",
     "xpack.snapshotRestore.policyValidation.scheduleRequiredErrorMessage": "计划必填。",


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/92990

Per https://github.com/elastic/kibana/issues/92990#issuecomment-790411513, we should no longer be restricting a user from adding more than one policy to a cloud-managed repository. This PR removes the validation logic we had in place for this.

Note: There was **not** an existing test for this validation, and since this is functionality being removed, I did not add any tests for this specific scenario. However, I did update the existing validation tests for the logistics step to be more robust.

### How to test
You will need to mock the cloud environment to test this PR.

1. Specify the `path.repo` variable when starting ES:

   ``` 
   yarn es snapshot --license trial -E path.repo=/tmp/es-backups
   ```

2. Add the `cluster.metadata.managed_repository` and `cluster.metadata.managed_policies` settings via Console:

   ```
   PUT /_cluster/settings
   {
     "persistent": {
       "cluster.metadata.managed_repository": "found-snapshots",
       "cluster.metadata.managed_policies": ["managed-policy"]
     }
   }
   ```
3. Create a repository with the same name as your setting value (`found-snapshots`)
4. Create a policy with the same name as your setting value (`managed-policy`)
5. Verify you are able to create a second SLM policy with the `found-snapshots` repository without any validation errors.


### Release note
The Snapshot and Restore UI now allows a user to configure more than one Snapshot Lifecycle Management (SLM) policy for a cloud-managed repository.
