### PR TITLE
[App Search] API logs: remove incorrect error toast on successful poll

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_logs_logic.ts
@@ -117,10 +117,6 @@ export const ApiLogsLogic = kea<MakeLogicType<ApiLogsValues, ApiLogsActions>>({
         // while polls are stored in-state until the user manually triggers the 'Refresh' action
         if (isPoll) {
           actions.onPollInterval(response);
-          flashErrorToast(POLLING_ERROR_TITLE, {
-            text: POLLING_ERROR_TEXT,
-            toastLifeTimeMs: POLLING_DURATION * 0.75,
-          });
         } else {
           actions.updateView(response);
         }


### PR DESCRIPTION
## Summary

WHO ADDED AN EXTRA `flashErrorToast` FOR DEBUGGING AND FORGOT TO REMOVE IT IN https://github.com/elastic/kibana/pull/95981? CERTAINLY NOT ME

### Checklist

- [x] [Lie down](https://i.kym-cdn.com/entries/icons/facebook/000/012/073/7686178464_fdc8ea66c7.jpg)
- [x] Try not to cry
- [x] Cry a lot