### PR TITLE
[App Search] Add describe('listeners') blocks to older logic tests

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/credentials/credentials_logic.test.ts
@@ -1025,7 +1025,9 @@ describe('CredentialsLogic', () => {
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('fetchCredentials', () => {
       const meta = {
         page: {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/document_creation/document_creation_logic.test.ts
@@ -294,7 +294,9 @@ describe('DocumentCreationLogic', () => {
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('onSubmitFile', () => {
       describe('with a valid file', () => {
         beforeAll(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/documents/document_detail_logic.test.ts
@@ -54,7 +54,9 @@ describe('DocumentDetailLogic', () => {
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('getDocumentDetails', () => {
       it('will call an API endpoint and then store the result', async () => {
         const fields = [{ name: 'name', value: 'python', type: 'string' }];

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_logic.test.ts
@@ -172,7 +172,9 @@ describe('EngineLogic', () => {
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('initializeEngine', () => {
       it('fetches and sets engine data', async () => {
         mount({ engineName: 'some-engine' });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview_logic.test.ts
@@ -78,7 +78,9 @@ describe('EngineOverviewLogic', () => {
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('pollForOverviewMetrics', () => {
       it('fetches data and calls onPollingSuccess', async () => {
         mount();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
@@ -177,7 +177,9 @@ describe('LogRetentionLogic', () => {
         });
       });
     });
+  });
 
+  describe('listeners', () => {
     describe('saveLogRetention', () => {
       beforeEach(() => {
         mount();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.test.ts
@@ -266,6 +266,37 @@ describe('LogRetentionLogic', () => {
           LogRetentionOptions.Analytics
         );
       });
+
+      it('will call saveLogRetention if NOT already enabled', () => {
+        mount({
+          logRetention: {
+            [LogRetentionOptions.Analytics]: {
+              enabled: false,
+            },
+          },
+        });
+        jest.spyOn(LogRetentionLogic.actions, 'saveLogRetention');
+
+        LogRetentionLogic.actions.toggleLogRetention(LogRetentionOptions.Analytics);
+
+        expect(LogRetentionLogic.actions.saveLogRetention).toHaveBeenCalledWith(
+          LogRetentionOptions.Analytics,
+          true
+        );
+      });
+
+      it('will do nothing if logRetention option is not yet set', () => {
+        mount({
+          logRetention: {},
+        });
+        jest.spyOn(LogRetentionLogic.actions, 'saveLogRetention');
+        jest.spyOn(LogRetentionLogic.actions, 'setOpenedModal');
+
+        LogRetentionLogic.actions.toggleLogRetention(LogRetentionOptions.API);
+
+        expect(LogRetentionLogic.actions.saveLogRetention).not.toHaveBeenCalled();
+        expect(LogRetentionLogic.actions.setOpenedModal).not.toHaveBeenCalled();
+      });
     });
 
     describe('fetchLogRetention', () => {
@@ -307,37 +338,6 @@ describe('LogRetentionLogic', () => {
 
         expect(http.get).not.toHaveBeenCalled();
       });
-    });
-
-    it('will call saveLogRetention if NOT already enabled', () => {
-      mount({
-        logRetention: {
-          [LogRetentionOptions.Analytics]: {
-            enabled: false,
-          },
-        },
-      });
-      jest.spyOn(LogRetentionLogic.actions, 'saveLogRetention');
-
-      LogRetentionLogic.actions.toggleLogRetention(LogRetentionOptions.Analytics);
-
-      expect(LogRetentionLogic.actions.saveLogRetention).toHaveBeenCalledWith(
-        LogRetentionOptions.Analytics,
-        true
-      );
-    });
-
-    it('will do nothing if logRetention option is not yet set', () => {
-      mount({
-        logRetention: {},
-      });
-      jest.spyOn(LogRetentionLogic.actions, 'saveLogRetention');
-      jest.spyOn(LogRetentionLogic.actions, 'setOpenedModal');
-
-      LogRetentionLogic.actions.toggleLogRetention(LogRetentionOptions.API);
-
-      expect(LogRetentionLogic.actions.saveLogRetention).not.toHaveBeenCalled();
-      expect(LogRetentionLogic.actions.setOpenedModal).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

In our more recent Kea logic test files, we've been splitting up action vs listener tests into top-level `describe('actions')` and `describe('listeners')` blocks to help more organize our test files and make finding/collapsing certain blocks more straightforward. I believe https://github.com/elastic/kibana/pull/87561#discussion_r552928810 was the first place we discussed making this change.

This PR goes back into our older logic migrations and updates them to have `describe('listeners')` blocks to match our recent code.

It also has a misc. 2nd commit where I noticed 2 it blocks in a logic file weren't grouped with a parent listener describe().

### Checklist

- [x] All unit tests pass as before