### PR TITLE
[APM] RangeId invalidates the dependencies of all useFechers.

### DIFF
--- a/x-pack/plugins/apm/public/context/url_params_context/mock_url_params_context_provider.tsx
+++ b/x-pack/plugins/apm/public/context/url_params_context/mock_url_params_context_provider.tsx
@@ -32,7 +32,6 @@ export function MockUrlParamsContextProvider({
   return (
     <UrlParamsContext.Provider
       value={{
-        rangeId: 0,
         refreshTimeRange,
         urlParams,
         uiFilters: {},

--- a/x-pack/plugins/apm/public/hooks/use_fetcher.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_fetcher.tsx
@@ -14,7 +14,6 @@ import {
   AutoAbortedAPMClient,
 } from '../services/rest/createCallApmApi';
 import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
-import { useUrlParams } from '../context/url_params_context/use_url_params';
 
 export enum FETCH_STATUS {
   LOADING = 'loading',
@@ -77,7 +76,6 @@ export function useFetcher<TReturn>(
     status: FETCH_STATUS.NOT_INITIATED,
   });
   const [counter, setCounter] = useState(0);
-  const { rangeId } = useUrlParams();
 
   useEffect(() => {
     let controller: AbortController = new AbortController();
@@ -160,7 +158,6 @@ export function useFetcher<TReturn>(
   }, [
     counter,
     preservePreviousData,
-    rangeId,
     showToastOnError,
     ...fnDeps,
     /* eslint-enable react-hooks/exhaustive-deps */


### PR DESCRIPTION
closes #93942

Because of the rangeId dependency on `useFetcher`, every time the `Refresh` button was clicked it refetched all APIs because a new value was set on rangeId. 

It wasn't a problem until the Time comparison feature was introduced. The time comparison APIs must wait until the primary statistics API finishes to then request the comparison data, but the rangeId dependency was making the comparison APIs to be invoked twice.

Before:
<img width="2964" alt="Screen Shot 2021-03-26 at 14 03 03" src="https://user-images.githubusercontent.com/55978943/112678842-d2778a00-8e41-11eb-910c-664a03c60327.png">

After:
<img width="3196" alt="Screen Shot 2021-03-26 at 14 04 00" src="https://user-images.githubusercontent.com/55978943/112678860-d99e9800-8e41-11eb-92d0-ad96c8aea5e6.png">
