### PR TITLE
[Enterprise Search] Upgrade Kea to 2.3, update LogicMounter helper w/ props support

### DIFF
--- a/package.json
+++ b/package.json
@@ -712,7 +712,7 @@
     "json5": "^1.0.1",
     "jsondiffpatch": "0.4.1",
     "jsts": "^1.6.2",
-    "kea": "^2.2.0",
+    "kea": "^2.3.0",
     "keymirror": "0.1.1",
     "leaflet": "1.5.1",
     "leaflet-draw": "0.4.14",

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea.mock.ts
@@ -80,7 +80,7 @@ export const setMockActions = (actions: object) => {
  * const { mount, unmount } = new LogicMounter(SomeLogic);
  *
  * it('some test', () => {
- *   mount({ someValue: 'hello' });
+ *   mount({ someValue: 'hello' }, { someProp: 'world' });
  *   unmount();
  * });
  */
@@ -88,6 +88,7 @@ import { resetContext, Logic, LogicInput } from 'kea';
 
 interface LogicFile {
   inputs: Array<LogicInput<Logic>>;
+  build(props?: object): void;
   mount(): Function;
 }
 export class LogicMounter {
@@ -110,8 +111,10 @@ export class LogicMounter {
   };
 
   // Automatically reset context & mount the logic file
-  public mount = (values?: object) => {
+  public mount = (values?: object, props?: object) => {
     this.resetContext(values);
+    if (props) this.logicFile.build(props);
+
     const unmount = this.logicFile.mount();
     this.unmountFn = unmount;
     return unmount; // Keep Kea behavior of returning an unmount fn from mount

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/app_logic.test.ts
@@ -6,24 +6,19 @@
  */
 
 import { DEFAULT_INITIAL_APP_DATA } from '../../../common/__mocks__';
-
-import { resetContext } from 'kea';
+import { LogicMounter } from '../__mocks__';
 
 import { AppLogic } from './app_logic';
 
 describe('AppLogic', () => {
-  const mount = (props = {}) => {
-    AppLogic({ ...DEFAULT_INITIAL_APP_DATA, ...props });
-    AppLogic.mount();
-  };
+  const { mount } = new LogicMounter(AppLogic);
 
   beforeEach(() => {
     jest.clearAllMocks();
-    resetContext({});
   });
 
   it('sets values from props', () => {
-    mount();
+    mount({}, DEFAULT_INITIAL_APP_DATA);
 
     expect(AppLogic.values).toEqual({
       ilmEnabled: true,
@@ -53,7 +48,7 @@ describe('AppLogic', () => {
   describe('actions', () => {
     describe('setOnboardingComplete()', () => {
       it('sets true', () => {
-        mount({ appSearch: { onboardingComplete: false } });
+        mount({}, { ...DEFAULT_INITIAL_APP_DATA, appSearch: { onboardingComplete: false } });
 
         AppLogic.actions.setOnboardingComplete();
         expect(AppLogic.values.account.onboardingComplete).toEqual(true);
@@ -64,7 +59,7 @@ describe('AppLogic', () => {
   describe('selectors', () => {
     describe('myRole', () => {
       it('falls back to an empty object if role is missing', () => {
-        mount({ appSearch: {} });
+        mount({}, { ...DEFAULT_INITIAL_APP_DATA, appSearch: {} });
 
         expect(AppLogic.values.myRole).toEqual({});
       });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/curation_queries/curation_queries_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/components/curation_queries/curation_queries_logic.test.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import { resetContext } from 'kea';
+import { LogicMounter } from '../../../../../__mocks__';
 
 import { CurationQueriesLogic } from './curation_queries_logic';
 
 describe('CurationQueriesLogic', () => {
+  const { mount } = new LogicMounter(CurationQueriesLogic);
+
   const MOCK_QUERIES = ['a', 'b', 'c'];
 
   const DEFAULT_PROPS = { queries: MOCK_QUERIES };
@@ -19,18 +21,12 @@ describe('CurationQueriesLogic', () => {
     hasOnlyOneQuery: false,
   };
 
-  const mount = (props = {}) => {
-    CurationQueriesLogic({ ...DEFAULT_PROPS, ...props });
-    CurationQueriesLogic.mount();
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
-    resetContext({});
   });
 
   it('has expected default values passed from props', () => {
-    mount();
+    mount({}, DEFAULT_PROPS);
     expect(CurationQueriesLogic.values).toEqual(DEFAULT_VALUES);
   });
 
@@ -42,7 +38,7 @@ describe('CurationQueriesLogic', () => {
 
     describe('addQuery', () => {
       it('appends an empty string to the queries array', () => {
-        mount();
+        mount(DEFAULT_VALUES);
         CurationQueriesLogic.actions.addQuery();
 
         expect(CurationQueriesLogic.values).toEqual({
@@ -55,7 +51,7 @@ describe('CurationQueriesLogic', () => {
 
     describe('deleteQuery', () => {
       it('deletes the query string at the specified array index', () => {
-        mount();
+        mount(DEFAULT_VALUES);
         CurationQueriesLogic.actions.deleteQuery(1);
 
         expect(CurationQueriesLogic.values).toEqual({
@@ -67,7 +63,7 @@ describe('CurationQueriesLogic', () => {
 
     describe('editQuery', () => {
       it('edits the query string at the specified array index', () => {
-        mount();
+        mount(DEFAULT_VALUES);
         CurationQueriesLogic.actions.editQuery(2, 'z');
 
         expect(CurationQueriesLogic.values).toEqual({
@@ -81,7 +77,7 @@ describe('CurationQueriesLogic', () => {
   describe('selectors', () => {
     describe('hasEmptyQueries', () => {
       it('returns true if queries has any empty strings', () => {
-        mount({ queries: ['', '', ''] });
+        mount({}, { queries: ['', '', ''] });
 
         expect(CurationQueriesLogic.values.hasEmptyQueries).toEqual(true);
       });
@@ -89,7 +85,7 @@ describe('CurationQueriesLogic', () => {
 
     describe('hasOnlyOneQuery', () => {
       it('returns true if queries only has one item', () => {
-        mount({ queries: ['test'] });
+        mount({}, { queries: ['test'] });
 
         expect(CurationQueriesLogic.values.hasOnlyOneQuery).toEqual(true);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -18212,10 +18212,10 @@ kdbush@^3.0.0:
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
   integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
 
-kea@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-2.2.0.tgz#1ba4a174a53880cca8002a67cf62b19b30d09702"
-  integrity sha512-IzgTC6SC89wTLfiBMPlduG4r4YanxONYK4werz8RMZxPvcYw4XEEK8xQJguwVYtLCEGm4x5YiLCubGqGfRcbEw==
+kea@^2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-2.3.3.tgz#8fbd6d0c4ba5079c5abe46486bbc7dc1fd071a62"
+  integrity sha512-NZQHisfEvlg+e6BsHckW03IYaIBY+fuK4xiov7ShZ0GudUmNLhqgHSxUsykU/wdrCPEI6ANX1gyDIRTnUd3HyA==
 
 kew@~0.1.7:
   version "0.1.7"


### PR DESCRIPTION
## Summary

The general theme of this PR is setting up Kea to work even better with `props`. I'll shortly be using this for my upcoming CurationLogic work/PR, as I'll be passing a `curationId` prop into CurationLogic.

### Kea upgrade (a71f142)

The Kea 2.3 upgrade will allow us to use a new BindLogic API: https://kea.js.org/blog/kea-2.3/

```js
// Example
<BindLogic logic={CurationLogic} props={{ curationId: 'cur-123456789' }}>
  <Curation />
</BindLogic>
```

Which means I can avoid doing `useActions(CurationLogic({ curationId: 'cur-123456789' }))` within `<Curation />` and just do `useActions(CurationLogic)`.

### LogicMounter changes (82ae123 & 8a566ec)

This updates our `mount` test helper to allow passing in props as well as defaults. API looks the same as before, just with an extra param:

```js
const { mount } = new LogicMounter(SomeLogic);

const someDefaults = { hello: 'world' };
const someProps = { lorem: 'ipsum', dolor: 'sit amet' };

// All valid uses
mount();
mount(someDefaults);
mount(someDefaults, someProps);
```

### Checklist

- [x] 2.3 should not have introduced any breaking changes, but I did a basic QA smoke test of our App Search pages and confirmed they work as before.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios