### PR TITLE
[Enterprise Search] Change order of WS plugin instantiation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -113,11 +113,11 @@ export class EnterpriseSearchPlugin implements Plugin {
         const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
         const { chrome, http } = kibanaDeps.core;
         chrome.docTitle.change(WORKPLACE_SEARCH_PLUGIN.NAME);
+        await this.getInitialData(http);
 
         // The Workplace Search Personal dashboard needs the chrome hidden. We hide it globally
         // here first to prevent a flash of chrome on the Personal dashboard and unhide it for admin routes.
         chrome.setIsVisible(false);
-        await this.getInitialData(http);
         const pluginData = this.getPluginData();
 
         const { renderApp } = await import('./applications');


### PR DESCRIPTION
## Summary

There was an issue where the console was giving unmounted component errors introduced [here](https://github.com/elastic/kibana/pull/95984). Changing the order of the hiding of the Chrome removes the issue. Not sure why hiding the chrome before the data was fetched caused this but I can't seem to get the error to happen again with this order. 

![error](https://user-images.githubusercontent.com/1869731/113606684-f2f7cf00-960d-11eb-9288-d44c20a19c6c.png)
