### PR TITLE
[APM] docs: add more info on HTTP transactions/span

### DIFF
--- a/docs/apm/service-overview.asciidoc
+++ b/docs/apm/service-overview.asciidoc
@@ -38,6 +38,8 @@ image::apm/images/traffic-transactions.png[Traffic and transactions]
 === Error rate and errors
 
 The *Error rate* chart displays the average error rates relating to the service, within a specific time range.
+An HTTP response code greater than 400 does not necessarily indicate a failed transaction.
+<<transaction-error-rate,Learn more>>.
 
 The *Errors* table provides a high-level view of each error message when it first and last occurred,
 along with the total number of occurrences. This makes it very easy to quickly see which errors affect

--- a/docs/apm/transactions.asciidoc
+++ b/docs/apm/transactions.asciidoc
@@ -22,11 +22,21 @@ Visualize response codes: `2xx`, `3xx`, `4xx`, etc.
 Useful for determining if more responses than usual are being served with a particular response code.
 Like in the latency graph, you can zoom in on anomalies to further investigate them.
 
+[[transaction-error-rate]]
 *Error rate*::
-Visualize the total number of transactions with errors divided by the total number of transactions.
-The error rate value is based on the `event.outcome` field and is the relative number of failed transactions.
-Any unexpected increases, decreases, or irregular patterns can be investigated further
-with the <<errors,errors overview>>.
+The error rate represents the percentage of failed transactions from the perspective of the selected service.
+It's useful for visualizing unexpected increases, decreases, or irregular patterns in a service's transactions.
++
+[TIP]
+====
+HTTP **transactions** from the HTTP server perspective do not consider a `4xx` status code (client error) as a failure
+because the failure was caused by the caller, not the HTTP server. Thus, there will be no increase in error rate.
+
+HTTP **spans** from the client perspective however, are considered failures if the HTTP status code is ≥ 400.
+These spans will increase the error rate.
+
+If there is no HTTP status, both transactions and spans are considered successful unless an error is reported.
+====
 
 *Average duration by span type*::
 Visualize where your application is spending most of its time.


### PR DESCRIPTION
## Summary

This PR attempts to clear-up confusion around the error rate reported by HTTP spans and transactions. The information provided in this PR was sourced from the [APM agent spec](https://github.com/elastic/apm/tree/master/specs/agents).

