### PR TITLE
[Workplace Search] Add button on non-MVP pages to link to personal dashboard

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.test.tsx
@@ -9,13 +9,14 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiButtonEmpty } from '@elastic/eui';
-
 import { externalUrl } from '../../../shared/enterprise_search_url';
+import { WORKPLACE_SEARCH_URL_PREFIX } from '../../constants';
 
 import { WorkplaceSearchHeaderActions } from './';
 
 describe('WorkplaceSearchHeaderActions', () => {
+  const ENT_SEARCH_URL = 'http://localhost:3002';
+
   it('does not render without an Enterprise Search URL set', () => {
     const wrapper = shallow(<WorkplaceSearchHeaderActions />);
 
@@ -23,22 +24,32 @@ describe('WorkplaceSearchHeaderActions', () => {
   });
 
   it('renders a link to the personal dashboard', () => {
-    externalUrl.enterpriseSearchUrl = 'http://localhost:3002';
-
+    externalUrl.enterpriseSearchUrl = ENT_SEARCH_URL;
     const wrapper = shallow(<WorkplaceSearchHeaderActions />);
 
-    expect(wrapper.find(EuiButtonEmpty).first().prop('href')).toEqual(
-      'http://localhost:3002/ws/sources'
+    expect(wrapper.find('[data-test-subj="PersonalDashboardButton"]').prop('to')).toEqual(
+      '/p/sources'
     );
+    expect(wrapper.find('[data-test-subj="PersonalDashboardMVPButton"]')).toHaveLength(0);
   });
 
   it('renders a link to the search application', () => {
-    externalUrl.enterpriseSearchUrl = 'http://localhost:3002';
-
+    externalUrl.enterpriseSearchUrl = ENT_SEARCH_URL;
     const wrapper = shallow(<WorkplaceSearchHeaderActions />);
 
-    expect(wrapper.find(EuiButtonEmpty).last().prop('href')).toEqual(
+    expect(wrapper.find('[data-test-subj="HeaderSearchButton"]').prop('href')).toEqual(
       'http://localhost:3002/ws/search'
     );
+  });
+
+  it('renders an MVP link back to the legacy dashboard on the MVP page', () => {
+    window.history.pushState({}, 'Overview', WORKPLACE_SEARCH_URL_PREFIX);
+    externalUrl.enterpriseSearchUrl = ENT_SEARCH_URL;
+    const wrapper = shallow(<WorkplaceSearchHeaderActions />);
+
+    expect(wrapper.find('[data-test-subj="PersonalDashboardMVPButton"]').prop('href')).toEqual(
+      `${ENT_SEARCH_URL}/ws/sources`
+    );
+    expect(wrapper.find('[data-test-subj="PersonalDashboardButton"]')).toHaveLength(0);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.tsx
@@ -10,20 +10,46 @@ import React from 'react';
 import { EuiButtonEmpty, EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { externalUrl, getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
-import { NAV } from '../../constants';
+import { EuiButtonEmptyTo } from '../../../shared/react_router_helpers';
+import { NAV, WORKPLACE_SEARCH_URL_PREFIX } from '../../constants';
+import { PERSONAL_SOURCES_PATH } from '../../routes';
 
 export const WorkplaceSearchHeaderActions: React.FC = () => {
   if (!externalUrl.enterpriseSearchUrl) return null;
 
+  const isMVP = window.location.pathname.endsWith(WORKPLACE_SEARCH_URL_PREFIX);
+
+  const personalDashboardMVPButton = (
+    <EuiButtonEmpty
+      data-test-subj="PersonalDashboardMVPButton"
+      iconType="user"
+      href={getWorkplaceSearchUrl('/sources')}
+      target="_blank"
+    >
+      <EuiText size="s">{NAV.PERSONAL_DASHBOARD}</EuiText>
+    </EuiButtonEmpty>
+  );
+
+  const personalDashboardButton = (
+    <EuiButtonEmptyTo
+      data-test-subj="PersonalDashboardButton"
+      iconType="user"
+      to={PERSONAL_SOURCES_PATH}
+    >
+      <EuiText size="s">{NAV.PERSONAL_DASHBOARD}</EuiText>
+    </EuiButtonEmptyTo>
+  );
+
   return (
     <EuiFlexGroup gutterSize="s">
+      <EuiFlexItem>{isMVP ? personalDashboardMVPButton : personalDashboardButton}</EuiFlexItem>
       <EuiFlexItem>
-        <EuiButtonEmpty href={getWorkplaceSearchUrl('/sources')} target="_blank" iconType="user">
-          <EuiText size="s">{NAV.PERSONAL_DASHBOARD}</EuiText>
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiButtonEmpty href={getWorkplaceSearchUrl('/search')} target="_blank" iconType="search">
+        <EuiButtonEmpty
+          data-test-subj="HeaderSearchButton"
+          href={getWorkplaceSearchUrl('/search')}
+          target="_blank"
+          iconType="search"
+        >
           <EuiText size="s">{NAV.SEARCH}</EuiText>
         </EuiButtonEmpty>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

For the 7.13 release, we are opening up a private alpha to internal stakeholders for QA. There is a link in the header navigation that links to the Personal Dashboard in the Kibana UI. This PR adds a temporary workaround where users of the existing MVP keep the existing behavior, which is to take them into the legacy UI, where alpha users will have the link take them into the alpha Personal Dashboard

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
