### PR TITLE
Use `es` instead of `legacyEs` in APM API integration test

### DIFF
--- a/x-pack/test/apm_api_integration/tests/feature_controls.ts
+++ b/x-pack/test/apm_api_integration/tests/feature_controls.ts
@@ -14,7 +14,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const security = getService('security');
   const spaces = getService('spaces');
-  const es = getService('legacyEs');
+  const es = getService('es');
   const log = getService('log');
 
   const start = encodeURIComponent(new Date(Date.now() - 10000).toISOString());


### PR DESCRIPTION
References #83910.
