### PR TITLE
[App Search] API Logs - set up basic view & routing

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { EuiPageHeader } from '@elastic/eui';
+
+import { LogRetentionCallout, LogRetentionTooltip } from '../log_retention';
+
+import { ApiLogs } from './';
+
+describe('ApiLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(<ApiLogs engineBreadcrumb={['some engine']} />);
+
+    expect(wrapper.find(EuiPageHeader).prop('pageTitle')).toEqual('API Logs');
+    // TODO: Check for ApiLogsTable + NewApiEventsPrompt when those get added
+
+    expect(wrapper.find(LogRetentionCallout).prop('type')).toEqual('api');
+    expect(wrapper.find(LogRetentionTooltip).prop('type')).toEqual('api');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiPageHeader, EuiTitle, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+import { FlashMessages } from '../../../shared/flash_messages';
+import { SetAppSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
+import { BreadcrumbTrail } from '../../../shared/kibana_chrome/generate_breadcrumbs';
+
+import { LogRetentionCallout, LogRetentionTooltip, LogRetentionOptions } from '../log_retention';
+
+import { API_LOGS_TITLE, RECENT_API_EVENTS } from './constants';
+
+interface Props {
+  engineBreadcrumb: BreadcrumbTrail;
+}
+export const ApiLogs: React.FC<Props> = ({ engineBreadcrumb }) => {
+  return (
+    <>
+      <SetPageChrome trail={[...engineBreadcrumb, API_LOGS_TITLE]} />
+      <EuiPageHeader pageTitle={API_LOGS_TITLE} />
+
+      <FlashMessages />
+      <LogRetentionCallout type={LogRetentionOptions.API} />
+
+      <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false} wrap>
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h2>{RECENT_API_EVENTS}</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <LogRetentionTooltip type={LogRetentionOptions.API} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>{/* TODO: NewApiEventsPrompt */}</EuiFlexItem>
+      </EuiFlexGroup>
+
+      {/* TODO: ApiLogsTable */}
+    </>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { API_LOGS_TITLE } from './constants';
+export { ApiLogs } from './api_logs';

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_nav.tsx
@@ -246,8 +246,7 @@ export const EngineNav: React.FC = () => {
       )}
       {canViewEngineApiLogs && (
         <SideNavLink
-          isExternal
-          to={getAppSearchUrl(generateEnginePath(ENGINE_API_LOGS_PATH))}
+          to={generateEnginePath(ENGINE_API_LOGS_PATH)}
           data-test-subj="EngineAPILogsLink"
         >
           {API_LOGS_TITLE}

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.test.tsx
@@ -17,6 +17,7 @@ import { shallow } from 'enzyme';
 
 import { Loading } from '../../../shared/loading';
 import { AnalyticsRouter } from '../analytics';
+import { ApiLogs } from '../api_logs';
 import { CurationsRouter } from '../curations';
 import { EngineOverview } from '../engine_overview';
 import { RelevanceTuning } from '../relevance_tuning';
@@ -118,5 +119,12 @@ describe('EngineRouter', () => {
     const wrapper = shallow(<EngineRouter />);
 
     expect(wrapper.find(ResultSettings)).toHaveLength(1);
+  });
+
+  it('renders an API logs view', () => {
+    setMockValues({ ...values, myRole: { canViewEngineApiLogs: true } });
+    const wrapper = shallow(<EngineRouter />);
+
+    expect(wrapper.find(ApiLogs)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine/engine_router.tsx
@@ -31,9 +31,10 @@ import {
   ENGINE_CURATIONS_PATH,
   ENGINE_RESULT_SETTINGS_PATH,
   // ENGINE_SEARCH_UI_PATH,
-  // ENGINE_API_LOGS_PATH,
+  ENGINE_API_LOGS_PATH,
 } from '../../routes';
 import { AnalyticsRouter } from '../analytics';
+import { ApiLogs } from '../api_logs';
 import { CurationsRouter } from '../curations';
 import { DocumentDetail, Documents } from '../documents';
 import { OVERVIEW_TITLE } from '../engine_overview';
@@ -58,7 +59,7 @@ export const EngineRouter: React.FC = () => {
       canManageEngineCurations,
       canManageEngineResultSettings,
       // canManageEngineSearchUi,
-      // canViewEngineApiLogs,
+      canViewEngineApiLogs,
     },
   } = useValues(AppLogic);
 
@@ -113,6 +114,11 @@ export const EngineRouter: React.FC = () => {
       {canManageEngineResultSettings && (
         <Route path={ENGINE_RESULT_SETTINGS_PATH}>
           <ResultSettings engineBreadcrumb={engineBreadcrumb} />
+        </Route>
+      )}
+      {canViewEngineApiLogs && (
+        <Route path={ENGINE_API_LOGS_PATH}>
+          <ApiLogs engineBreadcrumb={engineBreadcrumb} />
         </Route>
       )}
       <Route>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/routes.ts
@@ -55,4 +55,4 @@ export const ENGINE_CURATIONS_NEW_PATH = `${ENGINE_CURATIONS_PATH}/new`;
 export const ENGINE_CURATION_PATH = `${ENGINE_CURATIONS_PATH}/:curationId`;
 
 export const ENGINE_SEARCH_UI_PATH = `${ENGINE_PATH}/reference_application/new`;
-export const ENGINE_API_LOGS_PATH = `${ENGINE_PATH}/api-logs`;
+export const ENGINE_API_LOGS_PATH = `${ENGINE_PATH}/api_logs`;


### PR DESCRIPTION
## Summary

Smol PR for setting up the routing/nav to the API logs page, with ILM callouts:

<img width="694" alt="" src="https://user-images.githubusercontent.com/549407/112389178-8b5a8f00-8cb1-11eb-98b2-fd39d39087b4.png">

<img width="521" alt="" src="https://user-images.githubusercontent.com/549407/112389199-931a3380-8cb1-11eb-872b-48f7d0e14dde.png">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)