### PR TITLE
[kbn/test] switch to @elastic/elasticsearch

### DIFF
--- a/packages/kbn-test/src/legacy_es/legacy_es_test_cluster.js
+++ b/packages/kbn-test/src/legacy_es/legacy_es_test_cluster.js
@@ -12,9 +12,9 @@ import { get, toPath } from 'lodash';
 import { Cluster } from '@kbn/es';
 import { CI_PARALLEL_PROCESS_PREFIX } from '../ci_parallel_process_prefix';
 import { esTestConfig } from './es_test_config';
+import { Client } from '@elastic/elasticsearch';
 
 import { KIBANA_ROOT } from '../';
-import * as legacyElasticsearch from 'elasticsearch';
 const path = require('path');
 const del = require('del');
 
@@ -102,8 +102,8 @@ export function createLegacyEsTestCluster(options = {}) {
      * Returns an ES Client to the configured cluster
      */
     getClient() {
-      return new legacyElasticsearch.Client({
-        host: this.getUrl(),
+      return new Client({
+        node: this.getUrl(),
       });
     }
 


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/83910

Switches the esClient exposed by `createLegacyEsTestCluster()` to be the modern `@elastic/elasticsearch` client. I've traced the uses of this function and it seems like there is only one place that is using the `getCallCluster()` helper now, and it's only passing basic args to this function, so I don't expect this update to have much impact as this is a legacy helper.