### PR TITLE
[CTI] Adds confidence field to signal elastic/security-team#961

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/get_signals_template.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/get_signals_template.ts
@@ -53,6 +53,8 @@ export const getSignalsTemplate = (index: string) => {
               ...ecsMapping.mappings.properties.threat.properties.indicator,
               properties: {
                 ...ecsMapping.mappings.properties.threat.properties.indicator.properties,
+                confidence:
+                  ecsMapping.mappings.properties.threat.properties.indicator.properties.confidence,
                 event: ecsMapping.mappings.properties.event,
               },
             },


### PR DESCRIPTION
## Summary

Adds confidence field to signal.
Closes elastic/security-team#961.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials