### PR TITLE
[App Search] DataPanel & LoadingOverlay component tweaks

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.scss
@@ -1,4 +1,7 @@
 .dataPanel {
+  position: relative;
+  overflow: hidden;
+
   // TODO: This CSS can be removed once EUI supports tables in `subdued` panels
   &--filled {
     .euiTable {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.test.tsx
@@ -11,6 +11,8 @@ import { shallow } from 'enzyme';
 
 import { EuiIcon, EuiButton } from '@elastic/eui';
 
+import { LoadingOverlay } from '../../../shared/loading';
+
 import { DataPanel } from './data_panel';
 
 describe('DataPanel', () => {
@@ -78,6 +80,18 @@ describe('DataPanel', () => {
 
       expect(wrapper.prop('color')).toEqual('subdued');
       expect(wrapper.prop('className')).toEqual('dataPanel dataPanel--filled');
+    });
+
+    it('renders a loading overlay based on isLoading flag', () => {
+      const wrapper = shallow(<DataPanel title={<h1>Test</h1>} />);
+
+      expect(wrapper.prop('aria-busy')).toBeFalsy();
+      expect(wrapper.find(LoadingOverlay)).toHaveLength(0);
+
+      wrapper.setProps({ isLoading: true });
+
+      expect(wrapper.prop('aria-busy')).toBeTruthy();
+      expect(wrapper.find(LoadingOverlay)).toHaveLength(1);
     });
 
     it('passes class names', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
@@ -19,6 +19,8 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
+import { LoadingOverlay } from '../../../shared/loading';
+
 import './data_panel.scss';
 
 interface Props {
@@ -27,6 +29,7 @@ interface Props {
   iconType?: string;
   action?: React.ReactNode;
   filled?: boolean;
+  isLoading?: boolean;
   className?: string;
 }
 
@@ -36,6 +39,7 @@ export const DataPanel: React.FC<Props> = ({
   iconType,
   action,
   filled,
+  isLoading,
   className,
   children,
   ...props // e.g., data-test-subj
@@ -45,7 +49,13 @@ export const DataPanel: React.FC<Props> = ({
   });
 
   return (
-    <EuiPanel {...props} color={filled ? 'subdued' : 'plain'} className={classes} hasShadow={false}>
+    <EuiPanel
+      {...props}
+      color={filled ? 'subdued' : 'plain'}
+      className={classes}
+      hasShadow={false}
+      aria-busy={isLoading}
+    >
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
@@ -68,6 +78,7 @@ export const DataPanel: React.FC<Props> = ({
       </EuiFlexGroup>
       <EuiSpacer />
       {children}
+      {isLoading && <LoadingOverlay />}
     </EuiPanel>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/data_panel/data_panel.tsx
@@ -48,21 +48,21 @@ export const DataPanel: React.FC<Props> = ({
     <EuiPanel {...props} color={filled ? 'subdued' : 'plain'} className={classes} hasShadow={false}>
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem>
-          <EuiFlexGroup>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
             {iconType && (
-              <EuiFlexItem>
+              <EuiFlexItem grow={false}>
                 <EuiIcon type={iconType} />
               </EuiFlexItem>
             )}
             <EuiFlexItem>
               <EuiTitle size="xs">{title}</EuiTitle>
-              {subtitle && (
-                <EuiText size="s" color="subdued">
-                  <p>{subtitle}</p>
-                </EuiText>
-              )}
             </EuiFlexItem>
           </EuiFlexGroup>
+          {subtitle && (
+            <EuiText size="s" color="subdued">
+              <p>{subtitle}</p>
+            </EuiText>
+          )}
         </EuiFlexItem>
         {action && <EuiFlexItem grow={false}>{action}</EuiFlexItem>}
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/loading/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/loading/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { Loading } from './loading';
+export { Loading, LoadingOverlay } from './loading';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.scss
@@ -6,8 +6,19 @@
  */
 
 .enterpriseSearchLoading {
+  z-index: $euiZLevel2;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%);
+}
+
+.enterpriseSearchLoadingOverlay {
+  z-index: $euiZLevel1;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba($euiColorEmptyShade, .75);
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.test.tsx
@@ -11,11 +11,20 @@ import { shallow } from 'enzyme';
 
 import { EuiLoadingSpinner } from '@elastic/eui';
 
-import { Loading } from './';
+import { Loading, LoadingOverlay } from './';
 
 describe('Loading', () => {
   it('renders', () => {
     const wrapper = shallow(<Loading />);
+    expect(wrapper.hasClass('enterpriseSearchLoading')).toBe(true);
     expect(wrapper.find(EuiLoadingSpinner)).toHaveLength(1);
+  });
+});
+
+describe('LoadingOverlay', () => {
+  it('renders', () => {
+    const wrapper = shallow(<LoadingOverlay />);
+    expect(wrapper.hasClass('enterpriseSearchLoadingOverlay')).toBe(true);
+    expect(wrapper.find(Loading)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/loading/loading.tsx
@@ -16,3 +16,9 @@ export const Loading: React.FC = () => (
     <EuiLoadingSpinner size="xl" />
   </div>
 );
+
+export const LoadingOverlay: React.FC = () => (
+  <div className="enterpriseSearchLoadingOverlay">
+    <Loading />
+  </div>
+);


### PR DESCRIPTION
## Summary

This PR is setup for upcoming Curation work/PRs.

- DataPanel: fix icons showing unaligned & w/ too much flex space 
- LoadingOverlay: add new loading component w/ overlay for per-panel loading indicators
- DataPanel: add `isLoading` prop to show a LoadingOverlay component

Screenshots will be included in the comments below.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### Accessibility note

Just want to that the below items are potential accessibility point of weaknesses in the app:

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))

Reasons:
- The LoadingOverlay component prevents mouse clicks over things it covers, but not necessarily keyboard presses (if the user is already focused within the panel)
- Implementing this from a dialogue / announcement POV is also fairly complex and would require a live region - I'm hoping `aria-busy` is a sufficient indicator for now
- Contrast-wise, this likely fails due to opacity shenanigans, but I'm less concerned about this due to the transient nature of the indicator

TL;DR - this isn't a perfect or accessible implementation of a loading indicator and is mostly visual-focused - it's definitely a tech debt item to re-evaluate this at some pointer for better screen reader and keyboard compatibility, possibly via the [`inert`](https://stackoverflow.com/a/56387500/4294462) property in the future.