### PR TITLE
[UX App] Improve api response performance

### DIFF
--- a/x-pack/plugins/apm/public/services/callApi.test.ts
+++ b/x-pack/plugins/apm/public/services/callApi.test.ts
@@ -44,7 +44,7 @@ describe('callApi', () => {
       await callApi(core, { pathname: `/api/apm/status/server` });
 
       expect(core.http.get).toHaveBeenCalledWith('/api/apm/status/server', {
-        query: { _inspect: true },
+        query: { _inspect: true, includeFrozen: true },
       });
     });
 

--- a/x-pack/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/plugins/apm/public/services/rest/callApi.ts
@@ -11,10 +11,12 @@ import LRU from 'lru-cache';
 import hash from 'object-hash';
 import { enableInspectEsQueries } from '../../../../observability/public';
 import { FetchOptions } from '../../../common/fetch_options';
+import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 
 function fetchOptionsWithDebug(
   fetchOptions: FetchOptions,
-  inspectableEsQueriesEnabled: boolean
+  inspectableEsQueriesEnabled: boolean,
+  includeFrozen?: boolean
 ) {
   const debugEnabled =
     inspectableEsQueriesEnabled &&
@@ -28,6 +30,7 @@ function fetchOptionsWithDebug(
     query: {
       ...fetchOptions.query,
       ...(debugEnabled ? { _inspect: true } : {}),
+      ...(includeFrozen ? { includeFrozen: true } : {}),
     },
   };
 }
@@ -47,6 +50,8 @@ export async function callApi<T = void>(
   const inspectableEsQueriesEnabled: boolean = uiSettings.get(
     enableInspectEsQueries
   );
+  const includeFrozen = uiSettings.get(UI_SETTINGS.SEARCH_INCLUDE_FROZEN);
+
   const cacheKey = getCacheKey(fetchOptions);
   const cacheResponse = cache.get(cacheKey);
   if (cacheResponse) {
@@ -55,7 +60,8 @@ export async function callApi<T = void>(
 
   const { pathname, method = 'get', ...options } = fetchOptionsWithDebug(
     fetchOptions,
-    inspectableEsQueriesEnabled
+    inspectableEsQueriesEnabled,
+    includeFrozen
   );
 
   const lowercaseMethod = method.toLowerCase() as

--- a/x-pack/plugins/apm/public/services/rest/callApi.ts
+++ b/x-pack/plugins/apm/public/services/rest/callApi.ts
@@ -18,10 +18,9 @@ function fetchOptionsWithDebug(
   inspectableEsQueriesEnabled: boolean,
   includeFrozen?: boolean
 ) {
-  const debugEnabled =
-    inspectableEsQueriesEnabled &&
-    startsWith(fetchOptions.pathname, '/api/apm');
+  const isApmEndPoint = startsWith(fetchOptions.pathname, '/api/apm');
 
+  const debugEnabled = inspectableEsQueriesEnabled && isApmEndPoint;
   const { body, ...rest } = fetchOptions;
 
   return {
@@ -30,7 +29,7 @@ function fetchOptionsWithDebug(
     query: {
       ...fetchOptions.query,
       ...(debugEnabled ? { _inspect: true } : {}),
-      ...(includeFrozen ? { includeFrozen: true } : {}),
+      ...(includeFrozen && isApmEndPoint ? { includeFrozen: true } : {}),
     },
   };
 }

--- a/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
+++ b/x-pack/plugins/apm/server/lib/helpers/setup_request.test.ts
@@ -52,6 +52,7 @@ function getMockRequest() {
     params: {
       query: {
         _inspect: false,
+        includeFrozen: false,
       },
     },
     core: {
@@ -266,7 +267,7 @@ describe('with includeFrozen=true', () => {
     const { mockContext, mockRequest } = getMockRequest();
 
     // mock includeFrozen to return true
-    mockContext.core.uiSettings.client.get.mockResolvedValue(true);
+    mockContext.params.query.includeFrozen = true;
 
     const { apmEventClient } = await setupRequest(mockContext, mockRequest);
 

--- a/x-pack/plugins/apm/server/lib/settings/apm_indices/index.ts
+++ b/x-pack/plugins/apm/server/lib/settings/apm_indices/index.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsClient } from 'kibana/server';
+import { ApmIndicesConfig, getApmIndices } from './get_apm_indices';
+import { APMConfig } from '../../../index';
+
+type ISavedObjectsClient = Pick<SavedObjectsClient, 'get'>;
+
+interface ApmIndicesSettings {
+  indices?: ApmIndicesConfig;
+  getIndices: (attr: {
+    config: APMConfig;
+    savedObjectsClient: ISavedObjectsClient;
+  }) => Promise<ApmIndicesConfig>;
+  refetch: (attr: {
+    config: APMConfig;
+    savedObjectsClient: ISavedObjectsClient;
+  }) => Promise<ApmIndicesConfig>;
+  reset: (attr: {
+    config: APMConfig;
+    savedObjectsClient: ISavedObjectsClient;
+  }) => void;
+  resetScheduled: NodeJS.Timeout | null;
+}
+
+export const apmIndicesSettings: ApmIndicesSettings = {
+  getIndices: async ({
+    config,
+    savedObjectsClient,
+  }: {
+    config: APMConfig;
+    savedObjectsClient: ISavedObjectsClient;
+  }) => {
+    if (apmIndicesSettings.indices) {
+      // non blocking call
+      apmIndicesSettings.reset({ config, savedObjectsClient });
+
+      return apmIndicesSettings.indices;
+    }
+    return apmIndicesSettings.refetch({ config, savedObjectsClient });
+  },
+  refetch: async ({
+    config,
+    savedObjectsClient,
+  }: {
+    config: APMConfig;
+    savedObjectsClient: ISavedObjectsClient;
+  }) => {
+    apmIndicesSettings.indices = await getApmIndices({
+      savedObjectsClient,
+      config,
+    });
+    return apmIndicesSettings.indices!;
+  },
+  resetScheduled: null,
+  reset: ({
+    config,
+    savedObjectsClient,
+  }: {
+    config: APMConfig;
+    savedObjectsClient: ISavedObjectsClient;
+  }) => {
+    if (!apmIndicesSettings.resetScheduled) {
+      apmIndicesSettings.resetScheduled = setTimeout(() => {
+        apmIndicesSettings.refetch({ config, savedObjectsClient });
+        apmIndicesSettings.resetScheduled = null;
+      }, 60 * 1000);
+    }
+  },
+};

--- a/x-pack/plugins/apm/server/lib/settings/apm_indices/save_apm_indices.ts
+++ b/x-pack/plugins/apm/server/lib/settings/apm_indices/save_apm_indices.ts
@@ -12,11 +12,14 @@ import {
 } from '../../../../common/apm_saved_object_constants';
 import { withApmSpan } from '../../../utils/with_apm_span';
 import { ApmIndicesConfig } from './get_apm_indices';
+import { apmIndicesSettings } from './index';
 
 export function saveApmIndices(
   savedObjectsClient: SavedObjectsClientContract,
   apmIndices: Partial<ApmIndicesConfig>
 ) {
+  apmIndicesSettings.indices = undefined;
+
   return withApmSpan('save_apm_indices', () =>
     savedObjectsClient.create(
       APM_INDICES_SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/apm/server/routes/create_api/index.test.ts
+++ b/x-pack/plugins/apm/server/routes/create_api/index.test.ts
@@ -191,7 +191,7 @@ describe('createApi', () => {
           body: {
             attributes: { _inspect: [] },
             message:
-              'Invalid value 1 supplied to : strict_keys/query: Partial<{| _inspect: pipe(JSON, boolean) |}>/_inspect: pipe(JSON, boolean)',
+              'Invalid value 1 supplied to : strict_keys/query: Partial<{| _inspect: pipe(JSON, boolean), includeFrozen: pipe(JSON, boolean) |}>/_inspect: pipe(JSON, boolean)',
           },
           statusCode: 400,
         });

--- a/x-pack/plugins/apm/server/routes/create_api/index.ts
+++ b/x-pack/plugins/apm/server/routes/create_api/index.ts
@@ -24,7 +24,12 @@ import type { ApmPluginRequestHandlerContext } from '../typings';
 
 const inspectRt = t.exact(
   t.partial({
-    query: t.exact(t.partial({ _inspect: jsonRt.pipe(t.boolean) })),
+    query: t.exact(
+      t.partial({
+        _inspect: jsonRt.pipe(t.boolean),
+        includeFrozen: jsonRt.pipe(t.boolean),
+      })
+    ),
   })
 );
 

--- a/x-pack/plugins/apm/server/routes/typings.ts
+++ b/x-pack/plugins/apm/server/routes/typings.ts
@@ -28,6 +28,10 @@ interface InspectQueryParam {
   query: { _inspect: boolean };
 }
 
+interface IncludeFrozenQueryParam {
+  query: { includeFrozen?: boolean };
+}
+
 export type InspectResponse = Array<{
   response: any;
   duration: number;
@@ -90,7 +94,7 @@ export interface ApmPluginRequestHandlerContext extends RequestHandlerContext {
 export type APMRequestHandlerContext<
   TRouteParams = {}
 > = ApmPluginRequestHandlerContext & {
-  params: TRouteParams & InspectQueryParam;
+  params: TRouteParams & InspectQueryParam & IncludeFrozenQueryParam;
   config: APMConfig;
   logger: Logger;
   plugins: {


### PR DESCRIPTION
## Summary

while investigating ux page api call times overhead on top of es query time, i found that fetching indices settings is an expensive operation.

Avoid unnecessary calls to fetch indices settings and also move ui settings to check includeFroze part to ui where cache is being used.

This will improve api response by approx 240ms on edge-olbt cluster.

here is how it looks

After: 
![image](https://user-images.githubusercontent.com/3505601/113752558-646a7700-970d-11eb-911a-4081a95ce2ec.png)


Before:
![image](https://user-images.githubusercontent.com/3505601/113752128-ead28900-970c-11eb-8f0a-ab1d4bc1d46d.png)


This was the problematic piece of code

```
    const [indices, includeFrozen] = await Promise.all([
      getApmIndices({
        savedObjectsClient: context.core.savedObjects.client,
        config,
      }),
      withApmSpan('get_ui_settings', () =>
        context.core.uiSettings.client.get(UI_SETTINGS.SEARCH_INCLUDE_FROZEN)
      ),
    ]);
```

Added this code to debug both scenerios 

```
    const startTime = process.hrtime();

    const indices = await apmIndicesSettings.getIndices({
      savedObjectsClient: context.core.savedObjects.client,
      config,
    });

    const highlightColor = 'bgRed';
    const diff = process.hrtime(startTime);
    const duration = `${Math.round(diff[0] * 1000 + diff[1] / 1e6)}ms`;
    const routeInfo = `${request.route.method.toUpperCase()} ${
      request.route.path
    }`;

    console.log(
      chalk.bold[highlightColor](`=== Debug: ${routeInfo} (${duration}) ===`)
    );
```