### PR TITLE
[APM] Optimized type checking for API tests

### DIFF
--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/optimize.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/optimize.js
@@ -18,7 +18,12 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const unlink = promisify(fs.unlink);
 
-const { kibanaRoot, tsconfigTpl, filesToIgnore } = require('./paths');
+const {
+  kibanaRoot,
+  tsconfigTpl,
+  tsconfigTplTest,
+  filesToIgnore,
+} = require('./paths');
 const { unoptimizeTsConfig } = require('./unoptimize');
 
 async function prepareBaseTsConfig() {
@@ -57,6 +62,23 @@ async function addApmFilesToRootTsConfig() {
   );
 }
 
+async function addApmFilesToTestTsConfig() {
+  const template = json5.parse(await readFile(tsconfigTplTest, 'utf-8'));
+  const testTsConfigFilename = path.join(
+    kibanaRoot,
+    'x-pack/test/tsconfig.json'
+  );
+  const testTsConfig = json5.parse(
+    await readFile(testTsConfigFilename, 'utf-8')
+  );
+
+  await writeFile(
+    testTsConfigFilename,
+    JSON.stringify({ ...testTsConfig, ...template, references: [] }, null, 2),
+    { encoding: 'utf-8' }
+  );
+}
+
 async function setIgnoreChanges() {
   for (const filename of filesToIgnore) {
     await execa('git', ['update-index', '--skip-worktree', filename]);
@@ -73,6 +95,8 @@ async function optimizeTsConfig() {
   await prepareBaseTsConfig();
 
   await addApmFilesToRootTsConfig();
+
+  await addApmFilesToTestTsConfig();
 
   await deleteApmTsConfig();
 

--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/paths.js
@@ -9,15 +9,18 @@ const path = require('path');
 
 const kibanaRoot = path.resolve(__dirname, '../../../../..');
 const tsconfigTpl = path.resolve(__dirname, './tsconfig.json');
+const tsconfigTplTest = path.resolve(__dirname, './test-tsconfig.json');
 
 const filesToIgnore = [
   path.resolve(kibanaRoot, 'tsconfig.json'),
   path.resolve(kibanaRoot, 'tsconfig.base.json'),
   path.resolve(kibanaRoot, 'x-pack/plugins/apm', 'tsconfig.json'),
+  path.resolve(kibanaRoot, 'x-pack/test', 'tsconfig.json'),
 ];
 
 module.exports = {
   kibanaRoot,
   tsconfigTpl,
+  tsconfigTplTest,
   filesToIgnore,
 };

--- a/x-pack/plugins/apm/scripts/optimize-tsconfig/test-tsconfig.json
+++ b/x-pack/plugins/apm/scripts/optimize-tsconfig/test-tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "types": [
+      "node"
+    ],
+    "noErrorTruncation": true
+  },
+  "include": [
+    "./apm_api_integration/**/*",
+    "../../packages/kbn-test/types/**/*",
+    "../../typings/**/*"
+  ],
+  "exclude": [
+    "**/__fixtures__/**/*"
+  ]
+}

--- a/x-pack/plugins/apm/scripts/precommit.js
+++ b/x-pack/plugins/apm/scripts/precommit.js
@@ -23,6 +23,8 @@ const tsconfig = useOptimizedTsConfig
   ? resolve(root, 'tsconfig.json')
   : resolve(root, 'x-pack/plugins/apm/tsconfig.json');
 
+const testTsconfig = resolve(root, 'x-pack/test/tsconfig.json');
+
 const tasks = new Listr(
   [
     {
@@ -55,16 +57,18 @@ const tasks = new Listr(
           ],
           execaOpts
         ).then(() =>
-          execa(
-            require.resolve('typescript/bin/tsc'),
-            [
-              '--project',
-              tsconfig,
-              '--pretty',
-              ...(useOptimizedTsConfig ? ['--noEmit'] : []),
-            ],
-            execaOpts
-          )
+          Promise.all([
+            execa(
+              require.resolve('typescript/bin/tsc'),
+              ['--project', tsconfig, '--pretty', '--noEmit'],
+              execaOpts
+            ),
+            execa(
+              require.resolve('typescript/bin/tsc'),
+              ['--project', testTsconfig, '--pretty', '--noEmit'],
+              execaOpts
+            ),
+          ])
         ),
     },
     {


### PR DESCRIPTION
Closes #95634.

Unfortunately I can only get this to work with a separate tsconfig file, as the mocha types conflict with jest's.