### PR TITLE
[Asset Management] Add Osquery action Cases integration

### DIFF
--- a/x-pack/plugins/cases/common/api/cases/comment.ts
+++ b/x-pack/plugins/cases/common/api/cases/comment.ts
@@ -37,6 +37,7 @@ export enum CommentType {
   user = 'user',
   alert = 'alert',
   generatedAlert = 'generated_alert',
+  osqueryAlert = 'osquery_alert',
 }
 
 export const ContextTypeUserRt = rt.type({
@@ -50,7 +51,11 @@ export const ContextTypeUserRt = rt.type({
  * it matches this structure. User attached alerts do not need to be transformed.
  */
 export const AlertCommentRequestRt = rt.type({
-  type: rt.union([rt.literal(CommentType.generatedAlert), rt.literal(CommentType.alert)]),
+  type: rt.union([
+    rt.literal(CommentType.generatedAlert),
+    rt.literal(CommentType.alert),
+    rt.literal(CommentType.osqueryAlert),
+  ]),
   alertId: rt.union([rt.array(rt.string), rt.string]),
   index: rt.union([rt.array(rt.string), rt.string]),
   rule: rt.type({

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -117,7 +117,7 @@ async function throwIfInvalidUpdateOfTypeWithAlerts({
       options: {
         fields: [],
         // there should never be generated alerts attached to an individual case but we'll check anyway
-        filter: `${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert}`,
+        filter: `${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.osqueryAlert}`,
         page: 1,
         perPage: 1,
       },
@@ -174,7 +174,7 @@ async function getAlertComments({
     id: idsOfCasesToSync,
     includeSubCaseComments: true,
     options: {
-      filter: `${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert}`,
+      filter: `${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.osqueryAlert}`,
     },
   });
 }

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -79,6 +79,8 @@ const getCommentContent = (comment: CommentResponse): string => {
   } else if (comment.type === CommentType.alert || comment.type === CommentType.generatedAlert) {
     const ids = getAlertIds(comment);
     return `Alert with ids ${ids.join(', ')} added to case`;
+  } else if (comment.type === CommentType.osqueryAlert) {
+    return `Osquery action alert with action_id: ${comment.alertId} added to case`;
   }
 
   return '';
@@ -86,7 +88,11 @@ const getCommentContent = (comment: CommentResponse): string => {
 
 const countAlerts = (comments: CaseResponse['comments']): number =>
   comments?.reduce<number>((total, comment) => {
-    if (comment.type === CommentType.alert || comment.type === CommentType.generatedAlert) {
+    if (
+      comment.type === CommentType.alert ||
+      comment.type === CommentType.generatedAlert ||
+      comment.type === CommentType.osqueryAlert
+    ) {
       return total + (Array.isArray(comment.alertId) ? comment.alertId.length : 1);
     }
     return total;
@@ -335,6 +341,7 @@ export const getCommentContextFromAttributes = (
         type: CommentType.user,
         comment: attributes.comment,
       };
+    case CommentType.osqueryAlert:
     case CommentType.generatedAlert:
     case CommentType.alert:
       return {

--- a/x-pack/plugins/cases/server/client/comments/add.ts
+++ b/x-pack/plugins/cases/server/client/comments/add.ts
@@ -121,7 +121,7 @@ const addGeneratedAlerts = async ({
   decodeCommentRequest(comment);
 
   // This function only supports adding generated alerts
-  if (comment.type !== CommentType.generatedAlert) {
+  if (comment.type !== CommentType.generatedAlert && comment.type !== CommentType.osqueryAlert) {
     throw Boom.internal('Attempting to add a non generated alert in the wrong context');
   }
 
@@ -134,7 +134,7 @@ const addGeneratedAlerts = async ({
     });
 
     if (
-      query.type === CommentType.generatedAlert &&
+      (query.type === CommentType.generatedAlert || query.type === CommentType.osqueryAlert) &&
       caseInfo.attributes.type !== CaseType.collection
     ) {
       throw Boom.badRequest('Sub case style alert comment cannot be added to an individual case');
@@ -170,7 +170,8 @@ const addGeneratedAlerts = async ({
 
     if (
       (newComment.attributes.type === CommentType.alert ||
-        newComment.attributes.type === CommentType.generatedAlert) &&
+        newComment.attributes.type === CommentType.generatedAlert ||
+        newComment.attributes.type === CommentType.osqueryAlert) &&
       caseInfo.attributes.settings.syncAlerts
     ) {
       const alertsToUpdate = createAlertUpdateRequest({

--- a/x-pack/plugins/cases/server/common/models/commentable_case.ts
+++ b/x-pack/plugins/cases/server/common/models/commentable_case.ts
@@ -138,7 +138,7 @@ export class CommentableCase {
               ...user,
             },
           },
-          version: this.subCase.version,
+          // version: this.subCase.version,
         });
 
         updatedSubCaseAttributes = {
@@ -158,7 +158,7 @@ export class CommentableCase {
           updated_at: date,
           updated_by: { ...user },
         },
-        version: this.collection.version,
+        // version: this.collection.version,
       });
 
       // this will contain the updated sub case information if the sub case was defined initially

--- a/x-pack/plugins/cases/server/plugin.ts
+++ b/x-pack/plugins/cases/server/plugin.ts
@@ -143,7 +143,21 @@ export class CasePlugin {
       });
     };
 
+    const getCasesClient = (scopedClusterClient, savedObjectsClient, user) =>
+      createExternalCasesClient({
+        scopedClusterClient,
+        savedObjectsClient,
+        user,
+        caseService: this.caseService!,
+        caseConfigureService: this.caseConfigureService!,
+        connectorMappingsService: this.connectorMappingsService!,
+        userActionService: this.userActionService!,
+        alertsService: this.alertsService!,
+        logger: this.log,
+      });
+
     return {
+      getCasesClient,
       getCasesClientWithRequestAndContext,
     };
   }

--- a/x-pack/plugins/cases/server/routes/api/cases/sub_case/patch_sub_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/sub_case/patch_sub_cases.ts
@@ -206,7 +206,7 @@ async function getAlertComments({
     client,
     id: ids,
     options: {
-      filter: `${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert}`,
+      filter: `${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.osqueryAlert}`,
     },
   });
 }

--- a/x-pack/plugins/cases/server/routes/api/utils.ts
+++ b/x-pack/plugins/cases/server/routes/api/utils.ts
@@ -353,7 +353,11 @@ export const isCommentRequestTypeUser = (
 export const isCommentRequestTypeAlertOrGenAlert = (
   context: CommentRequest
 ): context is CommentRequestAlertType => {
-  return context.type === CommentType.alert || context.type === CommentType.generatedAlert;
+  return (
+    context.type === CommentType.alert ||
+    context.type === CommentType.generatedAlert ||
+    context.type === CommentType.osqueryAlert
+  );
 };
 
 /**
@@ -366,7 +370,7 @@ export const isCommentRequestTypeAlertOrGenAlert = (
 export const isCommentRequestTypeGenAlert = (
   context: CommentRequest
 ): context is CommentRequestAlertType => {
-  return context.type === CommentType.generatedAlert;
+  return context.type === CommentType.generatedAlert || context.type === CommentType.osqueryAlert;
 };
 
 export const decodeCommentRequest = (comment: CommentRequest) => {

--- a/x-pack/plugins/cases/server/services/index.ts
+++ b/x-pack/plugins/cases/server/services/index.ts
@@ -484,7 +484,7 @@ export class CaseService implements CaseServiceSetup {
       associationType,
       id: ids,
       options: {
-        filter: `(${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert})`,
+        filter: `(${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.alert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.generatedAlert} OR ${CASE_COMMENT_SAVED_OBJECT}.attributes.type: ${CommentType.osqueryAlert})`,
       },
     });
 

--- a/x-pack/plugins/security_solution/public/cases/components/user_action_tree/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/user_action_tree/index.tsx
@@ -42,6 +42,7 @@ import {
   getUpdateAction,
   getAlertAttachment,
   getGeneratedAlertsAttachment,
+  getOsqueryAlertsAttachment,
   useFetchAlertData,
 } from './helpers';
 import { UserActionAvatar } from './user_action_avatar';
@@ -411,6 +412,37 @@ export const UserActionTree = React.memo(
                   getGeneratedAlertsAttachment({
                     action,
                     alertIds,
+                    ruleId: comment.rule?.id ?? '',
+                    ruleName: comment.rule?.name ?? i18n.UNKNOWN_RULE,
+                  }),
+                ];
+              } else if (comment != null && comment.type === CommentType.osqueryAlert) {
+                const previousComment = caseData.comments.find(
+                  (c) => c.id === caseUserActions[index - 1]?.commentId
+                );
+                const osqueryActionId = Array.isArray(comment.alertId)
+                  ? comment.alertId
+                  : [comment.alertId];
+
+                const alertIds = previousComment
+                  ? // @ts-expect-error update types
+                    Array.isArray(previousComment.alertId)
+                    ? // @ts-expect-error update types
+                      previousComment.alertId
+                    : // @ts-expect-error update types
+                      [previousComment.alertId]
+                  : [];
+
+                // if (isEmpty(alertIds)) {
+                //   return comments;
+                // }
+
+                return [
+                  ...comments,
+                  getOsqueryAlertsAttachment({
+                    action,
+                    alertIds,
+                    osqueryActionId,
                     ruleId: comment.rule?.id ?? '',
                     ruleName: comment.rule?.name ?? i18n.UNKNOWN_RULE,
                   }),

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -11,6 +11,7 @@ import { HomePublicPluginSetup } from '../../../../src/plugins/home/public';
 import { DataPublicPluginStart } from '../../../../src/plugins/data/public';
 import { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
 import { NewsfeedPublicPluginStart } from '../../../../src/plugins/newsfeed/public';
+import { LensPublicStart } from '../../../plugins/lens/public';
 import { Start as InspectorStart } from '../../../../src/plugins/inspector/public';
 import { UiActionsStart } from '../../../../src/plugins/ui_actions/public';
 import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/public';
@@ -50,6 +51,7 @@ export interface StartPlugins {
   data: DataPublicPluginStart;
   embeddable: EmbeddableStart;
   inspector: InspectorStart;
+  lens?: LensPublicStart;
   fleet?: FleetStart;
   lists?: ListsPluginStart;
   licensing: LicensingPluginStart;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
