### PR TITLE
[Lens] Change layout of top values function

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiFormRow,
@@ -13,9 +13,7 @@ import {
   EuiSwitch,
   EuiSwitchEvent,
   EuiSpacer,
-  EuiPopover,
-  EuiButtonEmpty,
-  EuiText,
+  EuiAccordion,
   EuiIconTip,
 } from '@elastic/eui';
 import { AggFunctionsMapping } from '../../../../../../../../src/plugins/data/public';
@@ -24,7 +22,7 @@ import { updateColumnParam, isReferenced } from '../../layer_helpers';
 import { DataType } from '../../../../types';
 import { OperationDefinition } from '../index';
 import { FieldBasedIndexPatternColumn } from '../column_types';
-import { ValuesRangeInput } from './values_range_input';
+import { ValuesInput } from './values_input';
 import { getEsAggsSuffix, getInvalidFieldMessage } from '../helpers';
 import type { IndexPatternLayer } from '../../../types';
 
@@ -193,8 +191,6 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
   paramEditor: function ParamEditor({ layer, updateLayer, currentColumn, columnId, indexPattern }) {
     const hasRestrictions = indexPattern.hasRestrictions;
 
-    const [popoverOpen, setPopoverOpen] = useState(false);
-
     const SEPARATOR = '$$$';
     function toValue(orderBy: TermsIndexPatternColumn['params']['orderBy']) {
       if (orderBy.type === 'alphabetical') {
@@ -237,7 +233,7 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
           display="columnCompressed"
           fullWidth
         >
-          <ValuesRangeInput
+          <ValuesInput
             value={currentColumn.params.size}
             onChange={(value) => {
               updateLayer(
@@ -251,71 +247,6 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
             }}
           />
         </EuiFormRow>
-        {!hasRestrictions && (
-          <EuiText textAlign="right">
-            <EuiPopover
-              ownFocus
-              button={
-                <EuiButtonEmpty
-                  size="xs"
-                  iconType="arrowDown"
-                  iconSide="right"
-                  onClick={() => {
-                    setPopoverOpen(!popoverOpen);
-                  }}
-                >
-                  {i18n.translate('xpack.lens.indexPattern.terms.advancedSettings', {
-                    defaultMessage: 'Advanced',
-                  })}
-                </EuiButtonEmpty>
-              }
-              isOpen={popoverOpen}
-              closePopover={() => {
-                setPopoverOpen(false);
-              }}
-            >
-              <EuiSwitch
-                label={i18n.translate('xpack.lens.indexPattern.terms.otherBucketDescription', {
-                  defaultMessage: 'Group other values as "Other"',
-                })}
-                compressed
-                data-test-subj="indexPattern-terms-other-bucket"
-                checked={Boolean(currentColumn.params.otherBucket)}
-                onChange={(e: EuiSwitchEvent) =>
-                  updateLayer(
-                    updateColumnParam({
-                      layer,
-                      columnId,
-                      paramName: 'otherBucket',
-                      value: e.target.checked,
-                    })
-                  )
-                }
-              />
-              <EuiSpacer size="m" />
-              <EuiSwitch
-                label={i18n.translate('xpack.lens.indexPattern.terms.missingBucketDescription', {
-                  defaultMessage: 'Include documents without this field',
-                })}
-                compressed
-                disabled={!currentColumn.params.otherBucket}
-                data-test-subj="indexPattern-terms-missing-bucket"
-                checked={Boolean(currentColumn.params.missingBucket)}
-                onChange={(e: EuiSwitchEvent) =>
-                  updateLayer(
-                    updateColumnParam({
-                      layer,
-                      columnId,
-                      paramName: 'missingBucket',
-                      value: e.target.checked,
-                    })
-                  )
-                }
-              />
-            </EuiPopover>
-            <EuiSpacer size="s" />
-          </EuiText>
-        )}
         <EuiFormRow
           label={
             <>
@@ -415,6 +346,57 @@ export const termsOperation: OperationDefinition<TermsIndexPatternColumn, 'field
             })}
           />
         </EuiFormRow>
+        {!hasRestrictions && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiAccordion
+              id="lnsTermsAdvanced"
+              buttonContent={i18n.translate('xpack.lens.indexPattern.terms.advancedSettings', {
+                defaultMessage: 'Advanced',
+              })}
+            >
+              <EuiSpacer size="m" />
+              <EuiSwitch
+                label={i18n.translate('xpack.lens.indexPattern.terms.otherBucketDescription', {
+                  defaultMessage: 'Group other values as "Other"',
+                })}
+                compressed
+                data-test-subj="indexPattern-terms-other-bucket"
+                checked={Boolean(currentColumn.params.otherBucket)}
+                onChange={(e: EuiSwitchEvent) =>
+                  updateLayer(
+                    updateColumnParam({
+                      layer,
+                      columnId,
+                      paramName: 'otherBucket',
+                      value: e.target.checked,
+                    })
+                  )
+                }
+              />
+              <EuiSpacer size="m" />
+              <EuiSwitch
+                label={i18n.translate('xpack.lens.indexPattern.terms.missingBucketDescription', {
+                  defaultMessage: 'Include documents without this field',
+                })}
+                compressed
+                disabled={!currentColumn.params.otherBucket}
+                data-test-subj="indexPattern-terms-missing-bucket"
+                checked={Boolean(currentColumn.params.missingBucket)}
+                onChange={(e: EuiSwitchEvent) =>
+                  updateLayer(
+                    updateColumnParam({
+                      layer,
+                      columnId,
+                      paramName: 'missingBucket',
+                      value: e.target.checked,
+                    })
+                  )
+                }
+              />
+            </EuiAccordion>
+          </>
+        )}
       </>
     );
   },

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/terms.test.tsx
@@ -8,12 +8,12 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { shallow, mount } from 'enzyme';
-import { EuiRange, EuiSelect, EuiSwitch, EuiSwitchEvent } from '@elastic/eui';
+import { EuiFieldNumber, EuiSelect, EuiSwitch, EuiSwitchEvent } from '@elastic/eui';
 import type { IUiSettingsClient, SavedObjectsClientContract, HttpSetup } from 'kibana/public';
 import type { IStorageWrapper } from 'src/plugins/kibana_utils/public';
 import { dataPluginMock } from '../../../../../../../../src/plugins/data/public/mocks';
 import { createMockedIndexPattern } from '../../../mocks';
-import { ValuesRangeInput } from './values_range_input';
+import { ValuesInput } from './values_input';
 import type { TermsIndexPatternColumn } from '.';
 import { termsOperation } from '../index';
 import { IndexPattern, IndexPatternLayer } from '../../../types';
@@ -888,7 +888,7 @@ describe('terms', () => {
         />
       );
 
-      expect(instance.find(EuiRange).prop('value')).toEqual('3');
+      expect(instance.find(EuiFieldNumber).prop('value')).toEqual('3');
     });
 
     it('should update state with the size value', () => {
@@ -904,7 +904,7 @@ describe('terms', () => {
       );
 
       act(() => {
-        instance.find(ValuesRangeInput).prop('onChange')!(7);
+        instance.find(ValuesInput).prop('onChange')!(7);
       });
 
       expect(updateLayerSpy).toHaveBeenCalledWith({

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/values_input.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/values_input.test.tsx
@@ -8,52 +8,50 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { shallow } from 'enzyme';
-import { EuiRange } from '@elastic/eui';
-import { ValuesRangeInput } from './values_range_input';
+import { EuiFieldNumber } from '@elastic/eui';
+import { ValuesInput } from './values_input';
 
 jest.mock('react-use/lib/useDebounce', () => (fn: () => void) => fn());
 
-describe('ValuesRangeInput', () => {
-  it('should render EuiRange correctly', () => {
+describe('Values', () => {
+  it('should render EuiFieldNumber correctly', () => {
     const onChangeSpy = jest.fn();
-    const instance = shallow(<ValuesRangeInput value={5} onChange={onChangeSpy} />);
+    const instance = shallow(<ValuesInput value={5} onChange={onChangeSpy} />);
 
-    expect(instance.find(EuiRange).prop('value')).toEqual('5');
+    expect(instance.find(EuiFieldNumber).prop('value')).toEqual('5');
   });
 
   it('should not run onChange function on mount', () => {
     const onChangeSpy = jest.fn();
-    shallow(<ValuesRangeInput value={5} onChange={onChangeSpy} />);
+    shallow(<ValuesInput value={5} onChange={onChangeSpy} />);
 
     expect(onChangeSpy.mock.calls.length).toBe(0);
   });
 
   it('should run onChange function on update', () => {
     const onChangeSpy = jest.fn();
-    const instance = shallow(<ValuesRangeInput value={5} onChange={onChangeSpy} />);
+    const instance = shallow(<ValuesInput value={5} onChange={onChangeSpy} />);
     act(() => {
-      instance.find(EuiRange).prop('onChange')!(
-        { currentTarget: { value: '7' } } as React.ChangeEvent<HTMLInputElement>,
-        true
-      );
+      instance.find(EuiFieldNumber).prop('onChange')!({
+        currentTarget: { value: '7' },
+      } as React.ChangeEvent<HTMLInputElement>);
     });
-    expect(instance.find(EuiRange).prop('value')).toEqual('7');
+    expect(instance.find(EuiFieldNumber).prop('value')).toEqual('7');
     expect(onChangeSpy.mock.calls.length).toBe(1);
     expect(onChangeSpy.mock.calls[0][0]).toBe(7);
   });
 
   it('should not run onChange function on update when value is out of 1-100 range', () => {
     const onChangeSpy = jest.fn();
-    const instance = shallow(<ValuesRangeInput value={5} onChange={onChangeSpy} />);
+    const instance = shallow(<ValuesInput value={5} onChange={onChangeSpy} />);
     act(() => {
-      instance.find(EuiRange).prop('onChange')!(
-        { currentTarget: { value: '107' } } as React.ChangeEvent<HTMLInputElement>,
-        true
-      );
+      instance.find(EuiFieldNumber).prop('onChange')!({
+        currentTarget: { value: '1007' },
+      } as React.ChangeEvent<HTMLInputElement>);
     });
     instance.update();
-    expect(instance.find(EuiRange).prop('value')).toEqual('107');
+    expect(instance.find(EuiFieldNumber).prop('value')).toEqual('1007');
     expect(onChangeSpy.mock.calls.length).toBe(1);
-    expect(onChangeSpy.mock.calls[0][0]).toBe(100);
+    expect(onChangeSpy.mock.calls[0][0]).toBe(1000);
   });
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/values_input.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/terms/values_input.tsx
@@ -7,10 +7,10 @@
 
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiRange } from '@elastic/eui';
+import { EuiFieldNumber } from '@elastic/eui';
 import { useDebounceWithOptions } from '../helpers';
 
-export const ValuesRangeInput = ({
+export const ValuesInput = ({
   value,
   onChange,
 }: {
@@ -18,7 +18,7 @@ export const ValuesRangeInput = ({
   onChange: (value: number) => void;
 }) => {
   const MIN_NUMBER_OF_VALUES = 1;
-  const MAX_NUMBER_OF_VALUES = 100;
+  const MAX_NUMBER_OF_VALUES = 1000;
 
   const [inputValue, setInputValue] = useState(String(value));
 
@@ -36,13 +36,11 @@ export const ValuesRangeInput = ({
   );
 
   return (
-    <EuiRange
+    <EuiFieldNumber
       min={MIN_NUMBER_OF_VALUES}
       max={MAX_NUMBER_OF_VALUES}
       step={1}
       value={inputValue}
-      showInput
-      showLabels
       compressed
       onChange={({ currentTarget }) => setInputValue(currentTarget.value)}
       aria-label={i18n.translate('xpack.lens.indexPattern.terms.size', {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/93912

This rearranges the layout of the top values function in two ways:
* Remove the slider for number of top values
* Change the "advanced" popover into an accordion

As a band-aid fix for the limit of top values (https://github.com/elastic/kibana/issues/95007), this PR is also increasing the maximum number of terms to 1000