### PR TITLE
[Workplace Search] Design polish: Groups, Security and Custom source

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/content_sources/components/add_source/save_custom.tsx
@@ -62,9 +62,10 @@ export const SaveCustom: React.FC<SaveCustomProps> = ({
 }) => (
   <>
     {header}
+    <EuiSpacer />
     <EuiFlexGroup direction="row">
       <EuiFlexItem grow={2}>
-        <EuiPanel paddingSize="l">
+        <EuiPanel paddingSize="l" hasShadow={false} color="subdued">
           <EuiFlexGroup direction="column" alignItems="center" responsive={false}>
             <EuiFlexItem>
               <EuiIcon type="checkInCircleFilled" color="#42CC89" size="xxl" />

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
@@ -19,11 +19,7 @@ import { ContentSection } from '../../../components/shared/content_section';
 import { SourcesTable } from '../../../components/shared/sources_table';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
 
-import {
-  GroupOverview,
-  EMPTY_SOURCES_DESCRIPTION,
-  EMPTY_USERS_DESCRIPTION,
-} from './group_overview';
+import { GroupOverview } from './group_overview';
 
 const deleteGroup = jest.fn();
 const showSharedSourcesModal = jest.fn();

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.test.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiFieldText } from '@elastic/eui';
+import { EuiFieldText, EuiEmptyPrompt } from '@elastic/eui';
 
 import { Loading } from '../../../../shared/loading';
 import { ContentSection } from '../../../components/shared/content_section';
@@ -92,7 +92,7 @@ describe('GroupOverview', () => {
     expect(updateGroupName).toHaveBeenCalled();
   });
 
-  it('renders empty state messages', () => {
+  it('renders empty state', () => {
     setMockValues({
       ...mockValues,
       group: {
@@ -103,10 +103,7 @@ describe('GroupOverview', () => {
     });
 
     const wrapper = shallow(<GroupOverview />);
-    const sourcesSection = wrapper.find('[data-test-subj="GroupContentSourcesSection"]') as any;
-    const usersSection = wrapper.find('[data-test-subj="GroupUsersSection"]') as any;
 
-    expect(sourcesSection.prop('description')).toEqual(EMPTY_SOURCES_DESCRIPTION);
-    expect(usersSection.prop('description')).toEqual(EMPTY_USERS_DESCRIPTION);
+    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -12,10 +12,12 @@ import { useActions, useValues } from 'kea';
 import {
   EuiButton,
   EuiConfirmModal,
+  EuiEmptyPrompt,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiPanel,
   EuiSpacer,
   EuiHorizontalRule,
 } from '@elastic/eui';
@@ -24,6 +26,7 @@ import { i18n } from '@kbn/i18n';
 import { Loading } from '../../../../shared/loading';
 import { TruncatedContent } from '../../../../shared/truncate';
 import { AppLogic } from '../../../app_logic';
+import noSharedSourcesIcon from '../../../assets/share_circle.svg';
 import { ContentSection } from '../../../components/shared/content_section';
 import { SourcesTable } from '../../../components/shared/sources_table';
 import { ViewContentHeader } from '../../../components/shared/view_content_header';
@@ -177,12 +180,26 @@ export const GroupOverview: React.FC = () => {
   const sourcesSection = (
     <ContentSection
       title={GROUP_SOURCES_TITLE}
-      description={hasContentSources ? GROUP_SOURCES_DESCRIPTION : EMPTY_SOURCES_DESCRIPTION}
+      description={GROUP_SOURCES_DESCRIPTION}
       action={manageSourcesButton}
       data-test-subj="GroupContentSourcesSection"
     >
-      {hasContentSources && sourcesTable}
+      {sourcesTable}
     </ContentSection>
+  );
+
+  const sourcesEmptyState = (
+    <>
+      <EuiPanel paddingSize="none" color="subdued">
+        <EuiEmptyPrompt
+          iconType={noSharedSourcesIcon}
+          title={<h2>{GROUP_SOURCES_TITLE}</h2>}
+          body={<p>{EMPTY_SOURCES_DESCRIPTION}</p>}
+          actions={manageSourcesButton}
+        />
+      </EuiPanel>
+      <EuiSpacer />
+    </>
   );
 
   const usersSection = !isFederatedAuth && (
@@ -258,7 +275,7 @@ export const GroupOverview: React.FC = () => {
     <>
       <ViewContentHeader title={truncatedName} />
       <EuiSpacer />
-      {sourcesSection}
+      {hasContentSources ? sourcesSection : sourcesEmptyState}
       {usersSection}
       {nameSection}
       {canDeleteGroup && deleteSection}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/components/group_overview.tsx
@@ -145,6 +145,12 @@ export const GroupOverview: React.FC = () => {
       values: { name },
     }
   );
+  const GROUP_SOURCES_TITLE = i18n.translate(
+    'xpack.enterpriseSearch.workplaceSearch.groups.overview.groupSourcesTitle',
+    {
+      defaultMessage: 'Group content sources',
+    }
+  );
   const GROUP_SOURCES_DESCRIPTION = i18n.translate(
     'xpack.enterpriseSearch.workplaceSearch.groups.overview.groupSourcesDescription',
     {
@@ -170,7 +176,7 @@ export const GroupOverview: React.FC = () => {
 
   const sourcesSection = (
     <ContentSection
-      title="Group content sources"
+      title={GROUP_SOURCES_TITLE}
       description={hasContentSources ? GROUP_SOURCES_DESCRIPTION : EMPTY_SOURCES_DESCRIPTION}
       action={manageSourcesButton}
       data-test-subj="GroupContentSourcesSection"

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/groups/groups.tsx
@@ -60,7 +60,7 @@ export const Groups: React.FC = () => {
     messages[0].description = (
       <EuiButtonTo
         to={getGroupPath(newGroup.id)}
-        color="primary"
+        color="secondary"
         data-test-subj="NewGroupManageButton"
       >
         {i18n.translate('xpack.enterpriseSearch.workplaceSearch.groups.newGroup.action', {

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/components/private_sources_table.tsx
@@ -152,7 +152,7 @@ export const PrivateSourcesTable: React.FC<PrivateSourcesTableProps> = ({
           {contentSources.map((source, i) => (
             <EuiTableRow key={i}>
               <EuiTableRowCell>{source.name}</EuiTableRowCell>
-              <EuiTableRowCell>
+              <EuiTableRowCell align="right">
                 <EuiSwitch
                   checked={!!source.isEnabled}
                   disabled={sectionDisabled}

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/security/security.tsx
@@ -115,6 +115,7 @@ export const Security: React.FC = () => {
     <EuiPanel
       paddingSize="none"
       hasShadow={false}
+      color="subdued"
       className={classNames({
         'euiPanel--disabled': !hasPlatinumLicense,
       })}
@@ -187,9 +188,11 @@ export const Security: React.FC = () => {
         messageText={SECURITY_UNSAVED_CHANGES_MESSAGE}
       />
       {header}
-      {allSourcesToggle}
-      {!hasPlatinumLicense && platinumLicenseCallout}
-      {sourceTables}
+      <EuiPanel color="subdued" hasBorder={false}>
+        {allSourcesToggle}
+        {!hasPlatinumLicense && platinumLicenseCallout}
+        {sourceTables}
+      </EuiPanel>
       {confirmModalVisible && confirmModal}
     </>
   );


### PR DESCRIPTION
## Summary

This PR completes the checklist items for groups and security [here](https://github.com/elastic/workplace-search-team/issues/1573#issuecomment-812019313). While I was here, I fixed the custom source completed screen and moved the toggle for the source to the right side (see row with Slack in the last row of images)

Best to review each commit with whitespace changes hidden.

| Before | After |
| ------------- | ------------- |
| ![gc-before](https://user-images.githubusercontent.com/1869731/114442385-1da7d180-9b92-11eb-975a-42cf86c10c20.png)  | ![gc-after](https://user-images.githubusercontent.com/1869731/114442378-1bde0e00-9b92-11eb-8f2a-923773b38fa1.png)  |
| ![ge-before](https://user-images.githubusercontent.com/1869731/114442386-1e406800-9b92-11eb-8603-bfc15d2d19a0.png)  | ![ge-after](https://user-images.githubusercontent.com/1869731/114442387-1ed8fe80-9b92-11eb-8f76-8622a4c11d15.png)  |
| ![cs-before](https://user-images.githubusercontent.com/1869731/114442389-1ed8fe80-9b92-11eb-9571-7a7a0b3944b7.png)  | ![cs-after](https://user-images.githubusercontent.com/1869731/114442390-1ed8fe80-9b92-11eb-87b5-be6c16097dff.png)  |
| ![image](https://user-images.githubusercontent.com/1869731/114445636-ea674180-9b95-11eb-954c-8bc55b23e66a.png)  | ![sec-after](https://user-images.githubusercontent.com/1869731/114442393-1f719500-9b92-11eb-85d2-f7cbdebeae7a.png)  |
### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
