### PR TITLE
[7.x] Use documentation link service for remote clusters (#93937)

### DIFF
--- a/src/core/public/doc_links/doc_links_service.ts
+++ b/src/core/public/doc_links/doc_links_service.ts
@@ -133,7 +133,7 @@ export class DocLinksService {
           remoteClustersProxy: `${ELASTICSEARCH_DOCS}modules-remote-clusters.html#proxy-mode`,
           remoteClusersProxySettings: `${ELASTICSEARCH_DOCS}modules-remote-clusters.html#remote-cluster-proxy-settings`,
           scriptParameters: `${ELASTICSEARCH_DOCS}modules-scripting-using.html#prefer-params`,
-          transportSettings: `${ELASTICSEARCH_DOCS}modules-transport.html`,
+          transportSettings: `${ELASTICSEARCH_DOCS}modules-network.html`,
         },
         siem: {
           guide: `${ELASTIC_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/index.html`,
@@ -236,6 +236,7 @@ export class DocLinksService {
         },
         ccs: {
           guide: `${ELASTICSEARCH_DOCS}modules-cross-cluster-search.html`,
+          skippingDisconnectedClusters: `${ELASTICSEARCH_DOCS}modules-cross-cluster-search.html#skip-unavailable-clusters`,
         },
         apis: {
           createIndex: `${ELASTICSEARCH_DOCS}indices-create-index.html`,

--- a/x-pack/plugins/remote_clusters/public/application/services/documentation.ts
+++ b/x-pack/plugins/remote_clusters/public/application/services/documentation.ts
@@ -13,13 +13,10 @@ export let transportPortUrl: string;
 export let proxyModeUrl: string;
 export let proxySettingsUrl: string;
 
-export function init(docLinks: DocLinksStart): void {
-  const { DOC_LINK_VERSION, ELASTIC_WEBSITE_URL } = docLinks;
-  const esDocBasePath = `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/${DOC_LINK_VERSION}`;
-
-  skippingDisconnectedClustersUrl = `${esDocBasePath}/modules-cross-cluster-search.html#_skipping_disconnected_clusters`;
-  remoteClustersUrl = `${esDocBasePath}/modules-remote-clusters.html`;
-  transportPortUrl = `${esDocBasePath}/modules-transport.html`;
-  proxyModeUrl = `${esDocBasePath}/modules-remote-clusters.html#proxy-mode`;
-  proxySettingsUrl = `${esDocBasePath}/modules-remote-clusters.html#remote-cluster-proxy-settings`;
+export function init({ links }: DocLinksStart): void {
+  skippingDisconnectedClustersUrl = `${links.ccs.skippingDisconnectedClusters}`;
+  remoteClustersUrl = `${links.elasticsearch.remoteClusters}`;
+  transportPortUrl = `${links.elasticsearch.transportSettings}`;
+  proxyModeUrl = `${links.elasticsearch.remoteClustersProxy}`;
+  proxySettingsUrl = `${links.elasticsearch.remoteClusersProxySettings}`;
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use documentation link service for remote clusters (#93937)