### PR TITLE
[TSVB] Pre-fills the index pattern for a new visualization

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/field_select.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/field_select.tsx
@@ -112,10 +112,6 @@ export function FieldSelect({
     }
   });
 
-  if (value && !selectedOptions.length) {
-    onChange([]);
-  }
-
   return (
     <EuiComboBox
       data-test-subj={dataTestSubj}

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_editor.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_editor.tsx
@@ -202,12 +202,32 @@ export class VisEditor extends Component<TimeseriesEditorProps, TimeseriesEditor
 
     dataStart.indexPatterns.getDefault().then(async (index) => {
       const defaultIndexTitle = index?.title ?? '';
+      const defaultIndexId = index?.id ?? '';
+      const defaultTimefieldName = index?.timeFieldName ?? '';
       const indexPatterns = extractIndexPatternValues(this.props.vis.params, defaultIndexTitle);
       const visFields = await fetchFields(indexPatterns);
 
-      this.setState((state) => ({
+      let model = this.state.model;
+      if (!model.index_pattern) {
+        model = {
+          ...model,
+          index_pattern: this.props.vis.params.use_kibana_indexes
+            ? {
+                id: defaultIndexId,
+              }
+            : defaultIndexTitle,
+        };
+      }
+      if (!model.time_field) {
+        model = {
+          ...model,
+          time_field: defaultTimefieldName,
+        };
+      }
+
+      this.setState({
         model: {
-          ...state.model,
+          ...model,
           /** @legacy
            *  please use IndexPatterns service instead
            * **/
@@ -215,10 +235,10 @@ export class VisEditor extends Component<TimeseriesEditorProps, TimeseriesEditor
           /** @legacy
            *  please use IndexPatterns service instead
            * **/
-          default_timefield: index?.timeFieldName ?? '',
+          default_timefield: defaultTimefieldName,
         },
         visFields,
-      }));
+      });
     });
 
     this.props.eventEmitter.on('updateEditor', this.updateModel);

--- a/src/plugins/vis_type_timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_type.ts
@@ -52,6 +52,8 @@ export const metricsVisDefinition = {
           stacked: 'none',
         },
       ],
+      time_field: '',
+      index_pattern: '',
       use_kibana_indexes: true,
       interval: '',
       axis_position: 'left',

--- a/src/plugins/vis_type_timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_type_timeseries/public/metrics_type.ts
@@ -52,8 +52,6 @@ export const metricsVisDefinition = {
           stacked: 'none',
         },
       ],
-      time_field: '',
-      index_pattern: '',
       use_kibana_indexes: true,
       interval: '',
       axis_position: 'left',

--- a/test/functional/apps/visualize/_tsvb_chart.ts
+++ b/test/functional/apps/visualize/_tsvb_chart.ts
@@ -136,8 +136,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         // Sometimes popovers take some time to appear in Firefox (#71979)
         await retry.tryForTime(20000, async () => {
           await PageObjects.visualBuilder.setIndexPatternValue('with-timefield', useKibanaIndexes);
-          await PageObjects.visualBuilder.waitForIndexPatternTimeFieldOptionsLoaded();
-          await PageObjects.visualBuilder.selectIndexPatternTimeField('timestamp');
         });
         const newValue = await PageObjects.visualBuilder.getMetricValue();
         expect(newValue).to.eql('1');


### PR DESCRIPTION
## Summary

Closes #95276

Until now, if a user created a TSVB visualization without changing the index pattern, the index pattern was not saved with the visualization.

This was causing the following bugs:
1. the index pattern reference was not saved
2. if the user changed the default index pattern, the visualization was not working properly.

This PR changes this behavior. Now, if the user creates a new TSVB visualization, the index pattern value is prefilled

![image](https://user-images.githubusercontent.com/17003240/112840211-bb39d600-90a7-11eb-823e-2a2e705e5fd5.png)
and it is saved correctly to the saved object.

As a result the saved object has the correct references:

![image](https://user-images.githubusercontent.com/17003240/112839396-d6f0ac80-90a6-11eb-9981-48971f9c2d39.png)
