### PR TITLE
[APM] Fix readme for running tsc

### DIFF
--- a/x-pack/plugins/apm/readme.md
+++ b/x-pack/plugins/apm/readme.md
@@ -118,7 +118,7 @@ _Note: Run the following commands from `kibana/`._
 ### Typescript
 
 ```
-yarn tsc --noEmit --project x-pack/plugins/apm/tsconfig.json --skipLibCheck
+yarn tsc --noEmit --emitDeclarationOnly false --project x-pack/plugins/apm/tsconfig.json --skipLibCheck
 ```
 
 ### Prettier


### PR DESCRIPTION
Running `yarn tsc --noEmit --project x-pack/plugins/apm/tsconfig.json --skipLibCheck` gave the following error

```
x-pack/plugins/apm/tsconfig.json:6:5 - error TS5053: Option 'emitDeclarationOnly' cannot be specified with option 'noEmit'.

6     "emitDeclarationOnly": true,
      ~~~~~~~~~~~~~~~~~~~~~


Found 1 error.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Adding `--emitDeclarationOnly false` seems to fix it