### PR TITLE
ESLint rules for Spaces and Security

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1368,6 +1368,14 @@ module.exports = {
           },
         ],
         'import/no-duplicates': ['error'],
+        'sort-imports': [
+          // This rule sorts imports of multiple members (destructured imports)
+          'error',
+          {
+            ignoreCase: true,
+            ignoreDeclarationSort: true,
+          },
+        ],
       },
     },
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1330,6 +1330,47 @@ module.exports = {
       },
     },
 
+    /**
+     * Platform Security Team overrides
+     */
+    {
+      files: [
+        'src/plugins/security_oss/**/*.{js,mjs,ts,tsx}',
+        'src/plugins/spaces_oss/**/*.{js,mjs,ts,tsx}',
+        'x-pack/plugins/encrypted_saved_objects/**/*.{js,mjs,ts,tsx}',
+        'x-pack/plugins/security/**/*.{js,mjs,ts,tsx}',
+        'x-pack/plugins/spaces/**/*.{js,mjs,ts,tsx}',
+      ],
+      rules: {
+        '@typescript-eslint/consistent-type-imports': 1,
+        'import/order': [
+          // This rule sorts import declarations
+          'error',
+          {
+            groups: [
+              'unknown',
+              ['builtin', 'external'],
+              'internal',
+              ['parent', 'sibling', 'index'],
+            ],
+            pathGroups: [
+              {
+                pattern: '{@kbn/**,src/**,kibana{,/**}}',
+                group: 'internal',
+              },
+            ],
+            pathGroupsExcludedImportTypes: [],
+            alphabetize: {
+              order: 'asc',
+              caseInsensitive: true,
+            },
+            'newlines-between': 'always',
+          },
+        ],
+        'import/no-duplicates': ['error'],
+      },
+    },
+
     {
       files: [
         // core-team owned code

--- a/src/plugins/security_oss/.eslintrc.json
+++ b/src/plugins/security_oss/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/consistent-type-imports": 1
-  }
-}

--- a/src/plugins/security_oss/public/insecure_cluster_service/insecure_cluster_service.test.tsx
+++ b/src/plugins/security_oss/public/insecure_cluster_service/insecure_cluster_service.test.tsx
@@ -7,7 +7,6 @@
  */
 
 import { nextTick } from '@kbn/test/jest';
-
 import { coreMock } from 'src/core/public/mocks';
 
 import { mockAppStateService } from '../app_state/app_state_service.mock';

--- a/src/plugins/security_oss/public/insecure_cluster_service/insecure_cluster_service.tsx
+++ b/src/plugins/security_oss/public/insecure_cluster_service/insecure_cluster_service.tsx
@@ -11,8 +11,8 @@ import { distinctUntilChanged, map } from 'rxjs/operators';
 
 import type { CoreSetup, CoreStart, MountPoint, Toast } from 'src/core/public';
 
-import type { ConfigType } from '../config';
 import type { AppStateServiceStart } from '../app_state';
+import type { ConfigType } from '../config';
 import { defaultAlertText, defaultAlertTitle } from './components';
 
 interface SetupDeps {

--- a/src/plugins/spaces_oss/.eslintrc.json
+++ b/src/plugins/spaces_oss/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/consistent-type-imports": 1
-  }
-}

--- a/src/plugins/spaces_oss/public/api.ts
+++ b/src/plugins/spaces_oss/public/api.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-import type { Observable } from 'rxjs';
 import type { ReactElement } from 'react';
+import type { Observable } from 'rxjs';
 
 import type { Space } from '../common';
 

--- a/src/plugins/spaces_oss/public/mocks/index.ts
+++ b/src/plugins/spaces_oss/public/mocks/index.ts
@@ -6,9 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { spacesApiMock } from '../api.mock';
-
 import type { SpacesOssPluginSetup, SpacesOssPluginStart } from '../';
+import { spacesApiMock } from '../api.mock';
 
 const createSetupContract = (): jest.Mocked<SpacesOssPluginSetup> => ({
   registerSpacesApi: jest.fn(),

--- a/src/plugins/spaces_oss/public/plugin.ts
+++ b/src/plugins/spaces_oss/public/plugin.ts
@@ -8,8 +8,8 @@
 
 import type { Plugin } from 'src/core/public';
 
-import type { SpacesOssPluginSetup, SpacesOssPluginStart } from './types';
 import type { SpacesApi } from './api';
+import type { SpacesOssPluginSetup, SpacesOssPluginStart } from './types';
 
 export class SpacesOssPlugin implements Plugin<SpacesOssPluginSetup, SpacesOssPluginStart, {}, {}> {
   private api?: SpacesApi;

--- a/x-pack/plugins/encrypted_saved_objects/.eslintrc.json
+++ b/x-pack/plugins/encrypted_saved_objects/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/consistent-type-imports": 1
-  }
-}

--- a/x-pack/plugins/security/.eslintrc.json
+++ b/x-pack/plugins/security/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/consistent-type-imports": 1
-  }
-}

--- a/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
@@ -49,11 +49,11 @@ import type {
   RoleIndexPrivilege,
 } from '../../../../common/model';
 import {
-  copyRole,
-  getExtendedRoleDeprecationNotice,
   isRoleDeprecated as checkIfRoleDeprecated,
   isRoleReadOnly as checkIfRoleReadOnly,
   isRoleReserved as checkIfRoleReserved,
+  copyRole,
+  getExtendedRoleDeprecationNotice,
   prepareRoleClone,
 } from '../../../../common/model';
 import type { UserAPIClient } from '../../users';

--- a/x-pack/plugins/security/server/authorization/authorization_service.test.ts
+++ b/x-pack/plugins/security/server/authorization/authorization_service.test.ts
@@ -11,6 +11,7 @@ import { nextTick } from '@kbn/test/jest';
 import { coreMock, elasticsearchServiceMock, loggingSystemMock } from 'src/core/server/mocks';
 
 // Note: this import must be before other relative imports for the mocks to work as intended.
+// eslint-disable-next-line import/order
 import {
   mockAuthorizationModeFactory,
   mockCheckPrivilegesDynamicallyWithRequestFactory,

--- a/x-pack/plugins/security/server/authorization/privileges/privileges.ts
+++ b/x-pack/plugins/security/server/authorization/privileges/privileges.ts
@@ -8,8 +8,8 @@
 import { uniq } from 'lodash';
 
 import type {
-  KibanaFeature,
   PluginSetupContract as FeaturesPluginSetup,
+  KibanaFeature,
 } from '../../../../features/server';
 import type { SecurityLicense } from '../../../common/licensing';
 import type { RawKibanaPrivileges } from '../../../common/model';

--- a/x-pack/plugins/spaces/.eslintrc.json
+++ b/x-pack/plugins/spaces/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/consistent-type-imports": 1
-  }
-}

--- a/x-pack/plugins/spaces/public/copy_saved_objects_to_space/components/copy_to_space_flyout_internal.tsx
+++ b/x-pack/plugins/spaces/public/copy_saved_objects_to_space/components/copy_to_space_flyout_internal.tsx
@@ -28,11 +28,11 @@ import type { ProcessedImportResponse } from 'src/plugins/saved_objects_manageme
 import type { Space } from 'src/plugins/spaces_oss/common';
 
 import { processImportResponse } from '../../../../../../src/plugins/saved_objects_management/public';
+import { useSpaces } from '../../spaces_context';
 import type { CopyOptions, ImportRetry, SavedObjectTarget } from '../types';
 import { CopyToSpaceFlyoutFooter } from './copy_to_space_flyout_footer';
 import { CopyToSpaceForm } from './copy_to_space_form';
 import { ProcessingCopyToSpace } from './processing_copy_to_space';
-import { useSpaces } from '../../spaces_context';
 
 export interface CopyToSpaceFlyoutProps {
   onClose: () => void;

--- a/x-pack/plugins/spaces/public/copy_saved_objects_to_space/lib/summarize_copy_result.test.ts
+++ b/x-pack/plugins/spaces/public/copy_saved_objects_to_space/lib/summarize_copy_result.test.ts
@@ -11,8 +11,8 @@ import type {
   SavedObjectsManagementRecord,
 } from 'src/plugins/saved_objects_management/public';
 
-import { summarizeCopyResult } from './summarize_copy_result';
 import type { SavedObjectTarget } from '../types';
+import { summarizeCopyResult } from './summarize_copy_result';
 
 // Sample data references:
 //

--- a/x-pack/plugins/spaces/public/create_feature_catalogue_entry.ts
+++ b/x-pack/plugins/spaces/public/create_feature_catalogue_entry.ts
@@ -6,7 +6,6 @@
  */
 
 import { i18n } from '@kbn/i18n';
-
 import type { FeatureCatalogueEntry } from 'src/plugins/home/public';
 
 import { FeatureCatalogueCategory } from '../../../../src/plugins/home/public';

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/share_saved_objects_to_space_action.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/share_saved_objects_to_space_action.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import type { SavedObjectsManagementRecord } from 'src/plugins/saved_objects_management/public';
-import type { SpacesApiUi, ShareToSpaceFlyoutProps } from 'src/plugins/spaces_oss/public';
+import type { ShareToSpaceFlyoutProps, SpacesApiUi } from 'src/plugins/spaces_oss/public';
 
 import { SavedObjectsManagementAction } from '../../../../../src/plugins/saved_objects_management/public';
 

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/share_saved_objects_to_space_column.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/share_saved_objects_to_space_column.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import type { SavedObjectsManagementColumn } from 'src/plugins/saved_objects_management/public';
-import type { SpacesApiUi, SpaceListProps } from 'src/plugins/spaces_oss/public';
+import type { SpaceListProps, SpacesApiUi } from 'src/plugins/spaces_oss/public';
 
 interface WrapperProps {
   spacesApiUi: SpacesApiUi;

--- a/x-pack/plugins/spaces/public/spaces_context/wrapper_internal.tsx
+++ b/x-pack/plugins/spaces/public/spaces_context/wrapper_internal.tsx
@@ -14,7 +14,7 @@ import type { SpacesContextProps } from 'src/plugins/spaces_oss/public';
 import type { SpacesManager } from '../spaces_manager';
 import type { ShareToSpacesData, ShareToSpaceTarget } from '../types';
 import { createSpacesReactContext } from './context';
-import type { SpacesReactContext, InternalProps } from './types';
+import type { InternalProps, SpacesReactContext } from './types';
 
 interface Services {
   application: ApplicationStart;


### PR DESCRIPTION
Follow-on to #91976 and #93056.

In that PR, I used a VS Code plugin to sort import declarations and multiple import members into the correct order, but this will result in drift over time.

In this PR, we use [`eslint-plugin-import`](https://github.com/benmosher/eslint-plugin-import) rules to ensure that import declarations are sorted, and the built-in [`sort-imports`](https://eslint.org/docs/rules/sort-imports) rule to ensure that multiple import members (destructured imports) are sorted.