### PR TITLE
[7.x] Remove unneeded articles from button text (#96045)

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/component_templates/component_template_list/table.tsx
+++ b/x-pack/plugins/index_management/public/application/components/component_templates/component_template_list/table.tsx
@@ -100,7 +100,7 @@ export const ComponentTable: FunctionComponent<Props> = ({
           {...reactRouterNavigate(history, '/create_component_template')}
         >
           {i18n.translate('xpack.idxMgmt.componentTemplatesList.table.createButtonLabel', {
-            defaultMessage: 'Create a component template',
+            defaultMessage: 'Create component template',
           })}
         </EuiButton>,
       ],

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
@@ -91,7 +91,7 @@ export const PipelineTable: FunctionComponent<Props> = ({
           {...reactRouterNavigate(history, '/create')}
         >
           {i18n.translate('xpack.ingestPipelines.list.table.createPipelineButtonLabel', {
-            defaultMessage: 'Create a pipeline',
+            defaultMessage: 'Create pipeline',
           })}
         </EuiButton>,
       ],

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_table/policy_table.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/policy_list/policy_table/policy_table.tsx
@@ -382,7 +382,7 @@ export const PolicyTable: React.FunctionComponent<Props> = ({
       >
         <FormattedMessage
           id="xpack.snapshotRestore.policyList.table.addPolicyButton"
-          defaultMessage="Create a policy"
+          defaultMessage="Create policy"
         />
       </EuiButton>,
     ],

--- a/x-pack/plugins/snapshot_restore/public/application/sections/home/repository_list/repository_table/repository_table.tsx
+++ b/x-pack/plugins/snapshot_restore/public/application/sections/home/repository_list/repository_table/repository_table.tsx
@@ -261,7 +261,7 @@ export const RepositoryTable: React.FunctionComponent<Props> = ({
       >
         <FormattedMessage
           id="xpack.snapshotRestore.repositoryList.addRepositoryButtonLabel"
-          defaultMessage="Register a repository"
+          defaultMessage="Register repository"
         />
       </EuiButton>,
     ],


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove unneeded articles from button text (#96045)