### PR TITLE
[App Search] Curation: set up server routes, API calls, & bare-bones view

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/constants.ts
@@ -19,6 +19,10 @@ export const CREATE_NEW_CURATION_TITLE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.engine.curations.create.title',
   { defaultMessage: 'Create new curation' }
 );
+export const MANAGE_CURATION_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.curations.manage.title',
+  { defaultMessage: 'Manage curation' }
+);
 
 export const DELETE_MESSAGE = i18n.translate(
   'xpack.enterpriseSearch.appSearch.engine.curations.deleteConfirmation',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import '../../../../__mocks__/react_router_history.mock';
+import '../../../../__mocks__/shallow_useeffect.mock';
+import { setMockActions, setMockValues, rerender } from '../../../../__mocks__';
+
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { shallow } from 'enzyme';
+
+import { EuiPageHeader } from '@elastic/eui';
+
+import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
+import { Loading } from '../../../../shared/loading';
+
+jest.mock('./curation_logic', () => ({ CurationLogic: jest.fn() }));
+import { CurationLogic } from './curation_logic';
+
+import { Curation } from './';
+
+describe('Curation', () => {
+  const props = {
+    curationsBreadcrumb: ['Engines', 'some-engine', 'Curations'],
+  };
+  const values = {
+    dataLoading: false,
+    curation: {
+      id: 'cur-123456789',
+      queries: ['query A', 'query B'],
+    },
+  };
+  const actions = {
+    loadCuration: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues(values);
+    setMockActions(actions);
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(<Curation {...props} />);
+
+    expect(wrapper.find(EuiPageHeader).prop('pageTitle')).toEqual('Manage curation');
+    expect(wrapper.find(SetPageChrome).prop('trail')).toEqual([
+      ...props.curationsBreadcrumb,
+      'query A, query B',
+    ]);
+  });
+
+  it('renders a loading component on page load', () => {
+    setMockValues({ ...values, dataLoading: true });
+    const wrapper = shallow(<Curation {...props} />);
+
+    expect(wrapper.find(Loading)).toHaveLength(1);
+  });
+
+  it('initializes CurationLogic with a curationId prop from URL param', () => {
+    (useParams as jest.Mock).mockReturnValueOnce({ curationId: 'hello-world' });
+    shallow(<Curation {...props} />);
+
+    expect(CurationLogic).toHaveBeenCalledWith({ curationId: 'hello-world' });
+  });
+
+  it('calls loadCuration on page load & whenever the curationId URL param changes', () => {
+    (useParams as jest.Mock).mockReturnValueOnce({ curationId: 'cur-123456789' });
+    const wrapper = shallow(<Curation {...props} />);
+    expect(actions.loadCuration).toHaveBeenCalledTimes(1);
+
+    (useParams as jest.Mock).mockReturnValueOnce({ curationId: 'cur-987654321' });
+    rerender(wrapper);
+    expect(actions.loadCuration).toHaveBeenCalledTimes(2);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useValues, useActions } from 'kea';
+
+import { EuiPageHeader, EuiSpacer } from '@elastic/eui';
+
+import { FlashMessages } from '../../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
+import { BreadcrumbTrail } from '../../../../shared/kibana_chrome/generate_breadcrumbs';
+import { Loading } from '../../../../shared/loading';
+
+import { MANAGE_CURATION_TITLE } from '../constants';
+
+import { CurationLogic } from './curation_logic';
+
+interface Props {
+  curationsBreadcrumb: BreadcrumbTrail;
+}
+
+export const Curation: React.FC<Props> = ({ curationsBreadcrumb }) => {
+  const { curationId } = useParams() as { curationId: string };
+  const { loadCuration } = useActions(CurationLogic({ curationId }));
+  const { dataLoading, curation } = useValues(CurationLogic({ curationId }));
+
+  useEffect(() => {
+    loadCuration();
+  }, [curationId]);
+
+  if (dataLoading) return <Loading />;
+
+  return (
+    <>
+      <SetPageChrome trail={[...curationsBreadcrumb, curation.queries.join(', ')]} />
+      <EuiPageHeader
+        pageTitle={MANAGE_CURATION_TITLE}
+        /* TODO: Restore defaults button */
+        responsive={false}
+      />
+
+      {/* TODO: Active query switcher / Manage queries modal */}
+
+      <EuiSpacer size="xl" />
+      <FlashMessages />
+
+      {/* TODO: PromotedDocuments section */}
+      {/* TODO: OrganicDocuments section */}
+      {/* TODO: HiddenDocuments section */}
+
+      {/* TODO: AddResult flyout */}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  LogicMounter,
+  mockHttpValues,
+  mockKibanaValues,
+  mockFlashMessageHelpers,
+} from '../../../../__mocks__';
+import '../../../__mocks__/engine_logic.mock';
+
+import { nextTick } from '@kbn/test/jest';
+
+import { CurationLogic } from './';
+
+describe('CurationLogic', () => {
+  const { mount } = new LogicMounter(CurationLogic);
+  const { http } = mockHttpValues;
+  const { navigateToUrl } = mockKibanaValues;
+  const { clearFlashMessages, flashAPIErrors } = mockFlashMessageHelpers;
+
+  const MOCK_CURATION_RESPONSE = {
+    id: 'cur-123456789',
+    last_updated: 'some timestamp',
+    queries: ['some search'],
+    promoted: [{ id: 'some-promoted-document' }],
+    organic: [
+      {
+        id: { raw: 'some-organic-document', snippet: null },
+        _meta: { id: 'some-organic-document', engine: 'some-engine' },
+      },
+    ],
+    hidden: [{ id: 'some-hidden-document' }],
+  };
+
+  const DEFAULT_VALUES = {
+    dataLoading: true,
+    curation: {
+      id: '',
+      last_updated: '',
+      queries: [],
+      promoted: [],
+      organic: [],
+      hidden: [],
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has expected default values', () => {
+    mount();
+    expect(CurationLogic.values).toEqual(DEFAULT_VALUES);
+  });
+
+  describe('actions', () => {
+    describe('onCurationLoad', () => {
+      it('should set curation state & dataLoading to false', () => {
+        mount();
+
+        CurationLogic.actions.onCurationLoad(MOCK_CURATION_RESPONSE);
+
+        expect(CurationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          curation: MOCK_CURATION_RESPONSE,
+          dataLoading: false,
+        });
+      });
+    });
+  });
+
+  describe('listeners', () => {
+    describe('loadCuration', () => {
+      it('should set dataLoading state', () => {
+        mount({ dataLoading: false }, { curationId: 'cur-123456789' });
+
+        CurationLogic.actions.loadCuration();
+
+        expect(CurationLogic.values).toEqual({
+          ...DEFAULT_VALUES,
+          dataLoading: true,
+        });
+      });
+
+      it('should make an API call and set curation state', async () => {
+        http.get.mockReturnValueOnce(Promise.resolve(MOCK_CURATION_RESPONSE));
+        mount({}, { curationId: 'cur-123456789' });
+        jest.spyOn(CurationLogic.actions, 'onCurationLoad');
+
+        CurationLogic.actions.loadCuration();
+        await nextTick();
+
+        expect(http.get).toHaveBeenCalledWith(
+          '/api/app_search/engines/some-engine/curations/cur-123456789'
+        );
+        expect(CurationLogic.actions.onCurationLoad).toHaveBeenCalledWith(MOCK_CURATION_RESPONSE);
+      });
+
+      it('handles errors/404s with a redirect to the Curations view', async () => {
+        http.get.mockReturnValueOnce(Promise.reject('error'));
+        mount({}, { curationId: 'cur-404' });
+
+        CurationLogic.actions.loadCuration();
+        await nextTick();
+
+        expect(flashAPIErrors).toHaveBeenCalledWith('error', { isQueued: true });
+        expect(navigateToUrl).toHaveBeenCalledWith('/engines/some-engine/curations');
+      });
+    });
+
+    describe('updateCuration', () => {
+      beforeAll(() => jest.useFakeTimers());
+      afterAll(() => jest.useRealTimers());
+
+      it('should make a PUT API call with queries and promoted/hidden IDs to update', async () => {
+        http.put.mockReturnValueOnce(Promise.resolve(MOCK_CURATION_RESPONSE));
+        mount({}, { curationId: 'cur-123456789' });
+        jest.spyOn(CurationLogic.actions, 'onCurationLoad');
+
+        CurationLogic.actions.updateCuration();
+        jest.runAllTimers();
+        await nextTick();
+
+        expect(http.put).toHaveBeenCalledWith(
+          '/api/app_search/engines/some-engine/curations/cur-123456789',
+          {
+            body: '{"queries":[],"query":"","promoted":[],"hidden":[]}', // Uses state currently in CurationLogic
+          }
+        );
+        expect(CurationLogic.actions.onCurationLoad).toHaveBeenCalledWith(MOCK_CURATION_RESPONSE);
+      });
+
+      it('should allow passing a custom queries param', async () => {
+        http.put.mockReturnValueOnce(Promise.resolve(MOCK_CURATION_RESPONSE));
+        mount({}, { curationId: 'cur-123456789' });
+        jest.spyOn(CurationLogic.actions, 'onCurationLoad');
+
+        CurationLogic.actions.updateCuration({ queries: ['hello', 'world'] });
+        jest.runAllTimers();
+        await nextTick();
+
+        expect(http.put).toHaveBeenCalledWith(
+          '/api/app_search/engines/some-engine/curations/cur-123456789',
+          {
+            body: '{"queries":["hello","world"],"query":"","promoted":[],"hidden":[]}',
+          }
+        );
+        expect(CurationLogic.actions.onCurationLoad).toHaveBeenCalledWith(MOCK_CURATION_RESPONSE);
+      });
+
+      it('handles errors', async () => {
+        http.put.mockReturnValueOnce(Promise.reject('error'));
+        mount({}, { curationId: 'cur-123456789' });
+
+        CurationLogic.actions.updateCuration();
+        jest.runAllTimers();
+        await nextTick();
+
+        expect(clearFlashMessages).toHaveBeenCalled();
+        expect(flashAPIErrors).toHaveBeenCalledWith('error');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/curation_logic.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { clearFlashMessages, flashAPIErrors } from '../../../../shared/flash_messages';
+import { HttpLogic } from '../../../../shared/http';
+import { KibanaLogic } from '../../../../shared/kibana';
+import { ENGINE_CURATIONS_PATH } from '../../../routes';
+import { EngineLogic, generateEnginePath } from '../../engine';
+
+import { Curation } from '../types';
+
+interface CurationValues {
+  dataLoading: boolean;
+  curation: Curation;
+}
+
+interface CurationActions {
+  loadCuration(): void;
+  onCurationLoad(curation: Curation): { curation: Curation };
+  updateCuration(options?: { queries?: string[] }): { queries?: string[] };
+}
+
+interface CurationProps {
+  curationId: Curation['id'];
+}
+
+export const CurationLogic = kea<MakeLogicType<CurationValues, CurationActions, CurationProps>>({
+  path: ['enterprise_search', 'app_search', 'curation_logic'],
+  actions: () => ({
+    loadCuration: true,
+    onCurationLoad: (curation) => ({ curation }),
+    updateCuration: ({ queries } = {}) => ({ queries }),
+  }),
+  reducers: () => ({
+    dataLoading: [
+      true,
+      {
+        loadCuration: () => true,
+        onCurationLoad: () => false,
+      },
+    ],
+    curation: [
+      {
+        id: '',
+        last_updated: '',
+        queries: [],
+        promoted: [],
+        organic: [],
+        hidden: [],
+      },
+      {
+        onCurationLoad: (_, { curation }) => curation,
+      },
+    ],
+  }),
+  listeners: ({ actions, values, props }) => ({
+    loadCuration: async () => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      try {
+        const response = await http.get(
+          `/api/app_search/engines/${engineName}/curations/${props.curationId}`
+        );
+        actions.onCurationLoad(response);
+      } catch (e) {
+        const { navigateToUrl } = KibanaLogic.values;
+
+        flashAPIErrors(e, { isQueued: true });
+        navigateToUrl(generateEnginePath(ENGINE_CURATIONS_PATH));
+      }
+    },
+    updateCuration: async ({ queries }, breakpoint) => {
+      const { http } = HttpLogic.values;
+      const { engineName } = EngineLogic.values;
+
+      await breakpoint(100);
+      clearFlashMessages();
+
+      try {
+        const response = await http.put(
+          `/api/app_search/engines/${engineName}/curations/${props.curationId}`,
+          {
+            body: JSON.stringify({
+              queries: queries || values.curation.queries,
+              query: '', // TODO: activeQuery state
+              promoted: [], // TODO: promotedIds state
+              hidden: [], // TODO: hiddenIds state
+            }),
+          }
+        );
+        actions.onCurationLoad(response);
+      } catch (e) {
+        flashAPIErrors(e);
+      }
+    },
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { CurationLogic } from './curation_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { CurationLogic } from './curation_logic';
+export { Curation } from './curation';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.test.tsx
@@ -17,6 +17,6 @@ describe('CurationsRouter', () => {
     const wrapper = shallow(<CurationsRouter engineBreadcrumb={['Engines', 'some-engine']} />);
 
     expect(wrapper.find(Switch)).toHaveLength(1);
-    expect(wrapper.find(Route)).toHaveLength(5);
+    expect(wrapper.find(Route)).toHaveLength(4);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curations_router.tsx
@@ -16,10 +16,10 @@ import {
   ENGINE_CURATIONS_PATH,
   ENGINE_CURATIONS_NEW_PATH,
   ENGINE_CURATION_PATH,
-  ENGINE_CURATION_ADD_RESULT_PATH,
 } from '../../routes';
 
 import { CURATIONS_TITLE, CREATE_NEW_CURATION_TITLE } from './constants';
+import { Curation } from './curation';
 import { Curations, CurationCreation } from './views';
 
 interface Props {
@@ -38,15 +38,8 @@ export const CurationsRouter: React.FC<Props> = ({ engineBreadcrumb }) => {
         <SetPageChrome trail={[...CURATIONS_BREADCRUMB, CREATE_NEW_CURATION_TITLE]} />
         <CurationCreation />
       </Route>
-      <Route exact path={ENGINE_CURATION_PATH}>
-        <SetPageChrome trail={[...CURATIONS_BREADCRUMB, 'curation queries']} />
-        TODO: Curation view (+ show a NotFound view if ID is invalid)
-      </Route>
-      <Route exact path={ENGINE_CURATION_ADD_RESULT_PATH}>
-        <SetPageChrome
-          trail={[...CURATIONS_BREADCRUMB, 'curation queries', 'add result manually']}
-        />
-        TODO: Curation Add Result view
+      <Route path={ENGINE_CURATION_PATH}>
+        <Curation curationsBreadcrumb={CURATIONS_BREADCRUMB} />
       </Route>
       <Route>
         <NotFound breadcrumbs={CURATIONS_BREADCRUMB} product={APP_SEARCH_PLUGIN} />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/types.ts
@@ -6,17 +6,24 @@
  */
 
 import { Meta } from '../../../../../common/types';
+import { Result } from '../result/types';
 
 export interface Curation {
   id: string;
   last_updated: string;
   queries: string[];
-  promoted: object[];
-  hidden: object[];
-  organic: object[];
+  promoted: CurationResult[];
+  hidden: CurationResult[];
+  organic: Result[];
 }
 
 export interface CurationsAPIResponse {
   results: Curation[];
   meta: Meta;
+}
+
+export interface CurationResult {
+  // TODO: Consider updating our internal API to return more standard Result data in the future
+  id: string;
+  [key: string]: string | string[];
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -50,7 +50,6 @@ export const ENGINE_RESULT_SETTINGS_PATH = `${ENGINE_PATH}/result-settings`;
 export const ENGINE_CURATIONS_PATH = `${ENGINE_PATH}/curations`;
 export const ENGINE_CURATIONS_NEW_PATH = `${ENGINE_CURATIONS_PATH}/new`;
 export const ENGINE_CURATION_PATH = `${ENGINE_CURATIONS_PATH}/:curationId`;
-export const ENGINE_CURATION_ADD_RESULT_PATH = `${ENGINE_CURATIONS_PATH}/:curationId/add_result`;
 
 export const ENGINE_SEARCH_UI_PATH = `${ENGINE_PATH}/reference_application/new`;
 export const ENGINE_API_LOGS_PATH = `${ENGINE_PATH}/api-logs`;

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.test.ts
@@ -130,6 +130,71 @@ describe('curations routes', () => {
     });
   });
 
+  describe('GET /api/app_search/engines/{engineName}/curations/{curationId}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/app_search/engines/{engineName}/curations/{curationId}',
+      });
+
+      registerCurationsRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/as/engines/:engineName/curations/:curationId',
+      });
+    });
+  });
+
+  describe('PUT /api/app_search/engines/{engineName}/curations/{curationId}', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'put',
+        path: '/api/app_search/engines/{engineName}/curations/{curationId}',
+      });
+
+      registerCurationsRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/as/engines/:engineName/curations/:curationId',
+      });
+    });
+
+    describe('validates', () => {
+      it('required body', () => {
+        const request = {
+          body: {
+            query: 'hello',
+            queries: ['hello', 'world'],
+            promoted: ['some-doc-id'],
+            hidden: ['another-doc-id'],
+          },
+        };
+        mockRouter.shouldValidate(request);
+      });
+
+      it('missing body', () => {
+        const request = { body: {} };
+        mockRouter.shouldThrow(request);
+      });
+    });
+  });
+
   describe('GET /api/app_search/engines/{engineName}/curations/find_or_create', () => {
     let mockRouter: MockRouter;
 

--- a/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/app_search/curations.ts
@@ -65,6 +65,42 @@ export function registerCurationsRoutes({
 
   router.get(
     {
+      path: '/api/app_search/engines/{engineName}/curations/{curationId}',
+      validate: {
+        params: schema.object({
+          engineName: schema.string(),
+          curationId: schema.string(),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/as/engines/:engineName/curations/:curationId',
+    })
+  );
+
+  router.put(
+    {
+      path: '/api/app_search/engines/{engineName}/curations/{curationId}',
+      validate: {
+        params: schema.object({
+          engineName: schema.string(),
+          curationId: schema.string(),
+        }),
+        body: schema.object({
+          query: schema.string(),
+          queries: schema.arrayOf(schema.string()),
+          promoted: schema.arrayOf(schema.string()),
+          hidden: schema.arrayOf(schema.string()),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/as/engines/:engineName/curations/:curationId',
+    })
+  );
+
+  router.get(
+    {
       path: '/api/app_search/engines/{engineName}/curations/find_or_create',
       validate: {
         params: schema.object({


### PR DESCRIPTION
## Summary

I recommend following along by commit. This PR adds some basic set-up for the single Curation view.

- Adds server routes
- Adds CurationLogic file with **ONLY** API calls/listeners (there will be more to this file in follow-up PRs)
- Adds Curation.ts view with **ONLY**  a title & breadcrumb, but you should be able to see the GET curation XHR call in your dev tools:
  <img width="940" alt="" src="https://user-images.githubusercontent.com/549407/110674873-2b2efd80-8187-11eb-8958-de6a346fe30f.png">
- Update CurationsRouter to remove the `add_result` route - per discussion with Davey, we'll be moving that to a flyout as it feels awkward as its own standalone page.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios