### PR TITLE
[Workplace Search] Make session_state optional in source request

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -858,7 +858,7 @@ export function registerOauthConnectorParamsRoute({
         query: schema.object({
           kibana_host: schema.string(),
           code: schema.string(),
-          session_state: schema.string(),
+          session_state: schema.maybe(schema.string()),
           state: schema.string(),
           oauth_verifier: schema.maybe(schema.string()),
         }),


### PR DESCRIPTION
Some OAuth plugins don’t send this key so we make it optional to prevent server errors.