### PR TITLE
[Timelion] Build optimization - move parser_async to chunk

### DIFF
--- a/src/plugins/vis_type_timelion/common/parser_async.ts
+++ b/src/plugins/vis_type_timelion/common/parser_async.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ParsedExpression } from './parser';
+
+/** Build optimization we want to exclude parser from main bundle **/
+export const parseTimelionExpressionAsync = async (input: string): Promise<ParsedExpression> => {
+  const { parseTimelionExpression } = await import('../common/parser');
+  return parseTimelionExpression(input);
+};

--- a/src/plugins/vis_type_timelion/common/parser_async.ts
+++ b/src/plugins/vis_type_timelion/common/parser_async.ts
@@ -8,7 +8,7 @@
 
 import { ParsedExpression } from './parser';
 
-/** Build optimization we want to exclude parser from main bundle **/
+/** Build optimizations, we want to exclude the parser from the main bundle **/
 export const parseTimelionExpressionAsync = async (input: string): Promise<ParsedExpression> => {
   const { parseTimelionExpression } = await import('../common/parser');
   return parseTimelionExpression(input);

--- a/src/plugins/vis_type_timelion/public/components/timelion_expression_input_helpers.ts
+++ b/src/plugins/vis_type_timelion/public/components/timelion_expression_input_helpers.ts
@@ -9,8 +9,8 @@
 import { startsWith } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { monaco } from '@kbn/monaco';
-import {
-  parseTimelionExpression,
+import { parseTimelionExpressionAsync } from '../../common/parser_async';
+import type {
   ParsedExpression,
   TimelionExpressionArgument,
   ExpressionLocation,
@@ -128,7 +128,7 @@ export async function suggest(
   argValueSuggestions: ArgValueSuggestions
 ) {
   try {
-    const result = parseTimelionExpression(expression);
+    const result = await parseTimelionExpressionAsync(expression);
 
     return await extractSuggestionsFromParsedResult(
       result,

--- a/src/plugins/vis_type_timelion/public/timelion_vis_type.tsx
+++ b/src/plugins/vis_type_timelion/public/timelion_vis_type.tsx
@@ -15,7 +15,7 @@ import { TimelionVisDependencies } from './plugin';
 import { toExpressionAst } from './to_ast';
 import { getIndexPatterns } from './helpers/plugin_services';
 
-import { parseTimelionExpression } from '../common/parser';
+import { parseTimelionExpressionAsync } from '../common/parser_async';
 
 import { VIS_EVENT_TO_TRIGGER, VisParams } from '../../visualizations/public';
 
@@ -50,9 +50,9 @@ export function getTimelionVisDefinition(dependencies: TimelionVisDependencies) 
     getSupportedTriggers: () => {
       return [VIS_EVENT_TO_TRIGGER.applyFilter];
     },
-    getUsedIndexPattern: (params: VisParams) => {
+    getUsedIndexPattern: async (params: VisParams) => {
       try {
-        const args = parseTimelionExpression(params.expression)?.args ?? [];
+        const args = (await parseTimelionExpressionAsync(params.expression))?.args ?? [];
         const indexArg = args.find(
           ({ type, name, function: fn }) => type === 'namedArg' && fn === 'es' && name === 'index'
         );


### PR DESCRIPTION
## Summary

[Timelion] Build optimization - move parser_async to chunk


#### Async chunks
> Total size of all lazy-loaded chunks that will be downloaded as the user navigates the app

| id | [before](https://github.com/elastic/kibana/commit/d0b6891abf13a9cd806f923ccc9c0db1f7f040cb) | [after](https://github.com/elastic/kibana/commit/5f14726bbb99491dc86671ff159fc8eb59b48d9f) | diff |
| --- | --- | --- | --- |
| `visTypeTimelion` | 49.9KB | 76.8KB | +26.9KB |

#### Page load bundle
> Size of the bundles that are downloaded on every page load. Target size is below 100kb

| id | [before](https://github.com/elastic/kibana/commit/d0b6891abf13a9cd806f923ccc9c0db1f7f040cb) | [after](https://github.com/elastic/kibana/commit/5f14726bbb99491dc86671ff159fc8eb59b48d9f) | diff |
| --- | --- | --- | --- |
| `visTypeTimelion` | 52.6KB | 26.3KB | -26.3KB |
