### PR TITLE
[App Search] Log retention role fix

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.test.tsx
@@ -63,15 +63,6 @@ describe('LogRetentionCallout', () => {
     expect(wrapper.find('.euiCallOutHeader__title').text()).toEqual('API Logs have been disabled.');
   });
 
-  it('does not render a settings link if the user cannot manage settings', () => {
-    setMockValues({ myRole: { canManageLogSettings: false }, logRetention: { api: DISABLED } });
-    const wrapper = mountWithIntl(<LogRetentionCallout type={LogRetentionOptions.API} />);
-
-    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
-    expect(wrapper.find(EuiLink)).toHaveLength(0);
-    expect(wrapper.find('p')).toHaveLength(0);
-  });
-
   it('does not render if log retention is enabled', () => {
     setMockValues({ ...values, logRetention: { api: { enabled: true } } });
     const wrapper = shallow(<LogRetentionCallout type={LogRetentionOptions.API} />);
@@ -96,6 +87,13 @@ describe('LogRetentionCallout', () => {
 
     it('does not fetch log retention data if it has already been loaded', () => {
       setMockValues({ ...values, logRetention: {} });
+      shallow(<LogRetentionCallout type={LogRetentionOptions.API} />);
+
+      expect(actions.fetchLogRetention).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch log retention data if the user does not have access to log settings', () => {
+      setMockValues({ ...values, logRetention: null, myRole: { canManageLogSettings: false } });
       shallow(<LogRetentionCallout type={LogRetentionOptions.API} />);
 
       expect(actions.fetchLogRetention).not.toHaveBeenCalled();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_callout.tsx
@@ -40,7 +40,7 @@ export const LogRetentionCallout: React.FC<Props> = ({ type }) => {
   const hasLogRetention = logRetention !== null;
 
   useEffect(() => {
-    if (!hasLogRetention) fetchLogRetention();
+    if (!hasLogRetention && canManageLogSettings) fetchLogRetention();
   }, []);
 
   const logRetentionSettings = logRetention?.[type];
@@ -72,24 +72,22 @@ export const LogRetentionCallout: React.FC<Props> = ({ type }) => {
           )
         }
       >
-        {canManageLogSettings && (
-          <p>
-            <FormattedMessage
-              id="xpack.enterpriseSearch.appSearch.logRetention.callout.description.manageSettingsDetail"
-              defaultMessage="To manage analytics & logging, {visitSettingsLink}."
-              values={{
-                visitSettingsLink: (
-                  <EuiLinkTo to={SETTINGS_PATH}>
-                    {i18n.translate(
-                      'xpack.enterpriseSearch.appSearch.logRetention.callout.description.manageSettingsLinkText',
-                      { defaultMessage: 'visit your settings' }
-                    )}
-                  </EuiLinkTo>
-                ),
-              }}
-            />
-          </p>
-        )}
+        <p>
+          <FormattedMessage
+            id="xpack.enterpriseSearch.appSearch.logRetention.callout.description.manageSettingsDetail"
+            defaultMessage="To manage analytics & logging, {visitSettingsLink}."
+            values={{
+              visitSettingsLink: (
+                <EuiLinkTo to={SETTINGS_PATH}>
+                  {i18n.translate(
+                    'xpack.enterpriseSearch.appSearch.logRetention.callout.description.manageSettingsLinkText',
+                    { defaultMessage: 'visit your settings' }
+                  )}
+                </EuiLinkTo>
+              ),
+            }}
+          />
+        </p>
       </EuiCallOut>
       <EuiSpacer />
     </>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.test.tsx
@@ -19,7 +19,10 @@ import { LogRetentionOptions, LogRetentionMessage } from '../';
 import { LogRetentionTooltip } from './';
 
 describe('LogRetentionTooltip', () => {
-  const values = { logRetention: {} };
+  const values = {
+    logRetention: {},
+    myRole: { canManageLogSettings: true },
+  };
   const actions = { fetchLogRetention: jest.fn() };
 
   beforeEach(() => {
@@ -53,7 +56,7 @@ describe('LogRetentionTooltip', () => {
   });
 
   it('does not render if log retention is not available', () => {
-    setMockValues({ logRetention: null });
+    setMockValues({ ...values, logRetention: null });
     const wrapper = mount(<LogRetentionTooltip type={LogRetentionOptions.API} />);
 
     expect(wrapper.isEmptyRender()).toBe(true);
@@ -61,14 +64,21 @@ describe('LogRetentionTooltip', () => {
 
   describe('on mount', () => {
     it('fetches log retention data when not already loaded', () => {
-      setMockValues({ logRetention: null });
+      setMockValues({ ...values, logRetention: null });
       shallow(<LogRetentionTooltip type={LogRetentionOptions.Analytics} />);
 
       expect(actions.fetchLogRetention).toHaveBeenCalled();
     });
 
     it('does not fetch log retention data if it has already been loaded', () => {
-      setMockValues({ logRetention: {} });
+      setMockValues({ ...values, logRetention: {} });
+      shallow(<LogRetentionTooltip type={LogRetentionOptions.Analytics} />);
+
+      expect(actions.fetchLogRetention).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch log retention data if the user does not have access to log settings', () => {
+      setMockValues({ ...values, logRetention: null, myRole: { canManageLogSettings: false } });
       shallow(<LogRetentionTooltip type={LogRetentionOptions.Analytics} />);
 
       expect(actions.fetchLogRetention).not.toHaveBeenCalled();

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/components/log_retention_tooltip.tsx
@@ -12,7 +12,9 @@ import { useValues, useActions } from 'kea';
 import { EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { LogRetentionLogic, LogRetentionMessage, LogRetentionOptions } from '../';
+import { AppLogic } from '../../../app_logic';
+
+import { LogRetentionLogic, LogRetentionMessage, LogRetentionOptions } from '../index';
 
 interface Props {
   type: LogRetentionOptions;
@@ -21,11 +23,14 @@ interface Props {
 export const LogRetentionTooltip: React.FC<Props> = ({ type, position = 'bottom' }) => {
   const { fetchLogRetention } = useActions(LogRetentionLogic);
   const { logRetention } = useValues(LogRetentionLogic);
+  const {
+    myRole: { canManageLogSettings },
+  } = useValues(AppLogic);
 
   const hasLogRetention = logRetention !== null;
 
   useEffect(() => {
-    if (!hasLogRetention) fetchLogRetention();
+    if (!hasLogRetention && canManageLogSettings) fetchLogRetention();
   }, []);
 
   return hasLogRetention ? (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.ts
@@ -70,7 +70,7 @@ export const LogRetentionLogic = kea<MakeLogicType<LogRetentionValues, LogRetent
   }),
   listeners: ({ actions, values }) => ({
     fetchLogRetention: async (_, breakpoint) => {
-      await breakpoint(250); // Prevents duplicate calls to the API (e.g., when a tooltip & callout are on the same page)
+      await breakpoint(100); // Prevents duplicate calls to the API (e.g., when a tooltip & callout are on the same page)
 
       try {
         const { http } = HttpLogic.values;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/log_retention/log_retention_logic.ts
@@ -14,7 +14,6 @@ import { LogRetentionOptions, LogRetention, LogRetentionServer } from './types';
 import { convertLogRetentionFromServerToClient } from './utils/convert_log_retention';
 
 interface LogRetentionActions {
-  setLogRetentionUpdating(): void;
   clearLogRetentionUpdating(): void;
   closeModals(): void;
   fetchLogRetention(): void;
@@ -36,7 +35,6 @@ interface LogRetentionValues {
 export const LogRetentionLogic = kea<MakeLogicType<LogRetentionValues, LogRetentionActions>>({
   path: ['enterprise_search', 'app_search', 'log_retention_logic'],
   actions: () => ({
-    setLogRetentionUpdating: true,
     clearLogRetentionUpdating: true,
     closeModals: true,
     fetchLogRetention: true,
@@ -57,7 +55,7 @@ export const LogRetentionLogic = kea<MakeLogicType<LogRetentionValues, LogRetent
       {
         clearLogRetentionUpdating: () => false,
         closeModals: () => false,
-        setLogRetentionUpdating: () => true,
+        fetchLogRetention: () => true,
         toggleLogRetention: () => true,
       },
     ],
@@ -71,12 +69,10 @@ export const LogRetentionLogic = kea<MakeLogicType<LogRetentionValues, LogRetent
     ],
   }),
   listeners: ({ actions, values }) => ({
-    fetchLogRetention: async () => {
-      if (values.isLogRetentionUpdating) return; // Prevent duplicate calls to the API
+    fetchLogRetention: async (_, breakpoint) => {
+      await breakpoint(250); // Prevents duplicate calls to the API (e.g., when a tooltip & callout are on the same page)
 
       try {
-        actions.setLogRetentionUpdating();
-
         const { http } = HttpLogic.values;
         const response = await http.get('/api/app_search/log_settings');
 


### PR DESCRIPTION
## Summary

Similar to the engine permission issues in https://github.com/elastic/kibana/pull/95127, I noticed this error/bug with our Analytics page while doing a quick smoke test of our app when logged in as a non-admin user.

### Before

Admin user (fine):
<img width="1179" alt="" src="https://user-images.githubusercontent.com/549407/112202478-ab655200-8bce-11eb-904f-4bc100c6fe5d.png">

When logged in as a non-admin user (errors):
<img width="1183" alt="" src="https://user-images.githubusercontent.com/549407/112202267-693c1080-8bce-11eb-8f67-364ab9aef07a.png">

I hadn't realized that just `GET`ing the log_settings API checks for the `canManageLogSettings` ability and kicks back an error if the user does not have that permission. As a result, we need to check for that ability before fetching log retention data.

### After

<img width="1175" alt="" src="https://user-images.githubusercontent.com/549407/112202909-2c244e00-8bcf-11eb-8307-9dc28c726d27.png">

This check should now hide the log retention tooltip/callout for non-admin users who cannot change settings (same behavior as the standalone UI), and an error should no longer appear on the page.

## QA

- Ensure you're on a platinum license (e.g. in the standalone UI, go to /ent/select and start a trial)
- In the standalone UI, create a role mapping for a Dev/Editor/Analyst user (e.g. username `test`) with access to all engines
- In Kibana > Stack Management > Users, create a `test` user with any password (e.g. `changeme`) and give it a role of `kibana_admin`
  - I suggest using an incognito window when testing steps when logged in as the dev/editor/analyst `test` user.
- In either Kibana or the Standalone UI, go to settings and disable Analytics log collection
- When logged in as the non-admin `test` user:
  - [x] Confirm that going to the Analytics page no longer shows a "cannot authenticate Enterprise Search user" error
  - [x] Confirm no log retention tooltip or callout appears
  - [x] Confirm no `/log_settings` API call is being made in your devtools XHR
- When logged in as the the `elastic` superuser:
  - [x] Confirm that going to the Analytics page still shows a log retention tooltip and callout
  - [x] Confirm only one `/log_settings` API call is being made in your devtools XHR

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios