### PR TITLE
[Enterprise Search] Design Pass: Role mappings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mapping.tsx
@@ -166,7 +166,7 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
         <EuiSpacer />
         <EuiFlexGroup alignItems="stretch">
           <EuiFlexItem>
-            <EuiPanel hasBorder paddingSize="l">
+            <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
               <EuiTitle size="s">
                 <h3>{ROLE_TITLE}</h3>
               </EuiTitle>
@@ -189,7 +189,7 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
           </EuiFlexItem>
           {hasAdvancedRoles && (
             <EuiFlexItem>
-              <EuiPanel hasBorder paddingSize="l">
+              <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
                 <EuiTitle size="s">
                   <h3>{ENGINE_ACCESS_TITLE}</h3>
                 </EuiTitle>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.tsx
@@ -17,6 +17,7 @@ import {
   EuiPageContent,
   EuiPageContentBody,
   EuiPageHeader,
+  EuiPanel,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -78,12 +79,14 @@ export const RoleMappings: React.FC = () => {
   const addMappingButton = <AddRoleMappingButton path={ROLE_MAPPING_NEW_PATH} />;
 
   const roleMappingEmptyState = (
-    <EuiEmptyPrompt
-      iconType="usersRolesApp"
-      title={<h2>{EMPTY_ROLE_MAPPINGS_TITLE}</h2>}
-      body={<p>{EMPTY_ROLE_MAPPINGS_BODY}</p>}
-      actions={addMappingButton}
-    />
+    <EuiPanel paddingSize="l" color="subdued" hasBorder={false}>
+      <EuiEmptyPrompt
+        iconType="usersRolesApp"
+        title={<h2>{EMPTY_ROLE_MAPPINGS_TITLE}</h2>}
+        body={<p>{EMPTY_ROLE_MAPPINGS_BODY}</p>}
+        actions={addMappingButton}
+      />
+    </EuiPanel>
   );
 
   const roleMappingsTable = (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/role_mappings/role_mappings.tsx
@@ -130,7 +130,7 @@ export const RoleMappings: React.FC = () => {
         pageTitle={ROLE_MAPPINGS_TITLE}
         description={ROLE_MAPPINGS_DESCRIPTION}
       />
-      <EuiPageContent hasBorder>
+      <EuiPageContent hasShadow={false} hasBorder={roleMappings.length > 0}>
         <EuiPageContentBody>
           <FlashMessages />
           {roleMappings.length === 0 ? roleMappingEmptyState : roleMappingsTable}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/add_role_mapping_button.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/add_role_mapping_button.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export const AddRoleMappingButton: React.FC<Props> = ({ path }) => (
-  <EuiButtonTo to={path} fill color="secondary">
+  <EuiButtonTo to={path} fill>
     {ADD_ROLE_MAPPING_BUTTON}
   </EuiButtonTo>
 );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/attribute_selector.tsx
@@ -100,7 +100,7 @@ export const AttributeSelector: React.FC<Props> = ({
   handleAuthProviderChange = () => null,
 }) => {
   return (
-    <EuiPanel data-test-subj="AttributeSelector" hasBorder paddingSize="l">
+    <EuiPanel data-test-subj="AttributeSelector" hasShadow={false} color="subdued" paddingSize="l">
       <EuiTitle size="s">
         <h3>{ATTRIBUTE_SELECTOR_TITLE}</h3>
       </EuiTitle>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.scss
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.scss
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+.roleMappingsTable {
+  td {
+    vertical-align: top;
+  }
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -154,7 +154,7 @@ export const RoleMappingsTable: React.FC<Props> = ({
                       {authProvider.map(getAuthProviderDisplayValue).join(', ')}
                     </EuiTableRowCell>
                   )}
-                  <EuiTableRowCell>
+                  <EuiTableRowCell align="right">
                     {id && <EuiLinkTo to={getRoleMappingPath(id)}>{MANAGE_BUTTON_LABEL}</EuiLinkTo>}
                     {toolTip && <EuiIconTip position="left" content={toolTip.content} />}
                   </EuiTableRowCell>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/role_mappings_table.tsx
@@ -29,6 +29,8 @@ import { MANAGE_BUTTON_LABEL } from '../constants';
 import { EuiLinkTo } from '../react_router_helpers';
 import { RoleRules } from '../types';
 
+import './role_mappings_table.scss';
+
 import {
   ANY_AUTH_PROVIDER,
   ANY_AUTH_PROVIDER_OPTION_LABEL,
@@ -108,7 +110,7 @@ export const RoleMappingsTable: React.FC<Props> = ({
       </EuiFlexGroup>
       <EuiSpacer />
       {filteredResults.length > 0 ? (
-        <EuiTable>
+        <EuiTable className="roleMappingsTable">
           <EuiTableHeader>
             <EuiTableHeaderCell>{EXTERNAL_ATTRIBUTE_LABEL}</EuiTableHeaderCell>
             <EuiTableHeaderCell>{ATTRIBUTE_VALUE_LABEL}</EuiTableHeaderCell>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mapping.tsx
@@ -141,7 +141,7 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
         <EuiSpacer />
         <EuiFlexGroup alignItems="stretch">
           <EuiFlexItem>
-            <EuiPanel hasBorder paddingSize="l">
+            <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
               <EuiTitle size="s">
                 <h3>{ROLE_LABEL}</h3>
               </EuiTitle>
@@ -158,7 +158,7 @@ export const RoleMapping: React.FC<RoleMappingProps> = ({ isNew }) => {
             </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiPanel hasBorder paddingSize="l">
+            <EuiPanel hasShadow={false} color="subdued" paddingSize="l">
               <EuiTitle size="s">
                 <h3>{GROUP_ASSIGNMENT_TITLE}</h3>
               </EuiTitle>

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/role_mappings/role_mappings.tsx
@@ -9,7 +9,7 @@ import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiEmptyPrompt } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
 
 import { FlashMessages } from '../../../shared/flash_messages';
 import { Loading } from '../../../shared/loading';
@@ -39,12 +39,14 @@ export const RoleMappings: React.FC = () => {
 
   const addMappingButton = <AddRoleMappingButton path={ROLE_MAPPING_NEW_PATH} />;
   const emptyPrompt = (
-    <EuiEmptyPrompt
-      iconType="usersRolesApp"
-      title={<h2>{EMPTY_ROLE_MAPPINGS_TITLE}</h2>}
-      body={<p>{EMPTY_ROLE_MAPPINGS_BODY}</p>}
-      actions={addMappingButton}
-    />
+    <EuiPanel paddingSize="l" color="subdued" hasBorder={false}>
+      <EuiEmptyPrompt
+        iconType="usersRolesApp"
+        title={<h2>{EMPTY_ROLE_MAPPINGS_TITLE}</h2>}
+        body={<p>{EMPTY_ROLE_MAPPINGS_BODY}</p>}
+        actions={addMappingButton}
+      />
+    </EuiPanel>
   );
   const roleMappingsTable = (
     <RoleMappingsTable


### PR DESCRIPTION
## Summary

This PR completes the checklist items for Role mappings [here](https://github.com/elastic/workplace-search-team/issues/1573#issuecomment-812019313). 

**Changes requested:**
- For the "No role mappings yet" message, add a full-width "color=subdued" and "padding=l" panel around the entire message (icon, title, message/description, and button)
- For the "No role mappings yet" message, change the button color to blue
- When creating a new role mapping, all panels should be "color=subdued"
- For the Users & roles screen (after a mapping has been added), the "Add mapping" button should be blue
  - If possible, for the table, vertically align all content within each table cell to the top. (ping me if this isn't clear)

Went ahead and applied the same changes to App Search while I was here. I only did the screenshot for App Search for the table cell alignment since this is a shared component. 

Best to review each commit with whitespace changes hidden.

**App Search**
| Before | After |
| ------------- | ------------- |
| ![as-rm-empty-before](https://user-images.githubusercontent.com/1869731/114452856-85fcb000-9b9e-11eb-816c-4d3bc98568c9.png)  | ![as-rm-empty-after](https://user-images.githubusercontent.com/1869731/114452859-86954680-9b9e-11eb-8b00-15aba100b056.png)  |
| ![as-rm-new-before](https://user-images.githubusercontent.com/1869731/114452846-85641980-9b9e-11eb-8f1d-be3216019fff.png)  | ![as-rm-new-after](https://user-images.githubusercontent.com/1869731/114452850-85641980-9b9e-11eb-8849-9cb963427ce3.png)  |
| ![as-rm-list-before](https://user-images.githubusercontent.com/1869731/114452853-85fcb000-9b9e-11eb-9e23-a24fbd3895b8.png)  | ![as-rm-list-after](https://user-images.githubusercontent.com/1869731/114452855-85fcb000-9b9e-11eb-8674-4f170af4aeba.png)  |
| ![as-rm-table-align-before](https://user-images.githubusercontent.com/1869731/114452841-8432ec80-9b9e-11eb-9655-4da1a101a453.png)  | ![as-rm-table-align-after](https://user-images.githubusercontent.com/1869731/114453574-471b2a00-9b9f-11eb-903c-6de02b9013bc.png)  |

**Workplace Search**
| Before | After |
| ------------- | ------------- |
| ![rm-empty-before](https://user-images.githubusercontent.com/1869731/114452837-839a5600-9b9e-11eb-9e47-6e06480fdafb.png)  | ![rm-empty-after](https://user-images.githubusercontent.com/1869731/114452840-8432ec80-9b9e-11eb-869e-0e0d64c72b1d.png)  |
| ![rm-new-before](https://user-images.githubusercontent.com/1869731/114452821-7f6e3880-9b9e-11eb-9a77-f274d7e04cd5.png)  | ![rm-new-after](https://user-images.githubusercontent.com/1869731/114452830-8137fc00-9b9e-11eb-9b7c-534b008dfdb6.png)  |
| ![rm-list-before](https://user-images.githubusercontent.com/1869731/114452832-82692900-9b9e-11eb-9b84-cb045f1c2f28.png)  | ![rm-list-after](https://user-images.githubusercontent.com/1869731/114452835-8301bf80-9b9e-11eb-9e8d-2fb61163649c.png)  |


### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
