### PR TITLE
[Security Solution] Return results from find and read rules even if they don't validate

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
@@ -13,11 +13,11 @@ import {
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
 import { findRules } from '../../rules/find_rules';
-import { transformValidateFindAlerts } from './validate';
 import { transformError, buildSiemResponse } from '../utils';
 import { getRuleActionsSavedObject } from '../../rule_actions/get_rule_actions_saved_object';
 import { ruleStatusSavedObjectsClientFactory } from '../../signals/rule_status_saved_objects_client';
 import { buildRouteValidation } from '../../../../utils/build_validation/route_validation';
+import { transformFindAlerts } from './utils';
 
 export const findRulesRoute = (router: SecuritySolutionPluginRouter) => {
   router.get(
@@ -96,12 +96,11 @@ export const findRulesRoute = (router: SecuritySolutionPluginRouter) => {
             return results;
           })
         );
-
-        const [validated, errors] = transformValidateFindAlerts(rules, ruleActions, ruleStatuses);
-        if (errors != null) {
-          return siemResponse.error({ statusCode: 500, body: errors });
+        const transformed = transformFindAlerts(rules, ruleActions, ruleStatuses);
+        if (transformed == null) {
+          return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
         } else {
-          return response.ok({ body: validated ?? {} });
+          return response.ok({ body: transformed ?? {} });
         }
       } catch (err) {
         const error = transformError(err);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/read_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/read_rules_route.ts
@@ -13,8 +13,7 @@ import {
 import { buildRouteValidation } from '../../../../utils/build_validation/route_validation';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
-import { getIdError } from './utils';
-import { transformValidate } from './validate';
+import { getIdError, transform } from './utils';
 import { transformError, buildSiemResponse } from '../utils';
 import { readRules } from '../../rules/read_rules';
 import { getRuleActionsSavedObject } from '../../rule_actions/get_rule_actions_saved_object';
@@ -75,11 +74,11 @@ export const readRulesRoute = (router: SecuritySolutionPluginRouter) => {
             currentStatus.attributes.statusDate = rule.executionStatus.lastExecutionDate.toISOString();
             currentStatus.attributes.status = 'failed';
           }
-          const [validated, errors] = transformValidate(rule, ruleActions, currentStatus);
-          if (errors != null) {
-            return siemResponse.error({ statusCode: 500, body: errors });
+          const transformed = transform(rule, ruleActions, currentStatus);
+          if (transformed == null) {
+            return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
           } else {
-            return response.ok({ body: validated ?? {} });
+            return response.ok({ body: transformed ?? {} });
           }
         } else {
           const error = getIdError({ id, ruleId });


### PR DESCRIPTION
## Summary
Partially addresses https://github.com/elastic/kibana/issues/93325
Due to some schema mismatches, it's possible for invalid rules that have extra fields to slip in to the detection engine. The `find` and `read` routes used relatively strict validation on the rules just before returning them to the API caller, and if the validation failed the route would return a 500 instead - preventing the API caller from even viewing rules that the schema says are invalid. This also breaks the rules page if even one rule on the page is invalid.

This PR removes the validation at that final step entirely, since if the rule exists in the data store we really want to be able to access it through the API even if it is invalid.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
