### PR TITLE
Adding a package with a known vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -764,6 +764,7 @@
     "pretty-ms": "5.0.0",
     "proxyquire": "1.8.0",
     "q": "^1.5.1",
+    "qs": "6.3.1",
     "querystring": "^0.2.0",
     "rbush": "^3.0.1",
     "re-resizable": "^6.1.1",

--- a/x-pack/plugins/security_solution/public/index.ts
+++ b/x-pack/plugins/security_solution/public/index.ts
@@ -5,9 +5,14 @@
  * 2.0.
  */
 
+// eslint-disable Not sure why I need to disable this. Removing this shows an error about 'qs' being an extraneous dep. Ignoring that specific rule gives me an error about how that rule doesn't need to be ignored.
+import qs from 'qs';
 import { PluginInitializerContext } from '../../../../src/core/public';
 import { Plugin } from './plugin';
 import { PluginSetup, PluginStart } from './types';
+
+// Using the library just in case we have some vulnerability detection that ignores unused deps
+qs.parse('whatever');
 
 export const plugin = (context: PluginInitializerContext): Plugin => new Plugin(context);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22627,6 +22627,11 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qs@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.1.tgz#918c0b3bcd36679772baf135b1acb4c1651ed79d"
+  integrity sha1-kYwLO802Z5dyuvE1say0wWUe150=
+
 qs@6.7.0, qs@^6.5.1, qs@^6.6.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"


### PR DESCRIPTION
Adding a package with a known vulnerability to see if CI will let it
through.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
