### PR TITLE
Fix cannot brush on bars of vertical bar chart to zoom into data

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/lib/handler.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/handler.js
@@ -83,7 +83,8 @@ export class Handler {
       return function (eventPayload) {
         switch (eventType) {
           case 'brush':
-            const xRaw = _.get(eventPayload.data, 'series[0].values[0].xRaw');
+            const { xRaw } = eventPayload.data.series[0]?.values.find(({ xRaw }) => Boolean(xRaw));
+
             if (!xRaw) return; // not sure if this is possible?
             const [start, end] = eventPayload.range;
             const range = [convertToTimestamp(start), convertToTimestamp(end)];


### PR DESCRIPTION
Closes: #94248

## Summary
**Describe the bug:**  This is a weird bug. 
If I have a vertical bar chart split on columns - I can brush once to see all the data. But after if I try to brush on split columns data - nothing happens. 

Please note - the value of **visualization:visualize:legacyChartsLibrary** is set to true for this test case. 

**Steps to reproduce:**
1. Install sample logs data 
2. Go to visualize - build a vertical bar chart on count on y -axis , date histogram on x -axis - and then split the chart on columns - terms buckets on machine.os keyword. Change the time period to 1 year - Kibana updates the chart correctly. 
3. Brush on the chart - it works once to zoom in. 
4. Brush again on the bars of chart on one of the columns nothing happens

**Root cause:**
In some cases, `series[0].values[0]` object does not contain the `xRaw` field. I think it's worth working out with this, on the other hand, I think that this way of getting `xRaw` is safer
![image](https://user-images.githubusercontent.com/20072247/110630118-04d48680-81b6-11eb-9686-4f514256729d.png)
