### PR TITLE
[TSVB] Fixes wrong field list on overriding index pattern for series

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/agg.tsx
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/agg.tsx
@@ -48,9 +48,9 @@ export function Agg(props: AggProps) {
     ...props.style,
   };
 
-  const indexPattern =
-    (props.series.override_index_pattern && props.series.series_index_pattern) ||
-    props.panel.index_pattern;
+  const indexPattern = props.series.override_index_pattern
+    ? props.series.series_index_pattern
+    : props.panel.index_pattern;
 
   return (
     <div className={props.className} style={style}>

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/filter_ratio.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/filter_ratio.js
@@ -51,8 +51,9 @@ export const FilterRatioAgg = (props) => {
     (query) => handleChange({ denominator: query }),
     [handleChange]
   );
-  const indexPattern =
-    (series.override_index_pattern && series.series_index_pattern) || panel.index_pattern;
+  const indexPattern = series.override_index_pattern
+    ? series.series_index_pattern
+    : panel.index_pattern;
 
   const defaults = {
     numerator: getDataStart().query.queryString.getDefaultQuery(),

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/percentile.js
@@ -39,8 +39,9 @@ export function PercentileAgg(props) {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleNumberChange = createNumberHandler(handleChange);
 
-  const indexPattern =
-    (series.override_index_pattern && series.series_index_pattern) || panel.index_pattern;
+  const indexPattern = series.override_index_pattern
+    ? series.series_index_pattern
+    : panel.index_pattern;
 
   useEffect(() => {
     if (!checkModel(model)) {

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_rate.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/positive_rate.js
@@ -65,9 +65,9 @@ export const PositiveRateAgg = (props) => {
   const handleSelectChange = createSelectHandler(handleChange);
 
   const htmlId = htmlIdGenerator();
-  const indexPattern =
-    (props.series.override_index_pattern && props.series.series_index_pattern) ||
-    props.panel.index_pattern;
+  const indexPattern = props.series.override_index_pattern
+    ? props.series.series_index_pattern
+    : props.panel.index_pattern;
 
   const selectedUnitOptions = UNIT_OPTIONS.filter((o) => o.value === model.unit);
 

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/std_agg.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/std_agg.js
@@ -31,8 +31,9 @@ export function StandardAgg(props) {
   const handleSelectChange = createSelectHandler(handleChange);
 
   const restrictFields = getSupportedFieldsByMetricType(model.type);
-  const indexPattern =
-    (series.override_index_pattern && series.series_index_pattern) || panel.index_pattern;
+  const indexPattern = series.override_index_pattern
+    ? series.series_index_pattern
+    : panel.index_pattern;
   const htmlId = htmlIdGenerator();
 
   return (

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/std_deviation.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/std_deviation.js
@@ -72,8 +72,9 @@ const StandardDeviationAggUi = (props) => {
   const handleSelectChange = createSelectHandler(handleChange);
   const handleTextChange = createTextHandler(handleChange);
 
-  const indexPattern =
-    (series.override_index_pattern && series.series_index_pattern) || panel.index_pattern;
+  const indexPattern = series.override_index_pattern
+    ? series.series_index_pattern
+    : panel.index_pattern;
   const htmlId = htmlIdGenerator();
   const selectedModeOption = modeOptions.find((option) => {
     return model.mode === option.value;

--- a/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/aggs/top_hit.js
@@ -100,8 +100,9 @@ const TopHitAggUi = (props) => {
     order: 'desc',
   };
   const model = { ...defaults, ...props.model };
-  const indexPattern =
-    (series.override_index_pattern && series.series_index_pattern) || panel.index_pattern;
+  const indexPattern = series.override_index_pattern
+    ? series.series_index_pattern
+    : panel.index_pattern;
 
   const aggWithOptionsRestrictFields = [
     PANEL_TYPES.TABLE,

--- a/src/plugins/vis_type_timeseries/public/application/components/series_config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/series_config.js
@@ -33,10 +33,9 @@ export const SeriesConfig = (props) => {
   const handleSelectChange = createSelectHandler(props.onChange);
   const handleTextChange = createTextHandler(props.onChange);
   const htmlId = htmlIdGenerator();
-  const seriesIndexPattern =
-    props.model.override_index_pattern && props.model.series_index_pattern
-      ? props.model.series_index_pattern
-      : props.indexPatternForQuery;
+  const seriesIndexPattern = props.model.override_index_pattern
+    ? props.model.series_index_pattern
+    : props.indexPatternForQuery;
 
   return (
     <div className="tvbAggRow">

--- a/src/plugins/vis_type_timeseries/public/application/components/split.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/split.js
@@ -63,8 +63,9 @@ export class Split extends Component {
 
   render() {
     const { model, panel, uiRestrictions, seriesQuantity } = this.props;
-    const indexPattern =
-      (model.override_index_pattern && model.series_index_pattern) || panel.index_pattern;
+    const indexPattern = model.override_index_pattern
+      ? model.series_index_pattern
+      : panel.index_pattern;
     const splitMode = get(this.props, 'model.split_mode', SPLIT_MODES.EVERYTHING);
     const Component = this.getComponent(splitMode, uiRestrictions);
 

--- a/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/config.js
+++ b/src/plugins/vis_type_timeseries/public/application/components/vis_types/timeseries/config.js
@@ -327,10 +327,9 @@ export const TimeseriesConfig = injectI18n(function (props) {
 
   const disableSeparateYaxis = model.separate_axis ? false : true;
 
-  const seriesIndexPattern =
-    props.model.override_index_pattern && props.model.series_index_pattern
-      ? props.model.series_index_pattern
-      : props.indexPatternForQuery;
+  const seriesIndexPattern = props.model.override_index_pattern
+    ? props.model.series_index_pattern
+    : props.indexPatternForQuery;
 
   const initialPalette = {
     ...model.palette,


### PR DESCRIPTION
## Summary

[TSVB] fix wrong field list on overriding index pattern for series

## Steps to reproduce
1) Install 2 sample data sets (**Sample eCommerce orders** and **Sample flight data**) and open 
2) Open TSVB 
**Important**: `kibana_sample_data_ecommerce` - should be a default index 
3) Go to `Panel Options` and set `kibana_sample_data_flights` as an index for your visualization
![image](https://user-images.githubusercontent.com/20072247/113565824-5127b080-9614-11eb-9b8f-9fe50a21092a.png)

4) Create `Average` aggregation and check field list. Should be available fields related to  `kibana_sample_data_flights`
![image](https://user-images.githubusercontent.com/20072247/113565928-79afaa80-9614-11eb-8808-39cc719553ae.png)

5) Open metric options and set `Override Index Patterns` to `true`. 

6) See the field list for Average aggregation.  
**Expected result:** I expect to see fields related to `kibana_sample_data_ecommerce` index 
In fact I see fields related tp `kibana_sample_data_flights` index 