### PR TITLE
[ci] cache maven image for load testing project

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,5 +2,8 @@
 
 set -e
 
+# cache image used by kibana-load-testing project
+docker pull "maven:3.6.3-openjdk-8-slim"
+
 ./.ci/packer_cache_for_branch.sh master
 ./.ci/packer_cache_for_branch.sh 7.x


### PR DESCRIPTION
## Summary

This PR caches Maven docker image, used by [kibana-load-testing](https://github.com/elastic/kibana-load-testing/blob/master/.ci/Jenkinsfile_cloud#L4) project.

According to [Infra team comment](https://github.com/elastic/kibana-load-testing/blob/master/.ci/Jenkinsfile_cloud#L4) this should help to avoid pulling image every single run on CI.