### PR TITLE
[App Search] Refactor Result Settings logic

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.test.ts
@@ -27,13 +27,13 @@ describe('ResultSettingsLogic', () => {
     saving: false,
     openModal: OpenModal.None,
     resultFields: {},
-    serverResultFields: {},
     lastSavedResultFields: {},
     schema: {},
     schemaConflicts: {},
   };
 
   const SELECTORS = {
+    serverResultFields: {},
     reducedServerResultFields: {},
     resultFieldsAtDefaultSettings: true,
     resultFieldsEmpty: true,
@@ -138,13 +138,6 @@ describe('ResultSettingsLogic', () => {
               snippetFallback: false,
             },
           },
-          // It stores the originally passed results as serverResultFields
-          serverResultFields: {
-            foo: { raw: { size: 5 } },
-            // Baz was not part of the original serverResultFields, it was injected based on the schema
-            baz: {},
-            bar: { raw: { size: 5 } },
-          },
           // The modal should be reset back to closed if it had been opened previously
           openModal: OpenModal.None,
           // Stores the provided schema details
@@ -210,10 +203,6 @@ describe('ResultSettingsLogic', () => {
             quuz: { raw: false, snippet: false, snippetFallback: false },
             corge: { raw: true, snippet: false, snippetFallback: true },
           },
-          serverResultFields: {
-            grault: { raw: { size: 5 } },
-            garply: { raw: true },
-          },
         });
 
         ResultSettingsLogic.actions.clearAllFields();
@@ -223,10 +212,6 @@ describe('ResultSettingsLogic', () => {
           resultFields: {
             quuz: {},
             corge: {},
-          },
-          serverResultFields: {
-            grault: {},
-            garply: {},
           },
         });
       });
@@ -239,10 +224,6 @@ describe('ResultSettingsLogic', () => {
             quuz: { raw: true, snippet: true, snippetFallback: true },
             corge: { raw: true, snippet: true, snippetFallback: true },
           },
-          serverResultFields: {
-            grault: { raw: { size: 5 } },
-            garply: { raw: true },
-          },
         });
 
         ResultSettingsLogic.actions.resetAllFields();
@@ -252,10 +233,6 @@ describe('ResultSettingsLogic', () => {
           resultFields: {
             quuz: { raw: true, snippet: false, snippetFallback: false },
             corge: { raw: true, snippet: false, snippetFallback: false },
-          },
-          serverResultFields: {
-            grault: { raw: {} },
-            garply: { raw: {} },
           },
         });
       });
@@ -280,10 +257,6 @@ describe('ResultSettingsLogic', () => {
           foo: { raw: true, snippet: true, snippetFallback: true },
           bar: { raw: true, snippet: true, snippetFallback: true },
         },
-        serverResultFields: {
-          foo: { raw: { size: 5 } },
-          bar: { raw: true },
-        },
       };
 
       it('should update settings for an individual field', () => {
@@ -301,11 +274,6 @@ describe('ResultSettingsLogic', () => {
           resultFields: {
             foo: { raw: true, snippet: false, snippetFallback: false },
             bar: { raw: true, snippet: true, snippetFallback: true },
-          },
-          serverResultFields: {
-            // Note that the specified settings for foo get converted to a "server" format here
-            foo: { raw: {} },
-            bar: { raw: true },
           },
         });
       });
@@ -470,11 +438,45 @@ describe('ResultSettingsLogic', () => {
       });
     });
 
-    describe('reducedServerResultFields', () => {
-      it('filters out fields that do not have any settings', () => {
+    describe('serverResultFields', () => {
+      it('returns resultFields formatted for the server', () => {
         mount({
-          serverResultFields: {
-            foo: { raw: { size: 5 } },
+          resultFields: {
+            foo: {
+              raw: true,
+              rawSize: 5,
+              snippet: true,
+              snippetFallback: true,
+              snippetSize: 3,
+            },
+            bar: {},
+            baz: {
+              raw: false,
+              snippet: false,
+              snippetFallback: false,
+            },
+          },
+        });
+
+        expect(ResultSettingsLogic.values.serverResultFields).toEqual({
+          foo: {
+            raw: { size: 5 },
+            snippet: { fallback: true, size: 3 },
+          },
+          bar: {},
+          baz: {},
+        });
+      });
+    });
+
+    describe('reducedServerResultFields', () => {
+      it('returns server formatted fields with empty settings filtered out', () => {
+        mount({
+          resultFields: {
+            foo: {
+              raw: true,
+              rawSize: 5,
+            },
             bar: {},
           },
         });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/result_settings_logic.ts
@@ -109,7 +109,6 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
         resultFields,
         schema,
         schemaConflicts,
-        ...splitResultFields(resultFields, schema),
       };
     },
     clearAllFields: () => true,
@@ -149,30 +148,6 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
         openConfirmResetModal: () => OpenModal.ConfirmResetModal,
         openConfirmSaveModal: () => OpenModal.ConfirmSaveModal,
         saving: () => OpenModal.None,
-      },
-    ],
-    nonTextResultFields: [
-      {},
-      {
-        initializeResultFields: (_, { nonTextResultFields }) => nonTextResultFields,
-        clearAllFields: (nonTextResultFields) => clearAllFields(nonTextResultFields),
-        resetAllFields: (nonTextResultFields) => resetAllFields(nonTextResultFields),
-        updateField: (nonTextResultFields, { fieldName, settings }) =>
-          nonTextResultFields.hasOwnProperty(fieldName)
-            ? { ...nonTextResultFields, [fieldName]: settings }
-            : nonTextResultFields,
-      },
-    ],
-    textResultFields: [
-      {},
-      {
-        initializeResultFields: (_, { textResultFields }) => textResultFields,
-        clearAllFields: (textResultFields) => clearAllFields(textResultFields),
-        resetAllFields: (textResultFields) => resetAllFields(textResultFields),
-        updateField: (textResultFields, { fieldName, settings }) =>
-          textResultFields.hasOwnProperty(fieldName)
-            ? { ...textResultFields, [fieldName]: settings }
-            : textResultFields,
       },
     ],
     resultFields: [
@@ -223,6 +198,20 @@ export const ResultSettingsLogic = kea<MakeLogicType<ResultSettingsValues, Resul
     ],
   }),
   selectors: ({ selectors }) => ({
+    textResultFields: [
+      () => [selectors.resultFields, selectors.schema],
+      (resultFields: FieldResultSettingObject, schema: Schema) => {
+        const { textResultFields } = splitResultFields(resultFields, schema);
+        return textResultFields;
+      },
+    ],
+    nonTextResultFields: [
+      () => [selectors.resultFields, selectors.schema],
+      (resultFields: FieldResultSettingObject, schema: Schema) => {
+        const { nonTextResultFields } = splitResultFields(resultFields, schema);
+        return nonTextResultFields;
+      },
+    ],
     resultFieldsAtDefaultSettings: [
       () => [selectors.resultFields],
       (resultFields) => areFieldsAtDefaultSettings(resultFields),

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.test.ts
@@ -12,9 +12,7 @@ import {
   areFieldsEmpty,
   convertServerResultFieldsToResultFields,
   convertToServerFieldResultSetting,
-  clearAllServerFields,
   clearAllFields,
-  resetAllServerFields,
   resetAllFields,
   splitResultFields,
 } from './utils';
@@ -33,20 +31,6 @@ describe('clearAllFields', () => {
   });
 });
 
-describe('clearAllServerFields', () => {
-  it('will reset every key in an object back to an empty object', () => {
-    expect(
-      clearAllServerFields({
-        foo: { raw: { size: 5 } },
-        bar: { raw: true },
-      })
-    ).toEqual({
-      foo: {},
-      bar: {},
-    });
-  });
-});
-
 describe('resetAllFields', () => {
   it('will reset every key in an object back to a default object', () => {
     expect(
@@ -57,20 +41,6 @@ describe('resetAllFields', () => {
     ).toEqual({
       foo: { raw: true, snippet: false, snippetFallback: false },
       bar: { raw: true, snippet: false, snippetFallback: false },
-    });
-  });
-});
-
-describe('resetAllServerFields', () => {
-  it('will reset every key in an object back to a default object', () => {
-    expect(
-      resetAllServerFields({
-        foo: { raw: { size: 5 } },
-        bar: { snippet: true },
-      })
-    ).toEqual({
-      foo: { raw: {} },
-      bar: { raw: {} },
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/result_settings/utils.ts
@@ -59,14 +59,8 @@ const convertToFieldResultSetting = (serverFieldResultSetting: ServerFieldResult
 
 export const clearAllFields = (fields: FieldResultSettingObject) => updateAllFields(fields, {});
 
-export const clearAllServerFields = (fields: ServerFieldResultSettingObject) =>
-  updateAllFields(fields, {});
-
 export const resetAllFields = (fields: FieldResultSettingObject) =>
   updateAllFields(fields, DEFAULT_FIELD_SETTINGS);
-
-export const resetAllServerFields = (fields: ServerFieldResultSettingObject) =>
-  updateAllFields(fields, { raw: {} });
 
 export const convertServerResultFieldsToResultFields = (
   serverResultFields: ServerFieldResultSettingObject,


### PR DESCRIPTION
## Summary

This PR refactors ResultSettingsLogic to convert `textResultFields`, `nonTextResultFields`, and `serverResultFields` to be selectors, rather than actual values in state. This greatly reduces the complexity of this file, as we do not have to keep redundant copies of data up to date. Since they are memoized selectors they are efficiently computed only when the underlying data changes.

This will likely be the first of a few refactors. I am selectively refactoring as I role out the UI.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
