### PR TITLE
[App Search] Add canHaveScopedEngines role helper

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.test.ts
@@ -20,6 +20,7 @@ describe('getRoleAbilities', () => {
       credentialTypes: ['admin', 'private', 'search'],
       canAccessAllEngines: true,
       can: expect.any(Function),
+      canHaveScopedEngines: expect.any(Function),
       // Has access
       canViewAccountCredentials: true,
       canManageEngines: true,
@@ -68,6 +69,23 @@ describe('getRoleAbilities', () => {
 
       expect(myRole.can('hello' as any, 'world')).toEqual(false);
       expect(myRole.can('edit', 'fakeSubject')).toEqual(false);
+    });
+  });
+
+  describe('canHaveScopedEngines()', () => {
+    it('returns false for owner and admin roles', () => {
+      const myRole = getRoleAbilities(mockRole);
+
+      expect(myRole.canHaveScopedEngines('owner')).toEqual(false);
+      expect(myRole.canHaveScopedEngines('admin')).toEqual(false);
+    });
+
+    it('returns true for dev, editor, and analyst roles', () => {
+      const myRole = getRoleAbilities(mockRole);
+
+      expect(myRole.canHaveScopedEngines('dev')).toEqual(true);
+      expect(myRole.canHaveScopedEngines('editor')).toEqual(true);
+      expect(myRole.canHaveScopedEngines('analyst')).toEqual(true);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/index.ts
@@ -19,6 +19,7 @@ export interface Role {
   credentialTypes: string[];
   canAccessAllEngines: boolean;
   can(action: AbilityTypes, subject: string): boolean;
+  canHaveScopedEngines(role: RoleTypes): boolean;
   canViewMetaEngines: boolean;
   canViewAccountCredentials: boolean;
   canViewEngineAnalytics: boolean;
@@ -60,7 +61,10 @@ export const getRoleAbilities = (role: Account['role']): Role => {
         (Array.isArray(role.ability[action]) && role.ability[action].includes(subject))
       );
     },
-    // TODO: canHaveScopedEngines fn
+    canHaveScopedEngines: (roleType: RoleTypes): boolean => {
+      const unscopedRoles = ['dev', 'editor', 'analyst'];
+      return unscopedRoles.includes(roleType);
+    },
   };
 
   // Clone top-level role props, and move some props out of `ability` and into the top-level for convenience


### PR DESCRIPTION
## Summary

@scottybollinger needs `canHaveScopedEngines` for his App Search role mappings work.

Ported over from https://github.com/elastic/ent-search/blob/master/app/javascript/app_search/classes.ts#L10-L13

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios