### PR TITLE
[Workplace Search] Add UI logic for GitHub Configure Step

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -6,6 +6,9 @@
  */
 
 import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { Location } from 'history';
 
 import { useActions, useValues } from 'kea';
 
@@ -31,6 +34,7 @@ import { SaveCustom } from './save_custom';
 import './add_source.scss';
 
 export const AddSource: React.FC<AddSourceProps> = (props) => {
+  const { search } = useLocation() as Location;
   const {
     initializeAddSource,
     setAddSourceStep,
@@ -83,9 +87,9 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
   const saveCustomSuccess = () => setAddSourceStep(AddSourceSteps.SaveCustomStep);
   const goToSaveCustom = () => createContentSource(CUSTOM_SERVICE_TYPE, saveCustomSuccess);
 
-  const goToFormSourceCreated = (sourceName: string) => {
+  const goToFormSourceCreated = () => {
     KibanaLogic.values.navigateToUrl(
-      `${getSourcesPath(SOURCE_ADDED_PATH, isOrganization)}/?name=${sourceName}`
+      `${getSourcesPath(SOURCE_ADDED_PATH, isOrganization)}${search}`
     );
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -59,6 +59,7 @@ describe('AddSourceLogic', () => {
     githubOrganizations: [],
     selectedGithubOrganizationsMap: {} as OrganizationsMap,
     selectedGithubOrganizations: [],
+    preContentSourceId: '',
   };
 
   const sourceConnectData = {
@@ -440,13 +441,14 @@ describe('AddSourceLogic', () => {
 
       describe('getPreContentSourceConfigData', () => {
         it('calls API and sets values', async () => {
+          mount({ preContentSourceId: '123' });
           const setPreContentSourceConfigDataSpy = jest.spyOn(
             AddSourceLogic.actions,
             'setPreContentSourceConfigData'
           );
           http.get.mockReturnValue(Promise.resolve(config));
 
-          AddSourceLogic.actions.getPreContentSourceConfigData('123');
+          AddSourceLogic.actions.getPreContentSourceConfigData();
 
           expect(http.get).toHaveBeenCalledWith('/api/workplace_search/org/pre_sources/123');
           await nextTick();
@@ -456,7 +458,7 @@ describe('AddSourceLogic', () => {
         it('handles error', async () => {
           http.get.mockReturnValue(Promise.reject('this is an error'));
 
-          AddSourceLogic.actions.getPreContentSourceConfigData('123');
+          AddSourceLogic.actions.getPreContentSourceConfigData();
           await nextTick();
 
           expect(flashAPIErrors).toHaveBeenCalledWith('this is an error');
@@ -616,7 +618,8 @@ describe('AddSourceLogic', () => {
       });
 
       it('getPreContentSourceConfigData', () => {
-        AddSourceLogic.actions.getPreContentSourceConfigData('123');
+        mount({ preContentSourceId: '123' });
+        AddSourceLogic.actions.getPreContentSourceConfigData();
 
         expect(http.get).toHaveBeenCalledWith('/api/workplace_search/account/pre_sources/123');
       });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -55,6 +55,7 @@ describe('AddSourceLogic', () => {
     sourceConfigData: {} as SourceConfigData,
     sourceConnectData: {} as SourceConnectData,
     newCustomSource: {} as CustomSource,
+    oauthConfigCompleted: false,
     currentServiceType: '',
     githubOrganizations: [],
     selectedGithubOrganizationsMap: {} as OrganizationsMap,

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -74,6 +74,7 @@ export interface AddSourceActions {
   setSourceIndexPermissionsValue(indexPermissionsValue: boolean): boolean;
   setCustomSourceData(data: CustomSource): CustomSource;
   setPreContentSourceConfigData(data: PreContentSourceResponse): PreContentSourceResponse;
+  setPreContentSourceId(preContentSourceId: string): string;
   setSelectedGithubOrganizations(option: string): string;
   resetSourceState(): void;
   createContentSource(
@@ -92,7 +93,7 @@ export interface AddSourceActions {
     successCallback: (oauthUrl: string) => void
   ): { serviceType: string; successCallback(oauthUrl: string): void };
   getSourceReConnectData(sourceId: string): { sourceId: string };
-  getPreContentSourceConfigData(preContentSourceId: string): { preContentSourceId: string };
+  getPreContentSourceConfigData(): void;
   setButtonNotLoading(): void;
 }
 
@@ -144,6 +145,7 @@ interface AddSourceValues {
   githubOrganizations: string[];
   selectedGithubOrganizationsMap: OrganizationsMap;
   selectedGithubOrganizations: string[];
+  preContentSourceId: string;
 }
 
 interface PreContentSourceResponse {
@@ -181,6 +183,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
     setSourceIndexPermissionsValue: (indexPermissionsValue: boolean) => indexPermissionsValue,
     setCustomSourceData: (data: CustomSource) => data,
     setPreContentSourceConfigData: (data: PreContentSourceResponse) => data,
+    setPreContentSourceId: (preContentSourceId: string) => preContentSourceId,
     setSelectedGithubOrganizations: (option: string) => option,
     getSourceConfigData: (serviceType: string) => ({ serviceType }),
     getSourceConnectData: (serviceType: string, successCallback: (oauthUrl: string) => string) => ({
@@ -188,7 +191,7 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
       successCallback,
     }),
     getSourceReConnectData: (sourceId: string) => ({ sourceId }),
-    getPreContentSourceConfigData: (preContentSourceId: string) => ({ preContentSourceId }),
+    getPreContentSourceConfigData: () => true,
     saveSourceConfig: (isUpdating: boolean, successCallback?: () => void) => ({
       isUpdating,
       successCallback,
@@ -344,6 +347,14 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         resetSourceState: () => ({}),
       },
     ],
+    preContentSourceId: [
+      '',
+      {
+        setPreContentSourceId: (_, preContentSourceId) => preContentSourceId,
+        setPreContentSourceConfigData: () => '',
+        resetSourceState: () => '',
+      },
+    ],
   },
   selectors: ({ selectors }) => ({
     selectedGithubOrganizations: [
@@ -407,8 +418,9 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         flashAPIErrors(e);
       }
     },
-    getPreContentSourceConfigData: async ({ preContentSourceId }) => {
+    getPreContentSourceConfigData: async () => {
       const { isOrganization } = AppLogic.values;
+      const { preContentSourceId } = values;
       const route = isOrganization
         ? `/api/workplace_search/org/pre_sources/${preContentSourceId}`
         : `/api/workplace_search/account/pre_sources/${preContentSourceId}`;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -499,10 +499,16 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
 
       try {
         const response = await http.get(route, { query });
-        const { serviceName, indexPermissions, serviceType, preContentSourceId } = response;
+        const {
+          serviceName,
+          indexPermissions,
+          serviceType,
+          preContentSourceId,
+          hasConfigureStep,
+        } = response;
 
         // GitHub requires an intermediate configuration step, where we collect the repos to index.
-        if (preContentSourceId && !values.oauthConfigCompleted) {
+        if (hasConfigureStep && !values.oauthConfigCompleted) {
           actions.setPreContentSourceId(preContentSourceId);
           navigateToUrl(`${ADD_GITHUB_PATH}/configure${search}`);
         } else {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -22,7 +22,7 @@ import { KibanaLogic } from '../../../../../shared/kibana';
 import { parseQueryParams } from '../../../../../shared/query_params';
 import { AppLogic } from '../../../../app_logic';
 import { CUSTOM_SERVICE_TYPE, WORKPLACE_SEARCH_URL_PREFIX } from '../../../../constants';
-import { SOURCES_PATH, getSourcesPath } from '../../../../routes';
+import { SOURCES_PATH, ADD_GITHUB_PATH, getSourcesPath } from '../../../../routes';
 import { CustomSource } from '../../../../types';
 import { staticSourceData } from '../../source_data';
 import { SourcesLogic } from '../../sources_logic';
@@ -492,12 +492,18 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
 
       try {
         const response = await http.get(route, { query });
+        const { serviceName, indexPermissions, serviceType, preContentSourceId } = response;
 
-        const { serviceName, indexPermissions, serviceType } = response;
+        // GitHub requires an intermediate configuration step, where we collect the repos to index.
+        if (preContentSourceId) {
+          actions.setPreContentSourceId(preContentSourceId);
+          navigateToUrl(`${ADD_GITHUB_PATH}/configure${search}`);
+        } else {
         setAddedSource(serviceName, indexPermissions, serviceType);
+          navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
+        }
       } catch (e) {
         flashAPIErrors(e);
-      } finally {
         navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
       }
     },

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -146,6 +146,7 @@ interface AddSourceValues {
   selectedGithubOrganizationsMap: OrganizationsMap;
   selectedGithubOrganizations: string[];
   preContentSourceId: string;
+  oauthConfigCompleted: boolean;
 }
 
 interface PreContentSourceResponse {
@@ -355,6 +356,12 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         resetSourceState: () => '',
       },
     ],
+    oauthConfigCompleted: [
+      false,
+      {
+        setPreContentSourceConfigData: () => true,
+      },
+    ],
   },
   selectors: ({ selectors }) => ({
     selectedGithubOrganizations: [
@@ -495,11 +502,11 @@ export const AddSourceLogic = kea<MakeLogicType<AddSourceValues, AddSourceAction
         const { serviceName, indexPermissions, serviceType, preContentSourceId } = response;
 
         // GitHub requires an intermediate configuration step, where we collect the repos to index.
-        if (preContentSourceId) {
+        if (preContentSourceId && !values.oauthConfigCompleted) {
           actions.setPreContentSourceId(preContentSourceId);
           navigateToUrl(`${ADD_GITHUB_PATH}/configure${search}`);
         } else {
-        setAddedSource(serviceName, indexPermissions, serviceType);
+          setAddedSource(serviceName, indexPermissions, serviceType);
           navigateToUrl(getSourcesPath(SOURCES_PATH, isOrganization));
         }
       } catch (e) {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_oauth.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configure_oauth.tsx
@@ -6,9 +6,7 @@
  */
 
 import React, { useEffect, useState, FormEvent } from 'react';
-import { useLocation } from 'react-router-dom';
 
-import { Location } from 'history';
 import { useActions, useValues } from 'kea';
 
 import {
@@ -22,14 +20,9 @@ import {
 import { EuiCheckboxGroupIdToSelectedMap } from '@elastic/eui/src/components/form/checkbox/checkbox_group';
 
 import { Loading } from '../../../../../shared/loading';
-import { parseQueryParams } from '../../../../../shared/query_params';
 
 import { AddSourceLogic } from './add_source_logic';
 import { CONFIG_OAUTH_LABEL, CONFIG_OAUTH_BUTTON } from './constants';
-
-interface OauthQueryParams {
-  preContentSourceId: string;
-}
 
 interface ConfigureOauthProps {
   header: React.ReactNode;
@@ -38,9 +31,6 @@ interface ConfigureOauthProps {
 }
 
 export const ConfigureOauth: React.FC<ConfigureOauthProps> = ({ name, onFormCreated, header }) => {
-  const { search } = useLocation() as Location;
-
-  const { preContentSourceId } = (parseQueryParams(search) as unknown) as OauthQueryParams;
   const [formLoading, setFormLoading] = useState(false);
 
   const {
@@ -58,7 +48,7 @@ export const ConfigureOauth: React.FC<ConfigureOauthProps> = ({ name, onFormCrea
   const checkboxOptions = githubOrganizations.map((item) => ({ id: item, label: item }));
 
   useEffect(() => {
-    getPreContentSourceConfigData(preContentSourceId);
+    getPreContentSourceConfigData();
   }, []);
 
   const handleChange = (option: string) => setSelectedGithubOrganizations(option);
@@ -101,6 +91,7 @@ export const ConfigureOauth: React.FC<ConfigureOauthProps> = ({ name, onFormCrea
   return (
     <>
       {header}
+      <EuiSpacer />
       {sectionLoading ? <Loading /> : configfieldsForm}
     </>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
@@ -176,7 +176,7 @@ export const CONFIG_CUSTOM_BUTTON = i18n.translate(
 export const CONFIG_OAUTH_LABEL = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.contentSource.configOauth.label',
   {
-    defaultMessage: 'Complete connection',
+    defaultMessage: 'Select GitHub organizations to sync',
   }
 );
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/workplace-search-team/issues/1588

This PR adds logic for step in the UI where GitHub collects the repos to index. 

![image](https://user-images.githubusercontent.com/1869731/112234298-357edc00-8c0a-11eb-9e34-15eda645bdd5.png)

Best to follow along by commit.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
