### PR TITLE
[Graph] Enable partial pasting in drilldowns

### DIFF
--- a/x-pack/plugins/graph/public/components/settings/url_template_form.tsx
+++ b/x-pack/plugins/graph/public/components/settings/url_template_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   EuiFormRow,
   EuiFieldText,
@@ -79,8 +79,6 @@ export function UrlTemplateForm(props: UrlTemplateFormProps) {
   const [open, setOpen] = useState(!isUpdateForm(props));
 
   const [autoformatUrl, setAutoformatUrl] = useState(false);
-
-  const textRef = useRef<HTMLInputElement>(null);
 
   function setValue<K extends keyof UrlTemplate>(key: K, value: UrlTemplate[K]) {
     setCurrentTemplate({ ...currentTemplate, [key]: value });
@@ -213,39 +211,22 @@ export function UrlTemplateForm(props: UrlTemplateFormProps) {
           }
         >
           <EuiFieldText
-            inputRef={textRef}
             fullWidth
             placeholder="https://www.google.co.uk/#q={{gquery}}"
             value={currentTemplate.url}
             onChange={(e) => {
               setValue('url', e.target.value);
-              setAutoformatUrl(false);
+              if (
+                (e.nativeEvent as InputEvent).inputType !== 'insertFromPaste' ||
+                !isKibanaUrl(e.target.value)
+              ) {
+                setAutoformatUrl(false);
+              }
             }}
             onPaste={(e) => {
-              // Note: in general this custom paste prevents the user from undo using the
-              // browser undo/redo commands. Maybe we could hint the user to click the "Reset"
-              // button if he tries to press CTRL+Z after the paste?
-              e.preventDefault();
               const pastedUrl = e.clipboardData.getData('text/plain');
               if (isKibanaUrl(pastedUrl)) {
                 setAutoformatUrl(true);
-              }
-              textRef.current?.focus();
-              const currentSelectionText = window.getSelection?.()?.toString();
-              if (
-                currentSelectionText == null ||
-                (currentSelectionText !== '' && currentSelectionText === currentTemplate.url)
-              ) {
-                return setValue('url', pastedUrl);
-              }
-              // workout where is the start and the end of the selection in the input
-              const el = document.activeElement as HTMLInputElement;
-              if (typeof el.selectionStart === 'number' && typeof el.selectionEnd === 'number') {
-                const finalUrl =
-                  el.value.slice(0, el.selectionStart) +
-                  pastedUrl +
-                  el.value.slice(el.selectionEnd);
-                return setValue('url', finalUrl);
               }
             }}
             isInvalid={urlPlaceholderMissing || (touched.url && !currentTemplate.url)}

--- a/x-pack/plugins/graph/public/components/settings/url_template_form.tsx
+++ b/x-pack/plugins/graph/public/components/settings/url_template_form.tsx
@@ -217,7 +217,7 @@ export function UrlTemplateForm(props: UrlTemplateFormProps) {
             onChange={(e) => {
               setValue('url', e.target.value);
               if (
-                (e.nativeEvent as InputEvent).inputType !== 'insertFromPaste' ||
+                (e.nativeEvent as InputEvent)?.inputType !== 'insertFromPaste' ||
                 !isKibanaUrl(e.target.value)
               ) {
                 setAutoformatUrl(false);


### PR DESCRIPTION
## Summary

Fixes #62154

While this PR addresses exactly the issue, I think there are still some possible improvements (which I couldn't workout yet ).

The current solution should be cross-browsers (I've tested in Safari, Chrome and Firefox), but haven't tested old Edge browsers.

![graph_drilldown_partial_paste](https://user-images.githubusercontent.com/924948/114429287-7ccf0b80-9bbd-11eb-9c4c-a91b667503a4.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the [cloud](https://github.com/elastic/cloud) and added to the [docker list](https://github.com/elastic/kibana/blob/c29adfef29e921cc447d2a5ed06ac2047ceab552/src/dev/build/tasks/os_packages/docker_generator/resources/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
