### PR TITLE
[APM] kuery is not applied to latency chart

### DIFF
--- a/x-pack/plugins/apm/server/lib/transactions/get_latency_charts/index.ts
+++ b/x-pack/plugins/apm/server/lib/transactions/get_latency_charts/index.ts
@@ -183,6 +183,7 @@ export async function getLatencyPeriods({
   latencyAggregationType,
   comparisonStart,
   comparisonEnd,
+  kuery,
 }: {
   serviceName: string;
   transactionType: string | undefined;
@@ -192,6 +193,7 @@ export async function getLatencyPeriods({
   latencyAggregationType: LatencyAggregationType;
   comparisonStart?: number;
   comparisonEnd?: number;
+  kuery?: string;
 }) {
   const { start, end } = setup;
   const options = {
@@ -200,6 +202,7 @@ export async function getLatencyPeriods({
     transactionName,
     setup,
     searchAggregatedTransactions,
+    kuery,
   };
 
   const currentPeriodPromise = getLatencyTimeseries({


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/94682

<img width="1985" alt="Screen Shot 2021-03-16 at 10 18 55" src="https://user-images.githubusercontent.com/55978943/111325509-2617f580-8642-11eb-8a84-6c1428f535b1.png">
<img width="1991" alt="Screen Shot 2021-03-16 at 10 19 02" src="https://user-images.githubusercontent.com/55978943/111325513-26b08c00-8642-11eb-946c-926096b63b7e.png">
