### PR TITLE
[Metrics UI] Disable anomaly alerting

### DIFF
--- a/x-pack/plugins/infra/public/alerting/common/components/metrics_alert_dropdown.tsx
+++ b/x-pack/plugins/infra/public/alerting/common/components/metrics_alert_dropdown.tsx
@@ -14,18 +14,15 @@ import {
   EuiContextMenuPanelDescriptor,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
-import { useInfraMLCapabilities } from '../../../containers/ml/infra_ml_capabilities';
 import { PrefilledInventoryAlertFlyout } from '../../inventory/components/alert_flyout';
 import { PrefilledThresholdAlertFlyout } from '../../metric_threshold/components/alert_flyout';
-import { PrefilledAnomalyAlertFlyout } from '../../metric_anomaly/components/alert_flyout';
 import { useLinkProps } from '../../../hooks/use_link_props';
 
-type VisibleFlyoutType = 'inventory' | 'threshold' | 'anomaly' | null;
+type VisibleFlyoutType = 'inventory' | 'threshold' | null;
 
 export const MetricsAlertDropdown = () => {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [visibleFlyoutType, setVisibleFlyoutType] = useState<VisibleFlyoutType>(null);
-  const { hasInfraMLCapabilities } = useInfraMLCapabilities();
 
   const closeFlyout = useCallback(() => setVisibleFlyoutType(null), [setVisibleFlyoutType]);
 
@@ -75,16 +72,7 @@ export const MetricsAlertDropdown = () => {
             }),
             onClick: () => setVisibleFlyoutType('inventory'),
           },
-        ].concat(
-          hasInfraMLCapabilities
-            ? {
-                name: i18n.translate('xpack.infra.alerting.createAnomalyAlertButton', {
-                  defaultMessage: 'Create anomaly alert',
-                }),
-                onClick: () => setVisibleFlyoutType('anomaly'),
-              }
-            : []
-        ),
+        ],
       },
       {
         id: 2,
@@ -101,7 +89,7 @@ export const MetricsAlertDropdown = () => {
         ],
       },
     ],
-    [manageAlertsLinkProps, setVisibleFlyoutType, hasInfraMLCapabilities]
+    [manageAlertsLinkProps, setVisibleFlyoutType]
   );
 
   const closePopover = useCallback(() => {
@@ -143,8 +131,6 @@ const AlertFlyout = ({ visibleFlyoutType, onClose }: AlertFlyoutProps) => {
       return <PrefilledInventoryAlertFlyout onClose={onClose} />;
     case 'threshold':
       return <PrefilledThresholdAlertFlyout onClose={onClose} />;
-    case 'anomaly':
-      return <PrefilledAnomalyAlertFlyout onClose={onClose} />;
     default:
       return null;
   }

--- a/x-pack/plugins/infra/public/plugin.ts
+++ b/x-pack/plugins/infra/public/plugin.ts
@@ -10,7 +10,6 @@ import { AppMountParameters, PluginInitializerContext } from 'kibana/public';
 import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
 import { createMetricThresholdAlertType } from './alerting/metric_threshold';
 import { createInventoryMetricAlertType } from './alerting/inventory';
-import { createMetricAnomalyAlertType } from './alerting/metric_anomaly';
 import { getAlertType as getLogsAlertType } from './alerting/log_threshold';
 import { registerFeatures } from './register_feature';
 import {
@@ -36,7 +35,6 @@ export class Plugin implements InfraClientPluginClass {
     pluginsSetup.triggersActionsUi.alertTypeRegistry.register(createInventoryMetricAlertType());
     pluginsSetup.triggersActionsUi.alertTypeRegistry.register(getLogsAlertType());
     pluginsSetup.triggersActionsUi.alertTypeRegistry.register(createMetricThresholdAlertType());
-    pluginsSetup.triggersActionsUi.alertTypeRegistry.register(createMetricAnomalyAlertType());
 
     if (pluginsSetup.observability) {
       pluginsSetup.observability.dashboard.register({


### PR DESCRIPTION
## Summary

This PR closes #93645 by removing the links to create the anomaly alerts in the Metrics UI. This also removes the registration code for registering the anomaly alerts in Kibana. We've decided to keep the remaining anomaly code in place since we plan on re-implementing this very soon.

Stack Management Alerts and Actions

![image](https://user-images.githubusercontent.com/41702/110157176-22b07e80-7da5-11eb-8863-fc623c514791.png)

Metrics UI

![image](https://user-images.githubusercontent.com/41702/110157200-28a65f80-7da5-11eb-86b8-6ee7c2e919b3.png)
