### PR TITLE
[Workplace Search] Fix redirect and state for personal oAuth plugin

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -16,6 +16,7 @@ import { shallow } from 'enzyme';
 import { Layout } from '../shared/layout';
 
 import { WorkplaceSearchHeaderActions } from './components/layout';
+import { SourceAdded } from './views/content_sources/components/source_added';
 import { ErrorState } from './views/error_state';
 import { Overview as OverviewMVP } from './views/overview_mvp';
 import { SetupGuide } from './views/setup_guide';
@@ -93,5 +94,11 @@ describe('WorkplaceSearchConfigured', () => {
     const wrapper = shallow(<WorkplaceSearchConfigured />);
 
     expect(wrapper.find(Layout).first().prop('readOnlyMode')).toEqual(true);
+  });
+
+  it('renders SourceAdded', () => {
+    const wrapper = shallow(<WorkplaceSearchConfigured />);
+
+    expect(wrapper.find(SourceAdded)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -24,12 +24,14 @@ import {
   GROUPS_PATH,
   SETUP_GUIDE_PATH,
   SOURCES_PATH,
+  SOURCE_ADDED_PATH,
   PERSONAL_SOURCES_PATH,
   ORG_SETTINGS_PATH,
   ROLE_MAPPINGS_PATH,
   SECURITY_PATH,
 } from './routes';
 import { SourcesRouter } from './views/content_sources';
+import { SourceAdded } from './views/content_sources/components/source_added';
 import { SourceSubNav } from './views/content_sources/components/source_sub_nav';
 import { PrivateSourcesLayout } from './views/content_sources/private_sources_layout';
 import { ErrorState } from './views/error_state';
@@ -81,6 +83,9 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
     <Switch>
       <Route path={SETUP_GUIDE_PATH}>
         <SetupGuide />
+      </Route>
+      <Route path={SOURCE_ADDED_PATH}>
+        <SourceAdded />
       </Route>
       <Route exact path="/">
         {errorConnecting ? <ErrorState /> : <OverviewMVP />}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -275,12 +275,12 @@ describe('AddSourceLogic', () => {
     describe('saveSourceParams', () => {
       const params = {
         code: 'code123',
-        state: '"{"state": "foo"}"',
-        session_state: 'session123',
+        state:
+          '{"action":"create","context":"organization","service_type":"gmail","csrf_token":"token==","index_permissions":false}',
       };
 
       const queryString =
-        'code=code123&state=%22%7B%22state%22%3A%20%22foo%22%7D%22&session_state=session123';
+        '?state=%7B%22action%22:%22create%22,%22context%22:%22organization%22,%22service_type%22:%22gmail%22,%22csrf_token%22:%22token%3D%3D%22,%22index_permissions%22:false%7D&code=code123';
 
       const response = { serviceName: 'name', indexPermissions: false, serviceType: 'zendesk' };
 
@@ -303,9 +303,18 @@ describe('AddSourceLogic', () => {
         await nextTick();
 
         expect(setAddedSourceSpy).toHaveBeenCalledWith(serviceName, indexPermissions, serviceType);
-        expect(navigateToUrl).toHaveBeenCalledWith(
-          getSourcesPath(SOURCES_PATH, AppLogic.values.isOrganization)
-        );
+        expect(navigateToUrl).toHaveBeenCalledWith(getSourcesPath(SOURCES_PATH, true));
+      });
+
+      it('redirects to private dashboard when account context', async () => {
+        const accountQueryString =
+          '?state=%7B%22action%22:%22create%22,%22context%22:%22account%22,%22service_type%22:%22gmail%22,%22csrf_token%22:%22token%3D%3D%22,%22index_permissions%22:false%7D&code=code';
+
+        AddSourceLogic.actions.saveSourceParams(accountQueryString);
+
+        await nextTick();
+
+        expect(navigateToUrl).toHaveBeenCalledWith(getSourcesPath(SOURCES_PATH, false));
       });
 
       it('handles error', async () => {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -470,12 +470,13 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
     },
     saveSourceParams: async ({ search }) => {
       const { http } = HttpLogic.values;
-      const { isOrganization } = AppLogic.values;
       const { navigateToUrl } = KibanaLogic.values;
       const { setAddedSource } = SourcesLogic.actions;
       const params = (parseQueryParams(search) as unknown) as OauthParams;
       const query = { ...params, kibana_host: kibanaHost };
       const route = '/api/workplace_search/sources/create';
+      const state = JSON.parse(params.state);
+      const isOrganization = state.context !== 'account';
 
       try {
         const response = await http.get(route, { query });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_added.tsx
@@ -11,6 +11,8 @@ import { useLocation } from 'react-router-dom';
 import { Location } from 'history';
 import { useActions } from 'kea';
 
+import { EuiPage, EuiPageBody } from '@elastic/eui';
+
 import { Loading } from '../../../../shared/loading';
 
 import { AddSourceLogic } from './add_source/add_source_logic';
@@ -28,5 +30,11 @@ export const SourceAdded: React.FC = () => {
     saveSourceParams(search);
   }, []);
 
-  return <Loading />;
+  return (
+    <EuiPage>
+      <EuiPageBody>
+        <Loading />
+      </EuiPageBody>
+    </EuiPage>
+  );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.test.tsx
@@ -34,7 +34,7 @@ describe('SourcesRouter', () => {
   });
 
   it('renders sources routes', () => {
-    const TOTAL_ROUTES = 62;
+    const TOTAL_ROUTES = 61;
     const wrapper = shallow(<SourcesRouter />);
 
     expect(wrapper.find(Switch)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
@@ -19,7 +19,6 @@ import { AppLogic } from '../../app_logic';
 import { NAV } from '../../constants';
 import {
   ADD_SOURCE_PATH,
-  SOURCE_ADDED_PATH,
   SOURCE_DETAILS_PATH,
   PERSONAL_SOURCES_PATH,
   SOURCES_PATH,
@@ -27,7 +26,6 @@ import {
 } from '../../routes';
 
 import { AddSource, AddSourceList } from './components/add_source';
-import { SourceAdded } from './components/source_added';
 import { OrganizationSources } from './organization_sources';
 import { PrivateSources } from './private_sources';
 import { staticSourceData } from './source_data';
@@ -114,10 +112,6 @@ export const SourcesRouter: React.FC = () => {
         <Route exact path={getSourcesPath(ADD_SOURCE_PATH, true)}>
           <SetPageChrome trail={[NAV.SOURCES, NAV.ADD_SOURCE]} />
           <AddSourceList />
-        </Route>
-        <Route path={getSourcesPath(SOURCE_ADDED_PATH, isOrganization)} exact>
-          <SetPageChrome trail={[NAV.SOURCES, NAV.ADD_SOURCE]} />
-          <SourceAdded />
         </Route>
         <Route path={getSourcesPath(SOURCE_DETAILS_PATH, isOrganization)}>
           <SourceRouter />


### PR DESCRIPTION
## Summary

This PR accomplishes 2 things.

1. The route for the source added component, which is basically a catch-all component that intercepts the redirect back from a source that has been configured that only renders a loading component, to live at the top level so that there is no flash of the Org UI when you are connecting a private source.

**Before**
![before](https://user-images.githubusercontent.com/1869731/112209012-00ad5d80-8be7-11eb-859e-ce4be2f2b731.gif)

**After**
![after](https://user-images.githubusercontent.com/1869731/112209026-02772100-8be7-11eb-95ef-024ac704c683.gif)

2. In ent-search, we used the Rails server to determine the context and in Kibana, we use a single callback URL with the context in the state. This refactors to use that state param. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios