### PR TITLE
[Workplace Search] Add missing tests to get 100% coverage

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -48,7 +48,7 @@ describe('AppLogic', () => {
     expect(AppLogic.values).toEqual(DEFAULT_VALUES);
   });
 
-  describe('initializeAppData()', () => {
+  describe('initializeAppData', () => {
     it('sets values based on passed props', () => {
       AppLogic.actions.initializeAppData(DEFAULT_INITIAL_APP_DATA);
 
@@ -66,11 +66,20 @@ describe('AppLogic', () => {
     });
   });
 
-  describe('setContext()', () => {
+  describe('setContext', () => {
     it('sets context', () => {
       AppLogic.actions.setContext(true);
 
       expect(AppLogic.values.isOrganization).toEqual(true);
+    });
+  });
+
+  describe('setSourceRestriction', () => {
+    it('sets property', () => {
+      mount(DEFAULT_INITIAL_APP_DATA);
+      AppLogic.actions.setSourceRestriction(true);
+
+      expect(AppLogic.values.account.canCreatePersonalSources).toEqual(true);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/routes.test.tsx
@@ -13,8 +13,15 @@ import { EuiLink } from '@elastic/eui';
 
 import {
   getContentSourcePath,
+  getGroupPath,
+  getGroupSourcePrioritizationPath,
+  getReindexJobRoute,
+  getRoleMappingPath,
+  getSourcesPath,
+  GROUPS_PATH,
   SOURCES_PATH,
   PERSONAL_SOURCES_PATH,
+  ROLE_MAPPINGS_PATH,
   SOURCE_DETAILS_PATH,
 } from './routes';
 
@@ -24,17 +31,66 @@ const TestComponent = ({ id, isOrg }: { id: string; isOrg?: boolean }) => {
 };
 
 describe('getContentSourcePath', () => {
-  it('should format org route', () => {
+  it('should format org path', () => {
     const wrapper = shallow(<TestComponent id="123" isOrg />);
     const path = wrapper.find(EuiLink).prop('href');
 
     expect(path).toEqual(`${SOURCES_PATH}/123`);
   });
 
-  it('should format user route', () => {
+  it('should format user path', () => {
     const wrapper = shallow(<TestComponent id="123" />);
     const path = wrapper.find(EuiLink).prop('href');
 
     expect(path).toEqual(`${PERSONAL_SOURCES_PATH}/123`);
+  });
+});
+
+describe('getGroupPath', () => {
+  it('should format path', () => {
+    expect(getGroupPath('123')).toEqual(`${GROUPS_PATH}/123`);
+  });
+});
+
+describe('getRoleMappingPath', () => {
+  it('should format path', () => {
+    expect(getRoleMappingPath('123')).toEqual(`${ROLE_MAPPINGS_PATH}/123`);
+  });
+});
+
+describe('getGroupSourcePrioritizationPath', () => {
+  it('should format path', () => {
+    expect(getGroupSourcePrioritizationPath('123')).toEqual(
+      `${GROUPS_PATH}/123/source_prioritization`
+    );
+  });
+});
+
+describe('getSourcesPath', () => {
+  const PATH = '/foo/123';
+
+  it('should format org path', () => {
+    expect(getSourcesPath(PATH, true)).toEqual(PATH);
+  });
+
+  it('should format user path', () => {
+    expect(getSourcesPath(PATH, false)).toEqual(`/p${PATH}`);
+  });
+});
+
+describe('getReindexJobRoute', () => {
+  const SOURCE_ID = '234';
+  const REINDEX_ID = '345';
+
+  it('should format org path', () => {
+    expect(getReindexJobRoute(SOURCE_ID, REINDEX_ID, true)).toEqual(
+      `/sources/${SOURCE_ID}/schema_errors/${REINDEX_ID}`
+    );
+  });
+
+  it('should format user path', () => {
+    expect(getReindexJobRoute(SOURCE_ID, REINDEX_ID, false)).toEqual(
+      `/p/sources/${SOURCE_ID}/schema_errors/${REINDEX_ID}`
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR adds a couple of tests that allow Workplace Search to achieve 💯 % test coverage 🎉 

![all](https://user-images.githubusercontent.com/1869731/112210077-3d2d8900-8be8-11eb-803f-227c63e0df0e.jpg)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
