### PR TITLE
[Enterprise Search] Change last breadcrumb to inactive/non-linked breadcrumb

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
@@ -89,8 +89,7 @@ describe('useEuiBreadcrumbs', () => {
       },
       {
         text: 'World',
-        href: '/app/enterprise_search/world',
-        onClick: expect.any(Function),
+        // Per EUI best practices, the last breadcrumb is inactive/is not a link
       },
     ]);
   });
@@ -164,8 +163,6 @@ describe('useEnterpriseSearchBreadcrumbs', () => {
       },
       {
         text: 'Page 2',
-        href: '/app/enterprise_search/page2',
-        onClick: expect.any(Function),
       },
     ]);
   });
@@ -174,8 +171,6 @@ describe('useEnterpriseSearchBreadcrumbs', () => {
     expect(useEnterpriseSearchBreadcrumbs()).toEqual([
       {
         text: 'Enterprise Search',
-        href: '/app/enterprise_search/overview',
-        onClick: expect.any(Function),
       },
     ]);
   });
@@ -219,8 +214,6 @@ describe('useAppSearchBreadcrumbs', () => {
       },
       {
         text: 'Page 2',
-        href: '/app/enterprise_search/app_search/page2',
-        onClick: expect.any(Function),
       },
     ]);
   });
@@ -234,8 +227,6 @@ describe('useAppSearchBreadcrumbs', () => {
       },
       {
         text: 'App Search',
-        href: '/app/enterprise_search/app_search/',
-        onClick: expect.any(Function),
       },
     ]);
   });
@@ -279,8 +270,6 @@ describe('useWorkplaceSearchBreadcrumbs', () => {
       },
       {
         text: 'Page 2',
-        href: '/app/enterprise_search/workplace_search/page2',
-        onClick: expect.any(Function),
       },
     ]);
   });
@@ -294,8 +283,6 @@ describe('useWorkplaceSearchBreadcrumbs', () => {
       },
       {
         text: 'Workplace Search',
-        href: '/app/enterprise_search/workplace_search/',
-        onClick: expect.any(Function),
       },
     ]);
   });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
@@ -41,6 +41,9 @@ describe('useGenerateBreadcrumbs', () => {
       { text: 'Groups', path: '/groups' },
       { text: 'Example Group Name', path: '/groups/{id}' },
       { text: 'Source Prioritization', path: '/groups/{id}/source_prioritization' },
+      // Note: We're still generating a path for the last breadcrumb even though useEuiBreadcrumbs
+      // will not render a link for it. This is because it's easier to keep our last-breadcrumb-specific
+      // logic in one place, & this way we still have a current path if (for some reason) we need it later.
     ]);
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.test.ts
@@ -14,6 +14,7 @@ jest.mock('../react_router_helpers', () => ({
 import { letBrowserHandleEvent } from '../react_router_helpers';
 
 import {
+  Breadcrumb,
   useGenerateBreadcrumbs,
   useEuiBreadcrumbs,
   useEnterpriseSearchBreadcrumbs,
@@ -94,42 +95,46 @@ describe('useEuiBreadcrumbs', () => {
     ]);
   });
 
-  it('prevents default navigation and uses React Router history on click', () => {
-    const breadcrumb = useEuiBreadcrumbs([{ text: '', path: '/test' }])[0] as any;
+  describe('link behavior for non-last breadcrumbs', () => {
+    // Test helper - adds a 2nd dummy breadcrumb so that paths from the first breadcrumb are generated
+    const useEuiBreadcrumb = (breadcrumb: Breadcrumb) =>
+      useEuiBreadcrumbs([breadcrumb, { text: '' }])[0] as any;
 
-    expect(breadcrumb.href).toEqual('/app/enterprise_search/test');
-    expect(mockHistory.createHref).toHaveBeenCalled();
+    it('prevents default navigation and uses React Router history on click', () => {
+      const breadcrumb = useEuiBreadcrumb({ text: '', path: '/test' });
 
-    const event = { preventDefault: jest.fn() };
-    breadcrumb.onClick(event);
+      expect(breadcrumb.href).toEqual('/app/enterprise_search/test');
+      expect(mockHistory.createHref).toHaveBeenCalled();
 
-    expect(event.preventDefault).toHaveBeenCalled();
-    expect(mockKibanaValues.navigateToUrl).toHaveBeenCalled();
-  });
+      const event = { preventDefault: jest.fn() };
+      breadcrumb.onClick(event);
 
-  it('does not call createHref if shouldNotCreateHref is passed', () => {
-    const breadcrumb = useEuiBreadcrumbs([
-      { text: '', path: '/test', shouldNotCreateHref: true },
-    ])[0] as any;
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(mockKibanaValues.navigateToUrl).toHaveBeenCalled();
+    });
 
-    expect(breadcrumb.href).toEqual('/test');
-    expect(mockHistory.createHref).not.toHaveBeenCalled();
-  });
+    it('does not call createHref if shouldNotCreateHref is passed', () => {
+      const breadcrumb = useEuiBreadcrumb({ text: '', path: '/test', shouldNotCreateHref: true });
 
-  it('does not prevent default browser behavior on new tab/window clicks', () => {
-    const breadcrumb = useEuiBreadcrumbs([{ text: '', path: '/' }])[0] as any;
+      expect(breadcrumb.href).toEqual('/test');
+      expect(mockHistory.createHref).not.toHaveBeenCalled();
+    });
 
-    (letBrowserHandleEvent as jest.Mock).mockImplementationOnce(() => true);
-    breadcrumb.onClick();
+    it('does not prevent default browser behavior on new tab/window clicks', () => {
+      const breadcrumb = useEuiBreadcrumb({ text: '', path: '/' });
 
-    expect(mockKibanaValues.navigateToUrl).not.toHaveBeenCalled();
-  });
+      (letBrowserHandleEvent as jest.Mock).mockImplementationOnce(() => true);
+      breadcrumb.onClick();
 
-  it('does not generate link behavior if path is excluded', () => {
-    const breadcrumb = useEuiBreadcrumbs([{ text: 'Unclickable breadcrumb' }])[0];
+      expect(mockKibanaValues.navigateToUrl).not.toHaveBeenCalled();
+    });
 
-    expect(breadcrumb.href).toBeUndefined();
-    expect(breadcrumb.onClick).toBeUndefined();
+    it('does not generate link behavior if path is excluded', () => {
+      const breadcrumb = useEuiBreadcrumb({ text: 'Unclickable breadcrumb' });
+
+      expect(breadcrumb.href).toBeUndefined();
+      expect(breadcrumb.onClick).toBeUndefined();
+    });
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -64,16 +64,20 @@ export const useGenerateBreadcrumbs = (trail: BreadcrumbTrail): Breadcrumbs => {
 /**
  * Convert IBreadcrumb objects to React-Router-friendly EUI breadcrumb objects
  * https://elastic.github.io/eui/#/navigation/breadcrumbs
+ *
+ * NOTE: Per EUI best practices, we remove the link behavior and
+ * generate an inactive breadcrumb for the last breadcrumb in the list.
  */
 
 export const useEuiBreadcrumbs = (breadcrumbs: Breadcrumbs): EuiBreadcrumb[] => {
   const { navigateToUrl, history } = useValues(KibanaLogic);
   const { http } = useValues(HttpLogic);
 
-  return breadcrumbs.map(({ text, path, shouldNotCreateHref }) => {
+  return breadcrumbs.map(({ text, path, shouldNotCreateHref }, i) => {
     const breadcrumb: EuiBreadcrumb = { text };
+    const isLastBreadcrumb = i === breadcrumbs.length - 1;
 
-    if (path) {
+    if (path && !isLastBreadcrumb) {
       breadcrumb.href = createHref(path, { history, http }, { shouldNotCreateHref });
       breadcrumb.onClick = (event) => {
         if (letBrowserHandleEvent(event)) return;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_breadcrumbs.ts
@@ -24,7 +24,7 @@ import { letBrowserHandleEvent, createHref } from '../react_router_helpers';
  * Types
  */
 
-interface Breadcrumb {
+export interface Breadcrumb {
   text: string;
   path?: string;
   // Used to navigate outside of the React Router basename,


### PR DESCRIPTION
## Summary

Per a conversation with @johnbarrierwilson and @scottybollinger, we've determined the last item in our breadcrumbs should be gray/inactive and not a clickable link. This is a fairly simple change with our breadcrumb helper.

### Screencaps

Before (left), after (right):

App Search example:
<img width="684" alt="App Search before" src="https://user-images.githubusercontent.com/549407/113920774-15b6ee80-979a-11eb-93bd-769a2c30dead.png"> <img width="683" alt="App Search after" src="https://user-images.githubusercontent.com/549407/113920631-df796f00-9799-11eb-8ca2-e73f906ca374.png">

Workplace Search example:
<img width="384" alt="Workplace Search before" src="https://user-images.githubusercontent.com/549407/113920794-1cddfc80-979a-11eb-84ce-2cc0722f0a70.png"> <img width="394" alt="Workplace Search after" src="https://user-images.githubusercontent.com/549407/113920649-e86a4080-9799-11eb-897d-e01983d06423.png">

Enterprise Search overview:
<img width="246" alt="Enterprise Search before" src="https://user-images.githubusercontent.com/549407/113920806-1ea7c000-979a-11eb-87b5-a44311d9d7f0.png"> <img width="249" alt="Enterprise Search after" src="https://user-images.githubusercontent.com/549407/113920636-e0aa9c00-9799-11eb-894b-b838f8a8b139.png">

## QA

- [x] Confirm all Enterprise Search breadcrumbs work as before, but with gray/non-clickable last breadcrumbs

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios