### PR TITLE
[App Search] Fix Relevance Tuning bugs

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { EuiAccordion } from '@elastic/eui';
+
+import { BoostIcon } from '../boost_icon';
+import { BoostType } from '../types';
+
+import { ValueBadge } from '../value_badge';
+
+import { BoostItem } from './boost_item';
+import { BoostItemContent } from './boost_item_content';
+
+describe('BoostItem', () => {
+  const boost = {
+    factor: 2,
+    type: BoostType.Value,
+    newBoost: true,
+    value: [''],
+  };
+
+  let wrapper: ShallowWrapper;
+  let accordian: ShallowWrapper;
+
+  beforeAll(() => {
+    wrapper = shallow(<BoostItem id="some_id" boost={boost} index={1} name="foo" />);
+    accordian = wrapper.find(EuiAccordion) as ShallowWrapper;
+  });
+
+  it('renders an accordion as open if it is a newly created boost', () => {
+    expect(accordian.prop('initialIsOpen')).toEqual(boost.newBoost);
+  });
+
+  it('renders an accordion button which shows a summary of the boost', () => {
+    const buttonContent = shallow(
+      accordian.prop('buttonContent') as React.ReactElement
+    ) as ShallowWrapper;
+
+    expect(buttonContent.find(BoostIcon).prop('type')).toEqual('value');
+    expect(buttonContent.find(ValueBadge).children().text()).toEqual('2');
+  });
+
+  it('renders boost content inside of the accordion', () => {
+    const content = wrapper.find(BoostItemContent);
+    expect(content.props()).toEqual({
+      boost,
+      index: 1,
+      name: 'foo',
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item.tsx
@@ -32,6 +32,7 @@ export const BoostItem: React.FC<Props> = ({ id, boost, index, name }) => {
       id={id}
       className="boosts__item"
       buttonContentClassName="boosts__itemButton"
+      initialIsOpen={!!boost.newBoost}
       buttonContent={
         <EuiFlexGroup responsive={false} alignItems="center">
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/boost_item_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/boost_item_content.test.tsx
@@ -35,6 +35,7 @@ describe('BoostItemContent', () => {
     const boost = {
       factor: 2,
       type: 'value' as BoostType,
+      value: [''],
     };
 
     const wrapper = shallow(<BoostItemContent boost={boost} index={3} name="foo" />);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/value_boost_form.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/value_boost_form.test.tsx
@@ -50,20 +50,6 @@ describe('ValueBoostForm', () => {
     expect(valueInput(wrapper, 2).prop('value')).toEqual('baz');
   });
 
-  it('renders a single empty text box if the boost has no value', () => {
-    const wrapper = shallow(
-      <ValueBoostForm
-        boost={{
-          ...boost,
-          value: undefined,
-        }}
-        index={3}
-        name="foo"
-      />
-    );
-    expect(valueInput(wrapper, 0).prop('value')).toEqual('');
-  });
-
   it('updates the corresponding value in state whenever a user changes the value in a text input', () => {
     const wrapper = shallow(<ValueBoostForm boost={boost} index={3} name="foo" />);
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/value_boost_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boost_item_content/value_boost_form.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 export const ValueBoostForm: React.FC<Props> = ({ boost, index, name }) => {
   const { updateBoostValue, removeBoostValue, addBoostValue } = useActions(RelevanceTuningLogic);
-  const values = boost.value || [''];
+  const values = boost.value;
 
   return (
     <>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boosts.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/boosts/boosts.test.tsx
@@ -108,6 +108,7 @@ describe('Boosts', () => {
     const boost1 = {
       factor: 2,
       type: 'value' as BoostType,
+      value: [''],
     };
     const boost2 = {
       factor: 10,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/constants.ts
@@ -83,6 +83,7 @@ export const BOOST_TYPE_TO_ICON_MAP = {
 const EMPTY_VALUE_BOOST: ValueBoost = {
   type: BoostType.Value,
   factor: 1,
+  value: [''],
   newBoost: true,
   function: undefined,
   operation: undefined,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_form.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_form.test.tsx
@@ -34,6 +34,7 @@ describe('RelevanceTuningForm', () => {
           {
             factor: 2,
             type: BoostType.Value,
+            value: [],
           },
         ],
       },
@@ -85,6 +86,7 @@ describe('RelevanceTuningForm', () => {
         {
           factor: 2,
           type: BoostType.Value,
+          value: [],
         },
       ]);
       expect(relevantTuningItems.at(1).prop('boosts')).toBeUndefined();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_item.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_item.test.tsx
@@ -25,6 +25,7 @@ describe('RelevanceTuningItem', () => {
       {
         factor: 2,
         type: BoostType.Value,
+        value: [''],
       },
     ],
     field: {
@@ -54,6 +55,7 @@ describe('RelevanceTuningItem', () => {
           {
             factor: 2,
             type: BoostType.Value,
+            value: [''],
           },
           {
             factor: 3,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_item_content/relevance_tuning_item_content.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_form/relevance_tuning_item_content/relevance_tuning_item_content.test.tsx
@@ -24,6 +24,7 @@ describe('RelevanceTuningItemContent', () => {
       {
         factor: 2,
         type: BoostType.Value,
+        value: [''],
       },
     ],
     field: {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -484,6 +484,14 @@ describe('RelevanceTuningLogic', () => {
                 type: BoostType.Value,
                 factor: 5,
                 newBoost: true, // This should be deleted before sent to the server
+                value: ['test'],
+              },
+            ],
+            bar: [
+              // This should be filtered out since empty value boosts are invalid
+              {
+                type: BoostType.Value,
+                factor: 5,
                 value: [''],
               },
             ],
@@ -496,7 +504,7 @@ describe('RelevanceTuningLogic', () => {
               {
                 type: BoostType.Value,
                 factor: 5,
-                value: [''],
+                value: ['test'],
               },
             ],
           },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -23,6 +23,7 @@ describe('RelevanceTuningLogic', () => {
         {
           type: BoostType.Value,
           factor: 5,
+          value: [],
         },
       ],
     },
@@ -483,6 +484,7 @@ describe('RelevanceTuningLogic', () => {
                 type: BoostType.Value,
                 factor: 5,
                 newBoost: true, // This should be deleted before sent to the server
+                value: [''],
               },
             ],
           },
@@ -494,6 +496,7 @@ describe('RelevanceTuningLogic', () => {
               {
                 type: BoostType.Value,
                 factor: 5,
+                value: [''],
               },
             ],
           },
@@ -700,6 +703,7 @@ describe('RelevanceTuningLogic', () => {
                 {
                   factor: 2,
                   type: BoostType.Value,
+                  value: [''],
                 },
               ],
             },
@@ -716,6 +720,7 @@ describe('RelevanceTuningLogic', () => {
               {
                 factor: 2,
                 type: BoostType.Value,
+                value: [''],
               },
               {
                 factor: 1,
@@ -773,6 +778,7 @@ describe('RelevanceTuningLogic', () => {
                 {
                   factor: 2,
                   type: BoostType.Value,
+                  value: [''],
                 },
               ],
             },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -324,6 +324,7 @@ describe('RelevanceTuningLogic', () => {
                 type: BoostType.Value,
                 factor: 5,
                 newBoost: true, // This should be deleted before sent to the server
+                value: ['test'],
               },
             ],
           },
@@ -341,6 +342,7 @@ describe('RelevanceTuningLogic', () => {
               {
                 type: BoostType.Value,
                 factor: 5,
+                value: ['test'],
               },
             ],
           },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -225,7 +225,7 @@ describe('RelevanceTuningLogic', () => {
 
   describe('listeners', () => {
     const { http } = mockHttpValues;
-    const { flashAPIErrors, setSuccessMessage } = mockFlashMessageHelpers;
+    const { flashAPIErrors, setSuccessMessage, clearFlashMessages } = mockFlashMessageHelpers;
     let scrollToSpy: jest.SpyInstance;
     let confirmSpy: jest.SpyInstance;
 
@@ -317,7 +317,7 @@ describe('RelevanceTuningLogic', () => {
         jest.useRealTimers();
       });
 
-      it('should make an API call and set state based on the response', async () => {
+      it('should make an API call, set state based on the response, and clear flash messages', async () => {
         const searchSettingsWithNewBoostProp = {
           boosts: {
             foo: [
@@ -376,6 +376,7 @@ describe('RelevanceTuningLogic', () => {
           }
         );
         expect(RelevanceTuningLogic.actions.setSearchResults).toHaveBeenCalledWith(searchResults);
+        expect(clearFlashMessages).toHaveBeenCalled();
       });
 
       it("won't send boosts or search_fields on the API call if there are none", async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.test.ts
@@ -485,14 +485,6 @@ describe('RelevanceTuningLogic', () => {
                 type: BoostType.Value,
                 factor: 5,
                 newBoost: true, // This should be deleted before sent to the server
-                value: ['test'],
-              },
-            ],
-            bar: [
-              // This should be filtered out since empty value boosts are invalid
-              {
-                type: BoostType.Value,
-                factor: 5,
                 value: [''],
               },
             ],
@@ -505,7 +497,7 @@ describe('RelevanceTuningLogic', () => {
               {
                 type: BoostType.Value,
                 factor: 5,
-                value: ['test'],
+                value: [''],
               },
             ],
           },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -311,7 +311,12 @@ export const RelevanceTuningLogic = kea<
 
       try {
         const response = await http.put(url, {
-          body: JSON.stringify(removeBoostStateProps(values.searchSettings)),
+          body: JSON.stringify({
+            ...removeBoostStateProps({
+              ...values.searchSettings,
+              boosts: removeEmptyValueBoosts(values.searchSettings.boosts),
+            }),
+          }),
         });
         setSuccessMessage(UPDATE_SUCCESS_MESSAGE);
         actions.onSearchSettingsSuccess(response);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -28,6 +28,7 @@ import {
   parseBoostCenter,
   removeBoostStateProps,
   normalizeBoostValues,
+  removeEmptyValueBoosts,
 } from './utils';
 
 interface RelevanceTuningProps {
@@ -273,13 +274,15 @@ export const RelevanceTuningLogic = kea<
 
       actions.setResultsLoading(true);
 
+      const filteredBoosts = removeEmptyValueBoosts(boosts);
+
       try {
         const response = await http.post(url, {
           query: {
             query,
           },
           body: JSON.stringify({
-            boosts: isEmpty(boosts) ? undefined : boosts,
+            boosts: isEmpty(filteredBoosts) ? undefined : filteredBoosts,
             search_fields: isEmpty(searchFields) ? undefined : searchFields,
           }),
         });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -8,7 +8,11 @@
 import { kea, MakeLogicType } from 'kea';
 import { omit, cloneDeep, isEmpty } from 'lodash';
 
-import { setSuccessMessage, flashAPIErrors } from '../../../shared/flash_messages';
+import {
+  setSuccessMessage,
+  flashAPIErrors,
+  clearFlashMessages,
+} from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { Schema, SchemaConflicts } from '../../../shared/types';
 
@@ -288,6 +292,7 @@ export const RelevanceTuningLogic = kea<
         });
 
         actions.setSearchResults(response.results);
+        clearFlashMessages();
       } catch (e) {
         flashAPIErrors(e);
       }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/relevance_tuning_logic.ts
@@ -316,12 +316,7 @@ export const RelevanceTuningLogic = kea<
 
       try {
         const response = await http.put(url, {
-          body: JSON.stringify({
-            ...removeBoostStateProps({
-              ...values.searchSettings,
-              boosts: removeEmptyValueBoosts(values.searchSettings.boosts),
-            }),
-          }),
+          body: JSON.stringify(removeBoostStateProps(values.searchSettings)),
         });
         setSuccessMessage(UPDATE_SUCCESS_MESSAGE);
         actions.onSearchSettingsSuccess(response);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/types.ts
@@ -45,7 +45,7 @@ export interface RawBoost extends Omit<Boost, 'value'> {
 }
 
 export interface ValueBoost extends Boost {
-  value?: string[];
+  value: string[];
   operation: undefined;
   function: undefined;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.test.ts
@@ -4,12 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { BoostType } from './types';
+import { Boost, BoostType } from './types';
 import {
   filterIfTerm,
   normalizeBoostValues,
   removeBoostStateProps,
   parseBoostCenter,
+  removeEmptyValueBoosts,
 } from './utils';
 
 describe('filterIfTerm', () => {
@@ -150,5 +151,33 @@ describe('normalizeBoostValues', () => {
       ],
       sp_def: [{ type: BoostType.Functional, factor: 5 }],
     });
+  });
+});
+
+describe('removeEmptyValueBoosts', () => {
+  const boosts: Record<string, Boost[]> = {
+    bar: [
+      { factor: 9.5, type: BoostType.Proximity },
+      { type: BoostType.Functional, factor: 5 },
+    ],
+    foo: [
+      { factor: 9.5, type: BoostType.Value, value: ['1'] },
+      { factor: 9.5, type: BoostType.Value, value: ['1', '', '   '] },
+      { factor: 9.5, type: BoostType.Value, value: [] },
+      { factor: 9.5, type: BoostType.Value, value: ['', '1'] },
+    ],
+    baz: [{ factor: 9.5, type: BoostType.Value, value: [''] }],
+  };
+
+  expect(removeEmptyValueBoosts(boosts)).toEqual({
+    bar: [
+      { factor: 9.5, type: BoostType.Proximity },
+      { type: BoostType.Functional, factor: 5 },
+    ],
+    foo: [
+      { factor: 9.5, type: BoostType.Value, value: ['1'] },
+      { factor: 9.5, type: BoostType.Value, value: ['1'] },
+      { factor: 9.5, type: BoostType.Value, value: ['1'] },
+    ],
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.test.ts
@@ -43,6 +43,7 @@ describe('removeBoostStateProps', () => {
             type: BoostType.Value,
             factor: 5,
             newBoost: true,
+            value: [''],
           },
         ],
       },
@@ -59,6 +60,7 @@ describe('removeBoostStateProps', () => {
           {
             type: BoostType.Value,
             factor: 5,
+            value: [''],
           },
         ],
       },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
@@ -83,7 +83,7 @@ export const removeEmptyValueBoosts = (
       const valueBoost = boost as ValueBoost;
       return {
         ...boost,
-        value: (valueBoost.value || []).filter((v) => v.trim() !== ''),
+        value: valueBoost.value.filter((v) => v.trim() !== ''),
       };
     });
   };

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/relevance_tuning/utils.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { cloneDeep, omit } from 'lodash';
+import { isEmpty, cloneDeep, omit } from 'lodash';
 
 import { NUMBER } from '../../../shared/constants/field_types';
 import { SchemaTypes } from '../../../shared/types';
 
-import { RawBoost, Boost, SearchSettings, BoostType } from './types';
+import { RawBoost, Boost, SearchSettings, BoostType, ValueBoost } from './types';
 
 // If the user hasn't entered a filter, then we can skip filtering the array entirely
 export const filterIfTerm = (array: string[], filterTerm: string): string[] => {
@@ -61,3 +61,50 @@ export const normalizeBoostValues = (boosts: Record<string, RawBoost[]>): Record
       [fieldName]: boostList.map(normalizeBoostValue),
     };
   }, {});
+
+// Our model allows for empty values to be added to boosts. However, the server will not accept
+// empty strings in values. To avoid that, we filter out empty values before sending them to the server.
+
+// I.e., the server will not accept any of the following, so we need to filter them out
+// value: undefined
+// value: []
+// value: ['']
+// value: ['foo', '']
+export const removeEmptyValueBoosts = (
+  boosts: Record<string, Boost[]>
+): Record<string, Boost[]> => {
+  // before:
+  //   { foo: { values: ['a', '', '   '] } }
+  // after:
+  //   { foo: { values: ['a'] } }
+  const trimBoostValues = (fieldBoosts: Boost[]) => {
+    return fieldBoosts.map((boost: Boost) => {
+      if (boost.type !== BoostType.Value) return boost;
+      const valueBoost = boost as ValueBoost;
+      return {
+        ...boost,
+        value: (valueBoost.value || []).filter((v) => v.trim() !== ''),
+      };
+    });
+  };
+
+  // before:
+  //   { foo: { values: ['a'] } }
+  //   { foo: { values: [] } }
+  // after:
+  //   { foo: { values: ['a'] } }
+  const filterEmptyValueBoosts = (fieldBoosts: Boost[]) => {
+    return fieldBoosts.filter(
+      (boost) => !(boost.type === BoostType.Value && boost.value && boost.value.length === 0)
+    );
+  };
+
+  return Object.entries(boosts).reduce((acc, [fieldName, fieldBoosts]) => {
+    const updatedBoosts = filterEmptyValueBoosts(trimBoostValues(fieldBoosts));
+    if (isEmpty(updatedBoosts)) return acc;
+    return {
+      ...acc,
+      [fieldName]: updatedBoosts,
+    };
+  }, {});
+};


### PR DESCRIPTION
## Summary

### Fix 1

If at any time you have added a value boost, but have not filled in a value in the form, meaning you've let a value boost text field empty, then attempting to query via preview will result in an error. This is a poor user experience. (See attached gif to wrap your head around this)

This happens because the API will not accept empty values for value boosts.

Therefore, there is a disconnect between our UI model and the server model. Our local model supports it, but the server does not.

To correct this issue, I'm simply filtering out empty value boosts before sending boosts to the server. It lets us keep our existing model, while also correcting the issue on the server. 

It also would have been possible to correct this in the server API, by accepting, but ignoring, empty value boosts. I chose to do this on the client as it seemed to be the simplest option at the moment.

It also would have been possible to move this validation to be client side, as to provide a more helpful error message. I felt it was a better UX to avoid an error message altogether.

Before:
![latest](https://user-images.githubusercontent.com/1427475/112014388-3710ad00-8b01-11eb-9fea-9c36c51aea36.gif)

### Fix 2

(EDIT: This fix has been removed)

In addition to being an issue with the search preview functionality, it is also an issue when saving relevance tuning.

I applied the same filtering logic to the save endpoint as well. It gives the UI effect of simply eliminating empty value boosts whenever the form is successfully saved:

Before:
![latest](https://user-images.githubusercontent.com/1427475/112014514-57406c00-8b01-11eb-87df-c28ed747e2ad.gif)

After:
![latest](https://user-images.githubusercontent.com/1427475/112014917-b7cfa900-8b01-11eb-9a12-676842639547.gif)

### Fix 3

When adding a new boost, the boost form was not expanded, which added an additional step for a user, because they'd need to add a boost and then expand the form in order to enter details. I simply toggle the form to open now, when a new boost is added.

After:
![latest](https://user-images.githubusercontent.com/1427475/112015938-a509a400-8b02-11eb-922d-9de895cbd45a.gif)

### Fix 4

When there are validation errors in the *search preview* query, the flash message was *not* reset after the validation error message is fixed. So it was unclear whether or not the issue was resolved.

This would work much better with some client side validation. However, in the meantime, I opted to simply ensure that the flash messages are cleared after every successful search preview query.


Before:
![latest](https://user-images.githubusercontent.com/1427475/112016488-22cdaf80-8b03-11eb-8868-36c2f26b6a74.gif)

After:
![latest](https://user-images.githubusercontent.com/1427475/112017224-ccad3c00-8b03-11eb-9437-28d813f43df7.gif)

### Updated typing

I updated our typing for ValueBoost to now *always* require a `value` property. This simplifies our code. You'll see a large diff related to this.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
