### PR TITLE
[Workplace Search] Design polish: source add lists

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/types.ts
@@ -85,6 +85,7 @@ export interface SourceDataItem {
   addPath: string;
   editPath: string;
   accountContextOnly: boolean;
+  privateSourcesEnabled: boolean;
 }
 
 export interface ContentSource {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
@@ -93,7 +93,20 @@ export const AddSourceList: React.FC = () => {
 
   return (
     <>
-      <ViewContentHeader title={PAGE_TITLE} />
+      <ViewContentHeader
+        title={PAGE_TITLE}
+        action={
+          <EuiFormRow>
+            <EuiFieldSearch
+              data-test-subj="FilterSourcesInput"
+              value={filterValue}
+              onChange={handleFilterChange}
+              fullWidth
+              placeholder={ADD_SOURCE_PLACEHOLDER}
+            />
+          </EuiFormRow>
+        }
+      />
       {showConfiguredSourcesList || isOrganization ? (
         <ContentSection>
           {showConfiguredSourcesList && (
@@ -103,18 +116,7 @@ export const AddSourceList: React.FC = () => {
             />
           )}
           {isOrganization && (
-            <>
-              <EuiFormRow>
-                <EuiFieldSearch
-                  data-test-subj="FilterSourcesInput"
-                  value={filterValue}
-                  onChange={handleFilterChange}
-                  fullWidth
-                  placeholder={ADD_SOURCE_PLACEHOLDER}
-                />
-              </EuiFormRow>
-              <AvailableSourcesList sources={visibleAvailableSources} />
-            </>
+            <AvailableSourcesList sources={visibleAvailableSources} />
           )}
         </ContentSection>
       ) : (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_list.tsx
@@ -65,12 +65,6 @@ export const AddSourceList: React.FC = () => {
     ({ serviceType }) => serviceType !== CUSTOM_SERVICE_TYPE
   );
 
-  const BASE_DESCRIPTION = hasSources ? '' : ADD_SOURCE_NEW_SOURCE_DESCRIPTION;
-  const PAGE_CONTEXT_DESCRIPTION = isOrganization
-    ? ADD_SOURCE_ORG_SOURCE_DESCRIPTION
-    : ADD_SOURCE_PRIVATE_SOURCE_DESCRIPTION;
-
-  const PAGE_DESCRIPTION = BASE_DESCRIPTION + PAGE_CONTEXT_DESCRIPTION;
   const HAS_SOURCES_TITLE = isOrganization
     ? ADD_SOURCE_ORG_SOURCES_TITLE
     : ADD_SOURCE_PRIVATE_SOURCES_TITLE;
@@ -99,27 +93,29 @@ export const AddSourceList: React.FC = () => {
 
   return (
     <>
-      <ViewContentHeader title={PAGE_TITLE} description={PAGE_DESCRIPTION} />
+      <ViewContentHeader title={PAGE_TITLE} />
       {showConfiguredSourcesList || isOrganization ? (
         <ContentSection>
-          <EuiSpacer size="m" />
-          <EuiFormRow>
-            <EuiFieldSearch
-              data-test-subj="FilterSourcesInput"
-              value={filterValue}
-              onChange={handleFilterChange}
-              fullWidth
-              placeholder={ADD_SOURCE_PLACEHOLDER}
-            />
-          </EuiFormRow>
-          <EuiSpacer size="xxl" />
           {showConfiguredSourcesList && (
             <ConfiguredSourcesList
               isOrganization={isOrganization}
               sources={visibleConfiguredSources}
             />
           )}
-          {isOrganization && <AvailableSourcesList sources={visibleAvailableSources} />}
+          {isOrganization && (
+            <>
+              <EuiFormRow>
+                <EuiFieldSearch
+                  data-test-subj="FilterSourcesInput"
+                  value={filterValue}
+                  onChange={handleFilterChange}
+                  fullWidth
+                  placeholder={ADD_SOURCE_PLACEHOLDER}
+                />
+              </EuiFormRow>
+              <AvailableSourcesList sources={visibleAvailableSources} />
+            </>
+          )}
         </ContentSection>
       ) : (
         <ContentSection>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.tsx
@@ -10,9 +10,10 @@ import React from 'react';
 import { useValues } from 'kea';
 
 import {
-  EuiCard,
   EuiFlexGrid,
+  EuiFlexGroup,
   EuiFlexItem,
+  EuiPanel,
   EuiSpacer,
   EuiTitle,
   EuiText,
@@ -23,14 +24,12 @@ import { i18n } from '@kbn/i18n';
 import { LicensingLogic } from '../../../../../shared/licensing';
 import { EuiLinkTo } from '../../../../../shared/react_router_helpers';
 import { SourceIcon } from '../../../../components/shared/source_icon';
-import { ADD_CUSTOM_PATH, getSourcesPath } from '../../../../routes';
+import { getSourcesPath } from '../../../../routes';
 import { SourceDataItem } from '../../../../types';
 
 import {
   AVAILABLE_SOURCE_EMPTY_STATE,
   AVAILABLE_SOURCE_TITLE,
-  AVAILABLE_SOURCE_BODY,
-  AVAILABLE_SOURCE_CUSTOM_SOURCE_BUTTON,
 } from './constants';
 
 interface AvailableSourcesListProps {
@@ -42,14 +41,20 @@ export const AvailableSourcesList: React.FC<AvailableSourcesListProps> = ({ sour
 
   const getSourceCard = ({ name, serviceType, addPath, accountContextOnly }: SourceDataItem) => {
     const disabled = !hasPlatinumLicense && accountContextOnly;
-    const card = (
-      <EuiCard
-        titleSize="xs"
-        title={name}
-        description={<></>}
-        isDisabled={disabled}
-        icon={<SourceIcon serviceType={serviceType} name={name} size="xxl" />}
-      />
+    const item = (
+      <EuiPanel color="subdued" hasShadow={false}>
+        <EuiFlexGroup alignItems="center" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <SourceIcon serviceType={serviceType} name={name} size="l" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s"><p>{name}</p></EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiLinkTo to={getSourcesPath(addPath, true)}>Configure</EuiLinkTo>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
     );
 
     if (disabled) {
@@ -65,15 +70,15 @@ export const AvailableSourcesList: React.FC<AvailableSourcesListProps> = ({ sour
             }
           )}
         >
-          {card}
+          {item}
         </EuiToolTip>
       );
     }
-    return <EuiLinkTo to={getSourcesPath(addPath, true)}>{card}</EuiLinkTo>;
+    return item;
   };
 
   const visibleSources = (
-    <EuiFlexGrid columns={3} gutterSize="m" responsive={false}>
+    <EuiFlexGrid columns={2} gutterSize="l" responsive={false}>
       {sources.map((source, i) => (
         <EuiFlexItem key={i} data-test-subj="AvailableSourceCard">
           {getSourceCard(source)}
@@ -89,21 +94,9 @@ export const AvailableSourcesList: React.FC<AvailableSourcesListProps> = ({ sour
   return (
     <>
       <EuiTitle size="s">
-        <h2>{AVAILABLE_SOURCE_TITLE}</h2>
+        <h3>{AVAILABLE_SOURCE_TITLE}</h3>
       </EuiTitle>
-      <EuiText>
-        <p>
-          {AVAILABLE_SOURCE_BODY}
-          <EuiLinkTo
-            to={getSourcesPath(ADD_CUSTOM_PATH, true)}
-            data-test-subj="CustomAPISourceLink"
-          >
-            {AVAILABLE_SOURCE_CUSTOM_SOURCE_BUTTON}
-          </EuiLinkTo>
-          .
-        </p>
-      </EuiText>
-      <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
       {sources.length > 0 ? visibleSources : emptyState}
     </>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/available_sources_list.tsx
@@ -43,7 +43,7 @@ export const AvailableSourcesList: React.FC<AvailableSourcesListProps> = ({ sour
     const disabled = !hasPlatinumLicense && accountContextOnly;
     const item = (
       <EuiPanel color="subdued" hasShadow={false}>
-        <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
           <EuiFlexItem grow={false}>
             <SourceIcon serviceType={serviceType} name={name} size="l" />
           </EuiFlexItem>
@@ -78,7 +78,7 @@ export const AvailableSourcesList: React.FC<AvailableSourcesListProps> = ({ sour
   };
 
   const visibleSources = (
-    <EuiFlexGrid columns={2} gutterSize="l" responsive={false}>
+    <EuiFlexGrid columns={2} gutterSize="m">
       {sources.map((source, i) => (
         <EuiFlexItem key={i} data-test-subj="AvailableSourceCard">
           {getSourceCard(source)}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/configured_sources_list.tsx
@@ -17,7 +17,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 
-import { EuiButtonTo, EuiButtonEmptyTo } from '../../../../../shared/react_router_helpers';
+import { EuiButtonTo } from '../../../../../shared/react_router_helpers';
 import { SourceIcon } from '../../../../components/shared/source_icon';
 import { getSourcesPath } from '../../../../routes';
 import { SourceDataItem } from '../../../../types';

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
@@ -187,21 +187,6 @@ export const CONFIG_OAUTH_BUTTON = i18n.translate(
   }
 );
 
-export const CONFIGURED_SOURCES_LIST_UNCONNECTED_TOOLTIP = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.unConnectedTooltip',
-  {
-    defaultMessage: 'No connected sources',
-  }
-);
-
-export const CONFIGURED_SOURCES_LIST_ACCOUNT_ONLY_TOOLTIP = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.accountOnlyTooltip',
-  {
-    defaultMessage:
-      'Private content source. Each user must add the content source from their own personal dashboard.',
-  }
-);
-
 export const CONFIGURED_SOURCES_CONNECT_BUTTON = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.connectButton',
   {
@@ -216,17 +201,31 @@ export const CONFIGURED_SOURCES_EMPTY_STATE = i18n.translate(
   }
 );
 
-export const CONFIGURED_SOURCES_TITLE = i18n.translate(
+export const CONFIGURED_ORG_SOURCES_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.title',
   {
-    defaultMessage: 'Configured content sources',
+    defaultMessage: 'Organization sources',
   }
 );
 
-export const CONFIGURED_SOURCES_EMPTY_BODY = i18n.translate(
+export const CONFIGURED_ORG_SOURCES_BODY = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.body',
   {
-    defaultMessage: 'Configured and ready for connection.',
+    defaultMessage: 'These sources use one account to provide content for the search experience.',
+  }
+);
+
+export const CONFIGURED_PRIVATE_SOURCES_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.title',
+  {
+    defaultMessage: 'Private sources',
+  }
+);
+
+export const CONFIGURED_PRIVATE_SOURCES_BODY = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.contentSource.configuredSources.body',
+  {
+    defaultMessage: 'These sources allow your organization\'s users to use their own accounts and content in the search experience.',
   }
 );
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
@@ -41,7 +41,7 @@ export const ADD_SOURCE_NO_SOURCES_TITLE = i18n.translate(
 export const ADD_SOURCE_ORG_SOURCES_TITLE = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.contentSource.addSourceList.orgSourcesTitle',
   {
-    defaultMessage: 'Add a shared content source',
+    defaultMessage: 'Sources ready for connection',
   }
 );
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/constants.ts
@@ -87,20 +87,6 @@ export const AVAILABLE_SOURCE_TITLE = i18n.translate(
   }
 );
 
-export const AVAILABLE_SOURCE_BODY = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.contentSource.availableSourceList.body',
-  {
-    defaultMessage: 'Configure an available source or build your own with the ',
-  }
-);
-
-export const AVAILABLE_SOURCE_CUSTOM_SOURCE_BUTTON = i18n.translate(
-  'xpack.enterpriseSearch.workplaceSearch.contentSource.availableSourceList.customSource.button',
-  {
-    defaultMessage: 'Custom API Source',
-  }
-);
-
 export const CONFIG_COMPLETED_PRIVATE_SOURCES_DOCS_LINK = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.contentSource.configCompleted.privateDisabled.button',
   {


### PR DESCRIPTION
## Summary

Work-in-progess to update the lists for adding/configuring/connecting a new source.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
