### PR TITLE
[APM] Use top_hits instead of top_metrics

### DIFF
--- a/x-pack/plugins/apm/server/lib/services/get_service_dependencies/get_destination_map.ts
+++ b/x-pack/plugins/apm/server/lib/services/get_service_dependencies/get_destination_map.ts
@@ -71,12 +71,9 @@ export const getDestinationMap = ({
               },
               aggs: {
                 sample: {
-                  top_metrics: {
-                    metrics: [
-                      { field: SPAN_TYPE },
-                      { field: SPAN_SUBTYPE },
-                      { field: SPAN_ID },
-                    ] as const,
+                  top_hits: {
+                    size: 1,
+                    _source: [SPAN_TYPE, SPAN_SUBTYPE, SPAN_ID],
                     sort: {
                       '@timestamp': 'desc',
                     },
@@ -91,15 +88,15 @@ export const getDestinationMap = ({
 
     const outgoingConnections =
       response.aggregations?.connections.buckets.map((bucket) => {
-        const fieldValues = bucket.sample.top[0].metrics;
+        const sample = bucket.sample.hits.hits[0]._source;
 
         return {
           [SPAN_DESTINATION_SERVICE_RESOURCE]: String(
             bucket.key[SPAN_DESTINATION_SERVICE_RESOURCE]
           ),
-          [SPAN_ID]: (fieldValues[SPAN_ID] ?? '') as string,
-          [SPAN_TYPE]: (fieldValues[SPAN_TYPE] ?? '') as string,
-          [SPAN_SUBTYPE]: (fieldValues[SPAN_SUBTYPE] ?? '') as string,
+          [SPAN_ID]: sample.span.id,
+          [SPAN_TYPE]: sample.span.type,
+          [SPAN_SUBTYPE]: sample.span.subtype,
         };
       }) ?? [];
 

--- a/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/distribution/get_buckets/index.ts
@@ -118,11 +118,8 @@ export async function getBuckets({
                     }),
                     aggs: {
                       samples: {
-                        top_metrics: {
-                          metrics: [
-                            { field: TRANSACTION_ID },
-                            { field: TRACE_ID },
-                          ] as const,
+                        top_hits: {
+                          _source: [TRANSACTION_ID, TRACE_ID],
                           size: 10,
                           sort: {
                             _score: 'desc',
@@ -138,11 +135,12 @@ export async function getBuckets({
 
         return (
           response.aggregations?.distribution.buckets.map((bucket) => {
+            const samples = bucket.samples.hits.hits;
             return {
               key: bucket.key,
-              samples: bucket.samples.top.map((sample) => ({
-                traceId: sample.metrics[TRACE_ID] as string,
-                transactionId: sample.metrics[TRANSACTION_ID] as string,
+              samples: samples.map(({ _source: sample }) => ({
+                traceId: sample.trace.id,
+                transactionId: sample.transaction.id,
               })),
             };
           }) ?? []

--- a/x-pack/test/apm_api_integration/tests/transactions/distribution.ts
+++ b/x-pack/test/apm_api_integration/tests/transactions/distribution.ts
@@ -82,16 +82,16 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           .toMatchInline(`
           Array [
             Object {
-              "traceId": "a4eb3781a21dc11d289293076fd1a1b3",
-              "transactionId": "21892bde4ff1364d",
+              "traceId": "af0f18dc0841cfc1f567e7e1d55cfda7",
+              "transactionId": "925f02e5ac122897",
             },
             Object {
               "traceId": "ccd327537120e857bdfa407434dfb9a4",
               "transactionId": "c5f923159cc1b8a6",
             },
             Object {
-              "traceId": "af0f18dc0841cfc1f567e7e1d55cfda7",
-              "transactionId": "925f02e5ac122897",
+              "traceId": "a4eb3781a21dc11d289293076fd1a1b3",
+              "transactionId": "21892bde4ff1364d",
             },
           ]
         `);


### PR DESCRIPTION
Closes #94676.

See also https://github.com/elastic/elasticsearch/issues/70453.