### PR TITLE
savedObjects plugin is deprecated and will be removed

### DIFF
--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -165,7 +165,7 @@ Content is fetched from the remote (https://feeds.elastic.co and https://feeds-s
 
 
 |{kib-repo}blob/{branch}/src/plugins/saved_objects/README.md[savedObjects]
-|The savedObjects plugin exposes utilities to manipulate saved objects on the client side.
+|NOTE: This plugin is deprecated and will be removed in 8.0. See https://github.com/elastic/kibana/issues/46435 for more information.
 
 
 |{kib-repo}blob/{branch}/src/plugins/saved_objects_management/README.md[savedObjectsManagement]

--- a/src/plugins/saved_objects/README.md
+++ b/src/plugins/saved_objects/README.md
@@ -1,3 +1,5 @@
 # `savedObjects` plugin
 
+NOTE: This plugin is deprecated and will be removed in 8.0. See https://github.com/elastic/kibana/issues/46435 for more information.
+
 The `savedObjects` plugin exposes utilities to manipulate saved objects on the client side.

--- a/src/plugins/saved_objects/public/plugin.ts
+++ b/src/plugins/saved_objects/public/plugin.ts
@@ -23,9 +23,13 @@ export interface SavedObjectSetup {
 }
 
 export interface SavedObjectsStart {
+  /** @deprecated */
   SavedObjectClass: new (raw: Record<string, any>) => SavedObject;
+  /** @deprecated */
   settings: {
+    /** @deprecated */
     getPerPage: () => number;
+    /** @deprecated */
     getListingLimit: () => number;
   };
 }

--- a/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/saved_object_save_modal.tsx
@@ -66,6 +66,7 @@ export interface SaveModalState {
 
 const generateId = htmlIdGenerator();
 
+/** @deprecated */
 export class SavedObjectSaveModal extends React.Component<Props, SaveModalState> {
   private warning = React.createRef<HTMLDivElement>();
   public readonly state = {

--- a/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
+++ b/src/plugins/saved_objects/public/saved_object/saved_object_loader.ts
@@ -22,6 +22,7 @@ export interface SavedObjectLoaderFindOptions {
 }
 
 /**
+ * @deprecated
  * The SavedObjectLoader class provides some convenience functions
  * to load and save one kind of saved objects (specified in the constructor).
  *

--- a/src/plugins/saved_objects/public/types.ts
+++ b/src/plugins/saved_objects/public/types.ts
@@ -21,6 +21,7 @@ import {
   SearchSourceFields,
 } from '../../data/public';
 
+/** @deprecated */
 export interface SavedObject {
   _serialize: () => { attributes: SavedObjectAttributes; references: SavedObjectReference[] };
   _source: Record<string, unknown>;


### PR DESCRIPTION
## Summary

As discussed in https://github.com/elastic/kibana/issues/46435 this plugin is technical debt left over from before the NP migration. It was converted to a NP plugin to unblock teams but really should have been removed along with the NP migration. Flagging this as deprecated to make this more visible and ensure we don't get new dependencies on this code.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
