### PR TITLE
[7.x] [Metrics UI] Use memory limit for K8S when available (#93686)

### DIFF
--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/memory.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/snapshot/memory.ts
@@ -8,5 +8,27 @@
 import { MetricsUIAggregation } from '../../../types';
 
 export const memory: MetricsUIAggregation = {
-  memory: { avg: { field: 'kubernetes.pod.memory.usage.node.pct' } },
+  memory_with_limit: {
+    avg: {
+      field: 'kubernetes.pod.memory.usage.limit.pct',
+    },
+  },
+  memory_without_limit: {
+    avg: {
+      field: 'kubernetes.pod.memory.usage.node.pct',
+    },
+  },
+  memory: {
+    bucket_script: {
+      buckets_path: {
+        with_limit: 'memory_with_limit',
+        without_limit: 'memory_without_limit',
+      },
+      script: {
+        source: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
+        lang: 'painless',
+      },
+      gap_policy: 'skip',
+    },
+  },
 };

--- a/x-pack/plugins/infra/common/inventory_models/pod/metrics/tsvb/pod_memory_usage.ts
+++ b/x-pack/plugins/infra/common/inventory_models/pod/metrics/tsvb/pod_memory_usage.ts
@@ -25,8 +25,22 @@ export const podMemoryUsage: TSVBMetricModelCreator = (
       metrics: [
         {
           field: 'kubernetes.pod.memory.usage.node.pct',
-          id: 'avg-memory-usage',
+          id: 'avg-memory-without',
           type: 'avg',
+        },
+        {
+          field: 'kubernetes.pod.memory.usage.limit.pct',
+          id: 'avg-memory-with',
+          type: 'avg',
+        },
+        {
+          id: 'memory-usage',
+          type: 'calculation',
+          variables: [
+            { id: 'memory_with', name: 'with_limit', field: 'avg-memory-with' },
+            { id: 'memory_without', name: 'without_limit', field: 'avg-memory-without' },
+          ],
+          script: 'params.with_limit > 0.0 ? params.with_limit : params.without_limit',
         },
       ],
     },


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Metrics UI] Use memory limit for K8S when available (#93686)