### PR TITLE
Fix missing alerts menu

### DIFF
--- a/x-pack/plugins/apm/public/application/action_menu/index.tsx
+++ b/x-pack/plugins/apm/public/application/action_menu/index.tsx
@@ -9,7 +9,7 @@ import { EuiHeaderLink, EuiHeaderLinks } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { getAlertingCapabilities } from '../../components/alerting/get_alert_capabilities';
+import { getAlertingCapabilities } from '../../components/alerting/get_alerting_capabilities';
 import { getAPMHref } from '../../components/shared/Links/apm/APMLink';
 import { useApmPluginContext } from '../../context/apm_plugin/use_apm_plugin_context';
 import { AlertingPopoverAndFlyout } from './alerting_popover_flyout';

--- a/x-pack/plugins/apm/public/components/alerting/get_alerting_capabilities.test.ts
+++ b/x-pack/plugins/apm/public/components/alerting/get_alerting_capabilities.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Capabilities } from 'kibana/public';
+import { ApmPluginSetupDeps } from '../../plugin';
+import { getAlertingCapabilities } from './get_alerting_capabilities';
+
+describe('getAlertingCapabilities', () => {
+  describe('when the alerting plugin is not enabled', () => {
+    it('returns isAlertingAvailable = false', () => {
+      expect(
+        getAlertingCapabilities(
+          {} as ApmPluginSetupDeps,
+          ({ apm: {} } as unknown) as Capabilities
+        ).isAlertingAvailable
+      ).toEqual(false);
+    });
+  });
+});

--- a/x-pack/plugins/apm/public/components/alerting/get_alerting_capabilities.ts
+++ b/x-pack/plugins/apm/public/components/alerting/get_alerting_capabilities.ts
@@ -14,7 +14,7 @@ export const getAlertingCapabilities = (
 ) => {
   const canReadAlerts = !!capabilities.apm['alerting:show'];
   const canSaveAlerts = !!capabilities.apm['alerting:save'];
-  const isAlertingPluginEnabled = 'alerts' in plugins;
+  const isAlertingPluginEnabled = !!plugins.alerting;
   const isAlertingAvailable =
     isAlertingPluginEnabled && (canReadAlerts || canSaveAlerts);
   const isMlPluginEnabled = 'ml' in plugins;


### PR DESCRIPTION
In #92898 the `alerts` plugin was renamed to `alerting`. We were checking if this plugin is enabled with a check like `'alerts' in plugins`, which is not type checked.

Change the check to use `!!plugins.alerting` so this type of change will be caught in the future.

Rename `get_alert_capabilities` to `get_alerting_capabilities` to match the name of the exported function. Add a test for it.
