### PR TITLE
[Discover] Move doc viewer table row actions to left

### DIFF
--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.scss
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.scss
@@ -52,7 +52,7 @@
   white-space: nowrap;
 }
 .kbnDocViewer__buttons {
-  width: 96px;
+  width: 108px;
 
   // Show all icons if one is focused,
   &:focus-within {
@@ -64,8 +64,8 @@
 
 .kbnDocViewer__field {
   width: $euiSize * 10;
-  @include euiBreakpoint('xs', 's') {
-    width: $euiSize * 6;
+  @include euiBreakpoint('xs', 's', 'm', 'l', 'xl') {
+    width: $euiSize * 5;
   }
 }
 

--- a/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.scss
+++ b/src/plugins/discover/public/application/components/doc_viewer/doc_viewer.scss
@@ -1,5 +1,5 @@
 .kbnDocViewerTable {
-  @include euiBreakpoint('xs', 's') {
+  @include euiBreakpoint('xs', 's','m') {
     table-layout: fixed;
   }
 }
@@ -64,8 +64,8 @@
 
 .kbnDocViewer__field {
   width: $euiSize * 10;
-  @include euiBreakpoint('xs', 's', 'm', 'l', 'xl') {
-    width: $euiSize * 5;
+  @include euiBreakpoint('xs', 's', 'm') {
+    width: $euiSize * 6;
   }
 }
 

--- a/src/plugins/discover/public/application/components/table/table_row.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row.tsx
@@ -54,6 +54,26 @@ export function DocViewTableRow({
   const key = field ? field : fieldMapping?.displayName;
   return (
     <tr key={key} data-test-subj={`tableDocViewRow-${key}`}>
+      {typeof onFilter === 'function' && (
+        <td className="kbnDocViewer__buttons">
+          <DocViewTableRowBtnFilterAdd
+            disabled={!fieldMapping || !fieldMapping.filterable}
+            onClick={() => onFilter(fieldMapping, valueRaw, '+')}
+          />
+          <DocViewTableRowBtnFilterRemove
+            disabled={!fieldMapping || !fieldMapping.filterable}
+            onClick={() => onFilter(fieldMapping, valueRaw, '-')}
+          />
+          {typeof onToggleColumn === 'function' && (
+            <DocViewTableRowBtnToggleColumn active={isColumnActive} onClick={onToggleColumn} />
+          )}
+          <DocViewTableRowBtnFilterExists
+            disabled={!fieldMapping || !fieldMapping.filterable}
+            onClick={() => onFilter('_exists_', field, '+')}
+            scripted={fieldMapping && fieldMapping.scripted}
+          />
+        </td>
+      )}
       <td className="kbnDocViewer__field">
         {field ? (
           <FieldName
@@ -83,26 +103,6 @@ export function DocViewTableRow({
           dangerouslySetInnerHTML={{ __html: value as string }}
         />
       </td>
-      {typeof onFilter === 'function' && (
-        <td className="kbnDocViewer__buttons">
-          <DocViewTableRowBtnFilterAdd
-            disabled={!fieldMapping || !fieldMapping.filterable}
-            onClick={() => onFilter(fieldMapping, valueRaw, '+')}
-          />
-          <DocViewTableRowBtnFilterRemove
-            disabled={!fieldMapping || !fieldMapping.filterable}
-            onClick={() => onFilter(fieldMapping, valueRaw, '-')}
-          />
-          {typeof onToggleColumn === 'function' && (
-            <DocViewTableRowBtnToggleColumn active={isColumnActive} onClick={onToggleColumn} />
-          )}
-          <DocViewTableRowBtnFilterExists
-            disabled={!fieldMapping || !fieldMapping.filterable}
-            onClick={() => onFilter('_exists_', field, '+')}
-            scripted={fieldMapping && fieldMapping.scripted}
-          />
-        </td>
-      )}
     </tr>
   );
 }


### PR DESCRIPTION
## Summary

This PR moves back the doc viewer table row action to the left side.
<img width="836" alt="Bildschirmfoto 2021-03-22 um 15 37 27" src="https://user-images.githubusercontent.com/463851/112007961-620cf800-8b25-11eb-8f40-3b63ab47b1e2.png">
Having those action on the right side caused difficulties for people with lot's of screen width. It's just a quick solution, because in the future we should use `EuiBasicTable` or `EuiDataGrid` to improve this component and get rid of legacy css.

