### PR TITLE
[Workplace Search] Add download diagnostics button to source settings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.test.tsx
@@ -106,4 +106,26 @@ describe('SourceSettings', () => {
       sourceConfigData.configuredFields.publicKey
     );
   });
+
+  describe('DownloadDiagnosticsButton', () => {
+    it('renders for org with correct href', () => {
+      const wrapper = shallow(<SourceSettings />);
+
+      expect(wrapper.find('[data-test-subj="DownloadDiagnosticsButton"]').prop('href')).toEqual(
+        '/api/workplace_search/org/sources/123/download_diagnostics'
+      );
+    });
+
+    it('renders for account with correct href', () => {
+      setMockValues({
+        ...mockValues,
+        isOrganization: false,
+      });
+      const wrapper = shallow(<SourceSettings />);
+
+      expect(wrapper.find('[data-test-subj="DownloadDiagnosticsButton"]').prop('href')).toEqual(
+        '/api/workplace_search/account/sources/123/download_diagnostics'
+      );
+    });
+  });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/source_settings.tsx
@@ -44,6 +44,9 @@ import {
   SOURCE_CONFIG_LINK,
   SOURCE_REMOVE_TITLE,
   SOURCE_REMOVE_DESCRIPTION,
+  SYNC_DIAGNOSTICS_TITLE,
+  SYNC_DIAGNOSTICS_DESCRIPTION,
+  SYNC_DIAGNOSTICS_BUTTON,
 } from '../constants';
 import { staticSourceData } from '../source_data';
 import { SourceLogic } from '../source_logic';
@@ -81,6 +84,10 @@ export const SourceSettings: React.FC = () => {
   const showConfig = isOrganization && !isEmpty(configuredFields);
 
   const { clientId, clientSecret, publicKey, consumerKey, baseUrl } = configuredFields || {};
+
+  const diagnosticsPath = isOrganization
+    ? `/api/workplace_search/org/sources/${id}/download_diagnostics`
+    : `/api/workplace_search/account/sources/${id}/download_diagnostics`;
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value);
 
@@ -167,6 +174,17 @@ export const SourceSettings: React.FC = () => {
           </EuiFormRow>
         </ContentSection>
       )}
+      <ContentSection title={SYNC_DIAGNOSTICS_TITLE} description={SYNC_DIAGNOSTICS_DESCRIPTION}>
+        <EuiButton
+          target="_blank"
+          href={diagnosticsPath}
+          isLoading={buttonLoading}
+          data-test-subj="DownloadDiagnosticsButton"
+          download
+        >
+          {SYNC_DIAGNOSTICS_BUTTON}
+        </EuiButton>
+      </ContentSection>
       <ContentSection title={SOURCE_REMOVE_TITLE} description={SOURCE_REMOVE_DESCRIPTION}>
         <EuiButton
           isLoading={buttonLoading}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/constants.ts
@@ -306,6 +306,28 @@ export const SOURCE_REMOVE_DESCRIPTION = i18n.translate(
   }
 );
 
+export const SYNC_DIAGNOSTICS_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.sources.syncDiagnosticsTitle',
+  {
+    defaultMessage: 'Sync Diagnostics',
+  }
+);
+
+export const SYNC_DIAGNOSTICS_DESCRIPTION = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.sources.syncDiagnosticsDescription',
+  {
+    defaultMessage:
+      'Retrieve relevant diagnostics data for troubleshooting active synchronization processes.',
+  }
+);
+
+export const SYNC_DIAGNOSTICS_BUTTON = i18n.translate(
+  'xpack.enterpriseSearch.workplaceSearch.sources.syncDiagnosticsButton',
+  {
+    defaultMessage: 'Download diagnostics data',
+  }
+);
+
 export const SOURCE_NAME_LABEL = i18n.translate(
   'xpack.enterpriseSearch.workplaceSearch.sources.sourceName.label',
   {

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.test.ts
@@ -25,6 +25,7 @@ import {
   registerAccountSourceSchemasRoute,
   registerAccountSourceReindexJobRoute,
   registerAccountSourceReindexJobStatusRoute,
+  registerAccountSourceDownloadDiagnosticsRoute,
   registerOrgSourcesRoute,
   registerOrgSourcesStatusRoute,
   registerOrgSourceRoute,
@@ -40,6 +41,7 @@ import {
   registerOrgSourceSchemasRoute,
   registerOrgSourceReindexJobRoute,
   registerOrgSourceReindexJobStatusRoute,
+  registerOrgSourceDownloadDiagnosticsRoute,
   registerOrgSourceOauthConfigurationsRoute,
   registerOrgSourceOauthConfigurationRoute,
   registerOauthConnectorParamsRoute,
@@ -563,6 +565,29 @@ describe('sources routes', () => {
     });
   });
 
+  describe('GET /api/workplace_search/account/sources/{sourceId}/download_diagnostics', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/account/sources/{sourceId}/download_diagnostics',
+      });
+
+      registerAccountSourceDownloadDiagnosticsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/sources/:sourceId/download_diagnostics',
+      });
+    });
+  });
+
   describe('GET /api/workplace_search/org/sources', () => {
     let mockRouter: MockRouter;
 
@@ -1057,6 +1082,29 @@ describe('sources routes', () => {
     it('creates a request handler', () => {
       expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
         path: '/ws/org/sources/:sourceId/reindex_job/:jobId/status',
+      });
+    });
+  });
+
+  describe('GET /api/workplace_search/org/sources/{sourceId}/download_diagnostics', () => {
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockRouter = new MockRouter({
+        method: 'get',
+        path: '/api/workplace_search/org/sources/{sourceId}/download_diagnostics',
+      });
+
+      registerOrgSourceDownloadDiagnosticsRoute({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('creates a request handler', () => {
+      expect(mockRequestHandler.createRequest).toHaveBeenCalledWith({
+        path: '/ws/org/sources/:sourceId/download_diagnostics',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/workplace_search/sources.ts
@@ -398,6 +398,25 @@ export function registerAccountSourceReindexJobStatusRoute({
   );
 }
 
+export function registerAccountSourceDownloadDiagnosticsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/account/sources/{sourceId}/download_diagnostics',
+      validate: {
+        params: schema.object({
+          sourceId: schema.string(),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/sources/:sourceId/download_diagnostics',
+    })
+  );
+}
+
 // Org routes
 export function registerOrgSourcesRoute({
   router,
@@ -744,6 +763,25 @@ export function registerOrgSourceReindexJobStatusRoute({
   );
 }
 
+export function registerOrgSourceDownloadDiagnosticsRoute({
+  router,
+  enterpriseSearchRequestHandler,
+}: RouteDependencies) {
+  router.get(
+    {
+      path: '/api/workplace_search/org/sources/{sourceId}/download_diagnostics',
+      validate: {
+        params: schema.object({
+          sourceId: schema.string(),
+        }),
+      },
+    },
+    enterpriseSearchRequestHandler.createRequest({
+      path: '/ws/org/sources/:sourceId/download_diagnostics',
+    })
+  );
+}
+
 export function registerOrgSourceOauthConfigurationsRoute({
   router,
   enterpriseSearchRequestHandler,
@@ -894,6 +932,7 @@ export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
   registerAccountSourceSchemasRoute(dependencies);
   registerAccountSourceReindexJobRoute(dependencies);
   registerAccountSourceReindexJobStatusRoute(dependencies);
+  registerAccountSourceDownloadDiagnosticsRoute(dependencies);
   registerOrgSourcesRoute(dependencies);
   registerOrgSourcesStatusRoute(dependencies);
   registerOrgSourceRoute(dependencies);
@@ -909,6 +948,7 @@ export const registerSourcesRoutes = (dependencies: RouteDependencies) => {
   registerOrgSourceSchemasRoute(dependencies);
   registerOrgSourceReindexJobRoute(dependencies);
   registerOrgSourceReindexJobStatusRoute(dependencies);
+  registerOrgSourceDownloadDiagnosticsRoute(dependencies);
   registerOrgSourceOauthConfigurationsRoute(dependencies);
   registerOrgSourceOauthConfigurationRoute(dependencies);
   registerOauthConnectorParamsRoute(dependencies);


### PR DESCRIPTION
## closes https://github.com/elastic/workplace-search-team/issues/1576

## Summary

Ports [this PR](https://github.com/elastic/ent-search/pull/3207) to Kibana. Adds download diagnostics button to source settings.

![image](https://user-images.githubusercontent.com/1869731/112908392-0f978280-90b5-11eb-8939-e5feef82d698.png)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
