### PR TITLE
Document more "xpack.data_enhanced.search.sessions.*" settings

### DIFF
--- a/docs/settings/search-sessions-settings.asciidoc
+++ b/docs/settings/search-sessions-settings.asciidoc
@@ -11,33 +11,33 @@ Configure the search session settings in your `kibana.yml` configuration file.
 [cols="2*<"]
 |===
 a| `xpack.data_enhanced.`
-`search.sessions.enabled`
+`search.sessions.enabled` {ess-icon}
 | Set to `true` (default) to enable search sessions.
 
 a| `xpack.data_enhanced.`
-`search.sessions.trackingInterval`
+`search.sessions.trackingInterval` {ess-icon}
 | The frequency for updating the state of a search session. The default is `10s`.
 
 a| `xpack.data_enhanced.`
-`search.sessions.pageSize`
-| How many search sessions {kib} processs at once while monitoring
+`search.sessions.pageSize` {ess-icon}
+| How many search sessions {kib} processes at once while monitoring
 session progress. The default is `100`.
 
 a| `xpack.data_enhanced.`
-`search.sessions.notTouchedTimeout`
+`search.sessions.notTouchedTimeout` {ess-icon}
 | How long {kib} stores search results from unsaved sessions,
-after the last search in the session has completed. The default is `5m`.
+after the last search in the session completes. The default is `5m`.
 
 a| `xpack.data_enhanced.`
-`search.sessions.notTouchedInProgressTimeout`
+`search.sessions.notTouchedInProgressTimeout` {ess-icon}
 | How long a search session can run after a user navigates away without saving a session. The default is `1m`.
 
 a| `xpack.data_enhanced.`
-`search.sessions.maxUpdateRetries`
+`search.sessions.maxUpdateRetries` {ess-icon}
 | How many retries {kib} can perform while attempting to save a search session. The default is `3`.
 
 a| `xpack.data_enhanced.`
-`search.sessions.defaultExpiration`
+`search.sessions.defaultExpiration`{ess-icon}
 | How long search session results are stored before they are deleted.
 Extending a search session resets the expiration by the same value. The default is `7d`.
 |===

--- a/docs/settings/search-sessions-settings.asciidoc
+++ b/docs/settings/search-sessions-settings.asciidoc
@@ -16,28 +16,28 @@ a| `xpack.data_enhanced.`
 
 a| `xpack.data_enhanced.`
 `search.sessions.trackingInterval`
-| The frequency for updating the state of a search session. The default is 10s.
+| The frequency for updating the state of a search session. The default is `10s`.
 
 a| `xpack.data_enhanced.`
 `search.sessions.pageSize`
-| Controls how many search sessions Kibana processs at once while monitoring
-session progress. The default is 100.
+| How many search sessions {kib} processs at once while monitoring
+session progress. The default is `100`.
 
 a| `xpack.data_enhanced.`
 `search.sessions.notTouchedTimeout`
-| Controls for how long Kibana stores search results from unsaved sessions,
-after the last search in the session has completed. The default is 5m.
+| How long {kib} stores search results from unsaved sessions,
+after the last search in the session has completed. The default is `5m`.
 
 a| `xpack.data_enhanced.`
 `search.sessions.notTouchedInProgressTimeout`
-| Controls for how long a search session can run after a user navigates away without saving a session. The default is 1m.
+| How long a search session can run after a user navigates away without saving a session. The default is `1m`.
 
 a| `xpack.data_enhanced.`
 `search.sessions.maxUpdateRetries`
-| Controls how many retries Kibana can perform while attempting to save a search session. The default is 3.
+| How many retries {kib} can perform while attempting to save a search session. The default is `3`.
 
 a| `xpack.data_enhanced.`
 `search.sessions.defaultExpiration`
 | How long search session results are stored before they are deleted.
-Extending a search session resets the expiration by the same value. The default is 7d.
+Extending a search session resets the expiration by the same value. The default is `7d`.
 |===

--- a/docs/settings/search-sessions-settings.asciidoc
+++ b/docs/settings/search-sessions-settings.asciidoc
@@ -37,7 +37,7 @@ a| `xpack.data_enhanced.`
 | How many retries {kib} can perform while attempting to save a search session. The default is `3`.
 
 a| `xpack.data_enhanced.`
-`search.sessions.defaultExpiration`{ess-icon}
+`search.sessions.defaultExpiration` {ess-icon}
 | How long search session results are stored before they are deleted.
 Extending a search session resets the expiration by the same value. The default is `7d`.
 |===

--- a/docs/settings/search-sessions-settings.asciidoc
+++ b/docs/settings/search-sessions-settings.asciidoc
@@ -19,6 +19,24 @@ a| `xpack.data_enhanced.`
 | The frequency for updating the state of a search session. The default is 10s.
 
 a| `xpack.data_enhanced.`
+`search.sessions.pageSize`
+| Controls how many search sessions Kibana processs at once while monitoring
+session progress. The default is 100.
+
+a| `xpack.data_enhanced.`
+`search.sessions.notTouchedTimeout`
+| Controls for how long Kibana stores search results from unsaved sessions,
+after the last search in the session has completed. The default is 5m.
+
+a| `xpack.data_enhanced.`
+`search.sessions.notTouchedInProgressTimeout`
+| Controls for how long a search session can run after a user navigates away without saving a session. The default is 1m.
+
+a| `xpack.data_enhanced.`
+`search.sessions.maxUpdateRetries`
+| Controls how many retries Kibana can perform while attempting to save a search session. The default is 3.
+
+a| `xpack.data_enhanced.`
 `search.sessions.defaultExpiration`
 | How long search session results are stored before they are deleted.
 Extending a search session resets the expiration by the same value. The default is 7d.


### PR DESCRIPTION
## Summary

Documenting more `xpack.data_enhanced.search.sessions.*` config options since there were questions about some of them while troubleshooting https://github.com/elastic/kibana/issues/96124

I think that `pageSize` one is the most interesting one here.
All of these options were exposed in cloud

Preview: https://kibana_96542.docs-preview.app.elstc.co/guide/en/kibana/master/search-session-settings-kb.html


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
