### PR TITLE
[App Search] Various engines fixes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import '../../../../__mocks__/kea.mock';
-import { mockTelemetryActions } from '../../../../__mocks__';
+import { setMockValues, mockTelemetryActions } from '../../../../__mocks__';
 
 import React from 'react';
 
@@ -17,30 +17,47 @@ import { EuiEmptyPrompt } from '@elastic/eui';
 import { EmptyState } from './';
 
 describe('EmptyState', () => {
-  it('renders', () => {
-    const wrapper = shallow(<EmptyState />);
+  describe('when the user can manage/create engines', () => {
+    let wrapper: ShallowWrapper;
 
-    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
+    beforeAll(() => {
+      setMockValues({ myRole: { canManageEngines: true } });
+      wrapper = shallow(<EmptyState />);
+    });
+
+    it('renders a prompt to create an engine', () => {
+      expect(wrapper.find('[data-test-subj="AdminEmptyEnginesPrompt"]')).toHaveLength(1);
+    });
+
+    describe('create engine button', () => {
+      let prompt: ShallowWrapper;
+      let button: ShallowWrapper;
+
+      beforeAll(() => {
+        prompt = wrapper.find(EuiEmptyPrompt).dive();
+        button = prompt.find('[data-test-subj="EmptyStateCreateFirstEngineCta"]');
+      });
+
+      it('sends telemetry on create first engine click', () => {
+        button.simulate('click');
+        expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalled();
+      });
+
+      it('sends a user to engine creation', () => {
+        expect(button.prop('to')).toEqual('/engine_creation');
+      });
+    });
   });
 
-  describe('CTA Button', () => {
-    let wrapper: ShallowWrapper;
-    let prompt: ShallowWrapper;
-    let button: ShallowWrapper;
-
-    beforeEach(() => {
-      wrapper = shallow(<EmptyState />);
-      prompt = wrapper.find(EuiEmptyPrompt).dive();
-      button = prompt.find('[data-test-subj="EmptyStateCreateFirstEngineCta"]');
+  describe('when the user cannot manage/create engines', () => {
+    beforeAll(() => {
+      setMockValues({ myRole: { canManageEngines: false } });
     });
 
-    it('sends telemetry on create first engine click', () => {
-      button.simulate('click');
-      expect(mockTelemetryActions.sendAppSearchTelemetry).toHaveBeenCalled();
-    });
+    it('renders a prompt to contact the App Search admin', () => {
+      const wrapper = shallow(<EmptyState />);
 
-    it('sends a user to engine creation', () => {
-      expect(button.prop('to')).toEqual('/engine_creation');
+      expect(wrapper.find('[data-test-subj="NonAdminEmptyEnginesPrompt"]')).toHaveLength(1);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
@@ -7,14 +7,15 @@
 
 import React from 'react';
 
-import { useActions } from 'kea';
+import { useValues, useActions } from 'kea';
 
 import { EuiPageContent, EuiEmptyPrompt } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
 import { SetAppSearchChrome as SetPageChrome } from '../../../../shared/kibana_chrome';
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../../shared/telemetry';
+import { AppLogic } from '../../../app_logic';
 import { ENGINE_CREATION_PATH } from '../../../routes';
 
 import { EnginesOverviewHeader } from './header';
@@ -22,6 +23,9 @@ import { EnginesOverviewHeader } from './header';
 import './empty_state.scss';
 
 export const EmptyState: React.FC = () => {
+  const {
+    myRole: { canManageEngines },
+  } = useValues(AppLogic);
   const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
 
   return (
@@ -29,45 +33,71 @@ export const EmptyState: React.FC = () => {
       <SetPageChrome />
       <EnginesOverviewHeader />
       <EuiPageContent className="emptyState">
-        <EuiEmptyPrompt
-          className="emptyState__prompt"
-          iconType="eyeClosed"
-          title={
-            <h2>
-              <FormattedMessage
-                id="xpack.enterpriseSearch.appSearch.emptyState.title"
-                defaultMessage="Create your first engine"
-              />
-            </h2>
-          }
-          titleSize="l"
-          body={
-            <p>
-              <FormattedMessage
-                id="xpack.enterpriseSearch.appSearch.emptyState.description1"
-                defaultMessage="An App Search engine stores the documents for your search experience."
-              />
-            </p>
-          }
-          actions={
-            <EuiButtonTo
-              data-test-subj="EmptyStateCreateFirstEngineCta"
-              fill
-              to={ENGINE_CREATION_PATH}
-              onClick={() =>
-                sendAppSearchTelemetry({
-                  action: 'clicked',
-                  metric: 'create_first_engine_button',
-                })
-              }
-            >
-              <FormattedMessage
-                id="xpack.enterpriseSearch.appSearch.emptyState.createFirstEngineCta"
-                defaultMessage="Create an engine"
-              />
-            </EuiButtonTo>
-          }
-        />
+        {canManageEngines ? (
+          <EuiEmptyPrompt
+            data-test-subj="AdminEmptyEnginesPrompt"
+            className="emptyState__prompt"
+            iconType="eyeClosed"
+            title={
+              <h2>
+                {i18n.translate('xpack.enterpriseSearch.appSearch.emptyState.title', {
+                  defaultMessage: 'Create your first engine',
+                })}
+              </h2>
+            }
+            titleSize="l"
+            body={
+              <p>
+                {i18n.translate('xpack.enterpriseSearch.appSearch.emptyState.description1', {
+                  defaultMessage:
+                    'An App Search engine stores the documents for your search experience.',
+                })}
+              </p>
+            }
+            actions={
+              <EuiButtonTo
+                data-test-subj="EmptyStateCreateFirstEngineCta"
+                fill
+                to={ENGINE_CREATION_PATH}
+                onClick={() =>
+                  sendAppSearchTelemetry({
+                    action: 'clicked',
+                    metric: 'create_first_engine_button',
+                  })
+                }
+              >
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.emptyState.createFirstEngineCta',
+                  { defaultMessage: 'Create an engine' }
+                )}
+              </EuiButtonTo>
+            }
+          />
+        ) : (
+          <EuiEmptyPrompt
+            data-test-subj="NonAdminEmptyEnginesPrompt"
+            className="emptyState__prompt"
+            iconType="eyeClosed"
+            title={
+              <h2>
+                {i18n.translate('xpack.enterpriseSearch.appSearch.emptyState.nonAdmin.title', {
+                  defaultMessage: 'No engines available',
+                })}
+              </h2>
+            }
+            body={
+              <p>
+                {i18n.translate(
+                  'xpack.enterpriseSearch.appSearch.emptyState.nonAdmin.description',
+                  {
+                    defaultMessage:
+                      'Contact your App Search administrator to either create or grant you access to an engine.',
+                  }
+                )}
+              </p>
+            }
+          />
+        )}
       </EuiPageContent>
     </>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -41,6 +41,7 @@ describe('EnginesOverview', () => {
     },
     metaEnginesLoading: false,
     hasPlatinumLicense: false,
+    myRole: { canManageEngines: false },
   };
   const actions = {
     loadEngines: jest.fn(),
@@ -90,61 +91,72 @@ describe('EnginesOverview', () => {
       setMockValues(valuesWithEngines);
     });
 
-    it('renders and calls the engines API', async () => {
+    it('renders and calls the engines API', () => {
       const wrapper = shallow(<EnginesOverview />);
 
       expect(wrapper.find(EnginesTable)).toHaveLength(1);
       expect(actions.loadEngines).toHaveBeenCalled();
     });
 
-    it('renders a create engine button which takes users to the create engine page', () => {
-      const wrapper = shallow(<EnginesOverview />);
+    describe('when the user can manage/create engines', () => {
+      it('renders a create engine button which takes users to the create engine page', () => {
+        setMockValues({
+          ...valuesWithEngines,
+          myRole: { canManageEngines: true },
+        });
+        const wrapper = shallow(<EnginesOverview />);
 
-      expect(
-        wrapper.find('[data-test-subj="appSearchEnginesEngineCreationButton"]').prop('to')
-      ).toEqual('/engine_creation');
+        expect(
+          wrapper.find('[data-test-subj="appSearchEnginesEngineCreationButton"]').prop('to')
+        ).toEqual('/engine_creation');
+      });
     });
 
-    describe('when user has a platinum license', () => {
-      let wrapper: ShallowWrapper;
-
-      beforeEach(() => {
+    describe('when the account has a platinum license', () => {
+      it('renders a 2nd meta engines table & makes a 2nd meta engines call', () => {
         setMockValues({
           ...valuesWithEngines,
           hasPlatinumLicense: true,
         });
-        wrapper = shallow(<EnginesOverview />);
-      });
+        const wrapper = shallow(<EnginesOverview />);
 
-      it('renders a 2nd meta engines table ', async () => {
         expect(wrapper.find(EnginesTable)).toHaveLength(2);
-      });
-
-      it('makes a 2nd meta engines call', () => {
         expect(actions.loadMetaEngines).toHaveBeenCalled();
       });
 
-      it('renders a create engine button which takes users to the create meta engine page', () => {
-        expect(
-          wrapper.find('[data-test-subj="appSearchEnginesMetaEngineCreationButton"]').prop('to')
-        ).toEqual('/meta_engine_creation');
-      });
+      describe('when the user can manage/creation engines', () => {
+        it('renders a create engine button which takes users to the create meta engine page', () => {
+          setMockValues({
+            ...valuesWithEngines,
+            hasPlatinumLicense: true,
+            myRole: { canManageEngines: true },
+          });
+          const wrapper = shallow(<EnginesOverview />);
 
-      it('contains an EuiEmptyPrompt that takes users to the create meta when metaEngines is empty', () => {
-        setMockValues({
-          ...valuesWithEngines,
-          hasPlatinumLicense: true,
-          metaEngines: [],
+          expect(
+            wrapper.find('[data-test-subj="appSearchEnginesMetaEngineCreationButton"]').prop('to')
+          ).toEqual('/meta_engine_creation');
         });
-        wrapper = shallow(<EnginesOverview />);
-        const metaEnginesTable = wrapper.find(EnginesTable).last().dive();
-        const emptyPrompt = metaEnginesTable.dive().find(EuiEmptyPrompt).dive();
 
-        expect(
-          emptyPrompt
-            .find('[data-test-subj="appSearchMetaEnginesEmptyStateCreationButton"]')
-            .prop('to')
-        ).toEqual('/meta_engine_creation');
+        describe('when metaEngines is empty', () => {
+          it('contains an EuiEmptyPrompt that takes users to the create meta engine page', () => {
+            setMockValues({
+              ...valuesWithEngines,
+              hasPlatinumLicense: true,
+              myRole: { canManageEngines: true },
+              metaEngines: [],
+            });
+            const wrapper = shallow(<EnginesOverview />);
+            const metaEnginesTable = wrapper.find(EnginesTable).last().dive();
+            const emptyPrompt = metaEnginesTable.dive().find(EuiEmptyPrompt).dive();
+
+            expect(
+              emptyPrompt
+                .find('[data-test-subj="appSearchMetaEnginesEmptyStateCreationButton"]')
+                .prop('to')
+            ).toEqual('/meta_engine_creation');
+          });
+        });
       });
     });
 
@@ -152,7 +164,7 @@ describe('EnginesOverview', () => {
       const getTablePagination = (wrapper: ShallowWrapper) =>
         wrapper.find(EnginesTable).prop('pagination');
 
-      it('passes down page data from the API', async () => {
+      it('passes down page data from the API', () => {
         const wrapper = shallow(<EnginesOverview />);
         const pagination = getTablePagination(wrapper);
 
@@ -160,7 +172,7 @@ describe('EnginesOverview', () => {
         expect(pagination.pageIndex).toEqual(0);
       });
 
-      it('re-polls the API on page change', async () => {
+      it('re-polls the API on page change', () => {
         const wrapper = shallow(<EnginesOverview />);
 
         setMockValues({
@@ -178,7 +190,7 @@ describe('EnginesOverview', () => {
         expect(getTablePagination(wrapper).pageIndex).toEqual(50);
       });
 
-      it('calls onPagination handlers', async () => {
+      it('calls onPagination handlers', () => {
         setMockValues({
           ...valuesWithEngines,
           hasPlatinumLicense: true,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.test.tsx
@@ -124,7 +124,7 @@ describe('EnginesOverview', () => {
         expect(actions.loadMetaEngines).toHaveBeenCalled();
       });
 
-      describe('when the user can manage/creation engines', () => {
+      describe('when the user can manage/create engines', () => {
         it('renders a create engine button which takes users to the create meta engine page', () => {
           setMockValues({
             ...valuesWithEngines,

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_overview.tsx
@@ -25,6 +25,7 @@ import { LicensingLogic } from '../../../shared/licensing';
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
 import { convertMetaToPagination, handlePageChange } from '../../../shared/table_pagination';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
 import { EngineIcon, MetaEngineIcon } from '../../icons';
 import { ENGINE_CREATION_PATH, META_ENGINE_CREATION_PATH } from '../../routes';
 
@@ -44,6 +45,9 @@ import './engines_overview.scss';
 
 export const EnginesOverview: React.FC = () => {
   const { hasPlatinumLicense } = useValues(LicensingLogic);
+  const {
+    myRole: { canManageEngines },
+  } = useValues(AppLogic);
 
   const {
     dataLoading,
@@ -91,14 +95,16 @@ export const EnginesOverview: React.FC = () => {
             </EuiTitle>
           </EuiPageContentHeaderSection>
           <EuiPageContentHeaderSection>
-            <EuiButtonTo
-              color="primary"
-              fill
-              data-test-subj="appSearchEnginesEngineCreationButton"
-              to={ENGINE_CREATION_PATH}
-            >
-              {CREATE_AN_ENGINE_BUTTON_LABEL}
-            </EuiButtonTo>
+            {canManageEngines && (
+              <EuiButtonTo
+                color="primary"
+                fill
+                data-test-subj="appSearchEnginesEngineCreationButton"
+                to={ENGINE_CREATION_PATH}
+              >
+                {CREATE_AN_ENGINE_BUTTON_LABEL}
+              </EuiButtonTo>
+            )}
           </EuiPageContentHeaderSection>
         </EuiPageContentHeader>
         <EuiPageContentBody data-test-subj="appSearchEngines">
@@ -126,14 +132,16 @@ export const EnginesOverview: React.FC = () => {
                 </EuiTitle>
               </EuiPageContentHeaderSection>
               <EuiPageContentHeaderSection>
-                <EuiButtonTo
-                  color="primary"
-                  fill
-                  data-test-subj="appSearchEnginesMetaEngineCreationButton"
-                  to={META_ENGINE_CREATION_PATH}
-                >
-                  {CREATE_A_META_ENGINE_BUTTON_LABEL}
-                </EuiButtonTo>
+                {canManageEngines && (
+                  <EuiButtonTo
+                    color="primary"
+                    fill
+                    data-test-subj="appSearchEnginesMetaEngineCreationButton"
+                    to={META_ENGINE_CREATION_PATH}
+                  >
+                    {CREATE_A_META_ENGINE_BUTTON_LABEL}
+                  </EuiButtonTo>
+                )}
               </EuiPageContentHeaderSection>
             </EuiPageContentHeader>
             <EuiPageContentBody data-test-subj="appSearchMetaEngines">
@@ -149,13 +157,15 @@ export const EnginesOverview: React.FC = () => {
                     title={<h2>{META_ENGINE_EMPTY_PROMPT_TITLE}</h2>}
                     body={<p>{META_ENGINE_EMPTY_PROMPT_DESCRIPTION}</p>}
                     actions={
-                      <EuiButtonTo
-                        data-test-subj="appSearchMetaEnginesEmptyStateCreationButton"
-                        fill
-                        to={META_ENGINE_CREATION_PATH}
-                      >
-                        {CREATE_A_META_ENGINE_BUTTON_LABEL}
-                      </EuiButtonTo>
+                      canManageEngines && (
+                        <EuiButtonTo
+                          data-test-subj="appSearchMetaEnginesEmptyStateCreationButton"
+                          fill
+                          to={META_ENGINE_CREATION_PATH}
+                        >
+                          {CREATE_A_META_ENGINE_BUTTON_LABEL}
+                        </EuiButtonTo>
+                      )
                     }
                   />
                 }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.test.tsx
@@ -51,16 +51,21 @@ describe('EnginesTable', () => {
     onDeleteEngine,
   };
 
+  const resetMocks = () => {
+    jest.clearAllMocks();
+    setMockValues({
+      myRole: {
+        canManageEngines: false,
+      },
+    });
+  };
+
   describe('basic table', () => {
     let wrapper: ReactWrapper<any>;
     let table: ReactWrapper<any>;
 
     beforeAll(() => {
-      jest.clearAllMocks();
-      setMockValues({
-        // LicensingLogic
-        hasPlatinumLicense: false,
-      });
+      resetMocks();
       wrapper = mountWithIntl(<EnginesTable {...props} />);
       table = wrapper.find(EuiBasicTable);
     });
@@ -101,11 +106,7 @@ describe('EnginesTable', () => {
 
   describe('loading', () => {
     it('passes the loading prop', () => {
-      jest.clearAllMocks();
-      setMockValues({
-        // LicensingLogic
-        hasPlatinumLicense: false,
-      });
+      resetMocks();
       const wrapper = mountWithIntl(<EnginesTable {...props} loading />);
 
       expect(wrapper.find(EuiBasicTable).prop('loading')).toEqual(true);
@@ -114,6 +115,7 @@ describe('EnginesTable', () => {
 
   describe('noItemsMessage', () => {
     it('passes the noItemsMessage prop', () => {
+      resetMocks();
       const wrapper = mountWithIntl(<EnginesTable {...props} noItemsMessage={'No items.'} />);
       expect(wrapper.find(EuiBasicTable).prop('noItemsMessage')).toEqual('No items.');
     });
@@ -121,11 +123,7 @@ describe('EnginesTable', () => {
 
   describe('language field', () => {
     beforeAll(() => {
-      jest.clearAllMocks();
-      setMockValues({
-        // LicensingLogic
-        hasPlatinumLicense: false,
-      });
+      resetMocks();
     });
 
     it('renders language when available', () => {
@@ -181,29 +179,27 @@ describe('EnginesTable', () => {
   });
 
   describe('actions', () => {
-    it('will hide the action buttons if the user does not have a platinum license', () => {
-      jest.clearAllMocks();
-      setMockValues({
-        // LicensingLogic
-        hasPlatinumLicense: false,
-      });
+    it('will hide the action buttons if the user cannot manage/delete engines', () => {
+      resetMocks();
       const wrapper = shallow(<EnginesTable {...props} />);
       const tableRow = wrapper.find(EuiTableRow).first();
 
       expect(tableRow.find(EuiIcon)).toHaveLength(0);
     });
 
-    describe('when user has a platinum license', () => {
+    describe('when the user can manage/delete engines', () => {
       let wrapper: ReactWrapper<any>;
       let tableRow: ReactWrapper<any>;
       let actions: ReactWrapper<any>;
 
       beforeEach(() => {
-        jest.clearAllMocks();
+        resetMocks();
         setMockValues({
-          // LicensingLogic
-          hasPlatinumLicense: true,
+          myRole: {
+            canManageEngines: true,
+          },
         });
+
         wrapper = mountWithIntl(<EnginesTable {...props} />);
         tableRow = wrapper.find(EuiTableRow).first();
         actions = tableRow.find(EuiIcon);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -19,9 +19,9 @@ import { i18n } from '@kbn/i18n';
 import { FormattedNumber } from '@kbn/i18n/react';
 
 import { KibanaLogic } from '../../../shared/kibana';
-import { LicensingLogic } from '../../../shared/licensing';
 import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../shared/telemetry';
+import { AppLogic } from '../../app_logic';
 import { UNIVERSAL_LANGUAGE } from '../../constants';
 import { ENGINE_PATH } from '../../routes';
 import { generateEncodedPath } from '../../utils/encode_path_params';
@@ -52,7 +52,9 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
 }) => {
   const { sendAppSearchTelemetry } = useActions(TelemetryLogic);
   const { navigateToUrl } = useValues(KibanaLogic);
-  const { hasPlatinumLicense } = useValues(LicensingLogic);
+  const {
+    myRole: { canManageEngines },
+  } = useValues(AppLogic);
 
   const generateEncodedEnginePath = (engineName: string) =>
     generateEncodedPath(ENGINE_PATH, { engineName });
@@ -200,7 +202,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
     ],
   };
 
-  if (hasPlatinumLicense) {
+  if (canManageEngines) {
     columns.push(actionsColumn);
   }
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/engines_table.tsx
@@ -177,6 +177,7 @@ export const EnginesTable: React.FC<EnginesTableProps> = ({
         ),
         type: 'icon',
         icon: 'trash',
+        color: 'danger',
         onClick: (engine) => {
           if (
             window.confirm(


### PR DESCRIPTION
## Summary

Various engines fixes I've noticed recently during misc QA/demos, mostly around non-admin permissions:

## QA setup for Fixes 1-2

- Start a **non-platinum** Elasticsearch instance (e.g., wipe your data, restart whatever stack script you're using, etc)
- In Enterprise Search, create any source engine (e.g. the sample engine)

### Fix 1 - https://github.com/elastic/kibana/commit/550923ca301fdac630fe2accb59111af3a8ad24c
This updates the delete/trash icon to use the red/danger color to match our other tables (credentials, curations, etc.)

**Before (left), After (right)**
<img width="88" alt="" src="https://user-images.githubusercontent.com/549407/112073804-0bf28180-8b32-11eb-8b81-eca2cdc2f1c3.png"> <img width="123" alt="" src="https://user-images.githubusercontent.com/549407/112073803-0a28be00-8b32-11eb-94ef-4fa0decbba6c.png">

### Fix 2 - https://github.com/elastic/kibana/commit/8c1f55441dfa54f6c0ad32c57328acdc59c66884

The actions column wasn't correctly showing up based on the correct conditional. `hasPlatinumLicense` is used generally for whether the meta engines section should show up, but `canManageEngines` needs to be an additional conditional wrapper around whether a user can delete **any** engine (either source or meta).

**Screenshot of issue when on a non-platinum license:**
<img width="1070" alt="" src="https://user-images.githubusercontent.com/549407/111518047-f08f0d00-8712-11eb-810c-06af6b2ee858.png">

**Screencap of permissions issue on a non-admin user:**
![non-admin-user-deleting](https://user-images.githubusercontent.com/549407/112075116-16fae100-8b35-11eb-983c-aa9fe59a06d2.gif)

**QA steps:**
- When logged in as the `elastic` superuser:
  - [ ] (Before) Confirm that the actions column w/ the delete engine icon does not show up even though it should
  - [ ] (After checking out this branch) Confirm that the delete engine icon does show up
- When logged in as the `test` non-admin user:
  - [ ] (After checking out this branch) Confirm the actions column w/ the delete icon does not incorrectly show up

## QA setup for Fixes 3-4

- Upgrade your Elasticsearch instance to platinum (e.g. in the standalone UI, go to /ent/select and start a trial)
- In the standalone UI, create a role mapping for a Dev/Editor/Analyst user (e.g. username `test`) with access to all engines
- In Kibana > Stack Management > Users, create a `test` user with any password (e.g. `changeme`) and give it a role of `kibana_admin`
- I suggest using an incognito window when testing steps when logged in as the dev/editor/analyst `test` user.

### Fix 3 - https://github.com/elastic/kibana/commit/d4665282d7ee28f24a60b932bfc61aef34a90f0a

The Create engine / Create meta engine buttons should not be showing up for non-admin users / users who do not have `canManageEngines` permissions.

**Screencap of permissions issues on a non-admin user:**
![non-admin-user-creating](https://user-images.githubusercontent.com/549407/112075740-4e1dc200-8b36-11eb-8bb3-affc96f6e074.gif)

**QA steps:**
- When logged in as the `test` non-admin user:
  - [ ] (Before) Confirm that the Create engine buttons are showing up and lead to 404s
  - [ ] (After checking out this branch) Confirm the Create engine buttons no longer show up
- When logged in as the `elastic` superuser:
  - [ ] (After) Confirm that the Create engine buttons still show up for users who can create engines

### Fix 4 - https://github.com/elastic/kibana/commit/cfc5630c2b8eca0cbfb22d1ad1dcfa1cf28f4299

Similar to Fix 3, when the App Search instance has no engines whatsoever, we need to tweak the Create Engine empty prompt to 1. not show a Create engine button that 404s, and 2. to provide more helpful context/text as to what their options are.

**Screencap of permissions issues on a non-admin user:**
![non-admin-user-empty-prompt](https://user-images.githubusercontent.com/549407/112076060-e87e0580-8b36-11eb-9c8f-ab53505cffe4.gif)

**Standalone UI - empty prompt for a non-admin user:**
<img width="1072" alt="" src="https://user-images.githubusercontent.com/549407/112075891-9c32c580-8b36-11eb-87e3-54cb99242f9e.png">

**Kibana - After (non-admin user):**
<img width="877" alt="" src="https://user-images.githubusercontent.com/549407/112075871-90df9a00-8b36-11eb-96a8-61a30348de02.png">

**QA steps:**
- Delete all engines on your current App Search instance
- When logged in as the `test` non-admin user:
  - [ ] (Before) Confirm that the Create engine button in the empty prompt shows lead to a 404
  - [ ] (After checking out this branch) Confirm a separate empty prompt shows up with no Create engine button
- When logged in as the `elastic` superuser:
  - [ ] (After) Confirm that the previous Create engine prompt still show up for users who can create engines

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)