### PR TITLE
[Workplace Search] Support proxying OAuth1 callbacks

### DIFF
--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -857,9 +857,10 @@ export function registerOauthConnectorParamsRoute({
       validate: {
         query: schema.object({
           kibana_host: schema.string(),
-          code: schema.string(),
+          code: schema.maybe(schema.string()),
           session_state: schema.maybe(schema.string()),
           state: schema.string(),
+          oauth_token: schema.maybe(schema.string()),
           oauth_verifier: schema.maybe(schema.string()),
         }),
       },


### PR DESCRIPTION
A small change to the expected params for the OAuth callback endpoint was required to get some of our OAuth1 connection flows working.