### PR TITLE
[App Search] Create a stub page for Result Settings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -229,8 +229,7 @@ export const EngineNav: React.FC = () => {
       )}
       {canManageEngineResultSettings && (
         <SideNavLink
-          isExternal
-          to={getAppSearchUrl(generateEnginePath(ENGINE_RESULT_SETTINGS_PATH))}
+          to={generateEnginePath(ENGINE_RESULT_SETTINGS_PATH)}
           data-test-subj="EngineResultSettingsLink"
         >
           {RESULT_SETTINGS_TITLE}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -20,6 +20,7 @@ import { AnalyticsRouter } from '../analytics';
 import { CurationsRouter } from '../curations';
 import { EngineOverview } from '../engine_overview';
 import { RelevanceTuning } from '../relevance_tuning';
+import { ResultSettings } from '../result_settings';
 
 import { EngineRouter } from './engine_router';
 
@@ -110,5 +111,12 @@ describe('EngineRouter', () => {
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(RelevanceTuning)).toHaveLength(1);
+  });
+
+  it('renders a result settings view', () => {
+    setMockValues({ ...values, myRole: { canManageEngineResultSettings: true } });
+    const wrapper = shallow(<EngineRouter />);
+
+    expect(wrapper.find(ResultSettings)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -29,7 +29,7 @@ import {
   ENGINE_RELEVANCE_TUNING_PATH,
   // ENGINE_SYNONYMS_PATH,
   ENGINE_CURATIONS_PATH,
-  // ENGINE_RESULT_SETTINGS_PATH,
+  ENGINE_RESULT_SETTINGS_PATH,
   // ENGINE_SEARCH_UI_PATH,
   // ENGINE_API_LOGS_PATH,
 } from '../../routes';
@@ -40,6 +40,8 @@ import { OVERVIEW_TITLE } from '../engine_overview';
 import { EngineOverview } from '../engine_overview';
 import { ENGINES_TITLE } from '../engines';
 import { RelevanceTuning } from '../relevance_tuning';
+
+import { ResultSettings } from '../result_settings';
 
 import { EngineLogic } from './';
 
@@ -54,7 +56,7 @@ export const EngineRouter: React.FC = () => {
       canManageEngineRelevanceTuning,
       // canManageEngineSynonyms,
       canManageEngineCurations,
-      // canManageEngineResultSettings,
+      canManageEngineResultSettings,
       // canManageEngineSearchUi,
       // canViewEngineApiLogs,
     },
@@ -106,6 +108,11 @@ export const EngineRouter: React.FC = () => {
       {canManageEngineRelevanceTuning && (
         <Route path={ENGINE_RELEVANCE_TUNING_PATH}>
           <RelevanceTuning engineBreadcrumb={engineBreadcrumb} />
+        </Route>
+      )}
+      {canManageEngineResultSettings && (
+        <Route path={ENGINE_RESULT_SETTINGS_PATH}>
+          <ResultSettings engineBreadcrumb={engineBreadcrumb} />
         </Route>
       )}
       <Route>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { RESULT_SETTINGS_TITLE } from './constants';
+export { ResultSettings } from './result_settings';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.test.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { ResultSettings } from './result_settings';
+
+describe('RelevanceTuning', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(<ResultSettings engineBreadcrumb={['test']} />);
+    expect(wrapper.isEmptyRender()).toBe(false);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
@@ -7,13 +7,7 @@
 
 import React from 'react';
 
-import {
-  EuiPageHeader,
-  EuiPageHeaderSection,
-  EuiTitle,
-  EuiPageContentBody,
-  EuiPageContent,
-} from '@elastic/eui';
+import { EuiPageHeader, EuiPageContentBody, EuiPageContent } from '@elastic/eui';
 
 import { FlashMessages } from '../../../shared/flash_messages';
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
@@ -28,13 +28,7 @@ export const ResultSettings: React.FC<Props> = ({ engineBreadcrumb }) => {
   return (
     <>
       <SetPageChrome trail={[...engineBreadcrumb, RESULT_SETTINGS_TITLE]} />
-      <EuiPageHeader>
-        <EuiPageHeaderSection>
-          <EuiTitle size="l">
-            <h1>{RESULT_SETTINGS_TITLE}</h1>
-          </EuiTitle>
-        </EuiPageHeaderSection>
-      </EuiPageHeader>
+      <EuiPageHeader pageTitle={RESULT_SETTINGS_TITLE} />
       <EuiPageContent>
         <EuiPageContentBody>
           <FlashMessages />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import {
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiTitle,
+  EuiPageContentBody,
+  EuiPageContent,
+} from '@elastic/eui';
+
+import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+
+import { RESULT_SETTINGS_TITLE } from './constants';
+
+interface Props {
+  engineBreadcrumb: string[];
+}
+
+export const ResultSettings: React.FC<Props> = ({ engineBreadcrumb }) => {
+  return (
+    <>
+      <SetPageChrome trail={[...engineBreadcrumb, RESULT_SETTINGS_TITLE]} />
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l">
+            <h1>{RESULT_SETTINGS_TITLE}</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
+      <EuiPageContent>
+        <EuiPageContentBody>
+          <FlashMessages />
+        </EuiPageContentBody>
+      </EuiPageContent>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

This PR adds a stub page for Result Settings.

<img width="1279" alt="stub" src="https://user-images.githubusercontent.com/1427475/110667001-d051d200-8197-11eb-8a1e-95774f3a8729.png">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
