### PR TITLE
[Workplace Search] Update global state when org name changes

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.test.ts
@@ -82,4 +82,14 @@ describe('AppLogic', () => {
       expect(AppLogic.values.account.canCreatePersonalSources).toEqual(true);
     });
   });
+
+  describe('setOrgName', () => {
+    it('sets property', () => {
+      const NAME = 'new name';
+      mount(DEFAULT_INITIAL_APP_DATA);
+      AppLogic.actions.setOrgName(NAME);
+
+      expect(AppLogic.values.organization.name).toEqual(NAME);
+    });
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/app_logic.ts
@@ -22,6 +22,7 @@ interface AppValues extends WorkplaceSearchInitialData {
 interface AppActions {
   initializeAppData(props: InitialAppData): InitialAppData;
   setContext(isOrganization: boolean): boolean;
+  setOrgName(name: string): string;
   setSourceRestriction(canCreatePersonalSources: boolean): boolean;
 }
 
@@ -36,6 +37,7 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       isFederatedAuth,
     }),
     setContext: (isOrganization) => isOrganization,
+    setOrgName: (name: string) => name,
     setSourceRestriction: (canCreatePersonalSources: boolean) => canCreatePersonalSources,
   },
   reducers: {
@@ -61,6 +63,10 @@ export const AppLogic = kea<MakeLogicType<AppValues, AppActions>>({
       emptyOrg,
       {
         initializeAppData: (_, { workplaceSearch }) => workplaceSearch?.organization || emptyOrg,
+        setOrgName: (state, name) => ({
+          ...state,
+          name,
+        }),
       },
     ],
     account: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/settings/settings_logic.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../shared/flash_messages';
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana';
+import { AppLogic } from '../../app_logic';
 import { ORG_UPDATED_MESSAGE, OAUTH_APP_UPDATED_MESSAGE } from '../../constants';
 import { ORG_SETTINGS_CONNECTORS_PATH } from '../../routes';
 import { Connector } from '../../types';
@@ -150,6 +151,7 @@ export const SettingsLogic = kea<MakeLogicType<SettingsValues, SettingsActions>>
         const response = await http.put(route, { body });
         actions.setUpdatedName(response);
         setSuccessMessage(ORG_UPDATED_MESSAGE);
+        AppLogic.actions.setOrgName(name);
       } catch (e) {
         flashAPIErrors(e);
       }


### PR DESCRIPTION
## Summary

Currently, we instantiate the Workplace Search app with server props passed in from the server on [initial page load](https://github.com/elastic/kibana/blob/master/x-pack/plugins/enterprise_search/public/plugin.ts). This data includes the organization name. In our settings section, we fetch data from the server to get updated information, but once the data is changed, the global state does not get updated before a route change. This is only a problem in the case where a user has changed their org name and returns to the overview page before reloading the page. When this happens, the [onboarding step](https://github.com/elastic/kibana/blob/master/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/onboarding_steps.tsx#L125-L130) asking the user to change their org name is still visible.

![image](https://user-images.githubusercontent.com/1869731/112522659-e51f8f80-8d6b-11eb-9d19-c50c56c6ece9.png)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
