### PR TITLE
Get service name using `useRouteMatch`

### DIFF
--- a/x-pack/plugins/apm/public/application/action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/application/action_menu/index.tsx
@@ -8,7 +8,7 @@
 import { EuiHeaderLink, EuiHeaderLinks } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useServiceName } from '../../hooks/use_service_name';
 import { getAlertingCapabilities } from '../../components/alerting/get_alert_capabilities';
 import { getAPMHref } from '../../components/shared/Links/apm/APMLink';
 import { useApmPluginContext } from '../../context/apm_plugin/use_apm_plugin_context';
@@ -17,7 +17,7 @@ import { AnomalyDetectionSetupLink } from './anomaly_detection_setup_link';
 
 export function ActionMenu() {
   const { core, plugins } = useApmPluginContext();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { search } = window.location;
   const { application, http } = core;
   const { basePath } = http;

--- a/x-pack/plugins/apm/public/components/alerting/alerting_flyout/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/alerting_flyout/index.tsx
@@ -6,11 +6,12 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import { useKibana } from '../../../../../../../src/plugins/kibana_react/public';
 import { AlertType } from '../../../../common/alert_types';
 import { getInitialAlertValues } from '../get_initial_alert_values';
 import { TriggersAndActionsUIPublicPluginStart } from '../../../../../triggers_actions_ui/public';
+import { useServiceName } from '../../../hooks/use_service_name';
+
 interface Props {
   addFlyoutVisible: boolean;
   setAddFlyoutVisibility: React.Dispatch<React.SetStateAction<boolean>>;
@@ -23,7 +24,7 @@ interface KibanaDeps {
 
 export function AlertingFlyout(props: Props) {
   const { addFlyoutVisible, setAddFlyoutVisibility, alertType } = props;
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const {
     services: { triggersActionsUi },
   } = useKibana<KibanaDeps>();

--- a/x-pack/plugins/apm/public/components/alerting/error_count_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/error_count_alert_trigger/index.tsx
@@ -7,13 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { ForLastExpression } from '../../../../../triggers_actions_ui/public';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import { asInteger } from '../../../../common/utils/formatters';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useServiceName } from '../../../hooks/use_service_name';
 import { ChartPreview } from '../chart_preview';
 import { EnvironmentField, IsAboveField, ServiceField } from '../fields';
 import { getAbsoluteTimeRange } from '../helper';
@@ -35,7 +35,7 @@ interface Props {
 
 export function ErrorCountAlertTrigger(props: Props) {
   const { setAlertParams, setAlertProperty, alertParams } = props;
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
   const { start, end } = urlParams;
   const { environmentOptions } = useEnvironmentsFetcher({

--- a/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/service_alert_trigger/index.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFlexGrid, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 interface Props {
   setAlertParams: (key: string, value: any) => void;
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export function ServiceAlertTrigger(props: Props) {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
 
   const { fields, setAlertParams, defaults, chartPreview } = props;
 

--- a/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_duration_alert_trigger/index.tsx
@@ -9,7 +9,6 @@ import { EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { map } from 'lodash';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { ForLastExpression } from '../../../../../triggers_actions_ui/public';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import { getDurationFormatter } from '../../../../common/utils/formatters';
@@ -18,6 +17,7 @@ import { useApmServiceContext } from '../../../context/apm_service/use_apm_servi
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useServiceName } from '../../../hooks/use_service_name';
 import {
   getMaxY,
   getResponseTimeTickFormatter,
@@ -74,7 +74,7 @@ export function TransactionDurationAlertTrigger(props: Props) {
   const { setAlertParams, alertParams, setAlertProperty } = props;
   const { urlParams } = useUrlParams();
   const { transactionTypes, transactionType } = useApmServiceContext();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { start, end } = urlParams;
   const { environmentOptions } = useEnvironmentsFetcher({
     serviceName,

--- a/x-pack/plugins/apm/public/components/alerting/transaction_duration_anomaly_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_duration_anomaly_alert_trigger/index.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { useParams } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ANOMALY_SEVERITY } from '../../../../../ml/common';
@@ -24,6 +23,7 @@ import {
   TransactionTypeField,
 } from '../fields';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 interface Params {
   windowSize: number;
@@ -48,7 +48,7 @@ export function TransactionDurationAnomalyAlertTrigger(props: Props) {
   const { setAlertParams, alertParams, setAlertProperty } = props;
   const { urlParams } = useUrlParams();
   const { transactionTypes } = useApmServiceContext();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { start, end, transactionType } = urlParams;
   const { environmentOptions } = useEnvironmentsFetcher({
     serviceName,

--- a/x-pack/plugins/apm/public/components/alerting/transaction_error_rate_alert_trigger/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/transaction_error_rate_alert_trigger/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { ForLastExpression } from '../../../../../triggers_actions_ui/public';
 import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
 import { asPercent } from '../../../../common/utils/formatters';
@@ -14,6 +13,7 @@ import { useApmServiceContext } from '../../../context/apm_service/use_apm_servi
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher';
 import { useFetcher } from '../../../hooks/use_fetcher';
+import { useServiceName } from '../../../hooks/use_service_name';
 import { ChartPreview } from '../chart_preview';
 import {
   EnvironmentField,
@@ -43,7 +43,7 @@ export function TransactionErrorRateAlertTrigger(props: Props) {
   const { setAlertParams, alertParams, setAlertProperty } = props;
   const { urlParams } = useUrlParams();
   const { transactionTypes } = useApmServiceContext();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { start, end, transactionType } = urlParams;
   const { environmentOptions } = useEnvironmentsFetcher({
     serviceName,

--- a/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
@@ -16,7 +16,6 @@ import {
   Settings,
 } from '@elastic/charts';
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { EuiTitle, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
@@ -48,7 +47,7 @@ export function ErrorCorrelations({ onClose }: Props) {
     setSelectedSignificantTerm,
   ] = useState<SelectedSignificantTerm | null>(null);
 
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
   const {
     environment,

--- a/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/error_correlations.tsx
@@ -32,6 +32,7 @@ import { CustomFields } from './custom_fields';
 import { useFieldNames } from './use_field_names';
 import { useLocalStorage } from '../../../hooks/useLocalStorage';
 import { useUiTracker } from '../../../../../observability/public';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 type CorrelationsApiResponse = NonNullable<
   APIReturnType<'GET /api/apm/correlations/failed_transactions'>

--- a/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/latency_correlations.tsx
@@ -14,7 +14,6 @@ import {
   Settings,
 } from '@elastic/charts';
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { EuiTitle, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { getDurationFormatter } from '../../../../common/utils/formatters';
@@ -31,6 +30,7 @@ import { CustomFields, PercentileOption } from './custom_fields';
 import { useFieldNames } from './use_field_names';
 import { useLocalStorage } from '../../../hooks/useLocalStorage';
 import { useUiTracker } from '../../../../../observability/public';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 type CorrelationsApiResponse = NonNullable<
   APIReturnType<'GET /api/apm/correlations/slow_transactions'>
@@ -46,7 +46,7 @@ export function LatencyCorrelations({ onClose }: Props) {
     setSelectedSignificantTerm,
   ] = useState<SelectedSignificantTerm | null>(null);
 
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
   const {
     environment,

--- a/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/service_overview_throughput_chart.tsx
@@ -8,13 +8,13 @@
 import { EuiPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { asTransactionRate } from '../../../../common/utils/formatters';
 import { useFetcher } from '../../../hooks/use_fetcher';
 import { useTheme } from '../../../hooks/use_theme';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { TimeseriesChart } from '../../shared/charts/timeseries_chart';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 const INITIAL_STATE = {
   currentPeriod: [],
@@ -27,7 +27,7 @@ export function ServiceOverviewThroughputChart({
   height?: number;
 }) {
   const theme = useTheme();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const {
     urlParams: { environment, kuery, start, end },
   } = useUrlParams();

--- a/x-pack/plugins/apm/public/components/app/transaction_overview/use_transaction_list.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_overview/use_transaction_list.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { useParams } from 'react-router-dom';
 import { APIReturnType } from '../../../services/rest/createCallApmApi';
 import { useFetcher } from '../../../hooks/use_fetcher';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 type TransactionsAPIResponse = APIReturnType<'GET /api/apm/services/{serviceName}/transactions/groups'>;
 
@@ -22,7 +22,7 @@ export function useTransactionListFetcher() {
   const {
     urlParams: { environment, kuery, transactionType, start, end },
   } = useUrlParams();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { data = DEFAULT_RESPONSE, error, status } = useFetcher(
     (callApmApi) => {
       if (serviceName && start && end && transactionType) {

--- a/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/EnvironmentFilter/index.tsx
@@ -9,7 +9,7 @@ import { EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { History } from 'history';
 import React from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import {
   ENVIRONMENT_ALL,
   ENVIRONMENT_NOT_DEFINED,
@@ -17,6 +17,7 @@ import {
 import { useEnvironmentsFetcher } from '../../../hooks/use_environments_fetcher';
 import { useUrlParams } from '../../../context/url_params_context/use_url_params';
 import { fromQuery, toQuery } from '../Links/url_helpers';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 function updateEnvironmentUrl(
   history: History,
@@ -63,7 +64,7 @@ function getOptions(environments: string[]) {
 export function EnvironmentFilter() {
   const history = useHistory();
   const location = useLocation();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
 
   const { environment, start, end } = urlParams;

--- a/x-pack/plugins/apm/public/components/shared/KueryBar/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/KueryBar/index.tsx
@@ -23,6 +23,7 @@ import { getBoolFilter } from './get_bool_filter';
 // @ts-expect-error
 import { Typeahead } from './Typeahead';
 import { useProcessorEvent } from './use_processor_event';
+import { useServiceName } from '../../../hooks/use_service_name';
 
 const Container = euiStyled.div`
   margin-bottom: 10px;
@@ -39,10 +40,8 @@ function convertKueryToEsQuery(kuery: string, indexPattern: IIndexPattern) {
 }
 
 export function KueryBar(props: { prepend?: React.ReactNode | string }) {
-  const { groupId, serviceName } = useParams<{
-    groupId?: string;
-    serviceName?: string;
-  }>();
+  const { groupId } = useParams<{ groupId?: string }>();
+  const serviceName = useServiceName();
   const history = useHistory();
   const [state, setState] = useState<State>({
     suggestions: [],

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/use_transaction_breakdown.ts
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_breakdown_chart/use_transaction_breakdown.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { useParams } from 'react-router-dom';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useServiceName } from '../../../../hooks/use_service_name';
 
 export function useTransactionBreakdown() {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const {
     urlParams: { environment, kuery, start, end, transactionName },
   } = useUrlParams();

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_charts/ml_header.tsx
@@ -9,10 +9,10 @@ import { EuiFlexItem, EuiIconTip, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { euiStyled } from '../../../../../../../../src/plugins/kibana_react/common';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
+import { useServiceName } from '../../../../hooks/use_service_name';
 import { MLSingleMetricLink } from '../../Links/MachineLearningLinks/MLSingleMetricLink';
 
 interface Props {
@@ -33,7 +33,7 @@ const ShiftedEuiText = euiStyled(EuiText)`
 `;
 
 export function MLHeader({ hasValidMlLicense, mlJobId }: Props) {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
   const { transactionType } = useApmServiceContext();
 

--- a/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/charts/transaction_error_rate_chart/index.tsx
@@ -8,13 +8,13 @@
 import { EuiPanel, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { asPercent } from '../../../../../common/utils/formatters';
 import { useFetcher } from '../../../../hooks/use_fetcher';
 import { useTheme } from '../../../../hooks/use_theme';
 import { useUrlParams } from '../../../../context/url_params_context/use_url_params';
 import { TimeseriesChart } from '../timeseries_chart';
 import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useServiceName } from '../../../../hooks/use_service_name';
 
 function yLabelFormat(y?: number | null) {
   return asPercent(y || 0, 1);
@@ -30,7 +30,7 @@ export function TransactionErrorRateChart({
   showAnnotations = true,
 }: Props) {
   const theme = useTheme();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const {
     urlParams: { environment, kuery, start, end, transactionName },
   } = useUrlParams();

--- a/x-pack/plugins/apm/public/context/annotations/annotations_context.tsx
+++ b/x-pack/plugins/apm/public/context/annotations/annotations_context.tsx
@@ -6,9 +6,9 @@
  */
 
 import React, { createContext } from 'react';
-import { useParams } from 'react-router-dom';
 import { Annotation } from '../../../common/annotations';
 import { useFetcher } from '../../hooks/use_fetcher';
+import { useServiceName } from '../../hooks/use_service_name';
 import { useUrlParams } from '../url_params_context/use_url_params';
 
 export const AnnotationsContext = createContext({ annotations: [] } as {
@@ -22,7 +22,7 @@ export function AnnotationsContextProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const {
     urlParams: { environment, start, end },
   } = useUrlParams();

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_agent_name_fetcher.ts
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_agent_name_fetcher.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { useParams } from 'react-router-dom';
 import { useFetcher } from '../../hooks/use_fetcher';
+import { useServiceName } from '../../hooks/use_service_name';
 import { useUrlParams } from '../url_params_context/use_url_params';
 
 export function useServiceAgentNameFetcher() {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
   const { start, end } = urlParams;
   const { data, error, status } = useFetcher(

--- a/x-pack/plugins/apm/public/context/apm_service/use_service_transaction_types_fetcher.tsx
+++ b/x-pack/plugins/apm/public/context/apm_service/use_service_transaction_types_fetcher.tsx
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { useParams } from 'react-router-dom';
 import { useFetcher } from '../../hooks/use_fetcher';
+import { useServiceName } from '../../hooks/use_service_name';
 import { useUrlParams } from '../url_params_context/use_url_params';
 
 const INITIAL_DATA = { transactionTypes: [] };
 
 export function useServiceTransactionTypesFetcher() {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { urlParams } = useUrlParams();
   const { start, end } = urlParams;
   const { data = INITIAL_DATA } = useFetcher(

--- a/x-pack/plugins/apm/public/hooks/use_service_metric_charts_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_service_metric_charts_fetcher.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { useParams } from 'react-router-dom';
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { MetricsChartsByAgentAPIResponse } from '../../server/lib/metrics/get_metrics_chart_data_by_agent';
 import { useUrlParams } from '../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../context/apm_service/use_apm_service_context';
 import { useFetcher } from './use_fetcher';
+import { useServiceName } from './use_service_name';
 
 const INITIAL_DATA: MetricsChartsByAgentAPIResponse = {
   charts: [],
@@ -25,7 +25,7 @@ export function useServiceMetricChartsFetcher({
     urlParams: { environment, kuery, start, end },
   } = useUrlParams();
   const { agentName } = useApmServiceContext();
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
 
   const { data = INITIAL_DATA, error, status } = useFetcher(
     (callApmApi) => {

--- a/x-pack/plugins/apm/public/hooks/use_service_name.ts
+++ b/x-pack/plugins/apm/public/hooks/use_service_name.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useRouteMatch } from 'react-router-dom';
+
+/**
+ * Get the service name from the current URL path.
+ *
+ * Uses [`useRouteMatch`](https://reactrouter.com/web/api/Hooks/useroutematch)
+ * so it can work outside of a context where the component has the defined route
+ * as a parent, such as the header menu bar.
+ */
+export function useServiceName() {
+  const match = useRouteMatch<{ serviceName?: string }>(
+    '/services/:serviceName'
+  );
+  return match?.params?.serviceName;
+}

--- a/x-pack/plugins/apm/public/hooks/use_transaction_distribution_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_distribution_fetcher.ts
@@ -6,12 +6,13 @@
  */
 
 import { flatten, omit, isEmpty } from 'lodash';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { useFetcher } from './use_fetcher';
 import { toQuery, fromQuery } from '../components/shared/Links/url_helpers';
 import { maybe } from '../../common/utils/maybe';
 import { APIReturnType } from '../services/rest/createCallApmApi';
 import { useUrlParams } from '../context/url_params_context/use_url_params';
+import { useServiceName } from './use_service_name';
 
 type APIResponse = APIReturnType<'GET /api/apm/services/{serviceName}/transactions/charts/distribution'>;
 
@@ -22,7 +23,7 @@ const INITIAL_DATA = {
 };
 
 export function useTransactionDistributionFetcher() {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const {
     urlParams: {
       environment,

--- a/x-pack/plugins/apm/public/hooks/use_transaction_latency_chart_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_latency_chart_fetcher.ts
@@ -6,15 +6,15 @@
  */
 
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import { useFetcher } from './use_fetcher';
 import { useUrlParams } from '../context/url_params_context/use_url_params';
 import { useApmServiceContext } from '../context/apm_service/use_apm_service_context';
 import { getLatencyChartSelector } from '../selectors/latency_chart_selectors';
 import { useTheme } from './use_theme';
+import { useServiceName } from './use_service_name';
 
 export function useTransactionLatencyChartsFetcher() {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { transactionType } = useApmServiceContext();
   const theme = useTheme();
   const {

--- a/x-pack/plugins/apm/public/hooks/use_transaction_throughput_chart_fetcher.ts
+++ b/x-pack/plugins/apm/public/hooks/use_transaction_throughput_chart_fetcher.ts
@@ -6,15 +6,15 @@
  */
 
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import { useFetcher } from './use_fetcher';
 import { useUrlParams } from '../context/url_params_context/use_url_params';
 import { getThroughputChartSelector } from '../selectors/throughput_chart_selectors';
 import { useTheme } from './use_theme';
 import { useApmServiceContext } from '../context/apm_service/use_apm_service_context';
+import { useServiceName } from './use_service_name';
 
 export function useTransactionThroughputChartsFetcher() {
-  const { serviceName } = useParams<{ serviceName?: string }>();
+  const serviceName = useServiceName();
   const { transactionType } = useApmServiceContext();
   const theme = useTheme();
   const {


### PR DESCRIPTION
In #92012 the HeaderMenuPortal component was moved up in the tree to prevent unnecessary re-fetching of the ML jobs.

This made it so the service name would not be populated when creating an alert while viewing pages for a service. This is because we get the service name from `useParams`, which only works if you are the child of a `Route` component.

In the header menu, this is not the case, so `useParams` would return undefined.

[`useRouteMatch`](https://reactrouter.com/web/api/Hooks/useroutematch) lets you get a match from the URL without needing to be a child of a `Route` in the tree, so use that instead of `useParams` to get the serviceName.

Put that functionality in a `useServiceName` hook and use it everywhere we were previously using `useParams`.

Fixes #93518.
