### PR TITLE
[Metrics] Reduces page load limits already under 100kB

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,12 +1,12 @@
 pageLoadAssetSize:
   advancedSettings: 27596
-  alerting: 106936
+  alerting: 100000
   apm: 64385
   apmOss: 18996
   beatsManagement: 188135
   bfetch: 41874
   canvas: 1066647
-  charts: 195358
+  charts: 100000
   cloud: 21076
   console: 46091
   core: 692106
@@ -17,7 +17,7 @@ pageLoadAssetSize:
   data: 900000
   dataEnhanced: 50420
   devTools: 38637
-  discover: 105145
+  discover: 100000
   discoverEnhanced: 42730
   embeddable: 312874
   embeddableEnhanced: 41145
@@ -31,15 +31,15 @@ pageLoadAssetSize:
   graph: 31504
   grokdebugger: 26779
   home: 41661
-  indexLifecycleManagement: 107090
-  indexManagement: 140608
+  indexLifecycleManagement: 100000
+  indexManagement: 100000
   indexPatternManagement: 28222
   infra: 184320
   fleet: 415829
   ingestPipelines: 58003
-  inputControlVis: 172675
-  inspector: 148711
-  kibanaLegacy: 107711
+  inputControlVis: 100000
+  inspector: 100000
+  kibanaLegacy: 100000
   kibanaOverview: 56279
   kibanaReact: 161921
   kibanaUtils: 198829
@@ -57,13 +57,13 @@ pageLoadAssetSize:
   navigation: 37269
   newsfeed: 42228
   observability: 89709
-  painlessLab: 179748
+  painlessLab: 100000
   regionMap: 66098
   remoteClusters: 51327
-  reporting: 183418
+  reporting: 100000
   rollup: 97204
-  savedObjects: 108518
-  savedObjectsManagement: 101836
+  savedObjects: 100000
+  savedObjectsManagement: 100000
   savedObjectsTagging: 59482
   savedObjectsTaggingOss: 20590
   searchprofiler: 67080
@@ -72,7 +72,7 @@ pageLoadAssetSize:
   securitySolution: 283440
   share: 99061
   snapshotRestore: 79032
-  spaces: 387915
+  spaces: 100000
   telemetry: 91832
   telemetryManagementSection: 52443
   tileMap: 65337
@@ -93,9 +93,9 @@ pageLoadAssetSize:
   visTypeTagcloud: 37575
   visTypeTimelion: 68883
   visTypeTimeseries: 155203
-  visTypeVega: 153573
-  visTypeVislib: 242838
-  visTypeXy: 113478
+  visTypeVega: 100000
+  visTypeVislib: 100000
+  visTypeXy: 100000
   visualizations: 295025
   visualize: 57431
   watcher: 43598
@@ -104,7 +104,7 @@ pageLoadAssetSize:
   presentationUtil: 28545
   spacesOss: 18817
   indexPatternFieldEditor: 90489
-  osquery: 107090
+  osquery: 100000
   fileUpload: 25664
   banners: 17946
   mapsEms: 26072


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/95853

Reduces page load bundles already under 100kB, to be 100kB as an upper limit.