### PR TITLE
[Dashboard] Fix iFrame Filtering Issues

### DIFF
--- a/src/plugins/dashboard/public/application/dashboard_router.tsx
+++ b/src/plugins/dashboard/public/application/dashboard_router.tsx
@@ -84,6 +84,7 @@ export async function mountApp({
 
   const spacesApi = pluginsStart.spacesOss?.isSpacesAvailable ? pluginsStart.spacesOss : undefined;
   const activeSpaceId = spacesApi && (await spacesApi.activeSpace$.pipe(first()).toPromise())?.id;
+  let globalEmbedSettings: DashboardEmbedSettings | undefined;
 
   const dashboardServices: DashboardAppServices = {
     navigation,
@@ -149,9 +150,6 @@ export async function mountApp({
   const getDashboardEmbedSettings = (
     routeParams: ParsedQuery<string>
   ): DashboardEmbedSettings | undefined => {
-    if (!routeParams.embed) {
-      return undefined;
-    }
     return {
       forceShowTopNavMenu: Boolean(routeParams[dashboardUrlParams.showTopMenu]),
       forceShowQueryInput: Boolean(routeParams[dashboardUrlParams.showQueryInput]),
@@ -162,11 +160,13 @@ export async function mountApp({
 
   const renderDashboard = (routeProps: RouteComponentProps<{ id?: string }>) => {
     const routeParams = parse(routeProps.history.location.search);
-    const embedSettings = getDashboardEmbedSettings(routeParams);
+    if (routeParams.embed && !globalEmbedSettings) {
+      globalEmbedSettings = getDashboardEmbedSettings(routeParams);
+    }
     return (
       <DashboardApp
         history={routeProps.history}
-        embedSettings={embedSettings}
+        embedSettings={globalEmbedSettings}
         savedDashboardId={routeProps.match.params.id}
         redirectTo={(props: RedirectToProps) => redirect(routeProps, props)}
       />


### PR DESCRIPTION
## Summary

This PR fixes an issue in the dashboard router where the embed settings object is recreated any time the URL changes. This was caused by https://github.com/elastic/kibana/pull/82909.

Fixing this issue addresses many issues with dashboard filtering in an iframe:
Fixes https://github.com/elastic/kibana/issues/94465
Fixes https://github.com/elastic/kibana/issues/94467
Fixes https://github.com/elastic/kibana/issues/91590

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
