### PR TITLE
[Security Solution][Exceptions] - Fixes bug for prepopulated endpoint exceptions

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.test.tsx
@@ -723,15 +723,16 @@ describe('Exception helpers', () => {
       expect(prepopulatedItem.entries).toEqual([
         {
           entries: [
-            { field: 'subject_name', operator: 'included', type: 'match', value: '' },
-            { field: 'trusted', operator: 'included', type: 'match', value: '' },
+            { id: '123', field: 'subject_name', operator: 'included', type: 'match', value: '' },
+            { id: '123', field: 'trusted', operator: 'included', type: 'match', value: '' },
           ],
           field: 'file.Ext.code_signature',
           type: 'nested',
+          id: '123',
         },
-        { field: 'file.path.caseless', operator: 'included', type: 'match', value: '' },
-        { field: 'file.hash.sha256', operator: 'included', type: 'match', value: '' },
-        { field: 'event.code', operator: 'included', type: 'match', value: '' },
+        { id: '123', field: 'file.path.caseless', operator: 'included', type: 'match', value: '' },
+        { id: '123', field: 'file.hash.sha256', operator: 'included', type: 'match', value: '' },
+        { id: '123', field: 'event.code', operator: 'included', type: 'match', value: '' },
       ]);
     });
 
@@ -748,24 +749,39 @@ describe('Exception helpers', () => {
         {
           entries: [
             {
+              id: '123',
               field: 'subject_name',
               operator: 'included',
               type: 'match',
               value: 'someSubjectName',
             },
-            { field: 'trusted', operator: 'included', type: 'match', value: 'false' },
+            { id: '123', field: 'trusted', operator: 'included', type: 'match', value: 'false' },
           ],
           field: 'file.Ext.code_signature',
           type: 'nested',
+          id: '123',
         },
         {
+          id: '123',
           field: 'file.path.caseless',
           operator: 'included',
           type: 'match',
           value: 'some-file-path',
         },
-        { field: 'file.hash.sha256', operator: 'included', type: 'match', value: 'some-hash' },
-        { field: 'event.code', operator: 'included', type: 'match', value: 'some-event-code' },
+        {
+          id: '123',
+          field: 'file.hash.sha256',
+          operator: 'included',
+          type: 'match',
+          value: 'some-hash',
+        },
+        {
+          id: '123',
+          field: 'event.code',
+          operator: 'included',
+          type: 'match',
+          value: 'some-event-code',
+        },
       ]);
     });
   });
@@ -943,47 +959,77 @@ describe('Exception helpers', () => {
         {
           entries: [
             {
+              id: '123',
               field: 'subject_name',
               operator: 'included',
               type: 'match',
               value: 'some_subject',
             },
-            { field: 'trusted', operator: 'included', type: 'match', value: 'false' },
+            { id: '123', field: 'trusted', operator: 'included', type: 'match', value: 'false' },
           ],
           field: 'file.Ext.code_signature',
           type: 'nested',
+          id: '123',
         },
         {
+          id: '123',
           field: 'file.path.caseless',
           operator: 'included',
           type: 'match',
           value: 'some file path',
         },
-        { field: 'file.hash.sha256', operator: 'included', type: 'match', value: 'some hash' },
-        { field: 'event.code', operator: 'included', type: 'match', value: 'some event code' },
+        {
+          id: '123',
+          field: 'file.hash.sha256',
+          operator: 'included',
+          type: 'match',
+          value: 'some hash',
+        },
+        {
+          id: '123',
+          field: 'event.code',
+          operator: 'included',
+          type: 'match',
+          value: 'some event code',
+        },
       ]);
       expect(defaultItems[1].entries).toEqual([
         {
           entries: [
             {
+              id: '123',
               field: 'subject_name',
               operator: 'included',
               type: 'match',
               value: 'some_subject_2',
             },
-            { field: 'trusted', operator: 'included', type: 'match', value: 'true' },
+            { id: '123', field: 'trusted', operator: 'included', type: 'match', value: 'true' },
           ],
           field: 'file.Ext.code_signature',
           type: 'nested',
+          id: '123',
         },
         {
+          id: '123',
           field: 'file.path.caseless',
           operator: 'included',
           type: 'match',
           value: 'some file path',
         },
-        { field: 'file.hash.sha256', operator: 'included', type: 'match', value: 'some hash' },
-        { field: 'event.code', operator: 'included', type: 'match', value: 'some event code' },
+        {
+          id: '123',
+          field: 'file.hash.sha256',
+          operator: 'included',
+          type: 'match',
+          value: 'some hash',
+        },
+        {
+          id: '123',
+          field: 'event.code',
+          operator: 'included',
+          type: 'match',
+          value: 'some event code',
+        },
       ]);
     });
 
@@ -1014,59 +1060,91 @@ describe('Exception helpers', () => {
         {
           entries: [
             {
+              id: '123',
               field: 'subject_name',
               operator: 'included',
               type: 'match',
               value: 'some_subject',
             },
-            { field: 'trusted', operator: 'included', type: 'match', value: 'false' },
+            { id: '123', field: 'trusted', operator: 'included', type: 'match', value: 'false' },
           ],
           field: 'process.Ext.code_signature',
           type: 'nested',
+          id: '123',
         },
         {
+          id: '123',
           field: 'process.executable',
           operator: 'included',
           type: 'match',
           value: 'some file path',
         },
-        { field: 'process.hash.sha256', operator: 'included', type: 'match', value: 'some hash' },
         {
+          id: '123',
+          field: 'process.hash.sha256',
+          operator: 'included',
+          type: 'match',
+          value: 'some hash',
+        },
+        {
+          id: '123',
           field: 'Ransomware.feature',
           operator: 'included',
           type: 'match',
           value: 'some ransomware feature',
         },
-        { field: 'event.code', operator: 'included', type: 'match', value: 'ransomware' },
+        {
+          id: '123',
+          field: 'event.code',
+          operator: 'included',
+          type: 'match',
+          value: 'ransomware',
+        },
       ]);
       expect(defaultItems[1].entries).toEqual([
         {
           entries: [
             {
+              id: '123',
               field: 'subject_name',
               operator: 'included',
               type: 'match',
               value: 'some_subject_2',
             },
-            { field: 'trusted', operator: 'included', type: 'match', value: 'true' },
+            { id: '123', field: 'trusted', operator: 'included', type: 'match', value: 'true' },
           ],
           field: 'process.Ext.code_signature',
           type: 'nested',
+          id: '123',
         },
         {
+          id: '123',
           field: 'process.executable',
           operator: 'included',
           type: 'match',
           value: 'some file path',
         },
-        { field: 'process.hash.sha256', operator: 'included', type: 'match', value: 'some hash' },
         {
+          id: '123',
+          field: 'process.hash.sha256',
+          operator: 'included',
+          type: 'match',
+          value: 'some hash',
+        },
+        {
+          id: '123',
           field: 'Ransomware.feature',
           operator: 'included',
           type: 'match',
           value: 'some ransomware feature',
         },
-        { field: 'event.code', operator: 'included', type: 'match', value: 'ransomware' },
+        {
+          id: '123',
+          field: 'event.code',
+          operator: 'included',
+          type: 'match',
+          value: 'ransomware',
+        },
       ]);
     });
   });

--- a/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/exceptions/helpers.tsx
@@ -38,6 +38,7 @@ import {
   UpdateExceptionListItemSchema,
   EntryNested,
   OsTypeArray,
+  EntriesArray,
 } from '../../../shared_imports';
 import { IIndexPattern } from '../../../../../../../src/plugins/data/common';
 import { validate } from '../../../../common/validate';
@@ -45,6 +46,19 @@ import { Ecs } from '../../../../common/ecs';
 import { CodeSignature } from '../../../../common/ecs/file';
 import { WithCopyToClipboard } from '../../lib/clipboard/with_copy_to_clipboard';
 import { addIdToItem, removeIdFromItem } from '../../../../common';
+
+export const addIdToEntries = (entries: EntriesArray): EntriesArray => {
+  return entries.map((singleEntry) => {
+    if (singleEntry.type === 'nested') {
+      return addIdToItem({
+        ...singleEntry,
+        entries: singleEntry.entries.map((nestedEntry) => addIdToItem(nestedEntry)),
+      });
+    } else {
+      return addIdToItem(singleEntry);
+    }
+  });
+};
 
 /**
  * Returns the operator type, may not need this if using io-ts types
@@ -150,14 +164,14 @@ export const getNewExceptionItem = ({
   return {
     comments: [],
     description: `${ruleName} - exception list item`,
-    entries: [
-      addIdToItem({
+    entries: addIdToEntries([
+      {
         field: '',
         operator: 'included',
         type: 'match',
         value: '',
-      }),
-    ],
+      },
+    ]),
     item_id: undefined,
     list_id: listId,
     meta: {
@@ -464,7 +478,7 @@ export const getPrepopulatedEndpointException = ({
   const sha256Hash = file?.hash?.sha256 ?? '';
   return {
     ...getNewExceptionItem({ listId, namespaceType: listNamespace, ruleName }),
-    entries: [
+    entries: addIdToEntries([
       {
         field: 'file.Ext.code_signature',
         type: 'nested',
@@ -501,7 +515,7 @@ export const getPrepopulatedEndpointException = ({
         type: 'match',
         value: eventCode ?? '',
       },
-    ],
+    ]),
   };
 };
 
@@ -529,7 +543,7 @@ export const getPrepopulatedRansomwareException = ({
   const ransomwareFeature = Ransomware?.feature ?? '';
   return {
     ...getNewExceptionItem({ listId, namespaceType: listNamespace, ruleName }),
-    entries: [
+    entries: addIdToEntries([
       {
         field: 'process.Ext.code_signature',
         type: 'nested',
@@ -572,7 +586,7 @@ export const getPrepopulatedRansomwareException = ({
         type: 'match',
         value: eventCode ?? '',
       },
-    ],
+    ]),
   };
 };
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/93559

In a previous PR where we added `id` to exception entries, this case was missed where the exceptions are prepopulated for endpoint alerts.

To test bug, please follow steps detailed in linked issue.

#### Fix
![except_bug](https://user-images.githubusercontent.com/10927944/110397135-24d54000-8026-11eb-855b-83a31c9f9208.gif)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios