### PR TITLE
pass script to bash to support scripts which aren't actually executable

### DIFF
--- a/vars/runbld.groovy
+++ b/vars/runbld.groovy
@@ -1,8 +1,8 @@
 def call(script, label, enableJunitProcessing = false) {
-  def extraConfig = enableJunitProcessing ? "" : "--config ${env.WORKSPACE}/kibana/.ci/runbld_no_junit.yml"
+  // def extraConfig = enableJunitProcessing ? "" : "--config ${env.WORKSPACE}/kibana/.ci/runbld_no_junit.yml"
 
   sh(
-    script: "/usr/local/bin/runbld -d '${pwd()}' ${extraConfig} ${script}",
+    script: "bash ${script}",
     label: label ?: script
   )
 }


### PR DESCRIPTION
Fixes issue in https://github.com/elastic/kibana/pull/96195 which broke when scripts weren't actually executable.