### PR TITLE
POC - Sharing index patterns

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -109,7 +109,7 @@ export type {
   NavigateToAppOptions,
 } from './application';
 
-export { SimpleSavedObject } from './saved_objects';
+export { ResolvedSimpleSavedObject, SimpleSavedObject } from './saved_objects';
 export type {
   SavedObjectsBatchResponse,
   SavedObjectsBulkCreateObject,

--- a/src/core/public/saved_objects/index.ts
+++ b/src/core/public/saved_objects/index.ts
@@ -19,6 +19,7 @@ export type {
   SavedObjectsUpdateOptions,
   SavedObjectsBulkUpdateOptions,
 } from './saved_objects_client';
+export { ResolvedSimpleSavedObject } from './resolved_simple_saved_object';
 export { SimpleSavedObject } from './simple_saved_object';
 export type { SavedObjectsStart } from './saved_objects_service';
 export type {

--- a/src/core/public/saved_objects/resolved_simple_saved_object.ts
+++ b/src/core/public/saved_objects/resolved_simple_saved_object.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { SavedObjectsResolveResponse } from '../../server';
+import type { SimpleSavedObject } from './simple_saved_object';
+
+/**
+ * This class is a very simple wrapper for SavedObjects loaded from the server
+ * with the {@link SavedObjectsClient}.
+ *
+ * It provides basic functionality for creating/saving/deleting saved objects,
+ * but doesn't include any type-specific implementations.
+ *
+ * @public
+ */
+export class ResolvedSimpleSavedObject<T = unknown> {
+  constructor(
+    public savedObject: SimpleSavedObject<T>,
+    public outcome: SavedObjectsResolveResponse['outcome'],
+    public aliasTargetId: SavedObjectsResolveResponse['aliasTargetId']
+  ) {}
+}

--- a/src/core/public/saved_objects/saved_objects_client.test.ts
+++ b/src/core/public/saved_objects/saved_objects_client.test.ts
@@ -6,9 +6,12 @@
  * Side Public License, v 1.
  */
 
+import type { SavedObjectsResolveResponse } from 'src/core/server';
+
 import { SavedObjectsClient } from './saved_objects_client';
 import { SimpleSavedObject } from './simple_saved_object';
 import { httpServiceMock } from '../http/http_service.mock';
+import { ResolvedSimpleSavedObject } from './resolved_simple_saved_object';
 
 describe('SavedObjectsClient', () => {
   const doc = {
@@ -144,6 +147,64 @@ describe('SavedObjectsClient', () => {
       const result = await response;
       expect(result.type).toBe('config');
       expect(result.get('title')).toBe('Example title');
+    });
+  });
+
+  describe('#resolve', () => {
+    beforeEach(() => {
+      beforeEach(() => {
+        http.fetch.mockResolvedValue({
+          saved_object: doc,
+          outcome: 'conflict',
+          aliasTargetId: 'another-id',
+        } as SavedObjectsResolveResponse);
+      });
+    });
+
+    test('rejects if `type` is undefined', async () => {
+      expect(savedObjectsClient.resolve(undefined as any, doc.id)).rejects.toMatchInlineSnapshot(
+        `[Error: requires type and id]`
+      );
+    });
+
+    test('rejects if `id` is undefined', async () => {
+      expect(savedObjectsClient.resolve(doc.type, undefined as any)).rejects.toMatchInlineSnapshot(
+        `[Error: requires type and id]`
+      );
+    });
+
+    test('makes HTTP call', () => {
+      savedObjectsClient.resolve(doc.type, doc.id);
+      expect(http.fetch.mock.calls).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            "/api/saved_objects/resolve/config/AVwSwFxtcMV38qjDZoQg",
+            Object {
+              "body": undefined,
+              "method": undefined,
+              "query": undefined,
+            },
+          ],
+        ]
+      `);
+    });
+
+    test('rejects when HTTP call fails', async () => {
+      http.fetch.mockRejectedValueOnce(new Error('Request failed'));
+      await expect(savedObjectsClient.resolve(doc.type, doc.id)).rejects.toMatchInlineSnapshot(
+        `[Error: Request failed]`
+      );
+    });
+
+    test('resolves with ResolvedSimpleSavedObject instance', async () => {
+      const response = savedObjectsClient.resolve(doc.type, doc.id);
+      await expect(response).resolves.toBeInstanceOf(ResolvedSimpleSavedObject);
+
+      const result = await response;
+      expect(result.savedObject.type).toBe(doc.type);
+      expect(result.savedObject.get('title')).toBe('Example title');
+      expect(result.outcome).toBe('conflict');
+      expect(result.aliasTargetId).toBe('another-id');
     });
   });
 

--- a/src/core/public/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/public/saved_objects/saved_objects_service.mock.ts
@@ -18,6 +18,7 @@ const createStartContractMock = () => {
       bulkGet: jest.fn(),
       find: jest.fn(),
       get: jest.fn(),
+      resolve: jest.fn(),
       update: jest.fn(),
     },
   };

--- a/src/core/public/saved_objects/simple_saved_object.ts
+++ b/src/core/public/saved_objects/simple_saved_object.ts
@@ -30,6 +30,7 @@ export class SimpleSavedObject<T = unknown> {
   public coreMigrationVersion: SavedObjectType<T>['coreMigrationVersion'];
   public error: SavedObjectType<T>['error'];
   public references: SavedObjectType<T>['references'];
+  public namespaces: SavedObjectType<T>['namespaces'];
 
   constructor(
     private client: SavedObjectsClientContract,
@@ -42,6 +43,7 @@ export class SimpleSavedObject<T = unknown> {
       references,
       migrationVersion,
       coreMigrationVersion,
+      namespaces,
     }: SavedObjectType<T>
   ) {
     this.id = id;
@@ -51,6 +53,7 @@ export class SimpleSavedObject<T = unknown> {
     this._version = version;
     this.migrationVersion = migrationVersion;
     this.coreMigrationVersion = coreMigrationVersion;
+    this.namespaces = namespaces;
     if (error) {
       this.error = error;
     }

--- a/src/plugins/data/common/index_patterns/index.ts
+++ b/src/plugins/data/common/index_patterns/index.ts
@@ -9,7 +9,7 @@
 export * from './fields';
 export * from './types';
 export { IndexPatternsService, IndexPatternsContract } from './index_patterns';
-export type { IndexPattern } from './index_patterns';
+export type { IndexPattern, ResolvedIndexPattern } from './index_patterns';
 export * from './errors';
 export * from './expressions';
 export * from './constants';

--- a/src/plugins/data/common/index_patterns/index_patterns/_pattern_cache.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/_pattern_cache.ts
@@ -6,18 +6,16 @@
  * Side Public License, v 1.
  */
 
-import { IndexPattern } from './index_pattern';
-
-export interface PatternCache {
-  get: (id: string) => Promise<IndexPattern> | undefined;
-  set: (id: string, value: Promise<IndexPattern>) => Promise<IndexPattern>;
+export interface PatternCache<T> {
+  get: (id: string) => Promise<T> | undefined;
+  set: (id: string, value: Promise<T>) => Promise<T>;
   clear: (id: string) => void;
   clearAll: () => void;
 }
 
-export function createIndexPatternCache(): PatternCache {
+export function createIndexPatternCache<T>(): PatternCache<T> {
   const vals: Record<string, any> = {};
-  const cache: PatternCache = {
+  const cache: PatternCache<T> = {
     get: (id: string) => {
       return vals[id];
     },

--- a/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_pattern.ts
@@ -71,6 +71,8 @@ export class IndexPattern implements IIndexPattern {
    * SavedObject version
    */
   public version: string | undefined;
+  /** SavedObject namespaces */
+  public namespaces: string[];
   public sourceFilters?: SourceFilter[];
   private originalSavedObjectBody: SavedObjectBody = {};
   private shortDotsEnable: boolean = false;
@@ -109,6 +111,7 @@ export class IndexPattern implements IIndexPattern {
     this.fieldFormatMap = spec.fieldFormats || {};
 
     this.version = spec.version;
+    this.namespaces = spec.namespaces || [];
 
     this.title = spec.title || '';
     this.timeFieldName = spec.timeFieldName;
@@ -209,6 +212,7 @@ export class IndexPattern implements IIndexPattern {
     return {
       id: this.id,
       version: this.version,
+      namespaces: this.namespaces,
 
       title: this.title,
       timeFieldName: this.timeFieldName,

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -365,6 +365,7 @@ export class IndexPatternsService {
         fieldAttrs,
         allowNoIndex,
       },
+      namespaces,
     } = savedObject;
 
     const parsedSourceFilters = sourceFilters ? JSON.parse(sourceFilters) : undefined;
@@ -390,6 +391,7 @@ export class IndexPatternsService {
       fieldAttrs: parsedFieldAttrs,
       allowNoIndex,
       runtimeFieldMap: parsedRuntimeFieldMap,
+      namespaces,
     };
   };
 
@@ -486,9 +488,10 @@ export class IndexPatternsService {
    * @param id
    */
 
-  get = async (id: string): Promise<IndexPattern> => {
+  get = async (id: string, options: { forceRefresh?: boolean } = {}): Promise<IndexPattern> => {
+    const { forceRefresh } = options;
     const indexPatternPromise =
-      this.indexPatternCache.get(id) ||
+      (!forceRefresh && this.indexPatternCache.get(id)) ||
       this.indexPatternCache.set(id, this.getSavedObjectAndInit(id));
 
     // don't cache failed requests

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -246,6 +246,7 @@ export interface IndexPatternSpec {
   runtimeFieldMap?: Record<string, RuntimeField>;
   fieldAttrs?: FieldAttrs;
   allowNoIndex?: boolean;
+  namespaces?: string[];
 }
 
 export interface SourceFilter {

--- a/src/plugins/data/common/index_patterns/types.ts
+++ b/src/plugins/data/common/index_patterns/types.ts
@@ -101,6 +101,7 @@ export interface SavedObjectsClientCommonFindArgs {
 export interface SavedObjectsClientCommon {
   find: <T = unknown>(options: SavedObjectsClientCommonFindArgs) => Promise<Array<SavedObject<T>>>;
   get: <T = unknown>(type: string, id: string) => Promise<SavedObject<T>>;
+  resolve: <T = unknown>(type: string, id: string) => Promise<ResolvedSavedObject<T>>;
   update: (
     type: string,
     id: string,
@@ -249,4 +250,12 @@ export interface IndexPatternSpec {
 
 export interface SourceFilter {
   value: string;
+}
+
+export type ResolvedSavedObjectOutcome = 'exactMatch' | 'aliasMatch' | 'conflict';
+export interface ResolvedSavedObject<T = unknown> {
+  // TODO: refactor types and use SavedObjectsResolveResponse instead
+  saved_object: SavedObject<T>;
+  outcome: ResolvedSavedObjectOutcome;
+  aliasTargetId?: string;
 }

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -251,6 +251,7 @@ export const indexPatterns = {
 export {
   IndexPatternsContract,
   IndexPattern,
+  ResolvedIndexPattern,
   IIndexPatternFieldList,
   IndexPatternField,
 } from './index_patterns';

--- a/src/plugins/data/public/index_patterns/index.ts
+++ b/src/plugins/data/public/index_patterns/index.ts
@@ -22,6 +22,7 @@ export {
   IndexPatternsService,
   IndexPatternsContract,
   IndexPattern,
+  ResolvedIndexPattern,
   IndexPatternsApiClient,
 } from './index_patterns';
 export { UiSettingsPublicToCommon } from './ui_settings_wrapper';

--- a/src/plugins/data/public/index_patterns/saved_objects_client_wrapper.ts
+++ b/src/plugins/data/public/index_patterns/saved_objects_client_wrapper.ts
@@ -14,7 +14,10 @@ import {
   SavedObject,
 } from '../../common/index_patterns';
 
-type SOClient = Pick<SavedObjectsClient, 'find' | 'get' | 'update' | 'create' | 'delete'>;
+type SOClient = Pick<
+  SavedObjectsClient,
+  'find' | 'get' | 'resolve' | 'update' | 'create' | 'delete'
+>;
 
 const simpleSavedObjectToSavedObject = <T>(simpleSavedObject: SimpleSavedObject): SavedObject<T> =>
   ({
@@ -35,6 +38,10 @@ export class SavedObjectsClientPublicToCommon implements SavedObjectsClientCommo
   async get<T = unknown>(type: string, id: string) {
     const response = await this.savedObjectClient.get<T>(type, id);
     return simpleSavedObjectToSavedObject<T>(response);
+  }
+  async resolve<T = unknown>(type: string, id: string) {
+    const { savedObject, ...otherFields } = await this.savedObjectClient.resolve<T>(type, id);
+    return { ...otherFields, saved_object: simpleSavedObjectToSavedObject<T>(savedObject) };
   }
   async update(
     type: string,

--- a/src/plugins/data/server/index.ts
+++ b/src/plugins/data/server/index.ts
@@ -147,6 +147,7 @@ export {
   IndexPatternAttributes,
   UI_SETTINGS,
   IndexPattern,
+  ResolvedIndexPattern,
   IndexPatternLoadExpressionFunctionDefinition,
   IndexPatternsService,
   IndexPatternsService as IndexPatternsCommonService,

--- a/src/plugins/data/server/index_patterns/saved_objects_client_wrapper.ts
+++ b/src/plugins/data/server/index_patterns/saved_objects_client_wrapper.ts
@@ -25,6 +25,9 @@ export class SavedObjectsClientServerToCommon implements SavedObjectsClientCommo
   async get<T = unknown>(type: string, id: string) {
     return await this.savedObjectClient.get<T>(type, id);
   }
+  async resolve<T = unknown>(type: string, id: string) {
+    return await this.savedObjectClient.resolve<T>(type, id);
+  }
   async update(
     type: string,
     id: string,

--- a/src/plugins/data/server/saved_objects/index_patterns.ts
+++ b/src/plugins/data/server/saved_objects/index_patterns.ts
@@ -12,7 +12,7 @@ import { indexPatternSavedObjectTypeMigrations } from './index_pattern_migration
 export const indexPatternSavedObjectType: SavedObjectsType = {
   name: 'index-pattern',
   hidden: false,
-  namespaceType: 'multiple-isolated',
+  namespaceType: 'multiple',
   convertToMultiNamespaceTypeVersion: '8.0.0',
   management: {
     icon: 'indexPatternApp',

--- a/src/plugins/data/server/saved_objects/index_patterns.ts
+++ b/src/plugins/data/server/saved_objects/index_patterns.ts
@@ -12,7 +12,8 @@ import { indexPatternSavedObjectTypeMigrations } from './index_pattern_migration
 export const indexPatternSavedObjectType: SavedObjectsType = {
   name: 'index-pattern',
   hidden: false,
-  namespaceType: 'single',
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
   management: {
     icon: 'indexPatternApp',
     defaultSearchField: 'title',

--- a/src/plugins/index_pattern_management/kibana.json
+++ b/src/plugins/index_pattern_management/kibana.json
@@ -3,6 +3,6 @@
   "version": "kibana",
   "server": true,
   "ui": true,
-  "requiredPlugins": ["management", "data", "urlForwarding", "indexPatternFieldEditor"],
+  "requiredPlugins": ["management", "data", "urlForwarding", "indexPatternFieldEditor", "spacesOss"],
   "requiredBundles": ["kibanaReact", "kibanaUtils"]
 }

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern_container.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/edit_index_pattern_container.tsx
@@ -8,7 +8,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import { IndexPattern } from '../../../../../plugins/data/public';
+import { ResolvedIndexPattern } from '../../../../../plugins/data/public';
 import { useKibana } from '../../../../../plugins/kibana_react/public';
 import { IndexPatternManagmentContext } from '../../types';
 import { getEditBreadcrumbs } from '../breadcrumbs';
@@ -17,17 +17,17 @@ import { EditIndexPattern } from '../edit_index_pattern';
 
 const EditIndexPatternCont: React.FC<RouteComponentProps<{ id: string }>> = ({ ...props }) => {
   const { data, setBreadcrumbs } = useKibana<IndexPatternManagmentContext>().services;
-  const [indexPattern, setIndexPattern] = useState<IndexPattern>();
+  const [resolvedIndexPattern, setResolvedIndexPattern] = useState<ResolvedIndexPattern>();
 
   useEffect(() => {
-    data.indexPatterns.get(props.match.params.id).then((ip: IndexPattern) => {
-      setIndexPattern(ip);
-      setBreadcrumbs(getEditBreadcrumbs(ip));
+    data.indexPatterns.resolve(props.match.params.id).then((ip: ResolvedIndexPattern) => {
+      setResolvedIndexPattern(ip);
+      setBreadcrumbs(getEditBreadcrumbs(ip.indexPattern));
     });
   }, [data.indexPatterns, props.match.params.id, setBreadcrumbs]);
 
-  if (indexPattern) {
-    return <EditIndexPattern indexPattern={indexPattern} />;
+  if (resolvedIndexPattern) {
+    return <EditIndexPattern resolvedIndexPattern={resolvedIndexPattern} />;
   } else {
     return <></>;
   }

--- a/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/index_pattern_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -17,21 +17,28 @@ import {
   EuiBadgeGroup,
   EuiPageContent,
   EuiTitle,
+  EuiBasicTableColumn,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, PropsWithChildren } from 'react';
 import { i18n } from '@kbn/i18n';
 import { reactRouterNavigate, useKibana } from '../../../../../plugins/kibana_react/public';
+import {
+  ShareToSpaceFlyoutProps,
+  SpaceListProps,
+  SpacesContextProps,
+} from '../../../../spaces_oss/public';
 import { IndexPatternManagmentContext } from '../../types';
 import { CreateButton } from '../create_button';
 import { IndexPatternTableItem, IndexPatternCreationOption } from '../types';
-import { getIndexPatterns } from '../utils';
+import { getIndexPatterns, refreshIndexPattern } from '../utils';
 import { getListBreadcrumbs } from '../breadcrumbs';
 import { EmptyState } from './empty_state';
 import { MatchedItem, ResolveIndexResponseItemAlias } from '../create_index_pattern_wizard/types';
 import { EmptyIndexPatternPrompt } from './empty_index_pattern_prompt';
 import { getIndices } from '../create_index_pattern_wizard/lib';
+import { IPM_APP_ID } from '../../constants';
 
 const pagination = {
   initialPageSize: 10,
@@ -66,6 +73,8 @@ interface Props extends RouteComponentProps {
   canSave: boolean;
 }
 
+const getEmptyElement = <T,>() => ({ children }: PropsWithChildren<T>) => <>{children}</>;
+
 export const IndexPatternTable = ({ canSave, history }: Props) => {
   const {
     setBreadcrumbs,
@@ -76,6 +85,7 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
     application,
     http,
     data,
+    spacesOss,
     getMlCardState,
   } = useKibana<IndexPatternManagmentContext>().services;
   const [indexPatterns, setIndexPatterns] = useState<IndexPatternTableItem[]>([]);
@@ -126,20 +136,11 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
 
   chrome.docTitle.change(title);
 
-  const columns = [
+  const columns: Array<EuiBasicTableColumn<IndexPatternTableItem>> = [
     {
       field: 'title',
       name: 'Pattern',
-      render: (
-        name: string,
-        index: {
-          id: string;
-          tags?: Array<{
-            key: string;
-            name: string;
-          }>;
-        }
-      ) => (
+      render: (name, index) => (
         <>
           <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `patterns/${index.id}`)}>
             {name}
@@ -157,6 +158,74 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
       sortable: ({ sort }: { sort: string }) => sort,
     },
   ];
+
+  const LazySpacesContextProvider = useMemo(
+    () =>
+      spacesOss.isSpacesAvailable
+        ? spacesOss.ui.components.getSpacesContextProvider
+        : getEmptyElement<SpacesContextProps>(),
+    [spacesOss]
+  );
+  const LazySpaceList = useMemo(
+    () =>
+      spacesOss.isSpacesAvailable
+        ? spacesOss.ui.components.getSpaceList
+        : getEmptyElement<SpaceListProps>(),
+    [spacesOss]
+  );
+  const LazyShareToSpaceFlyout = useMemo(
+    () =>
+      spacesOss.isSpacesAvailable
+        ? spacesOss.ui.components.getShareToSpaceFlyout
+        : getEmptyElement<ShareToSpaceFlyoutProps>(),
+    [spacesOss]
+  );
+
+  const [shareToSpaceFlyout, setShareToSpaceFlyout] = useState<JSX.Element | null>(null);
+  if (spacesOss.isSpacesAvailable) {
+    columns.push(
+      {
+        field: 'namespaces',
+        name: 'Shared spaces', // TODO: i18n
+        width: '30%',
+        render: (namespaces: string[]) => <LazySpaceList namespaces={namespaces} />,
+      },
+      {
+        name: 'Actions',
+        width: '66px',
+        actions: [
+          {
+            name: 'Changed shared spaces', // TODO: i18n
+            description: 'Change the spaces this index pattern is shared to', // TODO: i18n
+            icon: 'share',
+            type: 'icon',
+            onClick: (item) => {
+              const props: ShareToSpaceFlyoutProps = {
+                savedObjectTarget: {
+                  type: 'index-pattern',
+                  id: item.id,
+                  namespaces: item.namespaces,
+                  title: item.title,
+                  icon: 'indexPatternApp',
+                  noun: 'index pattern', // TODO: i18n
+                },
+                onUpdate: () => {
+                  refreshIndexPattern(
+                    item,
+                    indexPatterns,
+                    indexPatternManagementStart,
+                    data.indexPatterns
+                  ).then((newIndexPatterns) => setIndexPatterns(newIndexPatterns));
+                },
+                onClose: () => setShareToSpaceFlyout(null),
+              };
+              setShareToSpaceFlyout(<LazyShareToSpaceFlyout {...props} />);
+            },
+          },
+        ],
+      }
+    );
+  }
 
   const createButton = canSave ? (
     <CreateButton options={creationOptions}>
@@ -199,36 +268,40 @@ export const IndexPatternTable = ({ canSave, history }: Props) => {
   }
 
   return (
-    <EuiPageContent data-test-subj="indexPatternTable" role="region" aria-label={ariaRegion}>
-      <EuiFlexGroup justifyContent="spaceBetween">
-        <EuiFlexItem grow={false}>
-          <EuiTitle>
-            <h2>{title}</h2>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-          <EuiText>
-            <p>
-              <FormattedMessage
-                id="indexPatternManagement.indexPatternTable.indexPatternExplanation"
-                defaultMessage="Create and manage the index patterns that help you retrieve your data from Elasticsearch."
-              />
-            </p>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>{createButton}</EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer />
-      <EuiInMemoryTable
-        allowNeutralSort={false}
-        itemId="id"
-        isSelectable={false}
-        items={indexPatterns}
-        columns={columns}
-        pagination={pagination}
-        sorting={sorting}
-        search={search}
-      />
-    </EuiPageContent>
+    <LazySpacesContextProvider feature={IPM_APP_ID}>
+      <EuiPageContent data-test-subj="indexPatternTable" role="region" aria-label={ariaRegion}>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiTitle>
+              <h2>{title}</h2>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            <EuiText>
+              <p>
+                <FormattedMessage
+                  id="indexPatternManagement.indexPatternTable.indexPatternExplanation"
+                  defaultMessage="Create and manage the index patterns that help you retrieve your data from Elasticsearch."
+                />
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{createButton}</EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer />
+        <EuiInMemoryTable
+          allowNeutralSort={false}
+          itemId="id"
+          isSelectable={false}
+          items={indexPatterns}
+          columns={columns}
+          hasActions={spacesOss.isSpacesAvailable}
+          pagination={pagination}
+          sorting={sorting}
+          search={search}
+        />
+        {shareToSpaceFlyout}
+      </EuiPageContent>
+    </LazySpacesContextProvider>
   );
 };
 

--- a/src/plugins/index_pattern_management/public/components/types.ts
+++ b/src/plugins/index_pattern_management/public/components/types.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import type { IndexPatternTag } from '../service/list/config';
+
 export interface IndexPatternCreationOption {
   text: string;
   description?: string;
@@ -16,6 +18,7 @@ export interface IndexPatternTableItem {
   id: string;
   title: string;
   default: boolean;
-  tag?: string[];
+  tags?: IndexPatternTag[];
+  namespaces: string[];
   sort: string;
 }

--- a/src/plugins/index_pattern_management/public/components/utils.ts
+++ b/src/plugins/index_pattern_management/public/components/utils.ts
@@ -8,6 +8,7 @@
 
 import { IndexPatternsContract } from 'src/plugins/data/public';
 import { IndexPatternManagementStart } from '../plugin';
+import type { IndexPatternTableItem } from './types';
 
 export async function getIndexPatterns(
   defaultIndex: string,
@@ -16,24 +17,14 @@ export async function getIndexPatterns(
 ) {
   const existingIndexPatterns = await indexPatternsService.getIdsWithTitle(true);
   const indexPatternsListItems = await Promise.all(
-    existingIndexPatterns.map(async ({ id, title }) => {
+    existingIndexPatterns.map(async ({ id }) => {
       const isDefault = defaultIndex === id;
-      const pattern = await indexPatternsService.get(id);
-      const tags = (indexPatternManagementStart as IndexPatternManagementStart).list.getIndexPatternTags(
-        pattern,
-        isDefault
-      );
-
-      return {
+      return await getIndexPattern(
         id,
-        title,
-        default: isDefault,
-        tags,
-        // the prepending of 0 at the default pattern takes care of prioritization
-        // so the sorting will but the default index on top
-        // or on bottom of a the table
-        sort: `${isDefault ? '0' : '1'}${title}`,
-      };
+        isDefault,
+        indexPatternManagementStart,
+        indexPatternsService
+      );
     })
   );
 
@@ -48,4 +39,49 @@ export async function getIndexPatterns(
       }
     }) || []
   );
+}
+
+export async function refreshIndexPattern(
+  indexPattern: IndexPatternTableItem,
+  indexPatterns: IndexPatternTableItem[],
+  indexPatternManagementStart: IndexPatternManagementStart,
+  indexPatternsService: IndexPatternsContract
+) {
+  const newIndexPattern = await getIndexPattern(
+    indexPattern.id,
+    indexPattern.default,
+    indexPatternManagementStart,
+    indexPatternsService,
+    { forceRefresh: true }
+  );
+  const newIndexPatterns = [...indexPatterns];
+  const index = newIndexPatterns.findIndex(({ id }) => id === indexPattern.id);
+  newIndexPatterns[index] = newIndexPattern;
+  return newIndexPatterns;
+}
+
+async function getIndexPattern(
+  id: string,
+  isDefault: boolean,
+  indexPatternManagementStart: IndexPatternManagementStart,
+  indexPatternsService: IndexPatternsContract,
+  options?: { forceRefresh?: boolean }
+): Promise<IndexPatternTableItem> {
+  const pattern = await indexPatternsService.get(id, options);
+  const tags = (indexPatternManagementStart as IndexPatternManagementStart).list.getIndexPatternTags(
+    pattern,
+    isDefault
+  );
+
+  return {
+    id,
+    title: pattern.title,
+    default: isDefault,
+    tags,
+    namespaces: pattern.namespaces,
+    // the prepending of 0 at the default pattern takes care of prioritization
+    // so the sorting will but the default index on top
+    // or on bottom of a the table
+    sort: `${isDefault ? '0' : '1'}${pattern.title}`,
+  };
 }

--- a/src/plugins/index_pattern_management/public/constants.ts
+++ b/src/plugins/index_pattern_management/public/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const IPM_APP_ID = 'indexPatterns';
+export const newAppPath = `management/kibana/${IPM_APP_ID}`;
+export const legacyPatternsPath = 'management/kibana/index_patterns';

--- a/src/plugins/index_pattern_management/public/management_app/mount_management_section.tsx
+++ b/src/plugins/index_pattern_management/public/management_app/mount_management_section.tsx
@@ -42,7 +42,7 @@ export async function mountManagementSection(
 ) {
   const [
     { chrome, application, uiSettings, notifications, overlays, http, docLinks },
-    { data, indexPatternFieldEditor },
+    { data, indexPatternFieldEditor, spacesOss },
     indexPatternManagementStart,
   ] = await getStartServices();
   const canSave = Boolean(application.capabilities.indexPatterns.save);
@@ -61,6 +61,7 @@ export async function mountManagementSection(
     docLinks,
     data,
     indexPatternFieldEditor,
+    spacesOss,
     indexPatternManagementStart: indexPatternManagementStart as IndexPatternManagementStart,
     setBreadcrumbs: params.setBreadcrumbs,
     getMlCardState,

--- a/src/plugins/index_pattern_management/public/plugin.ts
+++ b/src/plugins/index_pattern_management/public/plugin.ts
@@ -18,6 +18,8 @@ import {
 
 import { ManagementSetup } from '../../management/public';
 import { IndexPatternFieldEditorStart } from '../../index_pattern_field_editor/public';
+import type { SpacesOssPluginStart } from '../../spaces_oss/public';
+import { IPM_APP_ID, legacyPatternsPath, newAppPath } from './constants';
 
 export interface IndexPatternManagementSetupDependencies {
   management: ManagementSetup;
@@ -27,6 +29,7 @@ export interface IndexPatternManagementSetupDependencies {
 export interface IndexPatternManagementStartDependencies {
   data: DataPublicPluginStart;
   indexPatternFieldEditor: IndexPatternFieldEditorStart;
+  spacesOss: SpacesOssPluginStart;
 }
 
 export type IndexPatternManagementSetup = IndexPatternManagementServiceSetup;
@@ -36,8 +39,6 @@ export type IndexPatternManagementStart = IndexPatternManagementServiceStart;
 const sectionsHeader = i18n.translate('indexPatternManagement.indexPattern.sectionsHeader', {
   defaultMessage: 'Index Patterns',
 });
-
-const IPM_APP_ID = 'indexPatterns';
 
 export class IndexPatternManagementPlugin
   implements
@@ -60,9 +61,6 @@ export class IndexPatternManagementPlugin
     if (!kibanaSection) {
       throw new Error('`kibana` management section not found.');
     }
-
-    const newAppPath = `management/kibana/${IPM_APP_ID}`;
-    const legacyPatternsPath = 'management/kibana/index_patterns';
 
     urlForwarding.forwardApp('management/kibana/index_pattern', newAppPath, (path) => '/create');
     urlForwarding.forwardApp(legacyPatternsPath, newAppPath, (path) => {

--- a/src/plugins/index_pattern_management/public/types.ts
+++ b/src/plugins/index_pattern_management/public/types.ts
@@ -20,6 +20,7 @@ import { ManagementAppMountParams } from '../../management/public';
 import { IndexPatternManagementStart } from './index';
 import { KibanaReactContextValue } from '../../kibana_react/public';
 import { IndexPatternFieldEditorStart } from '../../index_pattern_field_editor/public';
+import type { SpacesOssPluginStart } from '../../spaces_oss/public';
 
 export interface IndexPatternManagmentContext {
   chrome: ChromeStart;
@@ -31,6 +32,7 @@ export interface IndexPatternManagmentContext {
   docLinks: DocLinksStart;
   data: DataPublicPluginStart;
   indexPatternFieldEditor: IndexPatternFieldEditorStart;
+  spacesOss: SpacesOssPluginStart;
   indexPatternManagementStart: IndexPatternManagementStart;
   setBreadcrumbs: ManagementAppMountParams['setBreadcrumbs'];
   getMlCardState: () => MlCardState;

--- a/src/plugins/index_pattern_management/tsconfig.json
+++ b/src/plugins/index_pattern_management/tsconfig.json
@@ -20,5 +20,6 @@
     { "path": "../kibana_utils/tsconfig.json" },
     { "path": "../es_ui_shared/tsconfig.json" },
     { "path": "../index_pattern_field_editor/tsconfig.json" },
+    { "path": "../spaces_oss/tsconfig.json" },
   ]
 }


### PR DESCRIPTION
[skip-ci]

# 🚨 Notice 2021-08-19 🚨

This POC is out of date! See #107256 instead.

-----

Note: see each commit message for more details

### Overview

This PR is a proof-of-concept to:

1. **Convert index patterns to namespaceType 'multiple-isolated'** (_"share-capable"_ objects, planned for the 8.0 release) -- this will regenerate index pattern IDs to prepare them to be shareable; it requires that the index pattern management page uses the SavedObjectsClient's `resolve` API, and display some extra UI elements in case of issues with the newly introduced Legacy URL aliases
2. **Convert index patterns to namespaceType 'multiple'** (_"shareable"_ objects, planned for some 8.x release) -- this will allow index patterns to be shared between multiple spaces; it updates the index pattern management page to display a list of spaces and the "Change shared spaces" flyout

It also includes some preliminary commits to add support for the SOC `resolve` API in the SOC abstractions that the `index_pattern_management` plugin utilizes.

-----

### Not included

This PR is intended to demonstrate the steps it will take for a plugin author to convert a saved object to become _share-capable_ and subsequently to become _shareable_. It does not include other changes such as:

* Updates to unit tests
* Updates to docs

-----

### How to test

1. Start Kibana
2. Using Dev Tools, load staging data
   <details><summary>Staging data</summary>

   ```
   POST .kibana/_bulk
   { "index": { "_id" : "index-pattern:ff959d40-b880-11e8-a6d9-e546fe2bba5f" } }
   {"index-pattern":{"fieldFormatMap":"{\"taxful_total_price\":{\"id\":\"number\",\"params\":{\"pattern\":\"$0,0.[00]\"}}}","fields":"[]","timeFieldName":"order_date","title":"kibana_sample_data_ecommerce"},"type":"index-pattern","references":[],"namespaces":["default", "bravo"],"migrationVersion":{"index-pattern":"8.0.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:30:10.244Z"}
   { "index": { "_id" : "index-pattern:b75d094a-3b91-5d44-848c-4ccbe1338cf7" } }
   {"index-pattern":{"fieldFormatMap":"{\"taxful_total_price\":{\"id\":\"number\",\"params\":{\"pattern\":\"$0,0.[00]\"}}}","fields":"[]","timeFieldName":"order_date","title":"kibana_sample_data_ecommerce"},"type":"index-pattern","references":[],"namespaces":["alpha"],"originId":"ff959d40-b880-11e8-a6d9-e546fe2bba5f","migrationVersion":{"index-pattern":"8.0.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:31:09.236Z"}
   { "index": { "_id" : "index-pattern:cc855cd9-7c1b-526c-89f8-eacad4e2b799" } }
   {"index-pattern":{"fieldFormatMap":"{\"taxful_total_price\":{\"id\":\"number\",\"params\":{\"pattern\":\"$0,0.[00]\"}}}","fields":"[]","timeFieldName":"order_date","title":"kibana_sample_data_ecommerce"},"type":"index-pattern","references":[],"namespaces":["bravo"],"originId":"ff959d40-b880-11e8-a6d9-e546fe2bba5f","migrationVersion":{"index-pattern":"8.0.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:31:09.476Z"}
   { "index": { "_id" : "index-pattern:87ffef05-4fd1-5f00-9751-fb28ce6d391c" } }
   {"index-pattern":{"fieldFormatMap":"{\"taxful_total_price\":{\"id\":\"number\",\"params\":{\"pattern\":\"$0,0.[00]\"}}}","fields":"[]","timeFieldName":"order_date","title":"kibana_sample_data_ecommerce"},"type":"index-pattern","references":[],"namespaces":["*"],"originId":"ff959d40-b880-11e8-a6d9-e546fe2bba5f","migrationVersion":{"index-pattern":"8.0.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:31:09.236Z"}
   { "index": { "_id" : "legacy-url-alias:alpha:index-pattern:ff959d40-b880-11e8-a6d9-e546fe2bba5f" } }
   {"legacy-url-alias":{"targetNamespace":"alpha","targetType":"index-pattern","targetId":"b75d094a-3b91-5d44-848c-4ccbe1338cf7"},"type":"legacy-url-alias","references":[],"migrationVersion":{},"coreMigrationVersion":"8.0.0"}
   { "index": { "_id" : "legacy-url-alias:bravo:index-pattern:ff959d40-b880-11e8-a6d9-e546fe2bba5f" } }
   {"legacy-url-alias":{"targetNamespace":"bravo","targetType":"index-pattern","targetId":"cc855cd9-7c1b-526c-89f8-eacad4e2b799"},"type":"legacy-url-alias","references":[],"migrationVersion":{},"coreMigrationVersion":"8.0.0"}
   { "index": { "_id" : "legacy-url-alias:charlie:index-pattern:ff959d40-b880-11e8-a6d9-e546fe2bba5f" } }
   {"legacy-url-alias":{"targetNamespace":"charlie","targetType":"index-pattern","targetId":"87ffef05-4fd1-5f00-9751-fb28ce6d391c"},"type":"legacy-url-alias","references":[],"migrationVersion":{},"coreMigrationVersion":"8.0.0"}
   { "index": { "_id" : "space:alpha" } }
   {"space":{"name":"Alpha","disabledFeatures":[]},"type":"space","references":[],"migrationVersion":{"space":"6.6.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:30:35.109Z"}
   { "index": { "_id" : "space:bravo" } }
   {"space":{"name":"Bravo","disabledFeatures":[]},"type":"space","references":[],"migrationVersion":{"space":"6.6.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:30:41.088Z"}
   { "index": { "_id" : "space:charlie" } }
   {"space":{"name":"Charlie","disabledFeatures":[]},"type":"space","references":[],"migrationVersion":{"space":"6.6.0"},"coreMigrationVersion":"8.0.0","updated_at":"2021-03-30T13:31:00.820Z"}
   ```
   </details>
3. Navigate to **Home**, then load "Sample eCommerce orders" data
4. Navigate to **Stack Management** > **Index Patterns** to observe two index patterns that are visible in the _Default space_
   <details><summary>Index Patterns page screenshot</summary>

   ![image](https://user-images.githubusercontent.com/5295965/113184300-01677480-9223-11eb-8fc9-40c7518c1d30.png)
   </details>

The staging data simulates the following scenario:

* With Kibana 7.12, the user created three new spaces: _Alpha_, _Bravo_, and _Charlie_
* Then, the user added eCommerce sample data to the _Default space_, then copied it to the _A/B/C spaces_ (so there are four copies of the same index pattern)
* Then, the user has bookmarked the URLs to the index pattern in each space
* Then, the user upgraded Kibana to 8.0+, which converted the index patterns and regenerated their IDs in the _A/B/C spaces_ (creating new Legacy URL aliases for any object ID that was regenerated)
* Then, the user: a. shared the index pattern from the _Default space_ to the _Bravo space_, and b. shared the index pattern from the _Charlie space_ to _All spaces_

Now you can load the following URLs to test how index pattern IDs are resolved:

1. Default space: `/app/management/kibana/indexPatterns/patterns/ff959d40-b880-11e8-a6d9-e546fe2bba5f#/?_a=(tab:indexedFields)` -- this will result in `outcome: "exactMatch"`, with no changes in the UI
2. Alpha space: `/s/alpha/app/management/kibana/indexPatterns/patterns/ff959d40-b880-11e8-a6d9-e546fe2bba5f#/?_a=(tab:indexedFields)` -- this will result in `outcome: "aliasMatch"`, and it will redirect the user to the new URL for the updated object ID (`b75d094a-3b91-5d44-848c-4ccbe1338cf7`) and display a toast message
   <details><summary>Toast screenshot</summary>

   ![image](https://user-images.githubusercontent.com/5295965/113183836-7ab29780-9222-11eb-8e3f-ea02a24a42c0.png)
   </details>
3. Bravo space: `/s/bravo/app/management/kibana/indexPatterns/patterns/ff959d40-b880-11e8-a6d9-e546fe2bba5f#/?_a=(tab:indexedFields)` -- this will result in `outcome: "conflict"`, and it will show a callout to the user at the top of the page with an appropriate warning message
   <details><summary>Callout screenshot</summary>

   ![image](https://user-images.githubusercontent.com/5295965/113184004-af265380-9222-11eb-89dd-31e29def8324.png)
   </details>

If you go back to the Index Patterns page and share an object, you can observe that the index pattern is refreshed and the "Shared spaces" column is updated accordingly.
