### PR TITLE
[Curation] Add support for a custom drag handle to the Result component

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/results/curation_result.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/results/curation_result.test.tsx
@@ -8,6 +8,7 @@
 import { setMockValues } from '../../../../../__mocks__';
 
 import React from 'react';
+import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
@@ -29,12 +30,15 @@ describe('CurationResult', () => {
     { title: 'add', iconType: 'plus', onClick: () => {} },
     { title: 'remove', iconType: 'minus', onClick: () => {} },
   ];
+  const mockDragging = {} as DraggableProvidedDragHandleProps; // Passed from EuiDraggable
 
   let wrapper: ShallowWrapper;
 
   beforeAll(() => {
     setMockValues(values);
-    wrapper = shallow(<CurationResult result={mockResult} actions={mockActions} />);
+    wrapper = shallow(
+      <CurationResult result={mockResult} actions={mockActions} dragHandleProps={mockDragging} />
+    );
   });
 
   it('passes EngineLogic state', () => {
@@ -42,8 +46,9 @@ describe('CurationResult', () => {
     expect(wrapper.find(Result).prop('schemaForTypeHighlights')).toEqual('some mock schema');
   });
 
-  it('passes result and actions props', () => {
+  it('passes result, actions, and dragHandleProps props', () => {
     expect(wrapper.find(Result).prop('result')).toEqual(mockResult);
     expect(wrapper.find(Result).prop('actions')).toEqual(mockActions);
+    expect(wrapper.find(Result).prop('dragHandleProps')).toEqual(mockDragging);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/results/curation_result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/results/curation_result.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { useValues } from 'kea';
 
@@ -18,9 +19,10 @@ import { Result as ResultType, ResultAction } from '../../../result/types';
 interface Props {
   result: ResultType;
   actions: ResultAction[];
+  dragHandleProps?: DraggableProvidedDragHandleProps;
 }
 
-export const CurationResult: React.FC<Props> = ({ result, actions }) => {
+export const CurationResult: React.FC<Props> = ({ result, actions, dragHandleProps }) => {
   const {
     isMetaEngine,
     engine: { schema },
@@ -33,6 +35,7 @@ export const CurationResult: React.FC<Props> = ({ result, actions }) => {
         actions={actions}
         isMetaEngine={isMetaEngine}
         schemaForTypeHighlights={schema}
+        dragHandleProps={dragHandleProps}
       />
       <EuiSpacer size="m" />
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/library/library.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/library/library.tsx
@@ -14,6 +14,9 @@ import {
   EuiTitle,
   EuiPageContentBody,
   EuiPageContent,
+  EuiDragDropContext,
+  EuiDroppable,
+  EuiDraggable,
 } from '@elastic/eui';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
@@ -226,6 +229,28 @@ export const Library: React.FC = () => {
           </EuiTitle>
           <EuiSpacer />
           <Result {...props} actions={actions} shouldLinkToDetailPage />
+          <EuiSpacer />
+
+          <EuiSpacer />
+          <EuiTitle size="s">
+            <h3>With a drag handle</h3>
+          </EuiTitle>
+          <EuiSpacer />
+          <EuiDragDropContext onDragEnd={() => {}}>
+            <EuiDroppable spacing="m" droppableId="DraggableResultsTest">
+              {[1, 2, 3].map((_, i) => (
+                <EuiDraggable
+                  spacing="m"
+                  key={`draggable-${i}`}
+                  index={i}
+                  draggableId={`draggable-${i}`}
+                  customDragHandle
+                >
+                  {(provided) => <Result {...props} dragHandleProps={provided.dragHandleProps} />}
+                </EuiDraggable>
+              ))}
+            </EuiDroppable>
+          </EuiDragDropContext>
           <EuiSpacer />
 
           <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.scss
@@ -1,10 +1,10 @@
 .appSearchResult {
   display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: 1fr auto;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto 1fr auto;
   grid-template-areas:
-    'content actions'
-    'toggle actions';
+    'drag content actions'
+    'drag toggle actions';
   overflow: hidden; // Prevents child background-colors from clipping outside of panel border-radius
 
   &__content {
@@ -51,6 +51,15 @@
     &:focus {
       background-color: $euiPageBackgroundColor;
     }
+  }
+
+  &__dragHandle {
+    grid-area: drag;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: $euiSizeXL;
+    border-right: $euiBorderThin;
   }
 }
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { shallow, ShallowWrapper } from 'enzyme';
 
@@ -126,6 +127,20 @@ describe('Result', () => {
     it('will render custom actions seamlessly next to the document detail link', () => {
       const wrapper = shallow(<Result {...props} actions={actions} shouldLinkToDetailPage />);
       expect(wrapper.find('.appSearchResult__actionButton')).toHaveLength(3);
+    });
+  });
+
+  describe('dragging', () => {
+    // In the real world, the drag library sets data attributes, role, tabIndex, etc.
+    const mockDragHandleProps = ({
+      someMockProp: true,
+    } as unknown) as DraggableProvidedDragHandleProps;
+
+    it('will render a drag handle with the passed props', () => {
+      const wrapper = shallow(<Result {...props} dragHandleProps={mockDragHandleProps} />);
+
+      expect(wrapper.find('.appSearchResult__dragHandle')).toHaveLength(1);
+      expect(wrapper.find('.appSearchResult__dragHandle').prop('someMockProp')).toEqual(true);
     });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result/result.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
+import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import classNames from 'classnames';
 
@@ -31,6 +32,7 @@ interface Props {
   shouldLinkToDetailPage?: boolean;
   schemaForTypeHighlights?: Schema;
   actions?: ResultAction[];
+  dragHandleProps?: DraggableProvidedDragHandleProps;
 }
 
 const RESULT_CUTOFF = 5;
@@ -42,6 +44,7 @@ export const Result: React.FC<Props> = ({
   shouldLinkToDetailPage = false,
   schemaForTypeHighlights,
   actions = [],
+  dragHandleProps,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -87,6 +90,11 @@ export const Result: React.FC<Props> = ({
         values: { id: result[ID].raw },
       })}
     >
+      {dragHandleProps && (
+        <div {...dragHandleProps} className="appSearchResult__dragHandle">
+          <EuiIcon type="grab" />
+        </div>
+      )}
       {conditionallyLinkedArticle(
         <>
           <ResultHeader


### PR DESCRIPTION
## Summary

I forgot to add this when opening the [earlier Result PR](https://github.com/elastic/kibana/pull/94378) that added actions, doh 🤦‍♀️ Or maybe I'm just... _really_ a fan of atomic PRs, let's go with that 😐 

### Rationale

Order matters for the promoted documents list in Curations, so we need the ability to reorder results. For better UX, @daveyholler has requested we add a drag handle to the Result component (vs. making the entire component draggable w/o a grab icon).

### Screencaps

<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/111231372-6033b980-85a6-11eb-8eb2-5aa9a13246cc.png">

![reorder](https://user-images.githubusercontent.com/549407/111231390-688bf480-85a6-11eb-8edc-962da8ffcda0.gif)

Not captured in the above screencap - the `dragHandleProps` manages changing the cursor to a move/grab icon for us. Pretty neat!

## QA

Feel free to visit http://localhost:5601/xyz/app/enterprise_search/app_search/library to test out the UI/UX of dragging before the next Curation PR (please note however that the library example doesn't actually contain any real reordering logic).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

NOTE: I'm not 100% how keyboard accessibility is intended to work, but I'm marking that as out of scope as this would likely be something for either the EUI team to handle (likely via the underlying library, `react-beautiful-dnd`) and propagate across the org, rather than for our team to try and tackle ourselves.