### PR TITLE
[Lens] remove warnings when running tests

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
@@ -827,7 +827,7 @@ describe('IndexPattern Data Panel', () => {
         });
 
         // wait for indx pattern to be loaded
-        await new Promise((r) => setTimeout(r, 0));
+        await act(async ()=>await new Promise((r) => setTimeout(r, 0)))
 
         expect(props.indexPatternFieldEditor.openEditor).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -860,10 +860,11 @@ describe('IndexPattern Data Panel', () => {
             .prop('children') as ReactElement).props.items[0].props.onClick();
         });
         // wait for indx pattern to be loaded
-        await new Promise((r) => setTimeout(r, 0));
+        await act(async ()=>await new Promise((r) => setTimeout(r, 0)))
+        
         await (props.indexPatternFieldEditor.openEditor as jest.Mock).mock.calls[0][0].onSave();
         // wait for indx pattern to be loaded
-        await new Promise((r) => setTimeout(r, 0));
+        await act(async ()=>await new Promise((r) => setTimeout(r, 0)))
         expect(props.onUpdateIndexPattern).toHaveBeenCalledWith(
           expect.objectContaining({
             fields: [

--- a/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/datapanel.test.tsx
@@ -827,7 +827,7 @@ describe('IndexPattern Data Panel', () => {
         });
 
         // wait for indx pattern to be loaded
-        await act(async ()=>await new Promise((r) => setTimeout(r, 0)))
+        await act(async () => await new Promise((r) => setTimeout(r, 0)));
 
         expect(props.indexPatternFieldEditor.openEditor).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -860,11 +860,11 @@ describe('IndexPattern Data Panel', () => {
             .prop('children') as ReactElement).props.items[0].props.onClick();
         });
         // wait for indx pattern to be loaded
-        await act(async ()=>await new Promise((r) => setTimeout(r, 0)))
-        
+        await act(async () => await new Promise((r) => setTimeout(r, 0)));
+
         await (props.indexPatternFieldEditor.openEditor as jest.Mock).mock.calls[0][0].onSave();
         // wait for indx pattern to be loaded
-        await act(async ()=>await new Promise((r) => setTimeout(r, 0)))
+        await act(async () => await new Promise((r) => setTimeout(r, 0)));
         expect(props.onUpdateIndexPattern).toHaveBeenCalledWith(
           expect.objectContaining({
             fields: [


### PR DESCRIPTION
## Summary

When running tests, there are 14 warnings showing up in the console:
<img width="727" alt="Screenshot 2021-03-29 at 12 08 46" src="https://user-images.githubusercontent.com/4283304/112821886-84ec5e80-9087-11eb-832b-d85b27e49328.png">

This change makes them gone. I am not totally understanding why there were so many before (I would guess there would be 3) so if someone gets it, let me know :) 