### PR TITLE
[Cases][RBAC] Rename scope to owner

### DIFF
--- a/x-pack/plugins/cases/common/api/cases/case.ts
+++ b/x-pack/plugins/cases/common/api/cases/case.ts
@@ -38,8 +38,8 @@ const CaseBasicRt = rt.type({
   [caseTypeField]: CaseTypeRt,
   connector: CaseConnectorRt,
   settings: SettingsRt,
-  // TODO: should a user be able to update the scope?
-  scope: rt.string,
+  // TODO: should a user be able to update the owner?
+  owner: rt.string,
 });
 
 const CaseExternalServiceBasicRt = rt.type({
@@ -80,7 +80,7 @@ const CasePostRequestNoTypeRt = rt.type({
   title: rt.string,
   connector: CaseConnectorRt,
   settings: SettingsRt,
-  scope: rt.string,
+  owner: rt.string,
 });
 
 /**

--- a/x-pack/plugins/cases/common/api/cases/sub_case.ts
+++ b/x-pack/plugins/cases/common/api/cases/sub_case.ts
@@ -39,7 +39,7 @@ export const SubCasesFindRequestRt = rt.partial({
   searchFields: rt.array(rt.string),
   sortField: rt.string,
   sortOrder: rt.union([rt.literal('desc'), rt.literal('asc')]),
-  scope: rt.string,
+  owner: rt.string,
 });
 
 export const SubCaseResponseRt = rt.intersection([

--- a/x-pack/plugins/cases/common/constants.ts
+++ b/x-pack/plugins/cases/common/constants.ts
@@ -76,7 +76,7 @@ export const MAX_GENERATED_ALERTS_PER_SUB_CASE = MAX_ALERTS_PER_SUB_CASE / DEFAU
  * This must be the same value that the security solution plugin uses to define the case kind when it registers the
  * feature for the 7.13 migration only.
  */
-export const SECURITY_SOLUTION_SCOPE = 'securitySolution';
+export const SECURITY_SOLUTION_OWNER = 'securitySolution';
 
 /**
  * This flag governs enabling the case as a connector feature. It is disabled by default as the feature is not complete.

--- a/x-pack/plugins/cases/server/authorization/utils.ts
+++ b/x-pack/plugins/cases/server/authorization/utils.ts
@@ -9,11 +9,11 @@ import { remove, uniq } from 'lodash';
 import { nodeBuilder } from '../../../../../src/plugins/data/common';
 import { KueryNode } from '../../../../../src/plugins/data/server';
 
-export const getScopesFilter = (savedObjectType: string, scopes: string[]): KueryNode => {
+export const getOwnersFilter = (savedObjectType: string, owners: string[]): KueryNode => {
   return nodeBuilder.or(
-    scopes.reduce<KueryNode[]>((query, scope) => {
-      ensureFieldIsSafeForQuery('scope', scope);
-      query.push(nodeBuilder.is(`${savedObjectType}.attributes.scope`, scope));
+    owners.reduce<KueryNode[]>((query, owner) => {
+      ensureFieldIsSafeForQuery('owner', owner);
+      query.push(nodeBuilder.is(`${savedObjectType}.attributes.owner`, owner));
       return query;
     }, [])
   );
@@ -43,4 +43,4 @@ export const ensureFieldIsSafeForQuery = (field: string, value: string): boolean
 };
 
 export const includeFieldsRequiredForAuthentication = (fields: string[]): string[] =>
-  uniq([...fields, 'scope']);
+  uniq([...fields, 'owner']);

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -45,7 +45,7 @@ describe('create', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       };
 
       const savedObjectsClient = createMockSavedObjectsRepository({
@@ -57,7 +57,7 @@ describe('create', () => {
 
       expect(res).toMatchInlineSnapshot(`
         Object {
-          "scope": "awesome",
+          "owner": "awesome",
           "closed_at": null,
           "closed_by": null,
           "comments": Array [],
@@ -121,7 +121,7 @@ describe('create', () => {
                 "connector",
                 "settings",
               ],
-              "new_value": "{\\"type\\":\\"individual\\",\\"description\\":\\"This is a brand new case of a bad meanie defacing data\\",\\"title\\":\\"Super Bad Security Issue\\",\\"tags\\":[\\"defacement\\"],\\"connector\\":{\\"id\\":\\"123\\",\\"name\\":\\"Jira\\",\\"type\\":\\".jira\\",\\"fields\\":{\\"issueType\\":\\"Task\\",\\"priority\\":\\"High\\",\\"parent\\":null}},\\"settings\\":{\\"syncAlerts\\":true},\\"scope\\":\\"awesome\\"}",
+              "new_value": "{\\"type\\":\\"individual\\",\\"description\\":\\"This is a brand new case of a bad meanie defacing data\\",\\"title\\":\\"Super Bad Security Issue\\",\\"tags\\":[\\"defacement\\"],\\"connector\\":{\\"id\\":\\"123\\",\\"name\\":\\"Jira\\",\\"type\\":\\".jira\\",\\"fields\\":{\\"issueType\\":\\"Task\\",\\"priority\\":\\"High\\",\\"parent\\":null}},\\"settings\\":{\\"syncAlerts\\":true},\\"owner\\":\\"awesome\\"}",
               "old_value": null,
             },
             "references": Array [
@@ -151,7 +151,7 @@ describe('create', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       };
 
       const savedObjectsClient = createMockSavedObjectsRepository({
@@ -162,7 +162,7 @@ describe('create', () => {
 
       expect(res).toMatchInlineSnapshot(`
         Object {
-          "scope": "awesome",
+          "owner": "awesome",
           "closed_at": null,
           "closed_by": null,
           "comments": Array [],
@@ -216,7 +216,7 @@ describe('create', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       };
 
       const savedObjectsClient = createMockSavedObjectsRepository({
@@ -230,7 +230,7 @@ describe('create', () => {
 
       expect(res).toMatchInlineSnapshot(`
         Object {
-          "scope": "awesome",
+          "owner": "awesome",
           "closed_at": null,
           "closed_by": null,
           "comments": Array [],
@@ -429,7 +429,7 @@ describe('create', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       };
 
       const savedObjectsClient = createMockSavedObjectsRepository({
@@ -458,7 +458,7 @@ describe('create', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       };
       const savedObjectsClient = createMockSavedObjectsRepository({
         caseSavedObject: mockCases,

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -83,7 +83,7 @@ export const create = async ({
 
   try {
     try {
-      await auth.ensureAuthorized(query.scope, WriteOperations.Create);
+      await auth.ensureAuthorized(query.owner, WriteOperations.Create);
     } catch (error) {
       // TODO: log error using audit logger
       throw error;

--- a/x-pack/plugins/cases/server/client/cases/find.ts
+++ b/x-pack/plugins/cases/server/client/cases/find.ts
@@ -80,7 +80,7 @@ export const find = async ({
     });
 
     for (const theCase of cases.casesMap.values()) {
-      ensureSavedObjectIsAuthorized(theCase.scope);
+      ensureSavedObjectIsAuthorized(theCase.owner);
     }
 
     // TODO: Make sure we do not leak information when authorization is on

--- a/x-pack/plugins/cases/server/routes/api/cases/post_case.test.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/post_case.test.ts
@@ -46,7 +46,7 @@ describe('POST cases', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       },
     });
 
@@ -86,7 +86,7 @@ describe('POST cases', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       },
     });
 
@@ -120,7 +120,7 @@ describe('POST cases', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       },
     });
 
@@ -146,7 +146,7 @@ describe('POST cases', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       },
     });
 
@@ -180,7 +180,7 @@ describe('POST cases', () => {
         settings: {
           syncAlerts: true,
         },
-        scope: 'awesome',
+        owner: 'awesome',
       },
     });
 
@@ -196,7 +196,7 @@ describe('POST cases', () => {
     expect(response.status).toEqual(200);
     expect(response.payload).toMatchInlineSnapshot(`
       Object {
-        "scope": "awesome",
+        "owner": "awesome",
         "closed_at": null,
         "closed_by": null,
         "comments": Array [],

--- a/x-pack/plugins/cases/server/saved_object_types/cases.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/cases.ts
@@ -108,10 +108,10 @@ export const caseSavedObjectType: SavedObjectsType = {
           },
         },
       },
-      title: {
+      owner: {
         type: 'keyword',
       },
-      scope: {
+      title: {
         type: 'keyword',
       },
       status: {

--- a/x-pack/plugins/cases/server/saved_object_types/comments.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/comments.ts
@@ -21,7 +21,7 @@ export const caseCommentSavedObjectType: SavedObjectsType = {
       comment: {
         type: 'text',
       },
-      scope: {
+      owner: {
         type: 'keyword',
       },
       type: {

--- a/x-pack/plugins/cases/server/saved_object_types/configure.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/configure.ts
@@ -57,7 +57,7 @@ export const caseConfigureSavedObjectType: SavedObjectsType = {
       closure_type: {
         type: 'keyword',
       },
-      scope: {
+      owner: {
         type: 'keyword',
       },
       updated_at: {

--- a/x-pack/plugins/cases/server/saved_object_types/connector_mappings.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/connector_mappings.ts
@@ -28,7 +28,7 @@ export const caseConnectorMappingsSavedObjectType: SavedObjectsType = {
           },
         },
       },
-      scope: {
+      owner: {
         type: 'keyword',
       },
     },

--- a/x-pack/plugins/cases/server/saved_object_types/migrations.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/migrations.ts
@@ -15,7 +15,7 @@ import {
   AssociationType,
   ESConnectorFields,
 } from '../../common/api';
-import { SECURITY_SOLUTION_SCOPE } from '../../common/constants';
+import { SECURITY_SOLUTION_OWNER } from '../../common/constants';
 
 interface UnsanitizedCaseConnector {
   connector_id: string;
@@ -60,17 +60,17 @@ interface SanitizedCaseType {
   type: string;
 }
 
-interface SanitizedCaseClass {
-  scope: string;
+interface SanitizedCaseOwner {
+  owner: string;
 }
 
-const addScopeToSO = <T = Record<string, unknown>>(
+const addOwnerToSO = <T = Record<string, unknown>>(
   doc: SavedObjectUnsanitizedDoc<T>
-): SavedObjectSanitizedDoc<SanitizedCaseClass> => ({
+): SavedObjectSanitizedDoc<SanitizedCaseOwner> => ({
   ...doc,
   attributes: {
     ...doc.attributes,
-    scope: SECURITY_SOLUTION_SCOPE,
+    owner: SECURITY_SOLUTION_OWNER,
   },
   references: doc.references || [],
 });
@@ -131,8 +131,8 @@ export const caseMigrations = {
   },
   '7.13.0': (
     doc: SavedObjectUnsanitizedDoc<Record<string, unknown>>
-  ): SavedObjectSanitizedDoc<SanitizedCaseClass> => {
-    return addScopeToSO(doc);
+  ): SavedObjectSanitizedDoc<SanitizedCaseOwner> => {
+    return addOwnerToSO(doc);
   },
 };
 
@@ -158,8 +158,8 @@ export const configureMigrations = {
   },
   '7.13.0': (
     doc: SavedObjectUnsanitizedDoc<Record<string, unknown>>
-  ): SavedObjectSanitizedDoc<SanitizedCaseClass> => {
-    return addScopeToSO(doc);
+  ): SavedObjectSanitizedDoc<SanitizedCaseOwner> => {
+    return addOwnerToSO(doc);
   },
 };
 
@@ -204,8 +204,8 @@ export const userActionsMigrations = {
   },
   '7.13.0': (
     doc: SavedObjectUnsanitizedDoc<Record<string, unknown>>
-  ): SavedObjectSanitizedDoc<SanitizedCaseClass> => {
-    return addScopeToSO(doc);
+  ): SavedObjectSanitizedDoc<SanitizedCaseOwner> => {
+    return addOwnerToSO(doc);
   },
 };
 
@@ -259,23 +259,23 @@ export const commentsMigrations = {
   },
   '7.13.0': (
     doc: SavedObjectUnsanitizedDoc<Record<string, unknown>>
-  ): SavedObjectSanitizedDoc<SanitizedCaseClass> => {
-    return addScopeToSO(doc);
+  ): SavedObjectSanitizedDoc<SanitizedCaseOwner> => {
+    return addOwnerToSO(doc);
   },
 };
 
 export const connectorMappingsMigrations = {
   '7.13.0': (
     doc: SavedObjectUnsanitizedDoc<Record<string, unknown>>
-  ): SavedObjectSanitizedDoc<SanitizedCaseClass> => {
-    return addScopeToSO(doc);
+  ): SavedObjectSanitizedDoc<SanitizedCaseOwner> => {
+    return addOwnerToSO(doc);
   },
 };
 
 export const subCasesMigrations = {
   '7.13.0': (
     doc: SavedObjectUnsanitizedDoc<Record<string, unknown>>
-  ): SavedObjectSanitizedDoc<SanitizedCaseClass> => {
-    return addScopeToSO(doc);
+  ): SavedObjectSanitizedDoc<SanitizedCaseOwner> => {
+    return addOwnerToSO(doc);
   },
 };

--- a/x-pack/plugins/cases/server/saved_object_types/sub_case.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/sub_case.ts
@@ -47,7 +47,7 @@ export const subCaseSavedObjectType: SavedObjectsType = {
           },
         },
       },
-      scope: {
+      owner: {
         type: 'keyword',
       },
       status: {

--- a/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
+++ b/x-pack/plugins/cases/server/saved_object_types/user_actions.ts
@@ -43,7 +43,7 @@ export const caseUserActionSavedObjectType: SavedObjectsType = {
       old_value: {
         type: 'text',
       },
-      scope: {
+      owner: {
         type: 'keyword',
       },
     },

--- a/x-pack/plugins/security/server/authorization/actions/cases.test.ts
+++ b/x-pack/plugins/security/server/authorization/actions/cases.test.ts
@@ -20,23 +20,23 @@ describe('#get', () => {
     ${{}}
   `(`operation of ${JSON.stringify('$operation')}`, ({ operation }) => {
     const actions = new CasesActions(version);
-    expect(() => actions.get('scope', operation)).toThrowErrorMatchingSnapshot();
+    expect(() => actions.get('owner', operation)).toThrowErrorMatchingSnapshot();
   });
 
   it.each`
-    scope
+    owner
     ${null}
     ${undefined}
     ${''}
     ${1}
     ${true}
     ${{}}
-  `(`scope of ${JSON.stringify('$scope')}`, ({ scope }) => {
+  `(`owner of ${JSON.stringify('$owner')}`, ({ owner }) => {
     const actions = new CasesActions(version);
-    expect(() => actions.get(scope, 'operation')).toThrowErrorMatchingSnapshot();
+    expect(() => actions.get(owner, 'operation')).toThrowErrorMatchingSnapshot();
   });
 
-  it('returns `cases:${scope}/${operation}`', () => {
+  it('returns `cases:${owner}/${operation}`', () => {
     const alertingActions = new CasesActions(version);
     expect(alertingActions.get('security', 'bar-operation')).toBe(
       'cases:1.0.0-zeta1:security/bar-operation'

--- a/x-pack/plugins/security/server/authorization/actions/cases.ts
+++ b/x-pack/plugins/security/server/authorization/actions/cases.ts
@@ -14,15 +14,15 @@ export class CasesActions {
     this.prefix = `cases:${versionNumber}:`;
   }
 
-  public get(scope: string, operation: string): string {
+  public get(owner: string, operation: string): string {
     if (!operation || !isString(operation)) {
       throw new Error('operation is required and must be a string');
     }
 
-    if (!scope || !isString(scope)) {
-      throw new Error('scope is required and must be a string');
+    if (!owner || !isString(owner)) {
+      throw new Error('owner is required and must be a string');
     }
 
-    return `${this.prefix}${scope}/${operation}`;
+    return `${this.prefix}${owner}/${operation}`;
   }
 }

--- a/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/cases.ts
+++ b/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/cases.ts
@@ -19,9 +19,9 @@ export class FeaturePrivilegeCasesBuilder extends BaseFeaturePrivilegeBuilder {
     privilegeDefinition: FeatureKibanaPrivileges,
     feature: KibanaFeature
   ): string[] {
-    const getCasesPrivilege = (operations: string[], scopes: readonly string[]) => {
-      return scopes.flatMap((scope) =>
-        operations.map((operation) => this.actions.cases.get(scope, operation))
+    const getCasesPrivilege = (operations: string[], owners: readonly string[]) => {
+      return owners.flatMap((owner) =>
+        operations.map((operation) => this.actions.cases.get(owner, operation))
       );
     };
 

--- a/x-pack/plugins/security_solution/public/cases/components/create/form_context.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/create/form_context.tsx
@@ -84,7 +84,7 @@ export const FormContext: React.FC<Props> = ({
           connector: connectorToUpdate,
           settings: { syncAlerts },
           // TODO: need to replace this with the value that the plugin registers in the feature registration
-          scope: 'securitySolution',
+          owner: 'securitySolution',
         });
 
         if (afterCaseCreated && updatedCase) {

--- a/x-pack/plugins/security_solution/public/cases/components/create/schema.tsx
+++ b/x-pack/plugins/security_solution/public/cases/components/create/schema.tsx
@@ -19,8 +19,8 @@ export const schemaTags = {
   labelAppend: OptionalFieldLabel,
 };
 
-// TODO: remove scope from here?
-export type FormProps = Omit<CasePostRequest, 'connector' | 'settings' | 'scope'> & {
+// TODO: remove owner from here?
+export type FormProps = Omit<CasePostRequest, 'connector' | 'settings' | 'owner'> & {
   connectorId: string;
   fields: ConnectorTypeFields['fields'];
   syncAlerts: boolean;


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/95535 renamed `class` to `scope`. We decided that the wording was not appropriate and should be changed and finilized to `owner`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
