### PR TITLE
[App Search] Role mappings migration part 1

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -54,7 +54,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
   const { navigateToUrl } = useValues(KibanaLogic);
   const { hasPlatinumLicense } = useValues(LicensingLogic);
 
-  const generteEncodedEnginePath = (engineName: string) =>
+  const generateEncodedEnginePath = (engineName: string) =>
     generateEncodedPath(ENGINE_PATH, { engineName });
   const sendEngineTableLinkClickTelemetry = () =>
     sendAppSearchTelemetry({
@@ -71,7 +71,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
       render: (name: string) => (
         <EuiLinkTo
           data-test-subj="EngineNameLink"
-          to={generteEncodedEnginePath(name)}
+          to={generateEncodedEnginePath(name)}
           onClick={sendEngineTableLinkClickTelemetry}
         >
           {name}
@@ -159,7 +159,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
         icon: 'eye',
         onClick: (engineDetails) => {
           sendEngineTableLinkClickTelemetry();
-          navigateToUrl(generteEncodedEnginePath(engineDetails.name));
+          navigateToUrl(generateEncodedEnginePath(engineDetails.name));
         },
       },
       {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/utils.test.ts
@@ -11,6 +11,6 @@ describe('generateRoleMappingPath', () => {
   it('generates paths with roleId filled', () => {
     const roleId = 'role123';
 
-    expect(generateRoleMappingPath(roleId)).toEqual(`/role-mappings/${roleId}/edit`);
+    expect(generateRoleMappingPath(roleId)).toEqual(`/role_mappings/${roleId}`);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/utils.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { generateRoleMappingPath } from './utils';
+
+describe('generateRoleMappingPath', () => {
+  it('generates paths with roleId filled', () => {
+    const roleId = 'role123';
+
+    expect(generateRoleMappingPath(roleId)).toEqual(`/role-mappings/${roleId}/edit`);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/utils.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ROLE_MAPPING_PATH } from '../../routes';
+import { generateEncodedPath } from '../../utils/encode_path_params';
+
+export const generateRoleMappingPath = (roleId: string) =>
+  generateEncodedPath(ROLE_MAPPING_PATH, { roleId });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/index.test.tsx
@@ -156,7 +156,7 @@ describe('AppSearchNav', () => {
     const wrapper = shallow(<AppSearchNav />);
 
     expect(wrapper.find(SideNavLink).last().prop('to')).toEqual(
-      'http://localhost:3002/as#/role-mappings'
+      'http://localhost:3002/as/role_mappings'
     );
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -10,14 +10,13 @@ import { docLinks } from '../shared/doc_links';
 export const DOCS_PREFIX = docLinks.appSearchBase;
 
 export const ROOT_PATH = '/';
-export const NOT_FOUND_PATH = '/404';
 export const SETUP_GUIDE_PATH = '/setup_guide';
 export const LIBRARY_PATH = '/library';
 export const SETTINGS_PATH = '/settings/account';
 export const CREDENTIALS_PATH = '/credentials';
 
-export const ROLE_MAPPINGS_PATH = '/role-mappings';
-export const ROLE_MAPPING_PATH = `${ROLE_MAPPINGS_PATH}/:roleId/edit`;
+export const ROLE_MAPPINGS_PATH = '/role_mappings';
+export const ROLE_MAPPING_PATH = `${ROLE_MAPPINGS_PATH}/:roleId`;
 export const ROLE_MAPPING_NEW_PATH = `${ROLE_MAPPINGS_PATH}/new`;
 
 export const ENGINES_PATH = '/engines';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -10,11 +10,15 @@ import { docLinks } from '../shared/doc_links';
 export const DOCS_PREFIX = docLinks.appSearchBase;
 
 export const ROOT_PATH = '/';
+export const NOT_FOUND_PATH = '/404';
 export const SETUP_GUIDE_PATH = '/setup_guide';
 export const LIBRARY_PATH = '/library';
 export const SETTINGS_PATH = '/settings/account';
 export const CREDENTIALS_PATH = '/credentials';
-export const ROLE_MAPPINGS_PATH = '#/role-mappings'; // This page seems to 404 if the # isn't included
+
+export const ROLE_MAPPINGS_PATH = '/role-mappings';
+export const ROLE_MAPPING_PATH = `${ROLE_MAPPINGS_PATH}/:roleId/edit`;
+export const ROLE_MAPPING_NEW_PATH = `${ROLE_MAPPINGS_PATH}/new`;
 
 export const ENGINES_PATH = '/engines';
 export const ENGINE_CREATION_PATH = '/engine_creation';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/has_scoped_engines.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/utils/role/has_scoped_engines.test.ts
@@ -7,7 +7,7 @@
 
 import { roleHasScopedEngines } from './';
 
-describe('roleHasScopedEngines()', () => {
+describe('roleHasScopedEngines', () => {
   it('returns false for owner and admin roles', () => {
     expect(roleHasScopedEngines('owner')).toEqual(false);
     expect(roleHasScopedEngines('admin')).toEqual(false);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/__mocks__/roles.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/__mocks__/roles.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import { AttributeName } from '../../types';
+
 export const asRoleMapping = {
   id: null,
-  attributeName: 'role',
+  attributeName: 'role' as AttributeName,
   attributeValue: ['superuser'],
   authProvider: ['*'],
   roleType: 'owner',
@@ -23,7 +25,7 @@ export const asRoleMapping = {
 
 export const wsRoleMapping = {
   id: '602d4ba85foobarbaz123',
-  attributeName: 'username',
+  attributeName: 'username' as AttributeName,
   attributeValue: 'user',
   authProvider: ['*', 'other_auth'],
   roleType: 'admin',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.test.tsx
@@ -11,7 +11,9 @@ import { shallow, ShallowWrapper } from 'enzyme';
 
 import { EuiComboBox, EuiFieldText } from '@elastic/eui';
 
-import { AttributeSelector, AttributeName } from './attribute_selector';
+import { AttributeName } from '../types';
+
+import { AttributeSelector } from './attribute_selector';
 import { ANY_AUTH_PROVIDER, ANY_AUTH_PROVIDER_OPTION_LABEL } from './constants';
 
 const handleAttributeSelectorChange = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
@@ -20,6 +20,8 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
+import { AttributeName, AttributeExamples } from '../types';
+
 import {
   ANY_AUTH_PROVIDER,
   ANY_AUTH_PROVIDER_OPTION_LABEL,
@@ -30,8 +32,6 @@ import {
   EXTERNAL_ATTRIBUTE_LABEL,
   ATTRIBUTE_VALUE_LABEL,
 } from './constants';
-
-export type AttributeName = keyof AttributeExamples | 'role';
 
 interface Props {
   attributeName: AttributeName;
@@ -45,12 +45,6 @@ interface Props {
   handleAttributeSelectorChange(value: string, elasticsearchRole: string): void;
   handleAttributeValueChange(value: string): void;
   handleAuthProviderChange?(value: string[]): void;
-}
-
-interface AttributeExamples {
-  username: string;
-  email: string;
-  metadata: string;
 }
 
 interface ParentOption extends EuiComboBoxOptionOption<string> {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/constants.ts
@@ -107,3 +107,25 @@ export const MANAGE_ROLE_MAPPING_BUTTON = i18n.translate(
     defaultMessage: 'Manage',
   }
 );
+
+export const ROLE_MAPPINGS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.roleMappingsTitle',
+  {
+    defaultMessage: 'Users & roles',
+  }
+);
+
+export const EMPTY_ROLE_MAPPINGS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.emptyRoleMappingsTitle',
+  {
+    defaultMessage: 'No role mappings yet',
+  }
+);
+
+export const ROLE_MAPPINGS_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.roleMapping.roleMappingsDescription',
+  {
+    defaultMessage:
+      'Define role mappings for elasticsearch-native and elasticsearch-saml authentication.',
+  }
+);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -51,9 +51,17 @@ export interface RoleRules {
   metadata?: string;
 }
 
+export interface AttributeExamples {
+  username: string;
+  email: string;
+  metadata: string;
+}
+
+export type AttributeName = keyof AttributeExamples | 'role';
+
 export interface RoleMapping {
   id: string;
-  attributeName: string;
+  attributeName: AttributeName;
   attributeValue: string;
   authProvider: string[];
   roleType: string;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/constants.ts
@@ -59,13 +59,6 @@ export const GROUP_ASSIGNMENT_ALL_GROUPS_LABEL = i18n.translate(
   }
 );
 
-export const EMPTY_ROLE_MAPPINGS_TITLE = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.roleMapping.emptyRoleMappingsTitle',
-  {
-    defaultMessage: 'No role mappings yet',
-  }
-);
-
 export const EMPTY_ROLE_MAPPINGS_BODY = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.roleMapping.emptyRoleMappingsBody',
   {
@@ -78,20 +71,5 @@ export const ROLE_MAPPINGS_TABLE_HEADER = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.roleMapping.roleMappingsTableHeader',
   {
     defaultMessage: 'Group Access',
-  }
-);
-
-export const ROLE_MAPPINGS_TITLE = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.roleMapping.roleMappingsTitle',
-  {
-    defaultMessage: 'Users & roles',
-  }
-);
-
-export const ROLE_MAPPINGS_DESCRIPTION = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.roleMapping.roleMappingsDescription',
-  {
-    defaultMessage:
-      'Define role mappings for elasticsearch-native and elasticsearch-saml authentication.',
   }
 );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
@@ -14,16 +14,15 @@ import { EuiEmptyPrompt } from '@elastic/eui';
 import { FlashMessages } from '../../../shared/flash_messages';
 import { Loading } from '../../../shared/loading';
 import { AddRoleMappingButton, RoleMappingsTable } from '../../../shared/role_mapping';
+import {
+  EMPTY_ROLE_MAPPINGS_TITLE,
+  ROLE_MAPPINGS_TITLE,
+  ROLE_MAPPINGS_DESCRIPTION,
+} from '../../../shared/role_mapping/constants';
 import { ViewContentHeader } from '../../components/shared/view_content_header';
 import { getRoleMappingPath, ROLE_MAPPING_NEW_PATH } from '../../routes';
 
-import {
-  EMPTY_ROLE_MAPPINGS_TITLE,
-  EMPTY_ROLE_MAPPINGS_BODY,
-  ROLE_MAPPINGS_TABLE_HEADER,
-  ROLE_MAPPINGS_TITLE,
-  ROLE_MAPPINGS_DESCRIPTION,
-} from './constants';
+import { EMPTY_ROLE_MAPPINGS_BODY, ROLE_MAPPINGS_TABLE_HEADER } from './constants';
 
 import { RoleMappingsLogic } from './role_mappings_logic';
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings_logic.ts
@@ -10,8 +10,8 @@ import { kea, MakeLogicType } from 'kea';
 import { clearFlashMessages, flashAPIErrors } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
-import { AttributeName } from '../../../shared/role_mapping/attribute_selector';
 import { ANY_AUTH_PROVIDER } from '../../../shared/role_mapping/constants';
+import { AttributeName } from '../../../shared/types';
 import { ROLE_MAPPINGS_PATH } from '../../routes';
 import { RoleGroup, WSRoleMapping, Role } from '../../types';
 


### PR DESCRIPTION
## Summary

This PR is the first in the migration of the Role Mappings UI to Kibana. 

There are 2 unrelated changes I've snuck in here for convenience (https://github.com/elastic/kibana/commit/b4672cfc2c50c5b0042a37d51d9781c1169580ac, https://github.com/elastic/kibana/commit/3d38d501b1bc4e2e80e9b8bc37d04a7f3be3b22d)

There are 2 commits that move types (https://github.com/elastic/kibana/commit/4033d16652bc9f0e7a4de11116e518ea08267caa) and constants (https://github.com/elastic/kibana/commit/3ed896d7a1b23e79e47a33b54d94459326280c57) to shared for use in both apps.

Finally, routes and a path generator were added (https://github.com/elastic/kibana/commit/8920d560594b1483218431fe971c93bf211f51c7).

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
