### PR TITLE
[Fleet] Use EuiFieldPassword for password variables in policy editor

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/package_policy_input_var_field.tsx
@@ -15,6 +15,7 @@ import {
   EuiComboBox,
   EuiText,
   EuiCodeEditor,
+  EuiFieldPassword,
 } from '@elastic/eui';
 
 import { RegistryVarsEntry } from '../../../../types';
@@ -52,48 +53,58 @@ export const PackagePolicyInputVarField: React.FunctionComponent<{
         />
       );
     }
-    if (type === 'yaml') {
-      return (
-        <EuiCodeEditor
-          width="100%"
-          mode="yaml"
-          theme="textmate"
-          setOptions={{
-            minLines: 10,
-            maxLines: 30,
-            tabSize: 2,
-            showGutter: false,
-          }}
-          value={value}
-          onChange={(newVal) => onChange(newVal)}
-          onBlur={() => setIsDirty(true)}
-        />
-      );
+    switch (type) {
+      case 'yaml':
+        return (
+          <EuiCodeEditor
+            width="100%"
+            mode="yaml"
+            theme="textmate"
+            setOptions={{
+              minLines: 10,
+              maxLines: 30,
+              tabSize: 2,
+              showGutter: false,
+            }}
+            value={value}
+            onChange={(newVal) => onChange(newVal)}
+            onBlur={() => setIsDirty(true)}
+          />
+        );
+      case 'bool':
+        return (
+          <EuiSwitch
+            label={fieldLabel}
+            checked={value}
+            showLabel={false}
+            onChange={(e) => onChange(e.target.checked)}
+            onBlur={() => setIsDirty(true)}
+          />
+        );
+      case 'password':
+        return (
+          <EuiFieldPassword
+            type="dual"
+            isInvalid={isInvalid}
+            value={value === undefined ? '' : value}
+            onChange={(e) => onChange(e.target.value)}
+            onBlur={() => setIsDirty(true)}
+          />
+        );
+      default:
+        return (
+          <EuiFieldText
+            isInvalid={isInvalid}
+            value={value === undefined ? '' : value}
+            onChange={(e) => onChange(e.target.value)}
+            onBlur={() => setIsDirty(true)}
+          />
+        );
     }
-    if (type === 'bool') {
-      return (
-        <EuiSwitch
-          label={fieldLabel}
-          checked={value}
-          showLabel={false}
-          onChange={(e) => onChange(e.target.checked)}
-          onBlur={() => setIsDirty(true)}
-        />
-      );
-    }
-
-    return (
-      <EuiFieldText
-        isInvalid={isInvalid}
-        value={value === undefined ? '' : value}
-        onChange={(e) => onChange(e.target.value)}
-        onBlur={() => setIsDirty(true)}
-      />
-    );
   }, [isInvalid, multi, onChange, type, value, fieldLabel]);
 
   // Boolean cannot be optional by default set to false
-  const isOptional = type !== 'bool' && !required;
+  const isOptional = useMemo(() => type !== 'bool' && !required, [required, type]);
 
   return (
     <EuiFormRow


### PR DESCRIPTION
## Summary

Resolves #94098. This PR switches the input control to a password field for `type: password` package variables. The password field has a toggle to reveal the text input. Small code cleanup includes changing `if`s -> `switch` and memo'ing a flag.

This change can be seen in the policy editor for any package with a password variable, for example Redis:

![image](https://user-images.githubusercontent.com/1965714/110518940-a0d09600-80c1-11eb-8356-2e0dfb9b2c5b.png)
