### PR TITLE
[Graph] Map request failure for text fields with better error message

### DIFF
--- a/x-pack/plugins/graph/server/routes/explore.ts
+++ b/x-pack/plugins/graph/server/routes/explore.ts
@@ -67,6 +67,7 @@ export function registerExploreRoute({
                 cause.reason.includes('No support for examining floating point') ||
                 cause.reason.includes('Sample diversifying key must be a single valued-field') ||
                 cause.reason.includes('Failed to parse query') ||
+                cause.reason.includes('Text fields are not optimised for operations') ||
                 cause.type === 'parsing_exception'
               );
             });


### PR DESCRIPTION
## Summary

Fixes #84505

This PR maps the new copy for the text field error message and propose it to the final user, providing a better explanation.

<img width="1006" alt="Screenshot 2021-04-12 at 14 33 38" src="https://user-images.githubusercontent.com/924948/114395306-7bd9b200-9b9c-11eb-8205-3f0288ec2adb.png">

Note: to set the `agent` field just create a field for `agent.keyword` (log sample data), then edit it.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
