### PR TITLE
Clarify that saved objects are not moved from existing spaces on upgrade

### DIFF
--- a/docs/spaces/index.asciidoc
+++ b/docs/spaces/index.asciidoc
@@ -134,4 +134,4 @@ by setting `xpack.spaces.enabled` to `false` in your
 `kibana.yml` configuration file.
 
 If you are upgrading your
-version of {kib}, the default space will contain all of your existing saved objects.
+version of {kib} from a Kibana without space feature enabled or available (6.4 or lower), the default space will contain all of your existing saved objects.


### PR DESCRIPTION
## Summary

Current doc was added from [6.5](https://www.elastic.co/guide/en/kibana/6.5/spaces-getting-started.html) in the context of upgrade from 6.4 or lower where kibana space did not exist... The doc implies upgrade from 7.10 to 7.11 for example would moved all saved objects to Default space which is obviously not the case

Note if I start kibana 7.11.1 with xpack.spaces.enabled: false then enable it, saved objects will show/move to Default Space so this sentence should not be limited to upgrade from 6.4 or lower.
As a side note If I then disable space, saved objects outside of Default are not accessible till re-enabling space.
