### PR TITLE
[7.12][docs] minor typo in word

### DIFF
--- a/docs/user/monitoring/kibana-alerts.asciidoc
+++ b/docs/user/monitoring/kibana-alerts.asciidoc
@@ -84,7 +84,7 @@ by running checks on a schedule time of 1 minute with a re-notify interval of 6 
 This alert is triggered if a large (primary) shard size is found on any of the 
 specified index patterns. The trigger condition is met if an index's shard size is 
 55gb or higher in the last 5 minutes. The alert is grouped across all indices that match 
-the default patter of `*` by running checks on a schedule time of 1 minute with a re-notify 
+the default pattern of `*` by running checks on a schedule time of 1 minute with a re-notify 
 interval of 12 hours.
 
 [discrete]


### PR DESCRIPTION
## Summary

Minor typo `patter` should be `pattern`