### PR TITLE
[7.12] Return results from find and read rules even if they don't validate (#93713)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/find_rules_route.ts
@@ -13,11 +13,11 @@ import {
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
 import { findRules } from '../../rules/find_rules';
-import { transformValidateFindAlerts } from './validate';
 import { transformError, buildSiemResponse } from '../utils';
 import { getRuleActionsSavedObject } from '../../rule_actions/get_rule_actions_saved_object';
 import { ruleStatusSavedObjectsClientFactory } from '../../signals/rule_status_saved_objects_client';
 import { buildRouteValidation } from '../../../../utils/build_validation/route_validation';
+import { transformFindAlerts } from './utils';
 
 export const findRulesRoute = (router: SecuritySolutionPluginRouter) => {
   router.get(
@@ -96,12 +96,11 @@ export const findRulesRoute = (router: SecuritySolutionPluginRouter) => {
             return results;
           })
         );
-
-        const [validated, errors] = transformValidateFindAlerts(rules, ruleActions, ruleStatuses);
-        if (errors != null) {
-          return siemResponse.error({ statusCode: 500, body: errors });
+        const transformed = transformFindAlerts(rules, ruleActions, ruleStatuses);
+        if (transformed == null) {
+          return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
         } else {
-          return response.ok({ body: validated ?? {} });
+          return response.ok({ body: transformed ?? {} });
         }
       } catch (err) {
         const error = transformError(err);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/read_rules_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/rules/read_rules_route.ts
@@ -13,8 +13,7 @@ import {
 import { buildRouteValidation } from '../../../../utils/build_validation/route_validation';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { DETECTION_ENGINE_RULES_URL } from '../../../../../common/constants';
-import { getIdError } from './utils';
-import { transformValidate } from './validate';
+import { getIdError, transform } from './utils';
 import { transformError, buildSiemResponse } from '../utils';
 import { readRules } from '../../rules/read_rules';
 import { getRuleActionsSavedObject } from '../../rule_actions/get_rule_actions_saved_object';
@@ -75,11 +74,11 @@ export const readRulesRoute = (router: SecuritySolutionPluginRouter) => {
             currentStatus.attributes.statusDate = rule.executionStatus.lastExecutionDate.toISOString();
             currentStatus.attributes.status = 'failed';
           }
-          const [validated, errors] = transformValidate(rule, ruleActions, currentStatus);
-          if (errors != null) {
-            return siemResponse.error({ statusCode: 500, body: errors });
+          const transformed = transform(rule, ruleActions, currentStatus);
+          if (transformed == null) {
+            return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
           } else {
-            return response.ok({ body: validated ?? {} });
+            return response.ok({ body: transformed ?? {} });
           }
         } else {
           const error = getIdError({ id, ruleId });


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Return results from find and read rules even if they don't validate (#93713)