### PR TITLE
[Dashboard] Fix Title BWC

### DIFF
--- a/src/plugins/dashboard/common/embeddable/embeddable_saved_object_converters.ts
+++ b/src/plugins/dashboard/common/embeddable/embeddable_saved_object_converters.ts
@@ -29,17 +29,14 @@ export function convertPanelStateToSavedDashboardPanel(
   panelState: DashboardPanelState,
   version: string
 ): SavedDashboardPanel {
-  const customTitle: string | undefined = panelState.explicitInput.title
-    ? (panelState.explicitInput.title as string)
-    : undefined;
   const savedObjectId = (panelState.explicitInput as SavedObjectEmbeddableInput).savedObjectId;
   return {
     version,
     type: panelState.type,
     gridData: panelState.gridData,
     panelIndex: panelState.explicitInput.id,
+    title: panelState.explicitInput.title,
     embeddableConfig: omit(panelState.explicitInput, ['id', 'savedObjectId', 'title']),
-    ...(customTitle && { title: customTitle }),
     ...(savedObjectId !== undefined && { id: savedObjectId }),
   };
 }

--- a/src/plugins/dashboard/common/embeddable/embeddable_saved_object_converters.ts
+++ b/src/plugins/dashboard/common/embeddable/embeddable_saved_object_converters.ts
@@ -35,8 +35,8 @@ export function convertPanelStateToSavedDashboardPanel(
     type: panelState.type,
     gridData: panelState.gridData,
     panelIndex: panelState.explicitInput.id,
-    title: panelState.explicitInput.title,
     embeddableConfig: omit(panelState.explicitInput, ['id', 'savedObjectId', 'title']),
+    ...(panelState.explicitInput.title !== undefined && { title: panelState.explicitInput.title }),
     ...(savedObjectId !== undefined && { id: savedObjectId }),
   };
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/95135

This is a very small PR that fixes backwards compatibility for hidden panel titles. Before 7.10.0, hidden titles were saved as a blank string, and this partially recreates that behaviour. Now setting a panel's title to a blank string, or loading a hidden panel from pre 7.10 will make it hidden in view mode.

**How to test?**
a) You can test by simply giving any panel on a dashboard a custom title of an empty string. Previously this would revert to the saved object title, but now it will count as a valid title, and will be hidden if you switch to view mode.

b) A more drastic test would be to create a dashboard in any version before 7.10, hide some panel titles using the switch, then export that dashboard and import it in this branch. All the panels that were configured to have a hidden title should still be hidden in view mode. Switching to edit mode, you should see `[No Title]`