### PR TITLE
[Observability] Fix broken icon in Global Search

### DIFF
--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -39,7 +39,7 @@ export class Plugin implements PluginClass<ObservabilityPluginSetup, Observabili
 
   public setup(core: CoreSetup, plugins: ObservabilityPluginSetupDeps) {
     const category = DEFAULT_APP_CATEGORIES.observability;
-    const euiIconType = 'logo-observability';
+    const euiIconType = 'logoObservability';
     const mount = async (params: AppMountParameters<unknown>) => {
       // Load application bundle
       const { renderApp } = await import('./application');


### PR DESCRIPTION
## Summary

Fixes the broken icon in the Global Search entries for the Observability overview page. The `EuiIcon` reference was not correct.

<img width="290" alt="Screenshot 2021-03-24 at 22 15 51" src="https://user-images.githubusercontent.com/4104278/112385482-f62abb00-8cef-11eb-94cc-b84743d4ebff.png">

_Before_

<img width="648" alt="Screenshot 2021-03-24 at 21 48 34" src="https://user-images.githubusercontent.com/4104278/112385402-e01cfa80-8cef-11eb-8ceb-c7ae605f84c6.png">

_After_

<img width="632" alt="Screenshot 2021-03-24 at 22 25 53" src="https://user-images.githubusercontent.com/4104278/112385438-e9a66280-8cef-11eb-883f-0e85eeeab350.png">