### PR TITLE
[Workplace Search] Fix broken reauthenticate URLs and fix spelling

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -7,10 +7,6 @@
 
 import React from 'react';
 
-// Prefer importing entire lodash library, e.g. import { get } from "lodash"
-// eslint-disable-next-line no-restricted-imports
-import _kebabCase from 'lodash/kebabCase';
-
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -72,7 +68,7 @@ export const SourceRow: React.FC<SourceRowProps> = ({
   const fixLink = (
     <EuiLinkTo
       to={getSourcesPath(
-        `${ADD_SOURCE_PATH}/${_kebabCase(serviceType)}/re-authenticate?sourceId=${id}`,
+        `${ADD_SOURCE_PATH}/${serviceType}/re-authenticate?sourceId=${id}`,
         isOrganization
       )}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/source_row/source_row.tsx
@@ -68,7 +68,7 @@ export const SourceRow: React.FC<SourceRowProps> = ({
   const fixLink = (
     <EuiLinkTo
       to={getSourcesPath(
-        `${ADD_SOURCE_PATH}/${serviceType}/re-authenticate?sourceId=${id}`,
+        `${ADD_SOURCE_PATH}/${serviceType}/reauthenticate?sourceId=${id}`,
         isOrganization
       )}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.test.tsx
@@ -22,7 +22,7 @@ import { ConfigurationIntro } from './configuration_intro';
 import { ConfigureCustom } from './configure_custom';
 import { ConfigureOauth } from './configure_oauth';
 import { ConnectInstance } from './connect_instance';
-import { ReAuthenticate } from './re_authenticate';
+import { Reauthenticate } from './reauthenticate';
 import { SaveConfig } from './save_config';
 import { SaveCustom } from './save_custom';
 
@@ -142,13 +142,13 @@ describe('AddSourceList', () => {
     expect(wrapper.find(SaveCustom)).toHaveLength(1);
   });
 
-  it('renders ReAuthenticate step', () => {
+  it('renders Reauthenticate step', () => {
     setMockValues({
       ...mockValues,
-      addSourceCurrentStep: AddSourceSteps.ReAuthenticateStep,
+      addSourceCurrentStep: AddSourceSteps.ReauthenticateStep,
     });
     const wrapper = shallow(<AddSource sourceIndex={1} />);
 
-    expect(wrapper.find(ReAuthenticate)).toHaveLength(1);
+    expect(wrapper.find(Reauthenticate)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source.tsx
@@ -27,7 +27,7 @@ import { ConfigurationIntro } from './configuration_intro';
 import { ConfigureCustom } from './configure_custom';
 import { ConfigureOauth } from './configure_oauth';
 import { ConnectInstance } from './connect_instance';
-import { ReAuthenticate } from './re_authenticate';
+import { Reauthenticate } from './reauthenticate';
 import { SaveConfig } from './save_config';
 import { SaveCustom } from './save_custom';
 
@@ -150,8 +150,8 @@ export const AddSource: React.FC<AddSourceProps> = (props) => {
           header={header}
         />
       )}
-      {addSourceCurrentStep === AddSourceSteps.ReAuthenticateStep && (
-        <ReAuthenticate name={name} header={header} />
+      {addSourceCurrentStep === AddSourceSteps.ReauthenticateStep && (
+        <Reauthenticate name={name} header={header} />
       )}
     </>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.test.ts
@@ -276,7 +276,7 @@ describe('AddSourceLogic', () => {
         const addSourceProps = { sourceIndex: 1, reAuthenticate: true };
         AddSourceLogic.actions.initializeAddSource(addSourceProps);
 
-        expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ReAuthenticateStep);
+        expect(setAddSourceStepSpy).toHaveBeenCalledWith(AddSourceSteps.ReauthenticateStep);
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/add_source_logic.ts
@@ -42,7 +42,7 @@ export enum AddSourceSteps {
   ConfigureCustomStep = 'Configure Custom',
   ConfigureOauthStep = 'Configure Oauth',
   SaveCustomStep = 'Save Custom',
-  ReAuthenticateStep = 'ReAuthenticate',
+  ReauthenticateStep = 'Reauthenticate',
 }
 
 export interface OauthParams {
@@ -577,6 +577,6 @@ const getFirstStep = (props: AddSourceProps): AddSourceSteps => {
   if (isCustom) return AddSourceSteps.ConfigureCustomStep;
   if (connect) return AddSourceSteps.ConnectInstanceStep;
   if (configure) return AddSourceSteps.ConfigureOauthStep;
-  if (reAuthenticate) return AddSourceSteps.ReAuthenticateStep;
+  if (reAuthenticate) return AddSourceSteps.ReauthenticateStep;
   return AddSourceSteps.ConfigIntroStep;
 };

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/reauthenticate.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/reauthenticate.test.tsx
@@ -12,9 +12,9 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { ReAuthenticate } from './re_authenticate';
+import { Reauthenticate } from './reauthenticate';
 
-describe('ReAuthenticate', () => {
+describe('Reauthenticate', () => {
   // Needed to mock redirect window.location.replace(oauthUrl)
   const mockReplace = jest.fn();
   const mockWindow = {
@@ -44,14 +44,14 @@ describe('ReAuthenticate', () => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<ReAuthenticate {...props} />);
+    const wrapper = shallow(<Reauthenticate {...props} />);
 
     expect(wrapper.find('form')).toHaveLength(1);
   });
 
   it('handles form submission', () => {
     jest.spyOn(window.location, 'replace').mockImplementationOnce(mockReplace);
-    const wrapper = shallow(<ReAuthenticate {...props} />);
+    const wrapper = shallow(<Reauthenticate {...props} />);
 
     const preventDefault = jest.fn();
     wrapper.find('form').simulate('submit', { preventDefault });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/reauthenticate.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/reauthenticate.tsx
@@ -22,12 +22,12 @@ interface SourceQueryParams {
   sourceId: string;
 }
 
-interface ReAuthenticateProps {
+interface ReauthenticateProps {
   name: string;
   header: React.ReactNode;
 }
 
-export const ReAuthenticate: React.FC<ReAuthenticateProps> = ({ name, header }) => {
+export const Reauthenticate: React.FC<ReauthenticateProps> = ({ name, header }) => {
   const { search } = useLocation() as Location;
 
   const { sourceId } = (parseQueryParams(search) as unknown) as SourceQueryParams;
@@ -66,7 +66,7 @@ export const ReAuthenticate: React.FC<ReAuthenticateProps> = ({ name, header }) 
                 'xpack.enterpriseSearch.workplaceSearch.contentSource.reAuthenticate.body',
                 {
                   defaultMessage:
-                    'Your {name} credentials are no longer valid. Please re-authenticate with the original credentials to resume content syncing.',
+                    'Your {name} credentials are no longer valid. Please reauthenticate with the original credentials to resume content syncing.',
                   values: { name },
                 }
               )}
@@ -79,7 +79,7 @@ export const ReAuthenticate: React.FC<ReAuthenticateProps> = ({ name, header }) 
             {i18n.translate(
               'xpack.enterpriseSearch.workplaceSearch.contentSource.reAuthenticate.button',
               {
-                defaultMessage: 'Re-authenticate {name}',
+                defaultMessage: 'Reauthenticate {name}',
                 values: { name },
               }
             )}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/sources_router.tsx
@@ -82,7 +82,7 @@ export const SourcesRouter: React.FC = () => {
           </Route>
         ))}
         {staticSourceData.map(({ addPath, name }, i) => (
-          <Route key={i} exact path={`${getSourcesPath(addPath, isOrganization)}/re-authenticate`}>
+          <Route key={i} exact path={`${getSourcesPath(addPath, isOrganization)}/reauthenticate`}>
             <SetPageChrome trail={[NAV.SOURCES, NAV.ADD_SOURCE, name]} />
             <AddSource reAuthenticate sourceIndex={i} />
           </Route>


### PR DESCRIPTION
## closes https://github.com/elastic/workplace-search-team/issues/1619

## Summary

This PR fixes an issue where links to fix the broken connector instances were changed to kebab case from a previous life in `ent-search` and also fixes all incorrect spelling of reauthenticate in the app.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
