### PR TITLE
[Enterprise Search] Fix bug in indexing status

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.test.tsx
@@ -27,7 +27,7 @@ describe('IndexingStatus', () => {
   const props = {
     percentageComplete: 50,
     numDocumentsWithErrors: 1,
-    activeReindexJobId: '12',
+    activeReindexJobId: '12abc',
     viewLinkPath: '/path',
     statusPath: '/other_path',
     itemId: '1',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.test.tsx
@@ -27,7 +27,7 @@ describe('IndexingStatus', () => {
   const props = {
     percentageComplete: 50,
     numDocumentsWithErrors: 1,
-    activeReindexJobId: 12,
+    activeReindexJobId: '12',
     viewLinkPath: '/path',
     statusPath: '/other_path',
     itemId: '1',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.tsx
@@ -17,7 +17,7 @@ import { IndexingStatusContent } from './indexing_status_content';
 import { IndexingStatusErrors } from './indexing_status_errors';
 import { IndexingStatusLogic } from './indexing_status_logic';
 
-export interface IIndexingStatusProps {
+export interface IIndexingStatusProps extends IIndexingStatus {
   viewLinkPath: string;
   itemId: string;
   statusPath: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status.tsx
@@ -26,12 +26,9 @@ export interface IIndexingStatusProps extends IIndexingStatus {
   setGlobalIndexingStatus?(activeReindexJob: IIndexingStatus): void;
 }
 
-export const IndexingStatus: React.FC<IIndexingStatusProps> = ({
-  viewLinkPath,
-  statusPath,
-  onComplete,
-}) => {
-  const { percentageComplete, numDocumentsWithErrors } = useValues(IndexingStatusLogic);
+export const IndexingStatus: React.FC<IIndexingStatusProps> = (props) => {
+  const { viewLinkPath, statusPath, onComplete } = props;
+  const { percentageComplete, numDocumentsWithErrors } = useValues(IndexingStatusLogic(props));
   const { fetchIndexingStatus } = useActions(IndexingStatusLogic);
 
   useEffect(() => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
@@ -5,16 +5,22 @@
  * 2.0.
  */
 
-import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../__mocks__';
+import { mockFlashMessageHelpers, mockHttpValues } from '../../__mocks__';
 
 import { nextTick } from '@kbn/test/jest';
 
 import { IndexingStatusLogic } from './indexing_status_logic';
 
 describe('IndexingStatusLogic', () => {
-  const { mount, unmount } = new LogicMounter(IndexingStatusLogic);
   const { http } = mockHttpValues;
   const { flashAPIErrors } = mockFlashMessageHelpers;
+  const mount = () => {
+    IndexingStatusLogic({ percentageComplete: 100, numDocumentsWithErrors: 0 });
+    const unmount = IndexingStatusLogic.mount();
+    return unmount;
+  };
+
+  let unmount: Function;
 
   const mockStatusResponse = {
     percentageComplete: 50,
@@ -24,7 +30,7 @@ describe('IndexingStatusLogic', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mount();
+    unmount = mount();
   });
 
   it('has expected default values', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
-import { mockFlashMessageHelpers, mockHttpValues } from '../../__mocks__';
+import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../__mocks__';
+
+import { resetContext } from 'kea';
 
 import { nextTick } from '@kbn/test/jest';
 
@@ -14,13 +16,7 @@ import { IndexingStatusLogic } from './indexing_status_logic';
 describe('IndexingStatusLogic', () => {
   const { http } = mockHttpValues;
   const { flashAPIErrors } = mockFlashMessageHelpers;
-  const mount = () => {
-    IndexingStatusLogic({ percentageComplete: 100, numDocumentsWithErrors: 0 });
-    const unmount = IndexingStatusLogic.mount();
-    return unmount;
-  };
-
-  let unmount: Function;
+  const { mount, unmount } = new LogicMounter(IndexingStatusLogic);
 
   const mockStatusResponse = {
     percentageComplete: 50,
@@ -30,7 +26,8 @@ describe('IndexingStatusLogic', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    unmount = mount();
+    resetContext({});
+    mount({}, { percentageComplete: 100, numDocumentsWithErrors: 0 });
   });
 
   it('has expected default values', () => {
@@ -57,6 +54,7 @@ describe('IndexingStatusLogic', () => {
     jest.useFakeTimers();
     const statusPath = '/api/workplace_search/path/123';
     const onComplete = jest.fn();
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
     const TIMEOUT = 3000;
 
     it('calls API and sets values', async () => {
@@ -90,13 +88,13 @@ describe('IndexingStatusLogic', () => {
 
       await nextTick();
 
-      expect(clearInterval).toHaveBeenCalled();
+      expect(clearIntervalSpy).toHaveBeenCalled();
       expect(onComplete).toHaveBeenCalledWith(mockStatusResponse.numDocumentsWithErrors);
     });
 
     it('handles unmounting', async () => {
       unmount();
-      expect(clearInterval).toHaveBeenCalled();
+      expect(clearIntervalSpy).toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.test.ts
@@ -7,8 +7,6 @@
 
 import { LogicMounter, mockFlashMessageHelpers, mockHttpValues } from '../../__mocks__';
 
-import { resetContext } from 'kea';
-
 import { nextTick } from '@kbn/test/jest';
 
 import { IndexingStatusLogic } from './indexing_status_logic';
@@ -26,7 +24,6 @@ describe('IndexingStatusLogic', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    resetContext({});
     mount({}, { percentageComplete: 100, numDocumentsWithErrors: 0 });
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.ts
@@ -39,20 +39,20 @@ export const IndexingStatusLogic = kea<MakeLogicType<IndexingStatusValues, Index
       percentageComplete,
     }),
   },
-  reducers: {
+  reducers: ({ props }) => ({
     percentageComplete: [
-      100,
+      props.percentageComplete,
       {
         setIndexingStatus: (_, { percentageComplete }) => percentageComplete,
       },
     ],
     numDocumentsWithErrors: [
-      0,
+      props.numDocumentsWithErrors,
       {
         setIndexingStatus: (_, { numDocumentsWithErrors }) => numDocumentsWithErrors,
       },
     ],
-  },
+  }),
   listeners: ({ actions }) => ({
     fetchIndexingStatus: ({ statusPath, onComplete }: IndexingStatusProps) => {
       const { http } = HttpLogic.values;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/indexing_status/indexing_status_logic.ts
@@ -32,6 +32,7 @@ interface IndexingStatusValues {
 let pollingInterval: number;
 
 export const IndexingStatusLogic = kea<MakeLogicType<IndexingStatusValues, IndexingStatusActions>>({
+  path: ['enterprise_search', 'indexing_status_logic'],
   actions: {
     fetchIndexingStatus: ({ statusPath, onComplete }) => ({ statusPath, onComplete }),
     setIndexingStatus: ({ numDocumentsWithErrors, percentageComplete }) => ({


### PR DESCRIPTION
## Closes https://github.com/elastic/workplace-search-team/issues/1418

## Summary
This PR addresses a bug introduced in [this PR](https://github.com/elastic/kibana/pull/84710). The issue is that the logic file is instantiated with default values that are not actually in line with what is in the UI. We now pass props to the logic file to give it its default values. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios