### PR TITLE
[App Search] Hide Value and Functional boosts for geolocation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boosts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boosts.test.tsx
@@ -64,6 +64,20 @@ describe('Boosts', () => {
     expect(select.prop('options').map((o: any) => o.value)).toEqual(['add-boost', 'value']);
   });
 
+  it('will not render functional or value options if "type" prop is "geolocation"', () => {
+    const wrapper = shallow(
+      <Boosts
+        {...{
+          ...props,
+          type: 'geolocation' as SchemaTypes,
+        }}
+      />
+    );
+
+    const select = wrapper.find(EuiSuperSelect);
+    expect(select.prop('options').map((o: any) => o.value)).toEqual(['add-boost', 'proximity']);
+  });
+
   it('will add a boost of the selected type when a selection is made', () => {
     const wrapper = shallow(<Boosts {...props} />);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boosts.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boosts.tsx
@@ -13,7 +13,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle, EuiSuperSelect } from '@
 
 import { i18n } from '@kbn/i18n';
 
-import { TEXT } from '../../../../shared/constants/field_types';
+import { GEOLOCATION, TEXT } from '../../../../shared/constants/field_types';
 import { SchemaTypes } from '../../../../shared/types';
 
 import { BoostIcon } from '../boost_icon';
@@ -68,6 +68,8 @@ const BASE_OPTIONS = [
 const filterInvalidOptions = (value: BoostType, type: SchemaTypes) => {
   // Proximity and Functional boost types are not valid for text fields
   if (type === TEXT && [BoostType.Proximity, BoostType.Functional].includes(value)) return false;
+  // Value and Functional boost types are not valid for geolocation fields
+  if (type === GEOLOCATION && [BoostType.Functional, BoostType.Value].includes(value)) return false;
   return true;
 };
 


### PR DESCRIPTION
## Summary

Neither of these boost types are valid for a geolocation field.

Attempting to add either of these will result in an error.

<img width="1791" alt="fix error" src="https://user-images.githubusercontent.com/1427475/110022470-f7248a00-7cf9-11eb-841f-b5a461cb1408.png">

Updated UI:

<img width="982" alt="updated_ui" src="https://user-images.githubusercontent.com/1427475/110022702-4074d980-7cfa-11eb-8ad3-3fb206f6638b.png">


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
