### PR TITLE
[APM] Correlations custom fields: Sets target blank on the docs link

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/custom_fields.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/custom_fields.tsx
@@ -120,6 +120,7 @@ export function CustomFields({
                   ),
                   docsLink: (
                     <ElasticDocsLink
+                      target="_blank"
                       section="/kibana"
                       path="/advanced-queries.html"
                     >


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/93902

<img width="583" alt="Screenshot 2021-03-08 at 11 50 09" src="https://user-images.githubusercontent.com/4104278/110311694-71a81f00-8004-11eb-8137-812fb2a77773.png">