### PR TITLE
[Workplace Search] Design polish: groups pages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -60,7 +60,7 @@ export const Groups: React.FC = () => {
     messages[0].description = (
       <EuiButtonTo
         to={getGroupPath(newGroup.id)}
-        color="primary"
+        color="secondary"
         data-test-subj="NewGroupManageButton"
       >
         {i18n.translate('xpack.enterpriseSearch.workplaceSearch.groups.newGroup.action', {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

| Before | After |
| --- | --- |
| ![button update@2x](https://user-images.githubusercontent.com/2472911/112516492-5576e280-8d65-11eb-887b-8017b2498bd9.png) | ![button-update-2@2x](https://user-images.githubusercontent.com/2472911/112516516-5c9df080-8d65-11eb-9754-c67e565679e9.png) |

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
